### PR TITLE
[GURPS] Bug fix, Cosmetic Changes v1.4.8

### DIFF
--- a/GURPS/gurps.css
+++ b/GURPS/gurps.css
@@ -209,6 +209,14 @@ input {
     background-color: #E0E0E0;
 }
 
+.charsheet .sheet-row input[readonly], input[readonly="readonly"] {
+    background-color: #E0E0E0;
+}
+
+.charsheet .sheet-row input[type="text"]:disabled{background-color: #E0E0E0;}
+
+.charsheet .sheet-row input[type="number"]:disabled{background-color: #E0E0E0;}
+
 .repitem:nth-child(odd) .sheet-row-stats,
 .sheet-row:nth-child(even) {
     background: #F0F0FA;
@@ -709,11 +717,11 @@ input.sheet-toggle-unspoint-points[value="0"] ~ .sheet-row-total {
     display: block;
 } 
 
-.sheet-lift { width: calc(100% - 180px - 180px - 1.2em); }
+.sheet-lift { width: calc(100% - 180px - 180px - 100px - 1.6em); }
 .sheet-lift .sheet-col0 { width: 180px; }
 .sheet-lift .sheet-col1 { width: calc(100% - 180px); text-align: center; }
 
-.sheet-encumberance { width: calc(100% - 180px - 0.8em); }
+.sheet-encumberance { width: calc(100% - 180px - 100px - 1.2em); }
 .sheet-encumberance .sheet-col0 { width: 100px; }
 .sheet-encumberance .sheet-col1 { width: calc((100% - 100px) * 0.4); }
 .sheet-encumberance .sheet-colAll { width: calc((100% - 100px) * 0.166); }
@@ -747,22 +755,22 @@ input.sheet-toggle-unspoint-points[value="0"] ~ .sheet-row-total {
 .sheet-culture .sheet-col1 { width: 30px; }
 
 .sheet-traits { width: calc(100% - 0.4em); }
-.sheet-traits .sheet-col0 { width: calc(100% - 117px); }
+.sheet-traits .sheet-col0 { width: calc(100% - 137px); }
 .sheet-traits .sheet-col0 input { text-align:left; }
 .sheet-traits .sheet-col1 { width: 25px; }
 .sheet-traits .sheet-col2 { width: 22px; }
 .sheet-traits .sheet-col3 { width: 30px; }
-.sheet-traits .sheet-col4 { width: 40px; }
-.sheet-traits .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 137px); }
+.sheet-traits .sheet-col4 { width: 60px; }
+.sheet-traits .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 157px); }
 
 .sheet-disadvantages { width: calc(100% - 0.4em); }
-.sheet-disadvantages .sheet-col0 { width: calc(100% - 117px); }
+.sheet-disadvantages .sheet-col0 { width: calc(100% - 137px); }
 .sheet-disadvantages .sheet-col0 input { text-align:left; }
 .sheet-disadvantages .sheet-col1 { width: 25px; }
 .sheet-disadvantages .sheet-col2 { width: 22px; }
 .sheet-disadvantages .sheet-col3 { width: 30px; }
-.sheet-disadvantages .sheet-col4 { width: 40px; }
-.sheet-disadvantages .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 137px); }
+.sheet-disadvantages .sheet-col4 { width: 60px; }
+.sheet-disadvantages .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 157px); }
 
 .sheet-racial { width: calc(100% - 0.4em); }
 .sheet-racial .sheet-col0 { width: calc(100% - 117px); }
@@ -775,7 +783,7 @@ input.sheet-toggle-unspoint-points[value="0"] ~ .sheet-row-total {
 
 /* -- SKILLS -- */
 .sheet-skills { width: calc(100% - 0.4em); }
-.sheet-skills .sheet-col0 { width: calc(100% - 307px); }
+.sheet-skills .sheet-col0 { width: calc(100% - 327px); }
 .sheet-skills .sheet-col0 input { text-align:left; }
 .sheet-skills .sheet-col1 { width: 30px; }
 .sheet-skills .sheet-col2 { width: 40px; }
@@ -783,14 +791,14 @@ input.sheet-toggle-unspoint-points[value="0"] ~ .sheet-row-total {
 .sheet-skills .sheet-col4 { width: 50px; }
 .sheet-skills .sheet-col5 { width: 40px; }
 .sheet-skills .sheet-col6 { width: 30px; }
-.sheet-skills .sheet-col7 { width: 40px; }
+.sheet-skills .sheet-col7 { width: 60px; }
 .sheet-skills .sheet-col8 { width: 22px; }
-.sheet-skills .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 327px); }
+.sheet-skills .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 347px); }
 
 .sheet-techniques { width: calc(100% - 0.4em); }
-.sheet-techniques .sheet-col0 { width: calc((100% - 240px) * 0.55); }
+.sheet-techniques .sheet-col0 { width: calc((100% - 260px) * 0.55); }
 .sheet-techniques .sheet-col0 input { text-align:left; }
-.sheet-techniques .sheet-col1 { width: calc((100% - 273px) * 0.45); }
+.sheet-techniques .sheet-col1 { width: calc((100% - 293px) * 0.45); }
 .sheet-techniques .sheet-col1 input { text-align:left; }
 .sheet-techniques .sheet-col2 { width: 30px; }
 .sheet-techniques .sheet-col3 { width: 30px; }
@@ -798,8 +806,8 @@ input.sheet-toggle-unspoint-points[value="0"] ~ .sheet-row-total {
 .sheet-techniques .sheet-col5 { width: 30px; }
 .sheet-techniques .sheet-col6 { width: 53px; }
 .sheet-techniques .sheet-col7 { width: 30px; }
-.sheet-techniques .sheet-col8 { width: 40px; }
-.sheet-techniques .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc((100% - 240px) * 0.55 - 20px); }
+.sheet-techniques .sheet-col8 { width: 60px; }
+.sheet-techniques .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc((100% - 260px) * 0.55 - 20px); }
 
 /* -- COMBAT -- */
 .sheet-active-defense { width: calc(100% - 140px - 0.8em); }
@@ -819,9 +827,7 @@ input.sheet-toggle-unspoint-points[value="0"] ~ .sheet-row-total {
 .sheet-melee-attacks .sheet-col4 { width: 50px; }
 .sheet-melee-attacks .sheet-col4 input { text-align:left; }
 .sheet-melee-attacks .sheet-col5 { width: 30px; }
-.sheet-melee-attacks .sheet-col5 input[type="text"] {background-color : #87CEFA;}
 .sheet-melee-attacks .sheet-col6 { width: 22px; }
-.sheet-melee-attacks .sheet-col6 button[type="roll"] {background-color : #87CEFA;}
 .sheet-melee-attacks .sheet-header .sheet-col5 { width: 52px; }
 .sheet-melee-attacks .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 284px); }
 
@@ -839,9 +845,7 @@ input.sheet-toggle-unspoint-points[value="0"] ~ .sheet-row-total {
 .sheet-ranged-attacks .sheet-col8 { width: 39px; }
 .sheet-ranged-attacks .sheet-col9 { width: 35px; }
 .sheet-ranged-attacks .sheet-col10 { width: 30px; }
-.sheet-ranged-attacks .sheet-col10 input[type="text"] {background-color : #87CEFA;}
 .sheet-ranged-attacks .sheet-col11 { width: 22px; }
-.sheet-ranged-attacks .sheet-col11 button[type="roll"] {background-color : #87CEFA;}
 .sheet-ranged-attacks .sheet-header .sheet-col10 { width: 52px; }
 .sheet-ranged-attacks .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 468px); }
 
@@ -858,10 +862,10 @@ input.sheet-toggle-unspoint-points[value="0"] ~ .sheet-row-total {
 .sheet-items .sheet-col0 { width: calc(100% - 0.4em); }
 
 .sheet-items { width: calc(100% - 0.4em); }
-.sheet-items .sheet-col0 { width: calc(100% - 350px); }
+.sheet-items .sheet-col0 { width: calc(100% - 360px); }
 .sheet-items .sheet-col0 input { text-align:left; }
 .sheet-items .sheet-col1 { width: 30px; }
-.sheet-items .sheet-col2 { width: 50px; }
+.sheet-items .sheet-col2 { width: 60px; }
 .sheet-items .sheet-col3 { width: 20px; }
 .sheet-items .sheet-col3 input { text-align:left; }
 .sheet-items .sheet-col4 { width: 50px; }
@@ -871,7 +875,7 @@ input.sheet-toggle-unspoint-points[value="0"] ~ .sheet-row-total {
 .sheet-items .sheet-col6 input { text-align:right; }
 .sheet-items .sheet-col7 { width: 50px; }
 .sheet-items .sheet-col8 { width: 50px; }
-.sheet-items .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 370px); }
+.sheet-items .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 380px); }
 .sheet-items .sheet-row-totals .sheet-col0 { width: calc(100% - 380px); }
 .sheet-items .sheet-row-totals .sheet-col1 { width: 100px; }
 .sheet-items .sheet-row-totals .sheet-col2 { width: 100px; }

--- a/GURPS/gurps.html
+++ b/GURPS/gurps.html
@@ -62,10 +62,10 @@
 							<input type="number" name="attr_strength" value="10" readonly="readonly" >
 						</div>
 						<div class="sheet-cell sheet-col2">
-							<input type="number" name="attr_strength_mod" value="0" step="1" class="editable" />
+							<input type="number" name="attr_strength_mod" value="0" step="1" />
 						</div>
 						<div class="sheet-cell sheet-col3">
-							<input type="number" name="attr_strength_points" value="0" step="10" class="editable" />
+							<input type="number" name="attr_strength_points" value="0" step="10" />
 						</div>
 						<div class="sheet-cell sheet-col4">
 							<button type="roll" value="@{roll} [[3d6]] @{VS} ST [[@{strength} + @{modifier}]]" name="roll_vsST" />
@@ -86,10 +86,10 @@
 							<input type="number" name="attr_dexterity" value="10" readonly="readonly" >
 						</div>
 						<div class="sheet-cell sheet-col2">
-							<input type="number" name="attr_dexterity_mod" value="0" step="1" class="editable" />
+							<input type="number" name="attr_dexterity_mod" value="0" step="1" />
 						</div>
 						<div class="sheet-cell sheet-col3">
-							<input type="number" name="attr_dexterity_points" value="0" step="20" class="editable" />
+							<input type="number" name="attr_dexterity_points" value="0" step="20" />
 						</div>
 						<div class="sheet-cell sheet-col4">
 							<button type="roll" value="@{roll} [[3d6]] @{VS} DX [[@{dexterity} + @{modifier}]]" name="roll_vsDX" />
@@ -110,10 +110,10 @@
 							<input type="number" name="attr_intelligence" value="10" readonly="readonly" >
 						</div>
 						<div class="sheet-cell sheet-col2">
-							<input type="number" name="attr_intelligence_mod" value="0" step="1" class="editable" />
+							<input type="number" name="attr_intelligence_mod" value="0" step="1" />
 						</div>
 						<div class="sheet-cell sheet-col3">
-							<input type="number" name="attr_intelligence_points" value="0" step="20" class="editable" />
+							<input type="number" name="attr_intelligence_points" value="0" step="20" />
 						</div>
 						<div class="sheet-cell sheet-col4">
 							<button type="roll" value="@{roll} [[3d6]] @{VS} IQ [[@{intelligence} + @{modifier}]]" name="roll_vsIQ" />
@@ -131,13 +131,13 @@
 							</span>
 						</div>
 						<div class="sheet-cell sheet-col1">
-							<input type="number" name="attr_health" value="10" readonly="readonly">
+							<input type="number" name="attr_health" value="10" readonly="readonly" >
 						</div>
 						<div class="sheet-cell sheet-col2">
-							<input type="number" name="attr_health_mod" value="0" step="1" class="editable" />
+							<input type="number" name="attr_health_mod" value="0" step="1" />
 						</div>
 						<div class="sheet-cell sheet-col3">
-							<input type="number" name="attr_health_points" value="0" step="10" class="editable" />
+							<input type="number" name="attr_health_points" value="0" step="10" />
 						</div>
 						<div class="sheet-cell sheet-col4">
 							<button type="roll" value="@{roll} [[3d6]] @{VS} HT [[@{health} + @{modifier}]]" name="roll_vsHT" />
@@ -161,10 +161,10 @@
 						<input type="number" name="attr_perception" value="10" readonly="readonly" >
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" name="attr_perception_mod" value="0" step="1" class="editable" />
+						<input type="number" name="attr_perception_mod" value="0" step="1" />
 					</div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_perception_points" value="0" step="5" class="editable" />
+						<input type="number" name="attr_perception_points" value="0" step="5" />
 					</div>
 					<div class="sheet-cell sheet-col4">
 						<button type="roll" value="@{roll} [[3d6]] @{VS} Per [[@{perception} + @{modifier}]]" name="roll_vsPer" />
@@ -184,13 +184,13 @@
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_vision" value="10" readonly="readonly">
+						<input type="number" name="attr_vision" value="10" readonly="readonly" >
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" name="attr_vision_mod" value="0" step="1" class="editable" />
+						<input type="number" name="attr_vision_mod" value="0" step="1" />
 					</div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_vision_points" value="0" step="2" class="editable" />
+						<input type="number" name="attr_vision_points" value="0" step="2" />
 					</div>
 					<div class="sheet-cell sheet-col4">
 						<button type="roll" value="@{roll} [[3d6]] @{VS} Vision [[@{vision} + @{modifier}]]" name="roll_vsVision" />
@@ -210,13 +210,13 @@
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_hearing" value="10" readonly="readonly">
+						<input type="number" name="attr_hearing" value="10" readonly="readonly" >
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" name="attr_hearing_mod" value="0" step="1" class="editable" />
+						<input type="number" name="attr_hearing_mod" value="0" step="1" />
 					</div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_hearing_points" value="0" step="2" class="editable" />
+						<input type="number" name="attr_hearing_points" value="0" step="2" />
 					</div>
 					<div class="sheet-cell sheet-col4">
 						<button type="roll" value="@{roll} [[3d6]] @{VS} Hearing [[@{hearing} + @{modifier}]]" name="roll_vsHearing" />
@@ -236,13 +236,13 @@
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_taste_smell" value="10" readonly="readonly">
+						<input type="number" name="attr_taste_smell" value="10" readonly="readonly" >
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" name="attr_taste_smell_mod" value="0" step="1" class="editable" />
+						<input type="number" name="attr_taste_smell_mod" value="0" step="1" />
 					</div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_taste_smell_points" value="0" step="2" class="editable" />
+						<input type="number" name="attr_taste_smell_points" value="0" step="2" />
 					</div>
 					<div class="sheet-cell sheet-col4">
 						<button type="roll" value="@{roll} [[3d6]] @{VS} Taste or Smell [[@{taste_smell} + @{modifier}]]" name="roll_vsTasteSmell" />
@@ -262,13 +262,13 @@
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_touch" value="10" readonly="readonly">
+						<input type="number" name="attr_touch" value="10" readonly="readonly" >
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" name="attr_touch_mod" value="0" step="1" class="editable" />
+						<input type="number" name="attr_touch_mod" value="0" step="1" />
 					</div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_touch_points" value="0" step="2" class="editable" />
+						<input type="number" name="attr_touch_points" value="0" step="2" />
 					</div>
 					<div class="sheet-cell sheet-col4">
 						<button type="roll" value="@{roll} [[3d6]] @{VS} Touch [[@{touch} + @{modifier}]]" name="roll_vsTouch" />
@@ -288,13 +288,13 @@
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_willpower" value="10" readonly="readonly">
+						<input type="number" name="attr_willpower" value="10" readonly="readonly" >
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" name="attr_willpower_mod" value="0" step="1" class="editable" />
+						<input type="number" name="attr_willpower_mod" value="0" step="1" />
 					</div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_willpower_points" value="0" step="5" class="editable" />
+						<input type="number" name="attr_willpower_points" value="0" step="5" />
 					</div>
 					<div class="sheet-cell sheet-col4">
 						<button type="roll" value="@{roll} [[3d6]] @{VS} Will [[@{willpower} + @{modifier}]]" name="roll_vsWill" />
@@ -314,13 +314,13 @@
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_fear_check" value="10" readonly="readonly">
+						<input type="number" name="attr_fear_check" value="10" readonly="readonly" >
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" name="attr_fear_check_mod" value="0" step="1" class="editable" />
+						<input type="number" name="attr_fear_check_mod" value="0" step="1" />
 					</div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_fear_check_points" value="0" step="2" class="editable" />
+						<input type="number" name="attr_fear_check_points" value="0" step="2" />
 					</div>
 					<div class="sheet-cell sheet-col4">
 						<button type="roll" value="@{roll} [[3d6]] @{VS} Fright [[@{fear_check} + @{modifier}]]" name="roll_vsFearCheck" />
@@ -340,13 +340,13 @@
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_basic_speed" value="" readonly="readonly">
+						<input type="number" name="attr_basic_speed" value="" readonly="readonly" >
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" name="attr_basic_speed_mod" value="0" step="0.25" class="editable" />
+						<input type="number" name="attr_basic_speed_mod" value="0" step="0.25" />
 					</div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_basic_speed_points" value="0" step="5" class="editable" />
+						<input type="number" name="attr_basic_speed_points" value="0" step="5" />
 					</div>
 					<div class="sheet-cell sheet-col4">
 						<button class="sheet-roll-tracker" type="roll" value="/em has a speed of [[@{basic_speed} &{tracker}]]" name="roll_init" />
@@ -366,13 +366,13 @@
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_basic_move" value="" readonly="readonly">
+						<input type="number" name="attr_basic_move" value="" readonly="readonly" >
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" name="attr_basic_move_mod" value="0" step="1" class="editable" />
+						<input type="number" name="attr_basic_move_mod" value="0" step="1" />
 					</div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_basic_move_points" value="0" step="5" class="editable" />
+						<input type="number" name="attr_basic_move_points" value="0" step="5" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-dodge">
@@ -387,10 +387,10 @@
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_dodge" value="" readonly="readonly">
+						<input type="number" name="attr_dodge" value="" readonly="readonly" >
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" name="attr_dodge_mod" value="0" step="1" class="editable" />
+						<input type="number" name="attr_dodge_mod" value="0" step="1" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-lift-st sheet-hr">
@@ -403,17 +403,17 @@
 							<br />
 							3pts/level
 							<br />
-							Unmodified: <input class="sheet-inline" type="number" name="attr_lift_st_base" readonly="readonly">
+							Unmodified: <input class="sheet-inline" type="number" name="attr_lift_st_base" readonly="readonly" >
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_lift_st" value="0" readonly="readonly">
+						<input type="number" name="attr_lift_st" value="0" readonly="readonly" >
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" name="attr_lift_st_mod" value="0" step="1" class="editable" />
+						<input type="number" name="attr_lift_st_mod" value="0" step="1" />
 					</div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_lift_st_points" value="0" step="3" class="editable" />
+						<input type="number" name="attr_lift_st_points" value="0" step="3" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-basic-lift">
@@ -421,7 +421,7 @@
 						<div class="sheet-popup">Lift</div>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_basic_lift" value="0" readonly="readonly">
+						<input type="number" name="attr_basic_lift" value="0" readonly="readonly" >
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-strike-st sheet-hr">
@@ -434,17 +434,17 @@
 							<br />
 							5pts/level
 							<br />
-							Unmodified: <input class="sheet-inline" type="number" name="attr_striking_st_base" readonly="readonly">
+							Unmodified: <input class="sheet-inline" type="number" name="attr_striking_st_base" readonly="readonly" >
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_striking_st" value="0" readonly="readonly">
+						<input type="number" name="attr_striking_st" value="0" readonly="readonly" >
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" name="attr_striking_st_mod" value="0" step="1" class="editable" />
+						<input type="number" name="attr_striking_st_mod" value="0" step="1" />
 					</div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_striking_st_points" value="0" step="5" class="editable" />
+						<input type="number" name="attr_striking_st_points" value="0" step="5" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-thrust-damage">
@@ -493,7 +493,7 @@
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="text" name="attr_thrust" value="1d6-2" class="editable" />
+						<input type="text" name="attr_thrust" value="1d6-2" />
 					</div>
 					<div class="sheet-cell sheet-col4">
 					    <input type="hidden" name="attr_thrust_damage_dice_icon" class="thrust-damage-dice-icon" value="explode" />
@@ -546,7 +546,7 @@
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="text" name="attr_swing" value="1d6" class="editable" />
+						<input type="text" name="attr_swing" value="1d6" />
 					</div>
 					<div class="sheet-cell sheet-col4">
 						<input type="hidden" name="attr_swing_damage_dice_icon" class="swing-damage-dice-icon" value="explode" />
@@ -596,10 +596,10 @@
 						<input type="number" name="attr_hit_points_max" value="10" readonly="readonly" />
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" name="attr_hit_points_mod" value="0" step="1" class="editable" />
+						<input type="number" name="attr_hit_points_mod" value="0" step="1" />
 					</div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_hit_points_points" value="0" step="2" class="editable" />
+						<input type="number" name="attr_hit_points_points" value="0" step="2" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-sub-row sheet-row-current-points">
@@ -624,7 +624,7 @@
 									</tr>
 									<tr>
 										<td class="sheet-label">Verge of Collapse</td>
-										<td><input type="text" value="Less than 0" readonly="readonly"></td>
+										<td><input type="text" value="Less than 0" readonly="readonly" ></td>
 									</tr>
 									<tr>
 										<td colspan="2">
@@ -672,7 +672,7 @@
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_hit_points" value="10" class="editable" />
+						<input type="number" name="attr_hit_points" value="10" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-fatigue-points">
@@ -690,10 +690,10 @@
 						<input type="number" name="attr_fatigue_points_max" value="10" readonly="readonly" />
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" name="attr_fatigue_points_mod" value="0" step="1" class="editable" />
+						<input type="number" name="attr_fatigue_points_mod" value="0" step="1" />
 					</div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_fatigue_points_points" value="0" step="3" class="editable" />
+						<input type="number" name="attr_fatigue_points_points" value="0" step="3" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-sub-row sheet-row-current-points">
@@ -749,7 +749,7 @@
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_fatigue_points" value="10" class="editable" />
+						<input type="number" name="attr_fatigue_points" value="10" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-energy-points">
@@ -763,11 +763,11 @@
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_energy_points_max" class="editable" />
+						<input type="number" name="attr_energy_points_max" />
 					</div>
 					<div class="sheet-cell sheet-col2"></div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_energy_points_points" value="0" step="3" class="editable" />
+						<input type="number" name="attr_energy_points_points" value="0" step="3" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-sub-row sheet-row-current-points">
@@ -780,19 +780,19 @@
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_energy_points" value="0" class="editable" />
+						<input type="number" name="attr_energy_points" value="0" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-hr">
 					<div class="sheet-cell sheet-col0 sheet-label">
-						<input type="text" name="attr_user_pool1_name" class="editable" />
+						<input type="text" name="attr_user_pool1_name" />
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_user_pool1_max" class="editable" />
+						<input type="number" name="attr_user_pool1_max" />
 					</div>
 					<div class="sheet-cell sheet-col2"></div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_user_pool1_points" value=0 class="editable" />
+						<input type="number" name="attr_user_pool1_points" value=0 />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-sub-row sheet-row-current-points">
@@ -800,19 +800,19 @@
 						<div class="sheet-popup">Current</div>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_user_pool1" value="0" class="editable" />
+						<input type="number" name="attr_user_pool1" value="0" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row">
 					<div class="sheet-cell sheet-col0 sheet-label">
-						<input type="text" name="attr_user_pool2_name" class="editable" />
+						<input type="text" name="attr_user_pool2_name" />
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_user_pool2_max" class="editable" />
+						<input type="number" name="attr_user_pool2_max" />
 					</div>
 					<div class="sheet-cell sheet-col2"></div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_user_pool2_points" value=0 class="editable" />
+						<input type="number" name="attr_user_pool2_points" value=0 />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-sub-row sheet-row-current-points">
@@ -820,7 +820,7 @@
 						<div class="sheet-popup">Current</div>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_user_pool2" value="0" class="editable" />
+						<input type="number" name="attr_user_pool2" value="0" />
 					</div>
 				</div> <!-- .sheet-row -->
 			</div>
@@ -863,10 +863,10 @@
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="text" name="attr_tl" class="editable" />
+						<input type="text" name="attr_tl" />
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" step="5" name="attr_tl_pts" value="0" class="editable" />
+						<input type="number" step="5" name="attr_tl_pts" value="0" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-appearance">
@@ -896,7 +896,7 @@
 						Race
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="text" name="attr_race" class="editable" />
+						<input type="text" name="attr_race" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-gender">
@@ -904,7 +904,7 @@
 						Gender
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="text" name="attr_gender" class="editable" />
+						<input type="text" name="attr_gender" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-size">
@@ -912,7 +912,7 @@
 						Size Modifier
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_size" value="0" class="editable" />
+						<input type="number" name="attr_size" value="0" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-hand">
@@ -920,7 +920,7 @@
 						Pri Hand
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="text" name="attr_hand" class="editable" />
+						<input type="text" name="attr_hand" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-reactions">
@@ -928,7 +928,7 @@
 						Reactions
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="text" name="attr_reactions" class="editable" />
+						<input type="text" name="attr_reactions" />
 					</div>
 				</div> <!-- .sheet-row -->
 			</div> <!-- .sheet-table -->
@@ -969,7 +969,7 @@
 						Total
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="text" name="attr_total_points" value="150" class="editable" />
+						<input type="text" name="attr_total_points" value="150" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-attributes sheet-hr">
@@ -1001,7 +1001,7 @@
 						Other
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="text" name="attr_misc_points" value="0" class="editable" />
+						<input type="text" name="attr_misc_points" value="0" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-other">
@@ -1025,7 +1025,7 @@
 						Unspent
 					</div>
 					<div class="sheet-cell sheet-col1 sheet-unspent-points">
-						<input type="text" name="attr_unspent_points" value="0" class="editable" />
+						<input type="text" name="attr_unspent_points" value="0" />
 					</div>
 				</div> <!-- .sheet-row -->
 			</div> <!-- .sheet-table -->
@@ -1290,7 +1290,7 @@
 						Current (<span name="attr_encumbrance_level" value=""></span>)
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_total_weight" value="" readonly="readonly" />
+						<input type="number" step=".001"name="attr_total_weight" value="" readonly="readonly" />
 					</div>
 					<div class="sheet-cell sheet-col2">
 						<input type="number" name="attr_current_move" value="" readonly="readonly" />
@@ -2380,13 +2380,13 @@
 						Total Value:
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_total_value" value="0" readonly="readonly" />
+						<input type="number" step=".01" name="attr_total_value" value="0" readonly="readonly" />
 					</div>
 					<div class="sheet-cell sheet-col2 sheet-label">
 						Total Weight:
 					</div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_total_weight" value="0" readonly="readonly" />
+						<input type="number" step=".001" name="attr_total_weight" value="0" readonly="readonly" />
 					</div>
 				</div> <!-- .sheet-row -->
 			</div> <!-- .sheet-table -->
@@ -2495,7 +2495,7 @@
 	<div class="sheet-tab7">
 
 	<div>
-	<h3>Latest Changes: Updated 11/27/2018</h3>
+	<h3>Latest Changes: Updated 12/18/2018</h3>
 		
 	<h3>Known Issues</h3>
 	<ul>
@@ -2520,9 +2520,25 @@
 
 	<p>If there are others that are working on or wish to work on this sheet, lets coordinate using the Roll20 forum for now - perhaps later we can use GitHub.</p>
 
+		<h4>Version: 1.4.8</h4>
+
+	<p>Pull Request: 12/18/2018</p>
+
+	<ul>
+		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610)</li>
+		<li>Changed the PULL date for version 1.4.7 to 12/04/2018 – Cosmetic Only</li>
+		<li>Changed the width of the REF field in Advantages, Disadvantages, Skills, Techniques,  and Possessions – Cosmetic Only</li>
+		<li>Removed the visual cue for editable fields on the General Tab – Request by MANY  – Cosmetic Only</li>
+		<li>Added highlighted light gray color for calculated fields on all pages – Cosmetics Only</li>
+		<li>Removed the blue highlight from Melee and Ranged attacks as it is no longer needed – Cosmetic Only</li>
+		<li>Fixed alert indicating to use whole number on attributes that can be up to 2 or 3 decimal places in value in the Inventory section - Cosmetic Only</li>
+		<li>Resized the Life and Moving box and the Encumbrance box for FUTURE upgrades - Cosmetic Only</li>
+
+	</ul>
+	
 	<h4>Version: 1.4.7</h4>
 	
-	<p>Pull Request: 11/27/2018</p>
+	<p>Pull Request: 12/04/2018</p>
 
 	<ul>
 		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610)</li>
@@ -2849,7 +2865,7 @@
 
 	var noop = function () {}; // do nothing.
 
-	var version = "1.4.7";
+	var version = "1.4.8";
 
 	var modCascade = true;
 	var modCascadeAll = true;


### PR DESCRIPTION
Changed the PULL date for version 1.4.7 to 12/04/2018 – Cosmetic Only
Changed the width of the REF field in Advantages, Disadvantages, Skills, Techniques, and Possessions – Cosmetic Only
Removed the visual cue for editable fields on the General Tab – Requested by MANY – Cosmetic Only
Added highlighted light gray color for calculated fields on all pages – Cosmetics Only
Removed the blue highlight from Melee and Ranged attacks as it is no longer needed – Cosmetic Only
Fixed alert indicating to use whole number on attributes that can be up to 2 or 3 decimal places in value in the Inventory section - Cosmetic Only
Resized the Life and Moving box and the Encumbrance box for FUTURE upgrades - Cosmetic Only

## Changes / Comments

*Provide a few comments about what you have changed.*




## Roll20 Requests

*Include the name of the sheet you made changes to in the title.*

- If changes fix a bug or resolves a feature request, be sure to link to that issue. 
- For pull request that change multiple sheets please confirm these changes are intentional for all sheets. This will help us catch unintended submissions.
- When updating existing sheets if you are changing attribute names please note what steps you have taken, if any, to assist players in keeping their data.