### PR TITLE
Correct d20 modern to allow bars

### DIFF
--- a/d20 Modern/d20 Modern.html
+++ b/d20 Modern/d20 Modern.html
@@ -1671,9 +1671,9 @@
                     <option value="@{Charisma-mod}">Charisma</option>
                 </select></td>
             <td><input type="number" class="sheet-number" name="attr_fx-Known" value="0" /></td>
-            <td><input type="number" class="sheet-number" name="attr_fx-Max_Known" value="0" /></td>
-            <td><input type="number" class="sheet-number" name="attr_fx-PP_Max" value="0" /></td>
-            <td><input type="number" class="sheet-number" name="attr_fx-PP_Current" value="0" /></td>
+            <td><input type="number" class="sheet-number" name="attr_fx-Known_max" value="0" /></td>
+            <td><input type="number" class="sheet-number" name="attr_fx-PP_max" value="0" /></td>
+            <td><input type="number" class="sheet-number" name="attr_fx-PP" value="0" /></td>
             <th></th>
         </tr>
     </table>


### PR DESCRIPTION
## Changes / Comments

Modifies attr_fx-Known and attr_fx-PP to have a 'max' value instead of 'max' and 'current', thereby allowing for a PP bar on token.




## Roll20 Requests
* Renamed `attr_fx-Max_Known` to `attr_fx-Known_max`
* Renamed `attr_fx-PP_Max` to `attr_fx-PP_max`
* Renamed `attr_fx-PP-Current` to `attr_fx-PP`