### PR TITLE
fixed extra label display in levels

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.css
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.css
@@ -4711,7 +4711,7 @@ body:not(:-moz-handler-blocked) .sheet-charmancer .sheet-bottombar {
     color           : #fff;
 }
 
-.sheet-charmancer .sheet-levels-hp-row label {
+.sheet-charmancer .sheet-levels-hp-row .sheet-row div > label {
     display: inline;
 }
 


### PR DESCRIPTION
Last minute change before Ross begins. This will remove the extra label creating a gap in the by levels.