### PR TITLE
[GURPS] Mostly Cosmetic changes: GURPS.html, GURPS.css, Readme.rd v1.4.9

### DIFF
--- a/GURPS/README.md
+++ b/GURPS/README.md
@@ -3,8 +3,6 @@ In progress character sheet for the Generic Universal Roleplaying System.
 Styling is inspired primarily by GCS, but also with some influence from the official sheet. The goal was to design a reponsive character sheet that would look good even with a small screen width.
 
 
-TODO
- - Allow for free native language [DONE]
- - Add option for Language talent to reduce cost.
- - Populate Swing and Thrust damage based on Striking ST.
+To the Future Authors - from Mike W (12/20/2018)
+I need to mention that the original author(s) misspelled the words Miscellaneous (as Miscellwneous) and Encumbrance (as Encumberance) in both the CSS and HTML files. Rather than write extensive code to fix this, I just corrected the cosmetic portions only. Also note that the original author(s) use the word Fear in place of Fright although the proper word to use is Fright. As with the misspelled words, I changed no code other than the cosmetic side. This seemed simpler then spending hours writing code, transferring values from the attributes in question, and making sure it still functions. It also avoids having to explain it to the users in case they used those misspelled attributes in homemade macros.
 

--- a/GURPS/gurps.css
+++ b/GURPS/gurps.css
@@ -4,7 +4,7 @@
 }
 
 .sheet-wrapper {
-    min-width: 500px;
+    min-width: 852px;
 }
 
 .sheet-box {
@@ -210,22 +210,18 @@ input {
 }
 
 .charsheet .sheet-row input[readonly], input[readonly="readonly"] {
-    background-color: #E0E0E0;
+    background-color: #c9c9c9;
 }
 
-.charsheet .sheet-row input[type="text"]:disabled{background-color: #E0E0E0;}
+.charsheet .sheet-row input[type="text"]:disabled{background-color: #c9c9c9;}
 
-.charsheet .sheet-row input[type="number"]:disabled{background-color: #E0E0E0;}
+.charsheet .sheet-row input[type="number"]:disabled{background-color: #c9c9c9;}
 
-.repitem:nth-child(odd) .sheet-row-stats,
-.sheet-row:nth-child(even) {
-    background: #F0F0FA;
-}
+.charsheet .sheet-row input[type="text"]:enabled{border-bottom: 1px solid black;}
 
-.repitem:nth-child(even) .sheet-row-stats,
-.sheet-row:nth-child(odd) {
-    background: #FAFAF0;
-}
+.charsheet .sheet-row input[type="number"]:read-write{border-bottom: 1px solid black;}
+
+.charsheet .sheet-row input[type="number"]:-moz-read-write{border-bottom: 1px solid black;}
 
 .sheet-box .sheet-row-details {
     background: #FAFAFA;
@@ -634,7 +630,7 @@ input.sheet-module-roll:checked ~ .sheet-wrapper .sheet-module-off-roll,
 .sheet-main-attribute .sheet-row { height: 35px; }
 .sheet-main-attribute .sheet-row .sheet-col0 { font-size: 20px; }
 .sheet-main-attribute .sheet-row .sheet-col1 input { font-size: 20px; }
-.sheet-main-attribute .sheet-cell { padding: 0.25em; }
+
 .sheet-main-attribute .sheet-tooltip { font-size: 11px; }
 .sheet-attribute .sheet-row-perception { height: 25px; }
 .sheet-attribute .sheet-row-perception .sheet-col0 { font-size: 16px; }
@@ -644,6 +640,9 @@ input.sheet-module-roll:checked ~ .sheet-wrapper .sheet-module-off-roll,
 .sheet-attribute .sheet-row-willpower .sheet-col0 { font-size: 16px; }
 .sheet-attribute .sheet-row-willpower .sheet-col1 input { font-size: 16px; }
 .sheet-attribute .sheet-row-willpower .sheet-tooltip { font-size: 11px; }
+.sheet-attribute .sheet-row-thrust-damage .sheet-tooltip { font-size: 11px; margin-left: 50px; top: 200px; }
+.sheet-attribute .sheet-row-swing-damage .sheet-tooltip { font-size: 11px; margin-left: 50px; top: 200px; }
+
 
 .sheet-stats { width: 180px; }
 .sheet-stats input { font-size: 13px;}
@@ -773,27 +772,27 @@ input.sheet-toggle-unspoint-points[value="0"] ~ .sheet-row-total {
 .sheet-disadvantages .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 157px); }
 
 .sheet-racial { width: calc(100% - 0.4em); }
-.sheet-racial .sheet-col0 { width: calc(100% - 117px); }
+.sheet-racial .sheet-col0 { width: calc(100% - 137px); }
 .sheet-racial .sheet-col0 input { text-align:left; }
 .sheet-racial .sheet-col1 { width: 25px; }
 .sheet-racial .sheet-col2 { width: 22px; }
 .sheet-racial .sheet-col3 { width: 30px; }
-.sheet-racial .sheet-col4 { width: 40px; }
-.sheet-racial .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 137px); }
+.sheet-racial .sheet-col4 { width: 60px; }
+.sheet-racial .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 157px); }
 
 /* -- SKILLS -- */
 .sheet-skills { width: calc(100% - 0.4em); }
 .sheet-skills .sheet-col0 { width: calc(100% - 327px); }
 .sheet-skills .sheet-col0 input { text-align:left; }
-.sheet-skills .sheet-col1 { width: 30px; }
-.sheet-skills .sheet-col2 { width: 40px; }
-.sheet-skills .sheet-col3 { width: 55px; }
-.sheet-skills .sheet-col4 { width: 50px; }
-.sheet-skills .sheet-col5 { width: 40px; }
-.sheet-skills .sheet-col6 { width: 30px; }
-.sheet-skills .sheet-col7 { width: 60px; }
-.sheet-skills .sheet-col8 { width: 22px; }
-.sheet-skills .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 347px); }
+.sheet-skills .sheet-col1 { width: 22px; }
+.sheet-skills .sheet-col2 { width: 30px; }
+.sheet-skills .sheet-col3 { width: 40px; }
+.sheet-skills .sheet-col4 { width: 55px; }
+.sheet-skills .sheet-col5 { width: 50px; }
+.sheet-skills .sheet-col6 { width: 40px; }
+.sheet-skills .sheet-col7 { width: 30px; }
+.sheet-skills .sheet-col8 { width: 60px; }
+.sheet-skills .sheet-row-stats .sheet-col0 { margin-left: 27px; width: calc(100% - 354px); }
 
 .sheet-techniques { width: calc(100% - 0.4em); }
 .sheet-techniques .sheet-col0 { width: calc((100% - 260px) * 0.55); }
@@ -807,36 +806,36 @@ input.sheet-toggle-unspoint-points[value="0"] ~ .sheet-row-total {
 .sheet-techniques .sheet-col6 { width: 53px; }
 .sheet-techniques .sheet-col7 { width: 30px; }
 .sheet-techniques .sheet-col8 { width: 60px; }
-.sheet-techniques .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc((100% - 260px) * 0.55 - 20px); }
+.sheet-techniques .sheet-row-stats .sheet-col0 { margin-left: 27px; width: calc((100% - 260px) * 0.55 - 27px); }
 
 /* -- COMBAT -- */
 .sheet-active-defense { width: calc(100% - 140px - 0.8em); }
-.sheet-active-defense .sheet-col0 { width: calc(100% - 184px); }
+.sheet-active-defense .sheet-col0 { width: calc(100% - 169px); }
 .sheet-active-defense .sheet-col0 input { text-align:left; }
-.sheet-active-defense .sheet-col1 { width: 80px; }
+.sheet-active-defense .sheet-col1 { width: 65px; }
 .sheet-active-defense .sheet-col2 { width: 40px; }
 .sheet-active-defense .sheet-col3 { width: 30px; }
 .sheet-active-defense .sheet-col4 { width: 22px; }
 
 .sheet-melee-attacks { width: calc(100% - 140px - 0.8em); }
-.sheet-melee-attacks .sheet-col0 { width: calc(100% - 262px); }
+.sheet-melee-attacks .sheet-col0 { width: calc(100% - 257px); }
 .sheet-melee-attacks .sheet-col0 input { text-align:left; }
 .sheet-melee-attacks .sheet-col1 { width: 60px; }
 .sheet-melee-attacks .sheet-col2 { width: 30px; }
-.sheet-melee-attacks .sheet-col3 { width: 60px; }
+.sheet-melee-attacks .sheet-col3 { width: 55px; }
 .sheet-melee-attacks .sheet-col4 { width: 50px; }
 .sheet-melee-attacks .sheet-col4 input { text-align:left; }
 .sheet-melee-attacks .sheet-col5 { width: 30px; }
 .sheet-melee-attacks .sheet-col6 { width: 22px; }
 .sheet-melee-attacks .sheet-header .sheet-col5 { width: 52px; }
-.sheet-melee-attacks .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 284px); }
+.sheet-melee-attacks .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 279px); }
 
 .sheet-ranged-attacks { width: calc(100% - 140px - 0.8em); }
-.sheet-ranged-attacks .sheet-col0 { width: calc(100% - 446px); }
+.sheet-ranged-attacks .sheet-col0 { width: calc(100% - 441px); }
 .sheet-ranged-attacks .sheet-col0 input { text-align:left; }
 .sheet-ranged-attacks .sheet-col1 { width: 60px; }
 .sheet-ranged-attacks .sheet-col2 { width: 30px; }
-.sheet-ranged-attacks .sheet-col3 { width: 60px; }
+.sheet-ranged-attacks .sheet-col3 { width: 55px; }
 .sheet-ranged-attacks .sheet-col4 { width: 30px; }
 .sheet-ranged-attacks .sheet-col5 { width: 40px; }
 .sheet-ranged-attacks .sheet-col5 input { text-align:left; }
@@ -847,7 +846,7 @@ input.sheet-toggle-unspoint-points[value="0"] ~ .sheet-row-total {
 .sheet-ranged-attacks .sheet-col10 { width: 30px; }
 .sheet-ranged-attacks .sheet-col11 { width: 22px; }
 .sheet-ranged-attacks .sheet-header .sheet-col10 { width: 52px; }
-.sheet-ranged-attacks .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 468px); }
+.sheet-ranged-attacks .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 463px); }
 
 .sheet-damage-reduction { float: right; width: 140px; }
 .sheet-damage-reduction .sheet-col0 { width: 50px; }
@@ -875,7 +874,7 @@ input.sheet-toggle-unspoint-points[value="0"] ~ .sheet-row-total {
 .sheet-items .sheet-col6 input { text-align:right; }
 .sheet-items .sheet-col7 { width: 50px; }
 .sheet-items .sheet-col8 { width: 50px; }
-.sheet-items .sheet-row-stats .sheet-col0 { margin-left: 20px; width: calc(100% - 380px); }
+.sheet-items .sheet-row-stats .sheet-col0 { margin-left: 27px; width: calc(100% - 407px); }
 .sheet-items .sheet-row-totals .sheet-col0 { width: calc(100% - 380px); }
 .sheet-items .sheet-row-totals .sheet-col1 { width: 100px; }
 .sheet-items .sheet-row-totals .sheet-col2 { width: 100px; }

--- a/GURPS/gurps.html
+++ b/GURPS/gurps.html
@@ -340,7 +340,7 @@
 						</span>
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_basic_speed" value="" readonly="readonly" >
+						<input type="number" name="attr_basic_speed" value="" step="0.25" readonly="readonly" >
 					</div>
 					<div class="sheet-cell sheet-col2">
 						<input type="number" name="attr_basic_speed_mod" value="0" step="0.25" />
@@ -1121,7 +1121,7 @@
 		</div> <!-- .sheet-box .sheet-lift -->
 
 
-		<!-- _____ _____ ENCUMBERANCE BOX _____ _____ -->
+		<!-- _____ _____ ENCUMBERANCE BOX - Original author(s) misspelled this througout the file_____ _____ -->
 		<!-- Note: Many of the Move and Dodge calculations were complicated, this was to allow for a Minimum Move of 1 and a Minimum Dodge of 1 -->
 
 		<div class="sheet-box sheet-encumberance">
@@ -1140,22 +1140,22 @@
 						None (0)
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_lift_0" value="@{basic_lift}" disabled="disabled" />
+						<input type="text" name="attr_lift_0" value="@{basic_lift}" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" name="attr_move_0" value="@{basic_move}" disabled="disabled" />
+						<input type="text" name="attr_move_0" value="@{basic_move}" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col1" style="display: none;">
-						<input type="number" name="attr_air_0" value="0" disabled="disabled" />
+						<input type="text" name="attr_air_0" value="0" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col1" style="display: none;">
-						<input type="number" name="attr_water_0" value="0" disabled="disabled" />
+						<input type="text" name="attr_water_0" value="0" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col1" style="display: none;">
-						<input type="number" name="attr_jump_0" value="0" disabled="disabled" />
+						<input type="text" name="attr_jump_0" value="0" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_dodge_0" value="@{dodge} " disabled="disabled" />
+						<input type="text" name="attr_dodge_0" value="@{dodge} " disabled="disabled" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-encumberance-1">
@@ -1163,22 +1163,22 @@
 						Light (1)
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_lift_1" value="2 * @{basic_lift}" disabled="disabled" />
+						<input type="text" name="attr_lift_1" value="2 * @{basic_lift}" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" name="attr_move_1" value="[[((1 + floor((@{basic_move} * 0.8))) + abs(1 - floor((@{basic_move} * 0.8)))) / 2]]" disabled="disabled" />
+						<input type="text" name="attr_move_1" value="[[((1 + floor((@{basic_move} * 0.8))) + abs(1 - floor((@{basic_move} * 0.8)))) / 2]]" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col1" style="display: none;">
-						<input type="number" name="attr_air_1" value="0" disabled="disabled" />
+						<input type="text" name="attr_air_1" value="0" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col1" style="display: none;">
-						<input type="number" name="attr_water_1" value="0" disabled="disabled" />
+						<input type="text" name="attr_water_1" value="0" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col1" style="display: none;">
-						<input type="number" name="attr_jump_1" value="0" disabled="disabled" />
+						<input type="text" name="attr_jump_1" value="0" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_dodge_1" value="[[((1 + (@{dodge} - 1)) + abs(1 - (@{dodge} - 1))) / 2]]" disabled="disabled" />
+						<input type="text" name="attr_dodge_1" value="[[((1 + (@{dodge} - 1)) + abs(1 - (@{dodge} - 1))) / 2]]" disabled="disabled" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-encumberance-2">
@@ -1186,22 +1186,22 @@
 						Medium (2)
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_lift_2" value="floor(3 * @{basic_lift}*100)/100" disabled="disabled" />
+						<input type="text" name="attr_lift_2" value="floor(3 * @{basic_lift}*100)/100" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" name="attr_move_2" value="[[((1 + floor((@{basic_move} * 0.6))) + abs(1 - floor((@{basic_move} * 0.6)))) / 2]]"  disabled="disabled" />
+						<input type="text" name="attr_move_2" value="[[((1 + floor((@{basic_move} * 0.6))) + abs(1 - floor((@{basic_move} * 0.6)))) / 2]]"  disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col1" style="display: none;">
-						<input type="number" name="attr_air_2" value="0" disabled="disabled" />
+						<input type="text" name="attr_air_2" value="0" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col1" style="display: none;">
-						<input type="number" name="attr_water_2" value="0" disabled="disabled" />
+						<input type="text" name="attr_water_2" value="0" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col1" style="display: none;">
-						<input type="number" name="attr_jump_2" value="0" disabled="disabled" />
+						<input type="text" name="attr_jump_2" value="0" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_dodge_2" value="[[((1 + (@{dodge} - 2)) + abs(1 - (@{dodge} -2))) / 2]]" disabled="disabled" />
+						<input type="text" name="attr_dodge_2" value="[[((1 + (@{dodge} - 2)) + abs(1 - (@{dodge} -2))) / 2]]" disabled="disabled" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-encumberance-3">
@@ -1209,22 +1209,22 @@
 						Heavy (3)
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_lift_3" value="floor(6 * @{basic_lift}*100)/100" disabled="disabled" />
+						<input type="text" name="attr_lift_3" value="floor(6 * @{basic_lift}*100)/100" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" name="attr_move_3" value="[[((1 + floor((@{basic_move} * 0.4))) + abs(1 - floor((@{basic_move} * 0.4)))) / 2]]"  disabled="disabled" />
+						<input type="text" name="attr_move_3" value="[[((1 + floor((@{basic_move} * 0.4))) + abs(1 - floor((@{basic_move} * 0.4)))) / 2]]"  disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col1" style="display: none;">
-						<input type="number" name="attr_air_3" value="0" disabled="disabled" />
+						<input type="text" name="attr_air_3" value="0" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col1" style="display: none;">
-						<input type="number" name="attr_water_3" value="0" disabled="disabled" />
+						<input type="text" name="attr_water_3" value="0" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col1" style="display: none;">
-						<input type="number" name="attr_jump_3" value="0" disabled="disabled" />
+						<input type="text" name="attr_jump_3" value="0" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_dodge_3" value="[[((1 + (@{dodge} - 3)) + abs(1 - (@{dodge} -3))) / 2]]" disabled="disabled" />
+						<input type="text" name="attr_dodge_3" value="[[((1 + (@{dodge} - 3)) + abs(1 - (@{dodge} -3))) / 2]]" disabled="disabled" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-encumberance-4">
@@ -1232,22 +1232,22 @@
 						X-Heavy (4)
 					</div>
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_lift_4" value="10 * @{basic_lift}"  disabled="disabled" />
+						<input type="text" name="attr_lift_4" value="10 * @{basic_lift}"  disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" name="attr_move_4" value="[[((1 + floor((@{basic_move} * 0.2))) + abs(1 - floor((@{basic_move} * 0.2)))) / 2]]"  disabled="disabled" />
+						<input type="text" name="attr_move_4" value="[[((1 + floor((@{basic_move} * 0.2))) + abs(1 - floor((@{basic_move} * 0.2)))) / 2]]"  disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col1" style="display: none;">
-						<input type="number" name="attr_air_4" value="0" disabled="disabled" />
+						<input type="text" name="attr_air_4" value="0" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col1" style="display: none;">
-						<input type="number" name="attr_water_4" value="0" disabled="disabled" />
+						<input type="text" name="attr_water_4" value="0" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col1" style="display: none;">
-						<input type="number" name="attr_jump_4" value="0" disabled="disabled" />
+						<input type="text" name="attr_jump_4" value="0" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_dodge_4" value="[[((1 + (@{dodge} -4)) + abs(1 - (@{dodge} - 4))) / 2]]" disabled="disabled" />
+						<input type="text" name="attr_dodge_4" value="[[((1 + (@{dodge} -4)) + abs(1 - (@{dodge} - 4))) / 2]]" disabled="disabled" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<!-- Yes I realize encumbrance is spelled wrong here but the original authors misspelled it throughout the file so I did the same to stay backwards compatible. -->	
@@ -1267,22 +1267,22 @@
 					</div>
 
 					<div class="sheet-cell sheet-col1">
-						<input type="number" name="attr_lift_5" value="15 * @{basic_lift}"  disabled="disabled" />
+						<input type="text" name="attr_lift_5" value="15 * @{basic_lift}"  disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col2">
-						<input type="number" name="attr_move_5" value="[[((1 + floor((@{basic_move} * 0.2))) + abs(1 - floor((@{basic_move} * 0.2)))) / 2]]"  disabled="disabled" />
+						<input type="text" name="attr_move_5" value="[[((1 + floor((@{basic_move} * 0.2))) + abs(1 - floor((@{basic_move} * 0.2)))) / 2]]"  disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col1" style="display: none;">
-						<input type="number" name="attr_air_5" value="0" disabled="disabled" />
+						<input type="text" name="attr_air_5" value="0" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col1" style="display: none;">
-						<input type="number" name="attr_water_5" value="0" disabled="disabled" />
+						<input type="text" name="attr_water_5" value="0" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col1" style="display: none;">
-						<input type="number" name="attr_jump_5" value="0" disabled="disabled" />
+						<input type="text" name="attr_jump_5" value="0" disabled="disabled" />
 					</div>
 					<div class="sheet-cell sheet-col3">
-						<input type="number" name="attr_dodge_5" value="[[((1 + (@{dodge} -4)) + abs(1 - (@{dodge} - 4))) / 2]]"disabled="disabled" />
+						<input type="text" name="attr_dodge_5" value="[[((1 + (@{dodge} -4)) + abs(1 - (@{dodge} - 4))) / 2]]"disabled="disabled" />
 					</div>
 				</div> <!-- .sheet-row -->
 				<div class="sheet-row sheet-row-load sheet-hr">
@@ -1600,14 +1600,14 @@
 			<div class="sheet-table">
 				<div class="sheet-header">
 					<div class="sheet-cell sheet-col0">Skills</div>
-					<div class="sheet-cell sheet-col8"></div>
-					<div class="sheet-cell sheet-col1">TL</div>
-					<div class="sheet-cell sheet-col2">Level</div>
-					<div class="sheet-cell sheet-col3">Attr</div>
-					<div class="sheet-cell sheet-col4">Diff</div>
-					<div class="sheet-cell sheet-col5">Bonus</div>
-					<div class="sheet-cell sheet-col6">Pts</div>
-					<div class="sheet-cell sheet-col7">Ref</div>
+					<div class="sheet-cell sheet-col1"></div>
+					<div class="sheet-cell sheet-col2">TL</div>
+					<div class="sheet-cell sheet-col3">Level</div>
+					<div class="sheet-cell sheet-col4">Attr</div>
+					<div class="sheet-cell sheet-col5">Diff</div>
+					<div class="sheet-cell sheet-col6">Bonus</div>
+					<div class="sheet-cell sheet-col7">Pts</div>
+					<div class="sheet-cell sheet-col8">Ref</div>
 				</div> <!-- .sheet-header -->
 				<fieldset class="repeating_skills">
 					<input class="sheet-toggle" type="checkbox" />
@@ -1616,16 +1616,16 @@
 						<div class="sheet-cell sheet-col0">
 							<input type="text" name="attr_name" />
 						</div>
-						<div class="sheet-cell sheet-col8">
+						<div class="sheet-cell sheet-col1">
 							<button type="roll" value="@{roll} [[3d6]] @{VS} @{name} [[@{level} + @{modifier}]]" name="roll_vsSL" />
 						</div>
-						<div class="sheet-cell sheet-col1">
+						<div class="sheet-cell sheet-col2">
 							<input type="text" name="attr_tl" />
 						</div>
-						<div class="sheet-cell sheet-col2">
+						<div class="sheet-cell sheet-col3">
 							<input type="text" name="attr_level" disabled="disabled" value="@{base} + @{difficulty} + @{bonus} + (floor((@{points} * 0.25) + 2) * ceil( ( ( @{points} - 2 ) + abs( @{points} - 2) ) / 256 ) + @{points} * abs( ceil( ( ( @{points} - 2 ) + abs( @{points} - 2) ) / 256 ) - 1 ))"/>
 						</div>
-						<div class="sheet-cell sheet-col3">
+						<div class="sheet-cell sheet-col4">
 							<select name="attr_base">
 								<option value="@{strength}">ST</option>
 								<option value="@{dexterity}">DX</option>
@@ -1636,7 +1636,7 @@
 								<option value="10">10</option>
 							</select>
 						</div>
-						<div class="sheet-cell sheet-col4">
+						<div class="sheet-cell sheet-col5">
 							<select name="attr_difficulty">
 								<option value="-1">E</option>
 								<option value="-2">A</option>
@@ -1644,13 +1644,13 @@
 								<option value="-4">VH</option>
 							</select>
 						</div>
-						<div class="sheet-cell sheet-col5">
+						<div class="sheet-cell sheet-col6">
 							<input type="number" name="attr_bonus" value="0" />
 						</div>
-						<div class="sheet-cell sheet-col6">
+						<div class="sheet-cell sheet-col7">
 							<input type="number" name="attr_points" value="0" />
 						</div>
-						<div class="sheet-cell sheet-col7">
+						<div class="sheet-cell sheet-col8">
 							<input type="text" name="attr_ref" />
 						</div>
 					</div> <!-- .sheet-row -->
@@ -2357,13 +2357,13 @@
 							<input type="number" name="attr_cost" value="0.00" step="0.01" />
 						</div>
 						<div class="sheet-cell sheet-col6">
-							<input type="number" name="attr_weight" value="0" step="0.001" />
+							<input type="number" name="attr_weight" value="0.000" step="0.001" />
 						</div>
 						<div class="sheet-cell sheet-col7" style="text-align: right">
 							<span name="attr_costtotal" value="0.00" />
 						</div>
 						<div class="sheet-cell sheet-col8" style="text-align: right"> 
-							<span name="attr_weighttotal" value="0" />
+							<span name="attr_weighttotal" value="0.000" />
 						</div>
 					</div> <!-- .sheet-row -->
 					<div class="sheet-row sheet-row-details">
@@ -2495,7 +2495,7 @@
 	<div class="sheet-tab7">
 
 	<div>
-	<h3>Latest Changes: Updated 12/18/2018</h3>
+	<h3>Latest Changes: Updated 01/08/2019</h3>
 		
 	<h3>Known Issues</h3>
 	<ul>
@@ -2508,19 +2508,45 @@
 		<li>NOTE: Techniques, as it is now on the character sheet, does not really work well - that section will most likely be completely rewritten (I plan on doing it when I get some time and my skills at HTML improve).</li>
 	</ul>
 
+		<h3>Note to authors</h3>
+	<ul>
+		<p>I need to mention that the original author(s) misspelled the words Miscellaneous (as Miscellwneous) and Encumbrance (as Encumberance) in both the CSS and HTML files. Rather than write extensive code to fix this, I just corrected the cosmetic portions only. Also note that the original author(s) use the word Fear in place of Fright although the proper word to use is Fright. As with the misspelled words, I changed no code other than the cosmetic side. This seemed simpler then spending hours writing code, transferring values from the attributes in question, and making sure it still functions. It also avoids having to explain it to the users in case they used those misspelled attributes in homemade macros.</p>
+	</ul>
+	
 	<h3>Revision History</h3>
-	
-	<p>Please note: I, Mike W, am not one of the original authors of this sheet. All I have done is to fix a number of small issues, changed some formatting, and implemeted some suggested changes. The basic functionality of the sheet has remained the same.</p>
+	<ul>
+		<p>Please note: I, Mike W, am not one of the original authors of this sheet. All I have done is to fix a number of small issues, changed some formatting, and implemeted some suggested changes. The basic functionality of the sheet has remained the same.</p>
                   
-	<p>To report an Issues or a Suggestion, please use the Roll20 forum under Character Sheets & Compendium. Mike W has created a thread named: [GURPS] - Sheet #1 - Thread 1 (that seems to be similar to the naming convention used by other sheets).</p>
-	
-	<p>https://app.roll20.net/forum/post/6616836/gurps-sheet-number-1-thread-1/?pageforid=6644122#post-6644122</p>
+		<p>To report any Issues or a Suggestion, please use the Roll20 forum under Character Sheets & Compendium. I have created a thread named: [GURPS] - Sheet #1 - Thread 1 (that seems to be similar to the naming convention used by other sheets).</p>
+		
+		<p>https://app.roll20.net/forum/post/6616836/gurps-sheet-number-1-thread-1/?pageforid=6644122#post-6644122</p>
             
-	<p>In your post, please specify if it is an Issue or Suggestion with as much detail information as possible. Screen shots help a lot! I am just learning to work with HTML and CSS so I may not be able to do everything requested. I make no promises on how fast I may be able to implement a Fix or a Suggestion - so please be patient. -Thanks, Mike W.</p>
+		<p>In your post, please specify if it is an Issue or Suggestion with as much detail information as possible. Screen shots help a lot! I am just learning to work with HTML and CSS so I may not be able to do everything requested. I make no promises on how fast I may be able to implement a Fix or a Suggestion - so please be patient. -Thanks, Mike W.</p>
 
-	<p>If there are others that are working on or wish to work on this sheet, lets coordinate using the Roll20 forum for now - perhaps later we can use GitHub.</p>
+		<p>If there are others that are working on or wish to work on this sheet, lets coordinate using the Roll20 forum for now - perhaps later we can use GitHub.</p>
+	</ul>
+		
+	<h4>Version: 1.4.9</h4>
 
-		<h4>Version: 1.4.8</h4>
+	<p>Pull Request: 01/08/2019</p>
+
+	<ul>
+		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610)</li>
+		<li>Fixed the placement and alignment of the SCN, Macro, PTS, and REF fields in Racial Traits – Cosmetic Only</li>
+		<li>Added a Background color for all Calculated fields – Cosmetic Only</li>
+		<li>Remove odd and even row background color – Cosmetic Only</li>
+		<li>Added bottom border to all Input fields – Cosmetic Only</li>
+		<li>Fixed alert indicating to use whole numbers for Speed which can have can have up to 2 decimal places - Cosmetic Only</li>
+		<li>Added a ‘Note to Authors’ section in the Updates page</li>
+		<li>Updated the Readme.md file</li>
+		<li>Fixed Skills Column alignment order – Code Fix only</li>
+		<li>Set the Default selection for the Modifier Prompt to Single Modifier Prompt</li>
+		<li>Fixed ToolTip placement for Thrust and Swing attributes – Cosmetic only</li>
+		<li>Increased width of character sheet to the maximum possible – Cosmetic Only</li>
+
+	</ul>
+	
+	<h4>Version: 1.4.8</h4>
 
 	<p>Pull Request: 12/18/2018</p>
 
@@ -2550,7 +2576,6 @@
 		<li>Fix base tooltip font size from 10 to 11 to make it more readable - Cosmetic Only</li>
 		<li>Added tooltips for POINT SUM on the General page  for Total, Spent, and Unspent - Cosmetic Only</li>
 		<li>Under POINT SUM in the General page, changed ‘Starting’ to ‘Total’ and changed ‘Total’ to ‘Spent‘ - Requested first by Valter (UserID:285013), then by many others  – Cosmetic Only</li>
-			
 	</ul>
 	
 	<h4>Version: 1.4.6</h4>
@@ -2565,6 +2590,7 @@
 		<li>Fixed tooltip format specifically the width and placement  – Cosmetic Only</li>					
 		<li>Fixed tooltip for Attribute Mod, Shots, and RoF to fit the format – Cosmetic Only</li>
 		<li>Fixed the tooltip for Combat Reflexes, changed +3 fear to +2 Fright – Cosmetic Only </li>
+
 	</ul>
 
 		<h4>Version: 1.4.5</h4>
@@ -2578,6 +2604,7 @@
 		<li>Fixed version 1.4.3 Added back in – Cosmetic Only </li>
 		<li>Fixed version 1.4.4 Renumbered from  1.4.3 – Cosmetic Only </li>
 		<li>Renamed ‘Skils’ tab to ‘Skills’ – Cosmetic Only </li>
+
 	</ul>
 	
 	<h4>Version: 1.4.4</h4>
@@ -2591,6 +2618,7 @@
 				<li>Option to select damage dice icon</li>
 				<li>Initial development of additional movement options</li>
 				<li>Added help text to combat reflexes. Mainly helpful for users who haven't noticed the options.</li>
+	
 	</ul>
 	
 	<h4>Version: 1.4.3</h4>
@@ -2608,6 +2636,7 @@
 		<li>Change the background color of the Skill field and Macro field to a Light Blue for Melee Attacks and Ranged Attacks – Cosmetic Only</li>
 		<li>Added some ‘Hover’ information for the Traits and Skills Tabs  – Cosmetic Only</li>
 		<li>Restore some deleted Revision History – Cosmetic Only</li>
+	
 	</ul>
 		
 	<h4>Version: 1.4.2</h4>
@@ -2615,10 +2644,11 @@
 	<p>Pull Request: 10/23/2018</p>
 	<ul>
 		<li>Changes made by MadCoder https://github.com/MadCoder253/roll20-character-sheets/issues</li>
-				<li>Changed damage roll icons to red explosion to easily identify the difference from the skill roll icon</li>
-				<li>Update thrust and swing damage when striking ST is updated</li>
-				<li>Ability to enter values for Unspent points</li>
-				<li>When combat reflexes is toggled, update the dodge and fear check modifiers on the general tab</li>
+		<li>Changed damage roll icons to red explosion to easily identify the difference from the skill roll icon</li>
+		<li>Update thrust and swing damage when striking ST is updated</li>
+		<li>Ability to enter values for Unspent points</li>
+		<li>When combat reflexes is toggled, update the dodge and fear check modifiers on the general tab</li>
+	
 	</ul>
 	
 	<h4>Version: 1.4.1</h4>
@@ -2628,6 +2658,7 @@
 	<ul>
 		<li>Changes, Fixes, and Adds made by Mike W (UserID: 1414610)</li>
 		<li>Fixed Encumbrance Table calculations to always allow for a Minimum Move of 1 and a Minimum Dodge of 1.</li>
+	
 	</ul>
  
 	<h4>Version: 1.4.0</h4>
@@ -2760,12 +2791,12 @@
 	<div class="sheet-tab0">
 		<div class="sheet-options">
 			<div class="sheet-box">
-				<input type="radio" name="attr_modifier" value="0" checked="true" />
+				<input type="radio" name="attr_modifier" value="0" />
 				<span class="sheet-popup">No Modifier Prompt</span>
 				<span class="sheet-tooltip">
 					Rolls will be made immediately with no prompt.
 				</span>
-				<br /><input type="radio" name="attr_modifier" value="[[?{Modifier|0}]]" />
+				<br /><input type="radio" name="attr_modifier" value="[[?{Modifier|0}]]" checked="true" />
 				<span class="sheet-popup">Single Modifier Prompt</span>
 				<span class="sheet-tooltip">
 					Ask for a bonus or penalty to be added to dice rolls.
@@ -2865,7 +2896,7 @@
 
 	var noop = function () {}; // do nothing.
 
-	var version = "1.4.8";
+	var version = "1.4.9";
 
 	var modCascade = true;
 	var modCascadeAll = true;

--- a/GURPS/sheet.json
+++ b/GURPS/sheet.json
@@ -1,8 +1,8 @@
 {
 	"html": "gurps.html",
 	"css": "gurps.css",
-	"authors": "Devindra Payment (@Ardnived), Joseph Mason (@sdJasper), Ken Foubert (@MadCoder), Mike Wilson",
-	"roll20userid": "185617,106713,945642,1414610",
+	"authors": "Devindra Payment (@Ardnived), Joseph Mason (@sdJasper), Ken Foubert (@MadCoder), Mike Wilson, Sᵃᵛᵃᵍᵉ ǤM",
+	"roll20userid": "185617,106713,945642,1414610, 313347",
 	"preview": "gurps.png",
 	"instructions": "If you are a mentor, you can use this script to automatically determine success and failure. https://github.com/MadCoder253/roll20-character-sheets/blob/master/GURPS/script.js"
 }


### PR DESCRIPTION
•	Fixed the placement and alignment of the SCN, Macro, PTS, and REF fields in Racial Traits – Cosmetic Only
•	Added a Background color for all Calculated fields – Cosmetic Only
•	Remove odd and even row background color – Cosmetic Only
•	Added bottom border to all Input fields – Cosmetic Only
•	Fixed alert indicating to use whole numbers for Speed which can have can have up to 2 decimal places - Cosmetic Only
•	Added a ‘Note to Authors’ section in the Updates page
•	Updated the Readme.md file
•	Fixed Skills Column alignment order – Code Fix only
•	Set the Default selection for the Modifier Prompt to Single Modifier Prompt
•	Fixed ToolTip placement for Thrust and Swing attributes – Cosmetic only
•	Increased width of character sheet to the maximum possible – Cosmetic Only
•	Adjusted the width of Skills, Techniques, and Inventory so that when sorting you can see the full name – Cosmetic Only

## Changes / Comments

*Provide a few comments about what you have changed.*




## Roll20 Requests

*Include the name of the sheet you made changes to in the title.*

- If changes fix a bug or resolves a feature request, be sure to link to that issue. 
- For pull request that change multiple sheets please confirm these changes are intentional for all sheets. This will help us catch unintended submissions.
- When updating existing sheets if you are changing attribute names please note what steps you have taken, if any, to assist players in keeping their data.