### PR TITLE
[Mutant Year Zero] added missing attr-name

### DIFF
--- a/Mutant Year Zero Alternative/MutantYearZeroAlternative.html
+++ b/Mutant Year Zero Alternative/MutantYearZeroAlternative.html
@@ -976,7 +976,7 @@
                         <tr class="sheet-row-light">
                             <td class="sheet-text-label" colspan="4">
                                 Description: 
-                                <textarea class="sheet-text-ark-description">
+                                <textarea class="sheet-text-ark-description" name="attr_general-desc">
 								</textarea>
                             </td>
                         </tr>


### PR DESCRIPTION
## Changes
* added missing attr-name to textarea, so it saves info now.

## Comments
* bug noticed by [Sherm](https://app.roll20.net/users/3561), [forum post](https://app.roll20.net/forum/post/7095956/mutant-year-zero-ark-sheet)