### PR TITLE
D&D3.5 Fix Roll Buttons

### DIFF
--- a/D&D_3-5/charsheet_3-5.html
+++ b/D&D_3-5/charsheet_3-5.html
@@ -2,9 +2,9 @@
 <!-- by Diana P. -->
 <!-- based on Pathfinder sheets from Barry R., Sam, Brian, and Justin N. -->
 <!-- with lots of help from Toby-->
-<!-- Version 2.7.7 9/09/16 (First-pass at translation support)-->
+<!-- Version 2.7.8 1/7/19 (Fix roll buttons)-->
 
-<input type="hidden" name="attr_currentsheetversion" title="currentsheetversion" value="7.7"/>
+<input type="hidden" name="attr_currentsheetversion" title="currentsheetversion" value="7.8"/>
 <input type="radio" class="sheet-switch-pc-show sheet-switch" title="npc-show" name="attr_npc-show" value="1" checked /><span style="text-align: left;" data-i18n="pc" >PC </span><span> &nbsp; &nbsp; &nbsp; &nbsp;</span>
 <input type="radio" class="sheet-switch-npc-show sheet-switch" title="npc-show" name="attr_npc-show" value="2" /><span style="text-align: left;" data-i18n="npc">NPC</span>
 
@@ -117,7 +117,7 @@
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_str-base" value="10" title="str-base"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_str-misc" value="0" title="str-misc"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_str-temp" value="0" title="str-temp"></span>
-								<span class="sheet-table-data-center"><button type="roll" name="attr_strcheck" title="strcheck" value="@{str-macro}"></button></span>
+								<span class="sheet-table-data-center"><button type="roll" name="roll_strcheck" title="strcheck" value="@{str-macro}"></button></span>
 							</div>
 							<div class="sheet-pc-abilitymacros" colspan="7">
 								<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 140px; height: 20px;" name="attr_strnote" title="strnote" placeholder="Note" data-i18n-placeholder="note" ></textarea></span>
@@ -130,7 +130,7 @@
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_dex-base" title="dex-base" value="10"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_dex-misc" title="dex-misc" value="0"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_dex-temp" title="dex-temp" value="0"></span>
-								<span class="sheet-table-data-center"><button type="roll" name="attr_dexcheck" title="dexcheck" value="@{dex-macro}"></button></span>
+								<span class="sheet-table-data-center"><button type="roll" name="roll_dexcheck" title="dexcheck" value="@{dex-macro}"></button></span>
 							</div>
 							<div class="sheet-pc-abilitymacros">
 								<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 140px; height: 20px;" name="attr_dexnote" title="dexnote" placeholder="Note" data-i18n-placeholder="note" ></textarea></span>
@@ -143,7 +143,7 @@
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_con-base" title="con-base" value="10"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_con-misc" title="con-misc" value="0"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_con-temp" title="con-temp" value="0"></span>
-								<span class="sheet-table-data-center"><button type="roll" name="attr_concheck" title="concheck" value="@{con-macro}"></button></span>
+								<span class="sheet-table-data-center"><button type="roll" name="roll_concheck" title="concheck" value="@{con-macro}"></button></span>
 							</div>
 							<div class="sheet-pc-abilitymacros">
 								<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 140px; height: 20px;" name="attr_connote" title="connote" placeholder="Note" data-i18n-placeholder="note" ></textarea></span>
@@ -156,7 +156,7 @@
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_int-base" title="int-base" value="10"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_int-misc" title="int-misc" value="0"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_int-temp" title="int-temp" value="0"></span>
-								<span class="sheet-table-data-center"><button type="roll" name="attr_intcheck" title="intcheck" value="@{int-macro}"></button></span>
+								<span class="sheet-table-data-center"><button type="roll" name="roll_intcheck" title="intcheck" value="@{int-macro}"></button></span>
 							</div>
 							<div class="sheet-pc-abilitymacros">
 								<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 140px; height: 20px;" name="attr_intnote" title="intnote" placeholder="Note" data-i18n-placeholder="note" ></textarea></span>
@@ -169,7 +169,7 @@
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_wis-base" title="wis-base" value="10"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_wis-misc" title="wis-misc" value="0"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_wis-temp" title="wis-temp" value="0"></span>
-								<span class="sheet-table-data-center"><button type="roll" name="attr_wischeck" title="wischeck" value="@{wis-macro}"></button></span>
+								<span class="sheet-table-data-center"><button type="roll" name="roll_wischeck" title="wischeck" value="@{wis-macro}"></button></span>
 							</div>
 							<div class="sheet-pc-abilitymacros">
 								<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 140px; height: 20px;" name="attr_wisnote" title="wisnote" placeholder="Note" data-i18n-placeholder="note" ></textarea></span>
@@ -182,7 +182,7 @@
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_cha-base" title="cha-base" value="10"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_cha-misc" title="cha-misc" value="0"></span>
 								<span class="sheet-table-data-center"><input type="text" style="width: 45px;" name="attr_cha-temp" title="cha-temp" value="0"></span>
-								<span class="sheet-table-data-center"><button type="roll" name="attr_chacheck" title="chacheck" value="@{cha-macro}"></button></span>
+								<span class="sheet-table-data-center"><button type="roll" name="roll_chacheck" title="chacheck" value="@{cha-macro}"></button></span>
 							</div>
 							<div class="sheet-pc-abilitymacros">
 								<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 140px; height: 20px;" name="attr_chanote" title="chanote" placeholder="Note" data-i18n-placeholder="note" ></textarea></span>
@@ -213,7 +213,7 @@
 														<td><input class="sheet-inputbox" type="text" name="attr_initdexmod" title="initdexmod" value="floor(@{dex}/2-5)" disabled="true" style="height: 24px; width: 30px;"> +<br><div style="font-size: 0.5em;" data-i18n="dexterity-modifier">Dex Mod</div></td>
 														<td><input class="sheet-inputbox" type="text" name="attr_initmiscmod" title="initmiscmod" value="0" style="height: 24px; width: 30px;"><br><div style="font-size: 0.5em;" data-i18n="miscellaneous-modifier-a">Misc Mod</div></td>
 														<td><textarea rows="1" cols="40" style="width: 40px; height: 20px;" title="initmacro (modify to modify initiative roll macro)" name="attr_initmacro">&{template:DnD35Initiative} {{name=@{selected|character_name} }} {{check=Initiative:}} {{checkroll= [[ 1d20 + [[ @{selected|init} ]] + ( [[ (@{selected|init}) ]] /100) &{tracker} ]] }}</textarea></td>
-														<td><button class="tokenaction" type="roll" name="attr_initiative" title="initiative" value="@{initmacro}"></button> &nbsp; &nbsp;<br><div style="font-size: 0.5em;"> &nbsp; </div></td>
+														<td><button class="tokenaction" type="roll" name="roll_initiative" title="initiative" value="@{initmacro}"></button> &nbsp; &nbsp;<br><div style="font-size: 0.5em;"> &nbsp; </div></td>
 													</tr>
 												</table>
 											</td>
@@ -324,7 +324,7 @@
 													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_fortitudemagicmod" title="fortitudemagicmod" value="0"></span>
 													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_fortitudemiscmod" title="fortitudemiscmod" value="0"></span>
 													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_fortitudetempmod" title="fortitudetempmod" value="0"></span>
-													<span class="sheet-table-data-center"><button type="roll" style="width:20px;" name="attr_fortitudecheck" title="fortitudecheck" value="@{fortitudemacro}"></button></span>
+													<span class="sheet-table-data-center"><button type="roll" style="width:20px;" name="roll_fortitudecheck" title="fortitudecheck" value="@{fortitudemacro}"></button></span>
 												</div>
 												<div class="sheet-pc-savemacros">
 													<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 175px; height: 20px;" name="attr_fortitudenote" title="fortitudenote" placeholder="Note" data-i18n-placeholder="note" ></textarea></span>
@@ -339,7 +339,7 @@
 													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_reflexmagicmod" title="reflexmagicmod" value="0"></span>
 													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_reflexmiscmod" title="reflexmiscmod" value="0"></span>
 													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_reflextempmod" title="reflextempmod" value="0"></span>
-													<span class="sheet-table-data-center"><button type="roll" style="width:20px;" name="attr_reflexcheck" title="reflexcheck" value="@{reflexmacro}"></button></span>
+													<span class="sheet-table-data-center"><button type="roll" style="width:20px;" name="roll_reflexcheck" title="reflexcheck" value="@{reflexmacro}"></button></span>
 												</div>											
 												<div class="sheet-pc-savemacros">
 													<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 175px; height: 20px;" name="attr_reflexnote" title="reflexnote" placeholder="Note" data-i18n-placeholder="note"></textarea></span>
@@ -354,7 +354,7 @@
 													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_willmagicmod" title="willmagicmod" value="0"></span>
 													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_willmiscmod" title="willmiscmod" value="0"></span>
 													<span class="sheet-table-data-center">+<input type="text" style="width: 35px;" name="attr_willtempmod" title="willtempmod" value="0"></span>
-													<span class="sheet-table-data-center"><button type="roll" style="width:20px;" name="attr_willcheck" title="willcheck" value="@{willmacro}"></button></span>
+													<span class="sheet-table-data-center"><button type="roll" style="width:20px;" name="roll_willcheck" title="willcheck" value="@{willmacro}"></button></span>
 												</div>
 												<div class="sheet-pc-savemacros">
 													<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 175px; height: 20px;" name="attr_willnote" title="willnote" placeholder="Note" data-i18n-placeholder="note"></textarea></span>
@@ -394,7 +394,7 @@
 													<span class="sheet-table-data-center">+<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_grapplestrmod" title="grapplestrmod" value="floor(@{str}/2-5) " disabled="true" style="height: 24px; width: 50px;"></span>
 													<span class="sheet-table-data-center">+<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_specialattacksizemod" title="specialattacksizemod" value="(floor((@{size} + 50) / 58) + floor((@{size} + 50) / 54) + floor((@{size} + 50) / 52) + floor((@{size} + 50) / 51) + floor((@{size} + 50) / 50) + floor((@{size} + 50) / 49) + floor((@{size} + 50) / 47) + floor((@{size} + 50) / 43) -4) * (-4) " disabled="true" style="height: 24px; width: 50px;"></span>
 													<span class="sheet-table-data-center">+<input class="sheet-inputbox" type="text" style="width: 45px;" name="attr_grapplemiscmod" title="grapplemiscmod" value="0"></span>
-													<span class="sheet-table-data-center"><button type="roll" name="attr_Grapplecheck" title="Grapplecheck" value="@{grapplemacro}" ></button></span>
+													<span class="sheet-table-data-center"><button type="roll" name="roll_Grapplecheck" title="Grapplecheck" value="@{grapplemacro}" ></button></span>
 												</div>
 												<div class="sheet-table-row">
 													<span class="sheet-table-header2"> &nbsp; </span>
@@ -426,7 +426,7 @@
 													<span class="sheet-table-data-center">+<input class="sheet-inputbox" type="text" style="width: 43px;" name="attr_sizemodmab" title="sizemodmab" value="@{size}" disabled="true"></span>
 													<span class="sheet-table-data-center">+<input class="sheet-inputbox" type="text" style="width: 43px;" name="attr_mabmiscmod" title="mabmiscmod" value="0"></span>
 													<span class="sheet-table-data-center">+<input class="sheet-inputbox" type="text" style="width: 43px;" name="attr_mabtempmod" title="mabtempmod" value="0"></span>
-													<span class="sheet-table-data-center"><button type="roll" name="attr_meleeattackcheck" title="meleeattackcheck" value="@{meleeattackmacro}" ></button></span>
+													<span class="sheet-table-data-center"><button type="roll" name="roll_meleeattackcheck" title="meleeattackcheck" value="@{meleeattackmacro}" ></button></span>
 												</div>
 												<div class="sheet-pc-baseattackmacros">
 													<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 175px; height: 20px;" name="attr_meleeattacknote" title="meleeattacknote" placeholder="Note" data-i18n-placeholder="note"></textarea></span>
@@ -440,7 +440,7 @@
 													<span class="sheet-table-data-center">+<input class="sheet-inputbox" type="text" style="width: 43px;" name="attr_sizemodrab" title="sizemodrab" value="@{size}" disabled="true"></span>
 													<span class="sheet-table-data-center">+<input class="sheet-inputbox" type="text" style="width: 43px;" name="attr_rabmiscmod" title="rabmiscmod" value="0"></span>
 													<span class="sheet-table-data-center">+<input class="sheet-inputbox" type="text" style="width: 43px;" name="attr_rabtempmod" title="rabtempmod" value="0"></span>
-													<span class="sheet-table-data-center"><button type="roll" name="attr_rangedattackcheck" title="rangedattackcheck" value="@{rangedattackmacro}"></button></span>
+													<span class="sheet-table-data-center"><button type="roll" name="roll_rangedattackcheck" title="rangedattackcheck" value="@{rangedattackmacro}"></button></span>
 												</div>
 												<div class="sheet-pc-baseattackmacros">
 													<span class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 175px; height: 20px;" name="attr_rangedattacknote" title="rangedattacknote" placeholder="Note" data-i18n-placeholder="note"></textarea></span>
@@ -547,13 +547,13 @@
 											<tr>
 												<td colspan="6"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="attack-calculation-a">Attack Calc</span> / <span data-i18n="macro">Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon1attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon1attackcalc">1d20cs>@{weapon1critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] + @{weapon1stat}[Ability] +@{size}[size] +@{weapon1enh}[Weapon Enh] +@{weapon1focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon1attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon1attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon1name} }} {{attack1=hitting AC [[ @{weapon1attackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weapon1attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=for [[ @{weapon1damage} ]]dmg}} {{critdmg1=+ [[ @{weapon1crit} ]] crit dmg}} {{fullattackflag= [[ 0d1 ]] }} </textarea>
-												<button type="roll" name="attr_weapon1attack" text="attack" title="weapon1attack" value="@{weapon1attackmacro}" style="width: 20px;" > </button></td>
+												<button type="roll" name="roll_weapon1attack" text="attack" title="weapon1attack" value="@{weapon1attackmacro}" style="width: 20px;" > </button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="full-attack-macro" >Full Attack Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon1fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon1fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon1name} }} {{attack1=A1: [[ @{weapon1attackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weapon1attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=D1: [[ @{weapon1damage} ]] }} {{critdmg1=+ [[ @{weapon1crit} ]] }} {{fullattackflag= [[ ?{Full Attack?|No, 0d1|Yes, d1} ]] }} {{attack2=A2: [[ @{weapon1attackcalc}-5 ]] }} {{critconfirm2=Crit!: [[ @{weapon1attackcalc}-5 ]] }} {{damage2=D2: [[ @{weapon1damage} ]] }} {{critdmg2=+ [[ @{weapon1crit} ]] }} {{attack3=A3: [[ @{weapon1attackcalc}-10 ]] }} {{critconfirm3=Crit!: [[ @{weapon1attackcalc}-10 ]] }} {{damage3=D3: [[ @{weapon1damage} ]] }} {{critdmg3=+ [[ @{weapon1crit} ]] }} {{attack4=A4: [[ @{weapon1attackcalc}-15 ]] }} {{critconfirm4=Crit!: [[ @{weapon1attackcalc}-15 ]] }} {{damage4=D4: [[ @{weapon1damage} ]] }} {{critdmg4=+ [[ @{weapon1crit} ]] }} </textarea>
-													<button type="roll"name="attr_weapon1fullattack" text="Full Attack" title="weapon1fullattack" value="@{weapon1fullattackmacro}" style="width: 20px;" > </button></td>
+													<button type="roll" name="roll_weapon1fullattack" text="Full Attack" title="weapon1fullattack" value="@{weapon1fullattackmacro}" style="width: 20px;" > </button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="damage-calculation-a">Damage Calc</span> / <span data-i18n="critical-calculation-a">Crit Calc</span> / <span data-i18n="damage-macro">Damage Macro</span>:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon1damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon1damage (Edit this to adjust the damage calculation.)">1d6 + @{weapon1damagestat}[Weapon Dmg Ability] +@{weapon1enh}[Weapon Enh] +@{weapon1specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon1crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon1crit (Edit this to adjust the critical calculation.)"> [[ (@{weapon1critmult}-1) ]]d6 + [[ (@{weapon1critmult}-1) ]] *( @{weapon1damagestat}[Weapon Dmg Ability] +@{weapon1enh}[Weapon Enh] +@{weapon1specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon1damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon1damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon1name} }} {{damage1=does [[ @{weapon1damage} ]]damage}} {{fullattackflag= [[ 0d1 ]] }}</textarea>
-												<button type="roll" name="attr_weapon1damageroll" title="weapon1damageroll" style="width: 20px;" value="@{weapon1damagemacro}"></button></td>
+												<button type="roll" name="roll_weapon1damageroll" title="weapon1damageroll" style="width: 20px;" value="@{weapon1damagemacro}"></button></td>
 											</tr>
 										</table>
 									</div>
@@ -599,13 +599,13 @@
 											<tr>
 												<td colspan="6"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="attack-calculation-a">Attack Calc</span> / <span data-i18n="macro">Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon2attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon2attackcalc">1d20cs>@{weapon2critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] + @{weapon2stat}[Ability] +@{size}[size] +@{weapon2enh}[Weapon Enh] +@{weapon2focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon2attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon2attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon2name} }} {{attack1=hitting AC [[ @{weapon2attackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weapon2attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=for [[ @{weapon2damage} ]]dmg}} {{critdmg1=+ [[ @{weapon2crit} ]] crit dmg}} {{fullattackflag= [[ 0d1 ]] }} </textarea>
-												<button type="roll" name="attr_weapon2attack" text="attack" title="weapon2attack" value="@{weapon2attackmacro}" style="width: 20px;" ></button></td>
+												<button type="roll" name="roll_weapon2attack" text="attack" title="weapon2attack" value="@{weapon2attackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="full-attack-macro" >Full Attack Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon2fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon2fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon2name} }} {{attack1=A1: [[ @{weapon2attackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weapon2attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=D1: [[ @{weapon2damage} ]] }} {{critdmg1=+ [[ @{weapon2crit} ]] }} {{fullattackflag= [[ ?{Full Attack?|No, 0d1|Yes, d1} ]] }} {{attack2=A2: [[ @{weapon2attackcalc}-5 ]] }} {{critconfirm2=Crit!: [[ @{weapon2attackcalc}-5 ]] }} {{damage2=D2: [[ @{weapon2damage} ]] }} {{critdmg2=+ [[ @{weapon2crit} ]] }} {{attack3=A3: [[ @{weapon2attackcalc}-10 ]] }} {{critconfirm3=Crit!: [[ @{weapon2attackcalc}-10 ]] }} {{damage3=D3: [[ @{weapon2damage} ]] }} {{critdmg3=+ [[ @{weapon2crit} ]] }} {{attack4=A4: [[ @{weapon2attackcalc}-15 ]] }} {{critconfirm4=Crit!: [[ @{weapon2attackcalc}-15 ]] }} {{damage4=D4: [[ @{weapon2damage} ]] }} {{critdmg4=+ [[ @{weapon2crit} ]] }} </textarea>
-													<button type="roll"name="attr_weapon2fullattack" text="Full Attack" title="weapon2fullattack" value="@{weapon2fullattackmacro}" style="width: 20px;" ></button></td>
+													<button type="roll" name="roll_weapon2fullattack" text="Full Attack" title="weapon2fullattack" value="@{weapon2fullattackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="damage-calculation-a">Damage Calc</span> / <span data-i18n="critical-calculation-a">Crit Calc</span> / <span data-i18n="damage-macro">Damage Macro</span>:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon2damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon2damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 + @{weapon2damagestat}[Weapon Dmg Ability] +@{weapon2enh}[Weapon Enh] +@{weapon2specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon2crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon2crit (Edit this to adjust the critical calculation.)"> [[ (@{weapon2critmult}-1) ]]d6 + [[ (@{weapon2critmult}-1) ]] *( @{weapon2damagestat}[Weapon Dmg Ability] +@{weapon2enh}[Weapon Enh] +@{weapon2specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon2damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon2damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon2name} }} {{damage1=does [[ @{weapon2damage} ]]damage}} {{fullattackflag= [[ 0d1 ]] }}</textarea>
-												<button type="roll" name="attr_weapon2damageroll" title="weapon2damageroll" style="width: 20px;" value="@{weapon2damagemacro}"></button></td>
+												<button type="roll" name="roll_weapon2damageroll" title="weapon2damageroll" style="width: 20px;" value="@{weapon2damagemacro}"></button></td>
 											</tr>
 										</table>
 									</div>
@@ -651,13 +651,13 @@
 											<tr>
 												<td colspan="6"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="attack-calculation-a">Attack Calc</span> / <span data-i18n="macro">Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon3attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon3attackcalc">1d20cs>@{weapon3critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] + @{weapon3stat}[Ability] +@{size}[size] +@{weapon3enh}[Weapon Enh] +@{weapon3focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon3attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon3attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon3name} }} {{attack1=hitting AC [[ @{weapon3attackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weapon3attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=for [[ @{weapon3damage} ]]dmg}} {{critdmg1=+ [[ @{weapon3crit} ]] crit dmg}} {{fullattackflag= [[ 0d1 ]] }} </textarea>
-												<button type="roll" name="attr_weapon3attack" text="attack" title="weapon3attack" value="@{weapon3attackmacro}" style="width: 20px;" ></button></td>
+												<button type="roll" name="roll_weapon3attack" text="attack" title="weapon3attack" value="@{weapon3attackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="full-attack-macro" >Full Attack Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon3fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon3fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon3name} }} {{attack1=A1: [[ @{weapon3attackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weapon3attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=D1: [[ @{weapon3damage} ]] }} {{critdmg1=+ [[ @{weapon3crit} ]] }} {{fullattackflag= [[ ?{Full Attack?|No, 0d1|Yes, d1} ]] }} {{attack2=A2: [[ @{weapon3attackcalc}-5 ]] }} {{critconfirm2=Crit!: [[ @{weapon3attackcalc}-5 ]] }} {{damage2=D2: [[ @{weapon3damage} ]] }} {{critdmg2=+ [[ @{weapon3crit} ]] }} {{attack3=A3: [[ @{weapon3attackcalc}-10 ]] }} {{critconfirm3=Crit!: [[ @{weapon3attackcalc}-10 ]] }} {{damage3=D3: [[ @{weapon3damage} ]] }} {{critdmg3=+ [[ @{weapon3crit} ]] }} {{attack4=A4: [[ @{weapon3attackcalc}-15 ]] }} {{critconfirm4=Crit!: [[ @{weapon3attackcalc}-15 ]] }} {{damage4=D4: [[ @{weapon3damage} ]] }} {{critdmg4=+ [[ @{weapon3crit} ]] }} </textarea>
-													<button type="roll"name="attr_weapon3fullattack" text="Full Attack" title="weapon3fullattack" value="@{weapon3fullattackmacro}" style="width: 20px;" ></button></td>
+													<button type="roll" name="roll_weapon3fullattack" text="Full Attack" title="weapon3fullattack" value="@{weapon3fullattackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="damage-calculation-a">Damage Calc</span> / <span data-i18n="critical-calculation-a">Crit Calc</span> / <span data-i18n="damage-macro">Damage Macro</span>:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon3damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon3damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 + @{weapon3damagestat}[Weapon Dmg Ability] +@{weapon3enh}[Weapon Enh] +@{weapon3specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon3crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon3crit (Edit this to adjust the critical calculation.)"> [[ (@{weapon3critmult}-1) ]]d6 + [[ (@{weapon3critmult}-1) ]] *( @{weapon3damagestat}[Weapon Dmg Ability] +@{weapon3enh}[Weapon Enh] +@{weapon3specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon3damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon3damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon3name} }} {{damage1=does [[ @{weapon3damage} ]]damage}} {{fullattackflag= [[ 0d1 ]] }}</textarea>
-												<button type="roll" name="attr_weapon3damageroll" title="weapon3damageroll" style="width: 20px;" value="@{weapon3damagemacro}"></button></td>
+												<button type="roll" name="roll_weapon3damageroll" title="weapon3damageroll" style="width: 20px;" value="@{weapon3damagemacro}"></button></td>
 											</tr>
 										</table>
 									</div>
@@ -703,13 +703,13 @@
 											<tr>
 												<td colspan="6"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="attack-calculation-a">Attack Calc</span> / <span data-i18n="macro">Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon4attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon4attackcalc">1d20cs>@{weapon4critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] + @{weapon4stat}[Ability] +@{size}[size] +@{weapon4enh}[Weapon Enh] +@{weapon4focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon4attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon4attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon4name} }} {{attack1=hitting AC [[ @{weapon4attackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weapon4attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=for [[ @{weapon4damage} ]]dmg}} {{critdmg1=+ [[ @{weapon4crit} ]] crit dmg}} {{fullattackflag= [[ 0d1 ]] }} </textarea>
-												<button type="roll" name="attr_weapon4attack" text="attack" title="weapon4attack" value="@{weapon4attackmacro}" style="width: 20px;" ></button></td>
+												<button type="roll" name="roll_weapon4attack" text="attack" title="weapon4attack" value="@{weapon4attackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="full-attack-macro" >Full Attack Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon4fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon4fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon4name} }} {{attack1=A1: [[ @{weapon4attackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weapon4attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=D1: [[ @{weapon4damage} ]] }} {{critdmg1=+ [[ @{weapon4crit} ]] }} {{fullattackflag= [[ ?{Full Attack?|No, 0d1|Yes, d1} ]] }} {{attack2=A2: [[ @{weapon4attackcalc}-5 ]] }} {{critconfirm2=Crit!: [[ @{weapon4attackcalc}-5 ]] }} {{damage2=D2: [[ @{weapon4damage} ]] }} {{critdmg2=+ [[ @{weapon4crit} ]] }} {{attack3=A3: [[ @{weapon4attackcalc}-10 ]] }} {{critconfirm3=Crit!: [[ @{weapon4attackcalc}-10 ]] }} {{damage3=D3: [[ @{weapon4damage} ]] }} {{critdmg3=+ [[ @{weapon4crit} ]] }} {{attack4=A4: [[ @{weapon4attackcalc}-15 ]] }} {{critconfirm4=Crit!: [[ @{weapon4attackcalc}-15 ]] }} {{damage4=D4: [[ @{weapon4damage} ]] }} {{critdmg4=+ [[ @{weapon4crit} ]] }} </textarea>
-													<button type="roll"name="attr_weapon4fullattack" text="Full Attack" title="weapon4fullattack" value="@{weapon4fullattackmacro}" style="width: 20px;" ></button></td>
+													<button type="roll" name="roll_weapon4fullattack" text="Full Attack" title="weapon4fullattack" value="@{weapon4fullattackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="damage-calculation-a">Damage Calc</span> / <span data-i18n="critical-calculation-a">Crit Calc</span> / <span data-i18n="damage-macro">Damage Macro</span>:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon4damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon4damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 + @{weapon4damagestat}[Weapon Dmg Ability] +@{weapon4enh}[Weapon Enh] +@{weapon4specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon4crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon4crit (Edit this to adjust the critical calculation.)"> [[ (@{weapon4critmult}-1) ]]d6 + [[ (@{weapon4critmult}-1) ]] *( @{weapon4damagestat}[Weapon Dmg Ability] +@{weapon4enh}[Weapon Enh] +@{weapon4specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon4damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon4damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon4name} }} {{damage1=does [[ @{weapon4damage} ]]damage}} {{fullattackflag= [[ 0d1 ]] }}</textarea>
-												<button type="roll" name="attr_weapon4damageroll" title="weapon4damageroll" style="width: 20px;" value="@{weapon4damagemacro}"></button></td>
+												<button type="roll" name="roll_weapon4damageroll" title="weapon4damageroll" style="width: 20px;" value="@{weapon4damagemacro}"></button></td>
 											</tr>
 										</table>
 									</div>
@@ -755,13 +755,13 @@
 											<tr>
 												<td colspan="6"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="attack-calculation-a">Attack Calc</span> / <span data-i18n="macro">Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon5attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon5attackcalc">1d20cs>@{weapon5critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] + @{weapon5stat}[Ability] +@{size}[size] +@{weapon5enh}[Weapon Enh] +@{weapon5focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon5attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon5attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon5name} }} {{attack1=hitting AC [[ @{weapon5attackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weapon5attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=for [[ @{weapon5damage} ]]dmg}} {{critdmg1=+ [[ @{weapon5crit} ]] crit dmg}} {{fullattackflag= [[ 0d1 ]] }} </textarea>
-												<button type="roll" name="attr_weapon5attack" text="attack" title="weapon5attack" value="@{weapon5attackmacro}" style="width: 20px;" ></button></td>
+												<button type="roll" name="roll_weapon5attack" text="attack" title="weapon5attack" value="@{weapon5attackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="full-attack-macro" >Full Attack Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon5fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon5fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon5name} }} {{attack1=A1: [[ @{weapon5attackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weapon5attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=D1: [[ @{weapon5damage} ]] }} {{critdmg1=+ [[ @{weapon5crit} ]] }} {{fullattackflag= [[ ?{Full Attack?|No, 0d1|Yes, d1} ]] }} {{attack2=A2: [[ @{weapon5attackcalc}-5 ]] }} {{critconfirm2=Crit!: [[ @{weapon5attackcalc}-5 ]] }} {{damage2=D2: [[ @{weapon5damage} ]] }} {{critdmg2=+ [[ @{weapon5crit} ]] }} {{attack3=A3: [[ @{weapon5attackcalc}-10 ]] }} {{critconfirm3=Crit!: [[ @{weapon5attackcalc}-10 ]] }} {{damage3=D3: [[ @{weapon5damage} ]] }} {{critdmg3=+ [[ @{weapon5crit} ]] }} {{attack4=A4: [[ @{weapon5attackcalc}-15 ]] }} {{critconfirm4=Crit!: [[ @{weapon5attackcalc}-15 ]] }} {{damage4=D4: [[ @{weapon5damage} ]] }} {{critdmg4=+ [[ @{weapon5crit} ]] }} </textarea>
-													<button type="roll"name="attr_weapon5fullattack" text="Full Attack" title="weapon5fullattack" value="@{weapon5fullattackmacro}" style="width: 20px;" ></button></td>
+													<button type="roll" name="roll_weapon5fullattack" text="Full Attack" title="weapon5fullattack" value="@{weapon5fullattackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="damage-calculation-a">Damage Calc</span> / <span data-i18n="critical-calculation-a">Crit Calc</span> / <span data-i18n="damage-macro">Damage Macro</span>:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon5damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon5damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 + @{weapon5damagestat}[Weapon Dmg Ability] +@{weapon5enh}[Weapon Enh] +@{weapon5specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon5crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon5crit (Edit this to adjust the critical calculation.)"> [[ (@{weapon5critmult}-1) ]]d6 + [[ (@{weapon5critmult}-1) ]] *( @{weapon5damagestat}[Weapon Dmg Ability] +@{weapon5enh}[Weapon Enh] +@{weapon5specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon5damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon5damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon5name} }} {{damage1=does [[ @{weapon5damage} ]]damage}} {{fullattackflag= [[ 0d1 ]] }}</textarea>
-												<button type="roll" name="attr_weapon5damageroll" title="weapon5damageroll" style="width: 20px;" value="@{weapon5damagemacro}"></button></td>
+												<button type="roll" name="roll_weapon5damageroll" title="weapon5damageroll" style="width: 20px;" value="@{weapon5damagemacro}"></button></td>
 											</tr>
 										</table>
 									</div>
@@ -807,13 +807,13 @@
 											<tr>
 												<td colspan="6"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="attack-calculation-a">Attack Calc</span> / <span data-i18n="macro">Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon6attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon6attackcalc">1d20cs>@{weapon6critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] + @{weapon6stat}[Ability] +@{size}[size] +@{weapon6enh}[Weapon Enh] +@{weapon6focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon6attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon6attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon6name} }} {{attack1=hitting AC [[ @{weapon6attackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weapon6attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=for [[ @{weapon6damage} ]]dmg}} {{critdmg1=+ [[ @{weapon6crit} ]] crit dmg}} {{fullattackflag= [[ 0d1 ]] }} </textarea>
-												<button type="roll" name="attr_weapon6attack" text="attack" title="weapon6attack" value="@{weapon6attackmacro}" style="width: 20px;" ></button></td>
+												<button type="roll" name="roll_weapon6attack" text="attack" title="weapon6attack" value="@{weapon6attackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="full-attack-macro" >Full Attack Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon6fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon6fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon6name} }} {{attack1=A1: [[ @{weapon6attackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weapon6attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=D1: [[ @{weapon6damage} ]] }} {{critdmg1=+ [[ @{weapon6crit} ]] }} {{fullattackflag= [[ ?{Full Attack?|No, 0d1|Yes, d1} ]] }} {{attack2=A2: [[ @{weapon6attackcalc}-5 ]] }} {{critconfirm2=Crit!: [[ @{weapon6attackcalc}-5 ]] }} {{damage2=D2: [[ @{weapon6damage} ]] }} {{critdmg2=+ [[ @{weapon6crit} ]] }} {{attack3=A3: [[ @{weapon6attackcalc}-10 ]] }} {{critconfirm3=Crit!: [[ @{weapon6attackcalc}-10 ]] }} {{damage3=D3: [[ @{weapon6damage} ]] }} {{critdmg3=+ [[ @{weapon6crit} ]] }} {{attack4=A4: [[ @{weapon6attackcalc}-15 ]] }} {{critconfirm4=Crit!: [[ @{weapon6attackcalc}-15 ]] }} {{damage4=D4: [[ @{weapon6damage} ]] }} {{critdmg4=+ [[ @{weapon6crit} ]] }} </textarea>
-													<button type="roll"name="attr_weapon6fullattack" text="Full Attack" title="weapon6fullattack" value="@{weapon6fullattackmacro}" style="width: 20px;" ></button></td>
+													<button type="roll" name="roll_weapon6fullattack" text="Full Attack" title="weapon6fullattack" value="@{weapon6fullattackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="damage-calculation-a">Damage Calc</span> / <span data-i18n="critical-calculation-a">Crit Calc</span> / <span data-i18n="damage-macro">Damage Macro</span>:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon6damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon6damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 + @{weapon6damagestat}[Weapon Dmg Ability] +@{weapon6enh}[Weapon Enh] +@{weapon6specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon6crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon6crit (Edit this to adjust the critical calculation.)"> [[ (@{weapon6critmult}-1) ]]d6 + [[ (@{weapon6critmult}-1) ]] *( @{weapon6damagestat}[Weapon Dmg Ability] +@{weapon6enh}[Weapon Enh] +@{weapon6specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon6damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon6damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon6name} }} {{damage1=does [[ @{weapon6damage} ]]damage}} {{fullattackflag= [[ 0d1 ]] }}</textarea>
-												<button type="roll" name="attr_weapon6damageroll" title="weapon6damageroll" style="width: 20px;" value="@{weapon6damagemacro}"></button></td>
+												<button type="roll" name="roll_weapon6damageroll" title="weapon6damageroll" style="width: 20px;" value="@{weapon6damagemacro}"></button></td>
 											</tr>
 										</table>
 									</div>
@@ -859,13 +859,13 @@
 											<tr>
 												<td colspan="6"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="attack-calculation-a">Attack Calc</span> / <span data-i18n="macro">Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon7attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon7attackcalc">1d20cs>@{weapon7critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] + @{weapon7stat}[Ability] +@{size}[size] +@{weapon7enh}[Weapon Enh] +@{weapon7focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon7attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon7attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon7name} }} {{attack1=hitting AC [[ @{weapon7attackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weapon7attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=for [[ @{weapon7damage} ]]dmg}} {{critdmg1=+ [[ @{weapon7crit} ]] crit dmg}} {{fullattackflag= [[ 0d1 ]] }} </textarea>
-												<button type="roll" name="attr_weapon7attack" text="attack" title="weapon7attack" value="@{weapon7attackmacro}" style="width: 20px;" ></button></td>
+												<button type="roll" name="roll_weapon7attack" text="attack" title="weapon7attack" value="@{weapon7attackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="full-attack-macro" >Full Attack Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon7fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon7fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon7name} }} {{attack1=A1: [[ @{weapon7attackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weapon7attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=D1: [[ @{weapon7damage} ]] }} {{critdmg1=+ [[ @{weapon7crit} ]] }} {{fullattackflag= [[ ?{Full Attack?|No, 0d1|Yes, d1} ]] }} {{attack2=A2: [[ @{weapon7attackcalc}-5 ]] }} {{critconfirm2=Crit!: [[ @{weapon7attackcalc}-5 ]] }} {{damage2=D2: [[ @{weapon7damage} ]] }} {{critdmg2=+ [[ @{weapon7crit} ]] }} {{attack3=A3: [[ @{weapon7attackcalc}-10 ]] }} {{critconfirm3=Crit!: [[ @{weapon7attackcalc}-10 ]] }} {{damage3=D3: [[ @{weapon7damage} ]] }} {{critdmg3=+ [[ @{weapon7crit} ]] }} {{attack4=A4: [[ @{weapon7attackcalc}-15 ]] }} {{critconfirm4=Crit!: [[ @{weapon7attackcalc}-15 ]] }} {{damage4=D4: [[ @{weapon7damage} ]] }} {{critdmg4=+ [[ @{weapon7crit} ]] }} </textarea>
-													<button type="roll"name="attr_weapon7fullattack" text="Full Attack" title="weapon7fullattack" value="@{weapon7fullattackmacro}" style="width: 20px;" ></button></td>
+													<button type="roll" name="roll_weapon7fullattack" text="Full Attack" title="weapon7fullattack" value="@{weapon7fullattackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="damage-calculation-a">Damage Calc</span> / <span data-i18n="critical-calculation-a">Crit Calc</span> / <span data-i18n="damage-macro">Damage Macro</span>:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon7damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon7damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 + @{weapon7damagestat}[Weapon Dmg Ability] +@{weapon7enh}[Weapon Enh] +@{weapon7specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon7crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon7crit (Edit this to adjust the critical calculation.)"> [[ (@{weapon7critmult}-1) ]]d6 + [[ (@{weapon7critmult}-1) ]] *( @{weapon7damagestat}[Weapon Dmg Ability] +@{weapon7enh}[Weapon Enh] +@{weapon7specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon7damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon7damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon7name} }} {{damage1=does [[ @{weapon7damage} ]]damage}} {{fullattackflag= [[ 0d1 ]] }}</textarea>
-												<button type="roll" name="attr_weapon7damageroll" title="weapon7damageroll" style="width: 20px;" value="@{weapon7damagemacro}"></button></td>
+												<button type="roll" name="roll_weapon7damageroll" title="weapon7damageroll" style="width: 20px;" value="@{weapon7damagemacro}"></button></td>
 											</tr>
 										</table>
 									</div>
@@ -911,13 +911,13 @@
 											<tr>
 												<td colspan="6"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="attack-calculation-a">Attack Calc</span> / <span data-i18n="macro">Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon8attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon8attackcalc">1d20cs>@{weapon8critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] + @{weapon8stat}[Ability] +@{size}[size] +@{weapon8enh}[Weapon Enh] +@{weapon8focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon8attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon8attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon8name} }} {{attack1=hitting AC [[ @{weapon8attackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weapon8attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=for [[ @{weapon8damage} ]]dmg}} {{critdmg1=+ [[ @{weapon8crit} ]] crit dmg}} {{fullattackflag= [[ 0d1 ]] }} </textarea>
-												<button type="roll" name="attr_weapon8attack" text="attack" title="weapon8attack" value="@{weapon8attackmacro}" style="width: 20px;" ></button></td>
+												<button type="roll" name="roll_weapon8attack" text="attack" title="weapon8attack" value="@{weapon8attackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="full-attack-macro" >Full Attack Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon8fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon8fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon8name} }} {{attack1=A1: [[ @{weapon8attackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weapon8attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=D1: [[ @{weapon8damage} ]] }} {{critdmg1=+ [[ @{weapon8crit} ]] }} {{fullattackflag= [[ ?{Full Attack?|No, 0d1|Yes, d1} ]] }} {{attack2=A2: [[ @{weapon8attackcalc}-5 ]] }} {{critconfirm2=Crit!: [[ @{weapon8attackcalc}-5 ]] }} {{damage2=D2: [[ @{weapon8damage} ]] }} {{critdmg2=+ [[ @{weapon8crit} ]] }} {{attack3=A3: [[ @{weapon8attackcalc}-10 ]] }} {{critconfirm3=Crit!: [[ @{weapon8attackcalc}-10 ]] }} {{damage3=D3: [[ @{weapon8damage} ]] }} {{critdmg3=+ [[ @{weapon8crit} ]] }} {{attack4=A4: [[ @{weapon8attackcalc}-15 ]] }} {{critconfirm4=Crit!: [[ @{weapon8attackcalc}-15 ]] }} {{damage4=D4: [[ @{weapon8damage} ]] }} {{critdmg4=+ [[ @{weapon8crit} ]] }} </textarea>
-													<button type="roll"name="attr_weapon8fullattack" text="Full Attack" title="weapon8fullattack" value="@{weapon8fullattackmacro}" style="width: 20px;" ></button></td>
+													<button type="roll" name="roll_weapon8fullattack" text="Full Attack" title="weapon8fullattack" value="@{weapon8fullattackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="damage-calculation-a">Damage Calc</span> / <span data-i18n="critical-calculation-a">Crit Calc</span> / <span data-i18n="damage-macro">Damage Macro</span>:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon8damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon8damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 + @{weapon8damagestat}[Weapon Dmg Ability] +@{weapon8enh}[Weapon Enh] +@{weapon8specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon8crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon8crit (Edit this to adjust the critical calculation.)"> [[ (@{weapon8critmult}-1) ]]d6 + [[ (@{weapon8critmult}-1) ]] *( @{weapon8damagestat}[Weapon Dmg Ability] +@{weapon8enh}[Weapon Enh] +@{weapon8specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon8damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon8damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon8name} }} {{damage1=does [[ @{weapon8damage} ]]damage}} {{fullattackflag= [[ 0d1 ]] }}</textarea>
-												<button type="roll" name="attr_weapon8damageroll" title="weapon8damageroll" style="width: 20px;" value="@{weapon8damagemacro}"></button></td>
+												<button type="roll" name="roll_weapon8damageroll" title="weapon8damageroll" style="width: 20px;" value="@{weapon8damagemacro}"></button></td>
 											</tr>
 										</table>
 									</div>
@@ -963,13 +963,13 @@
 											<tr>
 												<td colspan="6"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="attack-calculation-a">Attack Calc</span> / <span data-i18n="macro">Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon9attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon9attackcalc">1d20cs>@{weapon9critmin} +@{bab}[BAB] +@{epicattackbonus}[Epic AB] + @{weapon9stat}[Ability] +@{size}[size] +@{weapon9enh}[Weapon Enh] +@{weapon9focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon9attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon9attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon9name} }} {{attack1=hitting AC [[ @{weapon9attackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weapon9attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=for [[ @{weapon9damage} ]]dmg}} {{critdmg1=+ [[ @{weapon9crit} ]] crit dmg}} {{fullattackflag= [[ 0d1 ]] }} </textarea>
-												<button type="roll" name="attr_weapon9attack" text="attack" title="weapon9attack" value="@{weapon9attackmacro}" style="width: 20px;" ></button></td>
+												<button type="roll" name="roll_weapon9attack" text="attack" title="weapon9attack" value="@{weapon9attackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="full-attack-macro" >Full Attack Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon9fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon9fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon9name} }} {{attack1=A1: [[ @{weapon9attackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weapon9attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=D1: [[ @{weapon9damage} ]] }} {{critdmg1=+ [[ @{weapon9crit} ]] }} {{fullattackflag= [[ ?{Full Attack?|No, 0d1|Yes, d1} ]] }} {{attack2=A2: [[ @{weapon9attackcalc}-5 ]] }} {{critconfirm2=Crit!: [[ @{weapon9attackcalc}-5 ]] }} {{damage2=D2: [[ @{weapon9damage} ]] }} {{critdmg2=+ [[ @{weapon9crit} ]] }} {{attack3=A3: [[ @{weapon9attackcalc}-10 ]] }} {{critconfirm3=Crit!: [[ @{weapon9attackcalc}-10 ]] }} {{damage3=D3: [[ @{weapon9damage} ]] }} {{critdmg3=+ [[ @{weapon9crit} ]] }} {{attack4=A4: [[ @{weapon9attackcalc}-15 ]] }} {{critconfirm4=Crit!: [[ @{weapon9attackcalc}-15 ]] }} {{damage4=D4: [[ @{weapon9damage} ]] }} {{critdmg4=+ [[ @{weapon9crit} ]] }} </textarea>
-													<button type="roll"name="attr_weapon9fullattack" text="Full Attack" title="weapon9fullattack" value="@{weapon9fullattackmacro}" style="width: 20px;" ></button></td>
+													<button type="roll" name="roll_weapon9fullattack" text="Full Attack" title="weapon9fullattack" value="@{weapon9fullattackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="damage-calculation-a">Damage Calc</span> / <span data-i18n="critical-calculation-a">Crit Calc</span> / <span data-i18n="damage-macro">Damage Macro</span>:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon9damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon9damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 + @{weapon9damagestat}[Weapon Dmg Ability] +@{weapon9enh}[Weapon Enh] +@{weapon9specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon9crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon9crit (Edit this to adjust the critical calculation.)"> [[ (@{weapon9critmult}-1) ]]d6 + [[ (@{weapon9critmult}-1) ]] *( @{weapon9damagestat}[Weapon Dmg Ability] +@{weapon9enh}[Weapon Enh] +@{weapon9specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon9damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon9damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon9name} }} {{damage1=does [[ @{weapon9damage} ]]damage}} {{fullattackflag= [[ 0d1 ]] }}</textarea>
-												<button type="roll" name="attr_weapon9damageroll" title="weapon9damageroll" style="width: 20px;" value="@{weapon9damagemacro}"></button></td>
+												<button type="roll" name="roll_weapon9damageroll" title="weapon9damageroll" style="width: 20px;" value="@{weapon9damagemacro}"></button></td>
 											</tr>
 										</table>
 									</div>
@@ -1015,13 +1015,13 @@
 											<tr>
 												<td colspan="6"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="attack-calculation-a">Attack Calc</span> / <span data-i18n="macro">Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon10attackcalc (Edit this to adjust the attack calculation)" name="attr_weapon10attackcalc">1d20cs>@{weapon10critmin} +@{bab} +@{epicattackbonus} [BAB] + @{weapon10stat}[Ability] +@{size}[size] +@{weapon10enh}[Weapon Enh] +@{weapon10focus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 												<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="weapon10attackmacro (Modify this macro to modify your attack macro)" name="attr_weapon10attackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon10name} }} {{attack1=hitting AC [[ @{weapon10attackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weapon10attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=for [[ @{weapon10damage} ]]dmg}} {{critdmg1=+ [[ @{weapon10crit} ]] crit dmg}} {{fullattackflag= [[ 0d1 ]] }} </textarea>
-												<button type="roll" name="attr_weapon10attack" text="attack" title="weapon10attack" value="@{weapon10attackmacro}" style="width: 20px;" ></button></td>
+												<button type="roll" name="roll_weapon10attack" text="attack" title="weapon10attack" value="@{weapon10attackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="full-attack-macro" >Full Attack Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="weapon10fullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weapon10fullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weapon10name} }} {{attack1=A1: [[ @{weapon10attackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weapon10attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=D1: [[ @{weapon10damage} ]] }} {{critdmg1=+ [[ @{weapon10crit} ]] }} {{fullattackflag= [[ ?{Full Attack?|No, 0d1|Yes, d1} ]] }} {{attack2=A2: [[ @{weapon10attackcalc}-5 ]] }} {{critconfirm2=Crit!: [[ @{weapon10attackcalc}-5 ]] }} {{damage2=D2: [[ @{weapon10damage} ]] }} {{critdmg2=+ [[ @{weapon10crit} ]] }} {{attack3=A3: [[ @{weapon10attackcalc}-10 ]] }} {{critconfirm3=Crit!: [[ @{weapon10attackcalc}-10 ]] }} {{damage3=D3: [[ @{weapon10damage} ]] }} {{critdmg3=+ [[ @{weapon10crit} ]] }} {{attack4=A4: [[ @{weapon10attackcalc}-15 ]] }} {{critconfirm4=Crit!: [[ @{weapon10attackcalc}-15 ]] }} {{damage4=D4: [[ @{weapon10damage} ]] }} {{critdmg4=+ [[ @{weapon10crit} ]] }} </textarea>
-													<button type="roll"name="attr_weapon10fullattack" text="Full Attack" title="weapon10fullattack" value="@{weapon10fullattackmacro}" style="width: 20px;" ></button></td>
+													<button type="roll" name="roll_weapon10fullattack" text="Full Attack" title="weapon10fullattack" value="@{weapon10fullattackmacro}" style="width: 20px;" ></button></td>
 												<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="damage-calculation-a">Damage Calc</span> / <span data-i18n="critical-calculation-a">Crit Calc</span> / <span data-i18n="damage-macro">Damage Macro</span>:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapon10damage" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon10damage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 + @{weapon10damagestat}[Weapon Dmg Ability] +@{weapon10enh}[Weapon Enh] +@{weapon10specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon10crit" rows="1" cols="45" style="height: 20px; width: 65px;" title="weapon10crit (Edit this to adjust the critical calculation.)"> [[ (@{weapon10critmult}-1) ]]d6 + [[ (@{weapon10critmult}-1) ]] *( @{weapon10damagestat}[Weapon Dmg Ability] +@{weapon10enh}[Weapon Enh] +@{weapon10specialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 												<textarea class="sheet-inputbox" type="text" name="attr_weapon10damagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="weapon10damagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weapon10name} }} {{damage1=does [[ @{weapon10damage} ]]damage}} {{fullattackflag= [[ 0d1 ]] }}</textarea>
-												<button type="roll" name="attr_weapon10damageroll" title="weapon10damageroll" style="width: 20px;" value="@{weapon10damagemacro}"></button></td>
+												<button type="roll" name="roll_weapon10damageroll" title="weapon10damageroll" style="width: 20px;" value="@{weapon10damagemacro}"></button></td>
 											</tr>
 										</table>
 									</div>
@@ -1068,13 +1068,13 @@
 												<tr>
 													<td colspan="6"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="attack-calculation-a">Attack Calc</span> / <span data-i18n="macro">Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="repeating_weapons_#_weaponattackcalc (Edit this to adjust the attack calculation)" name="attr_weaponattackcalc">1d20cs>@{weaponcritmin} +@{bab} +@{epicattackbonus} [BAB] + @{weaponstat}[Ability] +@{size}[size] +@{weaponenh}[Weapon Enh] +@{weaponfocus}[Weapon Focus] + ?{Flank (1=yes)|0}*2[Flank] +?{Power Attack? (put in penalty with negative sign ie -3)|0}[Pwr Attk] +?{Additional Attack Bonus?|0}[Ad'l Atk Bon] </textarea>
 													<textarea rows="1" cols="45" style="height: 18px; width: 120px;" title="repeating_weapons_#_weaponattackmacro (Modify this macro to modify your attack macro)" name="attr_weaponattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weaponname} }} {{attack1=hitting AC [[ @{weaponattackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weaponattackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=for [[ @{weapondamage} ]]dmg}} {{critdmg1=+ [[ @{weaponcrit} ]] crit dmg}} {{fullattackflag= [[ 0d1 ]] }} </textarea>
-													<button type="roll" name="attr_weaponattack" text="attack" title="repeating_weapons_#_weaponattack" value="@{weaponattackmacro}" style="width: 20px;" ></button></td>
+													<button type="roll" name="roll_weaponattack" text="attack" title="repeating_weapons_#_weaponattack" value="@{weaponattackmacro}" style="width: 20px;" ></button></td>
 													<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="full-attack-macro" >Full Attack Macro</span>:<br></div><textarea rows="1" cols="45" style="height: 18px; width: 155px;" title="repeating_weapons_#_weaponfullattackmacro (Modify this macro to modify your full round attack macro)" name="attr_weaponfullattackmacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}}} {{subtags=attacks with a @{weaponname} }} {{attack1=A1: [[ @{weaponattackcalc} ]] }} {{critconfirm1=Crit?: [[ @{weaponattackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=D1: [[ @{weapondamage} ]] }} {{critdmg1=+ [[ @{weaponcrit} ]] }} {{fullattackflag= [[ ?{Full Attack?|No, 0d1|Yes, d1} ]] }} {{attack2=A2: [[ @{weaponattackcalc}-5 ]] }} {{critconfirm2=Crit!: [[ @{weaponattackcalc}-5 ]] }} {{damage2=D2: [[ @{weapondamage} ]] }} {{critdmg2=+ [[ @{weaponcrit} ]] }} {{attack3=A3: [[ @{weaponattackcalc}-10 ]] }} {{critconfirm3=Crit!: [[ @{weaponattackcalc}-10 ]] }} {{damage3=D3: [[ @{weapondamage} ]] }} {{critdmg3=+ [[ @{weaponcrit} ]] }} {{attack4=A4: [[ @{weaponattackcalc}-15 ]] }} {{critconfirm4=Crit!: [[ @{weaponattackcalc}-15 ]] }} {{damage4=D4: [[ @{weapondamage} ]] }} {{critdmg4=+ [[ @{weaponcrit} ]] }} </textarea>
-														<button type="roll"name="attr_weaponfullattack" text="Full Attack" title="repeating_weapons_#_weaponfullattack" value="@{weaponfullattackmacro}" style="width: 20px;" ></button></td>
+														<button type="roll" name="roll_weaponfullattack" text="Full Attack" title="repeating_weapons_#_weaponfullattack" value="@{weaponfullattackmacro}" style="width: 20px;" ></button></td>
 													<td colspan="3"><div style="font-size: 0.5em; text-align: left;"><span data-i18n="damage-calculation-a">Damage Calc</span> / <span data-i18n="critical-calculation-a">Crit Calc</span> / <span data-i18n="damage-macro">Damage Macro</span>:<br></div><textarea class="sheet-inputbox" type="text" name="attr_weapondamage" rows="1" cols="45" style="height: 20px; width: 65px;" title="repeating_weapons_#_weapondamage (Edit this to adjust the damage calculation. Ie add +floor(@{str-mod} /2) if wielding 2h weapon for 1.5str on damage.)">1d6 + @{weapondamagestat}[Weapon Dmg Ability] +@{weaponenh}[Weapon Enh] +@{weaponspecialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon] </textarea>
 													<textarea class="sheet-inputbox" type="text" name="attr_weaponcrit" rows="1" cols="45" style="height: 20px; width: 65px;" title="repeating_weapons_#_weaponcrit (Edit this to adjust the critical calculation.)"> [[ (@{weaponcritmult}-1) ]]d6 + [[ (@{weaponcritmult}-1) ]] *( @{weapondamagestat}[Weapon Dmg Ability] +@{weaponenh}[Weapon Enh] +@{weaponspecialize}[Weapon Spec] +?{Power Attack Bonus?|0}[Pwr Attk] +?{Additional Damage Bonus?|0}[Ad'l Dmg Bon]) </textarea>
 													<textarea class="sheet-inputbox" type="text" name="attr_weapondamagemacro" rows="1" cols="45" style="height: 20px; width: 100px;" title="repeating_weapons_#_weapondamagemacro">&{template:DnD35Attack} {{pcflag=true}} {{name=@{character_name}'s @{weaponname} }} {{damage1=does [[ @{weapondamage} ]]damage}} {{fullattackflag= [[ 0d1 ]] }}</textarea>
-													<button type="roll" name="attr_weapondamageroll" title="repeating_weapons_#_weapondamageroll" style="width: 20px;" value="@{weapondamagemacro}"></button></td>
+													<button type="roll" name="roll_weapondamageroll" title="repeating_weapons_#_weapondamageroll" style="width: 20px;" value="@{weapondamagemacro}"></button></td>
 												</tr>
 											</table>
 										</fieldset>
@@ -1743,7 +1743,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_appraisemiscmod" title="appraisemiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_appraisenote" title="appraisenote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_appraisemacro" title="appraisemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Appraise](http://www.dandwiki.com/wiki/SRD:Appraise_Skill ) check:}} {{checkroll=[[1d20 + [[@{appraise}]] ]] }} {{notes=@{appraisenote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_appraisecheck" title="appraisecheck" value="@{appraisemacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_appraisecheck" title="appraisecheck" value="@{appraisemacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_balanceclassskill" title="balanceclassskill" value="1" style="width: 8px;"></td>
@@ -1756,7 +1756,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_balancemiscmod" title="balancemiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_balancenote" title="balancenote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_balancemacro" title="balancemacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Balance](http://www.dandwiki.com/wiki/SRD:Balance_Skill ) check:}} {{checkroll= [[ 1d20 + [[ @{balance} ]] ]] }} {{notes=@{balancenote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_balancecheck" title="balancecheck" value="@{balancemacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_balancecheck" title="balancecheck" value="@{balancemacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_bluffclassskill" title="bluffclassskill" value="1" style="width: 8px;"></td>
@@ -1769,7 +1769,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_bluffmiscmod" title="bluffmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_bluffnote" title="bluffnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_bluffmacro" title="bluffmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Bluff](http://www.dandwiki.com/wiki/SRD:Bluff_Skill ) check:}} {{checkroll=[[1d20 + [[@{bluff}]] ]] }} {{notes=@{bluffnote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_bluffcheck" title="bluffcheck" value="@{bluffmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_bluffcheck" title="bluffcheck" value="@{bluffmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_climbclassskill" title="climbclassskill" value="1" style="width: 8px;"></td>
@@ -1786,7 +1786,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_climbmiscmod" title="climbmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_climbnote" title="climbnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_climbmacro" title="climbmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Climb](http://www.dandwiki.com/wiki/SRD:Climb_Skill ) check:}} {{checkroll= [[ 1d20 + [[ @{climb} ]] ]] }} {{notes=@{climbnote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_climbcheck" title="climbcheck" value="@{climbmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_climbcheck" title="climbcheck" value="@{climbmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_concentrationclassskill" title="concentrationclassskill" value="1" style="width: 8px;"></td>
@@ -1799,7 +1799,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_concentrationmiscmod" title="concentrationmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_concentrationnote" title="concentrationnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_concentrationmacro" title="concentrationmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Concentration](http://www.dandwiki.com/wiki/SRD:Concentration_Skill ) check:}} {{checkroll= [[ 1d20 + [[ @{concentration} ]] ]] }} {{notes=@{concentrationnote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_concentrationcheck" title="concentrationcheck" value="@{concentrationmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_concentrationcheck" title="concentrationcheck" value="@{concentrationmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_craft1classskill" title="craft1classskill" value="1" style="width: 8px;"></td>
@@ -1812,7 +1812,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft1miscmod" title="craft1miscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_craft1note" title="craft1note (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_craft1macro" title="craft1macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Craft](http://www.dandwiki.com/wiki/SRD:Craft_Skill ) (@{craft1name}) check:}} {{checkroll= [[ 1d20 + [[ @{craft1} ]] +(?{Artisan's Tools? |None, -2|Normal, 0|Masterwork, 2})[Tool Circumstance Bonus] ]] }} {{notes=@{craft1note} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_craft1check" title="craft1check" value="@{craft1macro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_craft1check" title="craft1check" value="@{craft1macro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_craft2classskill" title="craft2classskill" value="1" style="width: 8px;"></td>
@@ -1825,7 +1825,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft2miscmod" title="craft2miscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_craft2note" title="craft2note (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_craft2macro" title="craft2macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Craft](http://www.dandwiki.com/wiki/SRD:Craft_Skill ) (@{craft2name}) check:}} {{checkroll= [[ 1d20 + [[ @{craft2} ]] +(?{Artisan's Tools? |None, -2|Normal, 0|Masterwork, 2})[Tool Circumstance Bonus] ]] }} {{notes=@{craft2note} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_craft2check" title="craft2check" value="@{craft2macro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_craft2check" title="craft2check" value="@{craft2macro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_craft3classskill" title="craft3classskill" value="1" style="width: 8px;"></td>
@@ -1838,7 +1838,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_craft3miscmod" title="craft3miscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_craft3note" title="craft3note (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_craft3macro" title="craft3macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Craft](http://www.dandwiki.com/wiki/SRD:Craft_Skill ) (@{craft3name}) check:}} {{checkroll= [[ 1d20 + [[ @{craft3} ]] +(?{Artisan's Tools? |None, -2|Normal, 0|Masterwork, 2})[Tool Circumstance Bonus] ]] }} {{notes=@{craft3note} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_craft3check" title="craft3check" value="@{craft3macro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_craft3check" title="craft3check" value="@{craft3macro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_decipherscriptclassskill" title="decipherscriptclassskill" value="1" style="width: 8px;"></td>
@@ -1851,7 +1851,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_decipherscriptmiscmod" title="decipherscriptmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_decipherscriptnote" title="decipherscriptnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_decipherscriptmacro" title="decipherscriptmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Decipher Script](http://www.dandwiki.com/wiki/SRD:Decipher_Script_Skill ) check:}} {{checkroll=[[1d20 + @{decipherscript} ]]}} {{notes=If fail, [[1d20 + @{wis-mod} ]] vs dc5 to avoid drawing a false conclusion.}} {{notes=@{decipherscriptnote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_decipherscriptcheck" title="decipherscriptcheck" value="@{decipherscriptmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_decipherscriptcheck" title="decipherscriptcheck" value="@{decipherscriptmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_diplomacyclassskill" title="diplomacyclassskill" value="1" style="width: 8px;"></td>
@@ -1864,7 +1864,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_diplomacymiscmod" title="diplomacymiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_diplomacynote" title="diplomacynote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_diplomacymacro" title="diplomacymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Diplomacy](http://www.dandwiki.com/wiki/SRD:Diplomacy_Skill ) check:}} {{checkroll=[[1d20 + [[@{diplomacy}]] ]] }} {{notes=@{diplomacynote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_diplomacycheck" title="diplomacycheck" value="@{diplomacymacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_diplomacycheck" title="diplomacycheck" value="@{diplomacymacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_disabledeviceclassskill" title="disabledeviceclassskill" value="1" style="width: 8px;"></td>
@@ -1877,7 +1877,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_disabledevicemiscmod" title="disabledevicemiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_disabledevicenote" title="disabledevicenote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_disabledevicemacro" title="disabledevicemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Disable Device](http://www.dandwiki.com/wiki/SRD:Disable_Device_Skill ) check:}} {{checkroll=[[1d20 + [[@{disabledevice}]] ]] }} {{notes=@{disabledevicenote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_disabledevicecheck" title="disabledevicecheck" value="@{disabledevicemacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_disabledevicecheck" title="disabledevicecheck" value="@{disabledevicemacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_disguiseclassskill" title="disguiseclassskill" value="1" style="width: 8px;"></td>
@@ -1890,7 +1890,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_disguisemiscmod" title="disguisemiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_disguisenote" title="disguisenote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_disguisemacro" title="disguisemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Disguise](http://www.dandwiki.com/wiki/SRD:Disguise_Skill ) check:}} {{checkroll=[[1d20 + [[@{disguise}]] ]] }} {{notes=@{disguisenote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_disguisecheck" title="disguisecheck" value="@{disguisemacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_disguisecheck" title="disguisecheck" value="@{disguisemacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_escapeartistclassskill" title="escapeartistclassskill" value="1" style="width: 8px;"></td>
@@ -1903,7 +1903,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_escapeartistmiscmod" title="escapeartistmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_escapeartistnote" title="escapeartistnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_escapeartistmacro" title="escapeartistmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Escape Artist](http://www.dandwiki.com/wiki/SRD:Escape_Artist_Skill ) check:}} {{checkroll= [[ 1d20 + [[ @{escapeartist} ]] ]] }} {{notes=@{escapeartistnote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_escapeartistcheck" title="escapeartistcheck" value="@{escapeartistmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_escapeartistcheck" title="escapeartistcheck" value="@{escapeartistmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_forgeryclassskill" title="forgeryclassskill" value="1" style="width: 8px;"></td>
@@ -1916,7 +1916,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_forgerymiscmod" title="forgerymiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_forgerynote" title="forgerynote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_forgerymacro" title="forgerymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Forgery](http://www.dandwiki.com/wiki/SRD:Forgery_Skill ) check:}} {{checkroll=[[1d20 + [[@{forgery}]] ]] }} {{notes=@{forgerynote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_forgerycheck" title="forgerycheck" value="@{forgerymacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_forgerycheck" title="forgerycheck" value="@{forgerymacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_gatherinformationclassskill" title="gatherinformationclassskill" value="1" style="width: 8px;"></td>
@@ -1929,7 +1929,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_gatherinformationmiscmod" title="gatherinformationmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_gatherinformationnote" title="gatherinformationnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_gatherinformationmacro" title="gatherinformationmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Gather Information](http://www.dandwiki.com/wiki/SRD:Gather_Information_Skill ) check:}} {{checkroll=[[1d20 + [[@{gatherinformation}]] ]] }} {{notes=@{gatherinformationnote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_gatherinformationcheck" title="gatherinformationcheck" value="@{gatherinformationmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_gatherinformationcheck" title="gatherinformationcheck" value="@{gatherinformationmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_handleanimalclassskill" title="handleanimalclassskill" value="1" style="width: 8px;"></td>
@@ -1942,7 +1942,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_handleanimalmiscmod" title="handleanimalmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_handleanimalnote" title="handleanimalnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_handleanimalmacro" title="handleanimalmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Handle Animal](http://www.dandwiki.com/wiki/SRD:Handle_Animal_Skill ) check:}} {{checkroll= [[ 1d20 + [[ @{handleanimal} ]] ]] }} {{notes=@{handleanimalnote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_handleanimalcheck" title="handleanimalcheck" value="@{handleanimalmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_handleanimalcheck" title="handleanimalcheck" value="@{handleanimalmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_healclassskill" title="healclassskill" value="1" style="width: 8px;"></td>
@@ -1955,7 +1955,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_healmiscmod" title="healmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_healnote" title="healnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_healmacro" title="healmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Heal](http://www.dandwiki.com/wiki/SRD:Heal_Skill ) check:}} {{checkroll=[[1d20 + [[@{heal}]] +(?{Healer's Kit? |No, 0|Yes, 2})[Healer's Kit Circumstance Bonus] ]] }} {{notes=@{healnote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_healcheck" title="healcheck" value="@{healmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_healcheck" title="healcheck" value="@{healmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_hideclassskill" title="hideclassskill" value="1" style="width: 8px;"></td>
@@ -1968,7 +1968,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_hidemiscmod" title="hidemiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_hidenote" title="hidenote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_hidemacro" title="hidemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Hide](http://www.dandwiki.com/wiki/SRD:Hide_Skill ) check:}} {{checkroll=[[1d20 + [[@{hide}]] ]] }} {{notes=@{hidenote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_hidecheck" title="hidecheck" value="@{hidemacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_hidecheck" title="hidecheck" value="@{hidemacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_intimidateclassskill" title="intimidateclassskill" value="1" style="width: 8px;"></td>
@@ -1981,7 +1981,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_intimidatemiscmod" title="intimidatemiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_intimidatenote" title="intimidatenote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_intimidatemacro" title="intimidatemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Intimidate](http://www.dandwiki.com/wiki/SRD:Intimidate_Skill ) check:}} {{checkroll=[[1d20 + [[@{intimidate}]] ]] }} {{notes=@{intimidatenote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_intimidatecheck" title="intimidatecheck" value="@{intimidatemacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_intimidatecheck" title="intimidatecheck" value="@{intimidatemacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_jumpclassskill" title="jumpclassskill" value="1" style="width: 8px;"></td>
@@ -1998,7 +1998,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_jumpmiscmod" title="jumpmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_jumpnote" title="jumpnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_jumpmacro" title="jumpmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Jump](http://www.dandwiki.com/wiki/SRD:Jump_Skill ) check:}} {{checkroll= [[ 1d20 + [[ @{jump} ]] ]] }} {{notes=@{jumpnote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_jumpcheck" title="jumpcheck" value="@{jumpmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_jumpcheck" title="jumpcheck" value="@{jumpmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_knowarcanaclassskill" title="knowarcanaclassskill" value="1" style="width: 8px;"></td>
@@ -2011,7 +2011,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowarcanamiscmod" title="knowarcanamiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowarcananote" title="knowarcananote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowarcanamacro" title="knowarcanamacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Arcana) check:}} {{checkroll=[[1d20 + [[@{knowarcana}]] ]] }} {{notes=@{knowarcananote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_knowarcanacheck" title="knowarcanacheck" value="@{knowarcanamacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_knowarcanacheck" title="knowarcanacheck" value="@{knowarcanamacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_knowengineerclassskill" title="knowengineerclassskill" value="1" style="width: 8px;"></td>
@@ -2024,7 +2024,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowengineermiscmod" title="knowengineermiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowengineernote" title="knowengineernote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowengineermacro" title="knowengineermacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Engineering) check:}} {{checkroll=[[1d20 + [[@{knowengineer}]] ]] }} {{notes=@{knowengineernote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_knowengineercheck" title="knowengineercheck" value="@{knowengineermacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_knowengineercheck" title="knowengineercheck" value="@{knowengineermacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_knowdungeonclassskill" title="knowdungeonclassskill" value="1" style="width: 8px;"></td>
@@ -2037,7 +2037,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowdungeonmiscmod" title="knowdungeonmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowdungeonnote" title="knowdungeonnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowdungeonmacro" title="knowdungeonmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Dungeoneering) check:}} {{checkroll=[[1d20 + [[@{knowdungeon}]] ]] }} {{notes=@{knowdungeonnote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_knowdungeoncheck" title="knowdungeoncheck" value="@{knowdungeonmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_knowdungeoncheck" title="knowdungeoncheck" value="@{knowdungeonmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_knowgeographyclassskill" title="knowgeographyclassskill" value="1" style="width: 8px;"></td>
@@ -2050,7 +2050,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowgeographymiscmod" title="knowgeographymiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowgeographynote" title="knowgeographynote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowgeographymacro" title="knowgeographymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Geography) check:}} {{checkroll=[[1d20 + [[@{knowgeography}]] ]] }} {{notes=@{knowgeographynote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_knowgeographycheck" title="knowgeographycheck" value="@{knowgeographymacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_knowgeographycheck" title="knowgeographycheck" value="@{knowgeographymacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_knowhistoryclassskill" title="knowhistoryclassskill" value="1" style="width: 8px;"></td>
@@ -2063,7 +2063,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowhistorymiscmod" title="knowhistorymiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowhistorynote" title="knowhistorynote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowhistorymacro" title="knowhistorymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (History) check:}} {{checkroll=[[1d20 + [[@{knowhistory}]] ]] }} {{notes=@{knowhistorynote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_knowhistorycheck" title="knowhistorycheck" value="@{knowhistorymacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_knowhistorycheck" title="knowhistorycheck" value="@{knowhistorymacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_knowlocalclassskill" title="knowlocalclassskill" value="1" style="width: 8px;"></td>
@@ -2076,7 +2076,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowlocalmiscmod" title="knowlocalmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowlocalnote" title="knowlocalnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowlocalmacro" title="knowlocalmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Local) check:}} {{checkroll=[[1d20 + [[@{knowlocal}]] ]] }} {{notes=@{knowlocalnote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_knowlocalcheck" title="knowlocalcheck" value="@{knowlocalmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_knowlocalcheck" title="knowlocalcheck" value="@{knowlocalmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_knownatureclassskill" title="knownatureclassskill" value="1" style="width: 8px;"></td>
@@ -2089,7 +2089,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knownaturemiscmod" title="knownaturemiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knownaturenote" title="knownaturenote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knownaturemacro" title="knownaturemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Nature) check:}} {{checkroll=[[1d20 + [[@{knownature}]] ]] }} {{notes=@{knownaturenote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_knownaturecheck" title="knownaturecheck" value="@{knownaturemacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_knownaturecheck" title="knownaturecheck" value="@{knownaturemacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_knownobilityclassskill" title="knownobilityclassskill" value="1" style="width: 8px;"></td>
@@ -2102,7 +2102,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knownobilitymiscmod" title="knownobilitymiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knownobilitynote" title="knownobilitynote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knownobilitymacro" title="knownobilitymacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Nobility) check:}} {{checkroll=[[1d20 + [[@{knownobility}]] ]] }} {{notes=@{knownobilitynote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_knownobilitycheck" title="knownobilitycheck" value="@{knownobilitymacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_knownobilitycheck" title="knownobilitycheck" value="@{knownobilitymacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_knowreligionclassskill" title="knowreligionclassskill" value="1" style="width: 8px;"></td>
@@ -2115,7 +2115,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowreligionmiscmod" title="knowreligionmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowreligionnote" title="knowreligionnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowreligionmacro" title="knowreligionmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (Religion) check:}} {{checkroll=[[1d20 + [[@{knowreligion}]] ]] }} {{notes=@{knowreligionnote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_knowreligioncheck" title="knowreligioncheck" value="@{knowreligionmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_knowreligioncheck" title="knowreligioncheck" value="@{knowreligionmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_knowplanesclassskill" title="knowplanesclassskill" value="1" style="width: 8px;"></td>
@@ -2128,7 +2128,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_knowplanesmiscmod" title="knowplanesmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowplanesnote" title="knowplanesnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_knowplanesmacro" title="knowplanesmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Knowledge](http://www.dandwiki.com/wiki/SRD:Knowledge_Skill ) (The Planes) check:}} {{checkroll=[[1d20 + [[@{knowplanes}]] ]] }} {{notes=@{knowplanesnote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_knowplanescheck" title="knowplanescheck" value="@{knowplanesmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_knowplanescheck" title="knowplanescheck" value="@{knowplanesmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_listenclassskill" title="listenclassskill" value="1" style="width: 8px;"></td>
@@ -2141,7 +2141,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_listenmiscmod" title="listenmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_listennote" title="listennote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_listenmacro" title="listenmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Listen](http://www.dandwiki.com/wiki/SRD:Listen_Skill ) check:}} {{checkroll=[[ 1d20 + [[ @{listen} ]] ]] }} {{notes=@{listennote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_listencheck" title="listencheck" value="@{listenmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_listencheck" title="listencheck" value="@{listenmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_movesilentclassskill" title="movesilentclassskill" value="1" style="width: 8px;"></td>
@@ -2154,7 +2154,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_movesilentmiscmod" title="movesilentmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_movesilentnote" title="movesilentnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_movesilentmacro" title="movesilentmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Move Silently](http://www.dandwiki.com/wiki/SRD:Move_Silently_Skill ) check:}} {{checkroll=[[1d20 + [[@{movesilent}]] ]] }} {{notes=@{movesilentnote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_movesilentcheck" title="movesilentcheck" value="@{movesilentmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_movesilentcheck" title="movesilentcheck" value="@{movesilentmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_openlockclassskill" title="openlockclassskill" value="1" style="width: 8px;"></td>
@@ -2167,7 +2167,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_openlockmiscmod" title="openlockmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_openlocknote" title="openlocknote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_openlockmacro" title="openlockmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Open Lock](http://www.dandwiki.com/wiki/SRD:Open_Lock_Skill ) check:}} {{checkroll=[[1d20 + [[@{openlock}]] +(?{Thieves' Tools? |None, -2|Normal, 0|Masterwork, 2})[Tool Circumstance Bonus] ]] }} {{notes=@{openlocknote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_openlockcheck" title="openlockcheck" value="@{openlockmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_openlockcheck" title="openlockcheck" value="@{openlockmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_perform1classskill" title="perform1classskill" value="1" style="width: 8px;"></td>
@@ -2180,7 +2180,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform1miscmod" title="perform1miscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_perform1note" title="perform1note (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_perform1macro" title="perform1macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Perform](http://www.dandwiki.com/wiki/SRD:Perform_Skill ) (@{perform1name}) check:}} {{checkroll= [[ 1d20 + [[ @{perform1} ]] +(?{Masterwork Instrument?|No, 0|Yes,2})[Instrument Circumstance Bonus] ]] }} {{notes=@{perform1note} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_perform1check" title="perform1check" value="@{perform1macro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_perform1check" title="perform1check" value="@{perform1macro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_perform2classskill" title="perform2classskill" value="1" style="width: 8px;"></td>
@@ -2193,7 +2193,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform2miscmod" title="perform2miscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_perform2note" title="perform2note (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_perform2macro" title="perform2macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Perform](http://www.dandwiki.com/wiki/SRD:Perform_Skill ) (@{perform2name}) check:}} {{checkroll= [[ 1d20 + [[ @{perform2} ]] +(?{Masterwork Instrument?|No, 0|Yes,2})[Instrument Circumstance Bonus] ]] }} {{notes=@{perform2note} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_perform2check" title="perform2check" value="@{perform2macro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_perform2check" title="perform2check" value="@{perform2macro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_perform3classskill" title="perform3classskill" value="1" style="width: 8px;"></td>
@@ -2206,7 +2206,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_perform3miscmod" title="perform3miscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_perform3note" title="perform3note (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_perform3macro" title="perform3macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Perform](http://www.dandwiki.com/wiki/SRD:Perform_Skill ) (@{perform2name}) check:}} {{checkroll= [[ 1d20 + [[ @{perform3} ]] +(?{Masterwork Instrument?|No, 0|Yes,2})[Instrument Circumstance Bonus] ]] }} {{notes=@{perform3note} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_perform3check" title="perform3check" value="@{perform3macro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_perform3check" title="perform3check" value="@{perform3macro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_profession1classskill" title="profession1classskill" value="1" style="width: 8px;"></td>
@@ -2219,7 +2219,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_profession1miscmod" title="profession1miscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_profession1note" title="profession1note (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_profession1macro" title="profession1macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Profession](http://www.dandwiki.com/wiki/SRD:Profession_Skill ) (@{profession1name}) check:}} {{checkroll= [[ 1d20 + [[ @{profession1} ]] ]] }} {{notes=@{profession1note} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_profession1check" title="profession1check" value="@{profession1macro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_profession1check" title="profession1check" value="@{profession1macro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_profession2classskill" title="profession2classskill" value="1" style="width: 8px;"></td>
@@ -2232,7 +2232,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_profession2miscmod" title="profession2miscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_profession2note" title="profession2note (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_profession2macro" title="profession2macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Profession](http://www.dandwiki.com/wiki/SRD:Profession_Skill ) (@{profession2name}) check:}} {{checkroll= [[ 1d20 + [[ @{profession2} ]] ]] }} {{notes=@{profession2note} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_profession2check" title="profession2check" value="@{profession2macro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_profession2check" title="profession2check" value="@{profession2macro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_profession3classskill" title="profession3classskill" value="1" style="width: 8px;"></td>
@@ -2245,7 +2245,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_profession3miscmod" title="profession3miscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_profession3note" title="profession3note (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_profession3macro" title="profession3macro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Profession](http://www.dandwiki.com/wiki/SRD:Profession_Skill ) (@{profession3name}) check:}} {{checkroll= [[ 1d20 + [[ @{profession3} ]] ]] }} {{notes=@{profession3note} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_profession3check" title="profession3check" value="@{profession3macro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_profession3check" title="profession3check" value="@{profession3macro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_rideclassskill" title="rideclassskill" value="1" style="width: 8px;"></td>
@@ -2258,7 +2258,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_ridemiscmod" title="ridemiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_ridenote" title="ridenote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_ridemacro" title="ridemacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Ride](http://www.dandwiki.com/wiki/SRD:Ride_Skill ) check:}} {{checkroll= [[ 1d20 + [[ @{ride} ]] ]] }} {{notes=@{ridenote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_ridecheck" title="ridecheck" value="@{ridemacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_ridecheck" title="ridecheck" value="@{ridemacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_searchclassskill" title="searchclassskill" value="1" style="width: 8px;"></td>
@@ -2271,7 +2271,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_searchmiscmod" title="searchmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_searchnote" title="searchnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_searchmacro" title="searchmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Search](http://www.dandwiki.com/wiki/SRD:Search_Skill ) check:}} {{checkroll=[[1d20 + [[@{search}]] ]] }} {{notes=@{searchnote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_searchcheck" title="searchcheck" value="@{searchmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_searchcheck" title="searchcheck" value="@{searchmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_sensemotiveclassskill" title="sensemotiveclassskill" value="1" style="width: 8px;"></td>
@@ -2284,7 +2284,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_sensemotivemiscmod" title="sensemotivemiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_sensemotivenote" title="sensemotivenote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_sensemotivemacro" title="sensemotivemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Sense Motive](http://www.dandwiki.com/wiki/SRD:Sense_Motive_Skill ) check:}} {{checkroll=[[1d20 + [[@{sensemotive}]] ]] }} {{notes=@{sensemotivenote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_sensemotivecheck" title="sensemotivecheck" value="@{sensemotivemacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_sensemotivecheck" title="sensemotivecheck" value="@{sensemotivemacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_sleightofhandclassskill" title="sleightofhandclassskill" value="1" style="width: 8px;"></td>
@@ -2297,7 +2297,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_sleightofhandmiscmod" title="sleightofhandmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_sleightofhandnote" title="sleightofhandnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_sleightofhandmacro" title="sleightofhandmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Sleight of Hand](http://www.dandwiki.com/wiki/SRD:Sleight_of_Hand_Skill ) check:}} {{checkroll=[[1d20 + [[@{sleightofhand}]] ]] }} {{notes=@{sleightofhandnote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_sleightofhandcheck" title="sleightofhandcheck" value="@{sleightofhandmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_sleightofhandcheck" title="sleightofhandcheck" value="@{sleightofhandmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_spellcraftclassskill" title="spellcraftclassskill" value="1" style="width: 8px;"></td>
@@ -2310,7 +2310,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_spellcraftmiscmod" title="spellcraftmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_spellcraftnote" title="spellcraftnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_spellcraftmacro" title="spellcraftmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Spellcraft](http://www.dandwiki.com/wiki/SRD:Spellcraft_Skill ) check:}} {{checkroll= [[ 1d20 + [[ @{spellcraft} ]] ]] }} {{notes=@{spellcraftnote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_spellcraftcheck" title="spellcraftcheck" value="@{spellcraftmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_spellcraftcheck" title="spellcraftcheck" value="@{spellcraftmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_spotclassskill" title="spotclassskill" value="1" style="width: 8px;"></td>
@@ -2323,7 +2323,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_spotmiscmod" title="spotmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_spotnote" title="spotnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_spotmacro" title="spotmacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Spot](http://www.dandwiki.com/wiki/SRD:Spot_Skill ) check:}} {{checkroll=[[1d20 + [[@{spot}]] ]] }} {{notes=@{spotnote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_spotcheck" title="spotcheck" value="@{spotmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_spotcheck" title="spotcheck" value="@{spotmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_survivalclassskill" title="survivalclassskill" value="1" style="width: 8px;"></td>
@@ -2336,7 +2336,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_survivalmiscmod" title="survivalmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_survivalnote" title="survivalnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_survivalmacro" title="survivalmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Survival](http://www.dandwiki.com/wiki/SRD:Survival_Skill ) check:}} {{checkroll= [[ 1d20 + [[ @{survival} ]] ]] }} {{notes=@{survivalnote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_survivalcheck" title="survivalcheck" value="@{survivalmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_survivalcheck" title="survivalcheck" value="@{survivalmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_swimclassskill" title="swimclassskill" value="1" style="width: 8px;"></td>
@@ -2349,7 +2349,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_swimmiscmod" title="swimmiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_swimnote" title="swimnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_swimmacro" title="swimmacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Swim](http://www.dandwiki.com/wiki/SRD:Swim_Skill ) check:}} {{checkroll= [[ 1d20 + [[ @{swim} ]] ]] }} {{notes=@{swimnote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_swimcheck" title="swimcheck" value="@{swimmacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_swimcheck" title="swimcheck" value="@{swimmacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_tumbleclassskill" title="tumbleclassskill" value="1" style="width: 8px;"></td>
@@ -2362,7 +2362,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_tumblemiscmod" title="tumblemiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_tumblenote" title="tumblenote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_tumblemacro" title="tumblemacro">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Tumble](http://www.dandwiki.com/wiki/SRD:Tumble_Skill ) check:}} {{checkroll= [[ 1d20 + [[ @{tumble} ]] ]] }} {{notes=@{tumblenote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_tumblecheck" title="tumblecheck" value="@{tumblemacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_tumblecheck" title="tumblecheck" value="@{tumblemacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_usemagicdeviceclassskill" title="usemagicdeviceclassskill" value="1" style="width: 8px;"></td>
@@ -2375,7 +2375,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_usemagicdevicemiscmod" title="usemagicdevicemiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_usemagicdevicenote" title="usemagicdevicenote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_usemagicdevicemacro" title="usemagicdevicemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Use Magic Device](http://www.dandwiki.com/wiki/SRD:Use_Magic_Device_Skill ) check:}} {{checkroll=[[1d20 + [[@{usemagicdevice}]] ]] }} {{notes=@{usemagicdevicenote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_usemagicdevicecheck" title="usemagicdevicecheck" value="@{usemagicdevicemacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_usemagicdevicecheck" title="usemagicdevicecheck" value="@{usemagicdevicemacro}" ></button></td>
 							</tr>
 							<tr>
 								<td><input type="checkbox" name="attr_useropeclassskill" title="useropeclassskill" value="1" style="width: 8px;"></td>
@@ -2388,7 +2388,7 @@
 								<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills" name="attr_useropemiscmod" title="useropemiscmod" value="0"></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_useropenote" title="useropenote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 								<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 160px; height: 20px;" name="attr_useropemacro" title="useropemacro">/w gm &{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=[Use Rope](http://www.dandwiki.com/wiki/SRD:Use_Rope_Skill ) check:}} {{checkroll=[[1d20 + [[@{userope}]] ]] }} {{notes=@{useropenote} }}</textarea></td>
-								<td class="sheet-table-data-center-sm"><button type="roll" name="attr_useropecheck" title="useropecheck" value="@{useropemacro}" ></button></td>
+								<td class="sheet-table-data-center-sm"><button type="roll" name="roll_useropecheck" title="useropecheck" value="@{useropemacro}" ></button></td>
 							</tr>
 						</table>
 					</td>
@@ -2435,7 +2435,7 @@
 						<td class="sheet-table-data-center-sm">+<input type="text" class="sheet-table-data-center-skills-rep" name="attr_otherskillmiscmod" title="repeating_skills_#_otherskillmiscmod" value="0" /></td>
 						<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 170px; height: 20px;" name="attr_otherskillnote" title="repeating_skills_#_otherskillnote (Notes for the note field on the default macro)" placeholder="Notes" data-i18n-placeholder="notes" ></textarea></td>
 						<td class="sheet-table-data-center-sm"><textarea rows="1" cols="50" style="width: 190px; height: 20px;" name="attr_otherskillmacro" title="repeating_skills_#_otherskillmacro : modify this macro to modify the skill check roll.">&{template:DnD35StdRoll} {{skillflag=true}} {{name=@{character_name} }} {{check=@{otherskillname} check:}} {{checkroll= [[ 1d20 + [[ @{otherskill} ]] ]] }} {{notes=@{otherskillnote} }}</textarea></td>
-						<td class="sheet-table-data-center-sm"><button type="roll" name="attr_otherskillcheck" title="repeating_skills_#_otherskillcheck" value="@{otherskillmacro}"></button></td>
+						<td class="sheet-table-data-center-sm"><button type="roll" name="roll_otherskillcheck" title="repeating_skills_#_otherskillcheck" value="@{otherskillmacro}"></button></td>
 						</tr>
 					</table>
 				</fieldset>
@@ -2553,7 +2553,7 @@
 											<td>
 											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro01" title="repeating_spells01_#_spellmacro01 : Edit this field to create the macro run by the roll button">&{template:DnD35StdRoll} {{spellflag=true}} {{name=@{character_name} }} {{subtags=casts [Cure Minor Wounds](http://www.dandwiki.com/wiki/Cure_minor_wounds ).}} {{School:= Conj(Healing)}} {{Level:= Cleric 0}} {{Cmpnts:=V,S}} {{Casting Time:=1 std action}} {{Range:= Touch}} {{Target:= Creature touched}} {{Duration:= Instantaneous}} {{Saving Throw:= Will Save(half) when used vs Undead}} {{Spell Resist.:= Undead can use spell resistance}} {{ Caster level check: = [[ 1d20+@{casterlevel}+@{spellpen} ]] vs spell resistance.}} {{compcheck= Conc: [[ {1d20 + [[ @{concentration} ]] }>?{Concentration DC=15+Spell Level or 10+Damage Received|16} ]] }} {{succeedcheck=Success! She casts her spell!}} {{failcheck=She fails :( }} {{notes= ?{Recipient's name|@{character_name}} receives 1 heath (or 1 point of damage if an undead creature) }} </textarea>
 												</td>
-											<td><button type="roll" name="attr_spellcast01" text="Spell Cast01" title="repeating_spells01_#_spellcast01" value="@{spellmacro01}" style="height: 24px; width: 20px;" ></button>
+											<td><button type="roll" name="roll_spellcast01" text="Spell Cast01" title="repeating_spells01_#_spellcast01" value="@{spellmacro01}" style="height: 24px; width: 20px;" ></button>
 											</td>
 										</tr>
 									</table>
@@ -2583,7 +2583,7 @@
 										<td>
 										<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro02" title="repeating_spells02_#_spellmacro02 : Edit this field to create the macro run by the roll button">&{template:DnD35StdRoll} {{spellflag=true}} {{name=@{character_name} }} {{subtags=casts [Mending](http://www.dandwiki.com/wiki/SRD:Mending ).}} {{check=One object within 10 feet of up to 1 lb. is repaired of small breaks or tears.}} {{checkroll=broken metallic objects such as a ring, a chain link, a medallion, or a slender dagger, are welded providing but one break exists. }} {{notes=Ceramic or wooden objects with multiple breaks can be invisibly rejoined to be as strong as new. A hole in a leather sack or a wineskin is completely healed over by mending. The spell can repair a magic item, but the item’s magical abilities are not restored. The spell cannot mend broken magic rods, staffs, or wands, nor does it affect creatures (including constructs). }}</textarea>
 											</td>
-										<td><button type="roll" name="attr_spellcast02" text="Spell Cast02" title="repeating_spells02_#_spellcast02" value="@{spellmacro02}" style="height: 24px; width: 20px;" ></button>
+										<td><button type="roll" name="roll_spellcast02" text="Spell Cast02" title="repeating_spells02_#_spellcast02" value="@{spellmacro02}" style="height: 24px; width: 20px;" ></button>
 										</td>
 									</tr>
 								</table>
@@ -2620,7 +2620,7 @@
 											<td>
 											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro11" title="repeating_spells_#_spellmacro11 : Edit this field to create the macro run by the roll button">&{template:DnD35StdRoll} {{spellflag=true}} {{name= @{character_name} casts Doom on @{target|token_name} }} {{School:=Necromancy (Fear, Mind affecting)}} {{Level: =Cleric 1}} {{Cmpnts:=V, S, DF}} {{Casting Time:= 1 std action}} {{Range:= Medium ( [[ 100+10*@{casterlevel} ]] ft)}} {{Target:= 1 living creature}} {{Duration:= [[ @{casterlevel} ]] min.}} {{Saving Throw:= Will negates (DC= [[ @{spelldc1} ]] ) }} {{Spell Resist.:= Yes }} {{Caster level check: = [[ 1d20+@{casterlevel}+@{spellpen} ]] vs spell resistance.}} {{compcheck= Conc: [[ {1d20 + [[ @{concentration} ]] }>?{Concentration DC=15+Spell Level or 10+Damage Received|16} ]] }} {{succeedcheck=Success! She casts her spell!}} {{failcheck=She fails :( }} {{notes=Target is filled with a feeling of horrible dread that causes it to become shaken (-2 on attack rolls, saves, skill checks, ability checks).}} </textarea>
 												</td>
-											<td><button type="roll" name="attr_spellcast11" text="Spell Cast11" title="repeating_spells_#_spellcast11" value="@{spellmacro11}" style="height: 24px; width: 20px;" ></button>
+											<td><button type="roll" name="roll_spellcast11" text="Spell Cast11" title="repeating_spells_#_spellcast11" value="@{spellmacro11}" style="height: 24px; width: 20px;" ></button>
 											</td>
 										</tr>
 									</table>
@@ -2650,7 +2650,7 @@
 										<td>
 										<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro12" title="repeating_spells12_#_spellmacro12 : Edit this field to create the macro run by the roll button">&{template:DnD35StdRoll} {{spellflag=true}} {{name=@{character_name} }} {{subtags=casts [Magic Missile!](http://www.dandwiki.com/wiki/SRD:Magic_Missile ).}} {{School:= Evo (Force)}} {{Level:= Sor/Wiz 1}} {{Cmpnts:=V,S}} {{Casting Time:=1 std action}} {{Range:= Medium ( [[ 100+10*@{casterlevel2} ]] ft)}} {{Target:= Up to five creatures, no two of which can be more than 15 ft. apart }} {{Duration:= Instantaneous}} {{Saving Throw:= None}} {{Spell Resist.:= Yes}} {{Caster level check: = [[ 1d20+@{casterlevel2}+@{spellpen} ]] vs spell resistance.}} {{compcheck= Conc: [[ {1d20 + [[ @{concentration} ]] }>?{Concentration DC=15+Spell Level or 10+Damage Received|16} ]] }} {{succeedcheck=Success! She casts her spell!}} {{failcheck=She fails :( }} {{check= [[ {(d1*((@{casterlevel2}-1-((@{casterlevel2}-1)%2))/2)+1),d1*5}dh1} ]] missiles fly from the caster’s fingers,}} {{checkroll=hitting for [[ 1d4+1 ]] | [[ 1d4+1 ]] | [[ 1d4+1 ]] | [[ 1d4+1 ]] | [[ 1d4+1 ]] force damage.}} {{notes= The missile strikes unerringly, even if the target is in melee combat or has less than total cover or total concealment. Specific parts of a creature can’t be singled out. Inanimate objects are not damaged by the spell. If you shoot multiple missiles, you can have them strike a single creature or several creatures. A single missile can strike only one creature. You must designate targets before you check for spell resistance or roll damage. }}</textarea>
 											</td>
-										<td><button type="roll" name="attr_spellcast12" text="Spell Cast12" title="repeating_spells12_#_spellcast12" value="@{spellmacro12}" style="height: 24px; width: 20px;" ></button>
+										<td><button type="roll" name="roll_spellcast12" text="Spell Cast12" title="repeating_spells12_#_spellcast12" value="@{spellmacro12}" style="height: 24px; width: 20px;" ></button>
 										</td>
 									</tr>
 								</table>
@@ -2687,7 +2687,7 @@
 											<td>
 											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro21" title="repeating_spells21_#_spellmacro21 : Edit this field to create the macro run by the roll button">&{template:DnD35StdRoll} {{spellflag=true}} {{name=@{character_name} }} {{subtags=casts [Cure Moderate Wounds](http://www.dandwiki.com/wiki/SRD:Cure_Moderate_Wounds ).}} {{School:= Conj(Healing)}} {{Level:= Blg 2, Brd 2, Clr 2, Drd 3, Healing 2, Pal 3, Rgr 3 }} {{Cmpnts:=V,S}} {{Casting Time:=1 std action}} {{Range:= Touch}} {{Target:= Creature touched}} {{Duration:= Instantaneous}} {{Saving Throw:= Will Save(half) when used vs Undead}} {{Spell Resist.:= Undead can use spell resistance}} {{Caster level check: = [[ 1d20+@{casterlevel}+@{spellpen} ]] vs spell resistance.}} {{compcheck= Conc: [[ {1d20 + [[ @{concentration} ]] }>?{Concentration DC=15+Spell Level or 10+Damage Received|17} ]] }} {{succeedcheck=Success! She casts her spell!}} {{failcheck=She fails :( }} {{check=@{target|token_name} receives }} {{checkroll= [[ 2d8+{@{casterlevel},10}dh1 ]] heath. }} {{notes=Undead creatures take damage instead of gaining healing. }}</textarea>
 												</td>
-											<td><button type="roll" name="attr_spellcast21" text="Spell Cast21" title="repeating_spells21_#_spellcast21" value="@{spellmacro21}" style="height: 24px; width: 20px;" ></button>
+											<td><button type="roll" name="roll_spellcast21" text="Spell Cast21" title="repeating_spells21_#_spellcast21" value="@{spellmacro21}" style="height: 24px; width: 20px;" ></button>
 											</td>
 										</tr>
 									</table>
@@ -2717,7 +2717,7 @@
 											<td>
 											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro22" title="repeating_spells22_#_spellmacro22 : Edit this field to create the macro run by the roll button">&{template:DnD35StdRoll} {{spellflag=true}} {{name=@{character_name} }} {{subtags= grants ?{target|@{character_name}} [Bear's Endurance](http://www.dandwiki.com/wiki/SRD:Bear%27s_Endurance )!}} {{School:= Transmutation}} {{Level:= Clr 2, Drd 2, Rgr 2, Sor/Wiz 2}} {{Cmpnts:=V, S, DF}} {{Casting Time:=1 std action}} {{Range:= Touch}} {{Target:= 1 creature touched }} {{Duration:= @{casterlevel2} mins.}} {{Saving Throw:= Will negates(harmless)}} {{Spell Resist.:= Yes}} {{Caster level check: = [[ 1d20+@{casterlevel2}+@{spellpen} ]] vs spell resistance.}} {{compcheck= Conc: [[ {1d20 + [[ @{concentration} ]] }>?{Concentration DC=15+Spell Level or 10+Damage Received|16} ]] }} {{succeedcheck=Success! She casts her spell!}} {{failcheck=She fails :( }} {{check= ?{target|@{character_name}} gains greater vitality and stamina, }} {{checkroll= receiving a +4 enh bonus to Constitution with the usual benefits to hit points(these temp hit points go away when spell ends), fortitude saves, constitution checks, etc. }}</textarea>
 												</td>
-											<td><button type="roll" name="attr_spellcast22" text="Spell Cast22" title="repeating_spells22_#_spellcast22" value="@{spellmacro22}" style="height: 24px; width: 20px;" ></button>
+											<td><button type="roll" name="roll_spellcast22" text="Spell Cast22" title="repeating_spells22_#_spellcast22" value="@{spellmacro22}" style="height: 24px; width: 20px;" ></button>
 											</td>
 										</tr>
 									</table>
@@ -2754,7 +2754,7 @@
 											<td>
 											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro31" title="repeating_spells31_#_spellmacro31 : Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
-											<td><button type="roll" name="attr_spellcast31" text="Spell Cast31" title="repeating_spells31_#_spellcast31" value="@{spellmacro31}" style="height: 24px; width: 20px;" ></button>
+											<td><button type="roll" name="roll_spellcast31" text="Spell Cast31" title="repeating_spells31_#_spellcast31" value="@{spellmacro31}" style="height: 24px; width: 20px;" ></button>
 											</td>
 										</tr>
 									</table>
@@ -2784,7 +2784,7 @@
 											<td>
 											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro32" title="repeating_spells32_#_spellmacro32 : Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
-											<td><button type="roll" name="attr_spellcast32" text="Spell Cast32" title="repeating_spells32_#_spellcast32" value="@{spellmacro32}" style="height: 24px; width: 20px;" ></button>
+											<td><button type="roll" name="roll_spellcast32" text="Spell Cast32" title="repeating_spells32_#_spellcast32" value="@{spellmacro32}" style="height: 24px; width: 20px;" ></button>
 											</td>
 										</tr>
 									</table>
@@ -2821,7 +2821,7 @@
 											<td>
 											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro41" title="repeating_spells41_#_spellmacro41 : Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
-											<td><button type="roll" name="attr_spellcast41" text="Spell Cast41" title="repeating_spells41_#_spellcast41" value="@{spellmacro41}" style="height: 24px; width: 20px;" ></button>
+											<td><button type="roll" name="roll_spellcast41" text="Spell Cast41" title="repeating_spells41_#_spellcast41" value="@{spellmacro41}" style="height: 24px; width: 20px;" ></button>
 											</td>
 										</tr>
 									</table>
@@ -2851,7 +2851,7 @@
 											<td>
 											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro42" title="repeating_spells42_#_spellmacro42 : Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
-											<td><button type="roll" name="attr_spellcast42" text="Spell Cast42" title="repeating_spells42_#_spellcast42" value="@{spellmacro42}" style="height: 24px; width: 20px;" ></button>
+											<td><button type="roll" name="roll_spellcast42" text="Spell Cast42" title="repeating_spells42_#_spellcast42" value="@{spellmacro42}" style="height: 24px; width: 20px;" ></button>
 											</td>
 										</tr>
 									</table>
@@ -2888,7 +2888,7 @@
 											<td>
 											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro51" title="repeating_spells51_#_spellmacro51 : Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
-											<td><button type="roll" name="attr_spellcast51" text="Spell Cast51" title="repeating_spells51_#_spellcast51" value="@{spellmacro51}" style="height: 24px; width: 20px;" ></button>
+											<td><button type="roll" name="roll_spellcast51" text="Spell Cast51" title="repeating_spells51_#_spellcast51" value="@{spellmacro51}" style="height: 24px; width: 20px;" ></button>
 											</td>
 										</tr>
 									</table>
@@ -2918,7 +2918,7 @@
 											<td>
 											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro52" title="repeating_spells52_#_spellmacro52 : Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
-											<td><button type="roll" name="attr_spellcast52" text="Spell Cast52" title="repeating_spells52_#_spellcast52" value="@{spellmacro52}" style="height: 24px; width: 20px;" ></button>
+											<td><button type="roll" name="roll_spellcast52" text="Spell Cast52" title="repeating_spells52_#_spellcast52" value="@{spellmacro52}" style="height: 24px; width: 20px;" ></button>
 											</td>
 										</tr>
 									</table>
@@ -2955,7 +2955,7 @@
 											<td>
 											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro61" title="repeating_spells61_#_spellmacro61 : Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
-											<td><button type="roll" name="attr_spellcast61" text="Spell Cast61" title="repeating_spells61_#_spellcast61" value="@{spellmacro61}" style="height: 24px; width: 20px;" ></button>
+											<td><button type="roll" name="roll_spellcast61" text="Spell Cast61" title="repeating_spells61_#_spellcast61" value="@{spellmacro61}" style="height: 24px; width: 20px;" ></button>
 											</td>
 										</tr>
 									</table>
@@ -2985,7 +2985,7 @@
 											<td>
 											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro62" title="repeating_spells62_#_spellmacro62 : Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
-											<td><button type="roll" name="attr_spellcast62" text="Spell Cast62" title="repeating_spells62_#_spellcast62" value="@{spellmacro62}" style="height: 24px; width: 20px;" ></button>
+											<td><button type="roll" name="roll_spellcast62" text="Spell Cast62" title="repeating_spells62_#_spellcast62" value="@{spellmacro62}" style="height: 24px; width: 20px;" ></button>
 											</td>
 										</tr>
 									</table>
@@ -3021,7 +3021,7 @@
 											<td>
 											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro71" title="repeating_spells71_#_spellmacro71 : Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
-											<td><button type="roll" name="attr_spellcast71" text="Spell Cast71" title="repeating_spells71_#_spellcast71" value="@{spellmacro71}" style="height: 24px; width: 20px;" ></button>
+											<td><button type="roll" name="roll_spellcast71" text="Spell Cast71" title="repeating_spells71_#_spellcast71" value="@{spellmacro71}" style="height: 24px; width: 20px;" ></button>
 											</td>
 										</tr>
 									</table>
@@ -3051,7 +3051,7 @@
 											<td>
 											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro72" title="repeating_spells72_#_spellmacro72 : Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
-											<td><button type="roll" name="attr_spellcast72" text="Spell Cast72" title="repeating_spells72_#_spellcast72" value="@{spellmacro72}" style="height: 24px; width: 20px;" ></button>
+											<td><button type="roll" name="roll_spellcast72" text="Spell Cast72" title="repeating_spells72_#_spellcast72" value="@{spellmacro72}" style="height: 24px; width: 20px;" ></button>
 											</td>
 										</tr>
 									</table>
@@ -3087,7 +3087,7 @@
 											<td>
 											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro81" title="repeating_spells81_#_spellmacro81 : Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
-											<td><button type="roll" name="attr_spellcast81" text="Spell Cast81" title="repeating_spells81_#_spellcast81" value="@{spellmacro81}" style="height: 24px; width: 20px;" ></button>
+											<td><button type="roll" name="roll_spellcast81" text="Spell Cast81" title="repeating_spells81_#_spellcast81" value="@{spellmacro81}" style="height: 24px; width: 20px;" ></button>
 											</td>
 										</tr>
 									</table>
@@ -3117,7 +3117,7 @@
 											<td>
 											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro82" title="repeating_spells82_#_spellmacro82 : Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
-											<td><button type="roll" name="attr_spellcast82" text="Spell Cast82" title="repeating_spells82_#_spellcast82" value="@{spellmacro82}" style="height: 24px; width: 20px;" ></button>
+											<td><button type="roll" name="roll_spellcast82" text="Spell Cast82" title="repeating_spells82_#_spellcast82" value="@{spellmacro82}" style="height: 24px; width: 20px;" ></button>
 											</td>
 										</tr>
 									</table>
@@ -3153,7 +3153,7 @@
 											<td>
 											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro91" title="repeating_spells91_#_spellmacro91 : Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
-											<td><button type="roll" name="attr_spellcast91" text="Spell Cast91" title="repeating_spells91_#_spellcast91" value="@{spellmacro91}" style="height: 24px; width: 20px;" ></button>
+											<td><button type="roll" name="roll_spellcast91" text="Spell Cast91" title="repeating_spells91_#_spellcast91" value="@{spellmacro91}" style="height: 24px; width: 20px;" ></button>
 											</td>
 										</tr>
 									</table>
@@ -3183,7 +3183,7 @@
 											<td>
 											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro92" title="repeating_spells92_#_spellmacro92 : Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
-											<td><button type="roll" name="attr_spellcast92" text="Spell Cast92" title="repeating_spells92_#_spellcast92" value="@{spellmacro92}" style="height: 24px; width: 20px;" ></button>
+											<td><button type="roll" name="roll_spellcast92" text="Spell Cast92" title="repeating_spells92_#_spellcast92" value="@{spellmacro92}" style="height: 24px; width: 20px;" ></button>
 											</td>
 										</tr>
 									</table>
@@ -3219,7 +3219,7 @@
 											<td>
 											<textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro101" title="repeating_spells101_#_spellmacro101 : Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
-											<td><button type="roll" name="attr_spellcast101" text="Spell Cast101" title="repeating_spells101_#_spellcast101" value="@{spellmacro101}" style="height: 24px; width: 20px;" ></button>
+											<td><button type="roll" name="roll_spellcast101" text="Spell Cast101" title="repeating_spells101_#_spellcast101" value="@{spellmacro101}" style="height: 24px; width: 20px;" ></button>
 											</td>
 										</tr>
 									</table>
@@ -3248,7 +3248,7 @@
 											<td style="width: 20px;"><input type="text" name="attr_spelllevel102" title="repeating_spells102_#_spelllevel102" value="*" ></td>
 											<td><textarea input class="sheet-inputbox" rows="1" cols="55" style="height: 20px; width: 150px;" name="attr_spellmacro102" title="repeating_spells102_#_spellmacro102 : Edit this field to create the macro run by the roll button" placeholder="spell macro goes here"></textarea>
 												</td>
-											<td><button type="roll" name="attr_spellcast102" text="Spell Cast102" title="repeating_spells102_#_spellcast102" value="@{spellmacro102}" style="height: 24px; width: 20px;" ></button>
+											<td><button type="roll" name="roll_spellcast102" text="Spell Cast102" title="repeating_spells102_#_spellcast102" value="@{spellmacro102}" style="height: 24px; width: 20px;" ></button>
 											</td>
 										</tr>
 									</table>
@@ -3423,11 +3423,11 @@
 										</div>
 										<div class="sheet-table-row">
 											<span class="sheet-table-col">Att<textarea input class="sheet-inputbox" rows="1" cols="55" style="width: 750px;" name="attr_summonattack" title="repeating_summons1_#_summonattack" placeholder="Attack"></textarea>
-											<button type="roll" name="attr_summonattackbutton" title="summonattackbutton" placeholder="@{summonattack}" style="height: 24px; width: 20px;" ></button></span>
+											<button type="roll" name="roll_summonattackbutton" title="summonattackbutton" placeholder="@{summonattack}" style="height: 24px; width: 20px;" ></button></span>
 										</div>
 										<div class="sheet-table-row">
 											<span class="sheet-table-col">FAtt<textarea input class="sheet-inputbox" rows="1" cols="55" style="width: 745px;" name="attr_summonfullattack" title="repeating_summons1_#_summonfullattack" placeholder="Full Attack"></textarea>
-											<button type="roll" name="attr_summonfullattackbutton" title="summonfullattackbutton" placeholder="@{summonfullattack}" style="height: 24px; width: 20px;" ></button></span>
+											<button type="roll" name="roll_summonfullattackbutton" title="summonfullattackbutton" placeholder="@{summonfullattack}" style="height: 24px; width: 20px;" ></button></span>
 										</div>
 										<div class="sheet-table-row">
 											<span class="sheet-table-col">Space/Reach:<input style="width: 40px;" type="text" name="attr_summonspace" title="repeating_summons1_#_summonspace" placeholder="Space">/<input style="width: 40px;" type="text" name="attr_summonreach" title="repeating_summons1_#_summonreach" placeholder="Reach"> &nbsp; &nbsp;</span>
@@ -3499,7 +3499,7 @@
 		</tr>
 		<tr>
 			<td class="sheet-table-header-right"><span data-i18n="initiative">Initiative</span>:</td>
-			<td class="sheet-table-left"><input style="width: 40px;" type="text" name="attr_npcinit" title="npcinit" value="0"> <textarea rows="1" cols="40" style="width: 565px; height: 20px;" title="npcinitmacro (modify to modify npc's initiative roll macro)" name="attr_npcinitmacro">/w gm &{template:DnD35Initiative} {{name=@{selected|token_name} }} {{check=Initiative:}} {{checkroll= [[ 1d20 + [[ @{selected|npcinit} ]] + ( [[ (@{selected|npcinit}) ]] /100) &{tracker} ]] }}</textarea><button type="roll" name="attr_npcinitiative" title="npcinitiative" value="@{npcinitmacro}"></button></td>
+			<td class="sheet-table-left"><input style="width: 40px;" type="text" name="attr_npcinit" title="npcinit" value="0"> <textarea rows="1" cols="40" style="width: 565px; height: 20px;" title="npcinitmacro (modify to modify npc's initiative roll macro)" name="attr_npcinitmacro">/w gm &{template:DnD35Initiative} {{name=@{selected|token_name} }} {{check=Initiative:}} {{checkroll= [[ 1d20 + [[ @{selected|npcinit} ]] + ( [[ (@{selected|npcinit}) ]] /100) &{tracker} ]] }}</textarea><button type="roll" name="roll_npcinitiative" title="npcinitiative" value="@{npcinitmacro}"></button></td>
 		</tr>
 		<tr>
 			<td class="sheet-table-header-right"><span data-i18n="speed">Speed</span>:</td>
@@ -3519,7 +3519,7 @@
 		</tr>
 		<tr>
 			<td class="sheet-table-header-right"> &nbsp; </td>
-			<td class="sheet-table-left"><textarea input class="sheet-inputbox" rows="1" cols="55" style="width: 615px;" name="attr_npcattackmacro" title="npcattackmacro" placeholder="Attack Macro" data-i18n-placeholder="attack-macro"></textarea><button type="roll" name="attr_npcattackbutton" title="npcattackbutton" value="@{npcattackmacro}" style="height: 24px; width: 20px;" ></button></td>
+			<td class="sheet-table-left"><textarea input class="sheet-inputbox" rows="1" cols="55" style="width: 615px;" name="attr_npcattackmacro" title="npcattackmacro" placeholder="Attack Macro" data-i18n-placeholder="attack-macro"></textarea><button type="roll" name="roll_npcattackbutton" title="npcattackbutton" value="@{npcattackmacro}" style="height: 24px; width: 20px;" ></button></td>
 		</tr>
 		<tr>
 			<td class="sheet-table-header-right"><span data-i18n="full-attack">Full Attack</span>:</td>
@@ -3527,7 +3527,7 @@
 		</tr>
 		<tr>
 			<td class="sheet-table-header-right"> &nbsp; </td>
-			<td class="sheet-table-left"><textarea input class="sheet-inputbox" rows="1" cols="55" style="width: 615px;" name="attr_npcfullattackmacro" title="npcfullattackmacro" placeholder="Full Attack Macro" data-i18n-placeholder="full-attack-macro"></textarea><button type="roll" name="attr_npcfullattackbutton" title="npcfullattackbutton" value="@{npcfullattackmacro}" style="height: 24px; width: 20px;" ></button></td>
+			<td class="sheet-table-left"><textarea input class="sheet-inputbox" rows="1" cols="55" style="width: 615px;" name="attr_npcfullattackmacro" title="npcfullattackmacro" placeholder="Full Attack Macro" data-i18n-placeholder="full-attack-macro"></textarea><button type="roll" name="roll_npcfullattackbutton" title="npcfullattackbutton" value="@{npcfullattackmacro}" style="height: 24px; width: 20px;" ></button></td>
 		</tr>
 		<tr>
 			<td class="sheet-table-header-right"><span data-i18n="space">Space</span>/<span data-i18n="reach">Reach</span>:</td>
@@ -3642,7 +3642,7 @@
 					</table>
 				</div> </span>
 				<span class="sheet-table-header-right" style="width: 117px;"> Example macro: </span><textarea input class="sheet-inputbox" rows="6" cols="55" style="height: 80px; width: 296px;" name="attr_exampleattack" title="exampleattack" >&{template:DnD35Attack} {{name=@{character_name}}} {{subtags=swings a @{weapon1name} }} {{pcflag=true}} {{attack1=A1: [[ @{weapon1attackcalc} ]] }} {{critconfirm1=Crit!: [[ @{weapon1attackcalc} ]] }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=D1: [[ @{weapon1damage} ]] }} {{critdmg1=+ [[ @{weapon1crit} ]] }} {{fullattackflag= [[?{Full Attack?|No, 0d1|Yes, d1} ]] }} {{attack2=A2: [[ @{weapon1attackcalc}-5 ]] }} {{critconfirm2=Crit!: [[ @{weapon1attackcalc}-5 ]] }} {{damage2=D2: [[ @{weapon1damage} ]] }} {{critdmg2=+ [[ @{weapon1crit} ]] }} {{attack3=A3: [[ @{weapon1attackcalc}-10 ]] }} {{critconfirm3=Crit!: [[ @{weapon1attackcalc}-10 ]] }} {{damage3=D3: [[ @{weapon1damage} ]] }} {{critdmg3=+ [[ @{weapon1crit} ]] }} {{attack4=A4: [[ @{weapon1attackcalc}-15 ]] }} {{critconfirm4=Crit!: [[ @{weapon1attackcalc}-15 ]] }} {{damage4=D4: [[ @{weapon1damage} ]] }} {{critdmg4=+ [[ @{weapon1crit} ]] }}</textarea>
-					<button type="roll" name="attr_exampleattackroll" title="exampleattackroll" value="@{exampleattack}"></button>
+					<button type="roll" name="roll_exampleattackroll" title="exampleattackroll" value="@{exampleattack}"></button>
 					<br> The pcflag sets the name and dividing line to be red. For this flag, the arrow in the dividing line points to the right.
 			</div>
 			<br>	
@@ -3664,7 +3664,7 @@
 					</table>
 				</div></span>
 				<span class="sheet-table-header-right" style="width: 117px;"> Example macro: </span><textarea input class="sheet-inputbox" rows="6" cols="55" style="height: 80px; width: 296px;" name="attr_examplenpcattack" title="examplenpcattack" >/w gm &{template:DnD35Attack} {{name=@{selected|token_name}}} {{subtags=attacks @{target|token_name} }} {{npcflag=true}} {{fullattackflag= [[ d1 ]] }} {{attack1=A1 (?{attack 1 name| claw} ): [[ {d20cs>?{attack 1 crit range?|20}+?{attack 1 bonus|0}}>@{target|bar2} ]] hit; }} {{critconfirm1=Crit!: [[ {d20+?{attack 1 bonus|0}}>@{target|bar2} ]] hit }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage1=D1:?{attack 1 damage?| [[ 1d6+6 ]] } }} {{critdmg1=+?{attack 1 addt'l crit damage?| [[ 1d6+6 ]] } crit dmg }} {{attack2=A2 (?{attack 2 name| claw} ): [[ {d20cs>?{attack 2 crit range?|20}+?{attack 2 bonus|0}}>@{target|bar2} ]] hit; }} {{critconfirm2=Crit!: [[ {d20+?{attack 2 bonus|0}}>@{target|bar2} ]] hit }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage2=D2:?{damage 2?| [[ 1d6+6 ]] } }} {{critdmg2=+?{addt'l crit damage 2?| [[ 1d6+6 ]] } crit dmg }} {{attack3=A3 (?{attack 3 name| bite} ): [[ {d20cs>?{attack 3 crit range?|20}+?{attack 3 bonus|0}}>@{target|bar2} ]] hit; }} {{critconfirm3=Crit!: [[ {d20+?{attack 3 bonus|0}}>@{target|bar2} ]] hit }} {{fumbleroll=Fumble: [[ d20 ]] }} {{damage3=D3:?{damage 3?| [[ 1d8+3 ]] phys + [[ 1d6 ]] acid} }} {{critdmg3=+?{addt'l crit damage 3?| [[ 1d6 ]] } crit dmg }} {{notes= Note: if it hits with both claws, it latches on and tears the flesh, automatically doing an additional [[ 2d6+12 ]]damage}} </textarea>
-					<button type="roll" name="attr_examplenpcattackroll" title="examplenpcattackroll" value="@{examplenpcattack}"></button>
+					<button type="roll" name="roll_examplenpcattackroll" title="examplenpcattackroll" value="@{examplenpcattack}"></button>
 					<br> The npcflag sets the name and dividing line to be red. For this flag, the arrow in the dividing line points to the left.
 					<br> Example of DnD35Attack with {{npcflag=true}} set.  This example has the fullattackflag set to d1 so it will always show the attacks. Also set to whisper to the gm for the NPC's attacks. This example compares against an AC value stored in bar2 to report success (1 hit) or failure (0 hit) of the attack.
 			</div>
@@ -3680,7 +3680,7 @@
 					</table>
 				</div></span>
 				<span class="sheet-table-header-right" style="width: 117px;"> Example macro: </span><textarea input class="sheet-inputbox" rows="6" cols="55" style="height: 80px; width: 296px;" name="attr_exampleinit" title="exampleinit" >&{template:DnD35Initiative} {{name=@{character_name} }} {{check=Initiative:}} {{checkroll= [[ 1d20 + [[ @{selected|init} ]] + ( [[ (@{selected|init}) ]] /100) &{tracker} ]] }}</textarea>
-					<button type="roll" name="attr_exampleinitroll" title="exampleinitroll" value="@{exampleinit}"></button>
+					<button type="roll" name="roll_exampleinitroll" title="exampleinitroll" value="@{exampleinit}"></button>
 					<br> The initflag used with DnD35StdRoll or DnD35Attack sets the name this same yellow and adds a thin solid yellow dividing line.
 			</div>
 			<br>
@@ -3710,7 +3710,7 @@
 					</table>
 				</div> </span>
 				<span class="sheet-table-header-right" style="width: 117px;"> Example macro: </span><textarea input class="sheet-inputbox" rows="6" cols="55" style="height: 80px; width: 296px;" name="attr_examplespell" title="examplespell" >&{template:DnD35StdRoll} {{spellflag=true}} {{name= @{character_name} casts Doom on @{target|token_name} }} {{School:=Necromancy (Fear, Mind affecting)}} {{Level: =Cleric 1}} {{Comp'nts:=V, S, DF}} {{Casting Time:= 1 std action}} {{Range:= Medium ( [[ 100+10*@{casterlevel} ]] ft)}} {{Target:= 1 living creature}} {{Duration:= [[ @{casterlevel} ]] min.}} {{Saving Throw:= Will negates (DC= [[ @{spelldc1} ]] ) }} {{Spell Resist.:= Yes }} {{ Caster level check: = [[ 1d20+@{casterlevel2}+@{spellpen} ]] vs spell resistance.}} {{compcheck= Conc: [[ {1d20 + [[ @{concentration} ]] }>?{Concentration DC=15+Spell Level or 10+Damage Received|16} ]] }} {{succeedcheck=Success! She casts her spell!}} {{failcheck=She fails :( }} {{notes=Target is filled with a feeling of horrible dread that causes it to become shaken (-2 on attack rolls, saves, skill checks, ability checks).}} </textarea>
-					<button type="roll" name="attr_examplespellroll" title="examplespellroll" value="@{examplespell}"></button>
+					<button type="roll" name="roll_examplespellroll" title="examplespellroll" value="@{examplespell}"></button>
 					<br> The spellflag sets the dividing line to be a blue 4-pointed star pattern and the name to be blue.
 			</div>
 			<br>
@@ -3733,7 +3733,7 @@
 					</table>
 				</div> </span>
 				<span class="sheet-table-header-right" style="width: 117px;"> Example macro: </span><textarea input class="sheet-inputbox" rows="6" cols="55" style="height: 80px; width: 296px;" name="attr_exampleability" title="exampleability" >&{template:DnD35StdRoll} {{name=@{character_name} }} {{abilityflag=true}} {{check=Strength check:}} {{checkroll= [[ 1d20 + [[ @{str-mod} ]] ]] }}"</textarea>
-					<button type="roll" name="attr_exampleabilityroll" title="exampleabilityroll" value="@{exampleability}"></button>
+					<button type="roll" name="roll_exampleabilityroll" title="exampleabilityroll" value="@{exampleability}"></button>
 					<br> The abilityflag sets the name and dividing line brown.
 			</div>
 			<br>
@@ -3756,7 +3756,7 @@
 					</table>
 				</div> </span>
 				<span class="sheet-table-header-right" style="width: 117px;"> Example macro: </span><textarea input class="sheet-inputbox" rows="6" cols="55" style="height: 80px; width: 296px;" name="attr_examplesave" title="examplesave" >&{template:DnD35StdRoll} {{name=@{character_name} }} {{saveflag=true}} {{subtags=braces against the attack}} {{check=Fortitude check:}} {{checkroll= [[ 1d20 + [[ @{fortitude} ]] ]] }}</textarea>
-					<button type="roll" name="attr_examplesaveroll" title="examplesaveroll" value="@{examplesave}"></button>
+					<button type="roll" name="roll_examplesaveroll" title="examplesaveroll" value="@{examplesave}"></button>
 					<br> The saveflag sets the name and thick dividing line to be purple.
 			</div>
 				<br>
@@ -3779,7 +3779,7 @@
 					</table>
 				</div> </span>
 				<span class="sheet-table-header-right" style="width: 117px;"> Example macro: </span><textarea input class="sheet-inputbox" rows="6" cols="55" style="height: 80px; width: 296px;" name="attr_exampleskill" title="exampleskill" >&{template:DnD35StdRoll} {{name=@{character_name} }} {{skillflag=true}} {{check=Appraise check:}} {{checkroll= [[ 1d20 + [[ @{appraise} ]] ]] }}</textarea>
-					<button type="roll" name="attr_exampleskillroll" title="exampleskillroll" value="@{exampleskill}"></button>
+					<button type="roll" name="roll_exampleskillroll" title="exampleskillroll" value="@{exampleskill}"></button>
 					<br> The skillflag sets the name and double-arrow dividing line a darkish green.
 			</div>
 			<br>
@@ -3802,7 +3802,7 @@
 					</table>
 				</div> </span>
 				<span class="sheet-table-header-right" style="width: 117px;"> Example macro: </span><textarea input class="sheet-inputbox" rows="6" cols="55" style="height: 80px; width: 296px;" name="attr_exampleskillcat" title="exampleskillcat" >&{template:DnD35StdRoll} {{name=@{character_name} }} {{skillcatflag=true}} {{check=Appraise check:}} {{checkroll= [[ 1d20 + [[ @{appraise} ]] ]] }}</textarea>
-					<button type="roll" name="attr_exampleskillcatroll" title="exampleskillcatroll" value="@{exampleskillcat}"></button>
+					<button type="roll" name="roll_exampleskillcatroll" title="exampleskillcatroll" value="@{exampleskillcat}"></button>
 					<br> The skillcatflag sets the dividing line to be an upward pointed arrow and both it and the name a teal color.
 			</div>
 			<br>
@@ -3824,7 +3824,7 @@
 					</table>
 				</div> </span>
 				<span class="sheet-table-header-right" style="width: 117px;"> Example macro: </span><textarea input class="sheet-inputbox" rows="6" cols="55" style="height: 80px; width: 296px;" name="attr_examplebasic" title="examplebasic" >&{template:DnD35StdRoll} {{basicflag=true}} {{name=Test Roll}} {{subtags=swinging violently}} {{subtags2=at the kitchen sink.}} {{attack= [[ 1d20 ]] }} {{damage= [[ 1d8 ]] }} {{note= This is some note content}} {{Saving throw= [[ @{will} ]] Will save}} {{Attack1: [[ d20cs>10+5 ]] *crit on 10+=Damage1: [[ d6+2 ]] }} {{Confirm: [[ d20+5 ]] =+ [[ d6+2 ]] ad'l dmg }} {{Attack2: [[ d20+5 ]] =Damage2: [[ d6+2 ]] }} {{Attack3: [[ d20+5 ]] =Damage3: [[ d6+2 ]] }} {{compcheck= Conc: [[ {1d20 + [[ @{concentration} ]] }>?{Concentration DC=15+Spell Level or 10+Damage Received|16} ]] }} {{succeedcheck=Success! The spell is cast!}} {{failcheck=Failure. :( }} {{notes=Additional notes under the notes tag will be at the bottom.}} </textarea>
-					<button type="roll" name="attr_examplebasicroll" title="examplebasicroll" value="@{examplebasic}"></button>
+					<button type="roll" name="roll_examplebasicroll" title="examplebasicroll" value="@{examplebasic}"></button>
 					<br> This basic grey and white appearance can be used with the various templates by setting {{basicflag=true}} . There is no dividing line with this appearance flag.
 			</div>
 		</td></tr>
@@ -4041,7 +4041,7 @@
 
 </div>
 <br>
-<p style="font-size: 0.8em;">D&D3.5e Character Sheet v2.<span name="attr_sheetversion" title="sheetversion" ></span> 09/09/16 by Diana P.</p>
+<p style="font-size: 0.8em;">D&D3.5e Character Sheet v2.<span name="attr_sheetversion" title="sheetversion" ></span> 01/07/19 by Diana P.</p>
 <p style="font-size: 0.8em;">Repeating section calculations with sheetworkers done using TheAaronSheet :: <a href="https://github.com/shdwjk/TheAaronSheet">https://github.com/shdwjk/TheAaronSheet</a></p>
 
 


### PR DESCRIPTION
Roll buttons were set as attributes not rolls, this fixes that.

## Changes / Comments

Changed all name="attr_xxx" to name="roll_xxx" for type ="roll" elements, fixing functionality for ability command buttons.  Fixes bug listed: https://app.roll20.net/forum/post/7100546/dnd-3-dot-5-diana-p-character-sheet-issue-with-ability-command-buttons/?pageforid=7100615#post-7100615 




## Roll20 Requests

*Include the name of the sheet you made changes to in the title.*

- If changes fix a bug or resolves a feature request, be sure to link to that issue. 
- For pull request that change multiple sheets please confirm these changes are intentional for all sheets. This will help us catch unintended submissions.
- When updating existing sheets if you are changing attribute names please note what steps you have taken, if any, to assist players in keeping their data.