### PR TITLE
Changed fallback font on d20 modern sheet to use serif

### DIFF
--- a/d20 Modern/d20 Modern.css
+++ b/d20 Modern/d20 Modern.css
@@ -9,7 +9,7 @@
     margin-bottom:0px;
     font-size:0.9em;
     height:2.2em;
-    font-family: Copperplate, 'Copperplate Gothic Light', fantasy;
+    font-family: Copperplate, 'Copperplate Gothic Light', serif;
 }
 .charsheet .repcontrol_edit
 {
@@ -22,7 +22,7 @@
     margin-bottom:5px;
     font-size:0.9em;
     height:2.2em;
-    font-family: Copperplate, 'Copperplate Gothic Light', fantasy;
+    font-family: Copperplate, 'Copperplate Gothic Light', serif;
 }
 .charsheet .repcontrol_del {
     background:red;
@@ -101,7 +101,7 @@ div.sheet-core-content {
     background-repeat: no-repeat;
 	color: #7F2108; 
 	font-weight: bold;
-    font-family: Copperplate, 'Copperplate Gothic Light', fantasy;
+    font-family: Copperplate, 'Copperplate Gothic Light', serif;
 	border-radius: 4px;
     border: 2px solid #7F2108;
 	
@@ -133,14 +133,14 @@ div.sheet-core-content {
 .sheet-tableI {
     margin-left:auto;
     margin-right:auto;
-    font-family: Copperplate, 'Copperplate Gothic Light', fantasy;
+    font-family: Copperplate, 'Copperplate Gothic Light', serif;
 }
 .sheet-tableI th {
     font-size:8px;
     vertical-align:super;
 }
 .sheet-font {
-    font-family: Copperplate, 'Copperplate Gothic Light', fantasy;
+    font-family: Copperplate, 'Copperplate Gothic Light', serif;
     font-weight:normal;
     }
 .sheet-tableII th {
@@ -179,7 +179,7 @@ input.sheet-text[type="text"]:focus {
     border-radius:0px;
     box-shadow:none;
     font-size:1.8em;
-    font-family: Copperplate, 'Copperplate Gothic Light', fantasy;
+    font-family: Copperplate, 'Copperplate Gothic Light', serif;
     text-align:center;
     background: transparent;
 }
@@ -299,17 +299,17 @@ select.sheet-Specialty {
 }
 
 h3 {
-    font-family: Copperplate, 'Copperplate Gothic Light', fantasy;
+    font-family: Copperplate, 'Copperplate Gothic Light', serif;
     text-align:center;
 }
 h4 {
-    font-family: Copperplate, 'Copperplate Gothic Light', fantasy;
+    font-family: Copperplate, 'Copperplate Gothic Light', serif;
     color: #000;
     font-weight:bold;
     text-align:center;
 }
 h5 {
-    font-family: Copperplate, 'Copperplate Gothic Light', fantasy;
+    font-family: Copperplate, 'Copperplate Gothic Light', serif;
     color: #000;
     font-weight:bold;
 }
@@ -318,7 +318,7 @@ textarea.sheet-notes {
     border: 2px solid #7F2108;
     height:130px;
     resize:vertical;
-    font-family: Copperplate, 'Copperplate Gothic Light', fantasy;
+    font-family: Copperplate, 'Copperplate Gothic Light', serif;
 }
 
 textarea.sheet-longnotes {
@@ -326,7 +326,7 @@ textarea.sheet-longnotes {
     border: 2px solid #7F2108;
     height:130px;
     resize:vertical;
-    font-family: Copperplate, 'Copperplate Gothic Light', fantasy;
+    font-family: Copperplate, 'Copperplate Gothic Light', serif;
 }
 
 /*-----Tootl Tips-----*/


### PR DESCRIPTION
## Changes / Comments
Changed the fallback font for the d20 modern character sheet to use the serif font family rather than the fantasy family. Some computers, when falling back to the fantasy family, default to wingdings. This was shown particularly often on linux computers using firefox.

There are no attribute changes or any changes other than the fallback font family, this is a non-destructive change for existing data.