### PR TITLE
Kult: Fix styling on Page Two

### DIFF
--- a/Kult Divinity Lost/KULT Divinity Lost.html
+++ b/Kult Divinity Lost/KULT Divinity Lost.html
@@ -162,7 +162,7 @@
     <span></span>
     </td>
     <td class="sheet-label3">Distressed</td>
-<td style="width: 20%;"></td>
+<td style="width: 17%;"></td>
     <td class="sheet-label4 sheet-label3">-1 Keep it Together</td>
 </tr>
 <tr style="border-bottom: 1px black solid">    


### PR DESCRIPTION
## Changes / Comments

Adjusting the width of the Stability table on page two, as my last PR made it a bit too wide and broke the formatting of everything below it.