### PR TITLE
Allow decimal parsing for 5E carrying capacity modificator

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -9790,10 +9790,10 @@
                 if(v.carrying_capacity_mod) {
                     var operator = v.carrying_capacity_mod.substring(0,1);
                     var value = v.carrying_capacity_mod.substring(1);
-                    if(["*","x","+","-"].indexOf(operator) > -1 && isNaN(parseInt(value,10)) === false) {
-                        if(operator == "*" || operator == "x") {str = str*parseInt(value,10);}
-                        else if(operator == "+") {str = str+parseInt(value,10);}
-                        else if(operator == "-") {str = str-parseInt(value,10);}
+                    if(["*","x","+","-"].indexOf(operator) > -1 && isNaN(parseFloat(value,10)) === false) {
+                        if(operator == "*" || operator == "x") {str = str*parseFloat(value,10);}
+                        else if(operator == "+") {str = str+parseFloat(value,10);}
+                        else if(operator == "-") {str = str-parseFloat(value,10);}
                     }
                 }
 

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -9787,6 +9787,8 @@
                     else if(v["size"].toLowerCase().trim() == "gargantuan") {size_multiplier = 8}
                 }
                 var str = str_base*size_multiplier;
+
+                // Parse the carrying capacitiy modificator if any
                 if(v.carrying_capacity_mod) {
                     var operator = v.carrying_capacity_mod.substring(0,1);
                     var value = v.carrying_capacity_mod.substring(1);


### PR DESCRIPTION
## Changes / Comments

Fix this issue: https://github.com/Roll20/roll20-character-sheets/issues/4562




