### PR TITLE
[LANCER RPG 1.8] fixed 'tech attack' field extending outside of the sheet frame

### DIFF
--- a/LANCER RPG (1.8)/LANCER.html
+++ b/LANCER RPG (1.8)/LANCER.html
@@ -1041,7 +1041,7 @@
                             </div> 
                         </div> <!--overcharge gauge-->
                         <div class="nested multi-input tab-flex-item" style="width:180px"> <!--frame base stats column-->
-                            <div class="flex-column-wrapper" style="width:inherit">
+                            <div class="flex-column-wrapper" style="width:inherit;height:165px">
                                 <div class="nested tab-flex-item" style="width:inherit">
                                     <div class="flex-element">
                                         <label style="margin-left:0px">ARMOR</label>


### PR DESCRIPTION
## Changes / Comments

There was a somewhat significant visual bug in the first sheet release—one of the fields extended outside of its frame and was mostly hidden from view. This has been fixed.
