### PR TITLE
5e D&D - DEV 1619 - Leveler HP fix

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.css
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.css
@@ -2338,8 +2338,12 @@ span.sheet-spellconcentration
     font-style: italic;
     margin-left: 4px;
 }
-.sheet-rolltemplate-mancerroll .sheet-result,
-.sheet-rolltemplate-mancerhproll .sheet-result {
+.sheet-rolltemplate-mancerhproll .sheet-desc  {
+    display    : inline-block;
+    margin-left: 5%;
+    width      : 50%;
+}
+.sheet-rolltemplate-mancerroll .sheet-result {
     margin-left: 80px;
 }
 
@@ -4735,12 +4739,7 @@ div.sheet-globaldisplay span {
     height: 1em;
     vertical-align: middle;
 }
-.charsheet .sheet-charmancer .sheet-levels-hp-row .sheet-class1_rollhp,
-.charsheet .sheet-charmancer .sheet-levels-hp-row .sheet-class2_rollhp,
-.charsheet .sheet-charmancer .sheet-levels-hp-row .sheet-class3_rollhp,
-.charsheet .sheet-charmancer .sheet-levels-hp-row .sheet-class4_rollhp {
-    display: inline-block !important;
-}
+
 .sheet-charmancer .sheet-levels-hp-row .sheet-hpbylevel-toggle,
 .sheet-charmancer .sheet-levels-hp-row .sheet-class1_rollhp,
 .sheet-charmancer .sheet-levels-hp-row .sheet-class2_rollhp,
@@ -4853,9 +4852,8 @@ div.sheet-globaldisplay span {
     cursor: not-allowed;
 }
 
-.sheet-charmancer .sheet-levels-multiclass .sheet-hp-flag[value="roll"] ~ div > button[type="roll"],
-.sheet-charmancer .sheet-levels-multiclass .sheet-hp-flag[value="roll"] ~ button[type="roll"],
-.sheet-charmancer .sheet-levels-multiclass .sheet-hp-flag[value="average"] ~ button[type="action"] {
+.sheet-charmancer .sheet-levels-multiclass .sheet-hp-flag[value="roll"] ~ div > button[name*="rollhp"], 
+.sheet-charmancer .sheet-levels-multiclass .sheet-hp-flag[value="average"] ~ div > button[name*="averagehp"] {
     background-color: #EC2127;
     color           : #fff;
 }

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.css
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.css
@@ -4853,7 +4853,9 @@ div.sheet-globaldisplay span {
 }
 
 .sheet-charmancer .sheet-levels-multiclass .sheet-hp-flag[value="roll"] ~ div > button[name*="rollhp"], 
-.sheet-charmancer .sheet-levels-multiclass .sheet-hp-flag[value="average"] ~ div > button[name*="averagehp"] {
+.sheet-charmancer .sheet-levels-multiclass .sheet-hp-flag[value="average"] ~ div > button[name*="averagehp"],
+.sheet-charmancer .sheet-levels-multiclass .sheet-hp-flag[value="roll"] ~ button[name*="rollhp"], 
+.sheet-charmancer .sheet-levels-multiclass .sheet-hp-flag[value="average"] ~ button[name*="averagehp"] {
     background-color: #EC2127;
     color           : #fff;
 }

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -15173,13 +15173,10 @@
         const mancerdata = getCharmancerData();
         const leveldata = mancerdata["lp-levels"].values;
         const repeating = mancerdata["lp-levels"].repeating || [];
-        let set = {};
         const sections = section ? [section] : ["class1", "class2", "class3", "class4"];
-
+        let set = {};
         _.each(sections, (levelclass) => {
-            let thishp = 0;
-            let first = true;
-            let rollflag = "";
+            let thishp = 0, first = true, rollflag = "";
             _.each(repeating, function(repid) {
                 if(repid.split("_")[2].split("-")[0] == levelclass && leveldata[`${repid}_result`]) {
                     let thisflag = leveldata[`${repid}_rollflag`] || "average";
@@ -15192,22 +15189,31 @@
                 }
             });
             set[`${levelclass}_hp_flag`] = rollflag;
-            set[`${levelclass}_addhp`] = thishp;
+            set[`${levelclass}_addhp`] = rollflag;
         });
         setAttrs(set, () => {recalcLpData()});
     };
 
     const update_hp = (firstTime) => {
-        const updateByLevel = (firstTime) => {
-            const mancerdata = getCharmancerData();
-            const leveldata = mancerdata["lp-levels"].values;
-            const repeating = mancerdata["lp-levels"].repeating || [];
+        const mancerdata = getCharmancerData();
+        const leveldata = mancerdata["lp-levels"].values;
+        const repeating = mancerdata["lp-levels"].repeating || [];
+        let set = {};
 
+        const updateByLevel = (firstTime) => {
             for(let classnum=1; classnum<=4; classnum++) {
                 const levelclass = `class${classnum}`, hitdie = leveldata[`${levelclass}_hitdie`],
                     current = leveldata[`${levelclass}_currentlevel`] ? parseInt(leveldata[`${levelclass}_currentlevel`]) : 0,
                     addlevel = leveldata[`${levelclass}_addlevel`] ? parseInt(leveldata[`${levelclass}_addlevel`]) : 0;
+                //Bonus for Draconic Ancestor
+                const subclassData = mancerdata["lp-levels"].data[`${levelclass}_subclass`];
+                const hproll = (subclassData && subclassData.blobs[`Draconic Resilience`]) ? `${hitdie}+1[Draconic Resilience]` : `${hitdie}`;
                 let levelarray = [], addarray = [], removearray = [], existing = [], average = getDieAvg(hitdie);
+
+                //DEV 1619 REMOVE Later
+                const dragon = (subclassData && subclassData.blobs[`Draconic Resilience`]) ? "Draconic Resilinece Found" : "Draconic Resilinece was not found";
+                console.log(dragon);
+
                 for(let x = current+1; x<=current+addlevel; x++) {
                     levelarray.push(`${levelclass}-${x}`);
                 }
@@ -15231,7 +15237,7 @@
                     _.each(addarray, function(repname) {
                         addRepeatingSection(rowid, "hpbylevel", repname, function(repid) {
                             if(!leveldata[`${repid}_result`]) set[`${repid}_result`] = average;
-                            set[`roll_${repid}_rollhp`] = `@{wtype}&{template:mancerhproll} {{title=Roll for HP Level ${_.last(repname.split("-"))}}} {{r1=[[1${hitdie}]]}}`;
+                            set[`roll_${repid}_rollhp`] = `@{wtype}&{template:mancerhproll} {{title=Roll for HP Level ${_.last(repname.split("-"))}}} {{r1=[[1${hproll}]]}}`;
                             update[`${repid} label`] = `Level ${_.last(repname.split("-"))}`;
                             if(repname == _.last(addarray)) {
                                 setCharmancerText(update);
@@ -15248,25 +15254,20 @@
                         recalcHpByLevel(levelclass);
                     });
                 }
+
+                if (addlevel && hitdie) {
+                    let dice = [];
+                    for (x = 1; x <= addlevel; x++) { dice.push(`{{r${x}=[[1${hproll}]]}}`); };
+                    const rollButton = `@{wtype}&{template:mancerhproll} {{title=Roll for HP}} ` + dice.join();
+                    if (rollButton != leveldata[`roll_${levelclass}_rollhp`]) {
+                        setAttrs({
+                            [`roll_${levelclass}_rollhp`] : rollButton
+                        });
+                    };
+                };
             };
         };
-        const mancerdata = getCharmancerData();
-        const leveldata = mancerdata["lp-levels"].values;
-        const repeating = mancerdata["lp-levels"].repeating || [];
-        let set = {};
 
-        for(let classnum=1; classnum<=4; classnum++) {
-            const levelclass = `class${classnum}`, hitdie = leveldata[`${levelclass}_hitdie`], levels = leveldata[`${levelclass}_addlevel`] || 0;
-            let dice = [];
-
-            for (x = 1; x <= levels; x++) {
-                dice.push(`{{r${x}=[[1${hitdie}]]}}`);
-            };
-
-            if (levels && hitdie) {
-                set[`roll_${levelclass}_rollhp`] = `@{wtype}&{template:mancerhproll} {{title=Roll for HP}}` + dice.join();
-            };
-        };
         setAttrs(set);
         if(firstTime) {
             addRepeatingSection("class1_by-levels", "row", "class1hprow", function() {
@@ -15409,23 +15410,25 @@
         setCharmancerText(update);
     });
 
-    on("clicked:class1_addhpAverage clicked:class2_addhpAverage clicked:class3_addhpAverage clicked:class4_addhpAverage", function(eventinfo) {
-        const mancerdata= getCharmancerData();
-        const leveldata = mancerdata["lp-levels"], levelclass = eventinfo.sourceAttribute.slice(0, 6), hitdie = leveldata.values[`${levelclass}_hitdie`], hp = getDieAvg(hitdie);
-        const repeating = mancerdata["lp-levels"].repeating || [];
-        let set = {};
+    ["class1", "class2", "class3", "class4"].forEach(levelclass => {
+        on(`clicked:${levelclass}_addhpAverage`, (eventinfo) => {
+            const mancerdata= getCharmancerData();
+            const leveldata = mancerdata["lp-levels"], hitdie = leveldata.values[`${levelclass}_hitdie`], hp = getDieAvg(hitdie);
+            const repeating = mancerdata["lp-levels"].repeating || [];
+            let set = {};
 
-        repeating.forEach(row => {
-            if (row.includes(`${levelclass}-`)) {
-               set[row + "_result"] = hp;
-               set[row + "_rollflag"] = "average";
-            };
+            repeating.forEach(row => {
+                if (row.includes(`${levelclass}-`)) {
+                   set[row + "_result"] = hp;
+                   set[row + "_rollflag"] = "average";
+                };
+            });
+
+            set[`${levelclass}_addhp`] = hp * parseInt(leveldata.values[`${levelclass}_addlevel`]);
+            set[`${levelclass}_hp_flag`] = "average";
+
+            setAttrs(set, function() { recalcLpData(); });
         });
-
-        set[`${levelclass}_addhp`] = hp * parseInt(leveldata.values[`${levelclass}_addlevel`]);
-        set[`${levelclass}_hp_flag`] = "average";
-
-        setAttrs(set, function() { recalcLpData(); });
     });
 
     on("clicked:class1 clicked:class2 clicked:class3 clicked:class4 clicked:class1_subclass clicked:class2_subclass clicked:class3_subclass clicked:class4_subclass", function(eventinfo) {
@@ -15437,8 +15440,6 @@
         getCompendiumPage(page, function(p) {
         });
     });
-
-    //END DEV 1378
 
     var getLevelingData = function(mancerdata) {
         mancerdata = mancerdata || getCharmancerData();

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -14784,15 +14784,28 @@
         var leveldata = getLevelingData(mancerdata);
         var abilities = abilities || getAbilityTotals(mancerdata, blobs);
         var previous = mancerdata["lp-welcome"].values["previous_attributes"] ? JSON.parse(mancerdata["lp-welcome"].values["previous_attributes"]) : {};
+        var prev_repeat = JSON.parse(mancerdata["lp-welcome"].values["previous_repeating"]), hpmod = prev_repeat["hpmod"];
         var newhp = 0;
         var additionalhp = 0;
         var totalpreviouslevel = parseInt(previous["base_level"]);
         for(var x=1; x<=3; x++) {
             if(previous["multiclass" + x + "_flag"] != "0") totalpreviouslevel += parseInt(previous["multiclass" + x + "_lvl"]);
         };
-        _.each(leveldata, function(level) {
-            newhp += level.addhp > 0 ? level.addhp + (level.addlevel * abilities["constitution_mod"]) : 0;
+
+        //Calculate HP Mods things like Hill Dwarf
+        let levelbonus = 0;
+        _.each(hpmod, (mod) => {
+            const bonus  = mod["mod"];
+            if (mod["levels"] === "total") {
+                levelbonus += parseInt(bonus);
+            };
         });
+
+        //Add up the hp per level
+        _.each(leveldata, function(level) {
+            newhp += level.addhp > 0 ? level.addhp + (level.addlevel * abilities["constitution_mod"]) + (level.addlevel * levelbonus) : 0;
+        });
+
         additionalhp = totalpreviouslevel * (abilities["constitution_mod"] - abilities["constitution_previous_mod"])
         return parseInt(previous["hp_max"]) + newhp + additionalhp;
     };
@@ -14953,7 +14966,6 @@
         getCompendiumPage(eventinfo.newValue, function(results) {});
     });
 
-    //DEV 1378
     on("page:lp-levels", function(eventinfo) {
         const mancerdata = getCharmancerData();
         const previous   = mancerdata["lp-welcome"].values["previous_attributes"] ? JSON.parse(mancerdata["lp-welcome"].values["previous_attributes"]) : {};
@@ -15154,7 +15166,7 @@
     });
 
     const recalcHpByLevel = (section) => {
-        console.log(section ? `RECALC HP: ${section}` : "RECALC HP: ALL");
+        //console.log(section ? `RECALC HP: ${section}` : "RECALC HP: ALL");
         const mancerdata = getCharmancerData();
         const leveldata = mancerdata["lp-levels"].values;
         const repeating = mancerdata["lp-levels"].repeating || [];
@@ -15196,19 +15208,6 @@
                     addlevel = leveldata[`${levelclass}_addlevel`] ? parseInt(leveldata[`${levelclass}_addlevel`]) : 0;
                 let levelarray = [], addarray = [], removearray = [], existing = [], average = getDieAvg(hitdie);
 
-                //Bonus for by class mp mods like Draconic Bloodline for Sorcerers
-                const welcome = JSON.parse(mancerdata["lp-welcome"].values["previous_repeating"]), hpmod = welcome["hpmod"];
-                let hpbonus = 0, bonusSource = [];
-
-                _.each(hpmod, (mod) => {
-                    if (mod["levels"] === "base") {
-                        const bonus  = mod["mod"], source = mod["source"];
-
-                        bonusSource.push(`[ ${source} ]`);
-                        hpbonus += parseInt(bonus);
-                    };
-                });
-
                 for(let x = current+1; x<=current+addlevel; x++) {
                     levelarray.push(`${levelclass}-${x}`);
                 }
@@ -15224,6 +15223,23 @@
                         existing.push(id.split("_")[2]);
                     }
                 });
+
+                //HP Bonus from subclass hp mods like Draconic Bloodline for Sorcerers
+                const prev_repeat = JSON.parse(mancerdata["lp-welcome"].values["previous_repeating"]), hpmod = prev_repeat["hpmod"], subclass = leveldata[`${levelclass}_subclass`];;
+                let hpbonus = 0, bonusSource = [];
+                _.each(hpmod, (mod) => {
+                    if (mod["levels"] === "base" && subclass && subclass.includes(mod["source"])) {
+                        bonusSource.push(mod["source"]);
+                        hpbonus += parseInt(mod["mod"]);
+                    };
+                });
+                //Multiclassing into Sorcer Draconic needs to update buttons
+                if (subclass && subclass.includes("Draconic Bloodline") && !bonusSource.includes("Draconic Bloodline")) {
+                    bonusSource.push("Draconic Bloodline");
+                    hpbonus += parseInt(1);
+                };
+                const templateBonus = (hpbonus > 0) ? `+${hpbonus}[${bonusSource}]` : "";
+
                 if(addarray.length > 0) {
                     let set = {}, update = {}, rowid = "";
                     _.each(repeating, function(repid) {
@@ -15232,8 +15248,8 @@
                     _.each(addarray, function(repname) {
                         addRepeatingSection(rowid, "hpbylevel", repname, function(repid) {
                             if(!leveldata[`${repid}_result`]) set[`${repid}_result`] = parseInt(average) + parseInt(hpbonus);
-                            set[`roll_${repid}_rollhp`] = `@{wtype}&{template:mancerhproll} {{title=Roll for HP Level ${_.last(repname.split("-"))}}} {{r1=[[1${hitdie}+${hpbonus}${bonusSource}]]}}`;
-                            set[`roll_${repid}_averagehp`] = `@{wtype}&{template:mancerhproll} {{title=Average for HP Level ${_.last(repname.split("-"))}}} {{a1=[[${average}+${hpbonus}${bonusSource}]]}}`;
+                            set[`roll_${repid}_rollhp`] = `@{wtype}&{template:mancerhproll} {{title=Roll for HP Level ${_.last(repname.split("-"))}}} {{r1=[[1${hitdie}${templateBonus}]]}}`;
+                            set[`roll_${repid}_averagehp`] = `@{wtype}&{template:mancerhproll} {{title=Average for HP Level ${_.last(repname.split("-"))}}} {{a1=[[${average}${templateBonus}]]}}`;
                             update[`${repid} label`] = `Level ${_.last(repname.split("-"))}`;
                             if(repname == _.last(addarray)) {
                                 setCharmancerText(update);
@@ -15253,13 +15269,12 @@
 
                 if (addlevel && hitdie) {
                     let dice = [], set = {};
-
                     //Set the roll buttons
-                    for (x = 1; x <= addlevel; x++) { dice.push(`{{r${x}=[[1${hitdie}+${hpbonus}${bonusSource}]]}}`); };
+                    for (x = 1; x <= addlevel; x++) { dice.push(`{{r${x}=[[1${hitdie}${templateBonus}]]}}`); };
                     set[`roll_${levelclass}_rollhp`] = `@{wtype}&{template:mancerhproll} {{title=Roll for HP}} ` + dice.join()
 
                     //Set the average hp button
-                    set[`roll_${levelclass}_averagehp`] = `@{wtype}&{template:mancerhproll} {{title=Average for HP}}{{a1=[[${average}+${hpbonus}${bonusSource}]]}}`
+                    set[`roll_${levelclass}_averagehp`] = `@{wtype}&{template:mancerhproll} {{title=Average for HP}}{{a1=[[${average}${templateBonus}]]}}`
 
                     setAttrs(set);
                 };
@@ -15315,20 +15330,19 @@
             const mancerdata = getCharmancerData();
             const leveldata = mancerdata["lp-levels"].values;
             const repeating = mancerdata["lp-levels"].repeating || [];
-            const source = eventinfo.sourceAttribute;
-            const flag = source.includes("rollhp") ? "roll" : "average";
+            const source = eventinfo.sourceAttribute, flag = source.includes("rollhp") ? "roll" : "average";
             let set = {}, sum = 0, rows = "";
 
             repeating.forEach(row => {
                 if (row.includes(`${levelclass}-`) && source.includes("rollhp")) {
-                    const test = row.split(`${levelclass}-`)[1];
-                    const diff = parseInt(leveldata[`${levelclass}_currentlevel`]) + 1;
-                    const num = parseInt(row.split(`${levelclass}-`)[1]) - diff;
+                    const num = parseInt(row.split(`${levelclass}-`)[1]) - 1;
                     set[row + "_result"] = eventinfo.roll[`${num}`].result;
                     set[row + "_rollflag"] = flag;
-                } else {
+                } else if (row.includes(`${levelclass}-`) && source.includes("average")) {
                     set[row + "_result"] = eventinfo.roll[0].result;
                     set[row + "_rollflag"] = flag;
+                } else {
+                    false
                 };
             });
 

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -5940,124 +5940,109 @@
                     {{/c1}}
                 </span>
             </div>
+            {{#a1}}
+                <div class="row">
+                <span class="desc">Average: </span><span class="result">{{a1}}</span>
+                </div>
+            {{/a1}}
             {{#r1}}
                 <div class="row">
-                    <span class="desc">Roll 1: </span>
-                    <span class="result">{{r1}}</span>
+                <span class="desc">Roll 1: </span><span class="result">{{r1}}</span>
                 </div>
             {{/r1}}
             {{#r2}}
                 <div class="row">
-                    <span class="desc">Roll 2: </span>
-                    <span class="result">{{r2}}</span>
+                    <span class="desc">Roll 2: </span><span class="result">{{r2}}</span>
                 </div>
             {{/r2}}
             {{#r3}}
                 <div class="row">
-                    <span class="desc">Roll 3: </span>
-                    <span class="result">{{r3}}</span>
+                    <span class="desc">Roll 3: </span><span class="result">{{r3}}</span>
                 </div>
             {{/r3}}
             {{#r4}}
                 <div class="row">
-                    <span class="desc">Roll 4: </span>
-                    <span class="result">{{r4}}</span>
+                    <span class="desc">Roll 4: </span><span class="result">{{r4}}</span>
                 </div>
             {{/r4}}
             {{#r5}}
                 <div class="row">
-                    <span class="desc">Roll 5: </span>
-                    <span class="result">{{r5}}</span>
+                    <span class="desc">Roll 5: </span><span class="result">{{r5}}</span>
                 </div>
             {{/r5}}
             {{#r6}}
                 <div class="row">
-                    <span class="desc">Roll 6: </span>
-                    <span class="result">{{r6}}</span>
+                    <span class="desc">Roll 6: </span><span class="result">{{r6}}</span>
                 </div>
             {{/r6}}
             {{#r7}}
                 <div class="row">
-                    <span class="desc">Roll 7: </span>
-                    <span class="result">{{r7}}</span>
+                    <span class="desc">Roll 7: </span><span class="result">{{r7}}</span>
                 </div>
             {{/r7}}
             {{#r8}}
                 <div class="row">
-                    <span class="desc">Roll 8: </span>
-                    <span class="result">{{r8}}</span>
+                    <span class="desc">Roll 8: </span><span class="result">{{r8}}</span>
                 </div>
             {{/r8}}
             {{#r9}}
                 <div class="row">
-                    <span class="desc">Roll 9: </span>
-                    <span class="result">{{r9}}</span>
+                    <span class="desc">Roll 9: </span><span class="result">{{r9}}</span>
                 </div>
             {{/r9}}
             {{#r10}}
                 <div class="row">
-                    <span class="desc">Roll 10: </span>
-                    <span class="result">{{r10}}</span>
+                    <span class="desc">Roll 10: </span><span class="result">{{r10}}</span>
                 </div>
             {{/r10}}
             {{#r11}}
                 <div class="row">
-                    <span class="desc">Roll 11: </span>
-                    <span class="result">{{r11}}</span>
+                    <span class="desc">Roll 11: </span><span class="result">{{r11}}</span>
                 </div>
             {{/r11}}
                         {{#r12}}
                 <div class="row">
-                    <span class="desc">Roll 12: </span>
-                    <span class="result">{{r12}}</span>
+                    <span class="desc">Roll 12: </span><span class="result">{{r12}}</span>
                 </div>
             {{/r12}}
             {{#r13}}
                 <div class="row">
-                    <span class="desc">Roll 13: </span>
-                    <span class="result">{{r13}}</span>
+                    <span class="desc">Roll 13: </span><span class="result">{{r13}}</span>
                 </div>
             {{/r13}}
             {{#r14}}
                 <div class="row">
-                    <span class="desc">Roll 14: </span>
-                    <span class="result">{{r14}}</span>
+                    <span class="desc">Roll 14: </span><span class="result">{{r14}}</span>
                 </div>
             {{/r14}}
             {{#r15}}
                 <div class="row">
-                    <span class="desc">Roll 15: </span>
-                    <span class="result">{{r15}}</span>
+                    <span class="desc">Roll 15: </span><span class="result">{{r15}}</span>
                 </div>
             {{/r15}}
             {{#r16}}
                 <div class="row">
-                    <span class="desc">Roll 16: </span>
-                    <span class="result">{{r16}}</span>
+                    <span class="desc">Roll 16: </span><span class="result">{{r16}}</span>
                 </div>
             {{/r16}}
             {{#r17}}
                 <div class="row">
-                    <span class="desc">Roll 17: </span>
-                    <span class="result">{{r17}}</span>
+                    <span class="desc">Roll 17: </span><span class="result">{{r17}}</span>
                 </div>
             {{/r17}}
             {{#r18}}
                 <div class="row">
-                    <span class="desc">Roll 18: </span>
-                    <span class="result">{{r18}}</span>
+                    <span class="desc">Roll 18: </span><span class="result">{{r18}}</span>
                 </div>
             {{/r18}}
             {{#r19}}
                 <div class="row">
-                    <span class="desc">Roll 19: </span>
-                    <span class="result">{{r19}}</span>
+                    <span class="desc">Roll 19: </span><span class="result">{{r19}}</span>
                 </div>
             {{/r19}}
             {{#r20}}
                 <div class="row">
-                    <span class="desc">Roll 20: </span>
-                    <span class="result">{{r20}}</span>
+                    <span class="desc">Roll 20: </span><span class="result">{{r20}}</span>
                 </div>
             {{/r20}}
         </div>
@@ -15169,7 +15154,6 @@
     });
 
     const recalcHpByLevel = (section) => {
-        console.log(section ? `RECALC HP: ${section}` : "RECALC HP: ALL");
         const mancerdata = getCharmancerData();
         const leveldata = mancerdata["lp-levels"].values;
         const repeating = mancerdata["lp-levels"].repeating || [];
@@ -15207,12 +15191,12 @@
                     addlevel = leveldata[`${levelclass}_addlevel`] ? parseInt(leveldata[`${levelclass}_addlevel`]) : 0;
                 //Bonus for Draconic Ancestor
                 const subclassData = mancerdata["lp-levels"].data[`${levelclass}_subclass`];
-                const hproll = (subclassData && subclassData.blobs[`Draconic Resilience`]) ? `${hitdie}+1[Draconic Resilience]` : `${hitdie}`;
+                const hpbonus = (subclassData && subclassData.blobs[`Draconic Resilience`]) ? `1[Draconic Resilience]` : `0`;
                 let levelarray = [], addarray = [], removearray = [], existing = [], average = getDieAvg(hitdie);
 
                 //DEV 1619 REMOVE Later
                 const dragon = (subclassData && subclassData.blobs[`Draconic Resilience`]) ? "Draconic Resilinece Found" : "Draconic Resilinece was not found";
-                console.log(dragon);
+                console.log(`%c ${dragon}`,'font-size: 14px; background: yellow;');
 
                 for(let x = current+1; x<=current+addlevel; x++) {
                     levelarray.push(`${levelclass}-${x}`);
@@ -15237,7 +15221,8 @@
                     _.each(addarray, function(repname) {
                         addRepeatingSection(rowid, "hpbylevel", repname, function(repid) {
                             if(!leveldata[`${repid}_result`]) set[`${repid}_result`] = average;
-                            set[`roll_${repid}_rollhp`] = `@{wtype}&{template:mancerhproll} {{title=Roll for HP Level ${_.last(repname.split("-"))}}} {{r1=[[1${hproll}]]}}`;
+                            set[`roll_${repid}_rollhp`] = `@{wtype}&{template:mancerhproll} {{title=Roll for HP Level ${_.last(repname.split("-"))}}} {{r1=[[1${hitdie}+${hpbonus}]]}}`;
+                            set[`roll_${repid}_averagehp`] = `@{wtype}&{template:mancerhproll} {{title=Average for HP Level ${_.last(repname.split("-"))}}} {{a1=[[${average}+${hpbonus}]]}}`;
                             update[`${repid} label`] = `Level ${_.last(repname.split("-"))}`;
                             if(repname == _.last(addarray)) {
                                 setCharmancerText(update);
@@ -15255,15 +15240,21 @@
                     });
                 }
 
+                //console.log('%c Oh my heavens! ', 'background: #222; color: #bada55');
+
+                console.log(mancerdata);
+
                 if (addlevel && hitdie) {
-                    let dice = [];
-                    for (x = 1; x <= addlevel; x++) { dice.push(`{{r${x}=[[1${hproll}]]}}`); };
-                    const rollButton = `@{wtype}&{template:mancerhproll} {{title=Roll for HP}} ` + dice.join();
-                    if (rollButton != leveldata[`roll_${levelclass}_rollhp`]) {
-                        setAttrs({
-                            [`roll_${levelclass}_rollhp`] : rollButton
-                        });
-                    };
+                    let dice = [], set = {};
+
+                    //Set the roll buttons
+                    for (x = 1; x <= addlevel; x++) { dice.push(`{{r${x}=[[1${hitdie}+${hpbonus}]]}}`); };
+                    set[`roll_${levelclass}_rollhp`] = `@{wtype}&{template:mancerhproll} {{title=Roll for HP}} ` + dice.join()
+
+                    //Set the average hp button
+                    set[`roll_${levelclass}_averagehp`] = `@{wtype}&{template:mancerhproll} {{title=Average for HP}}{{a1=[[${average}+${hpbonus}]]}}`
+
+                    setAttrs(set);
                 };
             };
         };
@@ -15314,30 +15305,44 @@
         setAttrs(set, () => {recalcHpByLevel()})
     });
 
-    on("mancerroll:class1_rollhp mancerroll:class2_rollhp mancerroll:class3_rollhp mancerroll:class4_rollhp", function(eventinfo) {
-        const mancerdata = getCharmancerData();
-        const leveldata = mancerdata["lp-levels"].values, levelclass = eventinfo.sourceAttribute.slice(0, 6);
-        const repeating = mancerdata["lp-levels"].repeating || [];
-        let set = {}, sum = 0, rows = "";
 
-        repeating.forEach(row => {
-            if (row.includes(`${levelclass}-`)) {
-                const diff = parseInt(leveldata[`${levelclass}_currentlevel`]) + 1;
-                const num = parseInt(row.split(`${levelclass}-`)[1]) - diff;
+    ["class1", "class2", "class3", "class4"].forEach(levelclass => {
+        on(`mancerroll:${levelclass}_rollhp mancerroll:${levelclass}_averagehp`, (eventinfo) => {
+            const mancerdata = getCharmancerData();
+            const leveldata = mancerdata["lp-levels"].values;
+            const repeating = mancerdata["lp-levels"].repeating || [];
+            const source = eventinfo.sourceAttribute;
+            let set = {}, sum = 0, rows = "";
 
-               set[row + "_result"] = eventinfo.roll[`${num}`].result;
-               set[row + "_rollflag"] = "roll";
+            repeating.forEach(row => {
+                if (row.includes(`${levelclass}-`) && source.includes("rollhp")) {
+                    const test = row.split(`${levelclass}-`)[1];
+                    const diff = parseInt(leveldata[`${levelclass}_currentlevel`]) + 1;
+                    const num = parseInt(row.split(`${levelclass}-`)[1]) - diff;
+                    set[row + "_result"] = eventinfo.roll[`${num}`].result;
+                    set[row + "_rollflag"] = "roll";
+                } else {
+                    set[row + "_result"] = eventinfo.roll[`0`].result;
+                };
+            });
+
+            //Add up the results for rollhp and multiply the average option by added levels
+            if (source.includes("rollhp")) {
+                _.each(eventinfo.roll, function(roll) {
+                    sum += parseInt(roll.result);
+                 });
+            } else {
+                sum = parseInt(eventinfo.roll[`0`].result) * leveldata[`${levelclass}_addlevel`];
             };
+
+            set[`${levelclass}_addhp`] = sum;
+
+            //Set hp_flag to be roll or average so the CSS will highlight the appropriate button
+            let flag = eventinfo.sourceAttribute.includes("roll") ? "roll" : "average";
+            set[`${levelclass}_hp_flag`] = flag;
+
+            setAttrs(set, function() { recalcLpData(); });
         });
-
-        _.each(eventinfo.roll, function(roll) {
-            sum += parseInt(roll.result);
-        });
-
-        set[`${levelclass}_addhp`] = sum;
-        set[`${levelclass}_hp_flag`] = "roll";
-
-        setAttrs(set, function() { recalcLpData(); });
     });
 
     on("clicked:multiclass_add clicked:multiclass_remove", function(eventinfo) {
@@ -15408,27 +15413,6 @@
         setCharmancerOptions("class" + tot, "Category:Classes", {disable: presets, category: "Classes"});
         update["multiclass_message"] = `<h3>Multiclass (${tot}/4)</h3>`;
         setCharmancerText(update);
-    });
-
-    ["class1", "class2", "class3", "class4"].forEach(levelclass => {
-        on(`clicked:${levelclass}_addhpAverage`, (eventinfo) => {
-            const mancerdata= getCharmancerData();
-            const leveldata = mancerdata["lp-levels"], hitdie = leveldata.values[`${levelclass}_hitdie`], hp = getDieAvg(hitdie);
-            const repeating = mancerdata["lp-levels"].repeating || [];
-            let set = {};
-
-            repeating.forEach(row => {
-                if (row.includes(`${levelclass}-`)) {
-                   set[row + "_result"] = hp;
-                   set[row + "_rollflag"] = "average";
-                };
-            });
-
-            set[`${levelclass}_addhp`] = hp * parseInt(leveldata.values[`${levelclass}_addlevel`]);
-            set[`${levelclass}_hp_flag`] = "average";
-
-            setAttrs(set, function() { recalcLpData(); });
-        });
     });
 
     on("clicked:class1 clicked:class2 clicked:class3 clicked:class4 clicked:class1_subclass clicked:class2_subclass clicked:class3_subclass clicked:class4_subclass", function(eventinfo) {
@@ -17287,7 +17271,7 @@
     <label></label>
     <input type="number" class="" name="comp_result" min="0">
     <button type="roll" name="roll_rollhp" value="" title="">Roll</button>
-    <button type="action" name="act_average" value="" title="">Average</button>
+    <button type="roll" name="roll_averagehp" value="" title="">Average</button>
 </charmancer>
 
 <!-- CHARACTERMANCER SLIDES -->
@@ -18548,9 +18532,11 @@
                     <div class="class1_rollhp" style="display: inline;">
                         <button type="roll" name="roll_class1_rollhp" value="" title="">Roll</button>
                     </div>
-                    <button type="action" name="act_class1_addhpAverage" value="" title="">Average</button>
+                    <div class="class1_averagehp" style="display: inline;">
+                        <button type="roll" name="roll_class1_averagehp" value="" title="">Average</button>
+                    </div>
                     <input class="hpbylevel-toggle" type="checkbox" name="comp_hpbyLevel" /><span class="collapse">9</span>
-                    <div class="class1_by-levels" style="margin-left: 11%;"></div>
+                    <div class="class1_by-levels"></div>
                 </div>
                 <div class="class_features_container">
                     <h3 class="class1_features_title choice" style="display: inline;">Class Features: </h3>
@@ -18590,9 +18576,11 @@
                     <div class="class2_rollhp" style="display: inline;">
                         <button type="roll" name="roll_class2_rollhp" value="" title="You must input a level increase to this class">Roll</button>
                     </div>
-                    <button type="action" name="act_class2_addhpAverage" value="" title="">Average</button>
+                    <div class="class2_averagehp" style="display: inline;">
+                        <button type="roll" name="roll_class2_averagehp" value="" title="">Average</button>
+                    </div>
                     <input class="hpbylevel-toggle" type="checkbox" name="comp_hpbyLevel" /><span class="collapse">9</span>
-                    <div class="class2_by-levels" style="margin-left: 11%;"></div>
+                    <div class="class2_by-levels"></div>
                 </div>
                 <div>
                     <h3 class="class2_features_title choice" style="display: inline;">Class Features: </h3>
@@ -18634,9 +18622,11 @@
                     <div class="class3_rollhp" style="display: inline;">
                         <button type="roll" name="roll_class3_rollhp" value="" title="You must input a level increase to this class">Roll</button>
                     </div>
-                    <button type="action" name="act_class3_addhpAverage" value="" title="">Average</button>
+                    <div class="class3_averagehp" style="display: inline;">
+                        <button type="roll" name="roll_class3_averagehp" value="" title="">Average</button>
+                    </div>
                     <input class="hpbylevel-toggle" type="checkbox" name="comp_hpbyLevel" /><span class="collapse">9</span>
-                    <div class="class3_by-levels" style="margin-left: 11%;"></div>
+                    <div class="class3_by-levels"></div>
                 </div>
                 <div>
                     <h3 class="class3_features_title choice" style="display: inline;">Class Features: </h3>
@@ -18676,9 +18666,11 @@
                     <div class="class4_rollhp" style="display: inline;">
                         <button type="roll" name="roll_class4_rollhp" value="" title="You must input a level increase to this class">Roll</button>
                     </div>
-                    <button type="action" name="act_class4_addhpAverage" value="" title="">Average</button>
+                    <div class="class4_averagehp" style="display: inline;">
+                        <button type="roll" name="roll_class4_averagehp" value="" title="">Average</button>
+                    </div>
                     <input class="hpbylevel-toggle" type="checkbox" name="comp_hpbyLevel" /><span class="collapse">9</span>
-                    <div class="class4_by-levels" style="margin-left: 11%;"></div>
+                    <div class="class4_by-levels"></div>
                 </div>
                 <div>
                     <h3 class="class4_features_title choice" style="display: inline;">Class Features: </h3>

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -15011,6 +15011,7 @@
                 set[`class${x1}_currentlevel`] = 0;
             };
 
+            //This is handling classes that have been multiclassed into while in the leveler
             if (mancerdata["lp-levels"] && mancerdata["lp-levels"].values[`class${x1}`] && parseInt(mancerdata["lp-levels"].values[`class${x1}_addlevel`]) > 0 && !levelclass.includes(`class${x1}`)) {
                 levelclass.push(`class${x1}`);
             };
@@ -15204,9 +15205,6 @@
         const leveldata = mancerdata["lp-levels"].values;
         const repeating = mancerdata["lp-levels"].repeating || [];
 
-        console.log(`%c UPDATE HP: ${levelclass}`, "color: green; font-weight:bold;");
-        console.log(`%c First Time: ${firstTime}`, "color: green; font-weight:bold;");
-
         const updateByLevel = (firstTime, levelclass) => {
             _.each(levelclass, (levelclass) => {
                 const current = leveldata[`${levelclass}_currentlevel`] ? parseInt(leveldata[`${levelclass}_currentlevel`]) : 0,
@@ -15279,8 +15277,6 @@
         const hitdie        = leveldata[`${levelclass}_hitdie`];
         let average         = getDieAvg(hitdie), set = {}, bonus = hpBonus(levelclass), hpbonus = bonus[0], bonusSource = bonus[1];
         const templateBonus = (hpbonus > 0) ? `+${hpbonus}[${bonusSource}]` : "";
-
-        //console.log(`%c Update Buttons ${levelclass}: template = ${templateBonus}, RepID ${repid}`, "color: blue;");
         
         set[`roll_${repid}_rollhp`]    = `@{wtype}&{template:mancerhproll} {{title=Roll for HP Level ${_.last(repid.split(`${levelclass}-`))}}} {{r1=[[1${hitdie}${templateBonus}]]}}`;
         set[`roll_${repid}_averagehp`] = `@{wtype}&{template:mancerhproll} {{title=Average for HP Level ${_.last(repid.split(`${levelclass}-`))}}} {{a1=[[${average}${templateBonus}]]}}`;
@@ -15318,8 +15314,6 @@
             hpbonus += parseInt(1);
         };
 
-        //console.log(`%c HP Bonus ${levelclass}: hpbonus = ${hpbonus}, bonusSource = ${bonusSource}`, "color: purple;");
-
         return [hpbonus, bonusSource];
     };
 
@@ -15328,8 +15322,6 @@
         const leveldata  = mancerdata["lp-levels"].values;
         const hitdie     = leveldata[`${levelclass}_hitdie`];
         let average      = getDieAvg(hitdie), bonus = hpBonus(levelclass), hpbonus = bonus[0], set = {};
-
-       //console.log(`%c Update Results ${levelclass}:`, "color: red;");
 
         if (!leveldata[`${repid}_result`]) {
             set[`${repid}_result`] = parseInt(average) + parseInt(hpbonus);
@@ -15501,6 +15493,7 @@
             const previousValue = (eventinfo.previousValue) ? eventinfo.previousValue : " ";
             let set             = {};
 
+            //This will update the results inputs with new hp values if the subclass is Draconic
             _.each(repeating, function(repid) {
                 if (repid.includes(`_${levelclass}-`) && newValue.includes("Draconic Bloodline") || previousValue.includes("Draconic Bloodline")) {
                     updateButtons(levelclass, repid);
@@ -15509,8 +15502,6 @@
             });
 
             setAttrs(set);
-
-            console.log(mancerdata);
         });
     });
 
@@ -18580,8 +18571,6 @@
     </div>
 </charmancer>
 
-
-<!-- DEV  1378 -->
 <charmancer class="sheet-charmancer-lp-levels">
     <div class="charmancer container">
         <ol class="steps lp-steps">
@@ -18824,7 +18813,6 @@
         <input type="hidden" name="comp_spells" />
     </div>
 </charmancer>
-<!-- END DEV  1378-->
 
 <charmancer class="sheet-charmancer-lp-choices">
     <div class="charmancer container">

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -15073,11 +15073,33 @@
         });
     });
 
-    on("mancerchange:class1_subclass mancerchange:class2_subclass mancerchange:class3_subclass mancerchange:class4_subclass", function(eventinfo) {
-        if(eventinfo.sourceType !== "worker") deleteCharmancerData(["lp-choices", "lp-asi", "lp-spells", "lp-summary"]);
-        getCompendiumPage(eventinfo.newValue, function(data) {
-            updateClassLevel(undefined, eventinfo.sourceAttribute.slice(0, 6));
-        });
+     //Trigger a change event when subclass changes
+    ["class1", "class2", "class3", "class4"].forEach(levelclass => {
+        on(`mancerchange:${levelclass}_subclass`, (eventinfo) => {
+            const mancerdata    = getCharmancerData();
+            const leveldata     = mancerdata["lp-levels"].values;
+            const repeating     = mancerdata["lp-levels"].repeating || [];
+            let set             = {};
+
+            if(eventinfo.sourceType !== "worker") deleteCharmancerData(["lp-choices", "lp-asi", "lp-spells", "lp-summary"]);
+            getCompendiumPage(eventinfo.newValue, function(data) {
+                updateClassLevel(undefined, eventinfo.sourceAttribute.slice(0, 6));
+            });
+
+            //This will update the results inputs with new hp values if the subclass is Draconic
+            if (eventinfo.sourceType !== "worker") {
+                const newValue      = (eventinfo.newValue) ? eventinfo.newValue : " ";
+                const previousValue = (eventinfo.previousValue) ? eventinfo.previousValue : " ";
+                _.each(repeating, function(repid) {
+                    if (repid.includes(`_${levelclass}-`) && newValue.includes("Draconic Bloodline") || previousValue.includes("Draconic Bloodline")) {
+                        updateButtons(levelclass, repid);
+                        updateResults(levelclass, repid, eventinfo);
+                    };
+                });
+            };
+
+            setAttrs(set);
+        });    
     });
 
     on("mancerchange:class1_addlevel mancerchange:class2_addlevel mancerchange:class3_addlevel mancerchange:class4_addlevel", function(eventinfo) {
@@ -15234,8 +15256,8 @@
                     });
                     _.each(addarray, function(repname) {
                         addRepeatingSection(rowid, "hpbylevel", repname, function(repid) {
-                            updateResults(levelclass, repid);
                             updateButtons(levelclass, repid);
+                            updateResults(levelclass, repid);
                             update[`${repid} label`] = `Level ${_.last(repname.split("-"))}`;
                             if(repname == _.last(addarray)) {
                                 setCharmancerText(update);
@@ -15480,28 +15502,6 @@
 
         changeCompendiumPage("sheet-levels-info", page);
         getCompendiumPage(page, function(p) {
-        });
-    });
-
-    //Trigger a change event when subclass changes
-    ["class1", "class2", "class3", "class4"].forEach(levelclass => {
-        on(`mancerchange:${levelclass}_subclass`, (eventinfo) => {
-            const mancerdata    = getCharmancerData();
-            const leveldata     = mancerdata["lp-levels"].values;
-            const repeating     = mancerdata["lp-levels"].repeating || [];
-            const newValue      = (eventinfo.newValue) ? eventinfo.newValue : " ";
-            const previousValue = (eventinfo.previousValue) ? eventinfo.previousValue : " ";
-            let set             = {};
-
-            //This will update the results inputs with new hp values if the subclass is Draconic
-            _.each(repeating, function(repid) {
-                if (repid.includes(`_${levelclass}-`) && newValue.includes("Draconic Bloodline") || previousValue.includes("Draconic Bloodline")) {
-                    updateButtons(levelclass, repid);
-                    updateResults(levelclass, repid, eventinfo);
-                };
-            });
-
-            setAttrs(set);
         });
     });
 

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -15090,12 +15090,18 @@
             if (eventinfo.sourceType !== "worker") {
                 const newValue      = (eventinfo.newValue) ? eventinfo.newValue : " ";
                 const previousValue = (eventinfo.previousValue) ? eventinfo.previousValue : " ";
-                _.each(repeating, function(repid) {
-                    if (repid.includes(`_${levelclass}-`) && newValue.includes("Draconic Bloodline") || previousValue.includes("Draconic Bloodline")) {
-                        updateButtons(levelclass, repid);
-                        updateResults(levelclass, repid, eventinfo);
-                    };
+                let repids          = [], updateArray = [];
+                _.each(repeating, (repid) => {
+                    if (repid.includes(`_${levelclass}-`)) { updateArray.push(repid); };
                 });
+                _.each(updateArray, (repid) => {
+                    if (newValue.includes("Draconic Bloodline") || previousValue.includes("Draconic Bloodline")) { repids.push(repid); };
+                });
+
+                if (repids.length > 0) {
+                    updateButtons(levelclass, repids);
+                    updateResults(levelclass, repids, eventinfo);
+                };
             };
 
             setAttrs(set);
@@ -15224,8 +15230,8 @@
 
     const update_hp = (firstTime, levelclass) => {
         const mancerdata = getCharmancerData();
-        const leveldata = mancerdata["lp-levels"].values;
-        const repeating = mancerdata["lp-levels"].repeating || [];
+        const leveldata  = mancerdata["lp-levels"].values;
+        const repeating  = mancerdata["lp-levels"].repeating || [];
 
         const updateByLevel = (firstTime, levelclass) => {
             _.each(levelclass, (levelclass) => {
@@ -15246,18 +15252,22 @@
                     if(id.split("_")[2].split("-")[0] == levelclass && !levelarray.includes(id.split("_")[2]) && !existing.includes(id.split("_")[2])) {
                         removearray.push(id);
                         existing.push(id.split("_")[2]);
-                    }
+                    };
                 });
 
                 if(addarray.length > 0) {
-                    let set = {}, update = {}, rowid = "";
-                    _.each(repeating, function(repid) {
+                    const last = addarray[addarray.length - 2];
+                    let set = {}, update = {}, rowid = "", repids = [];
+                    _.each(repeating, (repid) => {
                         if(repid.split("_")[2] == `${levelclass}hprow`) rowid = repid;
                     });
-                    _.each(addarray, function(repname) {
+                    _.each(addarray, (repname) => {
                         addRepeatingSection(rowid, "hpbylevel", repname, function(repid) {
-                            updateButtons(levelclass, repid);
-                            updateResults(levelclass, repid);
+                            repids.push(repid);
+                            if (repid.includes(last) || addarray.length == 1) {
+                                updateResults(levelclass, repids);
+                                updateButtons(levelclass, repids);
+                            };
                             update[`${repid} label`] = `Level ${_.last(repname.split("-"))}`;
                             if(repname == _.last(addarray)) {
                                 setCharmancerText(update);
@@ -15273,7 +15283,7 @@
                     clearRepeatingSectionById(removearray, () => {
                         recalcHpByLevel(levelclass);
                     });
-                }
+                };
             });
         };
 
@@ -15292,26 +15302,28 @@
         };
     };
 
-    const updateButtons = (levelclass, repid) => {
+    const updateButtons = (levelclass, repids) => {
         const mancerdata    = getCharmancerData();
         const leveldata     = mancerdata["lp-levels"].values;
         const addlevel      = leveldata[`${levelclass}_addlevel`] ? parseInt(leveldata[`${levelclass}_addlevel`]) : 0;
         const hitdie        = leveldata[`${levelclass}_hitdie`];
         let average         = getDieAvg(hitdie), set = {}, bonus = hpBonus(levelclass), hpbonus = bonus[0], bonusSource = bonus[1];
         const templateBonus = (hpbonus > 0) ? `+${hpbonus}[${bonusSource}]` : "";
-        
-        set[`roll_${repid}_rollhp`]    = `@{wtype}&{template:mancerhproll} {{title=Roll for HP Level ${_.last(repid.split(`${levelclass}-`))}}} {{r1=[[1${hitdie}${templateBonus}]]}}`;
-        set[`roll_${repid}_averagehp`] = `@{wtype}&{template:mancerhproll} {{title=Average for HP Level ${_.last(repid.split(`${levelclass}-`))}}} {{a1=[[${average}${templateBonus}]]}}`;
 
-        if (addlevel && hitdie) {
-            let dice = [];
-            //Set the roll buttons
-            for (x = 1; x <= addlevel; x++) { dice.push(`{{r${x}=[[1${hitdie}${templateBonus}]]}}`); };
-            set[`roll_${levelclass}_rollhp`] = `@{wtype}&{template:mancerhproll} {{title=Roll for HP}} ` + dice.join()
+         _.each(repids, (repid) => {
+            set[`roll_${repid}_rollhp`]    = `@{wtype}&{template:mancerhproll} {{title=Roll for HP Level ${_.last(repid.split(`${levelclass}-`))}}} {{r1=[[1${hitdie}${templateBonus}]]}}`;
+            set[`roll_${repid}_averagehp`] = `@{wtype}&{template:mancerhproll} {{title=Average for HP Level ${_.last(repid.split(`${levelclass}-`))}}} {{a1=[[${average}${templateBonus}]]}}`;
 
-            //Set the average hp button
-            set[`roll_${levelclass}_averagehp`] = `@{wtype}&{template:mancerhproll} {{title=Average for HP}}{{a1=[[${average}${templateBonus}]]}}`
-        };
+            if (addlevel && hitdie) {
+                let dice = [];
+                //Set the roll buttons
+                for (x = 1; x <= addlevel; x++) { dice.push(`{{r${x}=[[1${hitdie}${templateBonus}]]}}`); };
+                set[`roll_${levelclass}_rollhp`] = `@{wtype}&{template:mancerhproll} {{title=Roll for HP}} ` + dice.join()
+
+                //Set the average hp button
+                set[`roll_${levelclass}_averagehp`] = `@{wtype}&{template:mancerhproll} {{title=Average for HP}}{{a1=[[${average}${templateBonus}]]}}`
+            };
+        });
 
         setAttrs(set);
     };
@@ -15339,21 +15351,24 @@
         return [hpbonus, bonusSource];
     };
 
-    const updateResults = (levelclass, repid, eventinfo) => {
+    const updateResults = (levelclass, repids, eventinfo) => {
         const mancerdata = getCharmancerData();
         const leveldata  = mancerdata["lp-levels"].values;
         const hitdie     = leveldata[`${levelclass}_hitdie`];
         let average      = getDieAvg(hitdie), bonus = hpBonus(levelclass), hpbonus = bonus[0], set = {};
 
-        if (!leveldata[`${repid}_result`]) {
-            set[`${repid}_result`] = parseInt(average) + parseInt(hpbonus);
-        } else if (eventinfo && (eventinfo.newValue).includes("Draconic Bloodline")) {
-            set[`${repid}_result`] = parseInt(leveldata[`${repid}_result`]) + parseInt(hpbonus);
-        } else if (eventinfo && (eventinfo.previousValue).includes("Draconic Bloodline")) {
-            set[`${repid}_result`] = parseInt(leveldata[`${repid}_result`]) - 1;
-        } else {
-            false
-        };
+        _.each(repids, (repid) => {
+            console.log(repid);
+           if (!leveldata[`${repid}_result`]) {
+                set[`${repid}_result`] = parseInt(average) + parseInt(hpbonus);
+            } else if (eventinfo && (eventinfo.newValue).includes("Draconic Bloodline")) {
+                set[`${repid}_result`] = parseInt(leveldata[`${repid}_result`]) + parseInt(hpbonus);
+            } else if (eventinfo && (eventinfo.previousValue).includes("Draconic Bloodline")) {
+                set[`${repid}_result`] = parseInt(leveldata[`${repid}_result`]) - 1;
+            } else {
+                false
+            };
+        });
 
         setAttrs(set);
     };

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -15154,13 +15154,17 @@
     });
 
     const recalcHpByLevel = (section) => {
+        console.log(section ? `RECALC HP: ${section}` : "RECALC HP: ALL");
         const mancerdata = getCharmancerData();
         const leveldata = mancerdata["lp-levels"].values;
         const repeating = mancerdata["lp-levels"].repeating || [];
-        const sections = section ? [section] : ["class1", "class2", "class3", "class4"];
         let set = {};
+        const sections = section ? [section] : ["class1", "class2", "class3", "class4"];
+
         _.each(sections, (levelclass) => {
-            let thishp = 0, first = true, rollflag = "";
+            let thishp = 0;
+            let first = true;
+            let rollflag = "";
             _.each(repeating, function(repid) {
                 if(repid.split("_")[2].split("-")[0] == levelclass && leveldata[`${repid}_result`]) {
                     let thisflag = leveldata[`${repid}_rollflag`] || "average";
@@ -15173,7 +15177,7 @@
                 }
             });
             set[`${levelclass}_hp_flag`] = rollflag;
-            set[`${levelclass}_addhp`] = rollflag;
+            set[`${levelclass}_addhp`] = thishp;
         });
         setAttrs(set, () => {recalcLpData()});
     };
@@ -15184,19 +15188,26 @@
         const repeating = mancerdata["lp-levels"].repeating || [];
         let set = {};
 
+        //Updates all the Roll button templates
         const updateByLevel = (firstTime) => {
             for(let classnum=1; classnum<=4; classnum++) {
                 const levelclass = `class${classnum}`, hitdie = leveldata[`${levelclass}_hitdie`],
                     current = leveldata[`${levelclass}_currentlevel`] ? parseInt(leveldata[`${levelclass}_currentlevel`]) : 0,
                     addlevel = leveldata[`${levelclass}_addlevel`] ? parseInt(leveldata[`${levelclass}_addlevel`]) : 0;
-                //Bonus for Draconic Ancestor
-                const subclassData = mancerdata["lp-levels"].data[`${levelclass}_subclass`];
-                const hpbonus = (subclassData && subclassData.blobs[`Draconic Resilience`]) ? `1[Draconic Resilience]` : `0`;
                 let levelarray = [], addarray = [], removearray = [], existing = [], average = getDieAvg(hitdie);
 
-                //DEV 1619 REMOVE Later
-                const dragon = (subclassData && subclassData.blobs[`Draconic Resilience`]) ? "Draconic Resilinece Found" : "Draconic Resilinece was not found";
-                console.log(`%c ${dragon}`,'font-size: 14px; background: yellow;');
+                //Bonus for by class mp mods like Draconic Bloodline for Sorcerers
+                const welcome = JSON.parse(mancerdata["lp-welcome"].values["previous_repeating"]), hpmod = welcome["hpmod"];
+                let hpbonus = 0, bonusSource = [];
+
+                _.each(hpmod, (mod) => {
+                    if (mod["levels"] === "base") {
+                        const bonus  = mod["mod"], source = mod["source"];
+
+                        bonusSource.push(`[ ${source} ]`);
+                        hpbonus += parseInt(bonus);
+                    };
+                });
 
                 for(let x = current+1; x<=current+addlevel; x++) {
                     levelarray.push(`${levelclass}-${x}`);
@@ -15220,9 +15231,9 @@
                     });
                     _.each(addarray, function(repname) {
                         addRepeatingSection(rowid, "hpbylevel", repname, function(repid) {
-                            if(!leveldata[`${repid}_result`]) set[`${repid}_result`] = average;
-                            set[`roll_${repid}_rollhp`] = `@{wtype}&{template:mancerhproll} {{title=Roll for HP Level ${_.last(repname.split("-"))}}} {{r1=[[1${hitdie}+${hpbonus}]]}}`;
-                            set[`roll_${repid}_averagehp`] = `@{wtype}&{template:mancerhproll} {{title=Average for HP Level ${_.last(repname.split("-"))}}} {{a1=[[${average}+${hpbonus}]]}}`;
+                            if(!leveldata[`${repid}_result`]) set[`${repid}_result`] = parseInt(average) + parseInt(hpbonus);
+                            set[`roll_${repid}_rollhp`] = `@{wtype}&{template:mancerhproll} {{title=Roll for HP Level ${_.last(repname.split("-"))}}} {{r1=[[1${hitdie}+${hpbonus}${bonusSource}]]}}`;
+                            set[`roll_${repid}_averagehp`] = `@{wtype}&{template:mancerhproll} {{title=Average for HP Level ${_.last(repname.split("-"))}}} {{a1=[[${average}+${hpbonus}${bonusSource}]]}}`;
                             update[`${repid} label`] = `Level ${_.last(repname.split("-"))}`;
                             if(repname == _.last(addarray)) {
                                 setCharmancerText(update);
@@ -15240,19 +15251,15 @@
                     });
                 }
 
-                //console.log('%c Oh my heavens! ', 'background: #222; color: #bada55');
-
-                console.log(mancerdata);
-
                 if (addlevel && hitdie) {
                     let dice = [], set = {};
 
                     //Set the roll buttons
-                    for (x = 1; x <= addlevel; x++) { dice.push(`{{r${x}=[[1${hitdie}+${hpbonus}]]}}`); };
+                    for (x = 1; x <= addlevel; x++) { dice.push(`{{r${x}=[[1${hitdie}+${hpbonus}${bonusSource}]]}}`); };
                     set[`roll_${levelclass}_rollhp`] = `@{wtype}&{template:mancerhproll} {{title=Roll for HP}} ` + dice.join()
 
                     //Set the average hp button
-                    set[`roll_${levelclass}_averagehp`] = `@{wtype}&{template:mancerhproll} {{title=Average for HP}}{{a1=[[${average}+${hpbonus}]]}}`
+                    set[`roll_${levelclass}_averagehp`] = `@{wtype}&{template:mancerhproll} {{title=Average for HP}}{{a1=[[${average}+${hpbonus}${bonusSource}]]}}`
 
                     setAttrs(set);
                 };
@@ -15290,28 +15297,26 @@
         return Math.ceil(sum / num.length)
     };
 
-    on("mancerroll:repeating_class1hprow mancerroll:repeating_class2hprow mancerroll:repeating_class3hprow mancerroll:repeating_class4hprow", function(eventinfo) {
-        let set = {};
-        set[`${eventinfo.sourceSection}_result`] = eventinfo.roll[0].result;
-        set[`${eventinfo.sourceSection}_rollflag`] = "roll";
-        setAttrs(set, () => {recalcHpByLevel()})
+    //Roll & Average buttons inside the repeating hp section for each level
+    ["class1", "class2", "class3", "class4"].forEach(levelclass => {
+        on(`mancerroll:repeating_${levelclass}hprow`, (eventinfo) => {
+            const source = eventinfo.sourceAttribute, flag = source.includes("rollhp") ? "roll" : "average";
+            let set = {};
+
+            set[`${eventinfo.sourceSection}_result`]   = eventinfo.roll[0].result;
+            set[`${eventinfo.sourceSection}_rollflag`] = flag;
+            setAttrs(set, () => {recalcHpByLevel()})
+        });
     });
 
-    on("clicked:repeating_class1hprow clicked:repeating_class2hprow clicked:repeating_class3hprow clicked:repeating_class4hprow", function(eventinfo) {
-        const mancerdata = getCharmancerData();
-        let set = {};
-        set[`${eventinfo.sourceSection}_result`] = getDieAvg(mancerdata["lp-levels"].values[`${eventinfo.sourceSection.split("_")[2].split("-")[0]}_hitdie`]);
-        set[`${eventinfo.sourceSection}_rollflag`] = "average";
-        setAttrs(set, () => {recalcHpByLevel()})
-    });
-
-
+    //Roll & Average top level buttons for each class
     ["class1", "class2", "class3", "class4"].forEach(levelclass => {
         on(`mancerroll:${levelclass}_rollhp mancerroll:${levelclass}_averagehp`, (eventinfo) => {
             const mancerdata = getCharmancerData();
             const leveldata = mancerdata["lp-levels"].values;
             const repeating = mancerdata["lp-levels"].repeating || [];
             const source = eventinfo.sourceAttribute;
+            const flag = source.includes("rollhp") ? "roll" : "average";
             let set = {}, sum = 0, rows = "";
 
             repeating.forEach(row => {
@@ -15320,9 +15325,10 @@
                     const diff = parseInt(leveldata[`${levelclass}_currentlevel`]) + 1;
                     const num = parseInt(row.split(`${levelclass}-`)[1]) - diff;
                     set[row + "_result"] = eventinfo.roll[`${num}`].result;
-                    set[row + "_rollflag"] = "roll";
+                    set[row + "_rollflag"] = flag;
                 } else {
-                    set[row + "_result"] = eventinfo.roll[`0`].result;
+                    set[row + "_result"] = eventinfo.roll[0].result;
+                    set[row + "_rollflag"] = flag;
                 };
             });
 
@@ -15338,7 +15344,6 @@
             set[`${levelclass}_addhp`] = sum;
 
             //Set hp_flag to be roll or average so the CSS will highlight the appropriate button
-            let flag = eventinfo.sourceAttribute.includes("roll") ? "roll" : "average";
             set[`${levelclass}_hp_flag`] = flag;
 
             setAttrs(set, function() { recalcLpData(); });

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -14969,6 +14969,7 @@
     on("page:lp-levels", function(eventinfo) {
         const mancerdata = getCharmancerData();
         const previous   = mancerdata["lp-welcome"].values["previous_attributes"] ? JSON.parse(mancerdata["lp-welcome"].values["previous_attributes"]) : {};
+        let levelclass   = ["class1"];
         let set          = {};
         let update       = {};
         let baseclass    = previous["class"];
@@ -15005,12 +15006,17 @@
                     set[`class${x1}_subclass`] = "Subclasses:" + previous[`multiclass${x}_subclass`];
                     update[`subclass${x1}_selector`] = `<div>` + previous[`multiclass${x}_subclass`] + `</div>`;
                 };
-            } else  {
+                levelclass.push(`class${x1}`);
+            } else {
                 set[`class${x1}_currentlevel`] = 0;
+            };
+
+            if (mancerdata["lp-levels"] && mancerdata["lp-levels"].values[`class${x1}`] && parseInt(mancerdata["lp-levels"].values[`class${x1}_addlevel`]) > 0 && !levelclass.includes(`class${x1}`)) {
+                levelclass.push(`class${x1}`);
             };
         };
 
-        setAttrs(set, () => { update_hp(true) });
+        setAttrs(set, () => { update_hp(true, levelclass) });
         setCharmancerText(update);
 
         changeCompendiumPage("sheet-levels-info", classcompend);
@@ -15136,8 +15142,8 @@
         set.spells = spells.toString();
 
         setCharmancerText(update);
-        setAttrs(set, function() {
-            update_hp();
+        setAttrs(set, () => {
+            update_hp(false, [`${levelclass}`]);
             recalcButtons(undefined, "lp-levels");
         });
     };
@@ -15166,7 +15172,6 @@
     });
 
     const recalcHpByLevel = (section) => {
-        //console.log(section ? `RECALC HP: ${section}` : "RECALC HP: ALL");
         const mancerdata = getCharmancerData();
         const leveldata = mancerdata["lp-levels"].values;
         const repeating = mancerdata["lp-levels"].repeating || [];
@@ -15194,19 +15199,19 @@
         setAttrs(set, () => {recalcLpData()});
     };
 
-    const update_hp = (firstTime) => {
+    const update_hp = (firstTime, levelclass) => {
         const mancerdata = getCharmancerData();
         const leveldata = mancerdata["lp-levels"].values;
         const repeating = mancerdata["lp-levels"].repeating || [];
-        let set = {};
 
-        //Updates all the Roll button templates
-        const updateByLevel = (firstTime) => {
-            for(let classnum=1; classnum<=4; classnum++) {
-                const levelclass = `class${classnum}`, hitdie = leveldata[`${levelclass}_hitdie`],
-                    current = leveldata[`${levelclass}_currentlevel`] ? parseInt(leveldata[`${levelclass}_currentlevel`]) : 0,
-                    addlevel = leveldata[`${levelclass}_addlevel`] ? parseInt(leveldata[`${levelclass}_addlevel`]) : 0;
-                let levelarray = [], addarray = [], removearray = [], existing = [], average = getDieAvg(hitdie);
+        console.log(`%c UPDATE HP: ${levelclass}`, "color: green; font-weight:bold;");
+        console.log(`%c First Time: ${firstTime}`, "color: green; font-weight:bold;");
+
+        const updateByLevel = (firstTime, levelclass) => {
+            _.each(levelclass, (levelclass) => {
+                const current = leveldata[`${levelclass}_currentlevel`] ? parseInt(leveldata[`${levelclass}_currentlevel`]) : 0,
+                      addlevel = leveldata[`${levelclass}_addlevel`] ? parseInt(leveldata[`${levelclass}_addlevel`]) : 0;
+                let levelarray = [], addarray = [], removearray = [], existing = [];
 
                 for(let x = current+1; x<=current+addlevel; x++) {
                     levelarray.push(`${levelclass}-${x}`);
@@ -15224,22 +15229,6 @@
                     }
                 });
 
-                //HP Bonus from subclass hp mods like Draconic Bloodline for Sorcerers
-                const prev_repeat = JSON.parse(mancerdata["lp-welcome"].values["previous_repeating"]), hpmod = prev_repeat["hpmod"], subclass = leveldata[`${levelclass}_subclass`];;
-                let hpbonus = 0, bonusSource = [];
-                _.each(hpmod, (mod) => {
-                    if (mod["levels"] === "base" && subclass && subclass.includes(mod["source"])) {
-                        bonusSource.push(mod["source"]);
-                        hpbonus += parseInt(mod["mod"]);
-                    };
-                });
-                //Multiclassing into Sorcer Draconic needs to update buttons
-                if (subclass && subclass.includes("Draconic Bloodline") && !bonusSource.includes("Draconic Bloodline")) {
-                    bonusSource.push("Draconic Bloodline");
-                    hpbonus += parseInt(1);
-                };
-                const templateBonus = (hpbonus > 0) ? `+${hpbonus}[${bonusSource}]` : "";
-
                 if(addarray.length > 0) {
                     let set = {}, update = {}, rowid = "";
                     _.each(repeating, function(repid) {
@@ -15247,9 +15236,8 @@
                     });
                     _.each(addarray, function(repname) {
                         addRepeatingSection(rowid, "hpbylevel", repname, function(repid) {
-                            if(!leveldata[`${repid}_result`]) set[`${repid}_result`] = parseInt(average) + parseInt(hpbonus);
-                            set[`roll_${repid}_rollhp`] = `@{wtype}&{template:mancerhproll} {{title=Roll for HP Level ${_.last(repname.split("-"))}}} {{r1=[[1${hitdie}${templateBonus}]]}}`;
-                            set[`roll_${repid}_averagehp`] = `@{wtype}&{template:mancerhproll} {{title=Average for HP Level ${_.last(repname.split("-"))}}} {{a1=[[${average}${templateBonus}]]}}`;
+                            updateResults(levelclass, repid);
+                            updateButtons(levelclass, repid);
                             update[`${repid} label`] = `Level ${_.last(repname.split("-"))}`;
                             if(repname == _.last(addarray)) {
                                 setCharmancerText(update);
@@ -15266,50 +15254,108 @@
                         recalcHpByLevel(levelclass);
                     });
                 }
-
-                if (addlevel && hitdie) {
-                    let dice = [], set = {};
-                    //Set the roll buttons
-                    for (x = 1; x <= addlevel; x++) { dice.push(`{{r${x}=[[1${hitdie}${templateBonus}]]}}`); };
-                    set[`roll_${levelclass}_rollhp`] = `@{wtype}&{template:mancerhproll} {{title=Roll for HP}} ` + dice.join()
-
-                    //Set the average hp button
-                    set[`roll_${levelclass}_averagehp`] = `@{wtype}&{template:mancerhproll} {{title=Average for HP}}{{a1=[[${average}${templateBonus}]]}}`
-
-                    setAttrs(set);
-                };
-            };
+            });
         };
 
-        setAttrs(set);
         if(firstTime) {
             addRepeatingSection("class1_by-levels", "row", "class1hprow", function() {
                 addRepeatingSection("class2_by-levels", "row", "class2hprow", function() {
                     addRepeatingSection("class3_by-levels", "row", "class3hprow", function() {
                         addRepeatingSection("class4_by-levels", "row", "class4hprow", function() {
-                            updateByLevel(true);
+                            updateByLevel(true, levelclass);
                         });
                     });
                 });
             });
         } else {
-            updateByLevel(false);
-        }
+            updateByLevel(false, levelclass);
+        };
+    };
+
+    const updateButtons = (levelclass, repid) => {
+        const mancerdata    = getCharmancerData();
+        const leveldata     = mancerdata["lp-levels"].values;
+        const addlevel      = leveldata[`${levelclass}_addlevel`] ? parseInt(leveldata[`${levelclass}_addlevel`]) : 0;
+        const hitdie        = leveldata[`${levelclass}_hitdie`];
+        let average         = getDieAvg(hitdie), set = {}, bonus = hpBonus(levelclass), hpbonus = bonus[0], bonusSource = bonus[1];
+        const templateBonus = (hpbonus > 0) ? `+${hpbonus}[${bonusSource}]` : "";
+
+        //console.log(`%c Update Buttons ${levelclass}: template = ${templateBonus}, RepID ${repid}`, "color: blue;");
+        
+        set[`roll_${repid}_rollhp`]    = `@{wtype}&{template:mancerhproll} {{title=Roll for HP Level ${_.last(repid.split(`${levelclass}-`))}}} {{r1=[[1${hitdie}${templateBonus}]]}}`;
+        set[`roll_${repid}_averagehp`] = `@{wtype}&{template:mancerhproll} {{title=Average for HP Level ${_.last(repid.split(`${levelclass}-`))}}} {{a1=[[${average}${templateBonus}]]}}`;
+
+        if (addlevel && hitdie) {
+            let dice = [];
+            //Set the roll buttons
+            for (x = 1; x <= addlevel; x++) { dice.push(`{{r${x}=[[1${hitdie}${templateBonus}]]}}`); };
+            set[`roll_${levelclass}_rollhp`] = `@{wtype}&{template:mancerhproll} {{title=Roll for HP}} ` + dice.join()
+
+            //Set the average hp button
+            set[`roll_${levelclass}_averagehp`] = `@{wtype}&{template:mancerhproll} {{title=Average for HP}}{{a1=[[${average}${templateBonus}]]}}`
+        };
+
+        setAttrs(set);
+    };
+
+    const hpBonus = (levelclass) => {
+        const mancerdata = getCharmancerData();
+        const leveldata  = mancerdata["lp-levels"].values;
+
+        //HP Bonus from subclass hp mods like Draconic Bloodline for Sorcerers
+        const prev_repeat = JSON.parse(mancerdata["lp-welcome"].values["previous_repeating"]), hpmod = prev_repeat["hpmod"], subclass = leveldata[`${levelclass}_subclass`];;
+        let hpbonus = 0, bonusSource = [];
+        _.each(hpmod, (mod) => {
+            if (mod["levels"] === "base" && subclass && subclass.includes(mod["source"])) {
+                bonusSource.push(mod["source"]);
+                hpbonus += parseInt(mod["mod"]);
+            };
+        });
+
+        //Multiclassing into Sorcerer Draconic needs to update buttons
+        if (subclass && subclass.includes("Draconic Bloodline") && !bonusSource.includes("Draconic Bloodline")) {
+            bonusSource.push("Draconic Bloodline");
+            hpbonus += parseInt(1);
+        };
+
+        //console.log(`%c HP Bonus ${levelclass}: hpbonus = ${hpbonus}, bonusSource = ${bonusSource}`, "color: purple;");
+
+        return [hpbonus, bonusSource];
+    };
+
+    const updateResults = (levelclass, repid, eventinfo) => {
+        const mancerdata = getCharmancerData();
+        const leveldata  = mancerdata["lp-levels"].values;
+        const hitdie     = leveldata[`${levelclass}_hitdie`];
+        let average      = getDieAvg(hitdie), bonus = hpBonus(levelclass), hpbonus = bonus[0], set = {};
+
+       //console.log(`%c Update Results ${levelclass}:`, "color: red;");
+
+        if (!leveldata[`${repid}_result`]) {
+            set[`${repid}_result`] = parseInt(average) + parseInt(hpbonus);
+        } else if (eventinfo && (eventinfo.newValue).includes("Draconic Bloodline")) {
+            set[`${repid}_result`] = parseInt(leveldata[`${repid}_result`]) + parseInt(hpbonus);
+        } else if (eventinfo && (eventinfo.previousValue).includes("Draconic Bloodline")) {
+            set[`${repid}_result`] = parseInt(leveldata[`${repid}_result`]) - 1;
+        } else {
+            false
+        };
+
+        setAttrs(set);
     };
 
     const getDieAvg = (hitdie) => {
         if(!hitdie) return 0;
         const size = hitdie.slice(1);
         let num = [], sum = 0;
-        for(x = 1; x <= size; x++) {
-           num.push(x);
-        };
 
-        for(i = 0; i < num.length; i++) {
-            sum += num[i];
-        };
+        //Push an array of numbers
+        for(x = 1; x <= size; x++) { num.push(x); };
 
-        return Math.ceil(sum / num.length)
+        //Add up the nummbers above
+        for(i = 0; i < num.length; i++) { sum += num[i]; };
+
+        return Math.ceil(sum / num.length);
     };
 
     //Roll & Average buttons inside the repeating hp section for each level
@@ -15331,13 +15377,13 @@
             const leveldata = mancerdata["lp-levels"].values;
             const repeating = mancerdata["lp-levels"].repeating || [];
             const source = eventinfo.sourceAttribute, flag = source.includes("rollhp") ? "roll" : "average";
-            let set = {}, sum = 0, rows = "";
+            let set = {}, sum = 0, rows = "", num = 0;
 
             repeating.forEach(row => {
                 if (row.includes(`${levelclass}-`) && source.includes("rollhp")) {
-                    const num = parseInt(row.split(`${levelclass}-`)[1]) - 1;
                     set[row + "_result"] = eventinfo.roll[`${num}`].result;
                     set[row + "_rollflag"] = flag;
+                    num += 1;
                 } else if (row.includes(`${levelclass}-`) && source.includes("average")) {
                     set[row + "_result"] = eventinfo.roll[0].result;
                     set[row + "_rollflag"] = flag;
@@ -15346,15 +15392,16 @@
                 };
             });
 
-            //Add up the results for rollhp and multiply the average option by added levels
+            //Add up the results for rollhp or multiply the average option by added levels
             if (source.includes("rollhp")) {
                 _.each(eventinfo.roll, function(roll) {
                     sum += parseInt(roll.result);
                  });
             } else {
-                sum = parseInt(eventinfo.roll[`0`].result) * leveldata[`${levelclass}_addlevel`];
+                sum = parseInt(eventinfo.roll[0].result) * leveldata[`${levelclass}_addlevel`];
             };
 
+            // Set addhp to the total
             set[`${levelclass}_addhp`] = sum;
 
             //Set hp_flag to be roll or average so the CSS will highlight the appropriate button
@@ -15441,6 +15488,29 @@
 
         changeCompendiumPage("sheet-levels-info", page);
         getCompendiumPage(page, function(p) {
+        });
+    });
+
+    //Trigger a change event when subclass changes
+    ["class1", "class2", "class3", "class4"].forEach(levelclass => {
+        on(`mancerchange:${levelclass}_subclass`, (eventinfo) => {
+            const mancerdata    = getCharmancerData();
+            const leveldata     = mancerdata["lp-levels"].values;
+            const repeating     = mancerdata["lp-levels"].repeating || [];
+            const newValue      = (eventinfo.newValue) ? eventinfo.newValue : " ";
+            const previousValue = (eventinfo.previousValue) ? eventinfo.previousValue : " ";
+            let set             = {};
+
+            _.each(repeating, function(repid) {
+                if (repid.includes(`_${levelclass}-`) && newValue.includes("Draconic Bloodline") || previousValue.includes("Draconic Bloodline")) {
+                    updateButtons(levelclass, repid);
+                    updateResults(levelclass, repid, eventinfo);
+                };
+            });
+
+            setAttrs(set);
+
+            console.log(mancerdata);
         });
     });
 


### PR DESCRIPTION
## Changes / Comments

* Refactored Average buttons to be Roll buttons for user output
* Refactored HP by level sections so they now run more on demand
* Created some helper functions so they can be accessed more dynamically
* Hill Dwarf now adds HP per level
* Draconic Sorcerer now get HP per level of that class
* Switching between Sorcerer subclasses with dynamically change input results

## Roll20 Requests

*Include the name of the sheet you made changes to in the title.*

- If changes fix a bug or resolves a feature request, be sure to link to that issue. 
- For pull request that change multiple sheets please confirm these changes are intentional for all sheets. This will help us catch unintended submissions.
- When updating existing sheets if you are changing attribute names please note what steps you have taken, if any, to assist players in keeping their data.