### PR TITLE
[LANCER RPG 1.8] Numerous Style/QoL Fixes

### DIFF
--- a/LANCER RPG (1.8)/LANCER.css
+++ b/LANCER RPG (1.8)/LANCER.css
@@ -56,6 +56,12 @@
     margin-bottom:3px;
 }
 
+.sheet-mini-input > .sheet-flex-element
+{
+    margin-top:3px;
+}
+
+
 .sheet-nested
 {
     padding:0px;
@@ -271,38 +277,38 @@ input.sheet-long
 
 input.sheet-license
 {
-	width: 25px;
+    width: 25px;
     height: 30px;
-	opacity:0;
-	z-index:9999;
+    opacity:0;
+    z-index:9999;
 }
 
 input.sheet-structure, input.sheet-corestress{
-	margin-right:10px;
-	width: 55px;
+    margin-right:10px;
+    width: 55px;
     height: 40px;
-    cursor: pointer;	
-	position: relative;
-	opacity: 0;
-	z-index: 9999;
-	margin-top:0px;
+    cursor: pointer;    
+    position: relative;
+    opacity: 0;
+    z-index: 9999;
+    margin-top:0px;
 }
 
 input.sheet-overcharge
 {
-	width: 35px;
+    width: 35px;
     height: 40px;
-    cursor: pointer;	
-	position: relative;
-	opacity: 0;
-	z-index: 9999;
-	margin-top:0px;
+    cursor: pointer;    
+    position: relative;
+    opacity: 0;
+    z-index: 9999;
+    margin-top:0px;
 }
 
 input.sheet-corepower
 {
-    width:25px;
-    height:25px;
+    width:22px;
+    height:22px;
     left:30px;
     position:relative;
     opacity:0;
@@ -312,42 +318,42 @@ input.sheet-corepower
 
 span.sheet-overcharge
 {
-	text-align: center;
+    text-align: center;
     display: inline-block;
-	font-size: 13px;	
-	background: #c7c3b0;
-	color: black;
-	font-weight: bold;
-	width: 35px;
+    font-size: 13px;    
+    background: #c7c3b0;
+    color: black;
+    font-weight: bold;
+    width: 35px;
     height: 40px;
-    cursor: pointer;	
-	position: relative;
-	vertical-align: middle;
-	left:30px;
-	margin-left:-35px;
-	border: 2px solid black;
-	border-left:none;
-	margin-top:0px;
+    cursor: pointer;    
+    position: relative;
+    vertical-align: middle;
+    left:30px;
+    margin-left:-35px;
+    border: 2px solid black;
+    border-left:none;
+    margin-top:0px;
 }
 
 
 span.sheet-structure, span.sheet-corestress{
-	text-align: center;
+    text-align: center;
     display: inline-block;
-	font-size: 13px;	
-	background: #c7c3b0;
-	color: black;
-	font-weight: bold;
-	width: 55px;
+    font-size: 13px;    
+    background: #c7c3b0;
+    color: black;
+    font-weight: bold;
+    width: 55px;
     height: 40px;
-    cursor: pointer;	
-	vertical-align: middle;
-	margin-left:-65px;
-	border: 2px solid black;
-	border-left:none;
-	position:relative;
-	left:60px;
-	margin-top:0px;
+    cursor: pointer;    
+    vertical-align: middle;
+    margin-left:-65px;
+    border: 2px solid black;
+    border-left:none;
+    position:relative;
+    left:60px;
+    margin-top:0px;
 }
 
 span.sheet-pskill-fancy
@@ -368,18 +374,18 @@ span.sheet-license
     cursor:pointer;
     display: inline-block;
     line-height:30px;
-	text-align: center;
-	font-size: 13px;	
-	font-weight: bold;
-	background: #c7c3b0;
-	color: black;
-	width: 20px;
+    text-align: center;
+    font-size: 13px;    
+    font-weight: bold;
+    background: #c7c3b0;
+    color: black;
+    width: 20px;
     height: 30px;
-	border: 2px solid black;
-	border-left:none;
-	margin-left:-25px;
-	margin-top:0px;
-	margin-bottom:0px;
+    border: 2px solid black;
+    border-left:none;
+    margin-left:-25px;
+    margin-top:0px;
+    margin-bottom:0px;
     position:relative;
     left:22px;
     
@@ -404,15 +410,14 @@ span.sheet-corepower
 {
     display:inline-block;
     color: solid black;
-    background:white;
-    vertical-align:bottom;
     text-align:center;
-    width:25px;
-    height:25px;
-    font-size:9px;
-    background: #a1ff9e;
+    width:22px;
+    line-height:16px;
+    padding-top:0px;
+    height:22px;
+    font-size:14px;
     font-weight:bold;
-    padding-top:5px;
+    background: #a1ff9e;
     border: 2px solid black;
     border-radius:5px;
 }
@@ -492,8 +497,8 @@ textarea
 
 /*-------------TAB SETUP-------------*/
 /*this hides the contents of each tab by default*/
-.charsheet div[class^="sheet-section"] { 	
-	display: none;
+.charsheet div[class^="sheet-section"] {    
+    display: none;
 }
 
 /*this shows the tab content when the appropriate input field is selected*/
@@ -501,63 +506,63 @@ textarea
 .charsheet input.sheet-tab2:checked ~ div.sheet-section-talents,
 .charsheet input.sheet-tab3:checked ~ div.sheet-section-frame
 {
-	display: block;
+    display: block;
 }
 
-.charsheet input.sheet-tab99:checked ~ div[class^="sheet-section"] { 	
-	display: block;
+.charsheet input.sheet-tab99:checked ~ div[class^="sheet-section"] {    
+    display: block;
 }
 
 /*this hides the radio button for each tab, makes it 100px wide and 40px tall and makes sure it's above everything else*/
 .charsheet input.sheet-tab {
     width: 100px;
     height: 50px;
-    cursor: pointer;	
-	position: relative;
-	opacity: 0;
-	z-index: 9999;
+    cursor: pointer;    
+    position: relative;
+    opacity: 0;
+    z-index: 9999;
 }
 
 .charsheet input.sheet-acc-tab {
     width: 100px;
     height: 50px;
-    cursor: pointer;	
-	position: relative;
-	opacity: 0;
-	z-index: 9999;
+    cursor: pointer;    
+    position: relative;
+    opacity: 0;
+    z-index: 9999;
 }
 
 /*this styles the span with the tab information and slides to the left, so it appears underneath the radio button*/
 .charsheet span.sheet-tab {
-	text-align: center;
+    text-align: center;
     display: inline-block;
-	font-size: 13px;	
-	background: #c7c3b0;
-	color: black;
-	font-weight: bold;
-	border-radius: 4px;
-	width: 100px;
+    font-size: 13px;    
+    background: #c7c3b0;
+    color: black;
+    font-weight: bold;
+    border-radius: 4px;
+    width: 100px;
     height: 40px;
-    cursor: pointer;	
-	position: relative;
-	vertical-align: middle;
-	margin-left: -101px;/*originally 91px*/
+    cursor: pointer;    
+    position: relative;
+    vertical-align: middle;
+    margin-left: -101px;/*originally 91px*/
 }
 
 .charsheet span.sheet-acc-tab {
-	text-align: center;
+    text-align: center;
     display: inline-block;
-	font-size: 13px;	
-	background: #c7c3b0;
-	color: black;
-	font-weight: bold;
-	border-radius: 4px;
-	width: 100px;
+    font-size: 13px;    
+    background: #c7c3b0;
+    color: black;
+    font-weight: bold;
+    border-radius: 4px;
+    width: 100px;
     height: 40px;
-    cursor: pointer;	
-	position: relative;
-	vertical-align: middle;
-	margin-left: -101px;/*originally 91px*/
+    cursor: pointer;    
+    position: relative;
+    vertical-align: middle;
+    margin-left: -101px;/*originally 91px*/
 }
 
 /*license button color setup*/
@@ -585,7 +590,7 @@ input.sheet-license1:checked+span.sheet-license1
 {
     background: #2c424e;
     color: #bfc4c6;
-	border-radius: 4px;
+    border-radius: 4px;
 }
 
 /*acc button color setup*/
@@ -594,7 +599,7 @@ input.sheet-acc-tab2:checked + span.sheet-acc-tab2,
 input.sheet-acc-tab3:checked + span.sheet-acc-tab3
 {
     background: #ff9d87;
-	border-radius: 4px;
+    border-radius: 4px;
 }
 
 /*core stress/structure/overcharge color setup*/
@@ -665,7 +670,12 @@ input.sheet-corepower:checked + span.sheet-corepower
     background: #ce0606;
 }
 
+input.sheet-corepower:checked + span.sheet-corepower:after
+{
+    content:"⌾";
+}
 
-
-
-
+input.sheet-corepower:not(:checked) + span.sheet-corepower:after
+{
+content:"⍟";
+}

--- a/LANCER RPG (1.8)/LANCER.html
+++ b/LANCER RPG (1.8)/LANCER.html
@@ -201,27 +201,27 @@
 </script>
 
 <div style="background:#ddd;min-height:950px;min-width:820px;width:840px"> <!--> main container div<-->
-	<!-- tab/topbar setup -->
+    <!-- tab/topbar setup -->
     <input type="hidden" name="attr_net_pilot_acc" value="0"/>
     <input type="hidden" name="attr_net_acc" value="0"/>
-	<input type="radio" class="sheet-tab sheet-tab1" name="attr_core-tab" value="1" title="Pilot" checked="checked" /> 
-	<span class="tab tab1" style='line-height: 40px;'>PILOT</span>
-	<input type="radio" class="sheet-tab sheet-tab2" name="attr_core-tab" value="2" title="Talents" /> 
-	<span class="tab tab2" style='line-height: 40px;'>TALENTS</span>
-	<input type="radio" class="sheet-tab sheet-tab3" name="attr_core-tab" value="3" title="FRAME"  /> 
-	<span class="tab tab3" style='line-height: 40px;margin-right:115px'>FRAME</span>
-	
-	<!--acc/diff toolbar has been removed for now, will be re-added pending more robust acc calculation for pilot skills-->
-	
-	<!--><input type="radio" class="acc-tab acc-tab1" name="attr_acc_tab" value="acc" title="Accuracy" /> 
-	<span class="acc-tab acc-tab1" style='line-height: 40px;'>ACCURACY</span>
-	<input type="radio" class="acc-tab acc-tab2" name="attr_acc_tab" value="diff" title="Difficulty" /> 
-	<span class="acc-tab acc-tab2" style='line-height: 40px;'>DIFFICULTY</span>
-	<input type="radio" class="acc-tab acc-tab2" name="attr_acc_tab" value="none" title="None" /> 
-	<span class="acc-tab acc-tab2" style='line-height: 40px;'>NONE</span>
-	<input type="number" name="attr_acc_diff_mod" min="0" value="0" style="width:45px;height:40px;display:inline;margin-left:3px;text-align:center;font-size:18px;margin-top:2px"/>	
-	<!-- end tab setup-->
-	
+    <input type="radio" class="sheet-tab sheet-tab1" name="attr_core-tab" value="1" title="Pilot" checked="checked" /> 
+    <span class="tab tab1" style='line-height: 40px;'>PILOT</span>
+    <input type="radio" class="sheet-tab sheet-tab2" name="attr_core-tab" value="2" title="Talents" /> 
+    <span class="tab tab2" style='line-height: 40px;'>TALENTS</span>
+    <input type="radio" class="sheet-tab sheet-tab3" name="attr_core-tab" value="3" title="FRAME"  /> 
+    <span class="tab tab3" style='line-height: 40px;margin-right:115px'>FRAME</span>
+    
+    <!--acc/diff toolbar has been removed for now, will be re-added pending more robust acc calculation for pilot skills-->
+    
+    <!--><input type="radio" class="acc-tab acc-tab1" name="attr_acc_tab" value="acc" title="Accuracy" /> 
+    <span class="acc-tab acc-tab1" style='line-height: 40px;'>ACCURACY</span>
+    <input type="radio" class="acc-tab acc-tab2" name="attr_acc_tab" value="diff" title="Difficulty" /> 
+    <span class="acc-tab acc-tab2" style='line-height: 40px;'>DIFFICULTY</span>
+    <input type="radio" class="acc-tab acc-tab2" name="attr_acc_tab" value="none" title="None" /> 
+    <span class="acc-tab acc-tab2" style='line-height: 40px;'>NONE</span>
+    <input type="number" name="attr_acc_diff_mod" min="0" value="0" style="width:45px;height:40px;display:inline;margin-left:3px;text-align:center;font-size:18px;margin-top:2px"/> 
+    <!-- end tab setup-->
+    
     <div class="section-pilot"><!-- pilot tab -->   
         <div class="flex-row-wrapper" style="background:#ddd"> <!--row display; wraps entire tab -->
             <div class="nomarg 1x tab-flex-item" style="height:75px;width:800px"> <!-- header bar-->
@@ -269,7 +269,7 @@
                 </div>  <!--header inputs-->
             </div> <!--header bar-->
             <div class="flex-column-wrapper"> <!--wraps pilot column 1-->
-                <div class="border tab-flex-item" style="width:220px;height:110px"> <!-- pilot core stats block -->
+                <div class="border tab-flex-item" style="height:110px"> <!-- pilot core stats block -->
                     <div class="flex-element"> <!--block title-->
                         <label>CORE</label>
                     </div>
@@ -316,7 +316,7 @@
                     <div class="flex-element"> <!--block title-->
                         <label>SKILLS</label>
                     </div>
-                    <div class="align-just-between nested tab-flex-item" style="margin-left:2px">
+                    <div class="align-just-between nested tab-flex-item" style="margin-left:2px;margin-bottom:0px">
                         <input class="mid" type="text" name="attr_base-pilotskill" style="margin-right:2px" value="Skill Name"/>
                         <input class="short" type="text" name="attr_base-pilotskill-mod" style="margin-right:2px" value="0"/>
                         <select style="margin:0;width:53px;font-size:10px;padding:0px" name="attr_base-pilotskill-spec">
@@ -324,10 +324,10 @@
                             <option value="+1">SPEC</option>
                             <option value="-1">FLAW</option>
                         </select>
-                        <button type="roll" value="&{template:default}} {{name=@{base-pilotskill} Check}} {{@{base-pilotskill}=[[d20cs0cf0+@{base-pilotskill-mod}@{base-pilotskill-spec}d6kh1cs0cf0}]] }}"></button>
+                        <button type="roll" value="&{template:default}} {{name=@{base-pilotskill} Check}} {{@{base-pilotskill}=[[d20cs0cf0+@{base-pilotskill-mod}@{base-pilotskill-spec}d6kh1cs0cf0]] }}"></button>
                     </div>  
                     <fieldset class="repeating_pilotskills"> <!--pilot skills repeating set--> 
-                        <div class="align-just-between nested notop tab-flex-item" style="margin-left:2px">  <!--pilot skills repeating block--> 
+                        <div class="align-just-between nested tab-flex-item" style="margin-left:2px">  <!--pilot skills repeating block--> 
                             <input class="mid" type="text" name="attr_pilotskill" style="margin-right:2px"/>
                             <input class="short" type="text" name="attr_pilotskill-mod" style="margin-right:2px"/>
                             <select style="margin:0;width:53px;font-size:10px;padding:0" name="attr_pilotskill-spec">
@@ -335,7 +335,7 @@
                                 <option value="+1">SPEC</option>
                                 <option value="-1">FLAW</option>
                             </select>
-                            <button type="roll" value="&{template:default}} {{name=@{pilotskill} Check}} {{@{pilotskill}=[[d20cs0cf0+@{pilotskill-mod}@{pilotskill-spec}d6kh1cs0cf0}]] }}"></button>
+                            <button type="roll" value="&{template:default}} {{name=@{pilotskill} Check}} {{@{pilotskill}=[[d20cs0cf0+@{pilotskill-mod}@{pilotskill-spec}d6kh1cs0cf0]] }}"></button>
                         </div>  <!--pilot skills repeating block--> 
                     </fieldset> <!--pilot skills repeating set--> 
                     </div>
@@ -381,7 +381,7 @@
                     </div>
                 </div>  <!--pilot gear block -->
                 
-                <div class="multi-input border tab-flex-item" style="width:400px;min-height:150px"> <!--pilot base armor block-->
+                <div class="multi-input just-between border tab-flex-item" style="width:400px;min-height:150px"> <!--pilot base armor block-->
                     <div class="flex-element" style="width:100%;margin-bottom:0px"> <!--block title-->
                         <label>PILOT ARMOR 1</label>
                     </div>
@@ -407,19 +407,19 @@
                         <label class="mid">EVADE</label>
                     </div>
                     <div class="flex-element">
-                        <input type="number" class="1digit" name="attr_base_pilotarmor_evasion"/>
+                        <input type="number" class="2digit" name="attr_base_pilotarmor_evasion"/>
                     </div>
                     <div class="flex-element">
                         <label class="mid">E-DEF</label>
                     </div>
                     <div class="flex-element">
-                        <input type="number" class="1digit" name="attr_base_pilotarmor_edef"/>
+                        <input type="number" class="2digit" name="attr_base_pilotarmor_edef"/>
                     </div>
                     <div class="flex-element">
                         <label class="mid">SPD</label>
                     </div>
-                    <div class="1x flex-element">
-                        <input type="number" class="flex 1digit" name="attr_base_pilotarmor_spd"/>
+                    <div class="flex-element">
+                        <input type="number" class="2digit" name="attr_base_pilotarmor_spd"/>
                     </div>
                     <div class="flex-element">
                         <label class="mid">BONUSES </label>
@@ -434,7 +434,7 @@
                 </div> <!--pilot base armor block-->
                 <div class="pilotarmor-counter-div">  <!--counter div-->
                     <fieldset class="repeating_pilotarmor" style="width:400px;"> <!--pilot armor repeating set-->
-                        <div class="border multi-input tab-flex-item" style="width:400px;height:150px"> <!--pilot armor repeating block-->
+                        <div class="border just-between multi-input tab-flex-item" style="width:400px;height:150px"> <!--pilot armor repeating block-->
                             <div class="flex-element" style="width:100%;margin-bottom:0px"> <!--block title-->
                                <label class="pilotarmor-counter"></label> 
                             </div>
@@ -460,19 +460,19 @@
                                 <label class="mid">EVADE</label>
                             </div>
                             <div class="flex-element">
-                                <input type="number" class="1digit" name="attr_pilotarmor-evasion"/>
+                                <input type="number" class="2digit" name="attr_pilotarmor-evasion"/>
                             </div>
                             <div class="flex-element">
                                 <label class="mid">E-DEF</label>
                             </div>
                             <div class="flex-element">
-                                <input type="number" class="1digit" name="attr_pilotarmor-edef"/>
+                                <input type="number" class="2digit" name="attr_pilotarmor-edef"/>
                             </div>
                             <div class="flex-element">
                                 <label class="mid">SPD</label>
                             </div>
-                            <div class="1x flex-element">
-                                <input type="number" class="flex 1digit" name="attr_pilotarmor-spd"/>
+                            <div class="flex-element">
+                                <input type="number" class="2digit" name="attr_pilotarmor-spd"/>
                             </div>
                             <div class="flex-element">
                                 <label class="mid">BONUSES </label>
@@ -489,12 +489,12 @@
                 </div> <!--counter div-->
 
                 <div class="just-between nopad tab-flex-item" style="width:400px;min-height:150px;height:150px;margin-top:-23px"> <!--pilot base weapons joint block -->
-                    <div class="multi-input align-start nomarg border tab-flex-item" style="width:49%;height:165px"> <!--pilot base weapon block 1-->
+                    <div class="mini-input just-between nomarg border tab-flex-item" style="width:49%;height:150px"> <!--pilot base weapon block 1-->
                         <div class="flex-element"> <!--block title-->
                             <label>PILOT WEAPON 1</label>
                         </div>
                         <div class="just-end-self flex-element">
-                            <button type="roll" value="&{template:default}{{name=PILOT ATTACK: @{base_pilotwep1_name}}} {{ATK=[[d20cs0cf0+@{grit}]]}}{{DMG=[[@{base_pilotwep1_damage}]]}} {{RANGE=[[@{base_pilotwep1_range}]]}}{{TAGS=@{base_pilotwep1_tags}}}"></button>
+                            <button type="roll" value="&{template:default}{{name=PILOT ATTACK: @{base_pilotwep1_name}}} {{ATK=[[d20cs0cf0+@{grit}]]}}{{DMG=[[@{base_pilotwep1_damage}]] @{base_pilotwep1_dmgtype}}} {{RANGE=[[@{base_pilotwep1_range}]]}}{{TAGS=@{base_pilotwep1_tags}}}"></button>
                         </div>
                         <div class="flex-element"> 
                             <label class="mid">NAME</label>
@@ -508,18 +508,29 @@
                         <div class="flex-element"> 
                             <input class="1digit" type="number" name="attr_base_pilotwep1_rarity"/>
                         </div>
+                        <div class="flex-element" > 
+                            <label class="mid">RANGE</label>
+                        </div>
+                        <div class="flex-element"> 
+                            <input class="1digit" type="number" name="attr_base_pilotwep1_range"/>
+                        </div>
                         <div class="flex-element"> 
                             <label class="mid">DMG</label>
                         </div>
                         <div class="flex-element"> 
                             <input style="width:45px;text-align:center" type="text" name="attr_base_pilotwep1_damage"/>
                         </div>
-                        <div class="flex-element" > 
-                            <label class="mid">RANGE</label>
+                        <div class="flex-element"> 
+                            <label class="mid">TYPE</label>
                         </div>
                         <div class="flex-element"> 
-                            <input style="width:45px;text-align:center;margin-right:50px" type="text" name="attr_base_pilotwep1_range"/>
+                            <select style="width:45px;height:25px;padding:0" name="attr_base_pilotwep1_dmgtype">
+                                <option value="KIN">KIN</option>
+                                <option value="EXP">EXP</option>
+                                <option value="ERG">ERG</option>
+                            </select>
                         </div>
+
                         <div class="flex-element"> 
                             <label class="mid">TAGS</label>
                         </div>
@@ -528,12 +539,12 @@
                         </div>
                     </div><!--pilot base weapon block 1-->
                     
-                    <div class="multi-input align-start nomarg border tab-flex-item" style="width:49%;height:165px;"> <!--pilot base weapon block 2-->
+                    <div class="mini-input just-between nomarg border tab-flex-item" style="width:49%;height:150px;"> <!--pilot base weapon block 2-->
                         <div class="flex-element"> <!--block title-->
                             <label>PILOT WEAPON 2</label>
                         </div>
                         <div class="just-end-self flex-element">
-                            <button type="roll" value="&{template:default}{{name=PILOT ATTACK: @{base_pilotwep2_name}}} {{ATK=[[d20cs0cf0+@{grit}]]}}{{DMG=[[@{base_pilotwep2_damage}]]}} {{RANGE=[[@{base_pilotwep2_range}]]}}{{TAGS=@{base_pilotwep2_tags}}}"></button>
+                            <button type="roll" value="&{template:default}{{name=PILOT ATTACK: @{base_pilotwep2_name}}} {{ATK=[[d20cs0cf0+@{grit}]]}}{{DMG=[[@{base_pilotwep2_damage}]] @{base_pilotwep2_dmgtype}}} {{RANGE=[[@{base_pilotwep2_range}]]}}{{TAGS=@{base_pilotwep2_tags}}}"></button>
                         </div>
                         <div class="flex-element"> 
                             <label class="mid">NAME</label>
@@ -547,17 +558,27 @@
                         <div class="flex-element"> 
                             <input class="1digit" type="number" name="attr_base_pilotwep2_rarity"/>
                         </div>
-                        <div class="flex-element"> 
-                            <label class="mid">DMG</label>
-                        </div>
-                        <div class="flex-element"> 
-                            <input style="width:45px;;text-align:center" type="text" name="attr_base_pilotwep2_damage"/>
-                        </div>
                         <div class="flex-element" > 
                             <label class="mid">RANGE</label>
                         </div>
                         <div class="flex-element"> 
-                            <input style="width:45px;text-align:center;margin-right:50px" type="text" name="attr_base_pilotwep2_range"/>
+                            <input class="1digit" type="number" name="attr_base_pilotwep2_range"/>
+                        </div>
+                        <div class="flex-element"> 
+                            <label class="mid">DMG</label>
+                        </div>
+                        <div class="flex-element"> 
+                            <input style="width:45px;text-align:center" type="text" name="attr_base_pilotwep2_damage"/>
+                        </div>
+                        <div class="flex-element"> 
+                            <label class="mid">TYPE</label>
+                        </div>
+                        <div class="flex-element"> 
+                            <select style="width:45px;height:25px;padding:0" name="attr_base_pilotwep2_dmgtype">
+                                <option value="KIN">KIN</option>
+                                <option value="EXP">EXP</option>
+                                <option value="ERG">ERG</option>
+                            </select>
                         </div>
                         <div class="flex-element"> 
                             <label class="mid">TAGS</label>
@@ -569,12 +590,12 @@
                 </div> <!--pilot base weapons joint block -->
                 <div class="pilotwep-counter-div" style="width:410px"> <!--counter div-->
                     <fieldset class="repeating_pilotweapons" > <!--pilot weapon repeating set-->
-                        <div class="multi-input align-start border tab-flex-item" style="width:195px;height:165px;margin-top:20px"> <!--pilot weapon repeating item-->
+                        <div class="mini-input just-between border tab-flex-item" style="width:195px;height:150;margin-top:5px"> <!--pilot weapon repeating item-->
                             <div class="flex-element"> <!--block title-->
                                 <label class="pilotwep-counter"></label>
                             </div>
                             <div class="just-end-self flex-element">
-                                <button type="roll" value="&{template:default}{{name=PILOT ATTACK: @{pilotwep-name}}} {{ATK=[[d20cs0cf0+@{grit}]]}}{{DMG=[[@{pilotwep-damage}]]}} {{RANGE=[[@{pilotwep-range}]]}}{{TAGS=@{pilotwep-tags}}}{{TAGS=@{pilotwep-tags}}}"></button>
+                                <button type="roll" value="&{template:default}{{name=PILOT ATTACK: @{pilotwep-name}}} {{ATK=[[d20cs0cf0+@{grit}]]}}{{DMG=[[@{pilotwep-damage}]] @{pilotwep-dmgtype}}} {{RANGE=[[@{pilotwep-range}]]}}{{TAGS=@{pilotwep-tags}}}{{TAGS=@{pilotwep-tags}}}"></button>
                             </div>
                             <div class="flex-element"> 
                                 <label class="mid">NAME</label>
@@ -588,17 +609,27 @@
                             <div class="flex-element"> 
                                 <input class="1digit" type="number" name="attr_pilotwep-rarity"/>
                             </div>
-                            <div class="flex-element"> 
-                                <label class="mid">DMG</label>
-                            </div>
-                            <div class="flex-element"> 
-                                <input style="width:45px;;text-align:center" type="text" name="attr_pilotwep-damage"/>
-                            </div>
                             <div class="flex-element" > 
                                 <label class="mid">RANGE</label>
                             </div>
                             <div class="flex-element"> 
-                                <input style="width:45px;text-align:center;margin-right:50px" type="text" name="attr_pilotwep-range"/>
+                                <input class="1digit" type="number" name="attr_pilotwep-range"/>
+                            </div>
+                            <div class="flex-element"> 
+                                <label class="mid">DMG</label>
+                            </div>
+                            <div class="flex-element"> 
+                                <input style="width:45px;text-align:center" type="text" name="attr_pilotwep-damage"/>
+                            </div>
+                            <div class="flex-element"> 
+                                <label class="mid">TYPE</label>
+                            </div>
+                            <div class="flex-element"> 
+                                <select style="width:45px;height:25px;padding:0" name="attr_pilotwep-dmgtype">
+                                    <option value="KIN">KIN</option>
+                                    <option value="EXP">EXP</option>
+                                    <option value="ERG">ERG</option>
+                                </select>
                             </div>
                             <div class="flex-element"> 
                                 <label class="mid">TAGS</label>
@@ -619,13 +650,13 @@
                     <fieldset class="repeating_licenses"> <!--licenses repeating set-->
                         <div class="nopad flex-element-reverse";style="width:inherit;height:30px;margin-top:3px"> <!--license item repeating block-->
                             <input type="text" name="attr_licensename" style="width:62%;margin-left:0px;"/>
-                        	<input type="radio" class="license license3" name="attr_license-tab" value="3" title="License III" /> 
-                        	<span class="license license3" style='border-radius: 0px 5px 5px 0px'>III</span>
-                        	<input type="radio" class="license license2" name="attr_license-tab" value="2" title="License II" /> 
-                        	<span class="license license2" >II</span>
-                        	<input type="radio" class="license license1" name="attr_license-tab" value="1" checked='true' title="License I"/> 
-                        	<span class="license license1" style='border-left:2px solid black; border-radius: 5px 0px 0px 5px'>I</span>
-                        	
+                            <input type="radio" class="license license3" name="attr_license-tab" value="3" title="License III" /> 
+                            <span class="license license3" style='border-radius: 0px 5px 5px 0px'>III</span>
+                            <input type="radio" class="license license2" name="attr_license-tab" value="2" title="License II" /> 
+                            <span class="license license2" >II</span>
+                            <input type="radio" class="license license1" name="attr_license-tab" value="1" checked='true' title="License I"/> 
+                            <span class="license license1" style='border-left:2px solid black; border-radius: 5px 0px 0px 5px'>I</span>
+                            
                         </div> <!--license item repeating block-->
                     </fieldset> <!--licenses repeating set-->
                 </div> <!--pilot licenses block -->
@@ -666,12 +697,12 @@
                     </div>
                 </div> 
             </div><!--pilot col 3-->
-	    </div><!--pilot row wrapper-->
+        </div><!--pilot row wrapper-->
     </div> <!--pilot tab-->
-	
-	<div class="section-talents"><!-- Talents Tab -->
-    	<div class="flex-row-wrapper">
-            <div class="nomarg 1x tab-flex-item" style="height:75px;width:800px;margin-bottom:5px"> <!-- header bar-->
+    
+    <div class="section-talents"><!-- Talents Tab -->
+        <div class="flex-row-wrapper just-between">
+            <div class="nomarg 1x tab-flex-item" style="height:75px;width:800px;"> <!-- header bar-->
                 <div class="nested tab-flex-item">
                     <div class="flex-element"> 
                         <label class="LANCER">LANCER</label>
@@ -715,7 +746,7 @@
                     </div>
                 </div>  <!--header inputs-->
             </div> <!--header bar-->
-            <div class="border tab-flex-item" style="width:47%;margin-bottom:10px"> <!--base talent block 1-->
+            <div class="border tab-flex-item" style="width:405px;height:350px;margin-bottom:10px"> <!--base talent block 1-->
                 <div class="flex-element">
                     <label style="width:65px">TALENT</label>
                     <input type="text" name="attr_base_talent1-name" class="long"/>
@@ -727,24 +758,24 @@
                 <div class="flex-element" style="width:100%">
                     <label>RANK I</label>
                 </div>
-                <div class="flex-element" style="width:100%;height:45px">
+                <div class="flex-element" style="width:100%;height:75px">
                     <textarea name="attr_base_talent1-rank1-desc"></textarea>
                 </div>
                 <div class="flex-element" style="width:100%">
                     <label>RANK II</label>
                 </div>
-                <div class="flex-element" style="width:100%;height:45px">
+                <div class="flex-element" style="width:100%;height:75px">
                     <textarea name="attr_base_talent1-rank2-desc"></textarea>
                 </div>
                 <div class="flex-element" style="width:100%">
                     <label>RANK III</label>
                 </div>
-                <div class="flex-element" style="width:100%;height:45px">
+                <div class="flex-element" style="width:100%;height:75px">
                     <textarea name="attr_base_talent1-rank3-desc"></textarea>
                 </div>
             </div> <!--base talent block 1-->
             
-            <div class="border tab-flex-item" style="width:47%;margin-bottom:10px"> <!--base talent block 2-->
+            <div class="border tab-flex-item" style="width:405px;margin-bottom:10px"> <!--base talent block 2-->
                 <div class="flex-element">
                     <label style="width:65px">TALENT</label>
                     <input type="text" name="attr_base_talent2-name" class="long"/>
@@ -756,25 +787,25 @@
                 <div class="flex-element" style="width:100%">
                     <label>RANK I</label>
                 </div>
-                <div class="flex-element" style="width:100%;height:45px">
+                <div class="flex-element" style="width:100%;height:75px">
                     <textarea name="attr_base_talent2-rank1-desc"></textarea>
                 </div>
                 <div class="flex-element" style="width:100%">
                     <label>RANK II</label>
                 </div>
-                <div class="flex-element" style="width:100%;height:45px">
+                <div class="flex-element" style="width:100%;height:75px">
                     <textarea name="attr_base_talent2-rank2-desc"></textarea>
                 </div>
                 <div class="flex-element" style="width:100%">
                     <label>RANK III</label>
                 </div>
-                <div class="flex-element" style="width:100%;height:45px">
+                <div class="flex-element" style="width:100%;height:75px">
                     <textarea name="attr_base_talent2-rank3-desc"></textarea>
                 </div>
             </div> <!--base talent block 2-->
             
             <fieldset class="repeating_talents"> <!--talents repeating set-->
-                <div class="border tab-flex-item" style="width:47%;margin-bottom:10px"> <!--talents repeating item-->
+                <div class="border tab-flex-item" style="width:405px;margin-bottom:10px"> <!--talents repeating item-->
                     <div class="flex-element">
                         <label style="width:65px">TALENT</label>
                         <input type="text" name="attr_talent-name" class="long"/>
@@ -786,19 +817,19 @@
                     <div class="flex-element" style="width:100%">
                         <label>RANK I</label>
                     </div>
-                    <div class="flex-element" style="width:100%;height:45px">
+                    <div class="flex-element" style="width:100%;height:75px">
                         <textarea name="attr_talent-rank1-desc"></textarea>
                     </div>
                     <div class="flex-element" style="width:100%">
                         <label>RANK II</label>
                     </div>
-                    <div class="flex-element" style="width:100%;height:45px">
+                    <div class="flex-element" style="width:100%;height:75px">
                         <textarea name="attr_talent-rank2-desc"></textarea>
                     </div>
                     <div class="flex-element" style="width:100%">
                         <label>RANK III</label>
                     </div>
-                    <div class="flex-element" style="width:100%;height:45px">
+                    <div class="flex-element" style="width:100%;height:75px">
                         <textarea name="attr_talent-rank3-desc"></textarea>
                     </div>
                 </div> <!--talents repeating item-->
@@ -806,8 +837,8 @@
         </div> <!--row wrapper-->
     </div> <!--talents tab-->
 
-	<div class="sheet-section-frame"> <!-->FRAME Tab<-->
-    	<div class="flex-row-wrapper">
+    <div class="sheet-section-frame"> <!-->FRAME Tab<-->
+        <div class="flex-row-wrapper">
             <div class="nomarg 1x tab-flex-item" style="height:75px;width:800px"> <!-- header bar-->
                 <div class="nested tab-flex-item">
                     <div class="flex-element"> 
@@ -896,7 +927,7 @@
                             <label>SP</label>
                         </div>
                         <div class="3m-sides flex-element"> 
-                            <input class="2digit" type="number"name="attr_frame_sp">
+                            <input class="2digit" value="0" type="number"name="attr_frame_sp">
                         </div>
                         <div class="flex-element"> 
                             <label>PAINT</label>
@@ -907,35 +938,35 @@
                     </div>
                 </div>  <!--header inputs-->
             </div> <!--header bar-->
-    	    <div class="flex-column-wrapper"> <!--frame column 1-->
-    	        <div class="border tab-flex-item" style="width:495px;height:250px;padding:1px"> <!--frame stat tracking block-->
+            <div class="flex-column-wrapper"> <!--frame column 1-->
+                <div class="border tab-flex-item" style="height:250px;padding:1px"> <!--frame stat tracking block-->
                     <div class="flex-column-wrapper" style="margin-right:15px;margin-left:5px"> <!--frame stat column 1-->
                         <div class="nested tab-flex-item-column">
                             <label class="nomarg">STRUCTURE DAMAGE</label>
                             <div class="flex-element-reverse" style="margin-bottom:25px"> <!--structure damage gauge-->
-                            	<input type="radio" class="structure structurecrit" name="attr-structure-tab" value="4" title="DAMAGE CRITICAL" /> 
-                            	<span class="structure structurecrit" style='line-height: 40px;border-radius: 0px 5px 5px 0px'>CRIT</span>
-                            	<input type="radio" class="structure structure4" name="attr-structure-tab" value="3" title="3 Damage" /> 
-                            	<span class="structure structure4" style='line-height: 40px;'>3</span>
-                            	<input type="radio" class="structure structure3" name="attr-structure-tab" value="2" title="2 Damage" /> 
-                            	<span class="structure structure3" style='line-height: 40px;'>2</span>
-                            	<input type="radio" class="structure structure2" name="attr-structure-tab" value="1" title="1 Damage " /> 
-                            	<span class="structure structure2" style='line-height: 40px;'>1</span>
-                            	<input type="radio" class="structure structure1" name="attr-structure-tab" value="0" title="0 Damage" checked="checked"/> 
-                            	<span class="structure structure1"  style='line-height:40px;border-left:2px solid black;border-radius:5px 0px 0px 5px'>0</span>
+                                <input type="radio" class="structure structurecrit" name="attr-structure-tab" value="4" title="DAMAGE CRITICAL" /> 
+                                <span class="structure structurecrit" style='line-height: 40px;border-radius: 0px 5px 5px 0px'>CRIT</span>
+                                <input type="radio" class="structure structure4" name="attr-structure-tab" value="3" title="3 Damage" /> 
+                                <span class="structure structure4" style='line-height: 40px;'>3</span>
+                                <input type="radio" class="structure structure3" name="attr-structure-tab" value="2" title="2 Damage" /> 
+                                <span class="structure structure3" style='line-height: 40px;'>2</span>
+                                <input type="radio" class="structure structure2" name="attr-structure-tab" value="1" title="1 Damage " /> 
+                                <span class="structure structure2" style='line-height: 40px;'>1</span>
+                                <input type="radio" class="structure structure1" name="attr-structure-tab" value="0" title="0 Damage" checked="checked"/> 
+                                <span class="structure structure1"  style='line-height:40px;border-left:2px solid black;border-radius:5px 0px 0px 5px'>0</span>
                             </div> <!--structure damage gauge-->
                             <label class="nomarg">REACTOR STRESS</label>
                             <div class="flex-element-reverse" style="margin-bottom:10px"> <!--core stress gauge-->
-                            	<input type="radio" class="corestress corestressbreach" name="attr-corestress-tab" value="5" title="CORE BREACH"/> 
-                            	<span class="corestress corestressbreach" style='line-height:40px; font-size:10px; border-radius:0px 5px 5px 0px'>BREACH</span>
-                            	<input type="radio" class="corestress corestress4" name="attr-corestress-tab" value="4" title="3 Reactor Stress" /> 
-                            	<span class="corestress corestress4" style='line-height: 40px;'>3</span>
-                            	<input type="radio" class="corestress corestress3" name="attr-corestress-tab" value="3" title="2 Reactor Stress" /> 
-                            	<span class="corestress corestress3" style='line-height: 40px;'>2</span>
-                            	<input type="radio" class="corestress corestress2" name="attr-corestress-tab" value="2" title="1 Reactor Stress" /> 
-                            	<span class="corestress corestress2" style='line-height: 40px;'>1</span>
-                            	<input type="radio" class="corestress corestress1" name="attr-corestress-tab" value="1" title="0 Reactor Stress" checked="checked"/> 
-                            	<span class="corestress corestress1"  style='line-height: 40px; border-left:2px solid black; border-radius:5px 0px 0px 5px'>0</span>
+                                <input type="radio" class="corestress corestressbreach" name="attr-corestress-tab" value="5" title="CORE BREACH"/> 
+                                <span class="corestress corestressbreach" style='line-height:40px; font-size:10px; border-radius:0px 5px 5px 0px'>BREACH</span>
+                                <input type="radio" class="corestress corestress4" name="attr-corestress-tab" value="4" title="3 Reactor Stress" /> 
+                                <span class="corestress corestress4" style='line-height: 40px;'>3</span>
+                                <input type="radio" class="corestress corestress3" name="attr-corestress-tab" value="3" title="2 Reactor Stress" /> 
+                                <span class="corestress corestress3" style='line-height: 40px;'>2</span>
+                                <input type="radio" class="corestress corestress2" name="attr-corestress-tab" value="2" title="1 Reactor Stress" /> 
+                                <span class="corestress corestress2" style='line-height: 40px;'>1</span>
+                                <input type="radio" class="corestress corestress1" name="attr-corestress-tab" value="1" title="0 Reactor Stress" checked="checked"/> 
+                                <span class="corestress corestress1"  style='line-height: 40px; border-left:2px solid black; border-radius:5px 0px 0px 5px'>0</span>
                             </div> <!--core stress gauge-->
                         </div>
                         
@@ -1027,16 +1058,16 @@
                         <div class="nested tab-flex-item-column" style="margin-bottom:18px"> <!--overcharge gauge-->
                             <label class="nomarg">OVERCHARGE</label>
                             <div class="flex-element-reverse">
-                            	<input type="radio" class="overcharge overcharge4" name="attr_overcharge-tab" value="4" title="Overcharge d6+3" /> 
-                            	<span class="overcharge overcharge4" style='line-height: 40px; border-radius: 0px 5px 5px 0px;'>d6+3</span>
-                            	<input type="radio" class="overcharge overcharge3" name="attr_overcharge-tab" value="3" title="Overcharge d6" /> 
-                            	<span class="overcharge overcharge3" style='line-height: 40px;'>d6</span>
-                            	<input type="radio" class="overcharge overcharge2" name="attr_overcharge-tab" value="2" title="Overcharge d3" /> 
-                            	<span class="overcharge overcharge2" style='line-height: 40px;'>d3</span>
-                            	<input type="radio" class="overcharge overcharge1" name="attr_overcharge-tab" value="1" title="Overcharge 1"/> 
-                            	<span class="overcharge overcharge1" style='line-height:40px;'>1</span>
-                            	<input type="radio" class="overcharge overcharge0" name="attr_overcharge-tab" value="0" title="Overcharge 0" checked="true"/> 
-                            	<span class="overcharge overcharge0" style='line-height:40px; border-left:2px solid black; border-radius: 5px 0px 0px 5px'>0</span>
+                                <input type="radio" class="overcharge overcharge4" name="attr_overcharge-tab" value="4" title="Overcharge d6+3" /> 
+                                <span class="overcharge overcharge4" style='line-height: 40px; border-radius: 0px 5px 5px 0px;'>d6+3</span>
+                                <input type="radio" class="overcharge overcharge3" name="attr_overcharge-tab" value="3" title="Overcharge d6" /> 
+                                <span class="overcharge overcharge3" style='line-height: 40px;'>d6</span>
+                                <input type="radio" class="overcharge overcharge2" name="attr_overcharge-tab" value="2" title="Overcharge d3" /> 
+                                <span class="overcharge overcharge2" style='line-height: 40px;'>d3</span>
+                                <input type="radio" class="overcharge overcharge1" name="attr_overcharge-tab" value="1" title="Overcharge 1"/> 
+                                <span class="overcharge overcharge1" style='line-height:40px;'>1</span>
+                                <input type="radio" class="overcharge overcharge0" name="attr_overcharge-tab" value="0" title="Overcharge 0" checked="true"/> 
+                                <span class="overcharge overcharge0" style='line-height:40px; border-left:2px solid black; border-radius: 5px 0px 0px 5px'>0</span>
 
                             </div> 
                         </div> <!--overcharge gauge-->
@@ -1093,8 +1124,8 @@
                             </div>
                         </div> <!--frame base stats column-->
                     </div> <!--frame stat column 2-->
-    	        </div> <!--frame stat tracking block-->
-    	        
+                </div> <!--frame stat tracking block-->
+                
                 <div class="just-around border tab-flex-item" style="width:505px;height:250px"> <!--frame stat autocals block-->
                     <div class="just-around multi-input flex-column-wrapper">
                         <div class="flex-element">
@@ -1267,15 +1298,15 @@
                         </fieldset> <!--frame weapon repeating set-->
                     </div> <!--weapon counter div-->
                 </div> <!--frame weapons block-->
-    	    </div> <!--frame column 1-->
-    	    <div class="flex-column-wrapper"> <!--frame column 2-->
+            </div> <!--frame column 1-->
+            <div class="flex-column-wrapper"> <!--frame column 2-->
                 <div class="align-start border tab-flex-item" style="height:250px;width:315px"> <!--frame coresys block-->
                     <div>
                         <label>CORE SYSTEM PASSIVE</label>
                     </div>
                     <div class="just-end-self">
                         <input type="checkbox" name="attr_corepower" class="corepower" />
-                        <span class="corepower">PWR</span>
+                        <span class="corepower"></span>
                     </div>
                     <div style="width:100%"> 
                         <textarea class="nomarg" name="attr_core_system_passive" style="height:90px"></textarea>
@@ -1307,7 +1338,7 @@
                     </fieldset> <!--frame traits repeating set-->
                 </div> <!--frame traits block-->
                 
-                <div class="align-start multi-input border tab-flex-item" style="height:165px;width:315px"> <!--frame base systems block-->
+                <div class="align-start multi-input border tab-flex-item" style="height:165px;width:315px;margin-bottom:0px"> <!--frame base systems block-->
                     <div class="flex-element" style="width:100%">
                         <label style="width:80px;margin-right:0px">SYSTEM 1</label>
                         <input type="text" style="width:225px" name="attr_base_system_name"/>
@@ -1328,7 +1359,7 @@
                 
                 <div class="system-counter-div"> <!--systems counter div-->
                     <fieldset class="repeating_systems"> <!--frame systems repeating set-->
-                        <div class="align-start multi-input border tab-flex-item" style="height:165px;width:315px"> <!--frame systems repeating item-->
+                        <div class="align-start multi-input border tab-flex-item" style="height:165px;width:315px;margin-top:10px;margin-bottom:10px"> <!--frame systems repeating item-->
                             <div class="flex-element" style="width:100%">
                                 <label style="width:80px;margin-right:0px" class="system-counter"></label>
                                 <input type="text" style="width:225px" name="attr_system-name"/>
@@ -1349,9 +1380,9 @@
                     </fieldset> <!--frame systems repeating set-->
                     
                 </div> <!--systems counter div-->
-    	    </div> <!--frame column 2-->
-    	</div> <!--row wrapper-->
+            </div> <!--frame column 2-->
+        </div> <!--row wrapper-->
     </div><!--FRAME tab-->
-</div> <!--> main container div<-->
+</div> <!-- main container div<-->
 
 

--- a/LANCER RPG (1.8)/LANCER.html
+++ b/LANCER RPG (1.8)/LANCER.html
@@ -1041,7 +1041,7 @@
                             </div> 
                         </div> <!--overcharge gauge-->
                         <div class="nested multi-input tab-flex-item" style="width:180px"> <!--frame base stats column-->
-                            <div class="flex-column-wrapper" style="width:inherit">
+                            <div class="flex-column-wrapper" style="width:inherit;height:165px">
                                 <div class="nested tab-flex-item" style="width:inherit">
                                     <div class="flex-element">
                                         <label style="margin-left:0px">ARMOR</label>


### PR DESCRIPTION
## Changes / Comments

-Made talent rank text containers longer to accommodate longer description text
-Tweaked height/margins of several repeating fields to make them tile correctly
-Reorganized pilot weapons and armor fields to look cleaner
-Added a damage type dropdown for pilot weapons
-Resized various modules to make them flush with sheet gutters
-Added new toggle indicator for core power button 
-Added a default of 0 to SP value to prevent NaN on new sheet load
-fixed some macros with trailing brackets

