### PR TITLE
Dungeons the dragoning 40k 7th Edition: Default value for Level

### DIFF
--- a/Dungeons the Dragoning 40000 7th Edition/DtD.html
+++ b/Dungeons the Dragoning 40000 7th Edition/DtD.html
@@ -350,7 +350,7 @@
 						</tr>
 					</table>
 					<table width="100%">
-						<tr style="background-color: #C0C0C0"><td width="30%"></td><td><h4>Level:</h4></td><td><input type="text" name="attr_level" value="0" style="width: 50px; border-bottom: medium solid #404040"></td><td width="30%"></td></tr>
+						<tr style="background-color: #C0C0C0"><td width="30%"></td><td><h4>Level:</h4></td><td><input type="text" name="attr_level" value="1" style="width: 50px; border-bottom: medium solid #404040"></td><td width="30%"></td></tr>
 					</table>
 					<h4 align="center" style="background-color: #C0C0C0">Classes</h4>
 					<textarea style="width: 96%; height: 200px" name="attr_classList"></textarea>

--- a/Dungeons the Dragoning 40000 7th Edition/DtD.html
+++ b/Dungeons the Dragoning 40000 7th Edition/DtD.html
@@ -350,7 +350,7 @@
 						</tr>
 					</table>
 					<table width="100%">
-						<tr style="background-color: #C0C0C0"><td width="30%"></td><td><h4>Level:</h4></td><td><input type="text" name="attr_level" style="width: 50px; border-bottom: medium solid #404040"></td><td width="30%"></td></tr>
+						<tr style="background-color: #C0C0C0"><td width="30%"></td><td><h4>Level:</h4></td><td><input type="text" name="attr_level" value="0" style="width: 50px; border-bottom: medium solid #404040"></td><td width="30%"></td></tr>
 					</table>
 					<h4 align="center" style="background-color: #C0C0C0">Classes</h4>
 					<textarea style="width: 96%; height: 200px" name="attr_classList"></textarea>


### PR DESCRIPTION
## Changes / Comments
Added default value to level field in Dungeons the Dragoning character sheet to allow certain macros to function even when character sheet is incorrectly or incompletely filled out
*Provide a few comments about what you have changed.*




## Roll20 Requests

*Include the name of the sheet you made changes to in the title.*
Dungeons the dragoning 40k 7th Edition
- If changes fix a bug or resolves a feature request, be sure to link to that issue. 
- For pull request that change multiple sheets please confirm these changes are intentional for all sheets. This will help us catch unintended submissions.
- When updating existing sheets if you are changing attribute names please note what steps you have taken, if any, to assist players in keeping their data.