### PR TITLE
5e D&D - DEV 1845 - Fix Flat Attack Saves

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -6484,8 +6484,6 @@
                 var attackid = v[repeating_source + "_spellattackid"];
                 var lvl      = v[repeating_source + "_spelllevel"];
 
-                console.log(`%c Spell change: ${spellid}, ${attackid}, ${lvl} `, "color:purple; font-weight:bold;");
-
                 if(attackid && lvl && spellid) {
                     update_attack_from_spell(lvl, spellid, attackid)
                 }
@@ -9003,7 +9001,7 @@
     };
 
     var update_attacks = function(update_id, source) {
-        console.log("DOING UPDATE_ATTACKS: " + update_id);
+        console.log(`%c DOING UPDATE_ATTACKS: ${update_id}`, "color: blue;");
         if(update_id.substring(0,1) === "-" && update_id.length === 20) {
             do_update_attack([update_id], source);
         }
@@ -9092,7 +9090,7 @@
 
         getAttrs(attack_attribs, function(v) {
             _.each(attack_array, function(attackid) {
-                console.log("UPDATING ATTACK: " + attackid);
+                console.log(`%c UPDATING ATTACK: ${attackid}`, "color: blue;");
                 var callbacks = [];
                 var update = {};
                 var hbonus = "";
@@ -9172,7 +9170,7 @@
                     if(!v["repeating_attack_" + attackid + "_savedc"] || (v["repeating_attack_" + attackid + "_savedc"] && v["repeating_attack_" + attackid + "_savedc"] === "(@{spell_save_dc})")) {
                         var tempdc = v["spell_save_dc"];
                     }
-                    else if(v["repeating_attack_" + attackid + "_savedc"] && v["repeating_attack_" + attackid + "_savedc"] === "(@{saveflat})") {
+                    else if(v["repeating_attack_" + attackid + "_savedc"] && v["repeating_attack_" + attackid + "_savedc"].includes("@{saveflat}") {
                         var tempdc = isNaN(parseInt(v["repeating_attack_" + attackid + "_saveflat"])) === false ? parseInt(v["repeating_attack_" + attackid + "_saveflat"]) : "0";
                     }
                     else {


### PR DESCRIPTION
## Changes / Comments

- Update two console logs.
- Fix broken Flat Saves on Spell Attacks



## Roll20 Requests

*Include the name of the sheet you made changes to in the title.*

- If changes fix a bug or resolves a feature request, be sure to link to that issue. 
- For pull request that change multiple sheets please confirm these changes are intentional for all sheets. This will help us catch unintended submissions.
- When updating existing sheets if you are changing attribute names please note what steps you have taken, if any, to assist players in keeping their data.