### PR TITLE
Changes to Exo 2933 Character Sheet

### DIFF
--- a/Exo 2933/Exo2933.html
+++ b/Exo 2933/Exo2933.html
@@ -90,7 +90,7 @@ on("change:durbase change:durmod change:vig change:durtotal change:durarm sheet:
                 </div>
             <div class="sheet-col-3-7 sheet-core-stat-label">AGI</div>
             <div class="sheet-col-1-7 sheet-center">
-               <button type="roll"  name="roll_Agilidad" value="&{template:SWorlds} {{title=Agilidad}} {{subheader=@{character_name}}} {{roll1=[[(@{agi})+@{heridas}+@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!+@{heridas}+@{fatiga}+?{Modificador|0})]]}} {{ca=[[4]]}} {{1aumento=[[8]]}} {{2aumento=[[12]]}} {{3aumento=[[16]]}}"></button>
+               <button type="roll"  name="roll_Agilidad" value="&{template:SWorlds} {{title=Agilidad}} {{subheader=@{character_name}}} {{roll1=[[(@{agi})-@{heridas}-@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!-@{heridas}-@{fatiga}+?{Modificador|0})]]}} {{ca=[[4]]}} {{1aumento=[[8]]}} {{2aumento=[[12]]}} {{3aumento=[[16]]}}"></button>
             </div>
          </div>
          <div class="sheet-row">
@@ -107,7 +107,7 @@ on("change:durbase change:durmod change:vig change:durtotal change:durarm sheet:
                 </select></div>
             <div class="sheet-col-3-7 sheet-core-stat-label">AST</div>
             <div class="sheet-col-1-7 sheet-center">
-               <button type="roll"  name="roll_Astucia" value="&{template:SWorlds} {{title=Astucia}} {{subheader=@{character_name}}} {{roll1=[[(@{ast})+@{heridas}+@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!+@{heridas}+@{fatiga}+?{Modificador|0})]]}} {{ca=[[4]]}} {{1aumento=[[8]]}} {{2aumento=[[12]]}} {{3aumento=[[16]]}}"></button>
+               <button type="roll"  name="roll_Astucia" value="&{template:SWorlds} {{title=Astucia}} {{subheader=@{character_name}}} {{roll1=[[(@{ast})-@{heridas}-@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!-@{heridas}-@{fatiga}+?{Modificador|0})]]}} {{ca=[[4]]}} {{1aumento=[[8]]}} {{2aumento=[[12]]}} {{3aumento=[[16]]}}"></button>
             </div>
          </div>
          <div class="sheet-row">
@@ -124,7 +124,7 @@ on("change:durbase change:durmod change:vig change:durtotal change:durarm sheet:
                 </select></div>
             <div class="sheet-col-3-7 sheet-core-stat-label">ESP</div>
             <div class="sheet-col-1-7 sheet-center">
-               <button type="roll"  name="roll_Espiritu" value="&{template:SWorlds} {{title=Espíritu}} {{subheader=@{character_name}}} {{roll1=[[(@{esp})+@{heridas}+@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!+@{heridas}+@{fatiga}+?{Modificador|0})]]}} {{ca=[[4]]}} {{1aumento=[[8]]}} {{2aumento=[[12]]}} {{3aumento=[[16]]}}"></button>
+               <button type="roll"  name="roll_Espiritu" value="&{template:SWorlds} {{title=Espíritu}} {{subheader=@{character_name}}} {{roll1=[[(@{esp})-@{heridas}-@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!-@{heridas}-@{fatiga}+?{Modificador|0})]]}} {{ca=[[4]]}} {{1aumento=[[8]]}} {{2aumento=[[12]]}} {{3aumento=[[16]]}}"></button>
             </div>
          </div>
          <div class="sheet-row">
@@ -141,7 +141,7 @@ on("change:durbase change:durmod change:vig change:durtotal change:durarm sheet:
                 </select></div>
             <div class="sheet-col-3-7 sheet-core-stat-label">FUE</div>
             <div class="sheet-col-1-7 sheet-center">
-               <button type="roll"  name="roll_Fuerza" value="&{template:SWorlds} {{title=Fuerza}} {{subheader=@{character_name}}} {{roll1=[[(@{fue})+@{heridas}+@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!+@{heridas}+@{fatiga}+?{Modificador|0})]]}} {{ca=[[4]]}} {{1aumento=[[8]]}} {{2aumento=[[12]]}} {{3aumento=[[16]]}}"></button>
+               <button type="roll"  name="roll_Fuerza" value="&{template:SWorlds} {{title=Fuerza}} {{subheader=@{character_name}}} {{roll1=[[(@{fue})-@{heridas}-@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!-@{heridas}-@{fatiga}+?{Modificador|0})]]}} {{ca=[[4]]}} {{1aumento=[[8]]}} {{2aumento=[[12]]}} {{3aumento=[[16]]}}"></button>
             </div>
          </div>
          <div class="sheet-row">
@@ -158,7 +158,7 @@ on("change:durbase change:durmod change:vig change:durtotal change:durarm sheet:
                 </select></div>
             <div class="sheet-col-3-7 sheet-core-stat-label">VIG</div>
             <div class="sheet-col-1-7 sheet-center">
-               <button type="roll"  name="roll_Vigor" value="&{template:SWorlds} {{title=Vigor}} {{subheader=@{character_name}}} {{roll1=[[(@{vig})+@{heridas}+@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!+@{heridas}+@{fatiga}+?{Modificador|0})]]}} {{ca=[[4]]}} {{1aumento=[[8]]}} {{2aumento=[[12]]}} {{3aumento=[[16]]}}"></button>
+               <button type="roll"  name="roll_Vigor" value="&{template:SWorlds} {{title=Vigor}} {{subheader=@{character_name}}} {{roll1=[[(@{vig})-@{heridas}-@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!-@{heridas}-@{fatiga}+?{Modificador|0})]]}} {{ca=[[4]]}} {{1aumento=[[8]]}} {{2aumento=[[12]]}} {{3aumento=[[16]]}}"></button>
             </div>
          </div>
       </div>
@@ -187,7 +187,7 @@ on("change:durbase change:durmod change:vig change:durtotal change:durarm sheet:
                   <div class="sheet-col-1 sheet-center sheet-labelfatigue">
                      HERIDAS
                   </div>
-                  <div class="sheet-col-1 sheet-small-label sheet-center"><input class="sheet-labelmanus sheet-center" type="number" value="0" name="attr_heridas" min="-3" max="0" step="1"><br/></div>
+                  <div class="sheet-col-1 sheet-small-label sheet-center"><input class="sheet-labelmanus sheet-center" type="number" value="0" name="attr_heridas" min="0" max="3" step="1"><br/></div>
                </div>
             </div>
          </div>
@@ -214,7 +214,7 @@ on("change:durbase change:durmod change:vig change:durtotal change:durarm sheet:
                   <div class="sheet-col-1 sheet-labelfatigue">
                      FATIGA
                   </div>
-                  <div class="sheet-col-2-3 sheet-small-label sheet-center"><input class="sheet-labelmanus sheet-center" type="number" value="0" name="attr_fatiga" min="-2" max="0" step="1"><br/></div>
+                  <div class="sheet-col-2-3 sheet-small-label sheet-center"><input class="sheet-labelmanus sheet-center" type="number" value="0" name="attr_fatiga" min="0" max="2" step="1"><br/></div>
                </div>
             </div>
          </div>
@@ -246,39 +246,36 @@ on("change:durbase change:durmod change:vig change:durtotal change:durarm sheet:
       <div class="sheet-row" style="margin-left:-10px">
          <div class="sheet-col-23-24 sheet-padl">
          <span class="sheet-spacer"></span>
-         <h4 class="sheet-center">Ataques Automáticos (lánzalos sobre un token)</h4>
+         <h4 class="sheet-center">Armas y Daños</h4>
          <div class="sheet-row sheet-sub-header" style="margin-top: -3px;">
             <div class="sheet-col-1-5 sheet-center sheet-small-label sheet-vert-bottom">Nombre</div>
             <div class="sheet-col-1-11 sheet-center sheet-small-label sheet-vert-bottom">Daño</div>
+            <div class="sheet-col-1-11 sheet-center sheet-small-label sheet-vert-bottom">Mod</div>
             <div class="sheet-col-1-14 sheet-center sheet-small-label sheet-vert-bottom">FUE</div>
-            <div class="sheet-col-1-7 sheet-center sheet-small-label sheet-vert-bottom">Tipo</div>
+            <div class="sheet-col-1-8 sheet-center sheet-small-label sheet-vert-bottom">Alcance</div>
             <div class="sheet-col-1-11 sheet-center sheet-small-label sheet-vert-bottom">PA</div>
-            <div class="sheet-col-4-13 sheet-center sheet-small-label sheet-vert-bottom">Notas</div>
-            <div class="sheet-col-1-24 sheet-center sheet-small-label sheet-vert-bottom">Atq</div>
-            <div class="sheet-col-1-24 sheet-center sheet-small-label sheet-vert-bottom">Daño</div>
+            <div class="sheet-col-4-17 sheet-center sheet-small-label sheet-vert-bottom">Notas</div>
+            <div class="sheet-col-1-19 sheet-center sheet-small-label sheet-vert-bottom">Daño</div>
+            <div class="sheet-col-1-24 sheet-center sheet-small-label sheet-vert-bottom">Auto</div>
          </div>
          <fieldset class="repeating_attacks">
             <div class="sheet-row">
                <div class="sheet-col-1-5 sheet-pad1"><input type="text" name="attr_atq"></div>
-               <div class="sheet-col-1-11 sheet-pad1"><input type="text" name="attr_atqdmg"></div>
+               <div class="sheet-col-1-11 sheet-pad1"><input type="text" title="Introduce sólo el dado o dados sin modificadores. Solo 1 tipo de dado ej: 1d6" name="attr_atqdmg"></div>
+               <div class="sheet-col-1-11 sheet-pad1"><input type="number" value="0" step="1" title="Introduce sólo el modificador, ej: 1, -2, etc" name="attr_atqdmgmod"></div>
                <div class="sheet-col-1-14 sheet-pad1" style="margin-left:10px"><input type="checkbox" value="1" name="attr_atqfue"></div>
-               <div class="sheet-col-1-7 sheet-pad1"  style="margin-left:-14px">
-                    <select name="attr_weapontype">
-                        <option value="@{pelear}" >Melee</option>
-                        <option value="@{disparar}" >Proyectil</option>
-                        <option value="@{lanzar}" >Arrojadiza</option>
-                        <option value="@{arcana}" >Arcano</option>
-                    </select>
+               <div class="sheet-col-1-8 sheet-pad1 sheet-"  style="margin-left:-14px">
+                        <input type="text" class="sheet-center" name="attr_reach">
                    </div>
                <div class="sheet-col-1-11 sheet-left sheet-pad1"><input type="number" value="0" step="1" name="attr_weaponpa"></div>
-               <div class="sheet-col-4-13 sheet-left sheet-pad1"><input type="text" name="attr_weaponnotes"></div>
+               <div class="sheet-col-4-17 sheet-left sheet-pad1"><input type="text" name="attr_weaponnotes"></div>
                
                <div class="sheet-col-1-24 sheet-left sheet-padr" style="margin-left:-2px">
-                  <button type="roll" class="sheet-new-button2" name="roll_Attack2" value="&{template:SWorlds} {{title=Ataque de @{atq} a @{target|character_name}}} {{subheader=@{character_name}}} {{roll1=[[@{weapontype}+@{heridas}+@{fatiga}+?{Mod.Ataque|0}]]}} {{roll2=[[@{as}*(1d6!+@{heridas}+@{fatiga}+?{Mod.Ataque|0})]]}} {{ca=[[@{target|partotal}]]}} {{1aumento=[[@{target|partotal}+4]]}} {{2aumento=[[@{target|partotal}+8]]}} {{3aumento=[[@{target|partotal}+12]]}}"></button>
+                  <button type="roll" class="sheet-new-button2" name="roll_Dmg" value="&{template:SWorlds} {{title=Daño de @{atq}}} {{subheader=@{character_name}}} {{damage=[[@{atqdmg}!+@{atqdmgmod}+(@{atqfue}*@{fue})+?{Mod.Daño|0}+?{Aumento|No, 0|Sí, 1d6!}]]}}"></button>
                </div>
                
                <div class="sheet-col-1-24 sheet-left sheet-padr" style="margin-left:4px">
-                  <button type="roll" class="sheet-new-button2" name="roll_Damage" value="&{template:SWorlds} {{title=Daño de @{atq} a @{target|character_name}}} {{subheader=@{character_name}}} {{damage=[[@{atqdmg}!+(@{atqfue}*@{fue})+@{heridas}+@{fatiga}+?{Mod.Daño|0}+[[{{@{target|durarm},0}>1}*(@{weaponpa})]] ]]}} {{dureza=[[@{target|durtotal}]]}} {{1herida=[[@{target|durtotal}+4]]}} {{2herida=[[@{target|durtotal}+8]]}} {{3herida=[[@{target|durtotal}+12]]}} {{incap=[[@{target|durtotal}+16]]}}"></button>
+                  <button type="roll" class="sheet-new-button2" name="roll_DmgAuto" value="&{template:SWorlds} {{title=Daño de @{atq} a @{target|character_name}}} {{subheader=@{character_name}}} {{damage=[[@{atqdmg}!+@{atqdmgmod}+(@{atqfue}*@{fue})+?{Mod.Daño|0}+?{Aumento|No, 0|Sí, 1d6!}+[[{{@{target|durarm},0}>1}*(@{weaponpa})]] ]]}} {{dureza=[[@{target|durtotal}]]}} {{1herida=[[@{target|durtotal}+4]]}} {{2herida=[[@{target|durtotal}+8]]}} {{3herida=[[@{target|durtotal}+12]]}} {{incap=[[@{target|durtotal}+16]]}}"></button>
                </div>
             </div>
          </fieldset>
@@ -299,7 +296,7 @@ on("change:durbase change:durmod change:vig change:durtotal change:durarm sheet:
                     
                 </div>
             <div class="sheet-col-1-7 sheet-center sheet-small-label">
-                   <button type="roll" class="sheet-new-button2" name="roll_SinHab" value="&{template:SWorlds} {{title=Sin Habilidad}} {{subheader=@{character_name}}} {{roll1=[[(1d4!-2)+@{heridas}+@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!+@{heridas}+@{fatiga}+?{Modificador|0})]]}} {{ca=[[4]]}} {{1aumento=[[8]]}} {{2aumento=[[12]]}} {{3aumento=[[16]]}}"></button>     
+                   <button type="roll" class="sheet-new-button2" name="roll_SinHab" value="&{template:SWorlds} {{title=Sin Habilidad}} {{subheader=@{character_name}}} {{roll1=[[(1d4!-2)-@{heridas}-@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!-2-@{heridas}-@{fatiga}+?{Modificador|0})]]}} {{ca=[[4]]}} {{1aumento=[[8]]}} {{2aumento=[[12]]}} {{3aumento=[[16]]}}"></button>     
                 </div>
         </div>
         <div class="sheet-row">
@@ -318,7 +315,14 @@ on("change:durbase change:durmod change:vig change:durtotal change:durarm sheet:
                     </select>
                 </div>
             <div class="sheet-col-1-7 sheet-center sheet-small-label">
-                    <button type="roll" class="sheet-new-button2" name="roll_Pelear" value="&{template:SWorlds} {{title=Pelear}} {{subheader=@{character_name}}} {{roll1=[[@{pelear}+@{heridas}+@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!+@{heridas}+@{fatiga}+?{Modificador|0})]]}}"></button>
+                    <button type="roll" class="sheet-new-button2" name="roll_Pelear" value="&{template:SWorlds} {{title=Pelear}} {{subheader=@{character_name}}} {{roll1=[[@{pelear}-@{heridas}-@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!-@{heridas}-@{fatiga}+?{Modificador|0})]]}}"></button>
+                </div>
+        </div>
+        <div class="sheet-row">
+            <div class="sheet-col-6-7 sheet-left sheet-medium3-label" style="margin-top:6px">Pelear Auto (selecciona tu token)----</div>
+
+            <div class="sheet-col-1-7 sheet-center sheet-small-label">
+                   <button type="roll" class="sheet-new-button2" name="roll_Attack2" value="&{template:SWorlds} {{title= Pelea contra @{target|character_name}}} {{subheader=@{character_name}}} {{roll1=[[@{pelear}-@{heridas}-@{fatiga}+?{Mod.Ataque|0}]]}} {{roll2=[[@{as}*(1d6!-@{heridas}-@{fatiga}+?{Mod.Ataque|0})]]}} {{ca=[[@{target|partotal}]]}} {{1aumento=[[@{target|partotal}+4]]}} {{2aumento=[[@{target|partotal}+8]]}} {{3aumento=[[@{target|partotal}+12]]}}"></button>     
                 </div>
         </div>
         <div class="sheet-row">
@@ -337,7 +341,7 @@ on("change:durbase change:durmod change:vig change:durtotal change:durarm sheet:
                     </select>
                 </div>
             <div class="sheet-col-1-7 sheet-center sheet-small-label">
-                    <button type="roll" class="sheet-new-button2" name="roll_Disparar" value="&{template:SWorlds} {{title=Disparar}} {{subheader=@{character_name}}} {{roll1=[[@{disparar}+@{heridas}+@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!+@{heridas}+@{fatiga}+?{Modificador|0})]]}}"></button>
+                    <button type="roll" class="sheet-new-button2" name="roll_Disparar" value="&{template:SWorlds} {{title=Disparar}} {{subheader=@{character_name}}} {{roll1=[[@{disparar}-@{heridas}-@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!-@{heridas}-@{fatiga}+?{Modificador|0})]]}}  {{ca=[[4]]}} {{1aumento=[[8]]}} {{2aumento=[[12]]}} {{3aumento=[[16]]}}"></button>
                 </div>
         </div>
         <div class="sheet-row">
@@ -356,11 +360,11 @@ on("change:durbase change:durmod change:vig change:durtotal change:durarm sheet:
                     </select>
                 </div>
             <div class="sheet-col-1-7 sheet-center sheet-small-label">
-                    <button type="roll" class="sheet-new-button2" name="roll_Lanzar" value="&{template:SWorlds} {{title=Lanzar}} {{subheader=@{character_name}}} {{roll1=[[@{lanzar}+@{heridas}+@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!+@{heridas}+@{fatiga}+?{Modificador|0})]]}}"></button>
+                    <button type="roll" class="sheet-new-button2" name="roll_Lanzar" value="&{template:SWorlds} {{title=Lanzar}} {{subheader=@{character_name}}} {{roll1=[[@{lanzar}-@{heridas}-@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!-@{heridas}-@{fatiga}+?{Modificador|0})]]}}  {{ca=[[4]]}} {{1aumento=[[8]]}} {{2aumento=[[12]]}} {{3aumento=[[16]]}}"></button>
                 </div>
         </div>
         <div class="sheet-row">
-            <div class="sheet-col-4-7 sheet-left sheet-medium-label" style="margin-top:6px">Hab.Arcana</div>
+            <div class="sheet-col-4-7 sheet-left sheet-medium-label" style="margin-top:6px">H.Arcana</div>
             <div class="sheet-col-2-7 sheet-center sheet-small-label">
                     <select class="sheet-center sheet-medium2-label" name="attr_arcana">
                         <option value='1d4!-2'   >1d4-2   </option>
@@ -375,9 +379,10 @@ on("change:durbase change:durmod change:vig change:durtotal change:durarm sheet:
                     </select>
                 </div>
             <div class="sheet-col-1-7 sheet-center sheet-small-label">
-                   <button type="roll" class="sheet-new-button2" name="roll_Arcano" value="&{template:SWorlds} {{title=Habilidad Arcana}} {{subheader=@{character_name}}} {{roll1=[[@{arcana}+@{heridas}+@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!+@{heridas}+@{fatiga}+?{Modificador|0})]]}}"></button>     
+                   <button type="roll" class="sheet-new-button2" name="roll_Arcano" value="&{template:SWorlds} {{title=Habilidad Arcana}} {{subheader=@{character_name}}} {{roll1=[[@{arcana}-@{heridas}-@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!-@{heridas}-@{fatiga}+?{Modificador|0})]]}}  {{ca=[[4]]}} {{1aumento=[[8]]}} {{2aumento=[[12]]}} {{3aumento=[[16]]}}"></button>     
                 </div>
         </div>
+        
         <div class="sheet-row">
             <fieldset class="repeating_skills">
             <div class="sheet-col-4-7 sheet-left sheet-medium-label"><input type="text" name="attr_skillname"></div>
@@ -394,7 +399,7 @@ on("change:durbase change:durmod change:vig change:durtotal change:durarm sheet:
                     </select>
                 </div>
             <div class="sheet-col-1-7 sheet-center sheet-small-label">
-                    <button type="roll" class="sheet-new-button2" name="roll_Skill" value="&{template:SWorlds} {{title=@{skillname}}} {{subheader=@{character_name}}} {{roll1=[[@{skill}+@{heridas}+@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!+@{heridas}+@{fatiga}+?{Modificador|0})]]}}"></button>
+                    <button type="roll" class="sheet-new-button2" name="roll_Skill" value="&{template:SWorlds} {{title=@{skillname}}} {{subheader=@{character_name}}} {{roll1=[[@{skill}-@{heridas}-@{fatiga}+?{Modificador|0}]]}} {{roll2=[[@{as}*(1d6!-@{heridas}-@{fatiga}+?{Modificador|0})]]}}  {{ca=[[4]]}} {{1aumento=[[8]]}} {{2aumento=[[12]]}} {{3aumento=[[16]]}}"></button>
                 </div>
             </fieldset>
         </div>
@@ -434,14 +439,12 @@ on("change:durbase change:durmod change:vig change:durtotal change:durarm sheet:
                <div class="sheet-col-8-13 sheet-left">
                   <input class="sheet-rasgo sheet-left" type="text" name="attr_desventaja" />
                </div>
-               <div class="sheet-col-2-13 sheet-right sheet-medium-label" style="margin-top:5px">Rango
+               <div class="sheet-col-2-13 sheet-right sheet-medium-label" style="margin-top:5px">Tipo
                </div>
-               <div class="sheet-col-2-13 sheet-left">
+               <div class="sheet-col-2-13 sheet-left" style="margin-left:-5px">
                   <select name="attr_desventajarango">
-                        <option value='N' >N</option>
-                        <option value='E' >E</option>
-                        <option value='V' >V</option>
-                        <option value='H' >H</option>
+                        <option value='N' >Mayor</option>
+                        <option value='E' >Menor</option>
                     </select>
                </div>
                <input type="checkbox" class="sheet-arrow" checked><span></span>


### PR DESCRIPTION
The following has been changed:

- Added {ca=[[4]]} to all skills in order for the rolltemplate to calculate success in a savage-worlds like way.
- Added automated Fighting skill and roll against token (in red in the character sheet)
- Tag for Ataccks changes "Armas y Daños". Columns have had their width changed.
- Injuries field "Heridas" attr_heridas has been changed from negative scale to positive scale.
- Some labels changed, no attribute name changed.
- In the attacks rows, we include manual damage button (Roll_Dmg) and damage against token (Roll_DmgAuto). We have removed the attack rolls from them (Roll_Attack2).
- Added variable to check extra damage in buttons Roll_Dmg and Roll_DmgAuto, it is called ?{Aumento}
- Corrected the -2 modifier to non skilled roll button, and tag also corrected to "Sin Habilidad".

Regards