### PR TITLE
StarWars5e: Added a Ship sheet type with all necessary fields

### DIFF
--- a/StarWars5E/StarWars5E_CSS.css
+++ b/StarWars5E/StarWars5E_CSS.css
@@ -584,6 +584,7 @@ button[type=roll] * {
 .sheet-tool input,
 .sheet-proficiencies input,
 .sheet-pc .sheet-traits input,
+.sheet-ship .sheet-traits input,
 .sheet-power input,
 .sheet-options .sheet-body input,
 .sheet-resources input[type=number]
@@ -1056,6 +1057,8 @@ button[type=roll] * {
 .sheet-npc .sheet-npc_options-flag,
 .sheet-pc .sheet-trait .sheet-options-flag,
 .sheet-pc .sheet-global-mod .sheet-options-flag,
+.sheet-ship .sheet-trait .sheet-options-flag,
+.sheet-ship .sheet-global-mod .sheet-options-flag,
 .sheet-action .sheet-options-flag,
 .sheet-textbox .sheet-options-flag,
 .sheet-proficiencies .sheet-options-flag,
@@ -1100,10 +1103,13 @@ button[type=roll] * {
 }
 
 .sheet-pc .sheet-global-mod .sheet-options-flag:not(:checked) ~ .sheet-display,
-.sheet-pc .sheet-global-mod .sheet-options-flag:checked ~ .sheet-options {
+.sheet-pc .sheet-global-mod .sheet-options-flag:checked ~ .sheet-options,
+.sheet-ship .sheet-global-mod .sheet-options-flag:not(:checked) ~ .sheet-display,
+.sheet-ship .sheet-global-mod .sheet-options-flag:checked ~ .sheet-options {
     width: 80%;
     display: inline-block;
 }
+
 
 .sheet-attacks .sheet-options-flag:checked + span,
 .sheet-power .sheet-options-flag:checked + span,
@@ -4016,7 +4022,8 @@ body:not(:-moz-handler-blocked) .sheet-charmancer .sheet-bottombar {
     border: none;
 }
 
-.sheet-pc .sheet-global-mod .sheet-options-flag:not(:checked) ~ .sheet-display .sheet-title {
+.sheet-pc .sheet-global-mod .sheet-options-flag:not(:checked) ~ .sheet-display .sheet-title,
+.sheet-ship .sheet-global-mod .sheet-options-flag:not(:checked) ~ .sheet-display .sheet-title  {
     font-size: 9px;
     font-weight: bold;
     padding-top: 3px;
@@ -4032,7 +4039,8 @@ body:not(:-moz-handler-blocked) .sheet-charmancer .sheet-bottombar {
     text-align: left;
 }
 
-.sheet-pc .sheet-global-mod .sheet-options-flag:not(:checked) ~ .sheet-display .sheet-subheader {
+.sheet-pc .sheet-global-mod .sheet-options-flag:not(:checked) ~ .sheet-display .sheet-subheader,
+.sheet-ship .sheet-global-mod .sheet-options-flag:not(:checked) ~ .sheet-display .sheet-subheader {
     font-size: 9px;
     font-weight: bold;
     padding-top: 3px;
@@ -4048,14 +4056,17 @@ body:not(:-moz-handler-blocked) .sheet-charmancer .sheet-bottombar {
     text-align: left;
 }
 
-.sheet-pc .sheet-global-mod .sheet-active-flag {
+.sheet-pc .sheet-global-mod .sheet-active-flag,
+.sheet-ship .sheet-global-mod .sheet-active-flag {
     margin-bottom: 10px;
 }
 
-.sheet-pc .sheet-global-mod .sheet-options-flag:checked ~ .sheet-active-flag {
+.sheet-pc .sheet-global-mod .sheet-options-flag:checked ~ .sheet-active-flag,
+.sheet-ship .sheet-global-mod .sheet-options-flag:checked ~ .sheet-active-flag  {
     margin-bottom: 50px;
 }
 
-.sheet-pc .sheet-global-mod .sheet-options-flag:checked ~ .sheet-display {
+.sheet-pc .sheet-global-mod .sheet-options-flag:checked ~ .sheet-display,
+.sheet-ship .sheet-global-mod .sheet-options-flag:checked ~ .sheet-display {
     display: none;
 }

--- a/StarWars5E/StarWars5E_CSS.css
+++ b/StarWars5E/StarWars5E_CSS.css
@@ -164,8 +164,7 @@ input[type=radio].sheet-tab-button:checked + span {
     display: none;
 }
 
-.sheet-npc_toggle[value="2"] ~ .sheet-ship .sheet-page.sheet-ship-core,
-.sheet-npc_toggle[value="2"] ~ .sheet-ship .sheet-page.sheet-ship-modifications
+.sheet-npc_toggle[value="2"] ~ .sheet-ship .sheet-page.sheet-ship-core
 {
     display: none;
 }
@@ -214,7 +213,6 @@ input[type=radio].sheet-tab-button.sheet-core:checked ~ .sheet-page.sheet-core,
 input[type=radio].sheet-tab-button.sheet-bio:checked ~ .sheet-page.sheet-bio,
 input[type=radio].sheet-tab-button.sheet-powers:checked ~ .sheet-page.sheet-powers,
 input[type=radio].sheet-tab-button.sheet-options:checked ~ .sheet-page.sheet-options,
-input[type=radio].sheet-tab-button.sheet-ship-modifications:checked ~ .sheet-page.sheet-ship-modifications,
 input[type=radio].sheet-tab-button.sheet-ship-core:checked ~ .sheet-page.sheet-ship-core
 {
     display: block;
@@ -223,7 +221,7 @@ input[type=radio].sheet-tab-button.sheet-ship-core:checked ~ .sheet-page.sheet-s
 input[type=radio].sheet-tab-button.sheet-core,
 input[type=radio].sheet-tab-button.sheet-core + span
 {
-    right: 116px;
+    right: 20px;
     width: 45px;
 }
 
@@ -237,12 +235,6 @@ input[type=radio].sheet-tab-button.sheet-bio,
 input[type=radio].sheet-tab-button.sheet-bio + span {
     right: 83px;
     width: 30px;
-}
-
-input[type=radio].sheet-tab-button.sheet-ship-modifications,
-input[type=radio].sheet-tab-button.sheet-ship-modifications + span {
-    right: 20px;
-    width: 111px;
 }
 
 input[type=radio].sheet-tab-button.sheet-powers,
@@ -1141,23 +1133,29 @@ button[type=roll] * {
 .sheet-proficiency:hover .sheet-options-flag + span,
 .sheet-item:hover .sheet-inventorysubflag + span,
 .sheet-pc .sheet-trait:hover .sheet-output,
-.sheet-pc .sheet-header:hover .sheet-options-flag + span
+.sheet-pc .sheet-header:hover .sheet-options-flag + span,
+.sheet-ship .sheet-trait:hover .sheet-output,
+.sheet-ship .sheet-header:hover .sheet-options-flag + span
 {
     display: block;
 }
 
-.sheet-pc .sheet-header .sheet-options-flag {
+.sheet-pc .sheet-header .sheet-options-flag,
+.sheet-ship .sheet-header .sheet-options-flag {
     top: 8px;
     right: 4px;
 }
 
-.sheet-pc .sheet-header .sheet-options-flag + span {
+.sheet-pc .sheet-header .sheet-options-flag + span,
+.sheet-ship .sheet-header .sheet-options-flag + span {
     top: 8px;
     right: 4px;
 }
 
 .sheet-pc .sheet-global-mod .sheet-display-flag,
-.sheet-pc .sheet-trait .sheet-display-flag {
+.sheet-pc .sheet-trait .sheet-display-flag,
+.sheet-ship .sheet-global-mod .sheet-display-flag,
+.sheet-ship .sheet-trait .sheet-display-flag {
     opacity: 0;    
     position: absolute;
     top: 0px;
@@ -1167,17 +1165,21 @@ button[type=roll] * {
 }
 
 .sheet-pc .sheet-global-mod .sheet-options-flag:checked ~ .sheet-display-flag,
-.sheet-pc .sheet-trait .sheet-options-flag:checked ~ .sheet-display-flag {
+.sheet-pc .sheet-trait .sheet-options-flag:checked ~ .sheet-display-flag,
+.sheet-ship .sheet-global-mod .sheet-options-flag:checked ~ .sheet-display-flag,
+.sheet-ship .sheet-trait .sheet-options-flag:checked ~ .sheet-display-flag  {
     width: 0px;
     height: 0px;
 }
 
-.sheet-pc .sheet-trait .sheet-display-flag:checked ~ .sheet-display .sheet-desc
+.sheet-pc .sheet-trait .sheet-display-flag:checked ~ .sheet-display .sheet-desc,
+.sheet-ship .sheet-trait .sheet-display-flag:checked ~ .sheet-display .sheet-desc
 {
     display: none;
 }
 
-.sheet-pc .sheet-trait .sheet-output {
+.sheet-pc .sheet-trait .sheet-output,
+.sheet-ship .sheet-trait .sheet-output {
     position: absolute;
     top: -8px;
     right: 30px;
@@ -1191,7 +1193,8 @@ button[type=roll] * {
     display: none;
 }
 
-.sheet-pc .sheet-trait .sheet-output:before {
+.sheet-pc .sheet-trait .sheet-output:before,
+.sheet-ship .sheet-trait .sheet-output:before {
     content: "";
 }
 

--- a/StarWars5E/StarWars5E_CSS.css
+++ b/StarWars5E/StarWars5E_CSS.css
@@ -165,8 +165,7 @@ input[type=radio].sheet-tab-button:checked + span {
 }
 
 .sheet-npc_toggle[value="2"] ~ .sheet-ship .sheet-page.sheet-ship-core,
-.sheet-npc_toggle[value="2"] ~ .sheet-ship .sheet-page.sheet-ship-modifications,
-.sheet-npc_toggle[value="2"] ~ .sheet-ship .sheet-page.sheet-ship-options
+.sheet-npc_toggle[value="2"] ~ .sheet-ship .sheet-page.sheet-ship-modifications
 {
     display: none;
 }
@@ -216,8 +215,7 @@ input[type=radio].sheet-tab-button.sheet-bio:checked ~ .sheet-page.sheet-bio,
 input[type=radio].sheet-tab-button.sheet-powers:checked ~ .sheet-page.sheet-powers,
 input[type=radio].sheet-tab-button.sheet-options:checked ~ .sheet-page.sheet-options,
 input[type=radio].sheet-tab-button.sheet-ship-modifications:checked ~ .sheet-page.sheet-ship-modifications,
-input[type=radio].sheet-tab-button.sheet-ship-core:checked ~ .sheet-page.sheet-ship-core,
-input[type=radio].sheet-tab-button.sheet-ship-options:checked ~ .sheet-page.sheet-ship-options 
+input[type=radio].sheet-tab-button.sheet-ship-core:checked ~ .sheet-page.sheet-ship-core
 {
     display: block;
 }

--- a/StarWars5E/StarWars5E_CSS.css
+++ b/StarWars5E/StarWars5E_CSS.css
@@ -1,11 +1,13 @@
 .sheet-pc,
-.sheet-npc 
+.sheet-npc,
+.sheet-ship 
 {
     display: none;
 }
 
 .sheet-npc_toggle[value="0"] ~ .sheet-pc,
-.sheet-npc_toggle[value="1"] ~ .sheet-npc
+.sheet-npc_toggle[value="1"] ~ .sheet-npc,
+.sheet-npc_toggle[value="2"] ~ .sheet-ship
 {
     display: block;
 }
@@ -684,7 +686,7 @@ button[type=roll] * {
     padding-top: 5px;
 }
 
-.sheet-exhaustion-toggle[value="0"] ~ .sheet-exhaustion,
+.sheet-exhaustion-toggle[value="0"] ~ .sheet-exhaustion
 {
     display: none;
 }
@@ -772,7 +774,7 @@ button[type=roll] * {
     font-size: 20px;
 }
 
-.sheet-hp input[type="number"],
+.sheet-hp input[type="number"]
 {
     width: 100%;
     padding-right: 0px;
@@ -2208,7 +2210,7 @@ span.sheet-powerconcentration
 
 .sheet-rolltemplate-atk .sheet-sublabel span,
 .sheet-rolltemplate-atkdmg .sheet-sublabel span,
-.sheet-rolltemplate-dmg .sheet-sublabel span,
+.sheet-rolltemplate-dmg .sheet-sublabel span
 {
     font-weight: normal;
     color: black;
@@ -2517,7 +2519,7 @@ span.sheet-powerconcentration
     display: none;
 }
 
-.sheet-npc .sheet-display .sheet-flag[value]:not([value=""]) + div,
+.sheet-npc .sheet-display .sheet-flag[value]:not([value=""]) + div
 {
     display: block;
 } 
@@ -2545,7 +2547,7 @@ span.sheet-powerconcentration
 }
 
 .sheet-npc .sheet-saving button[type=roll] span,
-.sheet-npc .sheet-skills button[type=roll] span,
+.sheet-npc .sheet-skills button[type=roll] span
 {
     font-size: 13px;
     font-weight: normal;
@@ -2557,7 +2559,7 @@ span.sheet-powerconcentration
 }
 
 .sheet-npc .sheet-display .sheet-flag[value="1"] + button .sheet-spacer,
-.sheet-npc .sheet-display .sheet-flag[value="2"] + button .sheet-spacer,
+.sheet-npc .sheet-display .sheet-flag[value="2"] + button .sheet-spacer
 {
     display: none;
 }
@@ -2579,7 +2581,7 @@ span.sheet-powerconcentration
     content: ", ";
 }
 
-.sheet-negativeflag[value="1"] + .sheet-npcattr::before,
+.sheet-negativeflag[value="1"] + .sheet-npcattr::before
 {
     content: "(";
 }
@@ -2929,7 +2931,7 @@ span.sheet-powerconcentration
 .sheet-proficiencies .sheet-complex,
 .sheet-proficiencies .sheet-simple,
 .sheet-traits .sheet-complex,
-.sheet-traits .sheet-simple,
+.sheet-traits .sheet-simple
 {
     display: none;
 }
@@ -3061,7 +3063,7 @@ span.sheet-powerconcentration
 .sheet-equipment .sheet-encumberance[value="IMMOBILE"] ~ .sheet-immobile,
 .sheet-equipment .sheet-encumberance[value="HEAVILY ENCUMBERED"] ~ .sheet-heavily,
 .sheet-equipment .sheet-encumberance[value="ENCUMBERED"] ~ .sheet-encumbered,
-.sheet-equipment .sheet-encumberance[value="OVER CARRYING CAPACITY"] ~ .sheet-over,
+.sheet-equipment .sheet-encumberance[value="OVER CARRYING CAPACITY"] ~ .sheet-over
 {
     display: block;
 }
@@ -3106,7 +3108,7 @@ span.sheet-powerconcentration
 }
 
 .charsheet .sheet-powers .sheet-powerattackinfoflag[value="ATTACK"] ~ .sheet-powerattackinfo,
-.charsheet .sheet-npc .sheet-powerattackinfoflag[value="ATTACK"] ~ .sheet-powerattackinfo,
+.charsheet .sheet-npc .sheet-powerattackinfoflag[value="ATTACK"] ~ .sheet-powerattackinfo
 {
     display: block;
 }

--- a/StarWars5E/StarWars5E_CSS.css
+++ b/StarWars5E/StarWars5E_CSS.css
@@ -972,7 +972,8 @@ button[type=roll] * {
 
 .sheet-attacks .sheet-display button[type=roll],
 .sheet-tool .sheet-display button[type=roll],
-.sheet-proficiency .sheet-display button[type=roll]
+.sheet-proficiency .sheet-display button[type=roll],
+.sheet-deployment .sheet-display button[type=roll]
 {
     background-color: transparent;
     color: black;
@@ -988,7 +989,8 @@ button[type=roll] * {
 
 .sheet-attacks .sheet-display button[type=roll]::before,
 .sheet-tool .sheet-display button[type=roll]::before,
-.sheet-proficiency .sheet-display button[type=roll]::before
+.sheet-proficiency .sheet-display button[type=roll]::before,
+.sheet-deployment .sheet-display button[type=roll]::before
 {
     content: "" !important;
 }
@@ -1137,6 +1139,7 @@ button[type=roll] * {
 .sheet-action:hover .sheet-npc_options-flag + span,
 .sheet-textbox:hover > .sheet-options-flag + span,
 .sheet-proficiency:hover .sheet-options-flag + span,
+.sheet-deployment:hover .sheet-options-flag + span,
 .sheet-item:hover .sheet-inventorysubflag + span,
 .sheet-pc .sheet-trait:hover .sheet-output,
 .sheet-pc .sheet-header:hover .sheet-options-flag + span,
@@ -1643,6 +1646,7 @@ span.sheet-powerconcentration
 .sheet-power .sheet-options input[type=text],
 .sheet-options .sheet-body input[type=text],
 .sheet-proficiencies .sheet-options input[type=text],
+.sheet-proficiencies .sheet-options input[type=number],
 .sheet-traits .sheet-options input[type=text],
 .sheet-global-mod .sheet-options input[type=text]
 {

--- a/StarWars5E/StarWars5E_CSS.css
+++ b/StarWars5E/StarWars5E_CSS.css
@@ -318,7 +318,6 @@ input[type=radio].sheet-tab-button.sheet-powers + span {
 
 .sheet-header input[type=number] {
     text-align: center;
-    margin-bottom: -9px;
 }
 
 .sheet-header input[type=number]::-webkit-inner-spin-button,

--- a/StarWars5E/StarWars5E_CSS.css
+++ b/StarWars5E/StarWars5E_CSS.css
@@ -13,7 +13,7 @@
 }
 
 .sheet-container {
-    width: 750px;
+    width: 760px;
     background: #afc6d6;
     background: -moz-linear-gradient(left, #afc6d6 0%, #d6d6d6 30%, #d6d6d6 70%, #afc6d6 100%);
     background: -webkit-linear-gradient(left, #afc6d6 0%,#d6d6d6 30%,#d6d6d6 70%,#afc6d6 100%);
@@ -355,7 +355,7 @@ input[type=radio].sheet-tab-button.sheet-powers + span {
 }
 
 .sheet-header-info {
-    width: 482px;
+    width: 492px;
     margin-left: -2px;
     display: inline-block;
     border: 3px double #666;
@@ -377,16 +377,20 @@ input[type=radio].sheet-tab-button.sheet-powers + span {
 }
 
 .sheet-body {
-    width: 750px;
+    width: 760px;
     margin-top: 22px;
 }
 
 .sheet-col {
-    width: 32.97%;
+    width: 247px
+}
+
+.sheet-halfcol {
+    width: 50%
 }
 
 .sheet-col2-3 {
-    width: 490px;
+    width: 502px;
     margin-left: 5px;
     display: inline-block;
 }
@@ -762,6 +766,11 @@ button[type=roll] * {
     width: 240px;
     margin-bottom: 10px;
 }
+
+/* .sheet-ship-cargo {
+    width: 490px;
+    margin-bottom: 10px;
+} */
 
 .sheet-ac-init-speed-container div {
     width: calc(31%);

--- a/StarWars5E/StarWars5E_CSS.css
+++ b/StarWars5E/StarWars5E_CSS.css
@@ -221,13 +221,13 @@ input[type=radio].sheet-tab-button.sheet-ship-core:checked ~ .sheet-page.sheet-s
 input[type=radio].sheet-tab-button.sheet-core,
 input[type=radio].sheet-tab-button.sheet-core + span
 {
-    right: 20px;
+    right: 116px;
     width: 45px;
 }
 
 input[type=radio].sheet-tab-button.sheet-ship-core,
 input[type=radio].sheet-tab-button.sheet-ship-core + span {
-    right: 134px;
+    right: 20px;
     width: 45px;
 }
 

--- a/StarWars5E/StarWars5E_CSS.css
+++ b/StarWars5E/StarWars5E_CSS.css
@@ -164,6 +164,13 @@ input[type=radio].sheet-tab-button:checked + span {
     display: none;
 }
 
+.sheet-npc_toggle[value="2"] ~ .sheet-ship .sheet-page.sheet-ship-core,
+.sheet-npc_toggle[value="2"] ~ .sheet-ship .sheet-page.sheet-ship-modifications,
+.sheet-npc_toggle[value="2"] ~ .sheet-ship .sheet-page.sheet-ship-options
+{
+    display: none;
+}
+
 .sheet-npc_toggle[value="1"] + .sheet-npcpowercastingflag[value="1"] ~ .sheet-pc .sheet-page.sheet-powers .sheet-body {
     visibility: visible;
 }
@@ -207,14 +214,24 @@ input[type=radio].sheet-tab-button:checked + span {
 input[type=radio].sheet-tab-button.sheet-core:checked ~ .sheet-page.sheet-core,
 input[type=radio].sheet-tab-button.sheet-bio:checked ~ .sheet-page.sheet-bio,
 input[type=radio].sheet-tab-button.sheet-powers:checked ~ .sheet-page.sheet-powers,
-input[type=radio].sheet-tab-button.sheet-options:checked ~ .sheet-page.sheet-options 
+input[type=radio].sheet-tab-button.sheet-options:checked ~ .sheet-page.sheet-options,
+input[type=radio].sheet-tab-button.sheet-ship-modifications:checked ~ .sheet-page.sheet-ship-modifications,
+input[type=radio].sheet-tab-button.sheet-ship-core:checked ~ .sheet-page.sheet-ship-core,
+input[type=radio].sheet-tab-button.sheet-ship-options:checked ~ .sheet-page.sheet-ship-options 
 {
     display: block;
 }
 
 input[type=radio].sheet-tab-button.sheet-core,
-input[type=radio].sheet-tab-button.sheet-core + span {
+input[type=radio].sheet-tab-button.sheet-core + span
+{
     right: 116px;
+    width: 45px;
+}
+
+input[type=radio].sheet-tab-button.sheet-ship-core,
+input[type=radio].sheet-tab-button.sheet-ship-core + span {
+    right: 134px;
     width: 45px;
 }
 
@@ -222,6 +239,12 @@ input[type=radio].sheet-tab-button.sheet-bio,
 input[type=radio].sheet-tab-button.sheet-bio + span {
     right: 83px;
     width: 30px;
+}
+
+input[type=radio].sheet-tab-button.sheet-ship-modifications,
+input[type=radio].sheet-tab-button.sheet-ship-modifications + span {
+    right: 20px;
+    width: 111px;
 }
 
 input[type=radio].sheet-tab-button.sheet-powers,
@@ -1233,6 +1256,12 @@ button[type=roll] * {
 }
 
 .sheet-header .sheet-options-flag:checked ~ .sheet-options {
+    min-height: 74px;
+    vertical-align: top;
+    display: inline-block;
+}
+
+.sheet-ship .sheet-header .sheet-options {
     min-height: 74px;
     vertical-align: top;
     display: inline-block;

--- a/StarWars5E/StarWars5E_CSS.css
+++ b/StarWars5E/StarWars5E_CSS.css
@@ -573,6 +573,10 @@ button[type=roll] * {
     font-weight: bold;
 }
 
+.charsheet .sheet-ship .sheet-insp-prof-container .sheet-value input[type=number]{
+    width: 140%;
+}
+
 .sheet-insp-prof-container .sheet-value input,
 .sheet-saving-throw input[type=text],
 .sheet-skill input[type=text],

--- a/StarWars5E/StarWars5E_HTML.html
+++ b/StarWars5E/StarWars5E_HTML.html
@@ -273,6 +273,7 @@
                 <option value="1">NPC</option>
                 <option value="2">Ship</option>
             </select>
+        </div>
         <div class="row">
             <span data-i18n="roll-queries:-u">ROLL QUERIES:</span>
             <select name="attr_rtype">
@@ -600,7 +601,7 @@
             </fieldset>
         </div>
     </div>
-    <div class="actions_container"></div>
+    <div class="actions_container">
         <input class="dflag" type="hidden" name="attr_dflag" value="pick">
         <div class="row actions">
             <div class="row actiontitle" style="position: relative;">
@@ -920,2878 +921,967 @@
                     </div>
                 </fieldset>
             </div>
-        </div>
+        </div>   
+    </div>
 </div>
-
 
 <div class="container pc">
 
-<input class="tab-button core" type="radio" name="attr_tab" value="core" checked="checked"><span data-i18n="core-u">CORE</span>
-<input class="tab-button bio" type="radio" name="attr_tab" value="bio"><span data-i18n="bio-u">BIO</span>
-<input class="tab-button powers" type="radio" name="attr_tab" value="powers"><span data-i18n="powers-u">POWERS</span>
-<input class="tab-button options" type="radio" name="attr_tab" value="options"><span style="font-family: pictos">y</span>
-
-<div class="page core">
-    <div class="header">
-        <div class="name-container">
-            <img src="https://s22.postimg.cc/jnlp8fqc1/Star_Wars_5_E_Logo_Shrunk.png" style="padding-bottom: 10px;">
-            <input type="text" name="attr_character_name" style="width: 100%;">
-            <span class="label" data-i18n="char-name-u">CHARACTER NAME</span>
+    <input class="tab-button core" type="radio" name="attr_tab" value="core" checked="checked"><span data-i18n="core-u">CORE</span>
+    <input class="tab-button bio" type="radio" name="attr_tab" value="bio"><span data-i18n="bio-u">BIO</span>
+    <input class="tab-button powers" type="radio" name="attr_tab" value="powers"><span data-i18n="powers-u">POWERS</span>
+    <input class="tab-button options" type="radio" name="attr_tab" value="options"><span style="font-family: pictos">y</span>
+        
+    <div class="page core">
+        <div class="header">
+            <div class="name-container">
+                <img src="https://s22.postimg.cc/jnlp8fqc1/Star_Wars_5_E_Logo_Shrunk.png" style="padding-bottom: 10px;">
+                <input type="text" name="attr_character_name" style="width: 100%;">
+                <span class="label" data-i18n="char-name-u">CHARACTER NAME</span>
+            </div>
+            <input class="options-flag" type="checkbox" name="attr_options-class-selection" checked="checked"><span>y</span>
+            <div class="header-info sheet-options">
+                <div class="sheet-row" style="border-top: 2px dashed gold;">
+                    <span data-i18n="class:-u">CLASS:</span>
+                    <input type="hidden" name="attr_custom_class" class="sheet-flag">
+                    <select class="hiding class" name="attr_class">
+                        <option value="" data-i18n="choose">Choose</option>
+                        <option value="Berzerker" data-i18n="berzerker">Berzerker</option>
+                        <option value="Scholar" data-i18n="scholar">Scholar</option>
+                        <option value="Engineer" data-i18n="engineer">Engineer</option>
+                        <option value="Fighter" data-i18n="fighter">Fighter</option>
+                        <option value="Monk" data-i18n="monk">Monk</option>
+                        <option value="Guardian" data-i18n="guardian">Guardian</option>
+                        <option value="Scout" data-i18n="scout">Scout</option>
+                        <option value="Infiltrator" data-i18n="infiltrator">Infiltrator</option>
+                        <option value="Sentinel" data-i18n="sentinel">Sentinel</option>
+                        <option value="Consular" data-i18n="consular">Consular</option>
+                    </select>
+                    <input type="text" class="showing" name="attr_cust_classname" style="width: 90px;">
+                    <span data-i18n="subclass:-u">SUBCLASS:</span>
+                    <input type="text" name="attr_subclass">
+                    <span data-i18n="lvl:-u">LEVEL:</span>
+                    <input type="number" class="class-level" style="width: 40px" name="attr_base_level" value="1">
+                </div>
+                <div class="sheet-row">
+                    <span data-i18n="race:-u">RACE:</span>
+                    <input type="text" name="attr_race">
+                    <span data-i18n="subrace:-u">SUBRACE:</span>
+                    <input type="text" name="attr_subrace">
+                </div>
+            </div>
+            <div class="header-info sheet-display">
+                <div class="top">
+                    <div class="hlabel-container">
+                        <input type="text" name="attr_class_display" class="sheet-class-display sheet-no_events">
+                        <span class="label" data-i18n="class-level-u">CLASS & LEVEL</span>
+                    </div>
+                    <div class="hlabel-container">
+                        <input type="text" name="attr_background" style="width: 182px;">
+                        <span class="label" data-i18n="background-u">BACKGROUND</span>
+                    </div>
+                </div>
+                <div class="bottom">
+                    <div class="hlabel-container">
+                        <input type="text" name="attr_race_display" class="sheet-no_events">
+                        <span class="label" data-i18n="race-u">RACE</span>
+                    </div>
+                    <div class="hlabel-container">
+                        <input type="text" name="attr_alignment">
+                        <span class="label" data-i18n="alignment-u">ALIGNMENT</span>
+                    </div>
+                    <div class="hlabel-container">
+                        <input type="text" name="attr_experience">
+                        <span class="label" data-i18n="exp-pts-u">EXPERIENCE POINTS</span>
+                    </div>
+                </div>
+            </div>
         </div>
-        <input class="options-flag" type="checkbox" name="attr_options-class-selection" checked="checked"><span>y</span>
-        <div class="header-info sheet-options">
-            <div class="sheet-row" style="border-top: 2px dashed gold;">
-                <span data-i18n="class:-u">CLASS:</span>
-                <input type="hidden" name="attr_custom_class" class="sheet-flag">
-                <select class="hiding class" name="attr_class">
-                    <option value="" data-i18n="choose">Choose</option>
-                    <option value="Berzerker" data-i18n="berzerker">Berzerker</option>
-                    <option value="Scholar" data-i18n="scholar">Scholar</option>
-                    <option value="Engineer" data-i18n="engineer">Engineer</option>
-                    <option value="Fighter" data-i18n="fighter">Fighter</option>
-                    <option value="Monk" data-i18n="monk">Monk</option>
-                    <option value="Guardian" data-i18n="guardian">Guardian</option>
-                    <option value="Scout" data-i18n="scout">Scout</option>
-                    <option value="Infiltrator" data-i18n="infiltrator">Infiltrator</option>
-                    <option value="Sentinel" data-i18n="sentinel">Sentinel</option>
-                    <option value="Consular" data-i18n="consular">Consular</option>
-                </select>
-                <input type="text" class="showing" name="attr_cust_classname" style="width: 90px;">
-                <span data-i18n="subclass:-u">SUBCLASS:</span>
-                <input type="text" name="attr_subclass">
-                <span data-i18n="lvl:-u">LEVEL:</span>
-                <input type="number" class="class-level" style="width: 40px" name="attr_base_level" value="1">
-            </div>
-            <div class="sheet-row">
-                <span data-i18n="race:-u">RACE:</span>
-                <input type="text" name="attr_race">
-                <span data-i18n="subrace:-u">SUBRACE:</span>
-                <input type="text" name="attr_subrace">
-            </div>
-        </div>
-        <div class="header-info sheet-display">
-            <div class="top">
-                <div class="hlabel-container">
-                    <input type="text" name="attr_class_display" class="sheet-class-display sheet-no_events">
-                    <span class="label" data-i18n="class-level-u">CLASS & LEVEL</span>
-                </div>
-                <div class="hlabel-container">
-                    <input type="text" name="attr_background" style="width: 182px;">
-                    <span class="label" data-i18n="background-u">BACKGROUND</span>
-                </div>
-            </div>
-            <div class="bottom">
-                <div class="hlabel-container">
-                    <input type="text" name="attr_race_display" class="sheet-no_events">
-                    <span class="label" data-i18n="race-u">RACE</span>
-                </div>
-                <div class="hlabel-container">
-                    <input type="text" name="attr_alignment">
-                    <span class="label" data-i18n="alignment-u">ALIGNMENT</span>
-                </div>
-                <div class="hlabel-container">
-                    <input type="text" name="attr_experience">
-                    <span class="label" data-i18n="exp-pts-u">EXPERIENCE POINTS</span>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="body">
-        <div class="col col1">
-            <div class="attributes-container" style="margin-top: 10px;">
-                <div class="attr-container">
-                    <button type="roll" name="roll_strength" value="@{wtype}&{template:simple} {{rname=^{strength-u}}} {{mod=@{strength_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{strength_mod}@{jack_attr}[STR]]]}} @{rtype}+@{strength_mod}@{jack_attr}[STR]]]}} @{charname_output}" data-i18n="strength-u">STRENGTH</button>
-                    <span class="attr" name="attr_strength_mod" title="@{strength_mod}">0</span>
-                    <div class="attr-mod">
-                        <input class="baseattr" type="text" name="attr_strength_base" title="@{strength}" value="10">
-                        <input type="hidden" name="attr_strength" value="10">
-                        <input class="attr-flag" type="hidden" name="attr_strength_flag" value="0">
-                        <span class="finalattr" name="attr_strength">
+        <div class="body">
+            <div class="col col1">
+                <div class="attributes-container" style="margin-top: 10px;">
+                    <div class="attr-container">
+                        <button type="roll" name="roll_strength" value="@{wtype}&{template:simple} {{rname=^{strength-u}}} {{mod=@{strength_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{strength_mod}@{jack_attr}[STR]]]}} @{rtype}+@{strength_mod}@{jack_attr}[STR]]]}} @{charname_output}" data-i18n="strength-u">STRENGTH</button>
+                        <span class="attr" name="attr_strength_mod" title="@{strength_mod}">0</span>
+                        <div class="attr-mod">
+                            <input class="baseattr" type="text" name="attr_strength_base" title="@{strength}" value="10">
+                            <input type="hidden" name="attr_strength" value="10">
+                            <input class="attr-flag" type="hidden" name="attr_strength_flag" value="0">
+                            <span class="finalattr" name="attr_strength">
+                        </div>
+                    </div>
+                    <div class="attr-container">
+                        <button type="roll" name="roll_dexterity" value="@{wtype}&{template:simple} {{rname=^{dexterity-u}}} {{mod=@{dexterity_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{dexterity_mod}@{jack_attr}[DEX]]]}} @{rtype}+@{dexterity_mod}@{jack_attr}[DEX]]]}} @{charname_output}" data-i18n="dexterity-u">DEXTERITY</button>
+                        <span class="attr" name="attr_dexterity_mod" title="@{dexterity_mod}">0</span>
+                        <div class="attr-mod">
+                            <input class="baseattr" type="text" name="attr_dexterity_base" title="@{dexterity}" value="10">
+                            <input type="hidden" name="attr_dexterity" value="10">
+                            <input class="attr-flag" type="hidden" name="attr_dexterity_flag" value="0">
+                            <span class="finalattr" name="attr_dexterity">
+                        </div>
+                    </div>
+                    <div class="attr-container">
+                        <button type="roll" name="roll_constitution" value="@{wtype}&{template:simple} {{rname=^{constitution-u}}} {{mod=@{constitution_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{constitution_mod}@{jack_attr}[CON]]]}} @{rtype}+@{constitution_mod}@{jack_attr}[CON]]]}} @{charname_output}" data-i18n="constitution-u">CONSTITUTION</button>
+                        <span class="attr" name="attr_constitution_mod" title="@{constitution_mod}">0</span>
+                        <div class="attr-mod">
+                            <input class="baseattr" type="text" name="attr_constitution_base" title="@{constitution}" value="10">
+                            <input type="hidden" name="attr_constitution" value="10">
+                            <input class="attr-flag" type="hidden" name="attr_constitution_flag" value="0">
+                            <span class="finalattr" name="attr_constitution">
+                        </div>
+                    </div>
+                    <div class="attr-container">
+                        <button type="roll" name="roll_intelligence" value="@{wtype}&{template:simple} {{rname=^{intelligence-u}}} {{mod=@{intelligence_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{intelligence_mod}@{jack_attr}[INT]]]}} @{rtype}+@{intelligence_mod}@{jack_attr}[INT]]]}} @{charname_output}" data-i18n="intelligence-u">INTELLIGENCE</button>
+                        <span class="attr" name="attr_intelligence_mod" title="@{intelligence_mod}">0</span>
+                        <div class="attr-mod">
+                            <input class="baseattr" type="text" name="attr_intelligence_base" title="@{intelligence}" value="10">
+                            <input type="hidden" name="attr_intelligence" value="10">
+                            <input class="attr-flag" type="hidden" name="attr_intelligence_flag" value="0">
+                            <span class="finalattr" name="attr_intelligence">
+                        </div>
+                    </div>
+                    <div class="attr-container">
+                        <button type="roll" name="roll_wisdom" value="@{wtype}&{template:simple} {{rname=^{wisdom-u}}} {{mod=@{wisdom_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{wisdom_mod}@{jack_attr}[WIS]]]}} @{rtype}+@{wisdom_mod}@{jack_attr}[WIS]]]}} @{charname_output}" data-i18n="wisdom-u">WISDOM</button>
+                        <span class="attr" name="attr_wisdom_mod" title="@{wisdom_mod}">0</span>
+                        <div class="attr-mod">
+                            <input class="baseattr" type="text" name="attr_wisdom_base" title="@{wisdom}" value="10">
+                            <input type="hidden" name="attr_wisdom" value="10">
+                            <input class="attr-flag" type="hidden" name="attr_wisdom_flag" value="0">
+                            <span class="finalattr" name="attr_wisdom">
+                        </div>
+                    </div>
+                    <div class="attr-container">
+                        <button type="roll" name="roll_charisma" value="@{wtype}&{template:simple} {{rname=^{charisma-u}}} {{mod=@{charisma_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{charisma_mod}@{jack_attr}[CHA]]]}} @{rtype}+@{charisma_mod}@{jack_attr}[CHA]]]}} @{charname_output}" data-i18n="charisma-u">CHARISMA</button>
+                        <span class="attr" name="attr_charisma_mod" title="@{charisma_mod}">0</span>
+                        <div class="attr-mod">
+                            <input class="baseattr" type="text" name="attr_charisma_base" title="@{charisma}" value="10">
+                            <input type="hidden" name="attr_charisma" value="10">
+                            <input class="attr-flag" type="hidden" name="attr_charisma_flag" value="0">
+                            <span class="finalattr" name="attr_charisma">
+                        </div>
                     </div>
                 </div>
-                <div class="attr-container">
-                    <button type="roll" name="roll_dexterity" value="@{wtype}&{template:simple} {{rname=^{dexterity-u}}} {{mod=@{dexterity_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{dexterity_mod}@{jack_attr}[DEX]]]}} @{rtype}+@{dexterity_mod}@{jack_attr}[DEX]]]}} @{charname_output}" data-i18n="dexterity-u">DEXTERITY</button>
-                    <span class="attr" name="attr_dexterity_mod" title="@{dexterity_mod}">0</span>
-                    <div class="attr-mod">
-                        <input class="baseattr" type="text" name="attr_dexterity_base" title="@{dexterity}" value="10">
-                        <input type="hidden" name="attr_dexterity" value="10">
-                        <input class="attr-flag" type="hidden" name="attr_dexterity_flag" value="0">
-                        <span class="finalattr" name="attr_dexterity">
+                <div class="skills-saves-container">
+                    <div class="insp-prof-container">
+                        <div class="value">
+                            <input type="checkbox" name="attr_inspiration"><span></span>
+                        </div>
+                        <div class="label">
+                            <span data-i18n="inspiration-u">INSPIRATION</span>
+                        </div>
+                    </div>
+                    <div class="insp-prof-container">
+                        <div class="value">
+                            <span name="attr_pb" title="@{pb}"></span>
+                        </div>
+                        <div class="label">
+                            <span data-i18n="prof-bonus-u">PROFICIENCY BONUS</span>
+                        </div>
+                    </div>
+                    <div class="saving-throw-container">
+                        <div class="saving-throw">
+                            <input type="checkbox" name="attr_strength_save_prof" title="@{strength_save_prof}" value="(@{pb})">
+                            <span name="attr_strength_save_bonus" title="@{strength_save_bonus}">0</span>
+                            <button type="roll" name="roll_strength_save" value="@{wtype}&{template:simple} {{rname=^{strength-save-u}}} {{mod=@{strength_save_bonus}}} {{r1=[[@{d20}+@{strength_save_bonus}@{pbd_safe}]]}} @{rtype}+@{strength_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="strength">Strength</button>
+                        </div>
+                        <div class="saving-throw">
+                            <input type="checkbox" name="attr_dexterity_save_prof" title="@{dexterity_save_prof}" value="(@{pb})">
+                            <span name="attr_dexterity_save_bonus" title="@{dexterity_save_bonus}">0</span>
+                            <button type="roll" name="roll_dexterity_save" value="@{wtype}&{template:simple} {{rname=^{dexterity-save-u}}} {{mod=@{dexterity_save_bonus}}} {{r1=[[@{d20}+@{dexterity_save_bonus}@{pbd_safe}]]}} @{rtype}+@{dexterity_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="dexterity">Dexterity</button>
+                        </div>
+                        <div class="saving-throw">
+                            <input type="checkbox" name="attr_constitution_save_prof" title="@{constitution_save_prof}" value="(@{pb})">
+                            <span name="attr_constitution_save_bonus" title="@{constitution_save_bonus}">0</span>
+                            <button type="roll" name="roll_constitution_save" value="@{wtype}&{template:simple} {{rname=^{constitution-save-u}}} {{mod=@{constitution_save_bonus}}} {{r1=[[@{d20}+@{constitution_save_bonus}@{pbd_safe}]]}} @{rtype}+@{constitution_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="constitution">Constitution</button>
+                        </div>
+                        <div class="saving-throw">
+                            <input type="checkbox" name="attr_intelligence_save_prof" title="@{intelligence_save_prof}" value="(@{pb})">
+                            <span name="attr_intelligence_save_bonus" title="@{intelligence_save_bonus}">0</span>
+                            <button type="roll" name="roll_intelligence_save" value="@{wtype}&{template:simple} {{rname=^{intelligence-save-u}}} {{mod=@{intelligence_save_bonus}}} {{r1=[[@{d20}+@{intelligence_save_bonus}@{pbd_safe}]]}} @{rtype}+@{intelligence_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="intelligence">Intelligence</button>
+                        </div>
+                        <div class="saving-throw">
+                            <input type="checkbox" name="attr_wisdom_save_prof" title="@{wisdom_save_prof}" value="(@{pb})">
+                            <span name="attr_wisdom_save_bonus" title="@{wisdom_save_bonus}">0</span>
+                            <button type="roll" name="roll_wisdom_save" value="@{wtype}&{template:simple} {{rname=^{wisdom-save-u}}} {{mod=@{wisdom_save_bonus}}} {{r1=[[@{d20}+@{wisdom_save_bonus}@{pbd_safe}]]}} @{rtype}+@{wisdom_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="wisdom">Wisdom</button>
+                        </div>
+                        <div class="saving-throw">
+                            <input type="checkbox" name="attr_charisma_save_prof" title="@{charisma_save_prof}" value="(@{pb})">
+                            <span name="attr_charisma_save_bonus" title="@{charisma_save_bonus}">0</span>
+                            <button type="roll" name="roll_charisma_save" value="@{wtype}&{template:simple} {{rname=^{charisma-save-u}}} {{mod=@{charisma_save_bonus}}} {{r1=[[@{d20}+@{charisma_save_bonus}@{pbd_safe}]]}} @{rtype}+@{charisma_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="charisma">Charisma</button>
+                        </div>
+                        <input type="hidden" class="toggleflag" name="attr_global_save_mod_flag">
+                        <div class="hidden textarea globalattack">
+                            <span class="label" data-i18n="global-save-u">GLOBAL SAVE MODIFIER</span>
+                            <fieldset class="repeating_savemod">
+                                <div class="global-mod">
+                                    <input type="checkbox" name="attr_options-flag" class="options-flag" checked="checked" style="top: -15px;"><span>y</span>
+                                    <input type="checkbox" name="attr_global_save_active_flag" value="1" class="active-flag">
+                                    <div class="options">
+                                        <textarea type="textarea" name="attr_global_save_rollstring" placeholder="1d4[BLESS]" style="width: 125px;"></textarea>
+                                    </div>
+                                    <div class="display">
+                                        <span class="title" name="attr_global_save_rollstring"></span>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <div class="label">
+                            <span data-i18n="saving-throws-u">SAVING THROWS</span>
+                        </div>
+                    </div>
+                    <div class="skills-container skills-list">
+                        <div data-i18n-list="skills-list">
+                            <div class="skill" data-i18n-list-item="acrobatics">
+                                <input type="checkbox" name="attr_acrobatics_prof" title="@{acrobatics_prof}" value="(@{pb}*@{acrobatics_type})">
+                                <span name="attr_acrobatics_bonus" title="@{acrobatics_bonus}">0</span>
+                                <button type="roll" name="roll_acrobatics" value="@{wtype}&{template:simple} {{rname=^{acrobatics-u}}} {{mod=@{acrobatics_bonus}}} {{r1=[[@{d20}+@{acrobatics_bonus}@{pbd_safe}]]}} @{rtype}+@{acrobatics_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}" data-i18n="acrobatics-core">Acrobatics <span>(Dex)</span></button>
+                            </div>
+                            <div class="skill" data-i18n-list-item="animal_handling">
+                                <input type="checkbox" name="attr_animal_handling_prof" title="@{animal_handling_prof}" value="(@{pb}*@{animal_handling_type})">
+                                <span name='attr_animal_handling_bonus' title='@{animal_handling_bonus}'>0</span>
+                                <button type='roll' name='roll_animal_handling' value='@{wtype}&{template:simple} {{rname=^{animal_handling-u}}} {{mod=@{animal_handling_bonus}}} {{r1=[[@{d20}+@{animal_handling_bonus}@{pbd_safe}]]}} @{rtype}+@{animal_handling_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='animal_handling-core'>Animal Handling <span>(Wis)</span></button>
+                            </div>
+                            <div class="skill" data-i18n-list-item="technology">
+                                <input type="checkbox" name="attr_technology_prof" title="@{technology_prof}" value="(@{pb}*@{technology_type})">
+                                <span name='attr_technology_bonus' title='@{technology_bonus}'>0</span>
+                                <button type='roll' name='roll_technology' value='@{wtype}&{template:simple} {{rname=^{technology-u}}} {{mod=@{technology_bonus}}} {{r1=[[@{d20}+@{technology_bonus}@{pbd_safe}]]}} @{rtype}+@{technology_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='technology-core'>Technology <span>(Int)</span></button>
+                            </div>
+                            <div class="skill" data-i18n-list-item="athletics">
+                                <input type="checkbox" name="attr_athletics_prof" title="@{athletics_prof}" value="(@{pb}*@{athletics_type})">
+                                <span name='attr_athletics_bonus' title='@{athletics_bonus}'>0</span>
+                                <button type='roll' name='roll_athletics' value='@{wtype}&{template:simple} {{rname=^{athletics-u}}} {{mod=@{athletics_bonus}}} {{r1=[[@{d20}+@{athletics_bonus}@{pbd_safe}]]}} @{rtype}+@{athletics_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='athletics-core'>Athletics <span>(Str)</span></button>
+                            </div>
+                            <div class="skill" data-i18n-list-item="deception">
+                                <input type="checkbox" name="attr_deception_prof" title="@{deception_prof}" value="(@{pb}*@{deception_type})">
+                                <span name='attr_deception_bonus' title='@{deception_bonus}'>0</span>
+                                <button type='roll' name='roll_deception' value='@{wtype}&{template:simple} {{rname=^{deception-u}}} {{mod=@{deception_bonus}}} {{r1=[[@{d20}+@{deception_bonus}@{pbd_safe}]]}} @{rtype}+@{deception_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='deception-core'>Deception <span>(Cha)</span></button>
+                            </div>
+                            <div class="skill" data-i18n-list-item="lore">
+                                <input type="checkbox" name="attr_lore_prof" title="@{lore_prof}" value="(@{pb}*@{lore_type})">
+                                <span name='attr_lore_bonus' title='@{lore_bonus}'>0</span>
+                                <button type='roll' name='roll_lore' value='@{wtype}&{template:simple} {{rname=^{lore-u}}} {{mod=@{lore_bonus}}} {{r1=[[@{d20}+@{lore_bonus}@{pbd_safe}]]}} @{rtype}+@{lore_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='lore-core'>Lore <span>(Int)</span></button>
+                            </div>
+                            <div class="skill" data-i18n-list-item="insight">
+                                <input type="checkbox" name="attr_insight_prof" title="@{insight_prof}" value="(@{pb}*@{insight_type})">
+                                <span name='attr_insight_bonus' title='@{insight_bonus}'>0</span>
+                                <button type='roll' name='roll_insight' value='@{wtype}&{template:simple} {{rname=^{insight-u}}} {{mod=@{insight_bonus}}} {{r1=[[@{d20}+@{insight_bonus}@{pbd_safe}]]}} @{rtype}+@{insight_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='insight-core'>Insight <span>(Wis)</span></button>
+                            </div>
+                            <div class="skill" data-i18n-list-item="intimidation">
+                                <input type="checkbox" name="attr_intimidation_prof" title="@{intimidation_prof}" value="(@{pb}*@{intimidation_type})">
+                                <span name='attr_intimidation_bonus' title='@{intimidation_bonus}'>0</span>
+                                <button type='roll' name='roll_intimidation' value='@{wtype}&{template:simple} {{rname=^{intimidation-u}}} {{mod=@{intimidation_bonus}}} {{r1=[[@{d20}+@{intimidation_bonus}@{pbd_safe}]]}} @{rtype}+@{intimidation_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='intimidation-core'>Intimidation <span>(Cha)</span></button>
+                            </div>
+                            <div class="skill" data-i18n-list-item="investigation">
+                                <input type="checkbox" name="attr_investigation_prof" title="@{investigation_prof}" value="(@{pb}*@{investigation_type})">
+                                <span name='attr_investigation_bonus' title='@{investigation_bonus}'>0</span>
+                                <button type='roll' name='roll_investigation' value='@{wtype}&{template:simple} {{rname=^{investigation-u}}} {{mod=@{investigation_bonus}}} {{r1=[[@{d20}+@{investigation_bonus}@{pbd_safe}]]}} @{rtype}+@{investigation_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='investigation-core'>Investigation <span>(Int)</span></button>
+                            </div>
+                            <div class="skill" data-i18n-list-item="medicine">
+                                <input type="checkbox" name="attr_medicine_prof" title="@{medicine_prof}" value="(@{pb}*@{medicine_type})">
+                                <span name='attr_medicine_bonus' title='@{medicine_bonus}'>0</span>
+                                <button type='roll' name='roll_medicine' value='@{wtype}&{template:simple} {{rname=^{medicine-u}}} {{mod=@{medicine_bonus}}} {{r1=[[@{d20}+@{medicine_bonus}@{pbd_safe}]]}} @{rtype}+@{medicine_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='medicine-core'>Medicine <span>(Wis)</span></button>
+                            </div>
+                            <div class="skill" data-i18n-list-item="nature">
+                                <input type="checkbox" name="attr_nature_prof" title="@{nature_prof}" value="(@{pb}*@{nature_type})">
+                                <span name='attr_nature_bonus' title='@{nature_bonus}'>0</span>
+                                <button type='roll' name='roll_nature' value='@{wtype}&{template:simple} {{rname=^{nature-u}}} {{mod=@{nature_bonus}}} {{r1=[[@{d20}+@{nature_bonus}@{pbd_safe}]]}} @{rtype}+@{nature_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='nature-core'>Nature <span>(Int)</span></button>
+                            </div>
+                            <div class="skill" data-i18n-list-item="perception">
+                                <input type="checkbox" name="attr_perception_prof" title="@{perception_prof}" value="(@{pb}*@{perception_type})">
+                                <span name='attr_perception_bonus' title='@{perception_bonus}'>0</span>
+                                <button type='roll' name='roll_perception' value='@{wtype}&{template:simple} {{rname=^{perception-u}}} {{mod=@{perception_bonus}}} {{r1=[[@{d20}+@{perception_bonus}@{pbd_safe}]]}} @{rtype}+@{perception_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='perception-core'>Perception <span>(Wis)</span></button>
+                            </div>
+                            <div class="skill" data-i18n-list-item="performance">
+                                <input type="checkbox" name="attr_performance_prof" title="@{performance_prof}" value="(@{pb}*@{performance_type})">
+                                <span name='attr_performance_bonus' title='@{performance_bonus}'>0</span>
+                                <button type='roll' name='roll_performance' value='@{wtype}&{template:simple} {{rname=^{performance-u}}} {{mod=@{performance_bonus}}} {{r1=[[@{d20}+@{performance_bonus}@{pbd_safe}]]}} @{rtype}+@{performance_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='performance-core'>Performance <span>(Cha)</span></button>
+                            </div>
+                            <div class="skill" data-i18n-list-item="persuasion">
+                                <input type="checkbox" name="attr_persuasion_prof" title="@{persuasion_prof}" value="(@{pb}*@{persuasion_type})">
+                                <span name='attr_persuasion_bonus' title='@{persuasion_bonus}'>0</span>
+                                <button type='roll' name='roll_persuasion' value='@{wtype}&{template:simple} {{rname=^{persuasion-u}}} {{mod=@{persuasion_bonus}}} {{r1=[[@{d20}+@{persuasion_bonus}@{pbd_safe}]]}} @{rtype}+@{persuasion_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='persuasion-core'>Persuasion <span>(Wis)</span></button>
+                            </div>
+                            <div class="skill" data-i18n-list-item="piloting">
+                                <input type="checkbox" name="attr_piloting_prof" title="@{piloting_prof}" value="(@{pb}*@{piloting_type})">
+                                <span name='attr_piloting_bonus' title='@{piloting_bonus}'>0</span>
+                                <button type='roll' name='roll_piloting' value='@{wtype}&{template:simple} {{rname=^{piloting-u}}} {{mod=@{piloting_bonus}}} {{r1=[[@{d20}+@{piloting_bonus}@{pbd_safe}]]}} @{rtype}+@{piloting_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='piloting-core'>Piloting <span>(Int)</span></button>
+                            </div>
+                            <div class="skill" data-i18n-list-item="sleight_of_hand">
+                                <input type="checkbox" name="attr_sleight_of_hand_prof" title="@{sleight_of_hand_prof}" value="(@{pb}*@{sleight_of_hand_type})">
+                                <span name='attr_sleight_of_hand_bonus' title='@{sleight_of_hand_bonus}'>0</span>
+                                <button type='roll' name='roll_sleight_of_hand' value='@{wtype}&{template:simple} {{rname=^{sleight_of_hand-u}}} {{mod=@{sleight_of_hand_bonus}}} {{r1=[[@{d20}+@{sleight_of_hand_bonus}@{pbd_safe}]]}} @{rtype}+@{sleight_of_hand_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='sleight_of_hand-core'>Sleight of Hand <span>(Dex)</span></button>
+                            </div>
+                            <div class="skill" data-i18n-list-item="stealth">
+                                <input type="checkbox" name="attr_stealth_prof" title="@{stealth_prof}" value="(@{pb}*@{stealth_type})">
+                                <span name='attr_stealth_bonus' title='@{stealth_bonus}'>0</span>
+                                <button type='roll' name='roll_stealth' value='@{wtype}&{template:simple} {{rname=^{stealth-u}}} {{mod=@{stealth_bonus}}} {{r1=[[@{d20}+@{stealth_bonus}@{pbd_safe}]]}} @{rtype}+@{stealth_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='stealth-core'>Stealth <span>(Dex)</span></button>
+                            </div>
+                            <div class="skill" data-i18n-list-item="survival">
+                                <input type="checkbox" name="attr_survival_prof" title="@{survival_prof}" value="(@{pb}*@{survival_type})">
+                                <span name='attr_survival_bonus' title='@{survival_bonus}'>0</span>
+                                <button type='roll' name='roll_survival' value='@{wtype}&{template:simple} {{rname=^{survival-u}}} {{mod=@{survival_bonus}}} {{r1=[[@{d20}+@{survival_bonus}@{pbd_safe}]]}} @{rtype}+@{survival_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='survival-core'>Survival <span>(Wis)</span></button>
+                            </div>
+                        </div>
+                        <div class="label">
+                            <span data-i18n="skills-u">SKILLS</span>
+                        </div>
                     </div>
                 </div>
-                <div class="attr-container">
-                    <button type="roll" name="roll_constitution" value="@{wtype}&{template:simple} {{rname=^{constitution-u}}} {{mod=@{constitution_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{constitution_mod}@{jack_attr}[CON]]]}} @{rtype}+@{constitution_mod}@{jack_attr}[CON]]]}} @{charname_output}" data-i18n="constitution-u">CONSTITUTION</button>
-                    <span class="attr" name="attr_constitution_mod" title="@{constitution_mod}">0</span>
-                    <div class="attr-mod">
-                        <input class="baseattr" type="text" name="attr_constitution_base" title="@{constitution}" value="10">
-                        <input type="hidden" name="attr_constitution" value="10">
-                        <input class="attr-flag" type="hidden" name="attr_constitution_flag" value="0">
-                        <span class="finalattr" name="attr_constitution">
-                    </div>
-                </div>
-                <div class="attr-container">
-                    <button type="roll" name="roll_intelligence" value="@{wtype}&{template:simple} {{rname=^{intelligence-u}}} {{mod=@{intelligence_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{intelligence_mod}@{jack_attr}[INT]]]}} @{rtype}+@{intelligence_mod}@{jack_attr}[INT]]]}} @{charname_output}" data-i18n="intelligence-u">INTELLIGENCE</button>
-                    <span class="attr" name="attr_intelligence_mod" title="@{intelligence_mod}">0</span>
-                    <div class="attr-mod">
-                        <input class="baseattr" type="text" name="attr_intelligence_base" title="@{intelligence}" value="10">
-                        <input type="hidden" name="attr_intelligence" value="10">
-                        <input class="attr-flag" type="hidden" name="attr_intelligence_flag" value="0">
-                        <span class="finalattr" name="attr_intelligence">
-                    </div>
-                </div>
-                <div class="attr-container">
-                    <button type="roll" name="roll_wisdom" value="@{wtype}&{template:simple} {{rname=^{wisdom-u}}} {{mod=@{wisdom_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{wisdom_mod}@{jack_attr}[WIS]]]}} @{rtype}+@{wisdom_mod}@{jack_attr}[WIS]]]}} @{charname_output}" data-i18n="wisdom-u">WISDOM</button>
-                    <span class="attr" name="attr_wisdom_mod" title="@{wisdom_mod}">0</span>
-                    <div class="attr-mod">
-                        <input class="baseattr" type="text" name="attr_wisdom_base" title="@{wisdom}" value="10">
-                        <input type="hidden" name="attr_wisdom" value="10">
-                        <input class="attr-flag" type="hidden" name="attr_wisdom_flag" value="0">
-                        <span class="finalattr" name="attr_wisdom">
-                    </div>
-                </div>
-                <div class="attr-container">
-                    <button type="roll" name="roll_charisma" value="@{wtype}&{template:simple} {{rname=^{charisma-u}}} {{mod=@{charisma_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{charisma_mod}@{jack_attr}[CHA]]]}} @{rtype}+@{charisma_mod}@{jack_attr}[CHA]]]}} @{charname_output}" data-i18n="charisma-u">CHARISMA</button>
-                    <span class="attr" name="attr_charisma_mod" title="@{charisma_mod}">0</span>
-                    <div class="attr-mod">
-                        <input class="baseattr" type="text" name="attr_charisma_base" title="@{charisma}" value="10">
-                        <input type="hidden" name="attr_charisma" value="10">
-                        <input class="attr-flag" type="hidden" name="attr_charisma_flag" value="0">
-                        <span class="finalattr" name="attr_charisma">
-                    </div>
-                </div>
-            </div>
-            <div class="skills-saves-container">
-                <div class="insp-prof-container">
+                <div class="insp-prof-container" style="width: 100%; margin-top: 2px;">
                     <div class="value">
-                        <input type="checkbox" name="attr_inspiration"><span></span>
+                        <!-- <input type="text" name="attr_passive_wisdom" title="@{passive_wisdom}" value="(10+@{perception_bonus}+@{passiveperceptionmod})" disabled="true" ><span></span> -->
+                        <span name="attr_passive_wisdom"></span>
                     </div>
-                    <div class="label">
-                        <span data-i18n="inspiration-u">INSPIRATION</span>
-                    </div>
-                </div>
-                <div class="insp-prof-container">
-                    <div class="value">
-                        <span name="attr_pb" title="@{pb}"></span>
-                    </div>
-                    <div class="label">
-                        <span data-i18n="prof-bonus-u">PROFICIENCY BONUS</span>
+                    <div class="label" style="width: 217px;">
+                        <span data-i18n="pass-wis-u">PASSIVE WISDOM (PERCEPTION)</span>
                     </div>
                 </div>
-                <div class="saving-throw-container">
-                    <div class="saving-throw">
-                        <input type="checkbox" name="attr_strength_save_prof" title="@{strength_save_prof}" value="(@{pb})">
-                        <span name="attr_strength_save_bonus" title="@{strength_save_bonus}">0</span>
-                        <button type="roll" name="roll_strength_save" value="@{wtype}&{template:simple} {{rname=^{strength-save-u}}} {{mod=@{strength_save_bonus}}} {{r1=[[@{d20}+@{strength_save_bonus}@{pbd_safe}]]}} @{rtype}+@{strength_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="strength">Strength</button>
+                <div class="tool_proficiencies" style="margin-bottom: 10px; min-height: 100px; position: relative;">
+                    <div class="top">
+                        <span class="label" style="width: 106px;" data-i18n="tool-u">TOOL</span>
+                        <span class="label" style="width: 35px;" data-i18n="pro-u">PRO</span>
+                        <span class="label" style="width: 50px;" data-i18n="attr-u">ATTRIBUTE</span>
                     </div>
-                    <div class="saving-throw">
-                        <input type="checkbox" name="attr_dexterity_save_prof" title="@{dexterity_save_prof}" value="(@{pb})">
-                        <span name="attr_dexterity_save_bonus" title="@{dexterity_save_bonus}">0</span>
-                        <button type="roll" name="roll_dexterity_save" value="@{wtype}&{template:simple} {{rname=^{dexterity-save-u}}} {{mod=@{dexterity_save_bonus}}} {{r1=[[@{d20}+@{dexterity_save_bonus}@{pbd_safe}]]}} @{rtype}+@{dexterity_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="dexterity">Dexterity</button>
-                    </div>
-                    <div class="saving-throw">
-                        <input type="checkbox" name="attr_constitution_save_prof" title="@{constitution_save_prof}" value="(@{pb})">
-                        <span name="attr_constitution_save_bonus" title="@{constitution_save_bonus}">0</span>
-                        <button type="roll" name="roll_constitution_save" value="@{wtype}&{template:simple} {{rname=^{constitution-save-u}}} {{mod=@{constitution_save_bonus}}} {{r1=[[@{d20}+@{constitution_save_bonus}@{pbd_safe}]]}} @{rtype}+@{constitution_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="constitution">Constitution</button>
-                    </div>
-                    <div class="saving-throw">
-                        <input type="checkbox" name="attr_intelligence_save_prof" title="@{intelligence_save_prof}" value="(@{pb})">
-                        <span name="attr_intelligence_save_bonus" title="@{intelligence_save_bonus}">0</span>
-                        <button type="roll" name="roll_intelligence_save" value="@{wtype}&{template:simple} {{rname=^{intelligence-save-u}}} {{mod=@{intelligence_save_bonus}}} {{r1=[[@{d20}+@{intelligence_save_bonus}@{pbd_safe}]]}} @{rtype}+@{intelligence_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="intelligence">Intelligence</button>
-                    </div>
-                    <div class="saving-throw">
-                        <input type="checkbox" name="attr_wisdom_save_prof" title="@{wisdom_save_prof}" value="(@{pb})">
-                        <span name="attr_wisdom_save_bonus" title="@{wisdom_save_bonus}">0</span>
-                        <button type="roll" name="roll_wisdom_save" value="@{wtype}&{template:simple} {{rname=^{wisdom-save-u}}} {{mod=@{wisdom_save_bonus}}} {{r1=[[@{d20}+@{wisdom_save_bonus}@{pbd_safe}]]}} @{rtype}+@{wisdom_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="wisdom">Wisdom</button>
-                    </div>
-                    <div class="saving-throw">
-                        <input type="checkbox" name="attr_charisma_save_prof" title="@{charisma_save_prof}" value="(@{pb})">
-                        <span name="attr_charisma_save_bonus" title="@{charisma_save_bonus}">0</span>
-                        <button type="roll" name="roll_charisma_save" value="@{wtype}&{template:simple} {{rname=^{charisma-save-u}}} {{mod=@{charisma_save_bonus}}} {{r1=[[@{d20}+@{charisma_save_bonus}@{pbd_safe}]]}} @{rtype}+@{charisma_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="charisma">Charisma</button>
-                    </div>
-                    <input type="hidden" class="toggleflag" name="attr_global_save_mod_flag">
+                        <fieldset class="repeating_tool">
+                        <div class="tool">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_toolname" style="width: 120px;">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="prof-bonus:-u">PROFICIENCY BONUS:</span>
+                                    <select name="attr_toolbonus_base">
+                                        <option value="(@{pb})" selected="selected" data-i18n="prof-u">PROFICIENT</option>
+                                        <option value="(@{pb}*2)" data-i18n="expertise-u">EXPERTISE</option>
+                                        <option value="(floor(@{pb}/2))" data-i18n="jack-of-all-u">JACK OF ALL TRADES</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="attr:-u">ATTRIBUTE:</span>
+                                    <select name="attr_toolattr_base">
+                                        <option value="@{strength_mod}" selected="selected" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}" data-i18n="charisma-u">CHARISMA</option>
+                                        <option value="?{Attribute?|Strength,@{strength_mod}|Dexterity,@{dexterity_mod}|Constitution,@{constitution_mod}|Intelligence,@{intelligence_mod}|Wisdom,@{wisdom_mod}|Charisma,@{charisma_mod}}" data-i18n="query-attr-u">QUERY ATTRIBUTE</option>
+                                    </select>
+                                    <span data-i18n="mods:-u">MODS:</span>
+                                    <input type="text" class="num" name="attr_tool_mod" title="@{tool_mod}" value="0">
+                                </div>
+                            </div>
+                            <div class="display">
+                                <button type="roll" name="roll_tool" value="@{wtype}&{template:simple} {{rname=@{toolname}}} {{mod=@{toolbonus}}} {{r1=[[@{d20}+@{toolbonus}@{pbd_safe}]]}} @{rtype}+@{toolbonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}">
+                                    <span name="attr_toolname" style="width: 100px;"></span>
+                                    <input type="text" name="attr_toolbonus_display" style="width: 40px; text-align: center;">
+                                    <input type="hidden" name="attr_toolbonus">
+                                    <input type="text" name="attr_toolattr" style="width: 80px;">
+                                </button>
+                            </div>
+                        </div>
+                    </fieldset>
+                    <input type="hidden" class="toggleflag" name="attr_global_skill_mod_flag">
                     <div class="hidden textarea globalattack">
-                        <span class="label" data-i18n="global-save-u">GLOBAL SAVE MODIFIER</span>
-                        <fieldset class="repeating_savemod">
+                        <span class="label" data-i18n="global-skill-u">GLOBAL SKILL MODIFIER</span>
+                        <fieldset class="repeating_skillmod">
                             <div class="global-mod">
                                 <input type="checkbox" name="attr_options-flag" class="options-flag" checked="checked" style="top: -15px;"><span>y</span>
-                                <input type="checkbox" name="attr_global_save_active_flag" value="1" class="active-flag">
+                                <input type="checkbox" name="attr_global_skill_active_flag" value="1" class="active-flag">
                                 <div class="options">
-                                    <textarea type="textarea" name="attr_global_save_rollstring" placeholder="1d4[BLESS]" style="width: 125px;"></textarea>
+                                    <textarea type="textarea" name="attr_global_skill_rollstring" placeholder="1d4[GUIDANCE]"></textarea>
                                 </div>
                                 <div class="display">
-                                    <span class="title" name="attr_global_save_rollstring"></span>
+                                    <span class="title" name="attr_global_skill_rollstring"></span>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                    <div class="label" style="position: absolute; bottom: 0px; width: 100%; text-align: center;">
+                        <span data-i18n="tool-prof-u" style="display: inline;">TOOL PROFICIENCIES</span><span style="display: inline;"> & </span><span data-i18n="custom-skills-u" style="display: inline;">CUSTOM SKILLS</span>
+                    </div>
+                </div>
+                <div class="textbox-container proficiencies">
+                    <input type="hidden" class="inventoryflag" name="attr_simpleproficencies" value="complex">
+                    <textarea class="sheet-simple" name="attr_other_proficiencies_and_languages" style="min-height: 91px; height: 91px;"></textarea>
+                    <div class="complex">
+                        <div class="top">
+                            <span class="label" style="width: 60px;" data-i18n="type-u">TYPE</span>
+                            <span class="label" style="width: 135px;" data-i18n="proficency-u">PROFICIENCY</span>
+                        </div>
+                        <fieldset class="repeating_proficiencies">
+                            <div class="proficiency">
+                                <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
+                                <div class="options">
+                                    <div class="row">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <select name="attr_prof_type">
+                                            <option selected="selected" data-i18n="lang-u">LANGUAGE</option>
+                                            <option data-i18n="weapon-u">WEAPON</option>
+                                            <option data-i18n="armor-u">ARMOR</option>
+                                            <option data-i18n="other-u">OTHER</option>
+                                        </select>
+                                    </div>
+                                    <div class="row" style="margin-bottom: 3px;">
+                                        <span data-i18n="proficency-u">PROFICIENCY</span><span>:</span>
+                                        <input type="text" name="attr_name" style="width: 165px;" placeholder="Basic, Huttese, Binary">
+                                    </div>
+                                </div>
+                                <div class="display" style="margin-bottom: 2px;">
+                                    <button type="roll" name="roll_output" value="@{wtype}&{template:traits} @{charname_output} {{name=@{prof_type} PROFICIENCY}} {{description=@{name}}}">
+                                        <span name="attr_prof_type" style="width: 55px;"></span>
+                                        <span name="attr_name" style="width: 159px;"></span>
+                                    </button>
                                 </div>
                             </div>
                         </fieldset>
                     </div>
                     <div class="label">
-                        <span data-i18n="saving-throws-u">SAVING THROWS</span>
-                    </div>
-                </div>
-                <div class="skills-container skills-list">
-                    <div data-i18n-list="skills-list">
-                        <div class="skill" data-i18n-list-item="acrobatics">
-                            <input type="checkbox" name="attr_acrobatics_prof" title="@{acrobatics_prof}" value="(@{pb}*@{acrobatics_type})">
-                            <span name="attr_acrobatics_bonus" title="@{acrobatics_bonus}">0</span>
-                            <button type="roll" name="roll_acrobatics" value="@{wtype}&{template:simple} {{rname=^{acrobatics-u}}} {{mod=@{acrobatics_bonus}}} {{r1=[[@{d20}+@{acrobatics_bonus}@{pbd_safe}]]}} @{rtype}+@{acrobatics_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}" data-i18n="acrobatics-core">Acrobatics <span>(Dex)</span></button>
-                        </div>
-                        <div class="skill" data-i18n-list-item="animal_handling">
-                            <input type="checkbox" name="attr_animal_handling_prof" title="@{animal_handling_prof}" value="(@{pb}*@{animal_handling_type})">
-                            <span name='attr_animal_handling_bonus' title='@{animal_handling_bonus}'>0</span>
-                            <button type='roll' name='roll_animal_handling' value='@{wtype}&{template:simple} {{rname=^{animal_handling-u}}} {{mod=@{animal_handling_bonus}}} {{r1=[[@{d20}+@{animal_handling_bonus}@{pbd_safe}]]}} @{rtype}+@{animal_handling_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='animal_handling-core'>Animal Handling <span>(Wis)</span></button>
-                        </div>
-                        <div class="skill" data-i18n-list-item="technology">
-                            <input type="checkbox" name="attr_technology_prof" title="@{technology_prof}" value="(@{pb}*@{technology_type})">
-                            <span name='attr_technology_bonus' title='@{technology_bonus}'>0</span>
-                            <button type='roll' name='roll_technology' value='@{wtype}&{template:simple} {{rname=^{technology-u}}} {{mod=@{technology_bonus}}} {{r1=[[@{d20}+@{technology_bonus}@{pbd_safe}]]}} @{rtype}+@{technology_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='technology-core'>Technology <span>(Int)</span></button>
-                        </div>
-                        <div class="skill" data-i18n-list-item="athletics">
-                            <input type="checkbox" name="attr_athletics_prof" title="@{athletics_prof}" value="(@{pb}*@{athletics_type})">
-                            <span name='attr_athletics_bonus' title='@{athletics_bonus}'>0</span>
-                            <button type='roll' name='roll_athletics' value='@{wtype}&{template:simple} {{rname=^{athletics-u}}} {{mod=@{athletics_bonus}}} {{r1=[[@{d20}+@{athletics_bonus}@{pbd_safe}]]}} @{rtype}+@{athletics_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='athletics-core'>Athletics <span>(Str)</span></button>
-                        </div>
-                        <div class="skill" data-i18n-list-item="deception">
-                            <input type="checkbox" name="attr_deception_prof" title="@{deception_prof}" value="(@{pb}*@{deception_type})">
-                            <span name='attr_deception_bonus' title='@{deception_bonus}'>0</span>
-                            <button type='roll' name='roll_deception' value='@{wtype}&{template:simple} {{rname=^{deception-u}}} {{mod=@{deception_bonus}}} {{r1=[[@{d20}+@{deception_bonus}@{pbd_safe}]]}} @{rtype}+@{deception_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='deception-core'>Deception <span>(Cha)</span></button>
-                        </div>
-                        <div class="skill" data-i18n-list-item="lore">
-                            <input type="checkbox" name="attr_lore_prof" title="@{lore_prof}" value="(@{pb}*@{lore_type})">
-                            <span name='attr_lore_bonus' title='@{lore_bonus}'>0</span>
-                            <button type='roll' name='roll_lore' value='@{wtype}&{template:simple} {{rname=^{lore-u}}} {{mod=@{lore_bonus}}} {{r1=[[@{d20}+@{lore_bonus}@{pbd_safe}]]}} @{rtype}+@{lore_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='lore-core'>Lore <span>(Int)</span></button>
-                        </div>
-                        <div class="skill" data-i18n-list-item="insight">
-                            <input type="checkbox" name="attr_insight_prof" title="@{insight_prof}" value="(@{pb}*@{insight_type})">
-                            <span name='attr_insight_bonus' title='@{insight_bonus}'>0</span>
-                            <button type='roll' name='roll_insight' value='@{wtype}&{template:simple} {{rname=^{insight-u}}} {{mod=@{insight_bonus}}} {{r1=[[@{d20}+@{insight_bonus}@{pbd_safe}]]}} @{rtype}+@{insight_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='insight-core'>Insight <span>(Wis)</span></button>
-                        </div>
-                        <div class="skill" data-i18n-list-item="intimidation">
-                            <input type="checkbox" name="attr_intimidation_prof" title="@{intimidation_prof}" value="(@{pb}*@{intimidation_type})">
-                            <span name='attr_intimidation_bonus' title='@{intimidation_bonus}'>0</span>
-                            <button type='roll' name='roll_intimidation' value='@{wtype}&{template:simple} {{rname=^{intimidation-u}}} {{mod=@{intimidation_bonus}}} {{r1=[[@{d20}+@{intimidation_bonus}@{pbd_safe}]]}} @{rtype}+@{intimidation_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='intimidation-core'>Intimidation <span>(Cha)</span></button>
-                        </div>
-                        <div class="skill" data-i18n-list-item="investigation">
-                            <input type="checkbox" name="attr_investigation_prof" title="@{investigation_prof}" value="(@{pb}*@{investigation_type})">
-                            <span name='attr_investigation_bonus' title='@{investigation_bonus}'>0</span>
-                            <button type='roll' name='roll_investigation' value='@{wtype}&{template:simple} {{rname=^{investigation-u}}} {{mod=@{investigation_bonus}}} {{r1=[[@{d20}+@{investigation_bonus}@{pbd_safe}]]}} @{rtype}+@{investigation_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='investigation-core'>Investigation <span>(Int)</span></button>
-                        </div>
-                        <div class="skill" data-i18n-list-item="medicine">
-                            <input type="checkbox" name="attr_medicine_prof" title="@{medicine_prof}" value="(@{pb}*@{medicine_type})">
-                            <span name='attr_medicine_bonus' title='@{medicine_bonus}'>0</span>
-                            <button type='roll' name='roll_medicine' value='@{wtype}&{template:simple} {{rname=^{medicine-u}}} {{mod=@{medicine_bonus}}} {{r1=[[@{d20}+@{medicine_bonus}@{pbd_safe}]]}} @{rtype}+@{medicine_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='medicine-core'>Medicine <span>(Wis)</span></button>
-                        </div>
-                        <div class="skill" data-i18n-list-item="nature">
-                            <input type="checkbox" name="attr_nature_prof" title="@{nature_prof}" value="(@{pb}*@{nature_type})">
-                            <span name='attr_nature_bonus' title='@{nature_bonus}'>0</span>
-                            <button type='roll' name='roll_nature' value='@{wtype}&{template:simple} {{rname=^{nature-u}}} {{mod=@{nature_bonus}}} {{r1=[[@{d20}+@{nature_bonus}@{pbd_safe}]]}} @{rtype}+@{nature_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='nature-core'>Nature <span>(Int)</span></button>
-                        </div>
-                        <div class="skill" data-i18n-list-item="perception">
-                            <input type="checkbox" name="attr_perception_prof" title="@{perception_prof}" value="(@{pb}*@{perception_type})">
-                            <span name='attr_perception_bonus' title='@{perception_bonus}'>0</span>
-                            <button type='roll' name='roll_perception' value='@{wtype}&{template:simple} {{rname=^{perception-u}}} {{mod=@{perception_bonus}}} {{r1=[[@{d20}+@{perception_bonus}@{pbd_safe}]]}} @{rtype}+@{perception_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='perception-core'>Perception <span>(Wis)</span></button>
-                        </div>
-                        <div class="skill" data-i18n-list-item="performance">
-                            <input type="checkbox" name="attr_performance_prof" title="@{performance_prof}" value="(@{pb}*@{performance_type})">
-                            <span name='attr_performance_bonus' title='@{performance_bonus}'>0</span>
-                            <button type='roll' name='roll_performance' value='@{wtype}&{template:simple} {{rname=^{performance-u}}} {{mod=@{performance_bonus}}} {{r1=[[@{d20}+@{performance_bonus}@{pbd_safe}]]}} @{rtype}+@{performance_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='performance-core'>Performance <span>(Cha)</span></button>
-                        </div>
-                        <div class="skill" data-i18n-list-item="persuasion">
-                            <input type="checkbox" name="attr_persuasion_prof" title="@{persuasion_prof}" value="(@{pb}*@{persuasion_type})">
-                            <span name='attr_persuasion_bonus' title='@{persuasion_bonus}'>0</span>
-                            <button type='roll' name='roll_persuasion' value='@{wtype}&{template:simple} {{rname=^{persuasion-u}}} {{mod=@{persuasion_bonus}}} {{r1=[[@{d20}+@{persuasion_bonus}@{pbd_safe}]]}} @{rtype}+@{persuasion_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='persuasion-core'>Persuasion <span>(Wis)</span></button>
-                        </div>
-                        <div class="skill" data-i18n-list-item="piloting">
-                            <input type="checkbox" name="attr_piloting_prof" title="@{piloting_prof}" value="(@{pb}*@{piloting_type})">
-                            <span name='attr_piloting_bonus' title='@{piloting_bonus}'>0</span>
-                            <button type='roll' name='roll_piloting' value='@{wtype}&{template:simple} {{rname=^{piloting-u}}} {{mod=@{piloting_bonus}}} {{r1=[[@{d20}+@{piloting_bonus}@{pbd_safe}]]}} @{rtype}+@{piloting_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='piloting-core'>Piloting <span>(Int)</span></button>
-                        </div>
-                        <div class="skill" data-i18n-list-item="sleight_of_hand">
-                            <input type="checkbox" name="attr_sleight_of_hand_prof" title="@{sleight_of_hand_prof}" value="(@{pb}*@{sleight_of_hand_type})">
-                            <span name='attr_sleight_of_hand_bonus' title='@{sleight_of_hand_bonus}'>0</span>
-                            <button type='roll' name='roll_sleight_of_hand' value='@{wtype}&{template:simple} {{rname=^{sleight_of_hand-u}}} {{mod=@{sleight_of_hand_bonus}}} {{r1=[[@{d20}+@{sleight_of_hand_bonus}@{pbd_safe}]]}} @{rtype}+@{sleight_of_hand_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='sleight_of_hand-core'>Sleight of Hand <span>(Dex)</span></button>
-                        </div>
-                        <div class="skill" data-i18n-list-item="stealth">
-                            <input type="checkbox" name="attr_stealth_prof" title="@{stealth_prof}" value="(@{pb}*@{stealth_type})">
-                            <span name='attr_stealth_bonus' title='@{stealth_bonus}'>0</span>
-                            <button type='roll' name='roll_stealth' value='@{wtype}&{template:simple} {{rname=^{stealth-u}}} {{mod=@{stealth_bonus}}} {{r1=[[@{d20}+@{stealth_bonus}@{pbd_safe}]]}} @{rtype}+@{stealth_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='stealth-core'>Stealth <span>(Dex)</span></button>
-                        </div>
-                        <div class="skill" data-i18n-list-item="survival">
-                            <input type="checkbox" name="attr_survival_prof" title="@{survival_prof}" value="(@{pb}*@{survival_type})">
-                            <span name='attr_survival_bonus' title='@{survival_bonus}'>0</span>
-                            <button type='roll' name='roll_survival' value='@{wtype}&{template:simple} {{rname=^{survival-u}}} {{mod=@{survival_bonus}}} {{r1=[[@{d20}+@{survival_bonus}@{pbd_safe}]]}} @{rtype}+@{survival_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}' data-i18n='survival-core'>Survival <span>(Wis)</span></button>
-                        </div>
-                    </div>
-                    <div class="label">
-                        <span data-i18n="skills-u">SKILLS</span>
+                        <span style="margin-top: -10px;" data-i18n="other-prof-langs-u">OTHER PROFICIENCIES & LANGUAGES</span>
                     </div>
                 </div>
             </div>
-            <div class="insp-prof-container" style="width: 100%; margin-top: 2px;">
-                <div class="value">
-                    <!-- <input type="text" name="attr_passive_wisdom" title="@{passive_wisdom}" value="(10+@{perception_bonus}+@{passiveperceptionmod})" disabled="true" ><span></span> -->
-                    <span name="attr_passive_wisdom"></span>
-                </div>
-                <div class="label" style="width: 217px;">
-                    <span data-i18n="pass-wis-u">PASSIVE WISDOM (PERCEPTION)</span>
-                </div>
-            </div>
-            <div class="tool_proficiencies" style="margin-bottom: 10px; min-height: 100px; position: relative;">
-                <div class="top">
-                    <span class="label" style="width: 106px;" data-i18n="tool-u">TOOL</span>
-                    <span class="label" style="width: 35px;" data-i18n="pro-u">PRO</span>
-                    <span class="label" style="width: 50px;" data-i18n="attr-u">ATTRIBUTE</span>
-                </div>
-                 <fieldset class="repeating_tool">
-                    <div class="tool">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_toolname" style="width: 120px;">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="prof-bonus:-u">PROFICIENCY BONUS:</span>
-                                <select name="attr_toolbonus_base">
-                                    <option value="(@{pb})" selected="selected" data-i18n="prof-u">PROFICIENT</option>
-                                    <option value="(@{pb}*2)" data-i18n="expertise-u">EXPERTISE</option>
-                                    <option value="(floor(@{pb}/2))" data-i18n="jack-of-all-u">JACK OF ALL TRADES</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="attr:-u">ATTRIBUTE:</span>
-                                <select name="attr_toolattr_base">
-                                    <option value="@{strength_mod}" selected="selected" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}" data-i18n="charisma-u">CHARISMA</option>
-                                    <option value="?{Attribute?|Strength,@{strength_mod}|Dexterity,@{dexterity_mod}|Constitution,@{constitution_mod}|Intelligence,@{intelligence_mod}|Wisdom,@{wisdom_mod}|Charisma,@{charisma_mod}}" data-i18n="query-attr-u">QUERY ATTRIBUTE</option>
-                                </select>
-                                <span data-i18n="mods:-u">MODS:</span>
-                                <input type="text" class="num" name="attr_tool_mod" title="@{tool_mod}" value="0">
-                            </div>
-                        </div>
-                        <div class="display">
-                            <button type="roll" name="roll_tool" value="@{wtype}&{template:simple} {{rname=@{toolname}}} {{mod=@{toolbonus}}} {{r1=[[@{d20}+@{toolbonus}@{pbd_safe}]]}} @{rtype}+@{toolbonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}">
-                                <span name="attr_toolname" style="width: 100px;"></span>
-                                <input type="text" name="attr_toolbonus_display" style="width: 40px; text-align: center;">
-                                <input type="hidden" name="attr_toolbonus">
-                                <input type="text" name="attr_toolattr" style="width: 80px;">
-                            </button>
-                        </div>
+            <div class="col col2">
+                <div class="ac-init-speed-container">
+                    <div class="ac">
+                        <input type="text" name="attr_ac" title="@{ac}">
+                        <span class="label pc-ac" data-i18n="armor-class-u">ARMOR CLASS</span>
                     </div>
-                </fieldset>
-                <input type="hidden" class="toggleflag" name="attr_global_skill_mod_flag">
-                <div class="hidden textarea globalattack">
-                    <span class="label" data-i18n="global-skill-u">GLOBAL SKILL MODIFIER</span>
-                    <fieldset class="repeating_skillmod">
-                        <div class="global-mod">
-                            <input type="checkbox" name="attr_options-flag" class="options-flag" checked="checked" style="top: -15px;"><span>y</span>
-                            <input type="checkbox" name="attr_global_skill_active_flag" value="1" class="active-flag">
-                            <div class="options">
-                                <textarea type="textarea" name="attr_global_skill_rollstring" placeholder="1d4[GUIDANCE]"></textarea>
-                            </div>
-                            <div class="display">
-                                <span class="title" name="attr_global_skill_rollstring"></span>
-                            </div>
-                        </div>
-                    </fieldset>
+                    <div class="init">
+                        <span name="attr_initiative_bonus" title="@{initiative_bonus}"></span>
+                        <button type="roll" name="roll_initiative" value="@{wtype}&{template:simple} {{rname=^{init-u}}} {{mod=@{initiative_bonus}}} {{r1=[[@{initiative_style}+@{initiative_bonus}@{pbd_safe}[INIT] &{tracker}]]}} {{normal=1}} @{charname_output}" data-i18n="init-u">INITIATIVE</button>
+                    </div>
+                    <div class="speed">
+                        <input type="text" name="attr_speed" title="@{speed}">
+                        <span class="label" data-i18n="speed-u">SPEED</span>
+                    </div>
                 </div>
-                <div class="label" style="position: absolute; bottom: 0px; width: 100%; text-align: center;">
-                    <span data-i18n="tool-prof-u" style="display: inline;">TOOL PROFICIENCIES</span><span style="display: inline;"> & </span><span data-i18n="custom-skills-u" style="display: inline;">CUSTOM SKILLS</span>
-                </div>
-            </div>
-            <div class="textbox-container proficiencies">
-                <input type="hidden" class="inventoryflag" name="attr_simpleproficencies" value="complex">
-                <textarea class="sheet-simple" name="attr_other_proficiencies_and_languages" style="min-height: 91px; height: 91px;"></textarea>
-                <div class="complex">
+                <div class="hp">
                     <div class="top">
-                        <span class="label" style="width: 60px;" data-i18n="type-u">TYPE</span>
-                        <span class="label" style="width: 135px;" data-i18n="proficency-u">PROFICIENCY</span>
+                        <span data-i18n="hp-max-u">Hit Point Maximum</span>
+                        <input type="text" name="attr_hp_max" title="@{hp_max}">
                     </div>
-                    <fieldset class="repeating_proficiencies">
-                        <div class="proficiency">
+                    <input type="number" name="attr_hp" title="@{hp}">
+                    <span class="label" data-i18n="hp-current-u">CURRENT HIT POINTS</span>
+                </div>
+                <div class="hp" style="height: 56px;">
+                    <input type="number" name="attr_hp_temp" title="@{hp_temp}">
+                    <span class="label" data-i18n="hp-temp-u">TEMPORARY HIT POINTS</span>
+                </div>
+                <div class="hdice-dsaves-container" style="width: 242px;">
+                    <div class="subcontainer">
+                        <div class="top">
+                            <span data-i18n="total">Total</span>
+                            <input type="text" name="attr_hit_dice_max" title="@{hit_dice_max}">
+                        </div>
+                        <input type="number" name="attr_hit_dice" title="@{hit_dice}" style="margin-bottom: -6px;">
+                        <button type="roll" name="roll_hit_dice" value="@{wtype}&{template:simple} {{rname=^{hit-dice-u}}} {{mod=D@{hitdie_final}+[[@{constitution_mod}[CON]]]}} {{r1=[[1d@{hitdie_final}+[[@{constitution_mod}]][CON]]]}} {{normal=1}} @{charname_output}" data-i18n="hit-dice-u">HIT DICE</button>
+                    </div>
+                    <div class="subcontainer" style="float: right;">
+                        <div class="row-container">
+                            <span class="label" data-i18n="successes-u">SUCCESSES</span>
+                            <input type="checkbox" name="attr_deathsave_succ1">
+                            <input type="checkbox" name="attr_deathsave_succ2">
+                            <input type="checkbox" name="attr_deathsave_succ3">
+                        </div>
+                        <div class="row-container">
+                            <span class="label" data-i18n="failures-u">FAILURES</span>
+                            <input type="checkbox" name="attr_deathsave_fail1">
+                            <input type="checkbox" name="attr_deathsave_fail2">
+                            <input type="checkbox" name="attr_deathsave_fail3">
+                        </div>
+                        <button type="roll" name="roll_death_save" style="margin-top: 6px;" value="@{wtype}&{template:simple} {{rname=^{death-save-u}}} {{mod=@{death_save_bonus}}} {{r1=[[@{d20}+@{death_save_bonus}[MOD]@{globalsavingthrowbonus}]]}} {{normal=1}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="death-saves-u">DEATH SAVES</button>
+                    </div>
+                </div>
+                <input type="hidden" class="exhaustion-toggle" name="attr_exhaustion_toggle" value="0">
+                <div class="exhaustion" style="position: relative;">
+                    <input type="number" name="attr_exhaustion_level" step="1" min="0" max="6">
+                    <div class="ex-descriptions">
+                        <span class="ex-description" name="attr_exhaustion_1"></span>
+                        <span class="ex-description" name="attr_exhaustion_2"></span>
+                        <span class="ex-description" name="attr_exhaustion_3"></span>
+                        <span class="ex-description" name="attr_exhaustion_4"></span>
+                        <span class="ex-description" name="attr_exhaustion_5"></span>
+                        <span class="ex-description" name="attr_exhaustion_6"></span>
+                    </div>
+                    <span class="label" data-i18n="exhaustion-u">EXHAUSTION LEVEL</span>
+                </div>
+                <input type="hidden" class="ammoflag" name="attr_ammotracking">
+                <div class="attacks" style="position: relative;">
+                    <div class="top">
+                        <span class="label" style="width: 95px;" data-i18n="name-u">NAME</span>
+                        <span class="label" style="width: 35px;" data-i18n="atk-u">ATK</span>
+                        <span class="label" style="width: 65px;" data-i18n="dmg-type-u">DAMAGE/TYPE</span>
+                    </div>
+                    <fieldset class="repeating_attack">
+                        <div class="attack">
                             <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
                             <div class="options">
                                 <div class="row">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <select name="attr_prof_type">
-                                        <option selected="selected" data-i18n="lang-u">LANGUAGE</option>
-                                        <option data-i18n="weapon-u">WEAPON</option>
-                                        <option data-i18n="armor-u">ARMOR</option>
-                                        <option data-i18n="other-u">OTHER</option>
-                                    </select>
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_atkname">
                                 </div>
-                                <div class="row" style="margin-bottom: 3px;">
-                                    <span data-i18n="proficency-u">PROFICIENCY</span><span>:</span>
-                                    <input type="text" name="attr_name" style="width: 165px;" placeholder="Basic, Huttese, Binary">
+                                <div class="row">
+                                    <input type="checkbox" name="attr_atkflag" value="{{attack=1}}" checked="checked">
+                                    <span data-i18n="attack:-u">ATTACK:</span>
+                                    <select name="attr_atkattr_base">
+                                        <option value="@{strength_mod}" selected="selected" data-i18n="str-u">STR</option>
+                                        <option value="@{dexterity_mod}" data-i18n="dex-u">DEX</option>
+                                        <option value="@{constitution_mod}" data-i18n="con-u">CON</option>
+                                        <option value="@{intelligence_mod}" data-i18n="int-u">INT</option>
+                                        <option value="@{wisdom_mod}" data-i18n="wis-u">WIS</option>
+                                        <option value="@{charisma_mod}" data-i18n="cha-u">CHA</option>
+                                        <option value="power" data-i18n="power-u">POWER</option>
+                                        <option value="0">-</option>
+                                    </select>
+                                    <span>+</span>
+                                    <input type="text" class="num" name="attr_atkmod" placeholder="0">
+                                    <span>+</span>
+                                    <input type="checkbox" name="attr_atkprofflag" value="(@{pb})" checked="checked" style="margin-left: 3px;">
+                                    <span data-i18n="proficient-u">PROFICIENT</span>
+                                </div>
+                                <div class="row">
+                                    <span style="margin-left: 17px;" data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_atkrange" placeholder="Self (60-foot cone)" style="width: 170px;" data-i18n-placeholder="range-place">
+                                </div>
+                                <div class="row">
+                                    <span style="margin-left: 17px;" data-i18n="power-bonus:-u">POWER BONUS:</span>
+                                    <input type="text" class="num" name="attr_atkpower" placeholder="0">
+                                    <span data-i18n="crit-range-u">CRIT RANGE:</span>
+                                    <input type="text" class="num" name="attr_atkcritrange" value="20" placeholder="20">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_dmgflag" value="{{damage=1}} {{dmg1flag=1}}" checked="checked">
+                                    <span data-i18n="damage:-u">DAMAGE:</span>
+                                    <input type="text" name="attr_dmgbase" placeholder="1d6" style="width: 50px;">
+                                    <span>+</span>
+                                    <select name="attr_dmgattr">
+                                        <option value="@{strength_mod}" selected="selected" data-i18n="str-u">STR</option>
+                                        <option value="@{dexterity_mod}" data-i18n="dex-u">DEX</option>
+                                        <option value="@{constitution_mod}" data-i18n="con-u">CON</option>
+                                        <option value="@{intelligence_mod}" data-i18n="int-u">INT</option>
+                                        <option value="@{wisdom_mod}" data-i18n="wis-u">WIS</option>
+                                        <option value="@{charisma_mod}" data-i18n="cha-u">CHA</option>
+                                        <option value="power" data-i18n="power-u">POWER</option>
+                                        <option value="0">-</option>
+                                    </select>
+                                    <span>+</span>
+                                    <input type="text" class="num" name="attr_dmgmod" placeholder="0">
+                                </div>
+                                <div class="row">
+                                    <span style="margin-left: 17px;" data-i18n="type:-u">TYPE:</span>
+                                    <input type="text" name="attr_dmgtype" placeholder="Slashing" style="width: 50px;" data-i18n-placeholder="dmg-type-place">
+                                    <span data-i18n="crit:-u">CRIT:</span>
+                                    <input type="text" name="attr_dmgcustcrit" placeholder="1d6" style="width: 80px;">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_dmg2flag" value="{{damage=1}} {{dmg2flag=1}}">
+                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                    <input type="text" name="attr_dmg2base" placeholder="1d6" style="width: 50px;">
+                                    <span>+</span>
+                                    <select name="attr_dmg2attr">
+                                        <option value="@{strength_mod}" data-i18n="str-u">STR</option>
+                                        <option value="@{dexterity_mod}" data-i18n="dex-u">DEX</option>
+                                        <option value="@{constitution_mod}" data-i18n="con-u">CON</option>
+                                        <option value="@{intelligence_mod}" data-i18n="int-u">INT</option>
+                                        <option value="@{wisdom_mod}" data-i18n="wis-u">WIS</option>
+                                        <option value="@{charisma_mod}" data-i18n="cha-u">CHA</option>
+                                        <option value="power" data-i18n="power-u">POWER</option>
+                                        <option value="0" selected="selected">-</option>
+                                    </select>
+                                    <span>+</span>
+                                    <input type="text" class="num" name="attr_dmg2mod" placeholder="0">
+                                </div>
+                                <div class="row">
+                                    <span style="margin-left: 17px;" data-i18n="type:-u">TYPE:</span>
+                                    <input type="text" name="attr_dmg2type" placeholder="Slashing" style="width: 50px;" data-i18n-placeholder="dmg-type-place">
+                                    <span data-i18n="crit:-u">CRIT:</span>
+                                    <input type="text" name="attr_dmg2custcrit" placeholder="1d6" style="width: 80px;">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_saveflag" value="{{save=1}} {{saveattr=@{saveattr}}} {{savedesc=@{saveeffect}}} {{savedc=[[[[@{savedc}]][SAVE]]]}}">
+                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                    <select name="attr_saveattr">
+                                        <option value="Strength" selected="selected" data-i18n="str-u">STR</option>
+                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                        <option value="Constitution" data-i18n="con-u">CON</option>
+                                        <option value="Intelligence" data-i18n="int-u">INT</option>
+                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                    </select>
+                                    <span data-i18n="vs-dc:-u">VS DC:</span>
+                                    <select name="attr_savedc">
+                                        <option value="(@{power_save_dc})" selected="selected" data-i18n="power-u">POWER</option>
+                                        <option value="(@{strength_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="str-u">STR</option>
+                                        <option value="(@{dexterity_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="dex-u">DEX</option>
+                                        <option value="(@{constitution_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="con-u">CON</option>
+                                        <option value="(@{intelligence_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="int-u">INT</option>
+                                        <option value="(@{wisdom_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="wis-u">WIS</option>
+                                        <option value="(@{charisma_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="cha-u">CHA</option>
+                                        <option value="(@{saveflat})" data-i18n="flat-u">FLAT</option>
+                                    </select>
+                                    <input class="flatflag" type="hidden" name="attr_savedc">
+                                    <input class="num flat" type="text" name="attr_saveflat" placeholder="10" value="10">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="save-effect:-u">SAVE EFFECT:</span>
+                                    <input type="text" name="attr_saveeffect" placeholder="half damage" style="width: 160px;" data-i18n-placeholder="save-effect-place">
+                                </div>
+                                <div class="row ammo">
+                                    <span data-i18n="ammunition:-u">AMMUNITION:</span>
+                                    <input type="text" name="attr_ammo" placeholder="Arrows" style="width: 160px;" data-i18n-placeholder="ammunition-place">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                    <textarea name="attr_atk_desc" placeholder="Up to 2 creatures within 5 feet" data-i18n-placeholder="description-place"></textarea>
                                 </div>
                             </div>
-                            <div class="display" style="margin-bottom: 2px;">
-                                <button type="roll" name="roll_output" value="@{wtype}&{template:traits} @{charname_output} {{name=@{prof_type} PROFICIENCY}} {{description=@{name}}}">
-                                    <span name="attr_prof_type" style="width: 55px;"></span>
-                                    <span name="attr_name" style="width: 159px;"></span>
+                            <div class="display">
+                                <button type="roll" name="roll_attack" value="@{rollbase}">
+                                    <span name="attr_atkname" style="width: 85px;"></span>
+                                    <input type="text" name="attr_atkbonus" style="width: 40px; text-align: center;" value="">
+                                    <input type="text" name="attr_atkdmgtype" style="width: 90px;" value="">
                                 </button>
                             </div>
                         </div>
+                        <input type="hidden" name="attr_rollbase">
+                        <input type="hidden" name="attr_rollbase_dmg">
+                        <input type="hidden" name="attr_rollbase_crit">
+                        <input type="hidden" name="attr_hldmg">
+                        <input type="hidden" name="attr_powerlevel">
+                        <input type="hidden" name="attr_itemid">
+                        <input type="hidden" name="attr_powerid">
+                        <input type="hidden" name="attr_power_innate">
+                        <input type="hidden" name="attr_versatile_alt">
+                        <button type="roll" name="roll_attack_dmg" style="display: none;" value="@{rollbase_dmg}"></button>
+                        <button type="roll" name="roll_attack_crit" style="display: none;" value="@{rollbase_crit}"></button>
                     </fieldset>
-                </div>
-                <div class="label">
-                    <span style="margin-top: -10px;" data-i18n="other-prof-langs-u">OTHER PROFICIENCIES & LANGUAGES</span>
-                </div>
-            </div>
-        </div>
-        <div class="col col2">
-            <div class="ac-init-speed-container">
-                <div class="ac">
-                    <input type="text" name="attr_ac" title="@{ac}">
-                    <span class="label pc-ac" data-i18n="armor-class-u">ARMOR CLASS</span>
-                </div>
-                <div class="init">
-                    <span name="attr_initiative_bonus" title="@{initiative_bonus}"></span>
-                    <button type="roll" name="roll_initiative" value="@{wtype}&{template:simple} {{rname=^{init-u}}} {{mod=@{initiative_bonus}}} {{r1=[[@{initiative_style}+@{initiative_bonus}@{pbd_safe}[INIT] &{tracker}]]}} {{normal=1}} @{charname_output}" data-i18n="init-u">INITIATIVE</button>
-                </div>
-                <div class="speed">
-                    <input type="text" name="attr_speed" title="@{speed}">
-                    <span class="label" data-i18n="speed-u">SPEED</span>
-                </div>
-            </div>
-            <div class="hp">
-                <div class="top">
-                    <span data-i18n="hp-max-u">Hit Point Maximum</span>
-                    <input type="text" name="attr_hp_max" title="@{hp_max}">
-                </div>
-                <input type="number" name="attr_hp" title="@{hp}">
-                <span class="label" data-i18n="hp-current-u">CURRENT HIT POINTS</span>
-            </div>
-            <div class="hp" style="height: 56px;">
-                <input type="number" name="attr_hp_temp" title="@{hp_temp}">
-                <span class="label" data-i18n="hp-temp-u">TEMPORARY HIT POINTS</span>
-            </div>
-            <div class="hdice-dsaves-container" style="width: 242px;">
-                <div class="subcontainer">
-                    <div class="top">
-                        <span data-i18n="total">Total</span>
-                        <input type="text" name="attr_hit_dice_max" title="@{hit_dice_max}">
-                    </div>
-                    <input type="number" name="attr_hit_dice" title="@{hit_dice}" style="margin-bottom: -6px;">
-                    <button type="roll" name="roll_hit_dice" value="@{wtype}&{template:simple} {{rname=^{hit-dice-u}}} {{mod=D@{hitdie_final}+[[@{constitution_mod}[CON]]]}} {{r1=[[1d@{hitdie_final}+[[@{constitution_mod}]][CON]]]}} {{normal=1}} @{charname_output}" data-i18n="hit-dice-u">HIT DICE</button>
-                </div>
-                <div class="subcontainer" style="float: right;">
-                    <div class="row-container">
-                        <span class="label" data-i18n="successes-u">SUCCESSES</span>
-                        <input type="checkbox" name="attr_deathsave_succ1">
-                        <input type="checkbox" name="attr_deathsave_succ2">
-                        <input type="checkbox" name="attr_deathsave_succ3">
-                    </div>
-                    <div class="row-container">
-                        <span class="label" data-i18n="failures-u">FAILURES</span>
-                        <input type="checkbox" name="attr_deathsave_fail1">
-                        <input type="checkbox" name="attr_deathsave_fail2">
-                        <input type="checkbox" name="attr_deathsave_fail3">
-                    </div>
-                    <button type="roll" name="roll_death_save" style="margin-top: 6px;" value="@{wtype}&{template:simple} {{rname=^{death-save-u}}} {{mod=@{death_save_bonus}}} {{r1=[[@{d20}+@{death_save_bonus}[MOD]@{globalsavingthrowbonus}]]}} {{normal=1}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="death-saves-u">DEATH SAVES</button>
-                </div>
-            </div>
-            <input type="hidden" class="exhaustion-toggle" name="attr_exhaustion_toggle" value="0">
-            <div class="exhaustion" style="position: relative;">
-                <input type="number" name="attr_exhaustion_level" step="1" min="0" max="6">
-                <div class="ex-descriptions">
-                    <span class="ex-description" name="attr_exhaustion_1"></span>
-                    <span class="ex-description" name="attr_exhaustion_2"></span>
-                    <span class="ex-description" name="attr_exhaustion_3"></span>
-                    <span class="ex-description" name="attr_exhaustion_4"></span>
-                    <span class="ex-description" name="attr_exhaustion_5"></span>
-                    <span class="ex-description" name="attr_exhaustion_6"></span>
-                </div>
-                <span class="label" data-i18n="exhaustion-u">EXHAUSTION LEVEL</span>
-            </div>
-            <input type="hidden" class="ammoflag" name="attr_ammotracking">
-            <div class="attacks" style="position: relative;">
-                <div class="top">
-                    <span class="label" style="width: 95px;" data-i18n="name-u">NAME</span>
-                    <span class="label" style="width: 35px;" data-i18n="atk-u">ATK</span>
-                    <span class="label" style="width: 65px;" data-i18n="dmg-type-u">DAMAGE/TYPE</span>
-                </div>
-                <fieldset class="repeating_attack">
-                    <div class="attack">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_atkname">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_atkflag" value="{{attack=1}}" checked="checked">
-                                <span data-i18n="attack:-u">ATTACK:</span>
-                                <select name="attr_atkattr_base">
-                                    <option value="@{strength_mod}" selected="selected" data-i18n="str-u">STR</option>
-                                    <option value="@{dexterity_mod}" data-i18n="dex-u">DEX</option>
-                                    <option value="@{constitution_mod}" data-i18n="con-u">CON</option>
-                                    <option value="@{intelligence_mod}" data-i18n="int-u">INT</option>
-                                    <option value="@{wisdom_mod}" data-i18n="wis-u">WIS</option>
-                                    <option value="@{charisma_mod}" data-i18n="cha-u">CHA</option>
-                                    <option value="power" data-i18n="power-u">POWER</option>
-                                    <option value="0">-</option>
-                                </select>
-                                <span>+</span>
-                                <input type="text" class="num" name="attr_atkmod" placeholder="0">
-                                <span>+</span>
-                                <input type="checkbox" name="attr_atkprofflag" value="(@{pb})" checked="checked" style="margin-left: 3px;">
-                                <span data-i18n="proficient-u">PROFICIENT</span>
-                            </div>
-                            <div class="row">
-                                <span style="margin-left: 17px;" data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_atkrange" placeholder="Self (60-foot cone)" style="width: 170px;" data-i18n-placeholder="range-place">
-                            </div>
-                            <div class="row">
-                                <span style="margin-left: 17px;" data-i18n="power-bonus:-u">POWER BONUS:</span>
-                                <input type="text" class="num" name="attr_atkpower" placeholder="0">
-                                <span data-i18n="crit-range-u">CRIT RANGE:</span>
-                                <input type="text" class="num" name="attr_atkcritrange" value="20" placeholder="20">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_dmgflag" value="{{damage=1}} {{dmg1flag=1}}" checked="checked">
-                                <span data-i18n="damage:-u">DAMAGE:</span>
-                                <input type="text" name="attr_dmgbase" placeholder="1d6" style="width: 50px;">
-                                <span>+</span>
-                                <select name="attr_dmgattr">
-                                    <option value="@{strength_mod}" selected="selected" data-i18n="str-u">STR</option>
-                                    <option value="@{dexterity_mod}" data-i18n="dex-u">DEX</option>
-                                    <option value="@{constitution_mod}" data-i18n="con-u">CON</option>
-                                    <option value="@{intelligence_mod}" data-i18n="int-u">INT</option>
-                                    <option value="@{wisdom_mod}" data-i18n="wis-u">WIS</option>
-                                    <option value="@{charisma_mod}" data-i18n="cha-u">CHA</option>
-                                    <option value="power" data-i18n="power-u">POWER</option>
-                                    <option value="0">-</option>
-                                </select>
-                                <span>+</span>
-                                <input type="text" class="num" name="attr_dmgmod" placeholder="0">
-                            </div>
-                            <div class="row">
-                                <span style="margin-left: 17px;" data-i18n="type:-u">TYPE:</span>
-                                <input type="text" name="attr_dmgtype" placeholder="Slashing" style="width: 50px;" data-i18n-placeholder="dmg-type-place">
-                                <span data-i18n="crit:-u">CRIT:</span>
-                                <input type="text" name="attr_dmgcustcrit" placeholder="1d6" style="width: 80px;">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_dmg2flag" value="{{damage=1}} {{dmg2flag=1}}">
-                                <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                <input type="text" name="attr_dmg2base" placeholder="1d6" style="width: 50px;">
-                                <span>+</span>
-                                <select name="attr_dmg2attr">
-                                    <option value="@{strength_mod}" data-i18n="str-u">STR</option>
-                                    <option value="@{dexterity_mod}" data-i18n="dex-u">DEX</option>
-                                    <option value="@{constitution_mod}" data-i18n="con-u">CON</option>
-                                    <option value="@{intelligence_mod}" data-i18n="int-u">INT</option>
-                                    <option value="@{wisdom_mod}" data-i18n="wis-u">WIS</option>
-                                    <option value="@{charisma_mod}" data-i18n="cha-u">CHA</option>
-                                    <option value="power" data-i18n="power-u">POWER</option>
-                                    <option value="0" selected="selected">-</option>
-                                </select>
-                                <span>+</span>
-                                <input type="text" class="num" name="attr_dmg2mod" placeholder="0">
-                            </div>
-                            <div class="row">
-                                <span style="margin-left: 17px;" data-i18n="type:-u">TYPE:</span>
-                                <input type="text" name="attr_dmg2type" placeholder="Slashing" style="width: 50px;" data-i18n-placeholder="dmg-type-place">
-                                <span data-i18n="crit:-u">CRIT:</span>
-                                <input type="text" name="attr_dmg2custcrit" placeholder="1d6" style="width: 80px;">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_saveflag" value="{{save=1}} {{saveattr=@{saveattr}}} {{savedesc=@{saveeffect}}} {{savedc=[[[[@{savedc}]][SAVE]]]}}">
-                                <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                <select name="attr_saveattr">
-                                    <option value="Strength" selected="selected" data-i18n="str-u">STR</option>
-                                    <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                    <option value="Constitution" data-i18n="con-u">CON</option>
-                                    <option value="Intelligence" data-i18n="int-u">INT</option>
-                                    <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                    <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                </select>
-                                <span data-i18n="vs-dc:-u">VS DC:</span>
-                                <select name="attr_savedc">
-                                    <option value="(@{power_save_dc})" selected="selected" data-i18n="power-u">POWER</option>
-                                    <option value="(@{strength_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="str-u">STR</option>
-                                    <option value="(@{dexterity_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="dex-u">DEX</option>
-                                    <option value="(@{constitution_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="con-u">CON</option>
-                                    <option value="(@{intelligence_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="int-u">INT</option>
-                                    <option value="(@{wisdom_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="wis-u">WIS</option>
-                                    <option value="(@{charisma_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="cha-u">CHA</option>
-                                    <option value="(@{saveflat})" data-i18n="flat-u">FLAT</option>
-                                </select>
-                                <input class="flatflag" type="hidden" name="attr_savedc">
-                                <input class="num flat" type="text" name="attr_saveflat" placeholder="10" value="10">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="save-effect:-u">SAVE EFFECT:</span>
-                                <input type="text" name="attr_saveeffect" placeholder="half damage" style="width: 160px;" data-i18n-placeholder="save-effect-place">
-                            </div>
-                            <div class="row ammo">
-                                <span data-i18n="ammunition:-u">AMMUNITION:</span>
-                                <input type="text" name="attr_ammo" placeholder="Arrows" style="width: 160px;" data-i18n-placeholder="ammunition-place">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                                <textarea name="attr_atk_desc" placeholder="Up to 2 creatures within 5 feet" data-i18n-placeholder="description-place"></textarea>
-                            </div>
-                        </div>
-                        <div class="display">
-                            <button type="roll" name="roll_attack" value="@{rollbase}">
-                                <span name="attr_atkname" style="width: 85px;"></span>
-                                <input type="text" name="attr_atkbonus" style="width: 40px; text-align: center;" value="">
-                                <input type="text" name="attr_atkdmgtype" style="width: 90px;" value="">
-                            </button>
-                        </div>
-                    </div>
-                    <input type="hidden" name="attr_rollbase">
-                    <input type="hidden" name="attr_rollbase_dmg">
-                    <input type="hidden" name="attr_rollbase_crit">
-                    <input type="hidden" name="attr_hldmg">
-                    <input type="hidden" name="attr_powerlevel">
-                    <input type="hidden" name="attr_itemid">
-                    <input type="hidden" name="attr_powerid">
-                    <input type="hidden" name="attr_power_innate">
-                    <input type="hidden" name="attr_versatile_alt">
-                    <button type="roll" name="roll_attack_dmg" style="display: none;" value="@{rollbase_dmg}"></button>
-                    <button type="roll" name="roll_attack_crit" style="display: none;" value="@{rollbase_crit}"></button>
-                </fieldset>
-                <input type="hidden" class="toggleflag" name="attr_global_attack_mod_flag">
-                <div class="hidden textbox globalattack">
-                    <span class="label" data-i18n="global-attack-u">GLOBAL ATTACK MODIFIER</span>
-                    <fieldset class="repeating_tohitmod">
-                        <div class="global-mod">
-                            <input type="checkbox" name="attr_options-flag" class="options-flag" checked="checked" style="top: -15px;"><span>y</span>
-                            <input type="checkbox" name="attr_global_attack_active_flag" value="1" class="active-flag">
-                            <div class="options">
-                                <textarea type="textarea" name="attr_global_attack_rollstring" placeholder="1d4[BLESS]"></textarea>
-                            </div>
-                            <div class="display">
-                                <span class="title" name="attr_global_attack_rollstring"></span>
-                            </div>
-                        </div>
-                    </fieldset>
-                </div>
-                <input type="hidden" class="toggleflag" name="attr_global_damage_mod_flag">
-                <div class="hidden textbox globalattack">
-                    <span class="label" data-i18n="global-damage-u">GLOBAL DAMAGE MODIFIER</span>
-                    <fieldset class="repeating_damagemod">
-                        <div class="global-mod">
-                            <input type="checkbox" name="attr_options-flag" class="options-flag" checked="checked" style="top: -15px;"><span>y</span>
-                            <input type="checkbox" name="attr_global_damage_active_flag" value="1" class="active-flag">
-                            <div class="options">
-                                <textarea type="textarea" name="attr_global_damage_rollstring" placeholder="1d6[SNEAK ATTACK]"></textarea>
-                                <div class="row" style="margin-bottom: 5px;">
-                                    <span style="display: inline; margin-left: 25px;" data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_global_damage_type" value="">
+                    <input type="hidden" class="toggleflag" name="attr_global_attack_mod_flag">
+                    <div class="hidden textbox globalattack">
+                        <span class="label" data-i18n="global-attack-u">GLOBAL ATTACK MODIFIER</span>
+                        <fieldset class="repeating_tohitmod">
+                            <div class="global-mod">
+                                <input type="checkbox" name="attr_options-flag" class="options-flag" checked="checked" style="top: -15px;"><span>y</span>
+                                <input type="checkbox" name="attr_global_attack_active_flag" value="1" class="active-flag">
+                                <div class="options">
+                                    <textarea type="textarea" name="attr_global_attack_rollstring" placeholder="1d4[BLESS]"></textarea>
+                                </div>
+                                <div class="display">
+                                    <span class="title" name="attr_global_attack_rollstring"></span>
                                 </div>
                             </div>
-                            <div class="display" style="margin-bottom: 2px;">
-                                <span class="title" name="attr_global_damage_rollstring" style="width: 110px; padding-right: 0px;"></span>
-                                <span class="subheader" name="attr_global_damage_type" style="padding-right: 0px;"></span>
+                        </fieldset>
+                    </div>
+                    <input type="hidden" class="toggleflag" name="attr_global_damage_mod_flag">
+                    <div class="hidden textbox globalattack">
+                        <span class="label" data-i18n="global-damage-u">GLOBAL DAMAGE MODIFIER</span>
+                        <fieldset class="repeating_damagemod">
+                            <div class="global-mod">
+                                <input type="checkbox" name="attr_options-flag" class="options-flag" checked="checked" style="top: -15px;"><span>y</span>
+                                <input type="checkbox" name="attr_global_damage_active_flag" value="1" class="active-flag">
+                                <div class="options">
+                                    <textarea type="textarea" name="attr_global_damage_rollstring" placeholder="1d6[SNEAK ATTACK]"></textarea>
+                                    <div class="row" style="margin-bottom: 5px;">
+                                        <span style="display: inline; margin-left: 25px;" data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_global_damage_type" value="">
+                                    </div>
+                                </div>
+                                <div class="display" style="margin-bottom: 2px;">
+                                    <span class="title" name="attr_global_damage_rollstring" style="width: 110px; padding-right: 0px;"></span>
+                                    <span class="subheader" name="attr_global_damage_type" style="padding-right: 0px;"></span>
+                                </div>
                             </div>
+                        </fieldset>
+                    </div>
+                    <span class="label" style="margin-top: 0px; position: absolute; bottom: 0px;" data-i18n="atk-powercasting-u">ATTACKS & POWERCASTING</span>
+                </div>
+                <div class="equipment">
+                    <div class="money">
+                        <div class="coin">
+                            <span class="label" data-i18n="credit-piece-u">CR</span>
+                            <input type="text" name="attr_cr" title="@{cr}">
                         </div>
-                    </fieldset>
-                </div>
-                <span class="label" style="margin-top: 0px; position: absolute; bottom: 0px;" data-i18n="atk-powercasting-u">ATTACKS & POWERCASTING</span>
-            </div>
-            <div class="equipment">
-                <div class="money">
-                    <div class="coin">
-                        <span class="label" data-i18n="credit-piece-u">CR</span>
-                        <input type="text" name="attr_cr" title="@{cr}">
                     </div>
-                </div>
-                <input type="hidden" class="inventoryflag" name="attr_simpleinventory" value="complex">
-                <textarea class="simple" name="attr_equipment"></textarea>
-                <div class="complex">
-                    <input type="hidden" class="warningflag" name="attr_armorwarningflag">
-                    <div class="warning">
-                        <span data-i18n="warning-armor-sets-u">
-                            <input type="checkbox" name="attr_armorwarning" value="hide">
-                            WARNING - MULTIPLE SETS OF ARMOR OR SHIELDS HAVE BEEN ADDED AND AC IS NOT CORRECTLY CALCULATED. UNEQUIP THE ARMOR PIECE FROM THE ITEM DETAILS.
-                        </span>
-                    </div>
-                    <div class="header" style="height: auto;">
-                        <span class="pictos" style="width: 25px; font-size: 15px;">*</span>
-                        <span style="width: 100px; text-align: left;" data-i18n="item-name-u">ITEM NAME</SPAN>
-                        <span style="width: 25px;"><img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/5th%20Edition%20OGL%20by%20Roll20/images/weight_lbs.png" style="width: 15px; margin-bottom: -3px;"></span>
-                    </div>
-                    <fieldset class="repeating_inventory">
-                        <input type="hidden" class="equippedflag" name="attr_equipped">
-                        <div class="item">
-                            <input class="weight" type="text" name="attr_itemcount" value="1">
-                            <input class="name" type="text" name="attr_itemname">
-                            <input class="weight" type="text" name="attr_itemweight">
-                            <input class="inventorysubflag" type="checkbox" name="attr_inventorysubflag"><span>i</span>
-                            <div class="subitem">
-                                <input class="equipped" type="checkbox" name="attr_equipped" value="1" checked="checked">
-                                <span class="equippedlabel" data-i18n="equipped-u">EQUIPPED</span>
-                                <input class="equipped" type="checkbox" name="attr_useasresource" value="1">
-                                <span class="equippedlabel" data-i18n="use-as-resource-u">USE AS A RESOURCE</span>
-                                <input class="equipped" type="checkbox" name="attr_hasattack" value="1">
-                                <span class="equippedlabel" data-i18n="has-attack-u">HAS AN ATTACK</span>
-                                <span class="label" data-i18n="prop:-u">PROP:</span>
-                                <input class="subfield" type="text" name="attr_itemproperties">
-                                <span class="label" data-i18n="mods:-u">MODS:</span>
-                                <input class="subfield" type="text" name="attr_itemmodifiers">
-                                <textarea class="subtextarea" name="attr_itemcontent"></textarea>
+                    <input type="hidden" class="inventoryflag" name="attr_simpleinventory" value="complex">
+                    <textarea class="simple" name="attr_equipment"></textarea>
+                    <div class="complex">
+                        <input type="hidden" class="warningflag" name="attr_armorwarningflag">
+                        <div class="warning">
+                            <span data-i18n="warning-armor-sets-u">
+                                <input type="checkbox" name="attr_armorwarning" value="hide">
+                                WARNING - MULTIPLE SETS OF ARMOR OR SHIELDS HAVE BEEN ADDED AND AC IS NOT CORRECTLY CALCULATED. UNEQUIP THE ARMOR PIECE FROM THE ITEM DETAILS.
+                            </span>
+                        </div>
+                        <div class="header" style="height: auto;">
+                            <span class="pictos" style="width: 25px; font-size: 15px;">*</span>
+                            <span style="width: 100px; text-align: left;" data-i18n="item-name-u">ITEM NAME</SPAN>
+                            <span style="width: 25px;"><img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/5th%20Edition%20OGL%20by%20Roll20/images/weight_lbs.png" style="width: 15px; margin-bottom: -3px;"></span>
+                        </div>
+                        <fieldset class="repeating_inventory">
+                            <input type="hidden" class="equippedflag" name="attr_equipped">
+                            <div class="item">
+                                <input class="weight" type="text" name="attr_itemcount" value="1">
+                                <input class="name" type="text" name="attr_itemname">
+                                <input class="weight" type="text" name="attr_itemweight">
+                                <input class="inventorysubflag" type="checkbox" name="attr_inventorysubflag"><span>i</span>
+                                <div class="subitem">
+                                    <input class="equipped" type="checkbox" name="attr_equipped" value="1" checked="checked">
+                                    <span class="equippedlabel" data-i18n="equipped-u">EQUIPPED</span>
+                                    <input class="equipped" type="checkbox" name="attr_useasresource" value="1">
+                                    <span class="equippedlabel" data-i18n="use-as-resource-u">USE AS A RESOURCE</span>
+                                    <input class="equipped" type="checkbox" name="attr_hasattack" value="1">
+                                    <span class="equippedlabel" data-i18n="has-attack-u">HAS AN ATTACK</span>
+                                    <span class="label" data-i18n="prop:-u">PROP:</span>
+                                    <input class="subfield" type="text" name="attr_itemproperties">
+                                    <span class="label" data-i18n="mods:-u">MODS:</span>
+                                    <input class="subfield" type="text" name="attr_itemmodifiers">
+                                    <textarea class="subtextarea" name="attr_itemcontent"></textarea>
+                                </div>
+                                <input type="hidden" name="attr_itemattackid">
+                                <input type="hidden" name="attr_itemresourceid">
                             </div>
-                            <input type="hidden" name="attr_itemattackid">
-                            <input type="hidden" name="attr_itemresourceid">
+                        </fieldset>
+                        <div class="weighttotal">
+                            <span class="label" data-i18n="total-weight-u">TOTAL WEIGHT</span>
+                            <input type="text" name="attr_weighttotal" value="0">
+                            <input type="hidden" class="encumberance" name="attr_encumberance">
+                            <span class="encumb immobile" data-i18n="immobile-u">IMMOBILE</span>
+                            <span class="encumb heavily" data-i18n="heavily-encumbered-u">HEAVILY ENCUMBERED</span>
+                            <span class="encumb encumbered" data-i18n="encumbered-u">ENCUMBERED</span>
+                            <span class="encumb over" data-i18n="over-carrying-cap-u">OVER CARRYING CAPACITY</span>
                         </div>
-                    </fieldset>
-                    <div class="weighttotal">
-                        <span class="label" data-i18n="total-weight-u">TOTAL WEIGHT</span>
-                        <input type="text" name="attr_weighttotal" value="0">
-                        <input type="hidden" class="encumberance" name="attr_encumberance">
-                        <span class="encumb immobile" data-i18n="immobile-u">IMMOBILE</span>
-                        <span class="encumb heavily" data-i18n="heavily-encumbered-u">HEAVILY ENCUMBERED</span>
-                        <span class="encumb encumbered" data-i18n="encumbered-u">ENCUMBERED</span>
-                        <span class="encumb over" data-i18n="over-carrying-cap-u">OVER CARRYING CAPACITY</span>
                     </div>
+                    <span class="label" style="margin-top: 0px; position: absolute; bottom: 0px;" data-i18n="equipment-u">EQUIPMENT</span>
                 </div>
-                <span class="label" style="margin-top: 0px; position: absolute; bottom: 0px;" data-i18n="equipment-u">EQUIPMENT</span>
             </div>
-        </div>
-        <div class="col col3">
-            <div class="textbox pibf">
-                <input class="options-flag" type="checkbox" name="attr_options-flag-personality" checked="checked"><span>y</span>
-                <div class="options">
-                    <textarea name="attr_personality_traits" style="min-height: 50px; height: 50px;"></textarea>
-                </div>
-                <div class="display">
-                    <span name="attr_personality_traits"></span>
-                </div>
-                <span class="label" data-i18n="personality-traits-u">PERSONALITY TRAITS</span>
-            </div>
-            <div class="textbox pibf">
-                <input class="options-flag" type="checkbox" name="attr_options-flag-ideals" checked="checked"><span>y</span>
-                <div class="options">
-                    <textarea name="attr_ideals"></textarea>
-                </div>
-                <div class="display">
-                    <span name="attr_ideals"></span>
-                </div>
-                <span class="label" data-i18n="ideals-u">IDEALS</span>
-            </div>
-            <div class="textbox pibf">
-                <input class="options-flag" type="checkbox" name="attr_options-flag-bonds" checked="checked"><span>y</span>
-                <div class="options">
-                    <textarea name="attr_bonds"></textarea>
-                </div>
-                <div class="display">
-                    <span name="attr_bonds"></span>
-                </div>
-                <span class="label" data-i18n="bonds-u">BONDS</span>
-            </div>
-            <div class="textbox pibf">
-                <input class="options-flag" type="checkbox" name="attr_options-flag-flaws" checked="checked"><span>y</span>
-                <div class="options">
-                    <textarea name="attr_flaws" style="min-height: 46px; height: 46px;"></textarea>
-                </div>
-                <div class="display">
-                    <span name="attr_flaws"></span>
-                </div>
-                <span class="label" data-i18n="flaws-u">FLAWS</span>
-            </div>
-            <div class="resources">
-                <div class="hdice-dsaves-container" style="width: 246px; margin-top: 10px;">
-                    <div class="subcontainer" style="height: 64px; width: 119px;">
-                        <div class="top">
-                            <span data-i18n="total">Total</span>
-                            <input type="text" name="attr_class_resource_max" title="@{class_resource_max}">
-                        </div>
-                        <input type="number" name="attr_class_resource" title="@{class_resource}" style="margin-bottom: -6px;">
-                        <input type="text" class="label" name="attr_class_resource_name" title="@{class_resource_name}" placeholder="CLASS RESOURCE" data-i18n-placeholder="class-resource-u">
+            <div class="col col3">
+                <div class="textbox pibf">
+                    <input class="options-flag" type="checkbox" name="attr_options-flag-personality" checked="checked"><span>y</span>
+                    <div class="options">
+                        <textarea name="attr_personality_traits" style="min-height: 50px; height: 50px;"></textarea>
                     </div>
-                    <div class="subcontainer" style="height: 64px; width: 119px; float: right;">
-                        <div class="top">
-                            <span  data-i18n="total">Total</span>
-                            <input type="text" name="attr_other_resource_max" title="@{other_resource_max}">
-                        </div>
-                        <input type="number" name="attr_other_resource" title="@{other_resource}" style="margin-bottom: -6px;">
-                        <input type="text" class="label" name="attr_other_resource_name" title="@{other_resource_name}" placeholder="OTHER RESOURCE" data-i18n-placeholder="other-resource-u">
-                        <input type="hidden" name="attr_other_resource_itemid">
+                    <div class="display">
+                        <span name="attr_personality_traits"></span>
                     </div>
+                    <span class="label" data-i18n="personality-traits-u">PERSONALITY TRAITS</span>
                 </div>
-                <fieldset class="repeating_resource">
+                <div class="textbox pibf">
+                    <input class="options-flag" type="checkbox" name="attr_options-flag-ideals" checked="checked"><span>y</span>
+                    <div class="options">
+                        <textarea name="attr_ideals"></textarea>
+                    </div>
+                    <div class="display">
+                        <span name="attr_ideals"></span>
+                    </div>
+                    <span class="label" data-i18n="ideals-u">IDEALS</span>
+                </div>
+                <div class="textbox pibf">
+                    <input class="options-flag" type="checkbox" name="attr_options-flag-bonds" checked="checked"><span>y</span>
+                    <div class="options">
+                        <textarea name="attr_bonds"></textarea>
+                    </div>
+                    <div class="display">
+                        <span name="attr_bonds"></span>
+                    </div>
+                    <span class="label" data-i18n="bonds-u">BONDS</span>
+                </div>
+                <div class="textbox pibf">
+                    <input class="options-flag" type="checkbox" name="attr_options-flag-flaws" checked="checked"><span>y</span>
+                    <div class="options">
+                        <textarea name="attr_flaws" style="min-height: 46px; height: 46px;"></textarea>
+                    </div>
+                    <div class="display">
+                        <span name="attr_flaws"></span>
+                    </div>
+                    <span class="label" data-i18n="flaws-u">FLAWS</span>
+                </div>
+                <div class="resources">
                     <div class="hdice-dsaves-container" style="width: 246px; margin-top: 10px;">
                         <div class="subcontainer" style="height: 64px; width: 119px;">
                             <div class="top">
                                 <span data-i18n="total">Total</span>
-                                <input type="text" name="attr_resource_left_max" title="@{repeating_resource_left_max}">
+                                <input type="text" name="attr_class_resource_max" title="@{class_resource_max}">
                             </div>
-                            <input type="number" name="attr_resource_left" title="@{repeating_resource_left}" style="margin-bottom: -6px;">
-                            <input type="text" class="label" name="attr_resource_left_name" title="@{repeating_resource_left_name}" placeholder="OTHER RESOURCE" data-i18n-placeholder="other-resource-u">
-                            <input type="hidden" name="attr_resource_left_itemid">
+                            <input type="number" name="attr_class_resource" title="@{class_resource}" style="margin-bottom: -6px;">
+                            <input type="text" class="label" name="attr_class_resource_name" title="@{class_resource_name}" placeholder="CLASS RESOURCE" data-i18n-placeholder="class-resource-u">
                         </div>
-                        <div class="subcontainer" style="height: 64px; width: 119px;">
+                        <div class="subcontainer" style="height: 64px; width: 119px; float: right;">
                             <div class="top">
-                                <span data-i18n="total">Total</span>
-                                <input type="text" name="attr_resource_right_max" title="@{repeating_resource_right_max}">
+                                <span  data-i18n="total">Total</span>
+                                <input type="text" name="attr_other_resource_max" title="@{other_resource_max}">
                             </div>
-                            <input type="number" name="attr_resource_right" title="@{repeating_resource_right}" style="margin-bottom: -6px;">
-                            <input type="text" class="label" name="attr_resource_right_name" title="@{repeating_resource_right_name}" placeholder="OTHER RESOURCE" data-i18n-placeholder="other-resource-u">
-                            <input type="hidden" name="attr_resource_right_itemid">
+                            <input type="number" name="attr_other_resource" title="@{other_resource}" style="margin-bottom: -6px;">
+                            <input type="text" class="label" name="attr_other_resource_name" title="@{other_resource_name}" placeholder="OTHER RESOURCE" data-i18n-placeholder="other-resource-u">
+                            <input type="hidden" name="attr_other_resource_itemid">
                         </div>
                     </div>
-                </fieldset>
-            </div>
-            <div class="textbox traits" style="min-height: 480px;">
-                <input type="hidden" class="inventoryflag" name="attr_simpletraits" value="complex">
-                <textarea class="sheet-simple" name="attr_features_and_traits" style="min-height: 461px; height: 461px;"></textarea>
-                <div class="complex">
-                    <fieldset class="repeating_traits">
-                        <div class="trait">
-                            <button type="roll" name="roll_output" class="output" value="@{wtype}&{template:traits} @{charname_output} {{name=@{name}}} {{source=@{source}: @{source_type}}} {{description=@{description}}}">w</button>
-                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                            <input class="display-flag" type="checkbox" name="attr_display_flag">
-                            <div class="options">
-                                <div class="row">
-                                    <span data-i18n="name:-u">NAME:</span>
-                                    <input type="text" name="attr_name" style="width: 120px;">
+                    <fieldset class="repeating_resource">
+                        <div class="hdice-dsaves-container" style="width: 246px; margin-top: 10px;">
+                            <div class="subcontainer" style="height: 64px; width: 119px;">
+                                <div class="top">
+                                    <span data-i18n="total">Total</span>
+                                    <input type="text" name="attr_resource_left_max" title="@{repeating_resource_left_max}">
                                 </div>
-                                <div class="row">
-                                    <span data-i18n="source:-u">SOURCE:</span>
-                                    <select name="attr_source">
-                                        <option selected="selected" data-i18n="racial">Racial</option>
-                                        <option data-i18n="class">Class</option>
-                                        <option data-i18n="feat">Feat</option>
-                                        <option data-i18n="background">Background</option>
-                                        <option data-i18n="other">Other</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="source-type:-u">SOURCE TYPE:</span>
-                                    <input type="text" name="attr_source_type" style="width: 160px;" placeholder="Bothan/Fighter/4th Level">
-                                </div>
-                                <div class="row">
-                                    <textarea name="attr_description" style="min-height: 200px; height: 200px;"></textarea>
-                                </div>
+                                <input type="number" name="attr_resource_left" title="@{repeating_resource_left}" style="margin-bottom: -6px;">
+                                <input type="text" class="label" name="attr_resource_left_name" title="@{repeating_resource_left_name}" placeholder="OTHER RESOURCE" data-i18n-placeholder="other-resource-u">
+                                <input type="hidden" name="attr_resource_left_itemid">
                             </div>
-                            <div class="display" style="margin-bottom: 2px;">
-                                <span class="title" name="attr_name"></span>
-                                <span class="subheader">
-                                    <span name="attr_source"></span><span>: </span><span name="attr_source_type"></span>
-                                </span>
-                                <span class="desc" name="attr_description"></span>
+                            <div class="subcontainer" style="height: 64px; width: 119px;">
+                                <div class="top">
+                                    <span data-i18n="total">Total</span>
+                                    <input type="text" name="attr_resource_right_max" title="@{repeating_resource_right_max}">
+                                </div>
+                                <input type="number" name="attr_resource_right" title="@{repeating_resource_right}" style="margin-bottom: -6px;">
+                                <input type="text" class="label" name="attr_resource_right_name" title="@{repeating_resource_right_name}" placeholder="OTHER RESOURCE" data-i18n-placeholder="other-resource-u">
+                                <input type="hidden" name="attr_resource_right_itemid">
                             </div>
                         </div>
                     </fieldset>
                 </div>
-                <span class="label" data-i18n="feats-traits-u" style="margin-top: 0px; position: absolute; bottom: 0px;">FEATURES & TRAITS</span>
-            </div>
-            <input type="hidden" class="missing-info-flag" name="attr_missing_info">
-            <div class="missing-info">
-                <span><span class="info-popup pictos">i</span> Looking for missing data?</span>
-                <span class="missing-info-desc">Your data is in the simple version that can be re-enabled from the Settings(gear) tab of the character sheet. Under GENERAL OPTIONS and then FEATS & TRAITS. Set the section to be 'Simple'.</span>
-            </div>
-        </div>
-
-    </div>
-</div>
-
-<div class="page bio">
-    <div class="header">
-        <div class="name-container">
-            <img src="https://s22.postimg.cc/jnlp8fqc1/Star_Wars_5_E_Logo_Shrunk.png" style="padding-bottom: 10px;">
-            <input type="text" name="attr_character_name" style="width: 100%;">
-            <span class="label" data-i18n="char-name-u">CHARACTER NAME</span>
-        </div>
-        <div class="header-info">
-            <div class="top" style="position: relative; top: 10px;">
-                <div class="hlabel-container">
-                    <input type="text" name="attr_age" style="width: 120px;">
-                    <span class="label" data-i18n="age-u">AGE</span>
+                <div class="textbox traits" style="min-height: 480px;">
+                    <input type="hidden" class="inventoryflag" name="attr_simpletraits" value="complex">
+                    <textarea class="sheet-simple" name="attr_features_and_traits" style="min-height: 461px; height: 461px;"></textarea>
+                    <div class="complex">
+                        <fieldset class="repeating_traits">
+                            <div class="trait">
+                                <button type="roll" name="roll_output" class="output" value="@{wtype}&{template:traits} @{charname_output} {{name=@{name}}} {{source=@{source}: @{source_type}}} {{description=@{description}}}">w</button>
+                                <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
+                                <input class="display-flag" type="checkbox" name="attr_display_flag">
+                                <div class="options">
+                                    <div class="row">
+                                        <span data-i18n="name:-u">NAME:</span>
+                                        <input type="text" name="attr_name" style="width: 120px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="source:-u">SOURCE:</span>
+                                        <select name="attr_source">
+                                            <option selected="selected" data-i18n="racial">Racial</option>
+                                            <option data-i18n="class">Class</option>
+                                            <option data-i18n="feat">Feat</option>
+                                            <option data-i18n="background">Background</option>
+                                            <option data-i18n="other">Other</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="source-type:-u">SOURCE TYPE:</span>
+                                        <input type="text" name="attr_source_type" style="width: 160px;" placeholder="Bothan/Fighter/4th Level">
+                                    </div>
+                                    <div class="row">
+                                        <textarea name="attr_description" style="min-height: 200px; height: 200px;"></textarea>
+                                    </div>
+                                </div>
+                                <div class="display" style="margin-bottom: 2px;">
+                                    <span class="title" name="attr_name"></span>
+                                    <span class="subheader">
+                                        <span name="attr_source"></span><span>: </span><span name="attr_source_type"></span>
+                                    </span>
+                                    <span class="desc" name="attr_description"></span>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                    <span class="label" data-i18n="feats-traits-u" style="margin-top: 0px; position: absolute; bottom: 0px;">FEATURES & TRAITS</span>
                 </div>
-                <div class="hlabel-container">
-                    <input type="text" name="attr_size" style="width: 120px;">
-                    <span class="label" data-i18n="size-u">SIZE</span>
-                </div>
-                <div class="hlabel-container">
-                    <input type="text" name="attr_height" style="width: 120px;">
-                    <span class="label" data-i18n="height-u">HEIGHT</span>
-                </div>
-                <div class="hlabel-container">
-                    <input type="text" name="attr_weight" style="width: 120px;">
-                    <span class="label" data-i18n="weight-u">WEIGHT</span>
-                </div>
-            </div>
-            <div class="bottom">
-                <div class="hlabel-container">
-                    <input type="text" name="attr_eyes" style="width: 160px;">
-                    <span class="label" data-i18n="eye-u">EYES</span>
-                </div>
-                <div class="hlabel-container">
-                    <input type="text" name="attr_skin" style="width: 160px;">
-                    <span class="label" data-i18n="skin-u">SKIN</span>
-                </div>
-                <div class="hlabel-container">
-                    <input type="text" name="attr_hair" style="width: 160px;">
-                    <span class="label" data-i18n="hair-u">HAIR</span>
+                <input type="hidden" class="missing-info-flag" name="attr_missing_info">
+                <div class="missing-info">
+                    <span><span class="info-popup pictos">i</span> Looking for missing data?</span>
+                    <span class="missing-info-desc">Your data is in the simple version that can be re-enabled from the Settings(gear) tab of the character sheet. Under GENERAL OPTIONS and then FEATS & TRAITS. Set the section to be 'Simple'.</span>
                 </div>
             </div>
-        </div>
-    </div>
-    <div class="body">
-        <div class="col col1">
-            <div class="textbox">
-                <textarea name="attr_character_appearance" style="min-height: 300px; height: 300px;"></textarea>
-                <span class="label" data-i18n="char-appearance-u">CHARACTER APPEARANCE</span>
-            </div>
-            <div class="textbox">
-                <textarea name="attr_character_backstory" style="min-height: 623px; height: 623px;"></textarea>
-                <span class="label" data-i18n="char-backstory-u">CHARACTER BACKSTORY</span>
-            </div>
-            <div class="textbox">
-                <textarea name="attr_miscellaneous" style="min-height: 300px; height: 300px;"></textarea>
-                <span class="label" data-i18n="miscellaneous-u">MISCELLANEOUS</span>
-            </div>
-        </div>
-        <div class="col2-3">
-            <div class="textbox">
-                <textarea name="attr_allies_and_organizations" style="min-height: 288px; height: 300px;"></textarea>
-                <span class="label" data-i18n="allies-orgs-u">ALLIES & ORGANIZATIONS</span>
-            </div>
-            <div class="textbox">
-                <textarea name="attr_additional_feature_and_traits" style="min-height: 289px; height: 300px;"></textarea>
-                <span class="label" data-i18n="add-feats-traits-u">ADDITIONAL FEATURES & TRAITS</span>
-            </div>
-            <div class="textbox">
-                <textarea name="attr_treasure" style="min-height: 300px; height: 300px;"></textarea>
-                <span class="label" data-i18n="treasure-u">LOOT</span>
-            </div>
-            <div class="textbox">
-                <textarea name="attr_storage" style="min-height: 300px; height: 300px;"></textarea>
-                <span class="label" data-i18n="storage-u">STORAGE</span>
-            </div>
+    
         </div>
     </div>
-</div>
-
-<div class="page powers">
-    <div class="header">
-        <div class="name-container">
-            <img src="https://s22.postimg.cc/jnlp8fqc1/Star_Wars_5_E_Logo_Shrunk.png" style="padding-bottom: 10px;">
-            <input type="text" name="attr_character_name" style="width: 100%;">
-            <span class="label" data-i18n="char-name-u">CHARACTER NAME</span>
-        </div>
-        <div class="header-info">
-            <div class="part">
-                <select name="attr_powercasting_ability">
-                    <option value="0*" data-i18n="none-u">NONE</option>
-                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                </select>
-                <span class="label" data-i18n="power-ability-u">POWERCASTING ABILITY</span>
+        
+    <div class="page bio">
+        <div class="header">
+            <div class="name-container">
+                <img src="https://s22.postimg.cc/jnlp8fqc1/Star_Wars_5_E_Logo_Shrunk.png" style="padding-bottom: 10px;">
+                <input type="text" name="attr_character_name" style="width: 100%;">
+                <span class="label" data-i18n="char-name-u">CHARACTER NAME</span>
             </div>
-            <div class="part">
-                <span class="display" name="attr_power_save_dc"></span>
-                <span class="label" data-i18n="power-save-dc-u">POWER SAVE DC</span>
-            </div>
-            <div class="part">
-                <span class="display" name="attr_power_attack_bonus"></span>
-                <span class="label" data-i18n="power-atk-bonus-u">POWER ATTACK BONUS</span>
-            </div>
-        </div>
-    </div>
-    <input type="hidden" class="powericon_flag" name="attr_powericon_flag" value="all">
-    <div class="body">
-        <div class="col col1">
-        	<span class="power-labels">
-                <span data-i18n="force_slots_total-u" style="margin-right: 45px;">FORCE TOTAL</span>
-                <span data-i18n="force_slots_remaining-u">FORCE REMAINING</span>
-            </span>
-            <div class="power-level">
-                <div class="level">
-                    <span class="label">FP</span>
-                </div>
-
-                <div class="total">
-                    <input type="number" name="attr_force_power_points_total" value="0">
-                </div>
-                <div class="expended">
-                    <input type="number" name="attr_force_power_points_expended" value="0">
-                </div>
-            </div>
-            <span class="power-labels">
-                <span data-i18n="tech_slots_total-u" style="margin-right: 45px;">TECH TOTAL</span>
-                <span data-i18n="tech_slots_remaining-u">TECH REMAINING</span>
-            </span>
-            <div class="power-level">
-                <div class="level">
-                    <span class="label">TP</span>
-                </div>
-
-                <div class="total">
-                    <input type="number" name="attr_tech_power_points_total" value="0">
-                </div>
-                <div class="expended">
-                    <input type="number" name="attr_tech_power_points_expended" value="0">
-                </div>
-            </div>
-            <br>
-            <div class="power-level">
-                <div class="level">
-                    <span class="label">0</span>
-                </div>
-                <div class="cantrips">
-                    <span class="label" data-i18n="cantrips-u">AT-WILL</span>
-                </div>
-            </div>
-            <div class="power-container">
-                <fieldset class="repeating_power-cantrip">
-                    <div class="power">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_powername">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="school:-u">SCHOOL:</span>
-                                <select name="attr_powerschool">
-                                    <option value="force" data-i18n="force">Force</option>
-                                    <option value="tech" data-i18n="tech">Tech</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="casting-time:-u">CASTING TIME:</span>
-                                <input type="text" name="attr_powercastingtime">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_powerrange">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="target:-u">TARGET:</span>
-                                <input type="text" name="attr_powertarget">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_powerconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration-u">CONCENTRATION</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="duration:-u">DURATION:</span>
-                                <input type="text" name="attr_powerduration">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="power-ability-u">POWERCASTING ABILITY</span>
-                                <select name="attr_power_ability">
-                                    <option value="0*" data-i18n="none-u">NONE</option>
-                                    <option value="power" data-i18n="power-u">POWER</option>
-                                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="innate:-u">INNATE:</span>
-                                <input type="text" name="attr_innate" placeholder="1/day" value="">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="output:-u">OUTPUT:</span>
-                                <select name="attr_poweroutput">
-                                    <option value="POWERCARD" data-i18n="powercard-u">POWERCARD</option>
-                                    <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
-                                </select>
-                            </div>
-                            <input type="hidden" class="powerattackinfoflag" name="attr_poweroutput">
-                            <div class="powerattackinfo">
-                                <div class="row">
-                                    <span data-i18n="power-atk:-u">POWER ATTACK:</span>
-                                    <select name="attr_powerattack">
-                                        <option value="None" data-i18n="none">None</option>
-                                        <option value="Melee" data-i18n="melee">Melee</option>
-                                        <option value="Ranged" data-i18n="ranged">Ranged</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage:-u">DAMAGE:</span>
-                                    <input type="text" name="attr_powerdamage" style="width: 50px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_powerdamagetype" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                    <input type="text" name="attr_powerdamage2" style="width: 45px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_powerdamagetype2" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="healing:-u">HEALING:</span>
-                                    <input type="text" name="attr_powerhealing" style="width: 45px;">
-                                </div>
-                                <div class="row">
-                                    <input type="checkbox" name="attr_powerdmgmod" value="Yes">
-                                    <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="cantrip-progression:-u">AT-WILL PROGRESSION</span>
-                                    <select name="attr_power_damage_progression">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Cantrip Dice" data-i18n="cantrip-dice-u">AT-WILL DICE</option>
-                                        <option value="Cantrip Beam" data-i18n="cantrip-beam-u">AT-WILL BEAM</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                    <select name="attr_powersave">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Strength" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                        <option value="Constitution" data-i18n="con-u">CON</option>
-                                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                    </select>
-                                    <span data-i18n="effect:-u">EFFECT:</span>
-                                    <input type="text" name="attr_powersavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
-                                    <input type="text" name="attr_powerhldie" placeholder="1" style="width: 15px; text-align: right;">
-                                    <select name="attr_powerhldietype">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="d4">d4</option>
-                                        <option value="d6">d6</option>
-                                        <option value="d8">d8</option>
-                                        <option value="d10">d10</option>
-                                        <option value="d12">d12</option>
-                                        <option value="d20">d20</option>
-                                    </select>
-                                    <span>+</span>
-                                    <input type="text" name="attr_powerhlbonus" placeholder="0" style="width: 15px; text-align: center;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="include_power_desc:-u">INCLUDE POWER DESCRIPTION IN ATTACK:</span>
-                                    <select name="attr_includedesc">
-                                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                                        <option value="partial" data-i18n="partial">Partial</option>
-                                        <option value="on" data-i18n="on">On</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_powerdescription"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_powerathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
-                            </div>
-                            <input type="hidden" name="attr_powerattackid">
-                            <input type="hidden" name="attr_powerlevel" value="cantrip">
-                        </div>
-                        <div class="display">
-                            <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:power} {{level=@{powerschool} @{powerlevel}}}  {{name=@{powername}}} {{castingtime=@{powercastingtime}}} {{range=@{powerrange}}} {{target=@{powertarget}}}  {{duration=@{powerduration}}} {{description=@{powerdescription}}} {{athigherlevels=@{powerathigherlevels}}}  {{innate=@{innate}}} @{powerconcentration} @{charname_output}">
-                            <button class="powercard" type="roll" name="roll_power" value="@{rollcontent}">
-                                <span class="powername" name="attr_powername"></span>
-                                <input class="innate_flag" type="hidden" name="attr_innate" value="">
-                                <span class="innate" name="attr_innate"></span>
-                            </button>
-                            <input type="hidden" class="powerconcentration" name="attr_powerconcentration" value="0">
-                            <span class="powerconcentration" data-i18n="power-concentration">C</span>
-                        </div>
+            <div class="header-info">
+                <div class="top" style="position: relative; top: 10px;">
+                    <div class="hlabel-container">
+                        <input type="text" name="attr_age" style="width: 120px;">
+                        <span class="label" data-i18n="age-u">AGE</span>
                     </div>
-                </fieldset>
-            </div>
-
-            <div class="power-level">
-                <div class="level">
-                    <span class="label">1</span>
-                </div>
-            </div>
-            <div class="power-container">
-                <fieldset class="repeating_power-1">
-                    <div class="power">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_powername">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="school:-u">SCHOOL:</span>
-                                <select name="attr_powerschool">
-                                    <option value="force" data-i18n="force">Force</option>
-                                    <option value="tech" data-i18n="tech">Tech</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="casting-time:-u">CASTING TIME:</span>
-                                <input type="text" name="attr_powercastingtime">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_powerrange">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="target:-u">TARGET:</span>
-                                <input type="text" name="attr_powertarget">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_powerconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration-u">CONCENTRATION</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="duration:-u">DURATION:</span>
-                                <input type="text" name="attr_powerduration">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="power-ability-u">POWERCASTING ABILITY</span>
-                                <select name="attr_power_ability">
-                                    <option value="0*" data-i18n="none-u">NONE</option>
-                                    <option value="power" data-i18n="power-u">POWER</option>
-                                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="innate:-u">INNATE:</span>
-                                <input type="text" name="attr_innate" placeholder="1/day" value="">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="output:-u">OUTPUT:</span>
-                                <select name="attr_poweroutput">
-                                    <option value="POWERCARD" data-i18n="powercard-u">POWERCARD</option>
-                                    <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
-                                </select>
-                            </div>
-                            <input type="hidden" class="powerattackinfoflag" name="attr_poweroutput">
-                            <div class="powerattackinfo">
-                                <div class="row">
-                                    <span data-i18n="power-atk:-u">POWER ATTACK:</span>
-                                    <select name="attr_powerattack">
-                                        <option value="None" data-i18n="none">None</option>
-                                        <option value="Melee" data-i18n="melee">Melee</option>
-                                        <option value="Ranged" data-i18n="ranged">Ranged</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage:-u">DAMAGE:</span>
-                                    <input type="text" name="attr_powerdamage" style="width: 50px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_powerdamagetype" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                    <input type="text" name="attr_powerdamage2" style="width: 45px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_powerdamagetype2" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="healing:-u">HEALING:</span>
-                                    <input type="text" name="attr_powerhealing" style="width: 45px;">
-                                </div>
-                                <div class="row">
-                                    <input type="checkbox" name="attr_powerdmgmod" value="Yes">
-                                    <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                    <select name="attr_powersave">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Strength" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                        <option value="Constitution" data-i18n="con-u">CON</option>
-                                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                    </select>
-                                    <span data-i18n="effect:-u">EFFECT:</span>
-                                    <input type="text" name="attr_powersavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
-                                    <input type="text" name="attr_powerhldie" placeholder="1" style="width: 15px; text-align: right;">
-                                    <select name="attr_powerhldietype">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="d4">d4</option>
-                                        <option value="d6">d6</option>
-                                        <option value="d8">d8</option>
-                                        <option value="d10">d10</option>
-                                        <option value="d12">d12</option>
-                                        <option value="d20">d20</option>
-                                    </select>
-                                    <span>+</span>
-                                    <input type="text" name="attr_powerhlbonus" placeholder="0" style="width: 15px; text-align: center;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="include_power_desc:-u">INCLUDE POWER DESCRIPTION IN ATTACK:</span>
-                                    <select name="attr_includedesc">
-                                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                                        <option value="partial" data-i18n="partial">Partial</option>
-                                        <option value="on" data-i18n="on">On</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_powerdescription"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_powerathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
-                            </div>
-                            <input type="hidden" name="attr_powerattackid">
-                            <input type="hidden" name="attr_powerlevel" value="1">
-                        </div>
-                        <div class="display">
-                            <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:power} {{level=@{powerschool} @{powerlevel}}}  {{name=@{powername}}} {{castingtime=@{powercastingtime}}} {{range=@{powerrange}}} {{target=@{powertarget}}}  {{duration=@{powerduration}}} {{description=@{powerdescription}}} {{athigherlevels=@{powerathigherlevels}}}  {{innate=@{innate}}} @{powerconcentration} @{charname_output}">
-                            <input type="checkbox" name="attr_powerprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
-                            <button class="powercard" type="roll" name="roll_power" value="@{rollcontent}">
-                                <span class="powername" name="attr_powername"></span>
-                                <input class="innate_flag" type="hidden" name="attr_innate" value="">
-                                <span class="innate" name="attr_innate"></span>
-                            </button>
-                            <input type="hidden" class="powerconcentration" name="attr_powerconcentration" value="0">
-                            <span class="powerconcentration" data-i18n="power-concentration">C</span>
-                        </div>
+                    <div class="hlabel-container">
+                        <input type="text" name="attr_size" style="width: 120px;">
+                        <span class="label" data-i18n="size-u">SIZE</span>
                     </div>
-                </fieldset>
-            </div>
-
-            <div class="power-level">
-                <div class="level">
-                    <span class="label">2</span>
-                </div>
-            </div>
-            <div class="power-container">
-                <fieldset class="repeating_power-2">
-                    <div class="power">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_powername">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="school:-u">SCHOOL:</span>
-                                <select name="attr_powerschool">
-                                    <option value="force" data-i18n="force">Force</option>
-                                    <option value="tech" data-i18n="tech">Tech</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="casting-time:-u">CASTING TIME:</span>
-                                <input type="text" name="attr_powercastingtime">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_powerrange">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="target:-u">TARGET:</span>
-                                <input type="text" name="attr_powertarget">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_powerconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration-u">CONCENTRATION</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="duration:-u">DURATION:</span>
-                                <input type="text" name="attr_powerduration">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="power-ability-u">POWERCASTING ABILITY</span>
-                                <select name="attr_power_ability">
-                                    <option value="0*" data-i18n="none-u">NONE</option>
-                                    <option value="power" data-i18n="power-u">POWER</option>
-                                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="innate:-u">INNATE:</span>
-                                <input type="text" name="attr_innate" placeholder="1/day" value="">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="output:-u">OUTPUT:</span>
-                                <select name="attr_poweroutput">
-                                    <option value="POWERCARD" data-i18n="powercard-u">POWERCARD</option>
-                                    <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
-                                </select>
-                            </div>
-                            <input type="hidden" class="powerattackinfoflag" name="attr_poweroutput">
-                            <div class="powerattackinfo">
-                                <div class="row">
-                                    <span data-i18n="power-atk:-u">POWER ATTACK:</span>
-                                    <select name="attr_powerattack">
-                                        <option value="None" data-i18n="none">None</option>
-                                        <option value="Melee" data-i18n="melee">Melee</option>
-                                        <option value="Ranged" data-i18n="ranged">Ranged</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage:-u">DAMAGE:</span>
-                                    <input type="text" name="attr_powerdamage" style="width: 50px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_powerdamagetype" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                    <input type="text" name="attr_powerdamage2" style="width: 45px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_powerdamagetype2" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="healing:-u">HEALING:</span>
-                                    <input type="text" name="attr_powerhealing" style="width: 45px;">
-                                </div>
-                                <div class="row">
-                                    <input type="checkbox" name="attr_powerdmgmod" value="Yes">
-                                    <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                    <select name="attr_powersave">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Strength" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                        <option value="Constitution" data-i18n="con-u">CON</option>
-                                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                    </select>
-                                    <span data-i18n="effect:-u">EFFECT:</span>
-                                    <input type="text" name="attr_powersavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
-                                    <input type="text" name="attr_powerhldie" placeholder="1" style="width: 15px; text-align: right;">
-                                    <select name="attr_powerhldietype">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="d4">d4</option>
-                                        <option value="d6">d6</option>
-                                        <option value="d8">d8</option>
-                                        <option value="d10">d10</option>
-                                        <option value="d12">d12</option>
-                                        <option value="d20">d20</option>
-                                    </select>
-                                    <span>+</span>
-                                    <input type="text" name="attr_powerhlbonus" placeholder="0" style="width: 15px; text-align: center;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="include_power_desc:-u">INCLUDE POWER DESCRIPTION IN ATTACK:</span>
-                                    <select name="attr_includedesc">
-                                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                                        <option value="partial" data-i18n="partial">Partial</option>
-                                        <option value="on" data-i18n="on">On</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_powerdescription"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_powerathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
-                            </div>
-                            <input type="hidden" name="attr_powerattackid">
-                            <input type="hidden" name="attr_powerlevel" value="2">
-                        </div>
-                        <div class="display">
-                            <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:power} {{level=@{powerschool} @{powerlevel}}}  {{name=@{powername}}} {{castingtime=@{powercastingtime}}} {{range=@{powerrange}}} {{target=@{powertarget}}}  {{duration=@{powerduration}}} {{description=@{powerdescription}}} {{athigherlevels=@{powerathigherlevels}}}  {{innate=@{innate}}} @{powerconcentration} @{charname_output}">
-                            <input type="checkbox" name="attr_powerprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
-                            <button class="powercard" type="roll" name="roll_power" value="@{rollcontent}">
-                                <span class="powername" name="attr_powername"></span>
-                                <input class="innate_flag" type="hidden" name="attr_innate" value="">
-                                <span class="innate" name="attr_innate"></span>
-                            </button>
-                            <input type="hidden" class="powerconcentration" name="attr_powerconcentration" value="0">
-                            <span class="powerconcentration" data-i18n="power-concentration">C</span>
-                        </div>
+                    <div class="hlabel-container">
+                        <input type="text" name="attr_height" style="width: 120px;">
+                        <span class="label" data-i18n="height-u">HEIGHT</span>
                     </div>
-                </fieldset>
-            </div>
-
-        </div>
-        <div class="col col2">
-
-            <div class="power-level">
-                <div class="level">
-                    <span class="label">3</span>
-                </div>
-            </div>
-            <div class="power-container">
-                <fieldset class="repeating_power-3">
-                    <div class="power">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_powername">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="school:-u">SCHOOL:</span>
-                                <select name="attr_powerschool">
-                                    <option value="force" data-i18n="force">Force</option>
-                                    <option value="tech" data-i18n="tech">Tech</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="casting-time:-u">CASTING TIME:</span>
-                                <input type="text" name="attr_powercastingtime">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_powerrange">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="target:-u">TARGET:</span>
-                                <input type="text" name="attr_powertarget">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_powerconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration-u">CONCENTRATION</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="duration:-u">DURATION:</span>
-                                <input type="text" name="attr_powerduration">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="power-ability-u">POWERCASTING ABILITY</span>
-                                <select name="attr_power_ability">
-                                    <option value="0*" data-i18n="none-u">NONE</option>
-                                    <option value="power" data-i18n="power-u">POWER</option>
-                                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="innate:-u">INNATE:</span>
-                                <input type="text" name="attr_innate" placeholder="1/day" value="">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="output:-u">OUTPUT:</span>
-                                <select name="attr_poweroutput">
-                                    <option value="POWERCARD" data-i18n="powercard-u">POWERCARD</option>
-                                    <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
-                                </select>
-                            </div>
-                            <input type="hidden" class="powerattackinfoflag" name="attr_poweroutput">
-                            <div class="powerattackinfo">
-                                <div class="row">
-                                    <span data-i18n="power-atk:-u">POWER ATTACK:</span>
-                                    <select name="attr_powerattack">
-                                        <option value="None" data-i18n="none">None</option>
-                                        <option value="Melee" data-i18n="melee">Melee</option>
-                                        <option value="Ranged" data-i18n="ranged">Ranged</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage:-u">DAMAGE:</span>
-                                    <input type="text" name="attr_powerdamage" style="width: 50px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_powerdamagetype" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                    <input type="text" name="attr_powerdamage2" style="width: 45px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_powerdamagetype2" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="healing:-u">HEALING:</span>
-                                    <input type="text" name="attr_powerhealing" style="width: 45px;">
-                                </div>
-                                <div class="row">
-                                    <input type="checkbox" name="attr_powerdmgmod" value="Yes">
-                                    <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                    <select name="attr_powersave">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Strength" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                        <option value="Constitution" data-i18n="con-u">CON</option>
-                                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                    </select>
-                                    <span data-i18n="effect:-u">EFFECT:</span>
-                                    <input type="text" name="attr_powersavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
-                                    <input type="text" name="attr_powerhldie" placeholder="1" style="width: 15px; text-align: right;">
-                                    <select name="attr_powerhldietype">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="d4">d4</option>
-                                        <option value="d6">d6</option>
-                                        <option value="d8">d8</option>
-                                        <option value="d10">d10</option>
-                                        <option value="d12">d12</option>
-                                        <option value="d20">d20</option>
-                                    </select>
-                                    <span>+</span>
-                                    <input type="text" name="attr_powerhlbonus" placeholder="0" style="width: 15px; text-align: center;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="include_power_desc:-u">INCLUDE POWER DESCRIPTION IN ATTACK:</span>
-                                    <select name="attr_includedesc">
-                                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                                        <option value="partial" data-i18n="partial">Partial</option>
-                                        <option value="on" data-i18n="on">On</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_powerdescription"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_powerathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
-                            </div>
-                            <input type="hidden" name="attr_powerattackid">
-                            <input type="hidden" name="attr_powerlevel" value="3">
-                        </div>
-                        <div class="display">
-                            <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:power} {{level=@{powerschool} @{powerlevel}}}  {{name=@{powername}}} {{castingtime=@{powercastingtime}}} {{range=@{powerrange}}} {{target=@{powertarget}}}  {{duration=@{powerduration}}} {{description=@{powerdescription}}} {{athigherlevels=@{powerathigherlevels}}}  {{innate=@{innate}}} @{powerconcentration} @{charname_output}">
-                            <input type="checkbox" name="attr_powerprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
-                            <button class="powercard" type="roll" name="roll_power" value="@{rollcontent}">
-                                <span class="powername" name="attr_powername"></span>
-                                <input class="innate_flag" type="hidden" name="attr_innate" value="">
-                                <span class="innate" name="attr_innate"></span>
-                            </button>
-                            <input type="hidden" class="powerconcentration" name="attr_powerconcentration" value="0">
-                            <span class="powerconcentration" data-i18n="power-concentration">C</span>
-                        </div>
+                    <div class="hlabel-container">
+                        <input type="text" name="attr_weight" style="width: 120px;">
+                        <span class="label" data-i18n="weight-u">WEIGHT</span>
                     </div>
-                </fieldset>
-            </div>
-
-            <div class="power-level">
-                <div class="level">
-                    <span class="label">4</span>
                 </div>
-            </div>
-            <div class="power-container">
-                <fieldset class="repeating_power-4">
-                    <div class="power">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_powername">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="school:-u">SCHOOL:</span>
-                                <select name="attr_powerschool">
-                                    <option value="force" data-i18n="force">Force</option>
-                                    <option value="tech" data-i18n="tech">Tech</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="casting-time:-u">CASTING TIME:</span>
-                                <input type="text" name="attr_powercastingtime">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_powerrange">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="target:-u">TARGET:</span>
-                                <input type="text" name="attr_powertarget">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_powerconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration-u">CONCENTRATION</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="duration:-u">DURATION:</span>
-                                <input type="text" name="attr_powerduration">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="power-ability-u">POWERCASTING ABILITY</span>
-                                <select name="attr_power_ability">
-                                    <option value="0*" data-i18n="none-u">NONE</option>
-                                    <option value="power" data-i18n="power-u">POWER</option>
-                                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="innate:-u">INNATE:</span>
-                                <input type="text" name="attr_innate" placeholder="1/day" value="">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="output:-u">OUTPUT:</span>
-                                <select name="attr_poweroutput">
-                                    <option value="POWERCARD" data-i18n="powercard-u">POWERCARD</option>
-                                    <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
-                                </select>
-                            </div>
-                            <input type="hidden" class="powerattackinfoflag" name="attr_poweroutput">
-                            <div class="powerattackinfo">
-                                <div class="row">
-                                    <span data-i18n="power-atk:-u">POWER ATTACK:</span>
-                                    <select name="attr_powerattack">
-                                        <option value="None" data-i18n="none">None</option>
-                                        <option value="Melee" data-i18n="melee">Melee</option>
-                                        <option value="Ranged" data-i18n="ranged">Ranged</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage:-u">DAMAGE:</span>
-                                    <input type="text" name="attr_powerdamage" style="width: 50px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_powerdamagetype" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                    <input type="text" name="attr_powerdamage2" style="width: 45px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_powerdamagetype2" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="healing:-u">HEALING:</span>
-                                    <input type="text" name="attr_powerhealing" style="width: 45px;">
-                                </div>
-                                <div class="row">
-                                    <input type="checkbox" name="attr_powerdmgmod" value="Yes">
-                                    <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                    <select name="attr_powersave">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Strength" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                        <option value="Constitution" data-i18n="con-u">CON</option>
-                                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                    </select>
-                                    <span data-i18n="effect:-u">EFFECT:</span>
-                                    <input type="text" name="attr_powersavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
-                                    <input type="text" name="attr_powerhldie" placeholder="1" style="width: 15px; text-align: right;">
-                                    <select name="attr_powerhldietype">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="d4">d4</option>
-                                        <option value="d6">d6</option>
-                                        <option value="d8">d8</option>
-                                        <option value="d10">d10</option>
-                                        <option value="d12">d12</option>
-                                        <option value="d20">d20</option>
-                                    </select>
-                                    <span>+</span>
-                                    <input type="text" name="attr_powerhlbonus" placeholder="0" style="width: 15px; text-align: center;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="include_power_desc:-u">INCLUDE POWER DESCRIPTION IN ATTACK:</span>
-                                    <select name="attr_includedesc">
-                                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                                        <option value="partial" data-i18n="partial">Partial</option>
-                                        <option value="on" data-i18n="on">On</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_powerdescription"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_powerathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
-                            </div>
-                            <input type="hidden" name="attr_powerattackid">
-                            <input type="hidden" name="attr_powerlevel" value="4">
-                        </div>
-                        <div class="display">
-                            <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:power} {{level=@{powerschool} @{powerlevel}}}  {{name=@{powername}}} {{castingtime=@{powercastingtime}}} {{range=@{powerrange}}} {{target=@{powertarget}}}  {{duration=@{powerduration}}} {{description=@{powerdescription}}} {{athigherlevels=@{powerathigherlevels}}}  {{innate=@{innate}}} @{powerconcentration} @{charname_output}">
-                            <input type="checkbox" name="attr_powerprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
-                            <button class="powercard" type="roll" name="roll_power" value="@{rollcontent}">
-                                <span class="powername" name="attr_powername"></span>
-                                <input class="innate_flag" type="hidden" name="attr_innate" value="">
-                                <span class="innate" name="attr_innate"></span>
-                            </button>
-                            <input type="hidden" class="powerconcentration" name="attr_powerconcentration" value="0">
-                            <span class="powerconcentration" data-i18n="power-concentration">C</span>
-                        </div>
+                <div class="bottom">
+                    <div class="hlabel-container">
+                        <input type="text" name="attr_eyes" style="width: 160px;">
+                        <span class="label" data-i18n="eye-u">EYES</span>
                     </div>
-                </fieldset>
-            </div>
-<!-- Edited Spell Adding here ppl -->
-            <div class="power-level">
-                <div class="level">
-                    <span class="label">5</span>
+                    <div class="hlabel-container">
+                        <input type="text" name="attr_skin" style="width: 160px;">
+                        <span class="label" data-i18n="skin-u">SKIN</span>
+                    </div>
+                    <div class="hlabel-container">
+                        <input type="text" name="attr_hair" style="width: 160px;">
+                        <span class="label" data-i18n="hair-u">HAIR</span>
+                    </div>
                 </div>
-            </div>
-            <div class="power-container">
-                <fieldset class="repeating_power-5">
-                    <div class="power">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_powername">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="school:-u">SCHOOL:</span>
-                                <select name="attr_powerschool">
-                                    <option value="force" data-i18n="force">Force</option>
-                                    <option value="tech" data-i18n="tech">Tech</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="casting-time:-u">CASTING TIME:</span>
-                                <input type="text" name="attr_powercastingtime">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_powerrange">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="target:-u">TARGET:</span>
-                                <input type="text" name="attr_powertarget">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_powerconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration-u">CONCENTRATION</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="duration:-u">DURATION:</span>
-                                <input type="text" name="attr_powerduration">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="power-ability-u">POWERCASTING ABILITY</span>
-                                <select name="attr_power_ability">
-                                    <option value="0*" data-i18n="none-u">NONE</option>
-                                    <option value="power" data-i18n="power-u">POWER</option>
-                                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="innate:-u">INNATE:</span>
-                                <input type="text" name="attr_innate" placeholder="1/day" value="">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="output:-u">OUTPUT:</span>
-                                <select name="attr_poweroutput">
-                                    <option value="POWERCARD" data-i18n="powercard-u">POWERCARD</option>
-                                    <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
-                                </select>
-                            </div>
-                            <input type="hidden" class="powerattackinfoflag" name="attr_poweroutput">
-                            <div class="powerattackinfo">
-                                <div class="row">
-                                    <span data-i18n="power-atk:-u">POWER ATTACK:</span>
-                                    <select name="attr_powerattack">
-                                        <option value="None" data-i18n="none">None</option>
-                                        <option value="Melee" data-i18n="melee">Melee</option>
-                                        <option value="Ranged" data-i18n="ranged">Ranged</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage:-u">DAMAGE:</span>
-                                    <input type="text" name="attr_powerdamage" style="width: 50px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_powerdamagetype" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                    <input type="text" name="attr_powerdamage2" style="width: 45px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_powerdamagetype2" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="healing:-u">HEALING:</span>
-                                    <input type="text" name="attr_powerhealing" style="width: 45px;">
-                                </div>
-                                <div class="row">
-                                    <input type="checkbox" name="attr_powerdmgmod" value="Yes">
-                                    <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                    <select name="attr_powersave">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Strength" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                        <option value="Constitution" data-i18n="con-u">CON</option>
-                                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                    </select>
-                                    <span data-i18n="effect:-u">EFFECT:</span>
-                                    <input type="text" name="attr_powersavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
-                                    <input type="text" name="attr_powerhldie" placeholder="1" style="width: 15px; text-align: right;">
-                                    <select name="attr_powerhldietype">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="d4">d4</option>
-                                        <option value="d6">d6</option>
-                                        <option value="d8">d8</option>
-                                        <option value="d10">d10</option>
-                                        <option value="d12">d12</option>
-                                        <option value="d20">d20</option>
-                                    </select>
-                                    <span>+</span>
-                                    <input type="text" name="attr_powerhlbonus" placeholder="0" style="width: 15px; text-align: center;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="include_power_desc:-u">INCLUDE POWER DESCRIPTION IN ATTACK:</span>
-                                    <select name="attr_includedesc">
-                                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                                        <option value="partial" data-i18n="partial">Partial</option>
-                                        <option value="on" data-i18n="on">On</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_powerdescription"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_powerathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
-                            </div>
-                            <input type="hidden" name="attr_powerattackid">
-                            <input type="hidden" name="attr_powerlevel" value="5">
-                        </div>
-                        <div class="display">
-                            <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:power} {{level=@{powerschool} @{powerlevel}}}  {{name=@{powername}}} {{castingtime=@{powercastingtime}}} {{range=@{powerrange}}} {{target=@{powertarget}}}  {{duration=@{powerduration}}} {{description=@{powerdescription}}} {{athigherlevels=@{powerathigherlevels}}}  {{innate=@{innate}}} @{powerconcentration} @{charname_output}">
-                            <input type="checkbox" name="attr_powerprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
-                            <button class="powercard" type="roll" name="roll_power" value="@{rollcontent}">
-                                <span class="powername" name="attr_powername"></span>
-                                <input class="innate_flag" type="hidden" name="attr_innate" value="">
-                                <span class="innate" name="attr_innate"></span>
-                            </button>
-                            <input type="hidden" class="powerconcentration" name="attr_powerconcentration" value="0">
-                            <span class="powerconcentration" data-i18n="power-concentration">C</span>
-                        </div>
-                    </div>
-                </fieldset>
-            </div>
-<!-- Removed Components Here -->
-        </div>
-        <div class="col col3">
-
-            <div class="power-level">
-                <div class="level">
-                    <span class="label">6</span>
-                </div>
-            </div>
-            <div class="power-container">
-                <fieldset class="repeating_power-6">
-                    <div class="power">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_powername">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="school:-u">SCHOOL:</span>
-                                <select name="attr_powerschool">
-                                    <option value="force" data-i18n="force">Force</option>
-                                    <option value="tech" data-i18n="tech">Tech</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="casting-time:-u">CASTING TIME:</span>
-                                <input type="text" name="attr_powercastingtime">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_powerrange">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="target:-u">TARGET:</span>
-                                <input type="text" name="attr_powertarget">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_powerconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration-u">CONCENTRATION</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="duration:-u">DURATION:</span>
-                                <input type="text" name="attr_powerduration">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="power-ability-u">POWERCASTING ABILITY</span>
-                                <select name="attr_power_ability">
-                                    <option value="0*" data-i18n="none-u">NONE</option>
-                                    <option value="power" data-i18n="power-u">POWER</option>
-                                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="innate:-u">INNATE:</span>
-                                <input type="text" name="attr_innate" placeholder="1/day" value="">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="output:-u">OUTPUT:</span>
-                                <select name="attr_poweroutput">
-                                    <option value="POWERCARD" data-i18n="powercard-u">POWERCARD</option>
-                                    <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
-                                </select>
-                            </div>
-                            <input type="hidden" class="powerattackinfoflag" name="attr_poweroutput">
-                            <div class="powerattackinfo">
-                                <div class="row">
-                                    <span data-i18n="power-atk:-u">POWER ATTACK:</span>
-                                    <select name="attr_powerattack">
-                                        <option value="None" data-i18n="none">None</option>
-                                        <option value="Melee" data-i18n="melee">Melee</option>
-                                        <option value="Ranged" data-i18n="ranged">Ranged</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage:-u">DAMAGE:</span>
-                                    <input type="text" name="attr_powerdamage" style="width: 50px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_powerdamagetype" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                    <input type="text" name="attr_powerdamage2" style="width: 45px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_powerdamagetype2" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="healing:-u">HEALING:</span>
-                                    <input type="text" name="attr_powerhealing" style="width: 45px;">
-                                </div>
-                                <div class="row">
-                                    <input type="checkbox" name="attr_powerdmgmod" value="Yes">
-                                    <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                    <select name="attr_powersave">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Strength" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                        <option value="Constitution" data-i18n="con-u">CON</option>
-                                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                    </select>
-                                    <span data-i18n="effect:-u">EFFECT:</span>
-                                    <input type="text" name="attr_powersavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
-                                    <input type="text" name="attr_powerhldie" placeholder="1" style="width: 15px; text-align: right;">
-                                    <select name="attr_powerhldietype">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="d4">d4</option>
-                                        <option value="d6">d6</option>
-                                        <option value="d8">d8</option>
-                                        <option value="d10">d10</option>
-                                        <option value="d12">d12</option>
-                                        <option value="d20">d20</option>
-                                    </select>
-                                    <span>+</span>
-                                    <input type="text" name="attr_powerhlbonus" placeholder="0" style="width: 15px; text-align: center;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="include_power_desc:-u">INCLUDE POWER DESCRIPTION IN ATTACK:</span>
-                                    <select name="attr_includedesc">
-                                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                                        <option value="partial" data-i18n="partial">Partial</option>
-                                        <option value="on" data-i18n="on">On</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_powerdescription"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_powerathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
-                            </div>
-                            <input type="hidden" name="attr_powerattackid">
-                            <input type="hidden" name="attr_powerlevel" value="6">
-                        </div>
-                        <div class="display">
-                            <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:power} {{level=@{powerschool} @{powerlevel}}}  {{name=@{powername}}} {{castingtime=@{powercastingtime}}} {{range=@{powerrange}}} {{target=@{powertarget}}}  {{duration=@{powerduration}}} {{description=@{powerdescription}}} {{athigherlevels=@{powerathigherlevels}}}  {{innate=@{innate}}} @{powerconcentration} @{charname_output}">
-                            <input type="checkbox" name="attr_powerprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
-                            <button class="powercard" type="roll" name="roll_power" value="@{rollcontent}">
-                                <span class="powername" name="attr_powername"></span>
-                                <input class="innate_flag" type="hidden" name="attr_innate" value="">
-                                <span class="innate" name="attr_innate"></span>
-                            </button>
-                            <input type="hidden" class="powerconcentration" name="attr_powerconcentration" value="0">
-                            <span class="powerconcentration" data-i18n="power-concentration">C</span>
-                        </div>
-                    </div>
-                </fieldset>
-            </div>
-
-            <div class="power-level">
-                <div class="level">
-                    <span class="label">7</span>
-                </div>
-            </div>
-            <div class="power-container">
-                <fieldset class="repeating_power-7">
-                    <div class="power">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_powername">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="school:-u">SCHOOL:</span>
-                                <select name="attr_powerschool">
-                                    <option value="force" data-i18n="force">Force</option>
-                                    <option value="tech" data-i18n="tech">Tech</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="casting-time:-u">CASTING TIME:</span>
-                                <input type="text" name="attr_powercastingtime">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_powerrange">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="target:-u">TARGET:</span>
-                                <input type="text" name="attr_powertarget">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_powerconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration-u">CONCENTRATION</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="duration:-u">DURATION:</span>
-                                <input type="text" name="attr_powerduration">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="power-ability-u">POWERCASTING ABILITY</span>
-                                <select name="attr_power_ability">
-                                    <option value="0*" data-i18n="none-u">NONE</option>
-                                    <option value="power" data-i18n="power-u">POWER</option>
-                                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="innate:-u">INNATE:</span>
-                                <input type="text" name="attr_innate" placeholder="1/day" value="">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="output:-u">OUTPUT:</span>
-                                <select name="attr_poweroutput">
-                                    <option value="POWERCARD" data-i18n="powercard-u">POWERCARD</option>
-                                    <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
-                                </select>
-                            </div>
-                            <input type="hidden" class="powerattackinfoflag" name="attr_poweroutput">
-                            <div class="powerattackinfo">
-                                <div class="row">
-                                    <span data-i18n="power-atk:-u">POWER ATTACK:</span>
-                                    <select name="attr_powerattack">
-                                        <option value="None" data-i18n="none">None</option>
-                                        <option value="Melee" data-i18n="melee">Melee</option>
-                                        <option value="Ranged" data-i18n="ranged">Ranged</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage:-u">DAMAGE:</span>
-                                    <input type="text" name="attr_powerdamage" style="width: 50px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_powerdamagetype" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                    <input type="text" name="attr_powerdamage2" style="width: 45px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_powerdamagetype2" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="healing:-u">HEALING:</span>
-                                    <input type="text" name="attr_powerhealing" style="width: 45px;">
-                                </div>
-                                <div class="row">
-                                    <input type="checkbox" name="attr_powerdmgmod" value="Yes">
-                                    <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                    <select name="attr_powersave">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Strength" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                        <option value="Constitution" data-i18n="con-u">CON</option>
-                                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                    </select>
-                                    <span data-i18n="effect:-u">EFFECT:</span>
-                                    <input type="text" name="attr_powersavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
-                                    <input type="text" name="attr_powerhldie" placeholder="1" style="width: 15px; text-align: right;">
-                                    <select name="attr_powerhldietype">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="d4">d4</option>
-                                        <option value="d6">d6</option>
-                                        <option value="d8">d8</option>
-                                        <option value="d10">d10</option>
-                                        <option value="d12">d12</option>
-                                        <option value="d20">d20</option>
-                                    </select>
-                                    <span>+</span>
-                                    <input type="text" name="attr_powerhlbonus" placeholder="0" style="width: 15px; text-align: center;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="include_power_desc:-u">INCLUDE POWER DESCRIPTION IN ATTACK:</span>
-                                    <select name="attr_includedesc">
-                                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                                        <option value="partial" data-i18n="partial">Partial</option>
-                                        <option value="on" data-i18n="on">On</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_powerdescription"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_powerathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
-                            </div>
-                            <input type="hidden" name="attr_powerattackid">
-                            <input type="hidden" name="attr_powerlevel" value="7">
-                        </div>
-                        <div class="display">
-                            <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:power} {{level=@{powerschool} @{powerlevel}}}  {{name=@{powername}}} {{castingtime=@{powercastingtime}}} {{range=@{powerrange}}} {{target=@{powertarget}}}  {{duration=@{powerduration}}} {{description=@{powerdescription}}} {{athigherlevels=@{powerathigherlevels}}}  {{innate=@{innate}}} @{powerconcentration} @{charname_output}">
-                            <input type="checkbox" name="attr_powerprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
-                            <button class="powercard" type="roll" name="roll_power" value="@{rollcontent}">
-                                <span class="powername" name="attr_powername"></span>
-                                <input class="innate_flag" type="hidden" name="attr_innate" value="">
-                                <span class="innate" name="attr_innate"></span>
-                            </button>
-                            <input type="hidden" class="powerconcentration" name="attr_powerconcentration" value="0">
-                            <span class="powerconcentration" data-i18n="power-concentration">C</span>
-                        </div>
-                    </div>
-                </fieldset>
-            </div>
-
-            <div class="power-level">
-                <div class="level">
-                    <span class="label">8</span>
-                </div>
-            </div>
-            <div class="power-container">
-                <fieldset class="repeating_power-8">
-                    <div class="power">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_powername">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="school:-u">SCHOOL:</span>
-                                <select name="attr_powerschool">
-                                    <option value="force" data-i18n="force">Force</option>
-                                    <option value="tech" data-i18n="tech">Tech</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="casting-time:-u">CASTING TIME:</span>
-                                <input type="text" name="attr_powercastingtime">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_powerrange">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="target:-u">TARGET:</span>
-                                <input type="text" name="attr_powertarget">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_powerconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration-u">CONCENTRATION</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="duration:-u">DURATION:</span>
-                                <input type="text" name="attr_powerduration">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="power-ability-u">POWERCASTING ABILITY</span>
-                                <select name="attr_power_ability">
-                                    <option value="0*" data-i18n="none-u">NONE</option>
-                                    <option value="power" data-i18n="power-u">POWER</option>
-                                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="innate:-u">INNATE:</span>
-                                <input type="text" name="attr_innate" placeholder="1/day" value="">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="output:-u">OUTPUT:</span>
-                                <select name="attr_poweroutput">
-                                    <option value="POWERCARD" data-i18n="powercard-u">POWERCARD</option>
-                                    <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
-                                </select>
-                            </div>
-                            <input type="hidden" class="powerattackinfoflag" name="attr_poweroutput">
-                            <div class="powerattackinfo">
-                                <div class="row">
-                                    <span data-i18n="power-atk:-u">POWER ATTACK:</span>
-                                    <select name="attr_powerattack">
-                                        <option value="None" data-i18n="none">None</option>
-                                        <option value="Melee" data-i18n="melee">Melee</option>
-                                        <option value="Ranged" data-i18n="ranged">Ranged</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage:-u">DAMAGE:</span>
-                                    <input type="text" name="attr_powerdamage" style="width: 50px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_powerdamagetype" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                    <input type="text" name="attr_powerdamage2" style="width: 45px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_powerdamagetype2" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="healing:-u">HEALING:</span>
-                                    <input type="text" name="attr_powerhealing" style="width: 45px;">
-                                </div>
-                                <div class="row">
-                                    <input type="checkbox" name="attr_powerdmgmod" value="Yes">
-                                    <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                    <select name="attr_powersave">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Strength" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                        <option value="Constitution" data-i18n="con-u">CON</option>
-                                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                    </select>
-                                    <span data-i18n="effect:-u">EFFECT:</span>
-                                    <input type="text" name="attr_powersavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
-                                    <input type="text" name="attr_powerhldie" placeholder="1" style="width: 15px; text-align: right;">
-                                    <select name="attr_powerhldietype">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="d4">d4</option>
-                                        <option value="d6">d6</option>
-                                        <option value="d8">d8</option>
-                                        <option value="d10">d10</option>
-                                        <option value="d12">d12</option>
-                                        <option value="d20">d20</option>
-                                    </select>
-                                    <span>+</span>
-                                    <input type="text" name="attr_powerhlbonus" placeholder="0" style="width: 15px; text-align: center;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="include_power_desc:-u">INCLUDE POWER DESCRIPTION IN ATTACK:</span>
-                                    <select name="attr_includedesc">
-                                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                                        <option value="partial" data-i18n="partial">Partial</option>
-                                        <option value="on" data-i18n="on">On</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_powerdescription"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_powerathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
-                            </div>
-                            <input type="hidden" name="attr_powerattackid">
-                            <input type="hidden" name="attr_powerlevel" value="8">
-                        </div>
-                        <div class="display">
-                            <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:power} {{level=@{powerschool} @{powerlevel}}}  {{name=@{powername}}} {{castingtime=@{powercastingtime}}} {{range=@{powerrange}}} {{target=@{powertarget}}}  {{duration=@{powerduration}}} {{description=@{powerdescription}}} {{athigherlevels=@{powerathigherlevels}}}  {{innate=@{innate}}} @{powerconcentration} @{charname_output}">
-                            <input type="checkbox" name="attr_powerprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
-                            <button class="powercard" type="roll" name="roll_power" value="@{rollcontent}">
-                                <span class="powername" name="attr_powername"></span>
-                                <input class="innate_flag" type="hidden" name="attr_innate" value="">
-                                <span class="innate" name="attr_innate"></span>
-                            </button>
-                            <input type="hidden" class="powerconcentration" name="attr_powerconcentration" value="0">
-                            <span class="powerconcentration" data-i18n="power-concentration">C</span>
-                        </div>
-                    </div>
-                </fieldset>
-            </div>
-
-            <div class="power-level">
-                <div class="level">
-                    <span class="label">9</span>
-                </div>
-            </div>
-            <div class="power-container">
-                <fieldset class="repeating_power-9">
-                    <div class="power">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_powername">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="school:-u">SCHOOL:</span>
-                                <select name="attr_powerschool">
-                                    <option value="force" data-i18n="force">Force</option>
-                                    <option value="tech" data-i18n="tech">Tech</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="casting-time:-u">CASTING TIME:</span>
-                                <input type="text" name="attr_powercastingtime">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_powerrange">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="target:-u">TARGET:</span>
-                                <input type="text" name="attr_powertarget">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_powerconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration-u">CONCENTRATION</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="duration:-u">DURATION:</span>
-                                <input type="text" name="attr_powerduration">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="power-ability-u">POWERCASTING ABILITY</span>
-                                <select name="attr_power_ability">
-                                    <option value="0*" data-i18n="none-u">NONE</option>
-                                    <option value="power" data-i18n="power-u">POWER</option>
-                                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="innate:-u">INNATE:</span>
-                                <input type="text" name="attr_innate" placeholder="1/day" value="">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="output:-u">OUTPUT:</span>
-                                <select name="attr_poweroutput">
-                                    <option value="POWERCARD" data-i18n="powercard-u">POWERCARD</option>
-                                    <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
-                                </select>
-                            </div>
-                            <input type="hidden" class="powerattackinfoflag" name="attr_poweroutput">
-                            <div class="powerattackinfo">
-                                <div class="row">
-                                    <span data-i18n="power-atk:-u">POWER ATTACK:</span>
-                                    <select name="attr_powerattack">
-                                        <option value="None" data-i18n="none">None</option>
-                                        <option value="Melee" data-i18n="melee">Melee</option>
-                                        <option value="Ranged" data-i18n="ranged">Ranged</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage:-u">DAMAGE:</span>
-                                    <input type="text" name="attr_powerdamage" style="width: 50px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_powerdamagetype" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                    <input type="text" name="attr_powerdamage2" style="width: 45px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_powerdamagetype2" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="healing:-u">HEALING:</span>
-                                    <input type="text" name="attr_powerhealing" style="width: 45px;">
-                                </div>
-                                <div class="row">
-                                    <input type="checkbox" name="attr_powerdmgmod" value="Yes">
-                                    <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                    <select name="attr_powersave">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Strength" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                        <option value="Constitution" data-i18n="con-u">CON</option>
-                                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                    </select>
-                                    <span data-i18n="effect:-u">EFFECT:</span>
-                                    <input type="text" name="attr_powersavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
-                                    <input type="text" name="attr_powerhldie" placeholder="1" style="width: 15px; text-align: right;">
-                                    <select name="attr_powerhldietype">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="d4">d4</option>
-                                        <option value="d6">d6</option>
-                                        <option value="d8">d8</option>
-                                        <option value="d10">d10</option>
-                                        <option value="d12">d12</option>
-                                        <option value="d20">d20</option>
-                                    </select>
-                                    <span>+</span>
-                                    <input type="text" name="attr_powerhlbonus" placeholder="0" style="width: 15px; text-align: center;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="include_power_desc:-u">INCLUDE POWER DESCRIPTION IN ATTACK:</span>
-                                    <select name="attr_includedesc">
-                                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                                        <option value="partial" data-i18n="partial">Partial</option>
-                                        <option value="on" data-i18n="on">On</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_powerdescription"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_powerathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
-                            </div>
-                            <input type="hidden" name="attr_powerattackid">
-                            <input type="hidden" name="attr_powerlevel" value="9">
-                        </div>
-                        <div class="display">
-                            <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:power} {{level=@{powerschool} @{powerlevel}}}  {{name=@{powername}}} {{castingtime=@{powercastingtime}}} {{range=@{powerrange}}} {{target=@{powertarget}}} {{duration=@{powerduration}}} {{description=@{powerdescription}}} {{athigherlevels=@{powerathigherlevels}}}  {{innate=@{innate}}} @{powerconcentration} @{charname_output}">
-                            <input type="checkbox" name="attr_powerprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
-                            <button class="powercard" type="roll" name="roll_power" value="@{rollcontent}">
-                                <span class="powername" name="attr_powername"></span>
-                                <input class="innate_flag" type="hidden" name="attr_innate" value="">
-                                <span class="innate" name="attr_innate"></span>
-                            </button>
-                            <input type="hidden" class="powerconcentration" name="attr_powerconcentration" value="0">
-                            <span class="powerconcentration" data-i18n="power-concentration">C</span>
-                        </div>
-                    </div>
-                </fieldset>
-            </div>
-
-        </div>
-    </div>
-</div>
-
-<div class="page options">
-    <div class="header">
-        <div class="name-container">
-            <img src="https://s22.postimg.cc/jnlp8fqc1/Star_Wars_5_E_Logo_Shrunk.png" style="padding-bottom: 10px;">
-            <input type="text" name="attr_character_name" style="width: 100%;">
-            <span class="label" data-i18n="char-name-u">CHARACTER NAME</span>
-        </div>
-        <input class="options-flag" type="checkbox" name="attr_options-class-selection" checked="checked"><span>y</span>
-        <div class="header-info sheet-options">
-            <div class="sheet-row" style="border-top: 2px dashed gold;">
-                <span data-i18n="class:-u">CLASS:</span>
-                <input type="hidden" name="attr_custom_class" class="sheet-flag">
-                <select class="hiding class" name="attr_class">
-                    <option value="" data-i18n="choose">Choose</option>
-                    <option value="Berzerker" data-i18n="berzerker">Berzerker</option>
-                    <option value="Scholar" data-i18n="scholar">Scholar</option>
-                    <option value="Engineer" data-i18n="engineer">Engineer</option>
-                    <option value="Fighter" data-i18n="fighter">Fighter</option>
-                    <option value="Monk" data-i18n="monk">Monk</option>
-                    <option value="Guardian" data-i18n="guardian">Guardian</option>
-                    <option value="Scout" data-i18n="scout">Scout</option>
-                    <option value="Infiltrator" data-i18n="infiltrator">Infiltrator</option>
-                    <option value="Sentinel" data-i18n="sentinel">Sentinel</option>
-                    <option value="Consular" data-i18n="consular">Consular</option>
-                </select>
-                <input type="text" class="showing" name="attr_cust_classname" style="width: 90px;">
-                <span data-i18n="subclass:-u">SUBCLASS:</span>
-                <input type="text" name="attr_subclass">
-                <span data-i18n="lvl:-u">LEVEL:</span>
-                <input type="number" class="class-level" style="width: 40px" name="attr_base_level" value="1">
-            </div>
-            <div class="sheet-row">
-                <span data-i18n="race:-u">RACE:</span>
-                <input type="text" name="attr_race">
-                <span data-i18n="subrace:-u">SUBRACE:</span>
-                <input type="text" name="attr_subrace">
             </div>
         </div>
-        <div class="header-info sheet-display">
-            <div class="top">
-                <div class="hlabel-container">
-                    <input type="text" name="attr_class_display" class="sheet-class-display sheet-no_events">
-                    <span class="label" data-i18n="class-level-u">CLASS & LEVEL</span>
+        <div class="body">
+            <div class="col col1">
+                <div class="textbox">
+                    <textarea name="attr_character_appearance" style="min-height: 300px; height: 300px;"></textarea>
+                    <span class="label" data-i18n="char-appearance-u">CHARACTER APPEARANCE</span>
                 </div>
-                <div class="hlabel-container">
-                    <input type="text" name="attr_background" style="width: 182px;">
-                    <span class="label" data-i18n="background-u">BACKGROUND</span>
+                <div class="textbox">
+                    <textarea name="attr_character_backstory" style="min-height: 623px; height: 623px;"></textarea>
+                    <span class="label" data-i18n="char-backstory-u">CHARACTER BACKSTORY</span>
+                </div>
+                <div class="textbox">
+                    <textarea name="attr_miscellaneous" style="min-height: 300px; height: 300px;"></textarea>
+                    <span class="label" data-i18n="miscellaneous-u">MISCELLANEOUS</span>
                 </div>
             </div>
-            <div class="bottom">
-                <div class="hlabel-container">
-                    <input type="text" name="attr_race_display" class="sheet-no_events">
-                    <span class="label" data-i18n="race-u">RACE</span>
+            <div class="col2-3">
+                <div class="textbox">
+                    <textarea name="attr_allies_and_organizations" style="min-height: 288px; height: 300px;"></textarea>
+                    <span class="label" data-i18n="allies-orgs-u">ALLIES & ORGANIZATIONS</span>
                 </div>
-                <div class="hlabel-container">
-                    <input type="text" name="attr_alignment">
-                    <span class="label" data-i18n="alignment-u">ALIGNMENT</span>
+                <div class="textbox">
+                    <textarea name="attr_additional_feature_and_traits" style="min-height: 289px; height: 300px;"></textarea>
+                    <span class="label" data-i18n="add-feats-traits-u">ADDITIONAL FEATURES & TRAITS</span>
                 </div>
-                <div class="hlabel-container">
-                    <input type="text" name="attr_experience">
-                    <span class="label" data-i18n="exp-pts-u">EXPERIENCE POINTS</span>
+                <div class="textbox">
+                    <textarea name="attr_treasure" style="min-height: 300px; height: 300px;"></textarea>
+                    <span class="label" data-i18n="treasure-u">LOOT</span>
+                </div>
+                <div class="textbox">
+                    <textarea name="attr_storage" style="min-height: 300px; height: 300px;"></textarea>
+                    <span class="label" data-i18n="storage-u">STORAGE</span>
                 </div>
             </div>
         </div>
     </div>
-    <div class="body">
-        <div class="col col1">
-            <div class="class_options">
-                <div class="row">
-                    <span data-i18n="hit-die:-u">HIT DIE:</span>
-                    <select name="attr_hitdietype">
-                        <option value="4">D4</option>
-                        <option value="6">D6</option>
-                        <option value="8">D8</option>
-                        <option value="10">D10</option>
-                        <option value="12">D12</option>
-                    </select>
-                </div>
-                <div class="row">
-                    <span data-i18n="carrying-capacity-mod:-u">CARRYING CAPACITY MODIFIER:</span>
-                    <input type="text" class="num" name="attr_carrying_capacity_mod" placeholder="*2">
-                </div>
-                <div class="row">
-                    <span data-i18n="glob-atk-mod:-u">GLOBAL POWER ATTACK MODIFIER:</span>
-                    <input type="text" class="num" name="attr_globalpowermod" placeholder="0" value="0">
-                </div>
-                <div class="row">
-                    <span data-i18n="power-caster-lvl:-u">POWER CASTER LEVEL:</span>
-                    <input type="text" class="num" name="attr_caster_level">
-                </div>
-                <div class="row">
-                    <span data-i18n="power_dc_mod:-u">POWER SAVE DC MOD:</span>
-                    <input type="text" class="num" name="attr_power_dc_mod" placeholde="0" value="0">
-                </div>
-                <div class="row">
-                    <span data-i18n="power-icons:-u">POWER ICONS:</span>
-                    <select name="attr_powericon_flag">
-                        <option value="all" data-i18n="show_all">Show All</option>
-                        <option value="cp" data-i18n="cr_only">C&R Only</option>
-                        <option value="none" data-i18n="none">None</option>
-                    </select>
-                </div>
-                <div class="row">
-                    <input type="checkbox" name="attr_precognition_flag" value="1">
-                    <span data-i18n="precognition-u">PRECOGNITION (REROLL ONES)</span>
-                </div>
-                <div class="row">
-                    <input type="checkbox" name="attr_tech_fighter" value="1">
-                    <span data-i18n="tech-fighter-u">TECH FIGHTER</span>
-                </div>
-                <div class="row">
-                    <input type="checkbox" name="attr_tech_infiltrator" value="1">
-                    <span data-i18n="tech-infiltrator-u">TECH INFILTRATOR</span>
-                </div>
-                <div class="row title">
-                    <span data-i18n="class-options-u">CLASS OPTIONS</span>
-                </div>
+        
+    <div class="page powers">
+        <div class="header">
+            <div class="name-container">
+                <img src="https://s22.postimg.cc/jnlp8fqc1/Star_Wars_5_E_Logo_Shrunk.png" style="padding-bottom: 10px;">
+                <input type="text" name="attr_character_name" style="width: 100%;">
+                <span class="label" data-i18n="char-name-u">CHARACTER NAME</span>
             </div>
-            <div class="class_options">
-                <div class="row">
-                    <input type="checkbox" name="attr_multiclass1_flag" value="1">
-                    <span data-i18n="2nd-class:-u">2ND CLASS:</span>
-                    <select name="attr_multiclass1" style="width: 64px;">
-                        <option value="berzerker" data-i18n="berzerker">Berzerker</option>
-                        <option value="scholar" data-i18n="scholar">Scholar</option>
-                        <option value="engineer" data-i18n="engineer">Engineer</option>
-                        <option value="fighter" data-i18n="fighter">Fighter</option>
-                        <option value="monk" data-i18n="monk">Monk</option>
-                        <option value="guardian" data-i18n="guardian">Guardian</option>
-                        <option value="scout" data-i18n="scout">Scout</option>
-                        <option value="infiltrator" data-i18n="infiltrator">Infiltrator</option>
-                        <option value="sentinel" data-i18n="sentinel">Sentinel</option>
-                        <option value="consular" data-i18n="consular">Consular</option>
-                    </select>
-                    <span data-i18n="lvl:-u">LEVEL:</span>
-                    <input type="text" name="attr_multiclass1_lvl" value="1" style="width: 28px; text-align: center;">
-                    <span data-i18n="subclass:-u" class="sheet-subclass">SUBCLASS:</span>
-                    <input type="text" name="attr_multiclass1_subclass">
-                </div>
-                <div class="row">
-                    <input type="checkbox" name="attr_multiclass2_flag" value="1">
-                    <span data-i18n="3rd-class:-u">3RD CLASS:</span>
-                    <select name="attr_multiclass2" style="width: 64px;">
-                        <option value="berzerker" data-i18n="berzerker">Berzerker</option>
-                        <option value="scholar" data-i18n="scholar">Scholar</option>
-                        <option value="engineer" data-i18n="engineer">Engineer</option>
-                        <option value="fighter" data-i18n="fighter">Fighter</option>
-                        <option value="monk" data-i18n="monk">Monk</option>
-                        <option value="guardian" data-i18n="guardian">Guardian</option>
-                        <option value="scout" data-i18n="scout">Scout</option>
-                        <option value="infiltrator" data-i18n="infiltrator">Infiltrator</option>
-                        <option value="sentinel" data-i18n="sentinel">Sentinel</option>
-                        <option value="consular" data-i18n="consular">Consular</option>
-                    </select>
-                    <span data-i18n="lvl:-u">LEVEL:</span>
-                    <input type="text" name="attr_multiclass2_lvl" value="1" style="width: 28px; text-align: center;">
-                    <span data-i18n="subclass:-u" class="sheet-subclass">SUBCLASS:</span>
-                    <input type="text" name="attr_multiclass2_subclass">
-                </div>
-                <div class="row">
-                    <input type="checkbox" name="attr_multiclass3_flag" value="1">
-                    <span data-i18n="4th-class:-u">4TH CLASS:</span>
-                    <select name="attr_multiclass3" style="width: 64px;">
-                        <option value="berzerker" data-i18n="berzerker">Berzerker</option>
-                        <option value="scholar" data-i18n="scholar">Scholar</option>
-                        <option value="engineer" data-i18n="engineer">Engineer</option>
-                        <option value="fighter" data-i18n="fighter">Fighter</option>
-                        <option value="monk" data-i18n="monk">Monk</option>
-                        <option value="guardian" data-i18n="guardian">Guardian</option>
-                        <option value="scout" data-i18n="scout">Scout</option>
-                        <option value="infiltrator" data-i18n="infiltrator">Infiltrator</option>
-                        <option value="sentinel" data-i18n="sentinel">Sentinel</option>
-                        <option value="consular" data-i18n="consular">Consular</option>
-                    </select>
-                    <span data-i18n="lvl:-u">LEVEL:</span>
-                    <input type="text" name="attr_multiclass3_lvl" value="1" style="width: 28px; text-align: center;">
-                    <span data-i18n="subclass:-u" class="sheet-subclass">SUBCLASS:</span>
-                    <input type="text" name="attr_multiclass3_subclass">
-                </div>
-                <div class="row title">
-                    <span data-i18n="mutliclass-opts-u">MULTICLASS OPTIONS</span>
-                </div>
-            </div>
-            <div class="class_options">
-                <div class="row">
-                    <input type="checkbox" name="attr_custom_class" value="1">
-                    <span data-i18n="use-cust-class-u">USE CUSTOM CLASS</span>
-                </div>
-                <div class="row">
-                    <span data-i18n="class-name:-u">CLASS NAME:</span>
-                    <input type="text" name="attr_cust_classname">
-                </div>
-                <div class="row">
-                    <span data-i18n="hit-die:-u">HIT DIE:</span>
-                    <select name="attr_cust_hitdietype">
-                        <option value="4">D4</option>
-                        <option value="6">D6</option>
-                        <option value="8">D8</option>
-                        <option value="10">D10</option>
-                        <option value="12">D12</option>
-                    </select>
-                </div>
-                <div class="row">
-                    <span data-i18n="powercasting-ability:-u">POWERCASTING ABILITY:</span>
-                    <select name="attr_cust_powercasting_ability">
+            <div class="header-info">
+                <div class="part">
+                    <select name="attr_powercasting_ability">
                         <option value="0*" data-i18n="none-u">NONE</option>
                         <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
                         <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
@@ -3800,293 +1890,2481 @@
                         <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
                         <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
                     </select>
+                    <span class="label" data-i18n="power-ability-u">POWERCASTING ABILITY</span>
                 </div>
-                <div class="row">
-                    <span data-i18n="power-slots:-u">POWER SLOTS:</span>
-                    <select name="attr_cust_powerslots">
-                        <option value="none" data-i18n="none-u">NONE</option>
-                        <option value="full" data-i18n="power-full-u">FULL (Engineer, Druid, Consular)</option>
-                        <option value="half" data-i18n="power-half-u">HALF (Guardian, Scout)</option>
-                        <option value="third" data-i18n="power-third-u">THIRD (Tech Fighter/Infiltrator)</option>
-                    </select>
+                <div class="part">
+                    <span class="display" name="attr_power_save_dc"></span>
+                    <span class="label" data-i18n="power-save-dc-u">POWER SAVE DC</span>
                 </div>
-                <div class="row">
-                    <span data-i18n="saves-u">SAVES</span>
-                </div>
-                <div class="row">
-                    <input type="checkbox" name="attr_cust_strength_save_prof" value="(@{pb})">
-                    <span data-i18n="strength">Strength</span>
-                </div>
-                <div class="row">
-                    <input type="checkbox" name="attr_cust_dexterity_save_prof" value="(@{pb})">
-                    <span data-i18n="dexterity">Dexterity</span>
-                </div>
-                <div class="row">
-                    <input type="checkbox" name="attr_cust_constitution_save_prof" value="(@{pb})">
-                    <span data-i18n="constitution">Constitution</span>
-                </div>
-                <div class="row">
-                    <input type="checkbox" name="attr_cust_intelligence_save_prof" value="(@{pb})">
-                    <span data-i18n="intelligence">Intelligence</span>
-                </div>
-                <div class="row">
-                    <input type="checkbox" name="attr_cust_wisdom_save_prof" value="(@{pb})">
-                    <span data-i18n="wisdom">Wisdom</span>
-                </div>
-                <div class="row">
-                    <input type="checkbox" name="attr_cust_charisma_save_prof" value="(@{pb})">
-                    <span data-i18n="charisma">Charisma</span>
-                </div>
-                <div class="row title">
-                    <span data-i18n="cust-class-opts">CUSTOM CLASS OPTIONS</span>
+                <div class="part">
+                    <span class="display" name="attr_power_attack_bonus"></span>
+                    <span class="label" data-i18n="power-atk-bonus-u">POWER ATTACK BONUS</span>
                 </div>
             </div>
         </div>
-        <div class="col col2">
-            <div class="attribute_options" style="width: 234px;">
-                <div class="row skill">
-                    <span data-i18n="strength-u">STRENGTH</span>
-                    <span>+</span><input type="text" class="num" name="attr_strength_bonus" value="0" placeholder="0" title="@{strength_bonus}">
-                </div>
-                <div class="row skill">
-                    <span data-i18n="dexterity-u">DEXTERITY</span>
-                    <span>+</span><input type="text" class="num" name="attr_dexterity_bonus" value="0" placeholder="0" title="@{dexterity_bonus}">
-                </div>
-                <div class="row skill">
-                    <span data-i18n="constitution-u">CONSTITUTION</span>
-                    <span>+</span><input type="text" class="num" name="attr_constitution_bonus" value="0" placeholder="0" title="@{constitution_bonus}">
-                </div>
-                <div class="row skill">
-                    <span data-i18n="intelligence-u">INTELLIGENCE</span>
-                    <span>+</span><input type="text" class="num" name="attr_intelligence_bonus" value="0" placeholder="0" title="@{intelligence_bonus}">
-                </div>
-                <div class="row skill">
-                    <span data-i18n="wisdom-u">WISDOM</span>
-                    <span>+</span><input type="text" class="num" name="attr_wisdom_bonus" value="0" placeholder="0" title="@{wisdom_bonus}">
-                </div>
-                <div class="row skill">
-                    <span data-i18n="charisma-u">CHARISMA</span>
-                    <span>+</span><input type="text" class="num" name="attr_charisma_bonus" value="0" placeholder="0" title="@{charisma_bonus}">
-                </div>
-                <div class="row">
-                    <span data-i18n="initiative-mod:-u">INITIATIVE MODIFIER:</span>
-                    <input type="text" class="num" name="attr_initmod" placeholder="0" value="0">
-                </div>
-                <div class="row">
-                    <span data-i18n="initiative-style:-u">INITIATIVE STYLE:</span>
-                    <select name="attr_initiative_style">
-                        <option value="@{d20}" selected="selected" data-i18n="norm">Normal</option>
-                        <option value="{@{d20},@{d20}}kh1" data-i18n="adv">Advantage</option>
-                        <option value="{@{d20},@{d20}}kl1" data-i18n="disadv">Disadvantage</option>
-<!--                         <option value="?{Advantage?|Normal Roll,&#64;&#123;d20&#125;|Advantage,&#123;&#64;&#123;d20&#125;&#44;&#64;&#123;d20&#125;&#125;kh1|Disadvantage,&#123;&#64;&#123;d20&#125;&#44;&#64;&#123;d20&#125;&#125;kl1}" data-i18n="query-roll-adv">Query Advantage</option> -->
-<!-- Pajellen was here -->
-                    </select>
-                </div>
-                <div class="row">
-                     <input type="checkbox" name="attr_init_tiebreaker" value="@{dexterity}/100">
-                    <span data-i18n="add-dex-tiebreaker-u">ADD DEX TIEBREAKER TO INITIATIVE</span>
-                </div>
-                <div class="row">
-                    <span data-i18n="glob-ac-mod:-u">GLOBAL ARMOR CLASS MODIFIER:</span>
-                    <input type="text" class="num" name="attr_globalacmod" placeholder="0" value="0">
-                </div>
-                <div class="row">
-                    <span data-i18n="armor-class-tracking:-u">ARMOR CLASS TRACKING:</span>
-                    <select name="attr_custom_ac_flag">
-                        <option value="0" selected="selected" data-i18n="automatic">Automatic</option>
-                        <option value="1" data-i18n="custom">Custom</option>
-                        <option value="2" data-i18n="off">Off</option>
-                    </select>
-                </div>
-                <input class="toggleflag" type="hidden" name="attr_custom_ac_flag">
-                <div class="row hidden">
-                    <span data-i18n="custom_ac:-u">CUSTOM AC:</span>
-                    <input type="text" class="num" name="attr_custom_ac_base" placeholde="10" value="10">
-                    <span>+</span>
-                    <select name="attr_custom_ac_part1">
-                        <option value="none" selected="selected" data-i18n="none-u">NONE</option>
-                        <option value="Strength" data-i18n="str-u">STR</option>
-                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                        <option value="Constitution" data-i18n="con-u">CON</option>
-                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                    </select>
-                    <span>+</span>
-                    <select name="attr_custom_ac_part2">
-                        <option value="none" selected="selected" data-i18n="none-u">NONE</option>
-                        <option value="Strength" data-i18n="str-u">STR</option>
-                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                        <option value="Constitution" data-i18n="con-u">CON</option>
-                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                    </select>
-                </div>
-                <div class="row">
-                    <span data-i18n="hpmods:-u">HP MODIFIERS:</span>
-                </div>
-                <fieldset class="repeating_hpmod">
-                    <div style="padding-left: 15px;">
-                        <span data-i18n="source:-u">SOURCE:</span>
-                        <input type="text" name="attr_source">
-                        <span data-i18n="mod:-u">MOD:</span>
-                        <input type="text" name="attr_mod" class="num">
+        <input type="hidden" class="powericon_flag" name="attr_powericon_flag" value="all">
+        <div class="body">
+            <div class="col col1">
+                <span class="power-labels">
+                    <span data-i18n="force_slots_total-u" style="margin-right: 45px;">FORCE TOTAL</span>
+                    <span data-i18n="force_slots_remaining-u">FORCE REMAINING</span>
+                </span>
+                <div class="power-level">
+                    <div class="level">
+                        <span class="label">FP</span>
                     </div>
-                </fieldset>
-                <div class="row title">
-                    <span data-i18n="attribute-opts-u">ATTRIBUTE OPTIONS</span>
+    
+                    <div class="total">
+                        <input type="number" name="attr_force_power_points_total" value="0">
+                    </div>
+                    <div class="expended">
+                        <input type="number" name="attr_force_power_points_expended" value="0">
+                    </div>
+                </div>
+                <span class="power-labels">
+                    <span data-i18n="tech_slots_total-u" style="margin-right: 45px;">TECH TOTAL</span>
+                    <span data-i18n="tech_slots_remaining-u">TECH REMAINING</span>
+                </span>
+                <div class="power-level">
+                    <div class="level">
+                        <span class="label">TP</span>
+                    </div>
+    
+                    <div class="total">
+                        <input type="number" name="attr_tech_power_points_total" value="0">
+                    </div>
+                    <div class="expended">
+                        <input type="number" name="attr_tech_power_points_expended" value="0">
+                    </div>
+                </div>
+                <br>
+                <div class="power-level">
+                    <div class="level">
+                        <span class="label">0</span>
+                    </div>
+                    <div class="cantrips">
+                        <span class="label" data-i18n="cantrips-u">AT-WILL</span>
+                    </div>
+                </div>
+                <div class="power-container">
+                    <fieldset class="repeating_power-cantrip">
+                        <div class="power">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_powername">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="school:-u">SCHOOL:</span>
+                                    <select name="attr_powerschool">
+                                        <option value="force" data-i18n="force">Force</option>
+                                        <option value="tech" data-i18n="tech">Tech</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="casting-time:-u">CASTING TIME:</span>
+                                    <input type="text" name="attr_powercastingtime">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_powerrange">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="target:-u">TARGET:</span>
+                                    <input type="text" name="attr_powertarget">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_powerconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration-u">CONCENTRATION</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="duration:-u">DURATION:</span>
+                                    <input type="text" name="attr_powerduration">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="power-ability-u">POWERCASTING ABILITY</span>
+                                    <select name="attr_power_ability">
+                                        <option value="0*" data-i18n="none-u">NONE</option>
+                                        <option value="power" data-i18n="power-u">POWER</option>
+                                        <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="innate:-u">INNATE:</span>
+                                    <input type="text" name="attr_innate" placeholder="1/day" value="">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="output:-u">OUTPUT:</span>
+                                    <select name="attr_poweroutput">
+                                        <option value="POWERCARD" data-i18n="powercard-u">POWERCARD</option>
+                                        <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
+                                    </select>
+                                </div>
+                                <input type="hidden" class="powerattackinfoflag" name="attr_poweroutput">
+                                <div class="powerattackinfo">
+                                    <div class="row">
+                                        <span data-i18n="power-atk:-u">POWER ATTACK:</span>
+                                        <select name="attr_powerattack">
+                                            <option value="None" data-i18n="none">None</option>
+                                            <option value="Melee" data-i18n="melee">Melee</option>
+                                            <option value="Ranged" data-i18n="ranged">Ranged</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage:-u">DAMAGE:</span>
+                                        <input type="text" name="attr_powerdamage" style="width: 50px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_powerdamagetype" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                        <input type="text" name="attr_powerdamage2" style="width: 45px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_powerdamagetype2" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="healing:-u">HEALING:</span>
+                                        <input type="text" name="attr_powerhealing" style="width: 45px;">
+                                    </div>
+                                    <div class="row">
+                                        <input type="checkbox" name="attr_powerdmgmod" value="Yes">
+                                        <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="cantrip-progression:-u">AT-WILL PROGRESSION</span>
+                                        <select name="attr_power_damage_progression">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Cantrip Dice" data-i18n="cantrip-dice-u">AT-WILL DICE</option>
+                                            <option value="Cantrip Beam" data-i18n="cantrip-beam-u">AT-WILL BEAM</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                        <select name="attr_powersave">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Strength" data-i18n="str-u">STR</option>
+                                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                            <option value="Constitution" data-i18n="con-u">CON</option>
+                                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                        </select>
+                                        <span data-i18n="effect:-u">EFFECT:</span>
+                                        <input type="text" name="attr_powersavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
+                                        <input type="text" name="attr_powerhldie" placeholder="1" style="width: 15px; text-align: right;">
+                                        <select name="attr_powerhldietype">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="d4">d4</option>
+                                            <option value="d6">d6</option>
+                                            <option value="d8">d8</option>
+                                            <option value="d10">d10</option>
+                                            <option value="d12">d12</option>
+                                            <option value="d20">d20</option>
+                                        </select>
+                                        <span>+</span>
+                                        <input type="text" name="attr_powerhlbonus" placeholder="0" style="width: 15px; text-align: center;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="include_power_desc:-u">INCLUDE POWER DESCRIPTION IN ATTACK:</span>
+                                        <select name="attr_includedesc">
+                                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                                            <option value="partial" data-i18n="partial">Partial</option>
+                                            <option value="on" data-i18n="on">On</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_powerdescription"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_powerathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
+                                </div>
+                                <input type="hidden" name="attr_powerattackid">
+                                <input type="hidden" name="attr_powerlevel" value="cantrip">
+                            </div>
+                            <div class="display">
+                                <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:power} {{level=@{powerschool} @{powerlevel}}}  {{name=@{powername}}} {{castingtime=@{powercastingtime}}} {{range=@{powerrange}}} {{target=@{powertarget}}}  {{duration=@{powerduration}}} {{description=@{powerdescription}}} {{athigherlevels=@{powerathigherlevels}}}  {{innate=@{innate}}} @{powerconcentration} @{charname_output}">
+                                <button class="powercard" type="roll" name="roll_power" value="@{rollcontent}">
+                                    <span class="powername" name="attr_powername"></span>
+                                    <input class="innate_flag" type="hidden" name="attr_innate" value="">
+                                    <span class="innate" name="attr_innate"></span>
+                                </button>
+                                <input type="hidden" class="powerconcentration" name="attr_powerconcentration" value="0">
+                                <span class="powerconcentration" data-i18n="power-concentration">C</span>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+    
+                <div class="power-level">
+                    <div class="level">
+                        <span class="label">1</span>
+                    </div>
+                </div>
+                <div class="power-container">
+                    <fieldset class="repeating_power-1">
+                        <div class="power">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_powername">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="school:-u">SCHOOL:</span>
+                                    <select name="attr_powerschool">
+                                        <option value="force" data-i18n="force">Force</option>
+                                        <option value="tech" data-i18n="tech">Tech</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="casting-time:-u">CASTING TIME:</span>
+                                    <input type="text" name="attr_powercastingtime">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_powerrange">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="target:-u">TARGET:</span>
+                                    <input type="text" name="attr_powertarget">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_powerconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration-u">CONCENTRATION</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="duration:-u">DURATION:</span>
+                                    <input type="text" name="attr_powerduration">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="power-ability-u">POWERCASTING ABILITY</span>
+                                    <select name="attr_power_ability">
+                                        <option value="0*" data-i18n="none-u">NONE</option>
+                                        <option value="power" data-i18n="power-u">POWER</option>
+                                        <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="innate:-u">INNATE:</span>
+                                    <input type="text" name="attr_innate" placeholder="1/day" value="">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="output:-u">OUTPUT:</span>
+                                    <select name="attr_poweroutput">
+                                        <option value="POWERCARD" data-i18n="powercard-u">POWERCARD</option>
+                                        <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
+                                    </select>
+                                </div>
+                                <input type="hidden" class="powerattackinfoflag" name="attr_poweroutput">
+                                <div class="powerattackinfo">
+                                    <div class="row">
+                                        <span data-i18n="power-atk:-u">POWER ATTACK:</span>
+                                        <select name="attr_powerattack">
+                                            <option value="None" data-i18n="none">None</option>
+                                            <option value="Melee" data-i18n="melee">Melee</option>
+                                            <option value="Ranged" data-i18n="ranged">Ranged</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage:-u">DAMAGE:</span>
+                                        <input type="text" name="attr_powerdamage" style="width: 50px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_powerdamagetype" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                        <input type="text" name="attr_powerdamage2" style="width: 45px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_powerdamagetype2" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="healing:-u">HEALING:</span>
+                                        <input type="text" name="attr_powerhealing" style="width: 45px;">
+                                    </div>
+                                    <div class="row">
+                                        <input type="checkbox" name="attr_powerdmgmod" value="Yes">
+                                        <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                        <select name="attr_powersave">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Strength" data-i18n="str-u">STR</option>
+                                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                            <option value="Constitution" data-i18n="con-u">CON</option>
+                                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                        </select>
+                                        <span data-i18n="effect:-u">EFFECT:</span>
+                                        <input type="text" name="attr_powersavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
+                                        <input type="text" name="attr_powerhldie" placeholder="1" style="width: 15px; text-align: right;">
+                                        <select name="attr_powerhldietype">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="d4">d4</option>
+                                            <option value="d6">d6</option>
+                                            <option value="d8">d8</option>
+                                            <option value="d10">d10</option>
+                                            <option value="d12">d12</option>
+                                            <option value="d20">d20</option>
+                                        </select>
+                                        <span>+</span>
+                                        <input type="text" name="attr_powerhlbonus" placeholder="0" style="width: 15px; text-align: center;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="include_power_desc:-u">INCLUDE POWER DESCRIPTION IN ATTACK:</span>
+                                        <select name="attr_includedesc">
+                                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                                            <option value="partial" data-i18n="partial">Partial</option>
+                                            <option value="on" data-i18n="on">On</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_powerdescription"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_powerathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
+                                </div>
+                                <input type="hidden" name="attr_powerattackid">
+                                <input type="hidden" name="attr_powerlevel" value="1">
+                            </div>
+                            <div class="display">
+                                <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:power} {{level=@{powerschool} @{powerlevel}}}  {{name=@{powername}}} {{castingtime=@{powercastingtime}}} {{range=@{powerrange}}} {{target=@{powertarget}}}  {{duration=@{powerduration}}} {{description=@{powerdescription}}} {{athigherlevels=@{powerathigherlevels}}}  {{innate=@{innate}}} @{powerconcentration} @{charname_output}">
+                                <input type="checkbox" name="attr_powerprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
+                                <button class="powercard" type="roll" name="roll_power" value="@{rollcontent}">
+                                    <span class="powername" name="attr_powername"></span>
+                                    <input class="innate_flag" type="hidden" name="attr_innate" value="">
+                                    <span class="innate" name="attr_innate"></span>
+                                </button>
+                                <input type="hidden" class="powerconcentration" name="attr_powerconcentration" value="0">
+                                <span class="powerconcentration" data-i18n="power-concentration">C</span>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+    
+                <div class="power-level">
+                    <div class="level">
+                        <span class="label">2</span>
+                    </div>
+                </div>
+                <div class="power-container">
+                    <fieldset class="repeating_power-2">
+                        <div class="power">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_powername">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="school:-u">SCHOOL:</span>
+                                    <select name="attr_powerschool">
+                                        <option value="force" data-i18n="force">Force</option>
+                                        <option value="tech" data-i18n="tech">Tech</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="casting-time:-u">CASTING TIME:</span>
+                                    <input type="text" name="attr_powercastingtime">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_powerrange">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="target:-u">TARGET:</span>
+                                    <input type="text" name="attr_powertarget">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_powerconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration-u">CONCENTRATION</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="duration:-u">DURATION:</span>
+                                    <input type="text" name="attr_powerduration">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="power-ability-u">POWERCASTING ABILITY</span>
+                                    <select name="attr_power_ability">
+                                        <option value="0*" data-i18n="none-u">NONE</option>
+                                        <option value="power" data-i18n="power-u">POWER</option>
+                                        <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="innate:-u">INNATE:</span>
+                                    <input type="text" name="attr_innate" placeholder="1/day" value="">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="output:-u">OUTPUT:</span>
+                                    <select name="attr_poweroutput">
+                                        <option value="POWERCARD" data-i18n="powercard-u">POWERCARD</option>
+                                        <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
+                                    </select>
+                                </div>
+                                <input type="hidden" class="powerattackinfoflag" name="attr_poweroutput">
+                                <div class="powerattackinfo">
+                                    <div class="row">
+                                        <span data-i18n="power-atk:-u">POWER ATTACK:</span>
+                                        <select name="attr_powerattack">
+                                            <option value="None" data-i18n="none">None</option>
+                                            <option value="Melee" data-i18n="melee">Melee</option>
+                                            <option value="Ranged" data-i18n="ranged">Ranged</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage:-u">DAMAGE:</span>
+                                        <input type="text" name="attr_powerdamage" style="width: 50px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_powerdamagetype" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                        <input type="text" name="attr_powerdamage2" style="width: 45px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_powerdamagetype2" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="healing:-u">HEALING:</span>
+                                        <input type="text" name="attr_powerhealing" style="width: 45px;">
+                                    </div>
+                                    <div class="row">
+                                        <input type="checkbox" name="attr_powerdmgmod" value="Yes">
+                                        <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                        <select name="attr_powersave">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Strength" data-i18n="str-u">STR</option>
+                                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                            <option value="Constitution" data-i18n="con-u">CON</option>
+                                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                        </select>
+                                        <span data-i18n="effect:-u">EFFECT:</span>
+                                        <input type="text" name="attr_powersavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
+                                        <input type="text" name="attr_powerhldie" placeholder="1" style="width: 15px; text-align: right;">
+                                        <select name="attr_powerhldietype">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="d4">d4</option>
+                                            <option value="d6">d6</option>
+                                            <option value="d8">d8</option>
+                                            <option value="d10">d10</option>
+                                            <option value="d12">d12</option>
+                                            <option value="d20">d20</option>
+                                        </select>
+                                        <span>+</span>
+                                        <input type="text" name="attr_powerhlbonus" placeholder="0" style="width: 15px; text-align: center;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="include_power_desc:-u">INCLUDE POWER DESCRIPTION IN ATTACK:</span>
+                                        <select name="attr_includedesc">
+                                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                                            <option value="partial" data-i18n="partial">Partial</option>
+                                            <option value="on" data-i18n="on">On</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_powerdescription"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_powerathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
+                                </div>
+                                <input type="hidden" name="attr_powerattackid">
+                                <input type="hidden" name="attr_powerlevel" value="2">
+                            </div>
+                            <div class="display">
+                                <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:power} {{level=@{powerschool} @{powerlevel}}}  {{name=@{powername}}} {{castingtime=@{powercastingtime}}} {{range=@{powerrange}}} {{target=@{powertarget}}}  {{duration=@{powerduration}}} {{description=@{powerdescription}}} {{athigherlevels=@{powerathigherlevels}}}  {{innate=@{innate}}} @{powerconcentration} @{charname_output}">
+                                <input type="checkbox" name="attr_powerprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
+                                <button class="powercard" type="roll" name="roll_power" value="@{rollcontent}">
+                                    <span class="powername" name="attr_powername"></span>
+                                    <input class="innate_flag" type="hidden" name="attr_innate" value="">
+                                    <span class="innate" name="attr_innate"></span>
+                                </button>
+                                <input type="hidden" class="powerconcentration" name="attr_powerconcentration" value="0">
+                                <span class="powerconcentration" data-i18n="power-concentration">C</span>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+    
+            </div>
+            <div class="col col2">
+    
+                <div class="power-level">
+                    <div class="level">
+                        <span class="label">3</span>
+                    </div>
+                </div>
+                <div class="power-container">
+                    <fieldset class="repeating_power-3">
+                        <div class="power">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_powername">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="school:-u">SCHOOL:</span>
+                                    <select name="attr_powerschool">
+                                        <option value="force" data-i18n="force">Force</option>
+                                        <option value="tech" data-i18n="tech">Tech</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="casting-time:-u">CASTING TIME:</span>
+                                    <input type="text" name="attr_powercastingtime">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_powerrange">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="target:-u">TARGET:</span>
+                                    <input type="text" name="attr_powertarget">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_powerconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration-u">CONCENTRATION</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="duration:-u">DURATION:</span>
+                                    <input type="text" name="attr_powerduration">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="power-ability-u">POWERCASTING ABILITY</span>
+                                    <select name="attr_power_ability">
+                                        <option value="0*" data-i18n="none-u">NONE</option>
+                                        <option value="power" data-i18n="power-u">POWER</option>
+                                        <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="innate:-u">INNATE:</span>
+                                    <input type="text" name="attr_innate" placeholder="1/day" value="">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="output:-u">OUTPUT:</span>
+                                    <select name="attr_poweroutput">
+                                        <option value="POWERCARD" data-i18n="powercard-u">POWERCARD</option>
+                                        <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
+                                    </select>
+                                </div>
+                                <input type="hidden" class="powerattackinfoflag" name="attr_poweroutput">
+                                <div class="powerattackinfo">
+                                    <div class="row">
+                                        <span data-i18n="power-atk:-u">POWER ATTACK:</span>
+                                        <select name="attr_powerattack">
+                                            <option value="None" data-i18n="none">None</option>
+                                            <option value="Melee" data-i18n="melee">Melee</option>
+                                            <option value="Ranged" data-i18n="ranged">Ranged</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage:-u">DAMAGE:</span>
+                                        <input type="text" name="attr_powerdamage" style="width: 50px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_powerdamagetype" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                        <input type="text" name="attr_powerdamage2" style="width: 45px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_powerdamagetype2" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="healing:-u">HEALING:</span>
+                                        <input type="text" name="attr_powerhealing" style="width: 45px;">
+                                    </div>
+                                    <div class="row">
+                                        <input type="checkbox" name="attr_powerdmgmod" value="Yes">
+                                        <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                        <select name="attr_powersave">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Strength" data-i18n="str-u">STR</option>
+                                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                            <option value="Constitution" data-i18n="con-u">CON</option>
+                                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                        </select>
+                                        <span data-i18n="effect:-u">EFFECT:</span>
+                                        <input type="text" name="attr_powersavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
+                                        <input type="text" name="attr_powerhldie" placeholder="1" style="width: 15px; text-align: right;">
+                                        <select name="attr_powerhldietype">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="d4">d4</option>
+                                            <option value="d6">d6</option>
+                                            <option value="d8">d8</option>
+                                            <option value="d10">d10</option>
+                                            <option value="d12">d12</option>
+                                            <option value="d20">d20</option>
+                                        </select>
+                                        <span>+</span>
+                                        <input type="text" name="attr_powerhlbonus" placeholder="0" style="width: 15px; text-align: center;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="include_power_desc:-u">INCLUDE POWER DESCRIPTION IN ATTACK:</span>
+                                        <select name="attr_includedesc">
+                                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                                            <option value="partial" data-i18n="partial">Partial</option>
+                                            <option value="on" data-i18n="on">On</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_powerdescription"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_powerathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
+                                </div>
+                                <input type="hidden" name="attr_powerattackid">
+                                <input type="hidden" name="attr_powerlevel" value="3">
+                            </div>
+                            <div class="display">
+                                <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:power} {{level=@{powerschool} @{powerlevel}}}  {{name=@{powername}}} {{castingtime=@{powercastingtime}}} {{range=@{powerrange}}} {{target=@{powertarget}}}  {{duration=@{powerduration}}} {{description=@{powerdescription}}} {{athigherlevels=@{powerathigherlevels}}}  {{innate=@{innate}}} @{powerconcentration} @{charname_output}">
+                                <input type="checkbox" name="attr_powerprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
+                                <button class="powercard" type="roll" name="roll_power" value="@{rollcontent}">
+                                    <span class="powername" name="attr_powername"></span>
+                                    <input class="innate_flag" type="hidden" name="attr_innate" value="">
+                                    <span class="innate" name="attr_innate"></span>
+                                </button>
+                                <input type="hidden" class="powerconcentration" name="attr_powerconcentration" value="0">
+                                <span class="powerconcentration" data-i18n="power-concentration">C</span>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+    
+                <div class="power-level">
+                    <div class="level">
+                        <span class="label">4</span>
+                    </div>
+                </div>
+                <div class="power-container">
+                    <fieldset class="repeating_power-4">
+                        <div class="power">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_powername">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="school:-u">SCHOOL:</span>
+                                    <select name="attr_powerschool">
+                                        <option value="force" data-i18n="force">Force</option>
+                                        <option value="tech" data-i18n="tech">Tech</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="casting-time:-u">CASTING TIME:</span>
+                                    <input type="text" name="attr_powercastingtime">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_powerrange">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="target:-u">TARGET:</span>
+                                    <input type="text" name="attr_powertarget">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_powerconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration-u">CONCENTRATION</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="duration:-u">DURATION:</span>
+                                    <input type="text" name="attr_powerduration">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="power-ability-u">POWERCASTING ABILITY</span>
+                                    <select name="attr_power_ability">
+                                        <option value="0*" data-i18n="none-u">NONE</option>
+                                        <option value="power" data-i18n="power-u">POWER</option>
+                                        <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="innate:-u">INNATE:</span>
+                                    <input type="text" name="attr_innate" placeholder="1/day" value="">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="output:-u">OUTPUT:</span>
+                                    <select name="attr_poweroutput">
+                                        <option value="POWERCARD" data-i18n="powercard-u">POWERCARD</option>
+                                        <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
+                                    </select>
+                                </div>
+                                <input type="hidden" class="powerattackinfoflag" name="attr_poweroutput">
+                                <div class="powerattackinfo">
+                                    <div class="row">
+                                        <span data-i18n="power-atk:-u">POWER ATTACK:</span>
+                                        <select name="attr_powerattack">
+                                            <option value="None" data-i18n="none">None</option>
+                                            <option value="Melee" data-i18n="melee">Melee</option>
+                                            <option value="Ranged" data-i18n="ranged">Ranged</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage:-u">DAMAGE:</span>
+                                        <input type="text" name="attr_powerdamage" style="width: 50px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_powerdamagetype" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                        <input type="text" name="attr_powerdamage2" style="width: 45px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_powerdamagetype2" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="healing:-u">HEALING:</span>
+                                        <input type="text" name="attr_powerhealing" style="width: 45px;">
+                                    </div>
+                                    <div class="row">
+                                        <input type="checkbox" name="attr_powerdmgmod" value="Yes">
+                                        <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                        <select name="attr_powersave">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Strength" data-i18n="str-u">STR</option>
+                                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                            <option value="Constitution" data-i18n="con-u">CON</option>
+                                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                        </select>
+                                        <span data-i18n="effect:-u">EFFECT:</span>
+                                        <input type="text" name="attr_powersavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
+                                        <input type="text" name="attr_powerhldie" placeholder="1" style="width: 15px; text-align: right;">
+                                        <select name="attr_powerhldietype">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="d4">d4</option>
+                                            <option value="d6">d6</option>
+                                            <option value="d8">d8</option>
+                                            <option value="d10">d10</option>
+                                            <option value="d12">d12</option>
+                                            <option value="d20">d20</option>
+                                        </select>
+                                        <span>+</span>
+                                        <input type="text" name="attr_powerhlbonus" placeholder="0" style="width: 15px; text-align: center;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="include_power_desc:-u">INCLUDE POWER DESCRIPTION IN ATTACK:</span>
+                                        <select name="attr_includedesc">
+                                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                                            <option value="partial" data-i18n="partial">Partial</option>
+                                            <option value="on" data-i18n="on">On</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_powerdescription"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_powerathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
+                                </div>
+                                <input type="hidden" name="attr_powerattackid">
+                                <input type="hidden" name="attr_powerlevel" value="4">
+                            </div>
+                            <div class="display">
+                                <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:power} {{level=@{powerschool} @{powerlevel}}}  {{name=@{powername}}} {{castingtime=@{powercastingtime}}} {{range=@{powerrange}}} {{target=@{powertarget}}}  {{duration=@{powerduration}}} {{description=@{powerdescription}}} {{athigherlevels=@{powerathigherlevels}}}  {{innate=@{innate}}} @{powerconcentration} @{charname_output}">
+                                <input type="checkbox" name="attr_powerprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
+                                <button class="powercard" type="roll" name="roll_power" value="@{rollcontent}">
+                                    <span class="powername" name="attr_powername"></span>
+                                    <input class="innate_flag" type="hidden" name="attr_innate" value="">
+                                    <span class="innate" name="attr_innate"></span>
+                                </button>
+                                <input type="hidden" class="powerconcentration" name="attr_powerconcentration" value="0">
+                                <span class="powerconcentration" data-i18n="power-concentration">C</span>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+    <!-- Edited Spell Adding here ppl -->
+                <div class="power-level">
+                    <div class="level">
+                        <span class="label">5</span>
+                    </div>
+                </div>
+                <div class="power-container">
+                    <fieldset class="repeating_power-5">
+                        <div class="power">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_powername">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="school:-u">SCHOOL:</span>
+                                    <select name="attr_powerschool">
+                                        <option value="force" data-i18n="force">Force</option>
+                                        <option value="tech" data-i18n="tech">Tech</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="casting-time:-u">CASTING TIME:</span>
+                                    <input type="text" name="attr_powercastingtime">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_powerrange">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="target:-u">TARGET:</span>
+                                    <input type="text" name="attr_powertarget">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_powerconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration-u">CONCENTRATION</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="duration:-u">DURATION:</span>
+                                    <input type="text" name="attr_powerduration">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="power-ability-u">POWERCASTING ABILITY</span>
+                                    <select name="attr_power_ability">
+                                        <option value="0*" data-i18n="none-u">NONE</option>
+                                        <option value="power" data-i18n="power-u">POWER</option>
+                                        <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="innate:-u">INNATE:</span>
+                                    <input type="text" name="attr_innate" placeholder="1/day" value="">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="output:-u">OUTPUT:</span>
+                                    <select name="attr_poweroutput">
+                                        <option value="POWERCARD" data-i18n="powercard-u">POWERCARD</option>
+                                        <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
+                                    </select>
+                                </div>
+                                <input type="hidden" class="powerattackinfoflag" name="attr_poweroutput">
+                                <div class="powerattackinfo">
+                                    <div class="row">
+                                        <span data-i18n="power-atk:-u">POWER ATTACK:</span>
+                                        <select name="attr_powerattack">
+                                            <option value="None" data-i18n="none">None</option>
+                                            <option value="Melee" data-i18n="melee">Melee</option>
+                                            <option value="Ranged" data-i18n="ranged">Ranged</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage:-u">DAMAGE:</span>
+                                        <input type="text" name="attr_powerdamage" style="width: 50px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_powerdamagetype" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                        <input type="text" name="attr_powerdamage2" style="width: 45px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_powerdamagetype2" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="healing:-u">HEALING:</span>
+                                        <input type="text" name="attr_powerhealing" style="width: 45px;">
+                                    </div>
+                                    <div class="row">
+                                        <input type="checkbox" name="attr_powerdmgmod" value="Yes">
+                                        <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                        <select name="attr_powersave">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Strength" data-i18n="str-u">STR</option>
+                                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                            <option value="Constitution" data-i18n="con-u">CON</option>
+                                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                        </select>
+                                        <span data-i18n="effect:-u">EFFECT:</span>
+                                        <input type="text" name="attr_powersavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
+                                        <input type="text" name="attr_powerhldie" placeholder="1" style="width: 15px; text-align: right;">
+                                        <select name="attr_powerhldietype">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="d4">d4</option>
+                                            <option value="d6">d6</option>
+                                            <option value="d8">d8</option>
+                                            <option value="d10">d10</option>
+                                            <option value="d12">d12</option>
+                                            <option value="d20">d20</option>
+                                        </select>
+                                        <span>+</span>
+                                        <input type="text" name="attr_powerhlbonus" placeholder="0" style="width: 15px; text-align: center;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="include_power_desc:-u">INCLUDE POWER DESCRIPTION IN ATTACK:</span>
+                                        <select name="attr_includedesc">
+                                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                                            <option value="partial" data-i18n="partial">Partial</option>
+                                            <option value="on" data-i18n="on">On</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_powerdescription"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_powerathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
+                                </div>
+                                <input type="hidden" name="attr_powerattackid">
+                                <input type="hidden" name="attr_powerlevel" value="5">
+                            </div>
+                            <div class="display">
+                                <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:power} {{level=@{powerschool} @{powerlevel}}}  {{name=@{powername}}} {{castingtime=@{powercastingtime}}} {{range=@{powerrange}}} {{target=@{powertarget}}}  {{duration=@{powerduration}}} {{description=@{powerdescription}}} {{athigherlevels=@{powerathigherlevels}}}  {{innate=@{innate}}} @{powerconcentration} @{charname_output}">
+                                <input type="checkbox" name="attr_powerprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
+                                <button class="powercard" type="roll" name="roll_power" value="@{rollcontent}">
+                                    <span class="powername" name="attr_powername"></span>
+                                    <input class="innate_flag" type="hidden" name="attr_innate" value="">
+                                    <span class="innate" name="attr_innate"></span>
+                                </button>
+                                <input type="hidden" class="powerconcentration" name="attr_powerconcentration" value="0">
+                                <span class="powerconcentration" data-i18n="power-concentration">C</span>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+    <!-- Removed Components Here -->
+            </div>
+            <div class="col col3">
+    
+                <div class="power-level">
+                    <div class="level">
+                        <span class="label">6</span>
+                    </div>
+                </div>
+                <div class="power-container">
+                    <fieldset class="repeating_power-6">
+                        <div class="power">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_powername">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="school:-u">SCHOOL:</span>
+                                    <select name="attr_powerschool">
+                                        <option value="force" data-i18n="force">Force</option>
+                                        <option value="tech" data-i18n="tech">Tech</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="casting-time:-u">CASTING TIME:</span>
+                                    <input type="text" name="attr_powercastingtime">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_powerrange">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="target:-u">TARGET:</span>
+                                    <input type="text" name="attr_powertarget">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_powerconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration-u">CONCENTRATION</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="duration:-u">DURATION:</span>
+                                    <input type="text" name="attr_powerduration">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="power-ability-u">POWERCASTING ABILITY</span>
+                                    <select name="attr_power_ability">
+                                        <option value="0*" data-i18n="none-u">NONE</option>
+                                        <option value="power" data-i18n="power-u">POWER</option>
+                                        <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="innate:-u">INNATE:</span>
+                                    <input type="text" name="attr_innate" placeholder="1/day" value="">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="output:-u">OUTPUT:</span>
+                                    <select name="attr_poweroutput">
+                                        <option value="POWERCARD" data-i18n="powercard-u">POWERCARD</option>
+                                        <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
+                                    </select>
+                                </div>
+                                <input type="hidden" class="powerattackinfoflag" name="attr_poweroutput">
+                                <div class="powerattackinfo">
+                                    <div class="row">
+                                        <span data-i18n="power-atk:-u">POWER ATTACK:</span>
+                                        <select name="attr_powerattack">
+                                            <option value="None" data-i18n="none">None</option>
+                                            <option value="Melee" data-i18n="melee">Melee</option>
+                                            <option value="Ranged" data-i18n="ranged">Ranged</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage:-u">DAMAGE:</span>
+                                        <input type="text" name="attr_powerdamage" style="width: 50px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_powerdamagetype" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                        <input type="text" name="attr_powerdamage2" style="width: 45px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_powerdamagetype2" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="healing:-u">HEALING:</span>
+                                        <input type="text" name="attr_powerhealing" style="width: 45px;">
+                                    </div>
+                                    <div class="row">
+                                        <input type="checkbox" name="attr_powerdmgmod" value="Yes">
+                                        <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                        <select name="attr_powersave">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Strength" data-i18n="str-u">STR</option>
+                                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                            <option value="Constitution" data-i18n="con-u">CON</option>
+                                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                        </select>
+                                        <span data-i18n="effect:-u">EFFECT:</span>
+                                        <input type="text" name="attr_powersavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
+                                        <input type="text" name="attr_powerhldie" placeholder="1" style="width: 15px; text-align: right;">
+                                        <select name="attr_powerhldietype">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="d4">d4</option>
+                                            <option value="d6">d6</option>
+                                            <option value="d8">d8</option>
+                                            <option value="d10">d10</option>
+                                            <option value="d12">d12</option>
+                                            <option value="d20">d20</option>
+                                        </select>
+                                        <span>+</span>
+                                        <input type="text" name="attr_powerhlbonus" placeholder="0" style="width: 15px; text-align: center;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="include_power_desc:-u">INCLUDE POWER DESCRIPTION IN ATTACK:</span>
+                                        <select name="attr_includedesc">
+                                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                                            <option value="partial" data-i18n="partial">Partial</option>
+                                            <option value="on" data-i18n="on">On</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_powerdescription"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_powerathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
+                                </div>
+                                <input type="hidden" name="attr_powerattackid">
+                                <input type="hidden" name="attr_powerlevel" value="6">
+                            </div>
+                            <div class="display">
+                                <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:power} {{level=@{powerschool} @{powerlevel}}}  {{name=@{powername}}} {{castingtime=@{powercastingtime}}} {{range=@{powerrange}}} {{target=@{powertarget}}}  {{duration=@{powerduration}}} {{description=@{powerdescription}}} {{athigherlevels=@{powerathigherlevels}}}  {{innate=@{innate}}} @{powerconcentration} @{charname_output}">
+                                <input type="checkbox" name="attr_powerprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
+                                <button class="powercard" type="roll" name="roll_power" value="@{rollcontent}">
+                                    <span class="powername" name="attr_powername"></span>
+                                    <input class="innate_flag" type="hidden" name="attr_innate" value="">
+                                    <span class="innate" name="attr_innate"></span>
+                                </button>
+                                <input type="hidden" class="powerconcentration" name="attr_powerconcentration" value="0">
+                                <span class="powerconcentration" data-i18n="power-concentration">C</span>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+    
+                <div class="power-level">
+                    <div class="level">
+                        <span class="label">7</span>
+                    </div>
+                </div>
+                <div class="power-container">
+                    <fieldset class="repeating_power-7">
+                        <div class="power">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_powername">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="school:-u">SCHOOL:</span>
+                                    <select name="attr_powerschool">
+                                        <option value="force" data-i18n="force">Force</option>
+                                        <option value="tech" data-i18n="tech">Tech</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="casting-time:-u">CASTING TIME:</span>
+                                    <input type="text" name="attr_powercastingtime">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_powerrange">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="target:-u">TARGET:</span>
+                                    <input type="text" name="attr_powertarget">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_powerconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration-u">CONCENTRATION</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="duration:-u">DURATION:</span>
+                                    <input type="text" name="attr_powerduration">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="power-ability-u">POWERCASTING ABILITY</span>
+                                    <select name="attr_power_ability">
+                                        <option value="0*" data-i18n="none-u">NONE</option>
+                                        <option value="power" data-i18n="power-u">POWER</option>
+                                        <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="innate:-u">INNATE:</span>
+                                    <input type="text" name="attr_innate" placeholder="1/day" value="">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="output:-u">OUTPUT:</span>
+                                    <select name="attr_poweroutput">
+                                        <option value="POWERCARD" data-i18n="powercard-u">POWERCARD</option>
+                                        <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
+                                    </select>
+                                </div>
+                                <input type="hidden" class="powerattackinfoflag" name="attr_poweroutput">
+                                <div class="powerattackinfo">
+                                    <div class="row">
+                                        <span data-i18n="power-atk:-u">POWER ATTACK:</span>
+                                        <select name="attr_powerattack">
+                                            <option value="None" data-i18n="none">None</option>
+                                            <option value="Melee" data-i18n="melee">Melee</option>
+                                            <option value="Ranged" data-i18n="ranged">Ranged</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage:-u">DAMAGE:</span>
+                                        <input type="text" name="attr_powerdamage" style="width: 50px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_powerdamagetype" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                        <input type="text" name="attr_powerdamage2" style="width: 45px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_powerdamagetype2" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="healing:-u">HEALING:</span>
+                                        <input type="text" name="attr_powerhealing" style="width: 45px;">
+                                    </div>
+                                    <div class="row">
+                                        <input type="checkbox" name="attr_powerdmgmod" value="Yes">
+                                        <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                        <select name="attr_powersave">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Strength" data-i18n="str-u">STR</option>
+                                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                            <option value="Constitution" data-i18n="con-u">CON</option>
+                                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                        </select>
+                                        <span data-i18n="effect:-u">EFFECT:</span>
+                                        <input type="text" name="attr_powersavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
+                                        <input type="text" name="attr_powerhldie" placeholder="1" style="width: 15px; text-align: right;">
+                                        <select name="attr_powerhldietype">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="d4">d4</option>
+                                            <option value="d6">d6</option>
+                                            <option value="d8">d8</option>
+                                            <option value="d10">d10</option>
+                                            <option value="d12">d12</option>
+                                            <option value="d20">d20</option>
+                                        </select>
+                                        <span>+</span>
+                                        <input type="text" name="attr_powerhlbonus" placeholder="0" style="width: 15px; text-align: center;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="include_power_desc:-u">INCLUDE POWER DESCRIPTION IN ATTACK:</span>
+                                        <select name="attr_includedesc">
+                                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                                            <option value="partial" data-i18n="partial">Partial</option>
+                                            <option value="on" data-i18n="on">On</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_powerdescription"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_powerathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
+                                </div>
+                                <input type="hidden" name="attr_powerattackid">
+                                <input type="hidden" name="attr_powerlevel" value="7">
+                            </div>
+                            <div class="display">
+                                <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:power} {{level=@{powerschool} @{powerlevel}}}  {{name=@{powername}}} {{castingtime=@{powercastingtime}}} {{range=@{powerrange}}} {{target=@{powertarget}}}  {{duration=@{powerduration}}} {{description=@{powerdescription}}} {{athigherlevels=@{powerathigherlevels}}}  {{innate=@{innate}}} @{powerconcentration} @{charname_output}">
+                                <input type="checkbox" name="attr_powerprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
+                                <button class="powercard" type="roll" name="roll_power" value="@{rollcontent}">
+                                    <span class="powername" name="attr_powername"></span>
+                                    <input class="innate_flag" type="hidden" name="attr_innate" value="">
+                                    <span class="innate" name="attr_innate"></span>
+                                </button>
+                                <input type="hidden" class="powerconcentration" name="attr_powerconcentration" value="0">
+                                <span class="powerconcentration" data-i18n="power-concentration">C</span>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+    
+                <div class="power-level">
+                    <div class="level">
+                        <span class="label">8</span>
+                    </div>
+                </div>
+                <div class="power-container">
+                    <fieldset class="repeating_power-8">
+                        <div class="power">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_powername">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="school:-u">SCHOOL:</span>
+                                    <select name="attr_powerschool">
+                                        <option value="force" data-i18n="force">Force</option>
+                                        <option value="tech" data-i18n="tech">Tech</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="casting-time:-u">CASTING TIME:</span>
+                                    <input type="text" name="attr_powercastingtime">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_powerrange">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="target:-u">TARGET:</span>
+                                    <input type="text" name="attr_powertarget">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_powerconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration-u">CONCENTRATION</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="duration:-u">DURATION:</span>
+                                    <input type="text" name="attr_powerduration">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="power-ability-u">POWERCASTING ABILITY</span>
+                                    <select name="attr_power_ability">
+                                        <option value="0*" data-i18n="none-u">NONE</option>
+                                        <option value="power" data-i18n="power-u">POWER</option>
+                                        <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="innate:-u">INNATE:</span>
+                                    <input type="text" name="attr_innate" placeholder="1/day" value="">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="output:-u">OUTPUT:</span>
+                                    <select name="attr_poweroutput">
+                                        <option value="POWERCARD" data-i18n="powercard-u">POWERCARD</option>
+                                        <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
+                                    </select>
+                                </div>
+                                <input type="hidden" class="powerattackinfoflag" name="attr_poweroutput">
+                                <div class="powerattackinfo">
+                                    <div class="row">
+                                        <span data-i18n="power-atk:-u">POWER ATTACK:</span>
+                                        <select name="attr_powerattack">
+                                            <option value="None" data-i18n="none">None</option>
+                                            <option value="Melee" data-i18n="melee">Melee</option>
+                                            <option value="Ranged" data-i18n="ranged">Ranged</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage:-u">DAMAGE:</span>
+                                        <input type="text" name="attr_powerdamage" style="width: 50px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_powerdamagetype" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                        <input type="text" name="attr_powerdamage2" style="width: 45px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_powerdamagetype2" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="healing:-u">HEALING:</span>
+                                        <input type="text" name="attr_powerhealing" style="width: 45px;">
+                                    </div>
+                                    <div class="row">
+                                        <input type="checkbox" name="attr_powerdmgmod" value="Yes">
+                                        <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                        <select name="attr_powersave">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Strength" data-i18n="str-u">STR</option>
+                                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                            <option value="Constitution" data-i18n="con-u">CON</option>
+                                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                        </select>
+                                        <span data-i18n="effect:-u">EFFECT:</span>
+                                        <input type="text" name="attr_powersavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
+                                        <input type="text" name="attr_powerhldie" placeholder="1" style="width: 15px; text-align: right;">
+                                        <select name="attr_powerhldietype">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="d4">d4</option>
+                                            <option value="d6">d6</option>
+                                            <option value="d8">d8</option>
+                                            <option value="d10">d10</option>
+                                            <option value="d12">d12</option>
+                                            <option value="d20">d20</option>
+                                        </select>
+                                        <span>+</span>
+                                        <input type="text" name="attr_powerhlbonus" placeholder="0" style="width: 15px; text-align: center;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="include_power_desc:-u">INCLUDE POWER DESCRIPTION IN ATTACK:</span>
+                                        <select name="attr_includedesc">
+                                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                                            <option value="partial" data-i18n="partial">Partial</option>
+                                            <option value="on" data-i18n="on">On</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_powerdescription"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_powerathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
+                                </div>
+                                <input type="hidden" name="attr_powerattackid">
+                                <input type="hidden" name="attr_powerlevel" value="8">
+                            </div>
+                            <div class="display">
+                                <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:power} {{level=@{powerschool} @{powerlevel}}}  {{name=@{powername}}} {{castingtime=@{powercastingtime}}} {{range=@{powerrange}}} {{target=@{powertarget}}}  {{duration=@{powerduration}}} {{description=@{powerdescription}}} {{athigherlevels=@{powerathigherlevels}}}  {{innate=@{innate}}} @{powerconcentration} @{charname_output}">
+                                <input type="checkbox" name="attr_powerprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
+                                <button class="powercard" type="roll" name="roll_power" value="@{rollcontent}">
+                                    <span class="powername" name="attr_powername"></span>
+                                    <input class="innate_flag" type="hidden" name="attr_innate" value="">
+                                    <span class="innate" name="attr_innate"></span>
+                                </button>
+                                <input type="hidden" class="powerconcentration" name="attr_powerconcentration" value="0">
+                                <span class="powerconcentration" data-i18n="power-concentration">C</span>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+    
+                <div class="power-level">
+                    <div class="level">
+                        <span class="label">9</span>
+                    </div>
+                </div>
+                <div class="power-container">
+                    <fieldset class="repeating_power-9">
+                        <div class="power">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_powername">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="school:-u">SCHOOL:</span>
+                                    <select name="attr_powerschool">
+                                        <option value="force" data-i18n="force">Force</option>
+                                        <option value="tech" data-i18n="tech">Tech</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="casting-time:-u">CASTING TIME:</span>
+                                    <input type="text" name="attr_powercastingtime">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_powerrange">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="target:-u">TARGET:</span>
+                                    <input type="text" name="attr_powertarget">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_powerconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration-u">CONCENTRATION</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="duration:-u">DURATION:</span>
+                                    <input type="text" name="attr_powerduration">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="power-ability-u">POWERCASTING ABILITY</span>
+                                    <select name="attr_power_ability">
+                                        <option value="0*" data-i18n="none-u">NONE</option>
+                                        <option value="power" data-i18n="power-u">POWER</option>
+                                        <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="innate:-u">INNATE:</span>
+                                    <input type="text" name="attr_innate" placeholder="1/day" value="">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="output:-u">OUTPUT:</span>
+                                    <select name="attr_poweroutput">
+                                        <option value="POWERCARD" data-i18n="powercard-u">POWERCARD</option>
+                                        <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
+                                    </select>
+                                </div>
+                                <input type="hidden" class="powerattackinfoflag" name="attr_poweroutput">
+                                <div class="powerattackinfo">
+                                    <div class="row">
+                                        <span data-i18n="power-atk:-u">POWER ATTACK:</span>
+                                        <select name="attr_powerattack">
+                                            <option value="None" data-i18n="none">None</option>
+                                            <option value="Melee" data-i18n="melee">Melee</option>
+                                            <option value="Ranged" data-i18n="ranged">Ranged</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage:-u">DAMAGE:</span>
+                                        <input type="text" name="attr_powerdamage" style="width: 50px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_powerdamagetype" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                        <input type="text" name="attr_powerdamage2" style="width: 45px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_powerdamagetype2" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="healing:-u">HEALING:</span>
+                                        <input type="text" name="attr_powerhealing" style="width: 45px;">
+                                    </div>
+                                    <div class="row">
+                                        <input type="checkbox" name="attr_powerdmgmod" value="Yes">
+                                        <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                        <select name="attr_powersave">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Strength" data-i18n="str-u">STR</option>
+                                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                            <option value="Constitution" data-i18n="con-u">CON</option>
+                                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                        </select>
+                                        <span data-i18n="effect:-u">EFFECT:</span>
+                                        <input type="text" name="attr_powersavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
+                                        <input type="text" name="attr_powerhldie" placeholder="1" style="width: 15px; text-align: right;">
+                                        <select name="attr_powerhldietype">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="d4">d4</option>
+                                            <option value="d6">d6</option>
+                                            <option value="d8">d8</option>
+                                            <option value="d10">d10</option>
+                                            <option value="d12">d12</option>
+                                            <option value="d20">d20</option>
+                                        </select>
+                                        <span>+</span>
+                                        <input type="text" name="attr_powerhlbonus" placeholder="0" style="width: 15px; text-align: center;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="include_power_desc:-u">INCLUDE POWER DESCRIPTION IN ATTACK:</span>
+                                        <select name="attr_includedesc">
+                                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                                            <option value="partial" data-i18n="partial">Partial</option>
+                                            <option value="on" data-i18n="on">On</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_powerdescription"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_powerathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
+                                </div>
+                                <input type="hidden" name="attr_powerattackid">
+                                <input type="hidden" name="attr_powerlevel" value="9">
+                            </div>
+                            <div class="display">
+                                <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:power} {{level=@{powerschool} @{powerlevel}}}  {{name=@{powername}}} {{castingtime=@{powercastingtime}}} {{range=@{powerrange}}} {{target=@{powertarget}}} {{duration=@{powerduration}}} {{description=@{powerdescription}}} {{athigherlevels=@{powerathigherlevels}}}  {{innate=@{innate}}} @{powerconcentration} @{charname_output}">
+                                <input type="checkbox" name="attr_powerprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
+                                <button class="powercard" type="roll" name="roll_power" value="@{rollcontent}">
+                                    <span class="powername" name="attr_powername"></span>
+                                    <input class="innate_flag" type="hidden" name="attr_innate" value="">
+                                    <span class="innate" name="attr_innate"></span>
+                                </button>
+                                <input type="hidden" class="powerconcentration" name="attr_powerconcentration" value="0">
+                                <span class="powerconcentration" data-i18n="power-concentration">C</span>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+    
+            </div>
+        </div>
+    </div>
+        
+    <div class="page options">
+        <div class="header">
+            <div class="name-container">
+                <img src="https://s22.postimg.cc/jnlp8fqc1/Star_Wars_5_E_Logo_Shrunk.png" style="padding-bottom: 10px;">
+                <input type="text" name="attr_character_name" style="width: 100%;">
+                <span class="label" data-i18n="char-name-u">CHARACTER NAME</span>
+            </div>
+            <input class="options-flag" type="checkbox" name="attr_options-class-selection" checked="checked"><span>y</span>
+            <div class="header-info sheet-options">
+                <div class="sheet-row" style="border-top: 2px dashed gold;">
+                    <span data-i18n="class:-u">CLASS:</span>
+                    <input type="hidden" name="attr_custom_class" class="sheet-flag">
+                    <select class="hiding class" name="attr_class">
+                        <option value="" data-i18n="choose">Choose</option>
+                        <option value="Berzerker" data-i18n="berzerker">Berzerker</option>
+                        <option value="Scholar" data-i18n="scholar">Scholar</option>
+                        <option value="Engineer" data-i18n="engineer">Engineer</option>
+                        <option value="Fighter" data-i18n="fighter">Fighter</option>
+                        <option value="Monk" data-i18n="monk">Monk</option>
+                        <option value="Guardian" data-i18n="guardian">Guardian</option>
+                        <option value="Scout" data-i18n="scout">Scout</option>
+                        <option value="Infiltrator" data-i18n="infiltrator">Infiltrator</option>
+                        <option value="Sentinel" data-i18n="sentinel">Sentinel</option>
+                        <option value="Consular" data-i18n="consular">Consular</option>
+                    </select>
+                    <input type="text" class="showing" name="attr_cust_classname" style="width: 90px;">
+                    <span data-i18n="subclass:-u">SUBCLASS:</span>
+                    <input type="text" name="attr_subclass">
+                    <span data-i18n="lvl:-u">LEVEL:</span>
+                    <input type="number" class="class-level" style="width: 40px" name="attr_base_level" value="1">
+                </div>
+                <div class="sheet-row">
+                    <span data-i18n="race:-u">RACE:</span>
+                    <input type="text" name="attr_race">
+                    <span data-i18n="subrace:-u">SUBRACE:</span>
+                    <input type="text" name="attr_subrace">
                 </div>
             </div>
-            <div class="save_options" style="width: 234px;">
-                <div class="row skill">
-                    <span data-i18n="strength-save-u">Strength Save</span>
-                    <span>+</span><input type="text" class="num" name="attr_strength_save_mod" value="0" placeholder="0" title="@{strength_save_mod}">
-                </div>
-                <div class="row skill">
-                    <span data-i18n="dexterity-save-u">Dexterity Save</span>
-                    <span>+</span><input type="text" class="num" name="attr_dexterity_save_mod" value="0" placeholder="0" title="@{dexterity_save_mod}">
-                </div>
-                <div class="row skill">
-                    <span data-i18n="constitution-save-u">Constitution Save</span>
-                    <span>+</span><input type="text" class="num" name="attr_constitution_save_mod" value="0" placeholder="0" title="@{constitution_save_mod}">
-                </div>
-                <div class="row skill">
-                    <span data-i18n="intelligence-save-u">Intelligence Save</span>
-                    <span>+</span><input type="text" class="num" name="attr_intelligence_save_mod" value="0" placeholder="0" title="@{intelligence_save_mod}">
-                </div>
-                <div class="row skill">
-                    <span data-i18n="wisdom-save-u">Wisdom Save</span>
-                    <span>+</span><input type="text" class="num" name="attr_wisdom_save_mod" value="0" placeholder="0" title="@{wisdom_save_mod}">
-                </div>
-                <div class="row skill">
-                    <span data-i18n="charisma-save-u">Charisma Save</span>
-                    <span>+</span><input type="text" class="num" name="attr_charisma_save_mod" value="0" placeholder="0" title="@{charisma_save_mod}">
-                </div>
-                <div class="row">
-                    <span data-i18n="death-save-mod:-u">DEATH SAVE MODIFIER:</span>
-                    <input type="text" class="num" name="attr_death_save_mod" placeholder="0" value="0">
-                </div>
-                <div class="row">
-                    <span data-i18n="glob-saving-mod:-u">GLOBAL SAVING THROW MODIFIER:</span>
-                    <input type="text" class="num" name="attr_globalsavemod" placeholder="0" value="0">
-                </div>
-                <div class="row title">
-                    <span data-i18n="save-opts-u">SAVE OPTIONS</span>
-                </div>
-            </div>
-            <div class="skill_options" style="width: 234px;">
-                <div data-i18n-list="skills-list">
-                    <div class="row skill" data-i18n-list-item="acrobatics">
-                        <select name="attr_acrobatics_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
-                        <span data-i18n="acrobatics-core">Acrobatics <span>(Dex)</span></span>
-                        <span>+</span><input type="text" class="num" name="attr_acrobatics_flat" value="0" placeholder="0" title="@{acrobatics_flat}">
+            <div class="header-info sheet-display">
+                <div class="top">
+                    <div class="hlabel-container">
+                        <input type="text" name="attr_class_display" class="sheet-class-display sheet-no_events">
+                        <span class="label" data-i18n="class-level-u">CLASS & LEVEL</span>
                     </div>
-                    <div class="row skill" data-i18n-list-item="animal_handling">
-                        <select name="attr_animal_handling_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
-                        <span data-i18n="animal_handling-core">Animal Handling <span>(Wis)</span></span>
-                        <span>+</span><input type="text" class="num" name="attr_animal_handling_flat" value="0" placeholder="0" title="@{animal_handling_flat}">
-                    </div>
-                    <div class="row skill" data-i18n-list-item="technology">
-                        <select name="attr_technology_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
-                        <span data-i18n="technology-core">Technology <span>(Int)</span></span>
-                        <span>+</span><input type="text" class="num" name="attr_technology_flat" value="0" placeholder="0" title="@{technology_flat}">
-                    </div>
-                    <div class="row skill" data-i18n-list-item="athletics">
-                        <select name="attr_athletics_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
-                        <span data-i18n="athletics-core">Athletics <span>(Str)</span></span>
-                        <span>+</span><input type="text" class="num" name="attr_athletics_flat" value="0" placeholder="0" title="@{athletics_flat}">
-                    </div>
-                    <div class="row skill" data-i18n-list-item="deception">
-                        <select name="attr_deception_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
-                        <span data-i18n="deception-core">Deception <span>(Cha)</span></span>
-                        <span>+</span><input type="text" class="num" name="attr_deception_flat" value="0" placeholder="0" title="@{deception_flat}">
-                    </div>
-                    <div class="row skill" data-i18n-list-item="lore">
-                        <select name="attr_lore_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
-                        <span data-i18n="lore-core">Lore <span>(Int)</span></span>
-                        <span>+</span><input type="text" class="num" name="attr_lore_flat" value="0" placeholder="0" title="@{lore_flat}">
-                    </div>
-                    <div class="row skill" data-i18n-list-item="insight">
-                        <select name="attr_insight_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
-                        <span data-i18n="insight-core">Insight <span>(Wis)</span></span>
-                        <span>+</span><input type="text" class="num" name="attr_insight_flat" value="0" placeholder="0" title="@{insight_flat}">
-                    </div>
-                    <div class="row skill" data-i18n-list-item="intimidation">
-                        <select name="attr_intimidation_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
-                        <span data-i18n="intimidation-core">Intimidation <span>(Cha)</span></span>
-                        <span>+</span><input type="text" class="num" name="attr_intimidation_flat" value="0" placeholder="0" title="@{intimidation_flat}">
-                    </div>
-                    <div class="row skill" data-i18n-list-item="investigation">
-                        <select name="attr_investigation_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
-                        <span data-i18n="investigation-core">Investigation <span>(Int)</span></span>
-                        <span>+</span><input type="text" class="num" name="attr_investigation_flat" value="0" placeholder="0" title="@{investigation_flat}">
-                    </div>
-                    <div class="row skill" data-i18n-list-item="medicine">
-                        <select name="attr_medicine_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
-                        <span data-i18n="medicine-core">Medicine <span>(Wis)</span></span>
-                        <span>+</span><input type="text" class="num" name="attr_medicine_flat" value="0" placeholder="0" title="@{medicine_flat}">
-                    </div>
-                    <div class="row skill" data-i18n-list-item="nature">
-                        <select name="attr_nature_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
-                        <span data-i18n="nature-core">Nature <span>(Int)</span></span>
-                        <span>+</span><input type="text" class="num" name="attr_nature_flat" value="0" placeholder="0" title="@{nature_flat}">
-                    </div>
-                    <div class="row skill" data-i18n-list-item="perception">
-                        <select name="attr_perception_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
-                        <span data-i18n="perception-core">Perception <span>(Wis)</span></span>
-                        <span>+</span><input type="text" class="num" name="attr_perception_flat" value="0" placeholder="0" title="@{perception_flat}">
-                    </div>
-                    <div class="row skill" data-i18n-list-item="performance">
-                        <select name="attr_performance_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
-                        <span data-i18n="performance-core">Performance <span>(Cha)</span></span>
-                        <span>+</span><input type="text" class="num" name="attr_performance_flat" value="0" placeholder="0" title="@{performance_flat}">
-                    </div>
-                    <div class="row skill" data-i18n-list-item="persuasion">
-                        <select name="attr_persuasion_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
-                        <span data-i18n="persuasion-core">Persuasion <span>(Cha)</span></span>
-                        <span>+</span><input type="text" class="num" name="attr_persuasion_flat" value="0" placeholder="0" title="@{persuasion_flat}">
-                    </div>
-                    <div class="row skill" data-i18n-list-item="piloting">
-                        <select name="attr_piloting_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
-                        <span data-i18n="piloting-core">Piloting <span>(Int)</span></span>
-                        <span>+</span><input type="text" class="num" name="attr_piloting_flat" value="0" placeholder="0" title="@{piloting_flat}">
-                    </div>
-                    <div class="row skill" data-i18n-list-item="sleight_of_hand">
-                        <select name="attr_sleight_of_hand_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
-                        <span data-i18n="sleight_of_hand-core">Sleight of Hand <span>(Dex)</span></span>
-                        <span>+</span><input type="text" class="num" name="attr_sleight_of_hand_flat" value="0" placeholder="0" title="@{sleight_of_hand_flat}">
-                    </div>
-                    <div class="row skill" data-i18n-list-item="stealth">
-                        <select name="attr_stealth_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
-                        <span data-i18n="stealth-core">Stealth <span>(Dex)</span></span>
-                        <span>+</span><input type="text" class="num" name="attr_stealth_flat" value="0" placeholder="0" title="@{stealth_flat}">
-                    </div>
-                    <div class="row skill" data-i18n-list-item="survival">
-                        <select name="attr_survival_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
-                        <span data-i18n="survival-core">Survival <span>(Wis)</span></span>
-                        <span>+</span><input type="text" class="num" name="attr_survival_flat" value="0" placeholder="0" title="@{survival_flat}">
+                    <div class="hlabel-container">
+                        <input type="text" name="attr_background" style="width: 182px;">
+                        <span class="label" data-i18n="background-u">BACKGROUND</span>
                     </div>
                 </div>
-                <div class="row" style="margin-top:10px;">
-                    <input type="checkbox" name="attr_jack_of_all_trades" value="@{jack}">
-                    <span data-i18n="jack-of-all-u">JACK OF ALL TRADES</span>
-                </div>
-                <div class="row">
-                    <span data-i18n="pass-perc-mod:-u">PASSIVE PERCEPTION MODIFIER:</span>
-                    <input type="text" class="num" name="attr_passiveperceptionmod" placeholder="0" value="0">
-                </div>
-                <div class="row title">
-                    <span data-i18n="skill-opts-u">SKILL OPTIONS</span>
+                <div class="bottom">
+                    <div class="hlabel-container">
+                        <input type="text" name="attr_race_display" class="sheet-no_events">
+                        <span class="label" data-i18n="race-u">RACE</span>
+                    </div>
+                    <div class="hlabel-container">
+                        <input type="text" name="attr_alignment">
+                        <span class="label" data-i18n="alignment-u">ALIGNMENT</span>
+                    </div>
+                    <div class="hlabel-container">
+                        <input type="text" name="attr_experience">
+                        <span class="label" data-i18n="exp-pts-u">EXPERIENCE POINTS</span>
+                    </div>
                 </div>
             </div>
         </div>
-        <div class="col col3">
-            <div class="general_options">
-                <div class="version">
-                    <span data-i18n="version">v</span>
-                    <input type="text" name="attr_version">
+        <div class="body">
+            <div class="col col1">
+                <div class="class_options">
+                    <div class="row">
+                        <span data-i18n="hit-die:-u">HIT DIE:</span>
+                        <select name="attr_hitdietype">
+                            <option value="4">D4</option>
+                            <option value="6">D6</option>
+                            <option value="8">D8</option>
+                            <option value="10">D10</option>
+                            <option value="12">D12</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="carrying-capacity-mod:-u">CARRYING CAPACITY MODIFIER:</span>
+                        <input type="text" class="num" name="attr_carrying_capacity_mod" placeholder="*2">
+                    </div>
+                    <div class="row">
+                        <span data-i18n="glob-atk-mod:-u">GLOBAL POWER ATTACK MODIFIER:</span>
+                        <input type="text" class="num" name="attr_globalpowermod" placeholder="0" value="0">
+                    </div>
+                    <div class="row">
+                        <span data-i18n="power-caster-lvl:-u">POWER CASTER LEVEL:</span>
+                        <input type="text" class="num" name="attr_caster_level">
+                    </div>
+                    <div class="row">
+                        <span data-i18n="power_dc_mod:-u">POWER SAVE DC MOD:</span>
+                        <input type="text" class="num" name="attr_power_dc_mod" placeholde="0" value="0">
+                    </div>
+                    <div class="row">
+                        <span data-i18n="power-icons:-u">POWER ICONS:</span>
+                        <select name="attr_powericon_flag">
+                            <option value="all" data-i18n="show_all">Show All</option>
+                            <option value="cp" data-i18n="cr_only">C&R Only</option>
+                            <option value="none" data-i18n="none">None</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <input type="checkbox" name="attr_precognition_flag" value="1">
+                        <span data-i18n="precognition-u">PRECOGNITION (REROLL ONES)</span>
+                    </div>
+                    <div class="row">
+                        <input type="checkbox" name="attr_tech_fighter" value="1">
+                        <span data-i18n="tech-fighter-u">TECH FIGHTER</span>
+                    </div>
+                    <div class="row">
+                        <input type="checkbox" name="attr_tech_infiltrator" value="1">
+                        <span data-i18n="tech-infiltrator-u">TECH INFILTRATOR</span>
+                    </div>
+                    <div class="row title">
+                        <span data-i18n="class-options-u">CLASS OPTIONS</span>
+                    </div>
                 </div>
+                <div class="class_options">
+                    <div class="row">
+                        <input type="checkbox" name="attr_multiclass1_flag" value="1">
+                        <span data-i18n="2nd-class:-u">2ND CLASS:</span>
+                        <select name="attr_multiclass1" style="width: 64px;">
+                            <option value="berzerker" data-i18n="berzerker">Berzerker</option>
+                            <option value="scholar" data-i18n="scholar">Scholar</option>
+                            <option value="engineer" data-i18n="engineer">Engineer</option>
+                            <option value="fighter" data-i18n="fighter">Fighter</option>
+                            <option value="monk" data-i18n="monk">Monk</option>
+                            <option value="guardian" data-i18n="guardian">Guardian</option>
+                            <option value="scout" data-i18n="scout">Scout</option>
+                            <option value="infiltrator" data-i18n="infiltrator">Infiltrator</option>
+                            <option value="sentinel" data-i18n="sentinel">Sentinel</option>
+                            <option value="consular" data-i18n="consular">Consular</option>
+                        </select>
+                        <span data-i18n="lvl:-u">LEVEL:</span>
+                        <input type="text" name="attr_multiclass1_lvl" value="1" style="width: 28px; text-align: center;">
+                        <span data-i18n="subclass:-u" class="sheet-subclass">SUBCLASS:</span>
+                        <input type="text" name="attr_multiclass1_subclass">
+                    </div>
+                    <div class="row">
+                        <input type="checkbox" name="attr_multiclass2_flag" value="1">
+                        <span data-i18n="3rd-class:-u">3RD CLASS:</span>
+                        <select name="attr_multiclass2" style="width: 64px;">
+                            <option value="berzerker" data-i18n="berzerker">Berzerker</option>
+                            <option value="scholar" data-i18n="scholar">Scholar</option>
+                            <option value="engineer" data-i18n="engineer">Engineer</option>
+                            <option value="fighter" data-i18n="fighter">Fighter</option>
+                            <option value="monk" data-i18n="monk">Monk</option>
+                            <option value="guardian" data-i18n="guardian">Guardian</option>
+                            <option value="scout" data-i18n="scout">Scout</option>
+                            <option value="infiltrator" data-i18n="infiltrator">Infiltrator</option>
+                            <option value="sentinel" data-i18n="sentinel">Sentinel</option>
+                            <option value="consular" data-i18n="consular">Consular</option>
+                        </select>
+                        <span data-i18n="lvl:-u">LEVEL:</span>
+                        <input type="text" name="attr_multiclass2_lvl" value="1" style="width: 28px; text-align: center;">
+                        <span data-i18n="subclass:-u" class="sheet-subclass">SUBCLASS:</span>
+                        <input type="text" name="attr_multiclass2_subclass">
+                    </div>
+                    <div class="row">
+                        <input type="checkbox" name="attr_multiclass3_flag" value="1">
+                        <span data-i18n="4th-class:-u">4TH CLASS:</span>
+                        <select name="attr_multiclass3" style="width: 64px;">
+                            <option value="berzerker" data-i18n="berzerker">Berzerker</option>
+                            <option value="scholar" data-i18n="scholar">Scholar</option>
+                            <option value="engineer" data-i18n="engineer">Engineer</option>
+                            <option value="fighter" data-i18n="fighter">Fighter</option>
+                            <option value="monk" data-i18n="monk">Monk</option>
+                            <option value="guardian" data-i18n="guardian">Guardian</option>
+                            <option value="scout" data-i18n="scout">Scout</option>
+                            <option value="infiltrator" data-i18n="infiltrator">Infiltrator</option>
+                            <option value="sentinel" data-i18n="sentinel">Sentinel</option>
+                            <option value="consular" data-i18n="consular">Consular</option>
+                        </select>
+                        <span data-i18n="lvl:-u">LEVEL:</span>
+                        <input type="text" name="attr_multiclass3_lvl" value="1" style="width: 28px; text-align: center;">
+                        <span data-i18n="subclass:-u" class="sheet-subclass">SUBCLASS:</span>
+                        <input type="text" name="attr_multiclass3_subclass">
+                    </div>
+                    <div class="row title">
+                        <span data-i18n="mutliclass-opts-u">MULTICLASS OPTIONS</span>
+                    </div>
+                </div>
+                <div class="class_options">
+                    <div class="row">
+                        <input type="checkbox" name="attr_custom_class" value="1">
+                        <span data-i18n="use-cust-class-u">USE CUSTOM CLASS</span>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="class-name:-u">CLASS NAME:</span>
+                        <input type="text" name="attr_cust_classname">
+                    </div>
+                    <div class="row">
+                        <span data-i18n="hit-die:-u">HIT DIE:</span>
+                        <select name="attr_cust_hitdietype">
+                            <option value="4">D4</option>
+                            <option value="6">D6</option>
+                            <option value="8">D8</option>
+                            <option value="10">D10</option>
+                            <option value="12">D12</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="powercasting-ability:-u">POWERCASTING ABILITY:</span>
+                        <select name="attr_cust_powercasting_ability">
+                            <option value="0*" data-i18n="none-u">NONE</option>
+                            <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                            <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                            <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                            <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                            <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                            <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="power-slots:-u">POWER SLOTS:</span>
+                        <select name="attr_cust_powerslots">
+                            <option value="none" data-i18n="none-u">NONE</option>
+                            <option value="full" data-i18n="power-full-u">FULL (Engineer, Druid, Consular)</option>
+                            <option value="half" data-i18n="power-half-u">HALF (Guardian, Scout)</option>
+                            <option value="third" data-i18n="power-third-u">THIRD (Tech Fighter/Infiltrator)</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="saves-u">SAVES</span>
+                    </div>
+                    <div class="row">
+                        <input type="checkbox" name="attr_cust_strength_save_prof" value="(@{pb})">
+                        <span data-i18n="strength">Strength</span>
+                    </div>
+                    <div class="row">
+                        <input type="checkbox" name="attr_cust_dexterity_save_prof" value="(@{pb})">
+                        <span data-i18n="dexterity">Dexterity</span>
+                    </div>
+                    <div class="row">
+                        <input type="checkbox" name="attr_cust_constitution_save_prof" value="(@{pb})">
+                        <span data-i18n="constitution">Constitution</span>
+                    </div>
+                    <div class="row">
+                        <input type="checkbox" name="attr_cust_intelligence_save_prof" value="(@{pb})">
+                        <span data-i18n="intelligence">Intelligence</span>
+                    </div>
+                    <div class="row">
+                        <input type="checkbox" name="attr_cust_wisdom_save_prof" value="(@{pb})">
+                        <span data-i18n="wisdom">Wisdom</span>
+                    </div>
+                    <div class="row">
+                        <input type="checkbox" name="attr_cust_charisma_save_prof" value="(@{pb})">
+                        <span data-i18n="charisma">Charisma</span>
+                    </div>
+                    <div class="row title">
+                        <span data-i18n="cust-class-opts">CUSTOM CLASS OPTIONS</span>
+                    </div>
+                </div>
+            </div>
+            <div class="col col2">
+                <div class="attribute_options" style="width: 234px;">
+                    <div class="row skill">
+                        <span data-i18n="strength-u">STRENGTH</span>
+                        <span>+</span><input type="text" class="num" name="attr_strength_bonus" value="0" placeholder="0" title="@{strength_bonus}">
+                    </div>
+                    <div class="row skill">
+                        <span data-i18n="dexterity-u">DEXTERITY</span>
+                        <span>+</span><input type="text" class="num" name="attr_dexterity_bonus" value="0" placeholder="0" title="@{dexterity_bonus}">
+                    </div>
+                    <div class="row skill">
+                        <span data-i18n="constitution-u">CONSTITUTION</span>
+                        <span>+</span><input type="text" class="num" name="attr_constitution_bonus" value="0" placeholder="0" title="@{constitution_bonus}">
+                    </div>
+                    <div class="row skill">
+                        <span data-i18n="intelligence-u">INTELLIGENCE</span>
+                        <span>+</span><input type="text" class="num" name="attr_intelligence_bonus" value="0" placeholder="0" title="@{intelligence_bonus}">
+                    </div>
+                    <div class="row skill">
+                        <span data-i18n="wisdom-u">WISDOM</span>
+                        <span>+</span><input type="text" class="num" name="attr_wisdom_bonus" value="0" placeholder="0" title="@{wisdom_bonus}">
+                    </div>
+                    <div class="row skill">
+                        <span data-i18n="charisma-u">CHARISMA</span>
+                        <span>+</span><input type="text" class="num" name="attr_charisma_bonus" value="0" placeholder="0" title="@{charisma_bonus}">
+                    </div>
+                    <div class="row">
+                        <span data-i18n="initiative-mod:-u">INITIATIVE MODIFIER:</span>
+                        <input type="text" class="num" name="attr_initmod" placeholder="0" value="0">
+                    </div>
+                    <div class="row">
+                        <span data-i18n="initiative-style:-u">INITIATIVE STYLE:</span>
+                        <select name="attr_initiative_style">
+                            <option value="@{d20}" selected="selected" data-i18n="norm">Normal</option>
+                            <option value="{@{d20},@{d20}}kh1" data-i18n="adv">Advantage</option>
+                            <option value="{@{d20},@{d20}}kl1" data-i18n="disadv">Disadvantage</option>
+    <!--                         <option value="?{Advantage?|Normal Roll,&#64;&#123;d20&#125;|Advantage,&#123;&#64;&#123;d20&#125;&#44;&#64;&#123;d20&#125;&#125;kh1|Disadvantage,&#123;&#64;&#123;d20&#125;&#44;&#64;&#123;d20&#125;&#125;kl1}" data-i18n="query-roll-adv">Query Advantage</option> -->
+    <!-- Pajellen was here -->
+                        </select>
+                    </div>
+                    <div class="row">
+                            <input type="checkbox" name="attr_init_tiebreaker" value="@{dexterity}/100">
+                        <span data-i18n="add-dex-tiebreaker-u">ADD DEX TIEBREAKER TO INITIATIVE</span>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="glob-ac-mod:-u">GLOBAL ARMOR CLASS MODIFIER:</span>
+                        <input type="text" class="num" name="attr_globalacmod" placeholder="0" value="0">
+                    </div>
+                    <div class="row">
+                        <span data-i18n="armor-class-tracking:-u">ARMOR CLASS TRACKING:</span>
+                        <select name="attr_custom_ac_flag">
+                            <option value="0" selected="selected" data-i18n="automatic">Automatic</option>
+                            <option value="1" data-i18n="custom">Custom</option>
+                            <option value="2" data-i18n="off">Off</option>
+                        </select>
+                    </div>
+                    <input class="toggleflag" type="hidden" name="attr_custom_ac_flag">
+                    <div class="row hidden">
+                        <span data-i18n="custom_ac:-u">CUSTOM AC:</span>
+                        <input type="text" class="num" name="attr_custom_ac_base" placeholde="10" value="10">
+                        <span>+</span>
+                        <select name="attr_custom_ac_part1">
+                            <option value="none" selected="selected" data-i18n="none-u">NONE</option>
+                            <option value="Strength" data-i18n="str-u">STR</option>
+                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                            <option value="Constitution" data-i18n="con-u">CON</option>
+                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                        </select>
+                        <span>+</span>
+                        <select name="attr_custom_ac_part2">
+                            <option value="none" selected="selected" data-i18n="none-u">NONE</option>
+                            <option value="Strength" data-i18n="str-u">STR</option>
+                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                            <option value="Constitution" data-i18n="con-u">CON</option>
+                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="hpmods:-u">HP MODIFIERS:</span>
+                    </div>
+                    <fieldset class="repeating_hpmod">
+                        <div style="padding-left: 15px;">
+                            <span data-i18n="source:-u">SOURCE:</span>
+                            <input type="text" name="attr_source">
+                            <span data-i18n="mod:-u">MOD:</span>
+                            <input type="text" name="attr_mod" class="num">
+                        </div>
+                    </fieldset>
+                    <div class="row title">
+                        <span data-i18n="attribute-opts-u">ATTRIBUTE OPTIONS</span>
+                    </div>
+                </div>
+                <div class="save_options" style="width: 234px;">
+                    <div class="row skill">
+                        <span data-i18n="strength-save-u">Strength Save</span>
+                        <span>+</span><input type="text" class="num" name="attr_strength_save_mod" value="0" placeholder="0" title="@{strength_save_mod}">
+                    </div>
+                    <div class="row skill">
+                        <span data-i18n="dexterity-save-u">Dexterity Save</span>
+                        <span>+</span><input type="text" class="num" name="attr_dexterity_save_mod" value="0" placeholder="0" title="@{dexterity_save_mod}">
+                    </div>
+                    <div class="row skill">
+                        <span data-i18n="constitution-save-u">Constitution Save</span>
+                        <span>+</span><input type="text" class="num" name="attr_constitution_save_mod" value="0" placeholder="0" title="@{constitution_save_mod}">
+                    </div>
+                    <div class="row skill">
+                        <span data-i18n="intelligence-save-u">Intelligence Save</span>
+                        <span>+</span><input type="text" class="num" name="attr_intelligence_save_mod" value="0" placeholder="0" title="@{intelligence_save_mod}">
+                    </div>
+                    <div class="row skill">
+                        <span data-i18n="wisdom-save-u">Wisdom Save</span>
+                        <span>+</span><input type="text" class="num" name="attr_wisdom_save_mod" value="0" placeholder="0" title="@{wisdom_save_mod}">
+                    </div>
+                    <div class="row skill">
+                        <span data-i18n="charisma-save-u">Charisma Save</span>
+                        <span>+</span><input type="text" class="num" name="attr_charisma_save_mod" value="0" placeholder="0" title="@{charisma_save_mod}">
+                    </div>
+                    <div class="row">
+                        <span data-i18n="death-save-mod:-u">DEATH SAVE MODIFIER:</span>
+                        <input type="text" class="num" name="attr_death_save_mod" placeholder="0" value="0">
+                    </div>
+                    <div class="row">
+                        <span data-i18n="glob-saving-mod:-u">GLOBAL SAVING THROW MODIFIER:</span>
+                        <input type="text" class="num" name="attr_globalsavemod" placeholder="0" value="0">
+                    </div>
+                    <div class="row title">
+                        <span data-i18n="save-opts-u">SAVE OPTIONS</span>
+                    </div>
+                </div>
+                <div class="skill_options" style="width: 234px;">
+                    <div data-i18n-list="skills-list">
+                        <div class="row skill" data-i18n-list-item="acrobatics">
+                            <select name="attr_acrobatics_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
+                            <span data-i18n="acrobatics-core">Acrobatics <span>(Dex)</span></span>
+                            <span>+</span><input type="text" class="num" name="attr_acrobatics_flat" value="0" placeholder="0" title="@{acrobatics_flat}">
+                        </div>
+                        <div class="row skill" data-i18n-list-item="animal_handling">
+                            <select name="attr_animal_handling_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
+                            <span data-i18n="animal_handling-core">Animal Handling <span>(Wis)</span></span>
+                            <span>+</span><input type="text" class="num" name="attr_animal_handling_flat" value="0" placeholder="0" title="@{animal_handling_flat}">
+                        </div>
+                        <div class="row skill" data-i18n-list-item="technology">
+                            <select name="attr_technology_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
+                            <span data-i18n="technology-core">Technology <span>(Int)</span></span>
+                            <span>+</span><input type="text" class="num" name="attr_technology_flat" value="0" placeholder="0" title="@{technology_flat}">
+                        </div>
+                        <div class="row skill" data-i18n-list-item="athletics">
+                            <select name="attr_athletics_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
+                            <span data-i18n="athletics-core">Athletics <span>(Str)</span></span>
+                            <span>+</span><input type="text" class="num" name="attr_athletics_flat" value="0" placeholder="0" title="@{athletics_flat}">
+                        </div>
+                        <div class="row skill" data-i18n-list-item="deception">
+                            <select name="attr_deception_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
+                            <span data-i18n="deception-core">Deception <span>(Cha)</span></span>
+                            <span>+</span><input type="text" class="num" name="attr_deception_flat" value="0" placeholder="0" title="@{deception_flat}">
+                        </div>
+                        <div class="row skill" data-i18n-list-item="lore">
+                            <select name="attr_lore_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
+                            <span data-i18n="lore-core">Lore <span>(Int)</span></span>
+                            <span>+</span><input type="text" class="num" name="attr_lore_flat" value="0" placeholder="0" title="@{lore_flat}">
+                        </div>
+                        <div class="row skill" data-i18n-list-item="insight">
+                            <select name="attr_insight_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
+                            <span data-i18n="insight-core">Insight <span>(Wis)</span></span>
+                            <span>+</span><input type="text" class="num" name="attr_insight_flat" value="0" placeholder="0" title="@{insight_flat}">
+                        </div>
+                        <div class="row skill" data-i18n-list-item="intimidation">
+                            <select name="attr_intimidation_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
+                            <span data-i18n="intimidation-core">Intimidation <span>(Cha)</span></span>
+                            <span>+</span><input type="text" class="num" name="attr_intimidation_flat" value="0" placeholder="0" title="@{intimidation_flat}">
+                        </div>
+                        <div class="row skill" data-i18n-list-item="investigation">
+                            <select name="attr_investigation_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
+                            <span data-i18n="investigation-core">Investigation <span>(Int)</span></span>
+                            <span>+</span><input type="text" class="num" name="attr_investigation_flat" value="0" placeholder="0" title="@{investigation_flat}">
+                        </div>
+                        <div class="row skill" data-i18n-list-item="medicine">
+                            <select name="attr_medicine_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
+                            <span data-i18n="medicine-core">Medicine <span>(Wis)</span></span>
+                            <span>+</span><input type="text" class="num" name="attr_medicine_flat" value="0" placeholder="0" title="@{medicine_flat}">
+                        </div>
+                        <div class="row skill" data-i18n-list-item="nature">
+                            <select name="attr_nature_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
+                            <span data-i18n="nature-core">Nature <span>(Int)</span></span>
+                            <span>+</span><input type="text" class="num" name="attr_nature_flat" value="0" placeholder="0" title="@{nature_flat}">
+                        </div>
+                        <div class="row skill" data-i18n-list-item="perception">
+                            <select name="attr_perception_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
+                            <span data-i18n="perception-core">Perception <span>(Wis)</span></span>
+                            <span>+</span><input type="text" class="num" name="attr_perception_flat" value="0" placeholder="0" title="@{perception_flat}">
+                        </div>
+                        <div class="row skill" data-i18n-list-item="performance">
+                            <select name="attr_performance_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
+                            <span data-i18n="performance-core">Performance <span>(Cha)</span></span>
+                            <span>+</span><input type="text" class="num" name="attr_performance_flat" value="0" placeholder="0" title="@{performance_flat}">
+                        </div>
+                        <div class="row skill" data-i18n-list-item="persuasion">
+                            <select name="attr_persuasion_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
+                            <span data-i18n="persuasion-core">Persuasion <span>(Cha)</span></span>
+                            <span>+</span><input type="text" class="num" name="attr_persuasion_flat" value="0" placeholder="0" title="@{persuasion_flat}">
+                        </div>
+                        <div class="row skill" data-i18n-list-item="piloting">
+                            <select name="attr_piloting_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
+                            <span data-i18n="piloting-core">Piloting <span>(Int)</span></span>
+                            <span>+</span><input type="text" class="num" name="attr_piloting_flat" value="0" placeholder="0" title="@{piloting_flat}">
+                        </div>
+                        <div class="row skill" data-i18n-list-item="sleight_of_hand">
+                            <select name="attr_sleight_of_hand_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
+                            <span data-i18n="sleight_of_hand-core">Sleight of Hand <span>(Dex)</span></span>
+                            <span>+</span><input type="text" class="num" name="attr_sleight_of_hand_flat" value="0" placeholder="0" title="@{sleight_of_hand_flat}">
+                        </div>
+                        <div class="row skill" data-i18n-list-item="stealth">
+                            <select name="attr_stealth_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
+                            <span data-i18n="stealth-core">Stealth <span>(Dex)</span></span>
+                            <span>+</span><input type="text" class="num" name="attr_stealth_flat" value="0" placeholder="0" title="@{stealth_flat}">
+                        </div>
+                        <div class="row skill" data-i18n-list-item="survival">
+                            <select name="attr_survival_type"><option value="1" selected="selected" data-i18n="normal">Normal</option><option value="2" data-i18n="expirtise">Expertise</option></select>
+                            <span data-i18n="survival-core">Survival <span>(Wis)</span></span>
+                            <span>+</span><input type="text" class="num" name="attr_survival_flat" value="0" placeholder="0" title="@{survival_flat}">
+                        </div>
+                    </div>
+                    <div class="row" style="margin-top:10px;">
+                        <input type="checkbox" name="attr_jack_of_all_trades" value="@{jack}">
+                        <span data-i18n="jack-of-all-u">JACK OF ALL TRADES</span>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="pass-perc-mod:-u">PASSIVE PERCEPTION MODIFIER:</span>
+                        <input type="text" class="num" name="attr_passiveperceptionmod" placeholder="0" value="0">
+                    </div>
+                    <div class="row title">
+                        <span data-i18n="skill-opts-u">SKILL OPTIONS</span>
+                    </div>
+                </div>
+            </div>
+            <div class="col col3">
+                <div class="general_options">
+                    <div class="version">
+                        <span data-i18n="version">v</span>
+                        <input type="text" name="attr_version">
+                    </div>
+                    <div class="row">
+                        <span>SHEET TYPE:</span>
+                        <select name="attr_npc">
+                            <option value="0">PC</option>
+                            <option value="1">NPC</option>
+                            <option value="2">Ship</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="roll-queries:-u">ROLL QUERIES:</span>
+                        <select name="attr_rtype">
+                            <option value="{{always=1}} {{r2=[[@{d20}" data-i18n="always-roll-adv">Always Roll Advantage</option>
+                            <option value="@{advantagetoggle}" data-i18n="toggle-roll-adv">Advantage Toggle</option>
+                            <option value="{{query=1}} ?{Advantage?|Normal Roll,&#123&#123normal=1&#125&#125 &#123&#123r2=[[0d20|Advantage,&#123&#123advantage=1&#125&#125 &#123&#123r2=[[@{d20}|Disadvantage,&#123&#123disadvantage=1&#125&#125 &#123&#123r2=[[@{d20}}" data-i18n="query-roll-adv">Query Advantage</option>
+                            <option value="{{normal=1}} {{r2=[[0d20" data-i18n="never-roll-adv">Never Roll Advantage</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="whisp-rolls-gm:-u">WHISPER ROLLS TO GM:</span>
+                        <select name="attr_wtype">
+                            <option value="" data-i18n="never-whisper-roll">Never Whisper Rolls</option>
+                            <option value="@{whispertoggle}" data-i18n="toggle-roll-whisper">Whisper Toggle</option>
+                            <option value="?{Whisper?|Public Roll,|Whisper Roll,/w gm }" data-i18n="query-whisper-roll">Query Whisper</option>
+                            <option value="/w gm " data-i18n="always-whisper-roll">Always Whisper Rolls</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="auto-dmg-roll:-u">AUTO DAMAGE ROLL:</span>
+                        <select class="dtype" name="attr_dtype">
+                            <option value="pick" data-i18n="never-roll-dmg">Don't Auto Roll Damage</option>
+                            <option value="full" data-i18n="always-roll-dmg">Auto Roll Damage & Crit</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="core-die-roll:-u">CORE DIE ROLL:</span>
+                        <input type="text" name="attr_core_die" value="1d20" placeholder="1d20" title="@{core_die}">
+                    </div>
+                    <div class="row">
+                        <span data-i18n="prof-bonus:-u">PROFICIENCY BONUS:</span>
+                        <select class="dtype" name="attr_pb_type">
+                            <option value="level" data-i18n="by-level">By Level (Default)</option>
+                            <option value="die" data-i18n="prof-die">Proficency Die (DMG)</option>
+                            <option value="custom" data-i18n="custom">Custom</option>
+                        </select>
+                        <input type="hidden" name="attr_pb_type">
+                        <input class="pb_custom" type="text" style="float:right;" name="attr_pb_custom" placeholder="2d10">
+                    </div>
+                    <div class="row">
+                        <input type="checkbox" name="attr_global_save_mod_flag" value="1">
+                        <span data-i18n="show-global-save-field-u">SHOW GLOBAL SAVE MODIFIER FIELD</span>
+                    </div>
+                    <div class="row">
+                        <input type="checkbox" name="attr_global_skill_mod_flag" value="1">
+                        <span data-i18n="show-global-skill-field-u">SHOW GLOBAL SKILL MODIFIER FIELD</span>
+                    </div>
+                    <div class="row">
+                        <input type="checkbox" name="attr_global_attack_mod_flag" value="1">
+                        <span data-i18n="show-global-attack-field-u">SHOW GLOBAL ATTACK MODIFIER FIELD</span>
+                    </div>
+                    <div class="row">
+                        <input type="checkbox" name="attr_global_damage_mod_flag" value="1">
+                        <span data-i18n="show-global-damage-field-u">SHOW GLOBAL DAMAGE MODIFIER FIELD</span>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="add-char-to-templates:-u">ADD CHARACTER NAME TO TEMPLATES:</span>
+                        <select class="dtype" name="attr_charname_output">
+                            <option value="{{charname=@{character_name}}}" data-i18n="on">On</option>
+                            <option value="charname=@{character_name}" selected="selected" data-i18n="off">Off</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="level-calculations:-u">LEVEL CALCULATIONS:</span>
+                        <select class="dtype" name="attr_level_calculations">
+                            <option value="on" selected="selected" data-i18n="on">On</option>
+                            <option value="off" data-i18n="off">Off</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="encumbrance:-u">ENCUMBRANCE:</span>
+                        <select name="attr_encumberance_setting">
+                            <option value="off" data-i18n="simple">Simple</option>
+                            <option value="on" data-i18n="variant-phb">Variant (PHB p176)</option>
+                            <option value="disabled" data-i18n="off">Off</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="inventory:-u">INVENTORY:</span>
+                        <select name="attr_simpleinventory">
+                            <option value="complex" data-i18n="compendium-compatible">Compendium Compatible</option>
+                            <option value="simple" data-i18n="simple">Simple</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="feats-traits-u">FEATURES AND TRAITS</span><span>:</span>
+                        <select name="attr_simpletraits">
+                            <option value="complex" data-i18n="compendium-compatible">Compendium Compatible</option>
+                            <option value="simple" data-i18n="simple">Simple</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="prof-langs-u">PROFICENCIES AND LANGUAGES</span><span>:</span>
+                        <select name="attr_simpleproficencies">
+                            <option value="complex" data-i18n="compendium-compatible">Compendium Compatible</option>
+                            <option value="simple" data-i18n="simple">Simple</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="ammo-tracking:-u">AMMO TRACKING:</span>
+                        <select name="attr_ammotracking">
+                            <option value="on" data-i18n="on">On</option>
+                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                        </select>
+                        <span data-i18n-title="api-required-title" data-i18n="api-required-u" title="Try it now with easy one click API installation available with your Pro subscription." style="color:#666; cursor:help;">(API REQUIRED)</span>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="exhaustion-setting-u">SHOW EXHAUSTION TRACKING:</span>
+                        <select name="attr_exhaustion_toggle">
+                            <option value="1" data-i18n="on">On</option>
+                            <option value="0" data-i18n="off" selected="selected">Off</option>
+                        </select>
+                    </div>
+                    <div class="row title">
+                        <span data-i18n="general-opts-u">GENERAL OPTIONS</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+        
+    <div class="footer">
+        <div style="margin-right: 50px; margin-left: 10px;">
+            <span data-i18n="portions-sheet-utilize">
+                Portions of this sheet utilize content from the System Reference Document 5.0 under the OGL License. View OGL License and Copyright Notice. https://wiki.roll20.net/SRD_5.0_OGL_License
+            </span>
+        </div>
+        <div>
+            <span data-i18n="footer-wiki-link">
+                For more information about this character sheet, its functionality, or uses, please check out the Roll20 Wiki for official documentation. https://wiki.roll20.net/5th_Edition_OGL_by_Roll20
+            </span>
+        </div>
+    </div>
+        
+        
+    <!-- #region COMPENDIUM DROP CATCHERS -->
+    <input type="hidden" name="attr_drop_category" accept="Category">
+    <input type="hidden" name="attr_drop_name" accept="Name">
+    <input type="hidden" name="attr_drop_weight" accept="Weight">
+    <input type="hidden" name="attr_drop_properties" accept="Properties">
+    <input type="hidden" name="attr_drop_modifiers" accept="Modifiers">
+    <input type="hidden" name="attr_drop_content" accept="Content">
+    <input type="hidden" name="attr_drop_itemtype" accept="Item Type">
+    <input type="hidden" name="attr_drop_damage" accept="Damage">
+    <input type="hidden" name="attr_drop_damagetype" accept="Damage Type">
+    <input type="hidden" name="attr_drop_range" accept="Range">
+    <input type="hidden" name="attr_drop_ac" accept="AC">
+    <input type="hidden" name="attr_drop_actions" accept="data-Actions">
+    <input type="hidden" name="attr_drop_legendary_actions" accept="data-Legendary Actions">
+    <input type="hidden" name="attr_drop_legendary_actions_desc" accept="Legendary Actions Desc">
+    <input type="hidden" name="attr_drop_reactions" accept="data-Reactions">
+    <input type="hidden" name="attr_drop_traits" accept="data-Traits">
+        
+    <input type="hidden" name="attr_drop_attack_type" accept="Power Attack">
+    <input type="hidden" name="attr_drop_powerdesc" accept="data-description">
+    <input type="hidden" name="attr_drop_damage2" accept="Secondary Damage">
+    <input type="hidden" name="attr_drop_damagetype2" accept="Secondary Damage Type">
+    <input type="hidden" name="attr_drop_alt_damage" accept="Alternate Damage">
+    <input type="hidden" name="attr_drop_alt_damagetype" accept="Alternate Damage Type">
+    <input type="hidden" name="attr_drop_alt_damage2" accept="Alternate Secondary Damage">
+    <input type="hidden" name="attr_drop_alt_damagetype2" accept="Alternate Secondary Damage Type">
+    <input type="hidden" name="attr_drop_powerschool" accept="School">
+    <input type="hidden" name="attr_drop_powercastingtime" accept="Casting Time">
+    <input type="hidden" name="attr_drop_powertarget" accept="Target">
+    <input type="hidden" name="attr_drop_powercomp_materials" accept="Material">
+    <input type="hidden" name="attr_drop_powerconcentrationflag" accept="Concentration">
+    <input type="hidden" name="attr_drop_powerduration" accept="Duration">
+    <input type="hidden" name="attr_drop_powerhealing" accept="Healing">
+    <input type="hidden" name="attr_drop_powerdmgmod" accept="Add Casting Modifier">
+    <input type="hidden" name="attr_drop_powersave" accept="Save">
+    <input type="hidden" name="attr_drop_powersavesuccess" accept="Save Success">
+    <input type="hidden" name="attr_drop_powerhldie" accept="Higher Power Slot Dice">
+    <input type="hidden" name="attr_drop_powerhldietype" accept="Higher Power Slot Die">
+    <input type="hidden" name="attr_drop_powerhlbonus" accept="Higher Power Slot Bonus">
+    <input type="hidden" name="attr_drop_powerhldesc" accept="Higher Power Slot Desc">
+    <input type="hidden" name="attr_drop_powerlevel" accept="Level">
+    <input type="hidden" name="attr_drop_power_damage_progression" accept="Damage Progression">
+    
+    <input type="hidden" name="attr_drop_speed" accept="Speed">
+    <input type="hidden" name="attr_drop_str" accept="STR">
+    <input type="hidden" name="attr_drop_dex" accept="DEX">
+    <input type="hidden" name="attr_drop_con" accept="CON">
+    <input type="hidden" name="attr_drop_int" accept="INT">
+    <input type="hidden" name="attr_drop_wis" accept="WIS">
+    <input type="hidden" name="attr_drop_cha" accept="CHA">
+    <input type="hidden" name="attr_drop_vulnerabilities" accept="Vulnerabilities">
+    <input type="hidden" name="attr_drop_resistances" accept="Resistances">
+    <input type="hidden" name="attr_drop_immunities" accept="Immunities">
+    <input type="hidden" name="attr_drop_condition_immunities" accept="Condition Immunities">
+    <input type="hidden" name="attr_drop_languages" accept="Languages">
+    <input type="hidden" name="attr_drop_challenge_rating" accept="Challenge Rating">
+    
+    <input type="hidden" name="attr_drop_size" accept="Size">
+    <input type="hidden" name="attr_drop_type" accept="Type">
+    <input type="hidden" name="attr_drop_alignment" accept="Alignment">
+    <input type="hidden" name="attr_drop_hp" accept="HP">
+    <input type="hidden" name="attr_drop_saving_throws" accept="Saving Throws">
+    <input type="hidden" name="attr_drop_senses" accept="Senses">
+    <input type="hidden" name="attr_drop_passive_perception" accept="Passive Perception">
+    <input type="hidden" name="attr_drop_skills" accept="Skills">
+    <input type="hidden" name="attr_drop_token_size" accept="Token Size">
+    <input type="hidden" name="attr_drop_armor_prof" accept="data-Armor Proficiency">
+    <input type="hidden" name="attr_drop_hit_die" accept="Hit Die">
+    <input type="hidden" name="attr_drop_weapon_prof" accept="data-Weapon Proficiency">
+    <input type="hidden" name="attr_drop_powercasting_ability" accept="Powercasting Ability">
+    <input type="hidden" name="attr_drop_class_saving_throws" accept="data-Saving Throws">
+    <input type="hidden" name="attr_drop_language_prof" accept="data-Language Proficiency">
+    <input type="hidden" name="attr_drop_tool_prof" accept="data-Tool Proficiency">
+    <input type="hidden" name="attr_drop_hp_per_level" accept="data-HP per level">
+    <input type="hidden" name="attr_drop_class_powers" accept="data-Class Powers">
+    <input type="hidden" name="attr_drop_global_damage" accept="data-Global Damage">
+    <input type="hidden" name="attr_drop_feature_name" accept="data-Feature Name">
+    <input type="hidden" name="attr_drop_feature_description" accept="data-Feature Description">
+    <input type="hidden" name="attr_drop_resources" accept="data-Resources">
+
+    <!-- endregion COMPENDIUM DROP CATCHERS -->
+        
+    <!-- #region Manual Drop Fields-->
+    <input type="hidden" name="attr_drop_power_ability" accept="powercasting_ability">
+    <input type="hidden" name="attr_drop_toolbonus_base" accept="toolbonus_base">
+    <input type="hidden" name="attr_drop_itemcount" accept="itemcount">
+    
+    <input type="hidden" name="attr_drop_skill_proficiency" accept="data-Skill Proficiency">
+    <input type="hidden" name="attr_drop_parent" accept="data-Parent">
+    <!-- endregion Manual Drop Fields-->
+        
+</div> <!-- licensecontainer div close -->
+
+<div class="container ship">
+    <input class="tab-button ship-core" type="radio" name="attr_ship_tab" value="ship-core" checked="checked"><span data-i18n="core-u">CORE</span>
+    <input class="tab-button ship-modifications" type="radio" name="attr_ship_tab" value="ship-modifications"><span data-i18n="modifications-u">MODIFICATIONS</span>
+    <input class="tab-button ship-options" type="radio" name="attr_ship_tab" value="ship-options"><span style="font-family: pictos">y</span>
+    <div class="page ship-options">
+        <div class="header">
+            <div class="name-container">
+                <img src="https://s22.postimg.cc/jnlp8fqc1/Star_Wars_5_E_Logo_Shrunk.png" style="padding-bottom: 10px;">
+                <input type="text" name="attr_ship_name" style="width: 100%;">
+                <span class="label" data-i18n="ship-name-u">SHIP NAME</span>
+            </div>
+            <div class="header-info sheet-options">
+                <div class="sheet-row">
+                    <span data-i18n="ship-size:-u">SIZE:</span>
+                    <select class="hiding class" name="attr_ship_size">
+                        <option value="" data-i18n="choose">Choose</option>
+                        <option value="Tiny" data-i18n="tiny">Tiny</option>
+                        <option value="Small" data-i18n="small">Small</option>
+                        <option value="Medium" data-i18n="medium">Medium</option>
+                        <option value="Large" data-i18n="large">Large</option>
+                        <option value="Huge" data-i18n="huge">Huge</option>
+                        <option value="Gargantuan" data-i18n="gargantuan">Gargantuan</option>
+                    </select>
+                    <span data-i18n="ship-tier:-u">TIER:</span>
+                    <input type="number" class="class-level" style="width: 40px" name="attr_base_ship_tier" value="0">
+                </div>
+                <div class="sheet-row">
+                    <span data-i18n="ship-manufacturer:-u">MANUFACTURER/LINE/CLASS:</span>
+                    <input type="text">
+                </div>
+                <div class="sheet-row">
+                    <span data-i18n="ship-credits-invested:-u">CREDITS INVESTED:</span>
+                    <input type="text" name="attr_ship_cr">
+                    <span data-i18n="ship-credits-next-tier:-u">CREDITS NEEDED FOR NEXT TIER:</span>
+                    <input type="text" name="attr_ship_cr_next">
+                </div>
+            </div>
+        </div>
+        <div class="body">
+            <div class="row title">
+                <span data-i18n="ship-options-u">SHIP OPTIONS</span>
                 <div class="row">
                     <span>SHEET TYPE:</span>
                     <select name="attr_npc">
@@ -4095,235 +4373,89 @@
                         <option value="2">Ship</option>
                     </select>
                 </div>
-                <div class="row">
-                    <span data-i18n="roll-queries:-u">ROLL QUERIES:</span>
-                    <select name="attr_rtype">
-                        <option value="{{always=1}} {{r2=[[@{d20}" data-i18n="always-roll-adv">Always Roll Advantage</option>
-                        <option value="@{advantagetoggle}" data-i18n="toggle-roll-adv">Advantage Toggle</option>
-                        <option value="{{query=1}} ?{Advantage?|Normal Roll,&#123&#123normal=1&#125&#125 &#123&#123r2=[[0d20|Advantage,&#123&#123advantage=1&#125&#125 &#123&#123r2=[[@{d20}|Disadvantage,&#123&#123disadvantage=1&#125&#125 &#123&#123r2=[[@{d20}}" data-i18n="query-roll-adv">Query Advantage</option>
-                        <option value="{{normal=1}} {{r2=[[0d20" data-i18n="never-roll-adv">Never Roll Advantage</option>
+            </div>
+        </div>
+    </div>
+
+    <div class="page ship-core">
+        <div class="header">
+            <div class="name-container">
+                <img src="https://s22.postimg.cc/jnlp8fqc1/Star_Wars_5_E_Logo_Shrunk.png" style="padding-bottom: 10px;">
+                <input type="text" name="attr_ship_name" style="width: 100%;">
+                <span class="label" data-i18n="ship-name-u">SHIP NAME</span>
+            </div>
+            <div class="header-info sheet-options">
+                <div class="sheet-row">
+                    <span data-i18n="ship-size:-u">SIZE:</span>
+                    <select class="hiding class" name="attr_ship_size">
+                        <option value="" data-i18n="choose">Choose</option>
+                        <option value="Tiny" data-i18n="tiny">Tiny</option>
+                        <option value="Small" data-i18n="small">Small</option>
+                        <option value="Medium" data-i18n="medium">Medium</option>
+                        <option value="Large" data-i18n="large">Large</option>
+                        <option value="Huge" data-i18n="huge">Huge</option>
+                        <option value="Gargantuan" data-i18n="gargantuan">Gargantuan</option>
                     </select>
+                    <span data-i18n="ship-tier:-u">TIER:</span>
+                    <input type="number" class="class-level" style="width: 40px" name="attr_base_ship_tier" value="0">
                 </div>
-                <div class="row">
-                    <span data-i18n="whisp-rolls-gm:-u">WHISPER ROLLS TO GM:</span>
-                    <select name="attr_wtype">
-                        <option value="" data-i18n="never-whisper-roll">Never Whisper Rolls</option>
-                        <option value="@{whispertoggle}" data-i18n="toggle-roll-whisper">Whisper Toggle</option>
-                        <option value="?{Whisper?|Public Roll,|Whisper Roll,/w gm }" data-i18n="query-whisper-roll">Query Whisper</option>
-                        <option value="/w gm " data-i18n="always-whisper-roll">Always Whisper Rolls</option>
-                    </select>
+                <div class="sheet-row">
+                    <span data-i18n="ship-manufacturer:-u">MANUFACTURER/LINE/CLASS:</span>
+                    <input type="text">
                 </div>
-                <div class="row">
-                    <span data-i18n="auto-dmg-roll:-u">AUTO DAMAGE ROLL:</span>
-                    <select class="dtype" name="attr_dtype">
-                        <option value="pick" data-i18n="never-roll-dmg">Don't Auto Roll Damage</option>
-                        <option value="full" data-i18n="always-roll-dmg">Auto Roll Damage & Crit</option>
-                    </select>
-                </div>
-                <div class="row">
-                    <span data-i18n="core-die-roll:-u">CORE DIE ROLL:</span>
-                    <input type="text" name="attr_core_die" value="1d20" placeholder="1d20" title="@{core_die}">
-                </div>
-                <div class="row">
-                    <span data-i18n="prof-bonus:-u">PROFICIENCY BONUS:</span>
-                    <select class="dtype" name="attr_pb_type">
-                        <option value="level" data-i18n="by-level">By Level (Default)</option>
-                        <option value="die" data-i18n="prof-die">Proficency Die (DMG)</option>
-                        <option value="custom" data-i18n="custom">Custom</option>
-                    </select>
-                    <input type="hidden" name="attr_pb_type">
-                    <input class="pb_custom" type="text" style="float:right;" name="attr_pb_custom" placeholder="2d10">
-                </div>
-                <div class="row">
-                    <input type="checkbox" name="attr_global_save_mod_flag" value="1">
-                    <span data-i18n="show-global-save-field-u">SHOW GLOBAL SAVE MODIFIER FIELD</span>
-                </div>
-                <div class="row">
-                    <input type="checkbox" name="attr_global_skill_mod_flag" value="1">
-                    <span data-i18n="show-global-skill-field-u">SHOW GLOBAL SKILL MODIFIER FIELD</span>
-                </div>
-                <div class="row">
-                    <input type="checkbox" name="attr_global_attack_mod_flag" value="1">
-                    <span data-i18n="show-global-attack-field-u">SHOW GLOBAL ATTACK MODIFIER FIELD</span>
-                </div>
-                <div class="row">
-                    <input type="checkbox" name="attr_global_damage_mod_flag" value="1">
-                    <span data-i18n="show-global-damage-field-u">SHOW GLOBAL DAMAGE MODIFIER FIELD</span>
-                </div>
-                <div class="row">
-                    <span data-i18n="add-char-to-templates:-u">ADD CHARACTER NAME TO TEMPLATES:</span>
-                    <select class="dtype" name="attr_charname_output">
-                        <option value="{{charname=@{character_name}}}" data-i18n="on">On</option>
-                        <option value="charname=@{character_name}" selected="selected" data-i18n="off">Off</option>
-                    </select>
-                </div>
-                <div class="row">
-                    <span data-i18n="level-calculations:-u">LEVEL CALCULATIONS:</span>
-                    <select class="dtype" name="attr_level_calculations">
-                        <option value="on" selected="selected" data-i18n="on">On</option>
-                        <option value="off" data-i18n="off">Off</option>
-                    </select>
-                </div>
-                <div class="row">
-                    <span data-i18n="encumbrance:-u">ENCUMBRANCE:</span>
-                    <select name="attr_encumberance_setting">
-                        <option value="off" data-i18n="simple">Simple</option>
-                        <option value="on" data-i18n="variant-phb">Variant (PHB p176)</option>
-                        <option value="disabled" data-i18n="off">Off</option>
-                    </select>
-                </div>
-                <div class="row">
-                    <span data-i18n="inventory:-u">INVENTORY:</span>
-                    <select name="attr_simpleinventory">
-                        <option value="complex" data-i18n="compendium-compatible">Compendium Compatible</option>
-                        <option value="simple" data-i18n="simple">Simple</option>
-                    </select>
-                </div>
-                <div class="row">
-                    <span data-i18n="feats-traits-u">FEATURES AND TRAITS</span><span>:</span>
-                    <select name="attr_simpletraits">
-                        <option value="complex" data-i18n="compendium-compatible">Compendium Compatible</option>
-                        <option value="simple" data-i18n="simple">Simple</option>
-                    </select>
-                </div>
-                <div class="row">
-                    <span data-i18n="prof-langs-u">PROFICENCIES AND LANGUAGES</span><span>:</span>
-                    <select name="attr_simpleproficencies">
-                        <option value="complex" data-i18n="compendium-compatible">Compendium Compatible</option>
-                        <option value="simple" data-i18n="simple">Simple</option>
-                    </select>
-                </div>
-                <div class="row">
-                    <span data-i18n="ammo-tracking:-u">AMMO TRACKING:</span>
-                    <select name="attr_ammotracking">
-                        <option value="on" data-i18n="on">On</option>
-                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                    </select>
-                    <span data-i18n-title="api-required-title" data-i18n="api-required-u" title="Try it now with easy one click API installation available with your Pro subscription." style="color:#666; cursor:help;">(API REQUIRED)</span>
-                </div>
-                <div class="row">
-                    <span data-i18n="exhaustion-setting-u">SHOW EXHAUSTION TRACKING:</span>
-                    <select name="attr_exhaustion_toggle">
-                        <option value="1" data-i18n="on">On</option>
-                        <option value="0" data-i18n="off" selected="selected">Off</option>
-                    </select>
-                </div>
-                <div class="row title">
-                    <span data-i18n="general-opts-u">GENERAL OPTIONS</span>
+                <div class="sheet-row">
+                    <span data-i18n="ship-credits-invested:-u">CREDITS INVESTED:</span>
+                    <input type="text" name="attr_ship_cr">
+                    <span data-i18n="ship-credits-next-tier:-u">CREDITS NEEDED FOR NEXT TIER:</span>
+                    <input type="text" name="attr_ship_cr_next">
                 </div>
             </div>
+        </div>
+        <div class="body">
+            
+        </div>
+    </div>
+    <div class="page ship-modifications">
+        <div class="header">
+            <div class="name-container">
+                <img src="https://s22.postimg.cc/jnlp8fqc1/Star_Wars_5_E_Logo_Shrunk.png" style="padding-bottom: 10px;">
+                <input type="text" name="attr_ship_name" style="width: 100%;">
+                <span class="label" data-i18n="ship-name-u">SHIP NAME</span>
+            </div>
+            <div class="header-info sheet-options">
+                <div class="sheet-row">
+                    <span data-i18n="ship-size:-u">SIZE:</span>
+                    <select class="hiding class" name="attr_ship_size">
+                        <option value="" data-i18n="choose">Choose</option>
+                        <option value="Tiny" data-i18n="tiny">Tiny</option>
+                        <option value="Small" data-i18n="small">Small</option>
+                        <option value="Medium" data-i18n="medium">Medium</option>
+                        <option value="Large" data-i18n="large">Large</option>
+                        <option value="Huge" data-i18n="huge">Huge</option>
+                        <option value="Gargantuan" data-i18n="gargantuan">Gargantuan</option>
+                    </select>
+                    <span data-i18n="ship-tier:-u">TIER:</span>
+                    <input type="number" class="class-level" style="width: 40px" name="attr_base_ship_tier" value="0">
+                </div>
+                <div class="sheet-row">
+                    <span data-i18n="ship-manufacturer:-u">MANUFACTURER/LINE/CLASS:</span>
+                    <input type="text">
+                </div>
+                <div class="sheet-row">
+                    <span data-i18n="ship-credits-invested:-u">CREDITS INVESTED:</span>
+                    <input type="text" name="attr_ship_cr">
+                    <span data-i18n="ship-credits-next-tier:-u">CREDITS NEEDED FOR NEXT TIER:</span>
+                    <input type="text" name="attr_ship_cr_next">
+                </div>
+            </div>
+        </div>
+        <div class="body">
+
         </div>
     </div>
 </div>
 
-<div class="footer">
-    <div style="margin-right: 50px; margin-left: 10px;">
-        <span data-i18n="portions-sheet-utilize">
-            Portions of this sheet utilize content from the System Reference Document 5.0 under the OGL License. View OGL License and Copyright Notice. https://wiki.roll20.net/SRD_5.0_OGL_License
-        </span>
-    </div>
-    <div>
-        <span data-i18n="footer-wiki-link">
-            For more information about this character sheet, its functionality, or uses, please check out the Roll20 Wiki for official documentation. https://wiki.roll20.net/5th_Edition_OGL_by_Roll20
-        </span>
-    </div>
-</div>
-
-
-<!-- COMPENDIUM DROP CATCHERS -->
-<input type="hidden" name="attr_drop_category" accept="Category">
-<input type="hidden" name="attr_drop_name" accept="Name">
-<input type="hidden" name="attr_drop_weight" accept="Weight">
-<input type="hidden" name="attr_drop_properties" accept="Properties">
-<input type="hidden" name="attr_drop_modifiers" accept="Modifiers">
-<input type="hidden" name="attr_drop_content" accept="Content">
-<input type="hidden" name="attr_drop_itemtype" accept="Item Type">
-<input type="hidden" name="attr_drop_damage" accept="Damage">
-<input type="hidden" name="attr_drop_damagetype" accept="Damage Type">
-<input type="hidden" name="attr_drop_range" accept="Range">
-<input type="hidden" name="attr_drop_ac" accept="AC">
-<input type="hidden" name="attr_drop_actions" accept="data-Actions">
-<input type="hidden" name="attr_drop_legendary_actions" accept="data-Legendary Actions">
-<input type="hidden" name="attr_drop_legendary_actions_desc" accept="Legendary Actions Desc">
-<input type="hidden" name="attr_drop_reactions" accept="data-Reactions">
-<input type="hidden" name="attr_drop_traits" accept="data-Traits">
-
-<input type="hidden" name="attr_drop_attack_type" accept="Power Attack">
-<input type="hidden" name="attr_drop_powerdesc" accept="data-description">
-<input type="hidden" name="attr_drop_damage2" accept="Secondary Damage">
-<input type="hidden" name="attr_drop_damagetype2" accept="Secondary Damage Type">
-<input type="hidden" name="attr_drop_alt_damage" accept="Alternate Damage">
-<input type="hidden" name="attr_drop_alt_damagetype" accept="Alternate Damage Type">
-<input type="hidden" name="attr_drop_alt_damage2" accept="Alternate Secondary Damage">
-<input type="hidden" name="attr_drop_alt_damagetype2" accept="Alternate Secondary Damage Type">
-<input type="hidden" name="attr_drop_powerschool" accept="School">
-<input type="hidden" name="attr_drop_powercastingtime" accept="Casting Time">
-<input type="hidden" name="attr_drop_powertarget" accept="Target">
-<input type="hidden" name="attr_drop_powercomp_materials" accept="Material">
-<input type="hidden" name="attr_drop_powerconcentrationflag" accept="Concentration">
-<input type="hidden" name="attr_drop_powerduration" accept="Duration">
-<input type="hidden" name="attr_drop_powerhealing" accept="Healing">
-<input type="hidden" name="attr_drop_powerdmgmod" accept="Add Casting Modifier">
-<input type="hidden" name="attr_drop_powersave" accept="Save">
-<input type="hidden" name="attr_drop_powersavesuccess" accept="Save Success">
-<input type="hidden" name="attr_drop_powerhldie" accept="Higher Power Slot Dice">
-<input type="hidden" name="attr_drop_powerhldietype" accept="Higher Power Slot Die">
-<input type="hidden" name="attr_drop_powerhlbonus" accept="Higher Power Slot Bonus">
-<input type="hidden" name="attr_drop_powerhldesc" accept="Higher Power Slot Desc">
-<input type="hidden" name="attr_drop_powerlevel" accept="Level">
-<input type="hidden" name="attr_drop_power_damage_progression" accept="Damage Progression">
-
-<input type="hidden" name="attr_drop_speed" accept="Speed">
-<input type="hidden" name="attr_drop_str" accept="STR">
-<input type="hidden" name="attr_drop_dex" accept="DEX">
-<input type="hidden" name="attr_drop_con" accept="CON">
-<input type="hidden" name="attr_drop_int" accept="INT">
-<input type="hidden" name="attr_drop_wis" accept="WIS">
-<input type="hidden" name="attr_drop_cha" accept="CHA">
-<input type="hidden" name="attr_drop_vulnerabilities" accept="Vulnerabilities">
-<input type="hidden" name="attr_drop_resistances" accept="Resistances">
-<input type="hidden" name="attr_drop_immunities" accept="Immunities">
-<input type="hidden" name="attr_drop_condition_immunities" accept="Condition Immunities">
-<input type="hidden" name="attr_drop_languages" accept="Languages">
-<input type="hidden" name="attr_drop_challenge_rating" accept="Challenge Rating">
-
-<input type="hidden" name="attr_drop_size" accept="Size">
-<input type="hidden" name="attr_drop_type" accept="Type">
-<input type="hidden" name="attr_drop_alignment" accept="Alignment">
-<input type="hidden" name="attr_drop_hp" accept="HP">
-<input type="hidden" name="attr_drop_saving_throws" accept="Saving Throws">
-<input type="hidden" name="attr_drop_senses" accept="Senses">
-<input type="hidden" name="attr_drop_passive_perception" accept="Passive Perception">
-<input type="hidden" name="attr_drop_skills" accept="Skills">
-<input type="hidden" name="attr_drop_token_size" accept="Token Size">
-<input type="hidden" name="attr_drop_armor_prof" accept="data-Armor Proficiency">
-<input type="hidden" name="attr_drop_hit_die" accept="Hit Die">
-<input type="hidden" name="attr_drop_weapon_prof" accept="data-Weapon Proficiency">
-<input type="hidden" name="attr_drop_powercasting_ability" accept="Powercasting Ability">
-<input type="hidden" name="attr_drop_class_saving_throws" accept="data-Saving Throws">
-<input type="hidden" name="attr_drop_language_prof" accept="data-Language Proficiency">
-<input type="hidden" name="attr_drop_tool_prof" accept="data-Tool Proficiency">
-<input type="hidden" name="attr_drop_hp_per_level" accept="data-HP per level">
-<input type="hidden" name="attr_drop_class_powers" accept="data-Class Powers">
-<input type="hidden" name="attr_drop_global_damage" accept="data-Global Damage">
-<input type="hidden" name="attr_drop_feature_name" accept="data-Feature Name">
-<input type="hidden" name="attr_drop_feature_description" accept="data-Feature Description">
-<input type="hidden" name="attr_drop_resources" accept="data-Resources">
-
-<!-- Manual Drop Fields-->
-<input type="hidden" name="attr_drop_power_ability" accept="powercasting_ability">
-<input type="hidden" name="attr_drop_toolbonus_base" accept="toolbonus_base">
-<input type="hidden" name="attr_drop_itemcount" accept="itemcount">
-
-<input type="hidden" name="attr_drop_skill_proficiency" accept="data-Skill Proficiency">
-<input type="hidden" name="attr_drop_parent" accept="data-Parent">
-
-</div> <!-- licensecontainer div close -->
-
-<div class="container ship">
-</div>
-
-<!-- HIDDEN FIELDS -->
+<!-- #region HIDDEN FIELDS -->
 <input type="hidden" name="attr_d20" value="1d20">
 <input type="hidden" name="attr_level" value="1">
 <input type="hidden" name="attr_pb" value="2">
@@ -4398,8 +4530,7 @@
 <input type='hidden' name='attr_lvl9_slots_total' value='0'>
 
 <input type='hidden' name='attr_l1mancer_status' value='completed'>
-
-</div>
+<!-- endregion HIDDEN FIELDS -->
 
 <div class="compendium_warning">
     <span data-i18n="accepting-drop-u">ACCEPTING DROP FROM COMPENDIUM</span>

--- a/StarWars5E/StarWars5E_HTML.html
+++ b/StarWars5E/StarWars5E_HTML.html
@@ -1303,7 +1303,7 @@
                         <span data-i18n="tool-prof-u" style="display: inline;">TOOL PROFICIENCIES</span><span style="display: inline;"> & </span><span data-i18n="custom-skills-u" style="display: inline;">CUSTOM SKILLS</span>
                     </div>
                 </div>
-                <div class="textbox-container proficiencies">
+                <div class="textbox-container proficiencies" style="margin-bottom: 10px;">
                     <input type="hidden" class="inventoryflag" name="attr_simpleproficencies" value="complex">
                     <textarea class="sheet-simple" name="attr_other_proficiencies_and_languages" style="min-height: 91px; height: 91px;"></textarea>
                     <div class="complex">
@@ -1340,6 +1340,46 @@
                     </div>
                     <div class="label">
                         <span style="margin-top: -10px;" data-i18n="other-prof-langs-u">OTHER PROFICIENCIES & LANGUAGES</span>
+                    </div>
+                </div>
+                <div class="textbox-container proficiencies">
+                    <input type="hidden" class="inventoryflag" name="attr_simpleproficencies" value="complex">
+                    <textarea class="sheet-simple" name="attr_deployments" style="min-height: 91px; height: 91px;"></textarea>
+                    <div class="complex">
+                        <div class="top">
+                            <span class="label" style="width: 60px;" data-i18n="rank-u">RANK</span>
+                            <span class="label" style="width: 135px;" data-i18n="deployment-u">DEPLOYMENT</span>
+                        </div>
+                        <fieldset class="repeating_deployments">
+                            <div class="deployment">
+                                <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
+                                <div class="options">
+                                    <div class="row">
+                                        <span data-i18n="deployment:-u">DEPLOYMENT:</span>
+                                        <select name="attr_deployment_type">
+                                            <option selected="selected" data-i18n="coordinator">Coordinator</option>
+                                            <option data-i18n="gunner">Gunner</option>
+                                            <option data-i18n="mechanic">Mechanic</option>
+                                            <option data-i18n="operator">Operator</option>
+                                            <option data-i18n="pilot">Pilot</option>
+                                        </select>
+                                    </div>
+                                    <div class="row" style="margin-bottom: 3px;">
+                                        <span data-i18n="rank:-u">RANK:</span>
+                                        <input type="number" name="attr_deployment_rank" style="width: 40px;">
+                                    </div>
+                                </div>
+                                <div class="display" style="margin-bottom: 2px;">
+                                    <button type="roll" name="roll_output" value="@{wtype}&{template:traits} @{charname_output} {{name=@{deployment_type} @{deployment_rank}}} {{description=Deployment}}">
+                                        <span name="attr_deployment_rank" style="width: 55px;"></span>
+                                        <span name="attr_deployment_type" style="width: 159px;"></span>
+                                    </button>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                    <div class="label">
+                        <span style="margin-top: -10px;" data-i18n="deployments-u">DEPLOYMENTS</span>
                     </div>
                 </div>
             </div>
@@ -4730,7 +4770,7 @@
                         </div>
                         <span class="label" style="margin-top: 0px; position: absolute; bottom: 0px;" data-i18n="hidden-cargo-u">HIDDEN CARGO</span>
                     </div>
-                    <div class="textbox traits" style="min-height: 260px; width:480px; display:inline-block;">
+                    <div class="textbox traits" style="min-height: 378pxpx; width:480px; display:inline-block;">
                         <input type="hidden" class="inventoryflag" name="attr_simpletraits" value="complex">
                         <textarea class="sheet-simple" name="attr_features_and_traits" style="min-height: 260px; height: 260px;"></textarea>
                         <div class="complex" style="width: 475px;">

--- a/StarWars5E/StarWars5E_HTML.html
+++ b/StarWars5E/StarWars5E_HTML.html
@@ -4533,7 +4533,7 @@
                         </div>
                         <div class="insp-prof-container">
                             <div class="value">
-                                <input type="number" name="attr_pb">
+                                <input type="number" value="0" name="attr_pb">
                             </div>
                             <div class="label">
                                 <span data-i18n="pilot_prof_bonus-u">PILOT PROF BONUS</span>
@@ -5133,6 +5133,8 @@
 <input type='hidden' name='attr_lvl9_slots_total' value='0'>
 
 <input type='hidden' name='attr_l1mancer_status' value='completed'>
+<input type='hidden' name='attr_pilot_skill' value='0'>
+<input type='hidden' name='attr_ship_size' value='0'>
 <!-- endregion HIDDEN FIELDS -->
 
 <div class="compendium_warning">
@@ -6584,7 +6586,7 @@
                 return;
             }
             else {
-                update_skills(["stealth"]
+                update_skills(["stealth"]);
             }
         });  
     });
@@ -6596,7 +6598,7 @@
                 return;
             }
             else {
-                update_skills(["survival"]
+                update_skills(["survival"]);
             }
         });  
     });
@@ -7280,6 +7282,20 @@
             }
             check_l1_mancer();
         });
+    });
+
+    on("change:ship_size", function(eventinfo) {
+        if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+            return;
+        }
+        update_ac();
+    });
+
+    on("change:pilot_skill", function(eventinfo) {
+        if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+            return;
+        }
+        update_ac();
     });
 
     var update_attr = function(attr) {
@@ -9928,15 +9944,17 @@
                     var total = base + part1 + part2;
                     setAttrs({ac: total});
                 });
-            }
+            }         
             else {              
-                var ac_attrs = ["simpleinventory","dexterity_mod","globalacmod"];   
+                var ac_attrs = ["simpleinventory","dexterity_mod","globalacmod","npc","ship_size","pilot_skill"];   
                 getSectionIDs("repeating_inventory", function(idarray) {
                     update_inventory_from_ac_change("repeating_inventory_", idarray, ac_attrs);
                 });
-                getSectionIDs("repeating_hiddeninventory", function(idarray) {
-                    update_inventory_from_ac_change("repeating_hiddeninventory_", idarray, ac_attrs);
-                });
+                if(v.npc === "2") {
+                    getSectionIDs("repeating_hiddeninventory", function(idarray) {
+                        update_inventory_from_ac_change("repeating_hiddeninventory_", idarray, ac_attrs);
+                    });
+                }
             };
         });
     };
@@ -9980,34 +9998,70 @@
                 });
                 armorcount = armoritems.filter(function(item){ return item["type"].indexOf("armor") > -1 }).length;
                 shieldcount = armoritems.filter(function(item){ return item["type"].indexOf("shield") > -1 }).length;
-                var base = dexmod;
-                var armorac = 10;
-                var shieldac = 0;
-                var modac = 0;
 
-                _.each(armoritems, function(item) {
-                    if(item["type"].indexOf("light armor") > -1) {
-                        armorac = item["ac"];
-                        base = dexmod;
-                    }
-                    else if(item["type"].indexOf("medium armor") > -1) {
-                        armorac = item["ac"];
-                        base = Math.min(dexmod, 2);
-                    }
-                    else if(item["type"].indexOf("heavy armor") > -1) {
-                        armorac = item["ac"];
-                        base = 0;
-                    }
-                    else if(item["type"].indexOf("shield") > -1) {
-                        shieldac = item["ac"];
-                    }
-                    else {
-                        modac = modac + item["ac"]
-                    }
-                })
+                if(b.npc === "2") {
+                    var modac = 0;
 
-                total = base + armorac + shieldac + modac;
+                    _.each(armoritems, function(item) {
+                        modac = modac + item["ac"];
+                    })
 
+                    var pilotSkill = isNaN(parseInt(b.pilot_skill, 10)) === false ? parseInt(b.pilot_skill, 10) : 0;
+                    var shipSizeACBase = 0;
+                    switch(b.ship_size) {
+                        case "Tiny":
+                            shipSizeACBase = 10;
+                            break;
+                        case "Small":
+                            shipSizeACBase = 9;
+                            break;
+                        case "Medium":
+                            shipSizeACBase = 8;
+                            break;
+                        case "Large":
+                            shipSizeACBase = 7;
+                            break;
+                        case "Huge":
+                            shipSizeACBase = 6;
+                            break;
+                        case "Gargantuan":
+                            shipSizeACBase = 5;
+                            break;
+                        default:
+                            shipSizeACBase = 0;
+                            break;
+                    }
+                    total = shipSizeACBase + pilotSkill + modac;
+                }
+                else {
+                    var base = dexmod;
+                    var armorac = 10;
+                    var shieldac = 0;
+                    var modac = 0;
+    
+                    _.each(armoritems, function(item) {
+                        if(item["type"].indexOf("light armor") > -1) {
+                            armorac = item["ac"];
+                            base = dexmod;
+                        }
+                        else if(item["type"].indexOf("medium armor") > -1) {
+                            armorac = item["ac"];
+                            base = Math.min(dexmod, 2);
+                        }
+                        else if(item["type"].indexOf("heavy armor") > -1) {
+                            armorac = item["ac"];
+                            base = 0;
+                        }
+                        else if(item["type"].indexOf("shield") > -1) {
+                            shieldac = item["ac"];
+                        }
+                        else {
+                            modac = modac + item["ac"];
+                        }
+                    })
+
+                    total = base + armorac + shieldac + modac;
+                }
             };
             if(armorcount > 1 || shieldcount > 1) {
                 update["armorwarningflag"] = "show";

--- a/StarWars5E/StarWars5E_HTML.html
+++ b/StarWars5E/StarWars5E_HTML.html
@@ -4412,146 +4412,245 @@
             </div>
         </div>
         <div class="body">
-            <div class="col col1">
-                <div class="attributes-container" style="margin-top: 10px;">
-                    <div class="attr-container">
-                        <button type="roll" name="roll_strength" value="@{wtype}&{template:simple} {{rname=^{strength-u}}} {{mod=@{strength_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{strength_mod}@{jack_attr}[STR]]]}} @{rtype}+@{strength_mod}@{jack_attr}[STR]]]}} @{charname_output}" data-i18n="strength-u">STRENGTH</button>
-                        <span class="attr" name="attr_strength_mod" title="@{strength_mod}">0</span>
-                        <div class="attr-mod">
-                            <input class="baseattr" type="text" name="attr_strength_base" title="@{strength}" value="10">
-                            <input type="hidden" name="attr_strength" value="10">
-                            <input class="attr-flag" type="hidden" name="attr_strength_flag" value="0">
-                            <span class="finalattr" name="attr_strength">
+            <div class="col2-3">
+                <div style="display:inline" class="halfcol">
+                    <div class="attributes-container" style="margin-top: 10px;">
+                        <div class="attr-container">
+                            <button type="roll" name="roll_strength" value="@{wtype}&{template:simple} {{rname=^{strength-u}}} {{mod=@{strength_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{strength_mod}@{jack_attr}[STR]]]}} @{rtype}+@{strength_mod}@{jack_attr}[STR]]]}} @{charname_output}" data-i18n="strength-u">STRENGTH</button>
+                            <span class="attr" name="attr_strength_mod" title="@{strength_mod}">0</span>
+                            <div class="attr-mod">
+                                <input class="baseattr" type="text" name="attr_strength_base" title="@{strength}" value="10">
+                                <input type="hidden" name="attr_strength" value="10">
+                                <input class="attr-flag" type="hidden" name="attr_strength_flag" value="0">
+                                <span class="finalattr" name="attr_strength">
+                            </div>
+                        </div>
+                        <div class="attr-container">
+                            <button type="roll" name="roll_dexterity" value="@{wtype}&{template:simple} {{rname=^{dexterity-u}}} {{mod=@{dexterity_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{dexterity_mod}@{jack_attr}[DEX]]]}} @{rtype}+@{dexterity_mod}@{jack_attr}[DEX]]]}} @{charname_output}" data-i18n="dexterity-u">DEXTERITY</button>
+                            <span class="attr" name="attr_dexterity_mod" title="@{dexterity_mod}">0</span>
+                            <div class="attr-mod">
+                                <input class="baseattr" type="text" name="attr_dexterity_base" title="@{dexterity}" value="10">
+                                <input type="hidden" name="attr_dexterity" value="10">
+                                <input class="attr-flag" type="hidden" name="attr_dexterity_flag" value="0">
+                                <span class="finalattr" name="attr_dexterity">
+                            </div>
+                        </div>
+                        <div class="attr-container">
+                            <button type="roll" name="roll_constitution" value="@{wtype}&{template:simple} {{rname=^{constitution-u}}} {{mod=@{constitution_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{constitution_mod}@{jack_attr}[CON]]]}} @{rtype}+@{constitution_mod}@{jack_attr}[CON]]]}} @{charname_output}" data-i18n="constitution-u">CONSTITUTION</button>
+                            <span class="attr" name="attr_constitution_mod" title="@{constitution_mod}">0</span>
+                            <div class="attr-mod">
+                                <input class="baseattr" type="text" name="attr_constitution_base" title="@{constitution}" value="10">
+                                <input type="hidden" name="attr_constitution" value="10">
+                                <input class="attr-flag" type="hidden" name="attr_constitution_flag" value="0">
+                                <span class="finalattr" name="attr_constitution">
+                            </div>
                         </div>
                     </div>
-                    <div class="attr-container">
-                        <button type="roll" name="roll_dexterity" value="@{wtype}&{template:simple} {{rname=^{dexterity-u}}} {{mod=@{dexterity_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{dexterity_mod}@{jack_attr}[DEX]]]}} @{rtype}+@{dexterity_mod}@{jack_attr}[DEX]]]}} @{charname_output}" data-i18n="dexterity-u">DEXTERITY</button>
-                        <span class="attr" name="attr_dexterity_mod" title="@{dexterity_mod}">0</span>
-                        <div class="attr-mod">
-                            <input class="baseattr" type="text" name="attr_dexterity_base" title="@{dexterity}" value="10">
-                            <input type="hidden" name="attr_dexterity" value="10">
-                            <input class="attr-flag" type="hidden" name="attr_dexterity_flag" value="0">
-                            <span class="finalattr" name="attr_dexterity">
+                    <div class="skills-saves-container">
+                        <div class="insp-prof-container">
+                            <div class="value">
+                                <input type="number" name="attr_hyperdrive_class">
+                            </div>
+                            <div class="label">
+                                <span data-i18n="hyperdrive_class-u">HYPERDRIVE CLASS</span>
+                            </div>
                         </div>
-                    </div>
-                    <div class="attr-container">
-                        <button type="roll" name="roll_constitution" value="@{wtype}&{template:simple} {{rname=^{constitution-u}}} {{mod=@{constitution_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{constitution_mod}@{jack_attr}[CON]]]}} @{rtype}+@{constitution_mod}@{jack_attr}[CON]]]}} @{charname_output}" data-i18n="constitution-u">CONSTITUTION</button>
-                        <span class="attr" name="attr_constitution_mod" title="@{constitution_mod}">0</span>
-                        <div class="attr-mod">
-                            <input class="baseattr" type="text" name="attr_constitution_base" title="@{constitution}" value="10">
-                            <input type="hidden" name="attr_constitution" value="10">
-                            <input class="attr-flag" type="hidden" name="attr_constitution_flag" value="0">
-                            <span class="finalattr" name="attr_constitution">
+                        <div class="insp-prof-container">
+                            <div class="value">
+                                <input type="number" name="attr_navcomputer_bonus">
+                            </div>
+                            <div class="label">
+                                <span data-i18n="navcomputer_bonus-u">NAVCOMPUTER BONUS</span>
+                            </div>
+                        </div>
+                        <div class="saving-throw-container">
+                            <div class="saving-throw">
+                                <input type="checkbox" name="attr_strength_save_prof" title="@{strength_save_prof}" value="(@{pb})">
+                                <span name="attr_strength_save_bonus" title="@{strength_save_bonus}">0</span>
+                                <button type="roll" name="roll_strength_save" value="@{wtype}&{template:simple} {{rname=^{strength-save-u}}} {{mod=@{strength_save_bonus}}} {{r1=[[@{d20}+@{strength_save_bonus}@{pbd_safe}]]}} @{rtype}+@{strength_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="strength">Strength</button>
+                            </div>
+                            <div class="saving-throw">
+                                <input type="checkbox" name="attr_dexterity_save_prof" title="@{dexterity_save_prof}" value="(@{pb})">
+                                <span name="attr_dexterity_save_bonus" title="@{dexterity_save_bonus}">0</span>
+                                <button type="roll" name="roll_dexterity_save" value="@{wtype}&{template:simple} {{rname=^{dexterity-save-u}}} {{mod=@{dexterity_save_bonus}}} {{r1=[[@{d20}+@{dexterity_save_bonus}@{pbd_safe}]]}} @{rtype}+@{dexterity_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="dexterity">Dexterity</button>
+                            </div>
+                            <div class="saving-throw">
+                                <input type="checkbox" name="attr_constitution_save_prof" title="@{constitution_save_prof}" value="(@{pb})">
+                                <span name="attr_constitution_save_bonus" title="@{constitution_save_bonus}">0</span>
+                                <button type="roll" name="roll_constitution_save" value="@{wtype}&{template:simple} {{rname=^{constitution-save-u}}} {{mod=@{constitution_save_bonus}}} {{r1=[[@{d20}+@{constitution_save_bonus}@{pbd_safe}]]}} @{rtype}+@{constitution_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="constitution">Constitution</button>
+                            </div>
+                            <input type="hidden" class="toggleflag" name="attr_global_save_mod_flag">
+                            <div class="hidden textarea globalattack">
+                                <span class="label" data-i18n="global-save-u">GLOBAL SAVE MODIFIER</span>
+                                <fieldset class="repeating_savemod">
+                                    <div class="global-mod">
+                                        <input type="checkbox" name="attr_options-flag" class="options-flag" checked="checked" style="top: -15px;"><span>y</span>
+                                        <input type="checkbox" name="attr_global_save_active_flag" value="1" class="active-flag">
+                                        <div class="options">
+                                            <textarea type="textarea" name="attr_global_save_rollstring" placeholder="1d4[BLESS]" style="width: 125px;"></textarea>
+                                        </div>
+                                        <div class="display">
+                                            <span class="title" name="attr_global_save_rollstring"></span>
+                                        </div>
+                                    </div>
+                                </fieldset>
+                            </div>
+                            <div class="label">
+                                <span data-i18n="saving-throws-u">SAVING THROWS</span>
+                            </div>
                         </div>
                     </div>
                 </div>
-                <div class="skills-saves-container">
-                    <div class="insp-prof-container">
-                        <div class="value">
-                            <input type="number" name="attr_hyperdrive_class">
+                <div style="display:inline-block" class="halfcol">
+                    <div class="ac-init-speed-container">
+                        <div class="ac">
+                            <input type="text" name="attr_ac">
+                            <span class="label pc-ac" data-i18n="armor-class-u">ARMOR CLASS</span>
                         </div>
-                        <div class="label">
-                            <span data-i18n="hyperdrive_class-u">HYPERDRIVE CLASS</span>
-                        </div>
-                    </div>
-                    <div class="insp-prof-container">
-                        <div class="value">
-                            <input type="number" name="attr_navcomputer_bonus">
-                        </div>
-                        <div class="label">
-                            <span data-i18n="navcomputer_bonus-u">NAVCOMPUTER BONUS</span>
+                        <div class="speed">
+                                <input type="text" name="attr_ship_turnspeed">
+                                <span class="label" data-i18n="ship_turnspeed-u">TURNING SPEED</span>
+                            </div>
+                        <div class="speed">
+                            <input type="text" name="attr_ship_flyspeed">
+                            <span class="label" data-i18n="ship_flyspeed-u">FLYING SPEED</span>
                         </div>
                     </div>
-                    <div class="saving-throw-container">
-                        <div class="saving-throw">
-                            <input type="checkbox" name="attr_strength_save_prof" title="@{strength_save_prof}" value="(@{pb})">
-                            <span name="attr_strength_save_bonus" title="@{strength_save_bonus}">0</span>
-                            <button type="roll" name="roll_strength_save" value="@{wtype}&{template:simple} {{rname=^{strength-save-u}}} {{mod=@{strength_save_bonus}}} {{r1=[[@{d20}+@{strength_save_bonus}@{pbd_safe}]]}} @{rtype}+@{strength_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="strength">Strength</button>
+                    <div class="hp">
+                        <div class="top">
+                            <span data-i18n="hp-max-u">Hit Point Maximum</span>
+                            <input type="text" name="attr_hp_max" title="@{hp_max}">
                         </div>
-                        <div class="saving-throw">
-                            <input type="checkbox" name="attr_dexterity_save_prof" title="@{dexterity_save_prof}" value="(@{pb})">
-                            <span name="attr_dexterity_save_bonus" title="@{dexterity_save_bonus}">0</span>
-                            <button type="roll" name="roll_dexterity_save" value="@{wtype}&{template:simple} {{rname=^{dexterity-save-u}}} {{mod=@{dexterity_save_bonus}}} {{r1=[[@{d20}+@{dexterity_save_bonus}@{pbd_safe}]]}} @{rtype}+@{dexterity_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="dexterity">Dexterity</button>
+                        <input type="number" name="attr_hp" title="@{hp}">
+                        <span class="label" data-i18n="hp-current-u">CURRENT HIT POINTS</span>
+                    </div>
+                    <div class="hp">
+                        <div class="top">
+                            <span data-i18n="ship-shield-max-u">Shield Point Maximum</span>
+                            <input type="text" style="width:120px" name="attr_ship_shield_max">
                         </div>
-                        <div class="saving-throw">
-                            <input type="checkbox" name="attr_constitution_save_prof" title="@{constitution_save_prof}" value="(@{pb})">
-                            <span name="attr_constitution_save_bonus" title="@{constitution_save_bonus}">0</span>
-                            <button type="roll" name="roll_constitution_save" value="@{wtype}&{template:simple} {{rname=^{constitution-save-u}}} {{mod=@{constitution_save_bonus}}} {{r1=[[@{d20}+@{constitution_save_bonus}@{pbd_safe}]]}} @{rtype}+@{constitution_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="constitution">Constitution</button>
+                        <input type="number" name="attr_ship_shield_points">
+                        <span class="label" data-i18n="ship-shield-u">CURRENT SHIELD POINTS</span>
+                    </div>
+                    <div class="hdice-dsaves-container" style="width: 242px;">
+                        <div class="subcontainer">
+                            <div class="top">
+                                <span data-i18n="total">Total</span>
+                                <input type="text" name="attr_hit_dice_max" title="@{hit_dice_max}">
+                            </div>
+                            <input type="number" name="attr_hit_dice" title="@{hit_dice}" style="margin-bottom: -6px;">
+                            <button type="roll" name="roll_hit_dice" value="@{wtype}&{template:simple} {{rname=^{hit-dice-u}}} {{mod=D@{hitdie_final}+[[@{constitution_mod}[CON]]]}} {{r1=[[1d@{hitdie_final}+[[@{constitution_mod}]][CON]]]}} {{normal=1}} @{charname_output}" data-i18n="hit-dice-u">HIT DICE</button>
                         </div>
-                        <input type="hidden" class="toggleflag" name="attr_global_save_mod_flag">
-                        <div class="hidden textarea globalattack">
-                            <span class="label" data-i18n="global-save-u">GLOBAL SAVE MODIFIER</span>
-                            <fieldset class="repeating_savemod">
-                                <div class="global-mod">
-                                    <input type="checkbox" name="attr_options-flag" class="options-flag" checked="checked" style="top: -15px;"><span>y</span>
-                                    <input type="checkbox" name="attr_global_save_active_flag" value="1" class="active-flag">
-                                    <div class="options">
-                                        <textarea type="textarea" name="attr_global_save_rollstring" placeholder="1d4[BLESS]" style="width: 125px;"></textarea>
+                        <div class="subcontainer" >
+                            <div class="row-container" style="float:right;margin-top:20px">
+                                <span class="label" data-i18n="successes-u">SUCCESSES</span>
+                                <input type="checkbox" name="attr_deathsave_succ1">
+                                <input type="checkbox" name="attr_deathsave_succ2">
+                                <input type="checkbox" name="attr_deathsave_succ3">
+                            </div>
+                            <button type="roll" style="margin-top:16px;" name="roll_death_save" value="@{wtype}&{template:simple} {{rname=^{death-save-u}}} {{mod=@{death_save_bonus}}} {{r1=[[@{d20}+@{death_save_bonus}[MOD]@{globalsavingthrowbonus}]]}} {{normal=1}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="destruction-saves-u">DESTRUCTION SAVES</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="col2-3">
+                    <div style="display:inline-block" class="equipment">
+                        <input type="hidden" class="inventoryflag" name="attr_simpleinventory" value="complex">
+                        <textarea class="simple" name="attr_equipment"></textarea>
+                        <div class="complex" style="margin-left: 70px">
+                            <input type="hidden" class="warningflag" name="attr_armorwarningflag">
+                            <div class="warning">
+                                <span data-i18n="warning-armor-sets-u">
+                                    <input type="checkbox" name="attr_armorwarning" value="hide">
+                                    WARNING - MULTIPLE SETS OF ARMOR OR SHIELDS HAVE BEEN ADDED AND AC IS NOT CORRECTLY CALCULATED. UNEQUIP THE ARMOR PIECE FROM THE ITEM DETAILS.
+                                </span>
+                            </div>
+                            <div class="header" style="height: auto;">
+                                <span class="pictos" style="width: 25px; font-size: 15px;">*</span>
+                                <span style="width: 100px; text-align: left;" data-i18n="item-name-u">ITEM NAME</SPAN>
+                                <span style="width: 25px;"><img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/5th%20Edition%20OGL%20by%20Roll20/images/weight_lbs.png" style="width: 15px; margin-bottom: -3px;"></span>
+                            </div>
+                            <fieldset class="repeating_inventory">
+                                <input type="hidden" class="equippedflag" name="attr_equipped">
+                                <div class="item">
+                                    <input class="weight" type="text" name="attr_itemcount" value="1">
+                                    <input class="name" type="text" name="attr_itemname">
+                                    <input class="weight" type="text" name="attr_itemweight">
+                                    <input class="inventorysubflag" type="checkbox" name="attr_inventorysubflag"><span>i</span>
+                                    <div class="subitem">
+                                        <input class="equipped" type="checkbox" name="attr_equipped" value="1" checked="checked">
+                                        <span class="equippedlabel" data-i18n="equipped-u">EQUIPPED</span>
+                                        <input class="equipped" type="checkbox" name="attr_useasresource" value="1">
+                                        <span class="equippedlabel" data-i18n="use-as-resource-u">USE AS A RESOURCE</span>
+                                        <input class="equipped" type="checkbox" name="attr_hasattack" value="1">
+                                        <span class="equippedlabel" data-i18n="has-attack-u">HAS AN ATTACK</span>
+                                        <span class="label" data-i18n="prop:-u">PROP:</span>
+                                        <input class="subfield" type="text" name="attr_itemproperties">
+                                        <span class="label" data-i18n="mods:-u">MODS:</span>
+                                        <input class="subfield" type="text" name="attr_itemmodifiers">
+                                        <textarea class="subtextarea" name="attr_itemcontent"></textarea>
                                     </div>
-                                    <div class="display">
-                                        <span class="title" name="attr_global_save_rollstring"></span>
-                                    </div>
+                                    <input type="hidden" name="attr_itemattackid">
+                                    <input type="hidden" name="attr_itemresourceid">
                                 </div>
                             </fieldset>
+                            <div class="weighttotal">
+                                <span class="label" data-i18n="total-cargo-u">TOTAL CARGO</span>
+                                <input type="text" name="attr_weighttotal" value="0">
+                            </div>
                         </div>
-                        <div class="label">
-                            <span data-i18n="saving-throws-u">SAVING THROWS</span>
-                        </div>
+                        <span class="label" style="margin-top: 0px; position: absolute; bottom: 0px;" data-i18n="cargo-u">CARGO</span>
                     </div>
-                </div>
+                    <div style="display:inline-block" class="equipment">
+                        <input type="hidden" class="inventoryflag" name="attr_simpleinventory" value="complex">
+                        <textarea class="simple" name="attr_equipment"></textarea>
+                        <div class="complex" style="margin-left: 70px">
+                            <input type="hidden" class="warningflag" name="attr_armorwarningflag">
+                            <div class="warning">
+                                <span data-i18n="warning-armor-sets-u">
+                                    <input type="checkbox" name="attr_armorwarning" value="hide">
+                                    WARNING - MULTIPLE SETS OF ARMOR OR SHIELDS HAVE BEEN ADDED AND AC IS NOT CORRECTLY CALCULATED. UNEQUIP THE ARMOR PIECE FROM THE ITEM DETAILS.
+                                </span>
+                            </div>
+                            <div class="header" style="height: auto;">
+                                <span class="pictos" style="width: 25px; font-size: 15px;">*</span>
+                                <span style="width: 100px; text-align: left;" data-i18n="item-name-u">ITEM NAME</SPAN>
+                                <span style="width: 25px;"><img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/5th%20Edition%20OGL%20by%20Roll20/images/weight_lbs.png" style="width: 15px; margin-bottom: -3px;"></span>
+                            </div>
+                            <fieldset class="repeating_hiddeninventory">
+                                <input type="hidden" class="equippedflag" name="attr_equipped">
+                                <div class="item">
+                                    <input class="weight" type="text" name="attr_itemcount" value="1">
+                                    <input class="name" type="text" name="attr_itemname">
+                                    <input class="weight" type="text" name="attr_itemweight">
+                                    <input class="inventorysubflag" type="checkbox" name="attr_inventorysubflag"><span>i</span>
+                                    <div class="subitem">
+                                        <input class="equipped" type="checkbox" name="attr_equipped" value="1" checked="checked">
+                                        <span class="equippedlabel" data-i18n="equipped-u">EQUIPPED</span>
+                                        <input class="equipped" type="checkbox" name="attr_useasresource" value="1">
+                                        <span class="equippedlabel" data-i18n="use-as-resource-u">USE AS A RESOURCE</span>
+                                        <input class="equipped" type="checkbox" name="attr_hasattack" value="1">
+                                        <span class="equippedlabel" data-i18n="has-attack-u">HAS AN ATTACK</span>
+                                        <span class="label" data-i18n="prop:-u">PROP:</span>
+                                        <input class="subfield" type="text" name="attr_itemproperties">
+                                        <span class="label" data-i18n="mods:-u">MODS:</span>
+                                        <input class="subfield" type="text" name="attr_itemmodifiers">
+                                        <textarea class="subtextarea" name="attr_itemcontent"></textarea>
+                                    </div>
+                                    <input type="hidden" name="attr_itemattackid">
+                                    <input type="hidden" name="attr_itemresourceid">
+                                </div>
+                            </fieldset>
+                            <div class="weighttotal">
+                                <span class="label" data-i18n="total-hidden-cargo-u">TOTAL HIDDEN CARGO</span>
+                                <input type="text" name="attr_hiddenweighttotal" value="0">
+                            </div>
+                        </div>
+                        <span class="label" style="margin-top: 0px; position: absolute; bottom: 0px;" data-i18n="hidden-cargo-u">HIDDEN CARGO</span>
+                    </div>
+                </div>  
             </div>
-            <div class="col col2">
-                <div class="ac-init-speed-container">
-                    <div class="ac">
-                        <input type="text" name="attr_ac">
-                        <span class="label pc-ac" data-i18n="armor-class-u">ARMOR CLASS</span>
-                    </div>
-                    <div class="speed">
-                            <input type="text" name="attr_ship_turnspeed">
-                            <span class="label" data-i18n="ship_turnspeed-u">TURNING SPEED</span>
-                        </div>
-                    <div class="speed">
-                        <input type="text" name="attr_ship_flyspeed">
-                        <span class="label" data-i18n="ship_flyspeed-u">FLYING SPEED</span>
-                    </div>
-                </div>
-                <div class="hp">
-                    <div class="top">
-                        <span data-i18n="hp-max-u">Hit Point Maximum</span>
-                        <input type="text" name="attr_hp_max" title="@{hp_max}">
-                    </div>
-                    <input type="number" name="attr_hp" title="@{hp}">
-                    <span class="label" data-i18n="hp-current-u">CURRENT HIT POINTS</span>
-                </div>
-                <div class="hp">
-                    <div class="top">
-                        <span data-i18n="ship-shield-max-u">Shield Point Maximum</span>
-                        <input type="text" style="width:120px" name="attr_ship_shield_max">
-                    </div>
-                    <input type="number" name="attr_ship_shield_points">
-                    <span class="label" data-i18n="ship-shield-u">CURRENT SHIELD POINTS</span>
-                </div>
-                <div class="hdice-dsaves-container" style="width: 242px;">
-                    <div class="subcontainer">
-                        <div class="top">
-                            <span data-i18n="total">Total</span>
-                            <input type="text" name="attr_hit_dice_max" title="@{hit_dice_max}">
-                        </div>
-                        <input type="number" name="attr_hit_dice" title="@{hit_dice}" style="margin-bottom: -6px;">
-                        <button type="roll" name="roll_hit_dice" value="@{wtype}&{template:simple} {{rname=^{hit-dice-u}}} {{mod=D@{hitdie_final}+[[@{constitution_mod}[CON]]]}} {{r1=[[1d@{hitdie_final}+[[@{constitution_mod}]][CON]]]}} {{normal=1}} @{charname_output}" data-i18n="hit-dice-u">HIT DICE</button>
-                    </div>
-                    <div class="subcontainer" >
-                        <div class="row-container" style="float:right;margin-top:20px">
-                            <span class="label" data-i18n="successes-u">SUCCESSES</span>
-                            <input type="checkbox" name="attr_deathsave_succ1">
-                            <input type="checkbox" name="attr_deathsave_succ2">
-                            <input type="checkbox" name="attr_deathsave_succ3">
-                        </div>
-                        <button type="roll" style="margin-top:16px;" name="roll_death_save" value="@{wtype}&{template:simple} {{rname=^{death-save-u}}} {{mod=@{death_save_bonus}}} {{r1=[[@{d20}+@{death_save_bonus}[MOD]@{globalsavingthrowbonus}]]}} {{normal=1}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="destruction-saves-u">DESTRUCTION SAVES</button>
-                    </div>
-                </div>
-            </div>
-            <div class="col col3">
+            
+            <div class="col">
                 <input type="hidden" class="ammoflag" name="attr_ammotracking">
                 <div class="attacks" style="position: relative;">
                     <div class="top">
@@ -4747,7 +4846,92 @@
                     </div>
                     <span class="label" style="margin-top: 0px; position: absolute; bottom: 0px;" data-i18n="atk-powercasting-u">ATTACKS</span>
                 </div>
+                <div class="resources">
+                    <div class="hdice-dsaves-container" style="width: 246px; margin-top: 10px;">
+                        <div class="subcontainer" style="height: 64px; width: 119px;">
+                            <div class="top">
+                                <span data-i18n="total">Total</span>
+                                <input type="text" name="attr_class_resource_max" title="@{class_resource_max}">
+                            </div>
+                            <input type="number" name="attr_class_resource" title="@{class_resource}" style="margin-bottom: -6px;">
+                            <input type="text" class="label" name="attr_class_resource_name" title="@{class_resource_name}" placeholder="CLASS RESOURCE" data-i18n-placeholder="class-resource-u">
+                        </div>
+                        <div class="subcontainer" style="height: 64px; width: 119px; float: right;">
+                            <div class="top">
+                                <span  data-i18n="total">Total</span>
+                                <input type="text" name="attr_other_resource_max" title="@{other_resource_max}">
+                            </div>
+                            <input type="number" name="attr_other_resource" title="@{other_resource}" style="margin-bottom: -6px;">
+                            <input type="text" class="label" name="attr_other_resource_name" title="@{other_resource_name}" placeholder="OTHER RESOURCE" data-i18n-placeholder="other-resource-u">
+                            <input type="hidden" name="attr_other_resource_itemid">
+                        </div>
+                    </div>
+                    <fieldset class="repeating_resource">
+                        <div class="hdice-dsaves-container" style="width: 246px; margin-top: 10px;">
+                            <div class="subcontainer" style="height: 64px; width: 119px;">
+                                <div class="top">
+                                    <span data-i18n="total">Total</span>
+                                    <input type="text" name="attr_resource_left_max" title="@{repeating_resource_left_max}">
+                                </div>
+                                <input type="number" name="attr_resource_left" title="@{repeating_resource_left}" style="margin-bottom: -6px;">
+                                <input type="text" class="label" name="attr_resource_left_name" title="@{repeating_resource_left_name}" placeholder="OTHER RESOURCE" data-i18n-placeholder="other-resource-u">
+                                <input type="hidden" name="attr_resource_left_itemid">
+                            </div>
+                            <div class="subcontainer" style="height: 64px; width: 119px;">
+                                <div class="top">
+                                    <span data-i18n="total">Total</span>
+                                    <input type="text" name="attr_resource_right_max" title="@{repeating_resource_right_max}">
+                                </div>
+                                <input type="number" name="attr_resource_right" title="@{repeating_resource_right}" style="margin-bottom: -6px;">
+                                <input type="text" class="label" name="attr_resource_right_name" title="@{repeating_resource_right_name}" placeholder="OTHER RESOURCE" data-i18n-placeholder="other-resource-u">
+                                <input type="hidden" name="attr_resource_right_itemid">
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <div class="textbox traits" style="min-height: 480px;">
+                    <input type="hidden" class="inventoryflag" name="attr_simpletraits" value="complex">
+                    <textarea class="sheet-simple" name="attr_features_and_traits" style="min-height: 461px; height: 461px;"></textarea>
+                    <div class="complex">
+                        <fieldset class="repeating_traits">
+                            <div class="trait">
+                                <button type="roll" name="roll_output" class="output" value="@{wtype}&{template:traits} @{charname_output} {{name=@{name}}} {{source=@{source}: @{source_type}}} {{description=@{description}}}">w</button>
+                                <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
+                                <input class="display-flag" type="checkbox" name="attr_display_flag">
+                                <div class="options">
+                                    <div class="row">
+                                        <span data-i18n="name:-u">NAME:</span>
+                                        <input type="text" name="attr_name" style="width: 120px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="source:-u">SOURCE:</span>
+                                        <select name="attr_source">
+                                            <option selected="selected" data-i18n="tier">Tier</option>
+                                            <option data-i18n="other">Other</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="source-type:-u">SOURCE TYPE:</span>
+                                        <input type="text" name="attr_source_type" style="width: 160px;" placeholder="Tier 1">
+                                    </div>
+                                    <div class="row">
+                                        <textarea name="attr_description" style="min-height: 200px; height: 200px;"></textarea>
+                                    </div>
+                                </div>
+                                <div class="display" style="margin-bottom: 2px;">
+                                    <span class="title" name="attr_name"></span>
+                                    <span class="subheader">
+                                        <span name="attr_source"></span><span>: </span><span name="attr_source_type"></span>
+                                    </span>
+                                    <span class="desc" name="attr_description"></span>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                    <span class="label" data-i18n="feats-traits-u" style="margin-top: 0px; position: absolute; bottom: 0px;">FEATURES & TRAITS</span>
+                </div>
             </div>
+            
         </div>
     </div>
     <div class="page ship-modifications">
@@ -6343,6 +6527,60 @@
         });
     })
 
+    on("change:repeating_hiddeninventory:hasattack", function(eventinfo) {
+        if(eventinfo.sourceType === "sheetworker") {
+            return;
+        }
+
+        var itemid = eventinfo.sourceAttribute.substring(20, 40);
+        getAttrs(["repeating_hiddeninventory_" + itemid + "_hasattack", "repeating_hiddeninventory_" + itemid + "_itemattackid"], function(v) {
+            var attackid = v["repeating_hiddeninventory_" + itemid + "_itemattackid"];
+            var hasattack = v["repeating_hiddeninventory_" + itemid + "_hasattack"];
+            if(attackid && attackid != "" && hasattack == 0) {
+                remove_attack(attackid);
+            }
+            else if(hasattack == 1) {
+                create_attack_from_item(itemid, {hidden: true});
+            };
+        });
+    })
+
+    on("change:repeating_hiddeninventory:itemname change:repeating_hiddeninventory:itemproperties change:repeating_hiddeninventory:itemmodifiers change:repeating_hiddeninventory:itemcount", function(eventinfo) {
+        if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+            return;
+        }
+
+        var itemid = eventinfo.sourceAttribute.substring(20, 40);
+        getAttrs(["repeating_hiddeninventory_" + itemid + "_itemattackid", "repeating_hiddeninventory_" + itemid + "_itemresourceid"], function(v) {
+            var attackid = v["repeating_hiddeninventory_" + itemid + "_itemattackid"];
+            var resourceid = v["repeating_hiddeninventory_" + itemid + "_itemresourceid"];
+            if(attackid) {
+                update_attack_from_item(itemid, attackid, {hidden: true});
+            }
+            if(resourceid) {
+                update_resource_from_item(itemid, resourceid, false, {hidden: true});
+            }
+        });
+    });
+
+    on("change:repeating_hiddeninventory:useasresource", function(eventinfo) {
+        if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+            return;
+        }
+
+        var itemid = eventinfo.sourceAttribute.substring(20, 40);
+        getAttrs(["repeating_hiddeninventory_" + itemid + "_useasresource", "repeating_hiddeninventory_" + itemid + "_itemresourceid"], function(v) {
+            var useasresource = v["repeating_hiddeninventory_" + itemid + "_useasresource"];
+            var resourceid = v["repeating_hiddeninventory_" + itemid + "_itemresourceid"];
+            if(useasresource == 1) {
+                create_resource_from_item(itemid, {hidden: true});
+            }
+            else {
+                remove_resource(resourceid);
+            };
+        });
+    });
+
     on("change:repeating_inventory:itemname change:repeating_inventory:itemproperties change:repeating_inventory:itemmodifiers change:repeating_inventory:itemcount", function(eventinfo) {
         if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
             return;
@@ -6404,7 +6642,7 @@
 
     });
 
-    on("change:repeating_inventory:itemweight change:repeating_inventory:itemcount change:cp change:sp change:ep change:gp change:pp change:encumberance_setting change:size change:carrying_capacity_mod", function() {
+    on("change:repeating_inventory:itemweight change:repeating_inventory:itemcount change:cp change:sp change:ep change:gp change:pp change:encumberance_setting change:size change:carrying_capacity_mod change:repeating_hiddeninventory:itemweight change:repeating_hiddeninventory:itemcount", function() {
         update_weight();
     });
 
@@ -6416,6 +6654,18 @@
         getAttrs(["repeating_inventory_" + itemid + "_itemmodifiers"], function(v) {
             if(v["repeating_inventory_" + itemid + "_itemmodifiers"]) {
                 check_itemmodifiers(v["repeating_inventory_" + itemid + "_itemmodifiers"], eventinfo.previousValue);
+            };
+        });
+    });
+
+    on("change:repeating_hiddeninventory:itemmodifiers change:repeating_hiddeninventory:equipped", function(eventinfo) {
+        if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+            return;
+        }
+        var itemid = eventinfo.sourceAttribute.substring(20, 40);
+        getAttrs(["repeating_hiddeninventory_" + itemid + "_itemmodifiers"], function(v) {
+            if(v["repeating_hiddeninventory_" + itemid + "_itemmodifiers"]) {
+                check_itemmodifiers(v["repeating_hiddeninventory_" + itemid + "_itemmodifiers"], eventinfo.previousValue);
             };
         });
     });
@@ -6697,6 +6947,25 @@
         update_weight();
     });
 
+    on("remove:repeating_hiddeninventory", function(eventinfo) {
+        var itemid = eventinfo.sourceAttribute.substring(20, 40);
+        var attackids = eventinfo.removedInfo && eventinfo.removedInfo["repeating_hiddeninventory_" + itemid + "_itemattackid"] ? eventinfo.removedInfo["repeating_hiddeninventory_" + itemid + "_itemattackid"] : undefined;
+        var resourceid = eventinfo.removedInfo && eventinfo.removedInfo["repeating_hiddeninventory_" + itemid + "_itemresourceid"] ? eventinfo.removedInfo["repeating_hiddeninventory_" + itemid + "_itemresourceid"] : undefined;
+
+        if(attackids) {
+            _.each(attackids.split(","), function(value) { remove_attack(value); });
+        }
+        if(resourceid) {
+            remove_resource(resourceid);
+        }
+
+        if(eventinfo.removedInfo && eventinfo.removedInfo["repeating_hiddeninventory_" + itemid + "_itemmodifiers"]) {
+            check_itemmodifiers(eventinfo.removedInfo["repeating_hiddeninventory_" + itemid + "_itemmodifiers"]);
+        }
+
+        update_weight();
+    });
+
     on("remove:repeating_attack", function(eventinfo) {
         var attackid = eventinfo.sourceAttribute.substring(17, 37);
         var itemid = eventinfo.removedInfo["repeating_attack_" + attackid + "_itemid"];
@@ -6708,6 +6977,15 @@
                     var update = {};
                     update["repeating_inventory_" + itemid + "_itemattackid"] = "";
                     update["repeating_inventory_" + itemid + "_hasattack"] = 0;
+                    setAttrs(update, {silent: true});
+                }
+            });
+
+            getAttrs(["repeating_hiddeninventory_" + itemid + "_hasattack"], function(v) {
+                if(v["repeating_hiddeninventory_" + itemid + "_hasattack"] && v["repeating_hiddeninventory_" + itemid + "_hasattack"] == 1) {
+                    var update = {};
+                    update["repeating_hiddeninventory_" + itemid + "_itemattackid"] = "";
+                    update["repeating_hiddeninventory_" + itemid + "_hasattack"] = 0;
                     setAttrs(update, {silent: true});
                 }
             });
@@ -6727,17 +7005,32 @@
 
     on("remove:repeating_resource", function(eventinfo) {
         var resourceid = eventinfo.sourceAttribute.substring(19, 39);
-        var left_itemid = eventinfo.removedInfo["repeating_resource_" + resourceid + "_resource_left_itemid"];
-        var right_itemid = eventinfo.removedInfo["repeating_resource_" + resourceid + "_resource_right_itemid"];
+        var inventory = "repeating_inventory_";
         var update = {};
+
+        var left_itemid = eventinfo.removedInfo["repeating_resource_" + resourceid + "_resource_left_itemid"];   
+        getAttrs(["repeating_hiddeninventory_" + left_itemid + "_itemname"], function(x) {
+            if(x["repeating_hiddeninventory_" + left_itemid + "_itemname"]) {
+                inventory = "repeating_hiddeninventory_";
+            }
+        });
         if(left_itemid) {
-            update["repeating_inventory_" + left_itemid + "_useasresource"] = 0;
-            update["repeating_inventory_" + left_itemid + "_itemresourceid"] = "";
+            update[inventory + left_itemid + "_useasresource"] = 0;
+            update[inventory + left_itemid + "_itemresourceid"] = "";
         }
+
+        inventory = "repeating_inventory_";
+        var right_itemid = eventinfo.removedInfo["repeating_resource_" + resourceid + "_resource_right_itemid"];
+        getAttrs(["repeating_hiddeninventory_" + right_itemid + "_itemname"], function(y) {
+            if(y["repeating_hiddeninventory_" + right_itemid + "_itemname"]) {
+                inventory = "repeating_hiddeninventory_";
+            }
+        });
         if(right_itemid) {
-            update["repeating_inventory_" + right_itemid + "_useasresource"] = 0;
-            update["repeating_inventory_" + right_itemid + "_itemresourceid"] = "";
+            update[inventory + right_itemid + "_useasresource"] = 0;
+            update[inventory + right_itemid + "_itemresourceid"] = "";
         }
+
         setAttrs(update, {silent: true});
     });
 
@@ -6758,45 +7051,52 @@
     });
 
     var update_attr = function(attr) {
+        getSectionIDs("repeating_inventory", function(idarray) {
+            update_inventory_from_attr_change("repeating_inventory_", idarray, attr);
+        });
+        getSectionIDs("repeating_hiddeninventory", function(idarray) {
+            update_inventory_from_attr_change("repeating_hiddeninventory_", idarray, attr);
+        });
+    };
+
+    var update_inventory_from_attr_change = function(inventory, idarray, attr) {
         var update = {};
         var attr_fields = [attr + "_base",attr + "_bonus"];
-        getSectionIDs("repeating_inventory", function(idarray) {
-            _.each(idarray, function(currentID, i) {
-                attr_fields.push("repeating_inventory_" + currentID + "_equipped");
-                attr_fields.push("repeating_inventory_" + currentID + "_itemmodifiers");
+        _.each(idarray, function(currentID, i) {
+            attr_fields.push(inventory + currentID + "_equipped");
+            attr_fields.push(inventory + currentID + "_itemmodifiers");
+        });
+        getAttrs(attr_fields, function(v) {
+            var base = v[attr + "_base"] && !isNaN(parseInt(v[attr + "_base"], 10)) ? parseInt(v[attr + "_base"], 10) : 10;
+            var bonus = v[attr + "_bonus"] && !isNaN(parseInt(v[attr + "_bonus"], 10)) ? parseInt(v[attr + "_bonus"], 10) : 0;
+            var item_base = 0;
+            var item_bonus = 0;
+            _.each(idarray, function(currentID) {
+                if((!v[inventory + currentID + "_equipped"] || v[inventory + currentID + "_equipped"] === "1") && v[inventory + currentID + "_itemmodifiers"] && v[inventory + currentID + "_itemmodifiers"].toLowerCase().indexOf(attr > -1)) {
+                    var mods = v[inventory + currentID + "_itemmodifiers"].toLowerCase().split(",");
+                    _.each(mods, function(mod) {
+                        if(mod.indexOf(attr) > -1 && mod.indexOf("save") === -1) {
+                            if(mod.indexOf(":") > -1) {
+                                var new_base = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
+                                item_base = new_base && new_base > item_base ? new_base : item_base;
+                            }
+                            else if(mod.indexOf("-") > -1) {
+                                var new_mod = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
+                                item_bonus = new_mod ? item_bonus - new_mod : item_bonus;
+                            }
+                            else {
+                                var new_mod = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
+                                item_bonus = new_mod ? item_bonus + new_mod : item_bonus;
+                            }
+                        };
+                    });
+                }
             });
-            getAttrs(attr_fields, function(v) {
-                var base = v[attr + "_base"] && !isNaN(parseInt(v[attr + "_base"], 10)) ? parseInt(v[attr + "_base"], 10) : 10;
-                var bonus = v[attr + "_bonus"] && !isNaN(parseInt(v[attr + "_bonus"], 10)) ? parseInt(v[attr + "_bonus"], 10) : 0;
-                var item_base = 0;
-                var item_bonus = 0;
-                _.each(idarray, function(currentID) {
-                    if((!v["repeating_inventory_" + currentID + "_equipped"] || v["repeating_inventory_" + currentID + "_equipped"] === "1") && v["repeating_inventory_" + currentID + "_itemmodifiers"] && v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf(attr > -1)) {
-                        var mods = v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().split(",");
-                        _.each(mods, function(mod) {
-                            if(mod.indexOf(attr) > -1 && mod.indexOf("save") === -1) {
-                                if(mod.indexOf(":") > -1) {
-                                    var new_base = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
-                                    item_base = new_base && new_base > item_base ? new_base : item_base;
-                                }
-                                else if(mod.indexOf("-") > -1) {
-                                    var new_mod = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
-                                    item_bonus = new_mod ? item_bonus - new_mod : item_bonus;
-                                }
-                                else {
-                                    var new_mod = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
-                                    item_bonus = new_mod ? item_bonus + new_mod : item_bonus;
-                                }
-                            };
-                        });
-                    }
-                });
 
-                update[attr + "_flag"] = bonus > 0 || item_bonus > 0 || item_base > base ? 1 : 0;
-                base = base > item_base ? base : item_base;
-                update[attr] = base + bonus + item_bonus;
-                setAttrs(update);
-            });
+            update[attr + "_flag"] = bonus > 0 || item_bonus > 0 || item_base > base ? 1 : 0;
+            base = base > item_base ? base : item_base;
+            update[attr] = base + bonus + item_bonus;
+            setAttrs(update);
         });
     };
 
@@ -6812,45 +7112,53 @@
     };
 
     var update_save = function (attr) {
-        var save_attrs = [attr + "_mod", attr + "_save_prof", attr + "_save_mod","pb","globalsavemod","pb_type"];
         getSectionIDs("repeating_inventory", function(idarray) {
-            _.each(idarray, function(currentID, i) {
-                save_attrs.push("repeating_inventory_" + currentID + "_equipped");
-                save_attrs.push("repeating_inventory_" + currentID + "_itemmodifiers");
-            });
+            update_inventory_from_save_change("repeating_inventory_", idarray, attr);
+        });
 
-            getAttrs(save_attrs, function(v) {
-                var attr_mod = v[attr + "_mod"] ? parseInt(v[attr + "_mod"], 10) : 0;
-                var prof = v[attr + "_save_prof"] && v[attr + "_save_prof"] != 0 && !isNaN(v["pb"]) ? parseInt(v["pb"], 10) : 0;
-                var save_mod = v[attr + "_save_mod"] && !isNaN(parseInt(v[attr + "_save_mod"], 10)) ? parseInt(v[attr + "_save_mod"], 10) : 0;
-                var global = v["globalsavemod"] && !isNaN(v["globalsavemod"]) ? parseInt(v["globalsavemod"], 10) : 0;
-                var items = 0;
-                _.each(idarray, function(currentID) {
-                    if(v["repeating_inventory_" + currentID + "_equipped"] && v["repeating_inventory_" + currentID + "_equipped"] === "1" && v["repeating_inventory_" + currentID + "_itemmodifiers"] && (v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf("saving throws") > -1 || v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf(attr + " save") > -1)) {
-                        var mods = v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().split(",");
-                        _.each(mods, function(mod) {
-                            if(mod.indexOf(attr + " save") > -1) {
-                                var substr = mod.slice(mod.lastIndexOf(attr + " save") + attr.length + " save".length);
-                                var bonus = substr && substr.length > 0 && !isNaN(parseInt(substr,10)) ? parseInt(substr,10) : 0;
-                            }
-                            else if(mod.indexOf("saving throws") > -1) {
-                                var substr = mod.slice(mod.lastIndexOf("saving throws") + "saving throws".length);
-                                var bonus = substr && substr.length > 0 && !isNaN(parseInt(substr,10)) ? parseInt(substr,10) : 0;
-                            };
-                            if(bonus && bonus != 0) {
-                                items = items + bonus;
-                            };
-                        });
-                    }
-                });
-                var total = attr_mod + prof + save_mod + global + items;
-                if(v["pb_type"] && v["pb_type"] === "die" && v[attr + "_save_prof"] != 0 && attr != "death") {
-                    total = total + "+" + v["pb"];
-                };
-                var update = {};
-                update[attr + "_save_bonus"] = total;
-                setAttrs(update, {silent: true});
+        getSectionIDs("repeating_hiddeninventory", function(idarray) {
+            update_inventory_from_save_change("repeating_hiddeninventory_", idarray, attr);
+        });
+    };
+
+    var update_inventory_from_save_change = function(inventory, idarray, attr) {
+        var save_attrs = [attr + "_mod", attr + "_save_prof", attr + "_save_mod","pb","globalsavemod","pb_type"];
+        _.each(idarray, function(currentID, i) {
+            save_attrs.push(inventory + currentID + "_equipped");
+            save_attrs.push(inventory + currentID + "_itemmodifiers");
+        });
+
+        getAttrs(save_attrs, function(v) {
+            var attr_mod = v[attr + "_mod"] ? parseInt(v[attr + "_mod"], 10) : 0;
+            var prof = v[attr + "_save_prof"] && v[attr + "_save_prof"] != 0 && !isNaN(v["pb"]) ? parseInt(v["pb"], 10) : 0;
+            var save_mod = v[attr + "_save_mod"] && !isNaN(parseInt(v[attr + "_save_mod"], 10)) ? parseInt(v[attr + "_save_mod"], 10) : 0;
+            var global = v["globalsavemod"] && !isNaN(v["globalsavemod"]) ? parseInt(v["globalsavemod"], 10) : 0;
+            var items = 0;
+            _.each(idarray, function(currentID) {
+                if(v[inventory + currentID + "_equipped"] && v[inventory + currentID + "_equipped"] === "1" && v[inventory + currentID + "_itemmodifiers"] && (v[inventory + currentID + "_itemmodifiers"].toLowerCase().indexOf("saving throws") > -1 || v[inventory + currentID + "_itemmodifiers"].toLowerCase().indexOf(attr + " save") > -1)) {
+                    var mods = v[inventory + currentID + "_itemmodifiers"].toLowerCase().split(",");
+                    _.each(mods, function(mod) {
+                        if(mod.indexOf(attr + " save") > -1) {
+                            var substr = mod.slice(mod.lastIndexOf(attr + " save") + attr.length + " save".length);
+                            var bonus = substr && substr.length > 0 && !isNaN(parseInt(substr,10)) ? parseInt(substr,10) : 0;
+                        }
+                        else if(mod.indexOf("saving throws") > -1) {
+                            var substr = mod.slice(mod.lastIndexOf("saving throws") + "saving throws".length);
+                            var bonus = substr && substr.length > 0 && !isNaN(parseInt(substr,10)) ? parseInt(substr,10) : 0;
+                        };
+                        if(bonus && bonus != 0) {
+                            items = items + bonus;
+                        };
+                    });
+                }
             });
+            var total = attr_mod + prof + save_mod + global + items;
+            if(v["pb_type"] && v["pb_type"] === "die" && v[attr + "_save_prof"] != 0 && attr != "death") {
+                total = total + "+" + v["pb"];
+            };
+            var update = {};
+            update[attr + "_save_bonus"] = total;
+            setAttrs(update, {silent: true});
         });
     };
 
@@ -6872,7 +7180,6 @@
     var update_skills = function (skills_array) {
         var skill_parent = {athletics: "strength", acrobatics: "dexterity", sleight_of_hand: "dexterity", stealth: "dexterity", technology: "intelligence", lore: "intelligence", investigation: "intelligence", nature: "intelligence", piloting: "intelligence", animal_handling: "wisdom", insight: "wisdom", medicine: "wisdom", perception: "wisdom", survival: "wisdom", deception: "charisma", intimidation: "charisma", performance: "charisma", persuasion: "charisma"};
         var attrs_to_get = ["pb","pb_type","jack_of_all_trades","jack"];
-        var update = {};
         var callbacks = [];
 
         if(skills_array.indexOf("perception") > -1) {
@@ -6887,64 +7194,74 @@
         });
 
         getSectionIDs("repeating_inventory", function(idarray) {
-            _.each(idarray, function(currentID, i) {
-                attrs_to_get.push("repeating_inventory_" + currentID + "_equipped");
-                attrs_to_get.push("repeating_inventory_" + currentID + "_itemmodifiers");
-            });
+            update_inventory_from_skill_change("repeating_inventory_", idarray, callbacks, attrs_to_get, skill_parent, skills_array);
+        });
 
-            getAttrs(attrs_to_get, function(v) {
-                _.each(skills_array, function(s) {
-                    console.log("UPDATING SKILL: " + s);
-                    var attr_mod = v[skill_parent[s] + "_mod"] ? parseInt(v[skill_parent[s] + "_mod"], 10) : 0;
-                    var prof = v[s + "_prof"] != 0 && !isNaN(v["pb"]) ? parseInt(v["pb"], 10) : 0;
-                    var flat = v[s + "_flat"] && !isNaN(parseInt(v[s + "_flat"], 10)) ? parseInt(v[s + "_flat"], 10) : 0;
-                    var type = v[s + "_type"] && !isNaN(parseInt(v[s + "_type"], 10)) ? parseInt(v[s + "_type"], 10) : 1;
-                    var jack = v["jack_of_all_trades"] && v["jack_of_all_trades"] != 0 && v["jack"] ? v["jack"] : 0;
-                    var item_bonus = 0;
+        getSectionIDs("repeating_hiddeninventory", function(idarray) {
+            update_inventory_from_skill_change("repeating_hiddeninventory_", idarray, callbacks, attrs_to_get, skill_parent, skills_array);
+        });
+    };
 
-                    _.each(idarray, function(currentID) {
-                        if(v["repeating_inventory_" + currentID + "_equipped"] && v["repeating_inventory_" + currentID + "_equipped"] === "1" && v["repeating_inventory_" + currentID + "_itemmodifiers"] && (v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().replace(/ /g,"_").indexOf(s) > -1 || v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf("ability checks") > -1)) {
-                            var mods = v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().split(",");
-                            _.each(mods, function(mod) {
-                                if(mod.replace(/ /g,"_").indexOf(s) > -1 || mod.indexOf("ability checks") > -1) {
-                                    if(mod.indexOf("-") > -1) {
-                                        var new_mod = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
-                                        item_bonus = new_mod ? item_bonus - new_mod : item_bonus;
-                                    }
-                                    else {
-                                        var new_mod = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
-                                        item_bonus = new_mod ? item_bonus + new_mod : item_bonus;
-                                    }
-                                };
-                            });
-                        };
-                    });
+    var update_inventory_from_skill_change = function(inventory, idarray, callbacks, attrs_to_get, skill_parent, skills_array) {
+        var update = {};
 
-                    var total = attr_mod + flat + item_bonus;
+        _.each(idarray, function(currentID, i) {
+            attrs_to_get.push(inventory + currentID + "_equipped");
+            attrs_to_get.push(inventory + currentID + "_itemmodifiers");
+        });
 
-                    if(v["pb_type"] && v["pb_type"] === "die") {
-                        if(v[s + "_prof"] != 0) {
-                            type === 1 ? "" : "2"
-                            total = total + "+" + type + v["pb"];
-                        }
-                        else if(v[s + "_prof"] == 0 && jack != 0) {
-                            total = total + "+" + jack;
-                        };
-                    }
-                    else {
-                        if(v[s + "_prof"] != 0) {
-                            total = total + (prof * type);
-                        }
-                        else if(v[s + "_prof"] == 0 && jack != 0) {
-                            total = total + parseInt(jack, 10);
-                        };
+        getAttrs(attrs_to_get, function(v) {
+            _.each(skills_array, function(s) {
+                console.log("UPDATING SKILL: " + s);
+                var attr_mod = v[skill_parent[s] + "_mod"] ? parseInt(v[skill_parent[s] + "_mod"], 10) : 0;
+                var prof = v[s + "_prof"] != 0 && !isNaN(v["pb"]) ? parseInt(v["pb"], 10) : 0;
+                var flat = v[s + "_flat"] && !isNaN(parseInt(v[s + "_flat"], 10)) ? parseInt(v[s + "_flat"], 10) : 0;
+                var type = v[s + "_type"] && !isNaN(parseInt(v[s + "_type"], 10)) ? parseInt(v[s + "_type"], 10) : 1;
+                var jack = v["jack_of_all_trades"] && v["jack_of_all_trades"] != 0 && v["jack"] ? v["jack"] : 0;
+                var item_bonus = 0;
 
+                _.each(idarray, function(currentID) {
+                    if(v[inventory + currentID + "_equipped"] && v[inventory + currentID + "_equipped"] === "1" && v[inventory + currentID + "_itemmodifiers"] && (v[inventory + currentID + "_itemmodifiers"].toLowerCase().replace(/ /g,"_").indexOf(s) > -1 || v[inventory + currentID + "_itemmodifiers"].toLowerCase().indexOf("ability checks") > -1)) {
+                        var mods = v[inventory + currentID + "_itemmodifiers"].toLowerCase().split(",");
+                        _.each(mods, function(mod) {
+                            if(mod.replace(/ /g,"_").indexOf(s) > -1 || mod.indexOf("ability checks") > -1) {
+                                if(mod.indexOf("-") > -1) {
+                                    var new_mod = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
+                                    item_bonus = new_mod ? item_bonus - new_mod : item_bonus;
+                                }
+                                else {
+                                    var new_mod = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
+                                    item_bonus = new_mod ? item_bonus + new_mod : item_bonus;
+                                }
+                            };
+                        });
                     };
-                    update[s + "_bonus"] = total;
                 });
 
-                setAttrs(update, {silent: true}, function() {callbacks.forEach(function(callback) {callback(); })} );
+                var total = attr_mod + flat + item_bonus;
+
+                if(v["pb_type"] && v["pb_type"] === "die") {
+                    if(v[s + "_prof"] != 0) {
+                        type === 1 ? "" : "2"
+                        total = total + "+" + type + v["pb"];
+                    }
+                    else if(v[s + "_prof"] == 0 && jack != 0) {
+                        total = total + "+" + jack;
+                    };
+                }
+                else {
+                    if(v[s + "_prof"] != 0) {
+                        total = total + (prof * type);
+                    }
+                    else if(v[s + "_prof"] == 0 && jack != 0) {
+                        total = total + parseInt(jack, 10);
+                    };
+
+                };
+                update[s + "_bonus"] = total;
             });
+
+            setAttrs(update, {silent: true}, function() {callbacks.forEach(function(callback) {callback(); })} );
         });
     };
 
@@ -8287,24 +8604,38 @@
     };
 
     var create_attack_from_item = function(itemid, options) {
+        var inventory = "repeating_inventory_";
+        var isHidden = false;
+        if(options && options.hidden) {
+            inventory = "repeating_hiddeninventory_";
+            isHidden = true;
+        }
         var update = {};
         var newrowid = generateRowID();
-        update["repeating_inventory_" + itemid + "_itemattackid"] = newrowid;
+        update[inventory + itemid + "_itemattackid"] = newrowid;
         if(options && options.versatile) {
             var newrowid2 = generateRowID();
-            update["repeating_inventory_" + itemid + "_itemattackid"] += "," + newrowid2;
+            update[inventory + itemid + "_itemattackid"] += "," + newrowid2;
+            
             setAttrs(update, {}, function() {
-                update_attack_from_item(itemid, newrowid, {newattack: true, versatile: "primary"});
-                update_attack_from_item(itemid, newrowid2, {newattack: true, versatile: "secondary"});
+                update_attack_from_item(itemid, newrowid, {newattack: true, versatile: "primary", hidden: isHidden});
+                update_attack_from_item(itemid, newrowid2, {newattack: true, versatile: "secondary", hidden: isHidden});
             });
         }
         else {
-            setAttrs(update, {}, update_attack_from_item(itemid, newrowid, {newattack: true}));
+            setAttrs(update, {}, update_attack_from_item(itemid, newrowid, {newattack: true, hidden: isHidden}));
         }
     };
 
     var update_attack_from_item = function(itemid, attackid, options) {
-        getAttrs(["repeating_inventory_" + itemid + "_itemname","repeating_inventory_" + itemid + "_itemproperties","repeating_inventory_" + itemid + "_itemmodifiers", "strength", "dexterity"], function(v) {
+        var inventory = "repeating_inventory_";
+        var isHidden = false;
+        if(options && options.hidden) {
+            inventory = "repeating_hiddeninventory_";
+            isHidden = true;
+        }
+
+        getAttrs([inventory + itemid + "_itemname",inventory + itemid + "_itemproperties",inventory + itemid + "_itemmodifiers", "strength", "dexterity"], function(v) {
             var update = {}; var itemtype; var damage; var damagetype; var damage2; var damagetype2; var attackmod; var damagemod; var range;
             var alt = {};
 
@@ -8313,8 +8644,8 @@
                 update["repeating_attack_" + attackid + "_itemid"] = itemid;
             }
 
-            if(v["repeating_inventory_" + itemid + "_itemmodifiers"] && v["repeating_inventory_" + itemid + "_itemmodifiers"] != "") {
-                var mods = v["repeating_inventory_" + itemid + "_itemmodifiers"].split(",");
+            if(v[inventory + itemid + "_itemmodifiers"] && v[inventory + itemid + "_itemmodifiers"] != "") {
+                var mods = v[inventory + itemid + "_itemmodifiers"].split(",");
                 _.each(mods, function(mod) {
                     if(mod.indexOf("Item Type:") > -1) {itemtype = mod.split(":")[1].trim()}
                     else if(mod.indexOf("Alternate Secondary Damage Type:") > -1) {alt.damagetype2 = mod.split(":")[1].trim();}
@@ -8331,8 +8662,8 @@
                 });
             }
 
-            if(v["repeating_inventory_" + itemid + "_itemname"] && v["repeating_inventory_" + itemid + "_itemname"] != "") {
-                update["repeating_attack_" + attackid + "_atkname"] = v["repeating_inventory_" + itemid + "_itemname"];
+            if(v[inventory + itemid + "_itemname"] && v[inventory + itemid + "_itemname"] != "") {
+                update["repeating_attack_" + attackid + "_atkname"] = v[inventory + itemid + "_itemname"];
                 if(options && options.versatile === "primary") {
                     update["repeating_attack_" + attackid + "_atkname"] += " (One-Handed)";
                 } else if(options && options.versatile === "secondary") {
@@ -8375,7 +8706,7 @@
             if(range) {
                 update["repeating_attack_" + attackid + "_atkrange"] = range;
             }
-            var finesse = v["repeating_inventory_" + itemid + "_itemproperties"] && /finesse/i.test(v["repeating_inventory_" + itemid + "_itemproperties"]);
+            var finesse = v[inventory + itemid + "_itemproperties"] && /finesse/i.test(v[inventory + itemid + "_itemproperties"]);
             if( (itemtype && itemtype.indexOf("Ranged") > -1) || (finesse && +v.dexterity > +v.strength)) {
                 update["repeating_attack_" + attackid + "_atkattr_base"] = "@{dexterity_mod}";
                 update["repeating_attack_" + attackid + "_dmgattr"] = "@{dexterity_mod}";
@@ -8403,20 +8734,26 @@
         });
     };
 
-    var create_resource_from_item = function(itemid) {
+    var create_resource_from_item = function(itemid, options) {
         var update = {};
         var newrowid = generateRowID();
+        var inventory = "repeating_inventory_";
+        var isHidden = false;
+        if(options && options.hidden){
+            inventory = "repeating_hiddeninventory_";
+            isHidden = true;
+        }
 
         getAttrs(["other_resource_name"], function(x) {
             if(!x.other_resource_name || x.other_resource_name == "") {
-                update["repeating_inventory_" + itemid + "_itemresourceid"] = "other_resource";
-                setAttrs(update, {}, update_resource_from_item(itemid, "other_resource", true));
+                update[inventory + itemid + "_itemresourceid"] = "other_resource";
+                setAttrs(update, {}, update_resource_from_item(itemid, "other_resource", true, {hidden: isHidden}));
             }
             else {
                 getSectionIDs("repeating_resource", function(idarray) {
                     if(idarray.length == 0) {
-                        update["repeating_inventory_" + itemid + "_itemresourceid"] = newrowid + "_resource_left";
-                        setAttrs(update, {}, update_resource_from_item(itemid, newrowid + "_resource_left", true));
+                        update[inventory + itemid + "_itemresourceid"] = newrowid + "_resource_left";
+                        setAttrs(update, {}, update_resource_from_item(itemid, newrowid + "_resource_left", true, {hidden: isHidden}));
                     }
                     else {
                         var resource_names = [];
@@ -8429,19 +8766,19 @@
                             var existing = false;
                             _.each(idarray, function(currentID, i) {
                                 if((!y["repeating_resource_" + currentID + "_resource_left_name"] || y["repeating_resource_" + currentID + "_resource_left_name"] === "") && existing == false) {
-                                    update["repeating_inventory_" + itemid + "_itemresourceid"] = currentID + "_resource_left";
-                                    setAttrs(update, {}, update_resource_from_item(itemid, currentID + "_resource_left", true));
+                                    update[inventory + itemid + "_itemresourceid"] = currentID + "_resource_left";
+                                    setAttrs(update, {}, update_resource_from_item(itemid, currentID + "_resource_left", true, {hidden:isHidden}));
                                     existing = true;
                                 }
                                 else if((!y["repeating_resource_" + currentID + "_resource_right_name"] || y["repeating_resource_" + currentID + "_resource_right_name"] === "") && existing == false) {
-                                    update["repeating_inventory_" + itemid + "_itemresourceid"] = currentID + "_resource_right";
-                                    setAttrs(update, {}, update_resource_from_item(itemid, currentID + "_resource_right", true));
+                                    update[inventory + itemid + "_itemresourceid"] = currentID + "_resource_right";
+                                    setAttrs(update, {}, update_resource_from_item(itemid, currentID + "_resource_right", true, {hidden:isHidden}));
                                     existing = true;
                                 };
                             });
                             if(!existing) {
-                                update["repeating_inventory_" + itemid + "_itemresourceid"] = newrowid + "_resource_left";
-                                setAttrs(update, {}, update_resource_from_item(itemid, newrowid + "_resource_left", true));
+                                update[inventory + itemid + "_itemresourceid"] = newrowid + "_resource_left";
+                                setAttrs(update, {}, update_resource_from_item(itemid, newrowid + "_resource_left", true, {hidden:isHidden}));
                             }
                         });
 
@@ -8452,8 +8789,13 @@
 
     };
 
-    var update_resource_from_item = function(itemid, resourceid, newresource) {
-        getAttrs(["repeating_inventory_" + itemid + "_itemname","repeating_inventory_" + itemid + "_itemcount"], function(v) {
+    var update_resource_from_item = function(itemid, resourceid, newresource, options) {
+        var inventory = "repeating_inventory_";
+        if(options && options.hidden) {
+            inventory = "repeating_hiddeninventory_";
+        }
+
+        getAttrs([inventory + itemid + "_itemname",inventory + itemid + "_itemcount"], function(v) {
             var update = {}; var id;
 
             if(resourceid && resourceid == "other_resource") {
@@ -8467,16 +8809,16 @@
                 update[id + "_itemid"] = itemid;
             } ;
 
-            if(!v["repeating_inventory_" + itemid + "_itemname"]) {
-                update["repeating_inventory_" + itemid + "_useasresource"] = 0;
-                update["repeating_inventory_" + itemid + "_itemresourceid"] = "";
+            if(!v[inventory + itemid + "_itemname"]) {
+                update[inventory + itemid + "_useasresource"] = 0;
+                update[inventory + itemid + "_itemresourceid"] = "";
                 remove_resource(resourceid);
             };
-            if(v["repeating_inventory_" + itemid + "_itemname"] && v["repeating_inventory_" + itemid + "_itemname"] != "") {
-                update[id + "_name"] = v["repeating_inventory_" + itemid + "_itemname"];
+            if(v[inventory + itemid + "_itemname"] && v[inventory + itemid + "_itemname"] != "") {
+                update[id + "_name"] = v[inventory + itemid + "_itemname"];
             };
-            if(v["repeating_inventory_" + itemid + "_itemcount"] && v["repeating_inventory_" + itemid + "_itemcount"] != "") {
-                update[id] = v["repeating_inventory_" + itemid + "_itemcount"];
+            if(v[inventory + itemid + "_itemcount"] && v[inventory + itemid + "_itemcount"] != "") {
+                update[id] = v[inventory + itemid + "_itemcount"];
             };
 
             setAttrs(update, {silent: true});
@@ -8486,9 +8828,16 @@
 
     var update_item_from_resource = function(resourceid, itemid) {
         var update = {};
+        var inventory = "repeating_inventory_";
+
+        getAttrs(["repeating_hiddeninventory_" + itemid + "_itemname"], function(x) {
+            if(x["repeating_hiddeninventory_" + itemid + "_itemname"]) {
+                inventory = "repeating_hiddeninventory_";
+            }
+        });
         getAttrs([resourceid, resourceid + "_name"], function(v) {
-            update["repeating_inventory_" + itemid + "_itemcount"] = v[resourceid];
-            update["repeating_inventory_" + itemid + "_itemname"] = v[resourceid + "_name"];
+            update[inventory + itemid + "_itemcount"] = v[resourceid];
+            update[inventory + itemid + "_itemname"] = v[resourceid + "_name"];
             setAttrs(update, {silent: true}, function() {update_weight()});
         });
     };
@@ -9041,9 +9390,16 @@
     };
 
     var update_item_from_attack = function(itemid, attackid) {
-        getAttrs(["repeating_attack_" + attackid + "_atkname", "repeating_attack_" + attackid + "_dmgbase", "repeating_attack_" + attackid + "_dmg2base", "repeating_attack_" + attackid + "_dmgtype", "repeating_attack_" + attackid + "_dmg2type", "repeating_attack_" + attackid + "_atkrange", "repeating_attack_" + attackid + "_atkmod", "repeating_attack_" + attackid + "_dmgmod", "repeating_inventory_" + itemid + "_itemmodifiers", "repeating_attack_" + attackid + "_versatile_alt", "repeating_inventory_" + itemid + "_itemproperties", "repeating_attack_" + attackid + "_atkpower"], function(v) {
+        var inventory = "repeating_inventory_";
+        getAttrs(["repeating_hiddeninventory_" + itemid + "_itemname"], function(x){
+            if(x["repeating_hiddeninventory_" + itemid + "_itemname"]) {
+                inventory = "repeating_hiddeninventory_";
+            }
+        });
+
+        getAttrs(["repeating_attack_" + attackid + "_atkname", "repeating_attack_" + attackid + "_dmgbase", "repeating_attack_" + attackid + "_dmg2base", "repeating_attack_" + attackid + "_dmgtype", "repeating_attack_" + attackid + "_dmg2type", "repeating_attack_" + attackid + "_atkrange", "repeating_attack_" + attackid + "_atkmod", "repeating_attack_" + attackid + "_dmgmod", inventory + itemid + "_itemmodifiers", "repeating_attack_" + attackid + "_versatile_alt", inventory + itemid + "_itemproperties", "repeating_attack_" + attackid + "_atkpower"], function(v) {
             var update = {};
-            var mods = v["repeating_inventory_" + itemid + "_itemmodifiers"];
+            var mods = v[inventory + itemid + "_itemmodifiers"];
             var damage = v["repeating_attack_" + attackid + "_dmgbase"] ? v["repeating_attack_" + attackid + "_dmgbase"] : 0;
             var damage2 = v["repeating_attack_" + attackid + "_dmg2base"] ? v["repeating_attack_" + attackid + "_dmg2base"] : 0;
             var damagetype = v["repeating_attack_" + attackid + "_dmgtype"] ? v["repeating_attack_" + attackid + "_dmgtype"] : 0;
@@ -9055,14 +9411,14 @@
             var atktype = "";
             var altprefix = v["repeating_attack_" + attackid + "_versatile_alt"] === "1" ? "Alternate " : "";
 
-            if(/Alternate Damage:/i.test(v["repeating_inventory_" + itemid + "_itemmodifiers"])) {
-                update["repeating_inventory_" + itemid + "_itemname"] = v["repeating_attack_" + attackid + "_atkname"].replace(/\s*(?:\(One-Handed\)|\(Two-Handed\))/, "");
+            if(/Alternate Damage:/i.test(v[inventory + itemid + "_itemmodifiers"])) {
+                update[inventory + itemid + "_itemname"] = v["repeating_attack_" + attackid + "_atkname"].replace(/\s*(?:\(One-Handed\)|\(Two-Handed\))/, "");
             } else {
-                update["repeating_inventory_" + itemid + "_itemname"] = v["repeating_attack_" + attackid + "_atkname"];
+                update[inventory + itemid + "_itemname"] = v["repeating_attack_" + attackid + "_atkname"];
             }
 
             var attack_type_regex = /(?:^|,)\s*Item Type: (Melee|Ranged) Weapon(?:,|$)/i;
-            var attack_type_results = attack_type_regex.exec(v["repeating_inventory_" + itemid + "_itemmodifiers"]);
+            var attack_type_results = attack_type_regex.exec(v[inventory + itemid + "_itemmodifiers"]);
             atktype = attack_type_results ? attack_type_results[1] : "";
             if(mods) {
                 mods = mods.split(",");
@@ -9162,7 +9518,7 @@
                 }
             }
             if(!attackmod_found && (powermod !== 0 || attackmod !== 0)) {
-                var properties = v["repeating_inventory_" + itemid + "_itemproperties"];
+                var properties = v[inventory + itemid + "_itemproperties"];
                 if(properties && /Thrown/i.test(properties)) {
                     mods.push("Weapon Attacks: " + (powermod !== 0 ? powermod : attackmod));
                 }
@@ -9184,7 +9540,7 @@
                 }
             }
             if(!damagemod_found && (powermod !== 0 || damagemod !== 0)) {
-                var properties = v["repeating_inventory_" + itemid + "_itemproperties"];
+                var properties = v[inventory + itemid + "_itemproperties"];
                 if(properties && /Thrown/i.test(properties)) {
                     mods.push("Weapon Damage: " + (powermod !== 0 ? powermod : damagemod));
                 }
@@ -9193,7 +9549,7 @@
                 }
             }
 
-            update["repeating_inventory_" + itemid + "_itemmodifiers"] = mods.join(",");
+            update[inventory + itemid + "_itemmodifiers"] = mods.join(",");
 
             setAttrs(update, {silent: true});
         });
@@ -9204,12 +9560,18 @@
     };
 
     var remove_resource = function(id) {
-        var update = {};
+        var update = {};       
         getAttrs([id + "_itemid"], function(v) {
             var itemid = v[id + "_itemid"];
             if(itemid) {
-                update["repeating_inventory_" + itemid + "_useasresource"] = 0;
-                update["repeating_inventory_" + itemid + "_itemresourceid"] = "";
+                var inventory = "repeating_inventory_";
+                getAttrs(["repeating_hiddeninventory_" + itemid + "_itemname"], function(x){
+                    if(x["repeating_hiddeninventory_" + itemid + "_itemname"]) {
+                        inventory = "repeating_hiddeninventory_";
+                    }
+                });
+                update[inventory + itemid + "_useasresource"] = 0;
+                update[inventory + itemid + "_itemresourceid"] = "";
             };
             if(id == "other_resource") {
                 update["other_resource"] = "";
@@ -9236,79 +9598,86 @@
     };
 
     var update_weight = function() {
+        getSectionIDs("repeating_inventory", function(idarray) {
+            update_inventory_from_weight_change("repeating_inventory_", idarray, "weighttotal");
+        });
+        getSectionIDs("repeating_hiddeninventory", function(idarray) {
+            update_inventory_from_weight_change("repeating_hiddeninventory_", idarray, "hiddenweighttotal");
+        });
+    };
+
+    var update_inventory_from_weight_change = function (inventory, idarray, weightAttrToUpdate){
         var update = {};
         var wtotal = 0;
-        var weight_attrs = ["cp","sp","ep","gp","pp","encumberance_setting","strength","size","carrying_capacity_mod"];
-        getSectionIDs("repeating_inventory", function(idarray) {
+        var weight_attrs = ["cp","sp","ep","gp","pp","encumberance_setting","strength","size","carrying_capacity_mod"];        
+        _.each(idarray, function(currentID, i) {
+            weight_attrs.push(inventory + currentID + "_itemweight");
+            weight_attrs.push(inventory + currentID + "_itemcount");
+        });
+        getAttrs(weight_attrs, function(v) {
+            cp = isNaN(parseInt(v.cp, 10)) === false ? parseInt(v.cp, 10) : 0;
+            sp = isNaN(parseInt(v.sp, 10)) === false ? parseInt(v.sp, 10) : 0;
+            ep = isNaN(parseInt(v.ep, 10)) === false ? parseInt(v.ep, 10) : 0;
+            gp = isNaN(parseInt(v.gp, 10)) === false ? parseInt(v.gp, 10) : 0;
+            pp = isNaN(parseInt(v.pp, 10)) === false ? parseInt(v.pp, 10) : 0;
+            wtotal = wtotal + ((cp + sp + ep + gp + pp) / 50);
+
             _.each(idarray, function(currentID, i) {
-                weight_attrs.push("repeating_inventory_" + currentID + "_itemweight");
-                weight_attrs.push("repeating_inventory_" + currentID + "_itemcount");
+                if(v[inventory + currentID + "_itemweight"] && isNaN(parseInt(v[inventory + currentID + "_itemweight"], 10)) === false) {
+                    count = v[inventory + currentID + "_itemcount"] && isNaN(parseFloat(v[inventory + currentID + "_itemcount"])) === false ? parseFloat(v[inventory + currentID + "_itemcount"]) : 1;
+                    wtotal = wtotal + (parseFloat(v[inventory + currentID + "_itemweight"]) * count);
+                }
             });
-            getAttrs(weight_attrs, function(v) {
-                cp = isNaN(parseInt(v.cp, 10)) === false ? parseInt(v.cp, 10) : 0;
-                sp = isNaN(parseInt(v.sp, 10)) === false ? parseInt(v.sp, 10) : 0;
-                ep = isNaN(parseInt(v.ep, 10)) === false ? parseInt(v.ep, 10) : 0;
-                gp = isNaN(parseInt(v.gp, 10)) === false ? parseInt(v.gp, 10) : 0;
-                pp = isNaN(parseInt(v.pp, 10)) === false ? parseInt(v.pp, 10) : 0;
-                wtotal = wtotal + ((cp + sp + ep + gp + pp) / 50);
 
-                _.each(idarray, function(currentID, i) {
-                    if(v["repeating_inventory_" + currentID + "_itemweight"] && isNaN(parseInt(v["repeating_inventory_" + currentID + "_itemweight"], 10)) === false) {
-                        count = v["repeating_inventory_" + currentID + "_itemcount"] && isNaN(parseFloat(v["repeating_inventory_" + currentID + "_itemcount"])) === false ? parseFloat(v["repeating_inventory_" + currentID + "_itemcount"]) : 1;
-                        wtotal = wtotal + (parseFloat(v["repeating_inventory_" + currentID + "_itemweight"]) * count);
-                    }
-                });
+            update[weightAttrToUpdate] = wtotal;
 
-                update["weighttotal"] = wtotal;
-
-                var str_base = parseInt(v.strength, 10);
-                var size_multiplier = 1;
-                if(v["size"] && v["size"] != "") {
-                    if(v["size"].toLowerCase().trim() == "tiny") {size_multiplier = .5}
-                    else if(v["size"].toLowerCase().trim() == "large") {size_multiplier = 2}
-                    else if(v["size"].toLowerCase().trim() == "huge") {size_multiplier = 4}
-                    else if(v["size"].toLowerCase().trim() == "gargantuan") {size_multiplier = 8}
+            var str_base = parseInt(v.strength, 10);
+            var size_multiplier = 1;
+            if(v["size"] && v["size"] != "") {
+                if(v["size"].toLowerCase().trim() == "tiny") {size_multiplier = .5}
+                else if(v["size"].toLowerCase().trim() == "large") {size_multiplier = 2}
+                else if(v["size"].toLowerCase().trim() == "huge") {size_multiplier = 4}
+                else if(v["size"].toLowerCase().trim() == "gargantuan") {size_multiplier = 8}
+            }
+            var str = str_base*size_multiplier;
+            if(v.carrying_capacity_mod) {
+                var operator = v.carrying_capacity_mod.substring(0,1);
+                var value = v.carrying_capacity_mod.substring(1);
+                if(["*","x","+","-"].indexOf(operator) > -1 && isNaN(parseInt(value,10)) === false) {
+                    if(operator == "*" || operator == "x") {str = str*parseInt(value,10);}
+                    else if(operator == "+") {str = str+parseInt(value,10);}
+                    else if(operator == "-") {str = str-parseInt(value,10);}
                 }
-                var str = str_base*size_multiplier;
-                if(v.carrying_capacity_mod) {
-                    var operator = v.carrying_capacity_mod.substring(0,1);
-                    var value = v.carrying_capacity_mod.substring(1);
-                    if(["*","x","+","-"].indexOf(operator) > -1 && isNaN(parseInt(value,10)) === false) {
-                        if(operator == "*" || operator == "x") {str = str*parseInt(value,10);}
-                        else if(operator == "+") {str = str+parseInt(value,10);}
-                        else if(operator == "-") {str = str-parseInt(value,10);}
-                    }
-                }
+            }
 
-                if(!v.encumberance_setting || v.encumberance_setting === "off") {
-                    if(wtotal > str*15) {
-                        update["encumberance"] = "OVER CARRYING CAPACITY";
-                    }
-                    else {
-                        update["encumberance"] = " ";
-                    }
-                }
-                else if(v.encumberance_setting === "on") {
-                    if(wtotal > str*15) {
-                        update["encumberance"] = "IMMOBILE";
-                    }
-                    else if(wtotal > str*10) {
-                        update["encumberance"] = "HEAVILY ENCUMBERED";
-                    }
-                    else if(wtotal > str*5) {
-                        update["encumberance"] = "ENCUMBERED";
-                    }
-                    else {
-                        update["encumberance"] = " ";
-                    }
+            if(!v.encumberance_setting || v.encumberance_setting === "off") {
+                if(wtotal > str*15) {
+                    update["encumberance"] = "OVER CARRYING CAPACITY";
                 }
                 else {
                     update["encumberance"] = " ";
                 }
+            }
+            else if(v.encumberance_setting === "on") {
+                if(wtotal > str*15) {
+                    update["encumberance"] = "IMMOBILE";
+                }
+                else if(wtotal > str*10) {
+                    update["encumberance"] = "HEAVILY ENCUMBERED";
+                }
+                else if(wtotal > str*5) {
+                    update["encumberance"] = "ENCUMBERED";
+                }
+                else {
+                    update["encumberance"] = " ";
+                }
+            }
+            else {
+                update["encumberance"] = " ";
+            }
 
-                setAttrs(update, {silent: true});
+            setAttrs(update, {silent: true});
 
-            });
         });
     };
 
@@ -9328,90 +9697,97 @@
                     setAttrs({ac: total});
                 });
             }
-            else {
-                var update = {};
-                var ac_attrs = ["simpleinventory","dexterity_mod","globalacmod"];
+            else {              
+                var ac_attrs = ["simpleinventory","dexterity_mod","globalacmod"];   
                 getSectionIDs("repeating_inventory", function(idarray) {
-                    _.each(idarray, function(currentID, i) {
-                        ac_attrs.push("repeating_inventory_" + currentID + "_equipped");
-                        ac_attrs.push("repeating_inventory_" + currentID + "_itemmodifiers");
-                    });
-                    getAttrs(ac_attrs, function(b) {
-                        var globalacmod = isNaN(parseInt(b.globalacmod, 10)) === false ? parseInt(b.globalacmod, 10) : 0;
-                        var dexmod = +b["dexterity_mod"];
-                        var total = 10 + dexmod;
-                        var armorcount = 0;
-                        var shieldcount = 0;
-                        var armoritems = [];
-                        if(b.simpleinventory === "complex") {
-                            _.each(idarray, function(currentID, i) {
-                                if(b["repeating_inventory_" + currentID + "_equipped"] && b["repeating_inventory_" + currentID + "_equipped"] === "1" && b["repeating_inventory_" + currentID + "_itemmodifiers"] && b["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf("ac") > -1) {
-                                    var mods = b["repeating_inventory_" + currentID + "_itemmodifiers"].split(",");
-                                    var ac = 0;
-                                    var type = "mod";
-                                    _.each(mods, function(mod) {
-                                        if(mod.substring(0,10) === "Item Type:") {
-                                            type = mod.substring(11, mod.length).trim().toLowerCase();
-                                        }
-                                        if(mod.toLowerCase().indexOf("ac:") > -1 || mod.toLowerCase().indexOf("ac +") > -1 || mod.toLowerCase().indexOf("ac+") > -1) {
-                                            var regex = mod.replace(/[^0-9]/g, "");
-                                            var bonus = regex && regex.length > 0 && isNaN(parseInt(regex,10)) === false ? parseInt(regex,10) : 0;
-                                            ac = ac + bonus;
-                                        }
-                                        if(mod.toLowerCase().indexOf("ac -") > -1 || mod.toLowerCase().indexOf("ac-") > -1) {
-                                            var regex = mod.replace(/[^0-9]/g, "");
-                                            var bonus = regex && regex.length > 0 && isNaN(parseInt(regex,10)) === false ? parseInt(regex,10) : 0;
-                                            ac = ac - bonus;
-                                        }
-                                    });
-                                    armoritems.push({type: type, ac: ac});
-                                }
-                            });
-                            armorcount = armoritems.filter(function(item){ return item["type"].indexOf("armor") > -1 }).length;
-                            shieldcount = armoritems.filter(function(item){ return item["type"].indexOf("shield") > -1 }).length;
-                            var base = dexmod;
-                            var armorac = 10;
-                            var shieldac = 0;
-                            var modac = 0;
-
-                            _.each(armoritems, function(item) {
-                                if(item["type"].indexOf("light armor") > -1) {
-                                    armorac = item["ac"];
-                                    base = dexmod;
-                                }
-                                else if(item["type"].indexOf("medium armor") > -1) {
-                                    armorac = item["ac"];
-                                    base = Math.min(dexmod, 2);
-                                }
-                                else if(item["type"].indexOf("heavy armor") > -1) {
-                                    armorac = item["ac"];
-                                    base = 0;
-                                }
-                                else if(item["type"].indexOf("shield") > -1) {
-                                    shieldac = item["ac"];
-                                }
-                                else {
-                                    modac = modac + item["ac"]
-                                }
-                            })
-
-                            total = base + armorac + shieldac + modac;
-
-                        };
-                        if(armorcount > 1 || shieldcount > 1) {
-                            update["armorwarningflag"] = "show";
-                            update["armorwarning"] = "0";
-                        }
-                        else {
-                            update["armorwarningflag"] = "hide";
-                            update["armorwarning"] = "0";
-                        }
-                        console.log("total: " + total);
-                        update["ac"] = total + globalacmod;
-                        setAttrs(update, {silent: true});
-                    });
+                    update_inventory_from_ac_change("repeating_inventory_", idarray, ac_attrs);
+                });
+                getSectionIDs("repeating_hiddeninventory", function(idarray) {
+                    update_inventory_from_ac_change("repeating_hiddeninventory_", idarray, ac_attrs);
                 });
             };
+        });
+    };
+
+    var update_inventory_from_ac_change = function(inventory, idarray, ac_attrs) {
+        var update = {};
+        _.each(idarray, function(currentID, i) {
+            ac_attrs.push(inventory + currentID + "_equipped");
+            ac_attrs.push(inventory + currentID + "_itemmodifiers");
+        });
+        getAttrs(ac_attrs, function(b) {
+            var globalacmod = isNaN(parseInt(b.globalacmod, 10)) === false ? parseInt(b.globalacmod, 10) : 0;
+            var dexmod = +b["dexterity_mod"];
+            var total = 10 + dexmod;
+            var armorcount = 0;
+            var shieldcount = 0;
+            var armoritems = [];
+            if(b.simpleinventory === "complex") {
+                _.each(idarray, function(currentID, i) {
+                    if(b[inventory + currentID + "_equipped"] && b[inventory + currentID + "_equipped"] === "1" && b[inventory + currentID + "_itemmodifiers"] && b[inventory + currentID + "_itemmodifiers"].toLowerCase().indexOf("ac") > -1) {
+                        var mods = b[inventory + currentID + "_itemmodifiers"].split(",");
+                        var ac = 0;
+                        var type = "mod";
+                        _.each(mods, function(mod) {
+                            if(mod.substring(0,10) === "Item Type:") {
+                                type = mod.substring(11, mod.length).trim().toLowerCase();
+                            }
+                            if(mod.toLowerCase().indexOf("ac:") > -1 || mod.toLowerCase().indexOf("ac +") > -1 || mod.toLowerCase().indexOf("ac+") > -1) {
+                                var regex = mod.replace(/[^0-9]/g, "");
+                                var bonus = regex && regex.length > 0 && isNaN(parseInt(regex,10)) === false ? parseInt(regex,10) : 0;
+                                ac = ac + bonus;
+                            }
+                            if(mod.toLowerCase().indexOf("ac -") > -1 || mod.toLowerCase().indexOf("ac-") > -1) {
+                                var regex = mod.replace(/[^0-9]/g, "");
+                                var bonus = regex && regex.length > 0 && isNaN(parseInt(regex,10)) === false ? parseInt(regex,10) : 0;
+                                ac = ac - bonus;
+                            }
+                        });
+                        armoritems.push({type: type, ac: ac});
+                    }
+                });
+                armorcount = armoritems.filter(function(item){ return item["type"].indexOf("armor") > -1 }).length;
+                shieldcount = armoritems.filter(function(item){ return item["type"].indexOf("shield") > -1 }).length;
+                var base = dexmod;
+                var armorac = 10;
+                var shieldac = 0;
+                var modac = 0;
+
+                _.each(armoritems, function(item) {
+                    if(item["type"].indexOf("light armor") > -1) {
+                        armorac = item["ac"];
+                        base = dexmod;
+                    }
+                    else if(item["type"].indexOf("medium armor") > -1) {
+                        armorac = item["ac"];
+                        base = Math.min(dexmod, 2);
+                    }
+                    else if(item["type"].indexOf("heavy armor") > -1) {
+                        armorac = item["ac"];
+                        base = 0;
+                    }
+                    else if(item["type"].indexOf("shield") > -1) {
+                        shieldac = item["ac"];
+                    }
+                    else {
+                        modac = modac + item["ac"]
+                    }
+                })
+
+                total = base + armorac + shieldac + modac;
+
+            };
+            if(armorcount > 1 || shieldcount > 1) {
+                update["armorwarningflag"] = "show";
+                update["armorwarning"] = "0";
+            }
+            else {
+                update["armorwarningflag"] = "hide";
+                update["armorwarning"] = "0";
+            }
+            console.log("total: " + total);
+            update["ac"] = total + globalacmod;
+            setAttrs(update, {silent: true});
         });
     };
 
@@ -9424,53 +9800,60 @@
     };
 
     var update_initiative = function() {
+        getSectionIDs("repeating_inventory", function(idarray) {
+            update_inventory_from_initiative_change("repeating_inventory_", idarray);
+        });
+        getSectionIDs("repeating_hiddeninventory", function(idarray) {
+            update_inventory_from_initiative_change("repeating_hiddeninventory_", idarray);
+        });
+    };
+
+    var update_inventory_from_initiative_change = function(inventory, idarray) {
         var attrs_to_get = ["dexterity","dexterity_mod","initmod","jack_of_all_trades","jack","init_tiebreaker","pb_type"];
-        getSectionIDs("repeating_inventory", function(idarray){
-            _.each(idarray, function(currentID, i) {
-                attrs_to_get.push("repeating_inventory_" + currentID + "_equipped");
-                attrs_to_get.push("repeating_inventory_" + currentID + "_itemmodifiers");
-            });
-            getAttrs(attrs_to_get, function(v) {
-                var update = {};
-                var final_init = parseInt(v["dexterity_mod"], 10);
-                if(v["initmod"] && !isNaN(parseInt(v["initmod"], 10))) {
-                    final_init = final_init + parseInt(v["initmod"], 10);
+        _.each(idarray, function(currentID, i) {
+            attrs_to_get.push(inventory + currentID + "_equipped");
+            attrs_to_get.push(inventory + currentID + "_itemmodifiers");
+        });
+        getAttrs(attrs_to_get, function(v) {
+            var update = {};
+            var final_init = parseInt(v["dexterity_mod"], 10);
+            if(v["initmod"] && !isNaN(parseInt(v["initmod"], 10))) {
+                final_init = final_init + parseInt(v["initmod"], 10);
+            }
+            if(v["init_tiebreaker"] && v["init_tiebreaker"] != 0) {
+                final_init = final_init + (parseInt(v["dexterity"], 10)/100);
+            }
+            if(v["jack_of_all_trades"] && v["jack_of_all_trades"] != 0) {
+                if(v["pb_type"] && v["pb_type"] === "die" && v["jack"]) {
+                    // final_init = final_init + Math.floor(parseInt(v["jack"].substring(1),10)/2);
+                    final_init = final_init + "+" + v["jack"];
                 }
-                if(v["init_tiebreaker"] && v["init_tiebreaker"] != 0) {
-                    final_init = final_init + (parseInt(v["dexterity"], 10)/100);
+                else if(v["jack"] && !isNaN(parseInt(v["jack"], 10))) {
+                    final_init = final_init + parseInt(v["jack"], 10);
                 }
-                if(v["jack_of_all_trades"] && v["jack_of_all_trades"] != 0) {
-                    if(v["pb_type"] && v["pb_type"] === "die" && v["jack"]) {
-                        // final_init = final_init + Math.floor(parseInt(v["jack"].substring(1),10)/2);
-                        final_init = final_init + "+" + v["jack"];
-                    }
-                    else if(v["jack"] && !isNaN(parseInt(v["jack"], 10))) {
-                        final_init = final_init + parseInt(v["jack"], 10);
-                    }
-                }
-                _.each(idarray, function(currentID){
-                    if(v["repeating_inventory_" + currentID + "_equipped"] && v["repeating_inventory_" + currentID + "_equipped"] === "1" && v["repeating_inventory_" + currentID + "_itemmodifiers"] && v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf("ability checks") > -1) {
-                        var mods = v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().split(",");
-                        _.each(mods, function(mod) {
-                            if(mod.indexOf("ability checks") > -1) {
-                                if(mod.indexOf("-") > -1) {
-                                    var new_mod = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
-                                    final_init = new_mod ? final_init - new_mod : final_init;
-                                }
-                                else {
-                                    var new_mod = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
-                                    final_init = new_mod ? final_init + new_mod : final_init;
-                                }
+            }
+            _.each(idarray, function(currentID){
+                if(v[inventory + currentID + "_equipped"] && v[inventory + currentID + "_equipped"] === "1" && v[inventory + currentID + "_itemmodifiers"] && v[inventory + currentID + "_itemmodifiers"].toLowerCase().indexOf("ability checks") > -1) {
+                    var mods = v[inventory + currentID + "_itemmodifiers"].toLowerCase().split(",");
+                    _.each(mods, function(mod) {
+                        if(mod.indexOf("ability checks") > -1) {
+                            if(mod.indexOf("-") > -1) {
+                                var new_mod = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
+                                final_init = new_mod ? final_init - new_mod : final_init;
                             }
-                        });
-                    }
-                });
-                if(final_init % 1 != 0) {
-                    final_init = parseFloat(final_init.toPrecision(12)); // ROUNDING ERROR BUGFIX
+                            else {
+                                var new_mod = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
+                                final_init = new_mod ? final_init + new_mod : final_init;
+                            }
+                        }
+                    });
                 }
-                update["initiative_bonus"] = final_init;
-                setAttrs(update, {silent: true});
             });
+            if(final_init % 1 != 0) {
+                final_init = parseFloat(final_init.toPrecision(12)); // ROUNDING ERROR BUGFIX
+            }
+            update["initiative_bonus"] = final_init;
+            setAttrs(update, {silent: true});
         });
     };
 
@@ -9842,43 +10225,50 @@
             var itemfields = ["pb_type","pb"];
 
             getSectionIDs("repeating_inventory", function(idarray) {
-                _.each(idarray, function(currentID, i) {
-                    itemfields.push("repeating_inventory_" + currentID + "_equipped");
-                    itemfields.push("repeating_inventory_" + currentID + "_itemmodifiers");
-                });
-                getAttrs(itemfields, function(v) {
-                    _.each(idarray, function(currentID) {
-                        if((!v["repeating_inventory_" + currentID + "_equipped"] || v["repeating_inventory_" + currentID + "_equipped"] === "1") && v["repeating_inventory_" + currentID + "_itemmodifiers"] && v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf("power" > -1)) {
-                            var mods = v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().split(",");
-                            _.each(mods, function(mod) {
-                                if(mod.indexOf("power attack") > -1) {
-                                    var substr = mod.slice(mod.lastIndexOf("power attack") + "power attack".length);
-                                    atk = substr && substr.length > 0 && !isNaN(parseInt(substr,10)) ? atk + parseInt(substr,10) : atk;
-                                    power_mod = substr && substr.length > 0 && !isNaN(parseInt(substr,10)) ? power_mod + parseInt(substr,10) : power_mod;
-                                };
-                                if(mod.indexOf("power dc") > -1) {
-                                    var substr = mod.slice(mod.lastIndexOf("power dc") + "power dc".length);
-                                    dc = substr && substr.length > 0 && !isNaN(parseInt(substr,10)) ? dc + parseInt(substr,10) : dc;
-                                };
-                            });
+                update_inventory_from_power_info_change("repeating_inventory_", idarray, power_mod, atk, dc, itemfields, update);
+            });
+            getSectionIDs("repeating_hiddeninventory", function(idarray) {
+                update_inventory_from_power_info_change("repeating_hiddeninventory_", idarray, power_mod, atk, dc, itemfields, update);
+            });
+        });
+    };
+
+    var update_inventory_from_power_info_change = function(inventory, idarray, power_mod, atk, dc, itemfields, update) {
+        _.each(idarray, function(currentID, i) {
+            itemfields.push(inventory + currentID + "_equipped");
+            itemfields.push(inventory + currentID + "_itemmodifiers");
+        });
+        getAttrs(itemfields, function(v) {
+            _.each(idarray, function(currentID) {
+                if((!v[inventory + currentID + "_equipped"] || v[inventory + currentID + "_equipped"] === "1") && v[inventory + currentID + "_itemmodifiers"] && v[inventory + currentID + "_itemmodifiers"].toLowerCase().indexOf("power" > -1)) {
+                    var mods = v[inventory + currentID + "_itemmodifiers"].toLowerCase().split(",");
+                    _.each(mods, function(mod) {
+                        if(mod.indexOf("power attack") > -1) {
+                            var substr = mod.slice(mod.lastIndexOf("power attack") + "power attack".length);
+                            atk = substr && substr.length > 0 && !isNaN(parseInt(substr,10)) ? atk + parseInt(substr,10) : atk;
+                            power_mod = substr && substr.length > 0 && !isNaN(parseInt(substr,10)) ? power_mod + parseInt(substr,10) : power_mod;
+                        };
+                        if(mod.indexOf("power dc") > -1) {
+                            var substr = mod.slice(mod.lastIndexOf("power dc") + "power dc".length);
+                            dc = substr && substr.length > 0 && !isNaN(parseInt(substr,10)) ? dc + parseInt(substr,10) : dc;
                         };
                     });
-
-                    if(v["pb_type"] && v["pb_type"] === "die") {
-                        atk = atk + "+" + v["pb"];
-                        dc = dc + parseInt(v["pb"].substring(1), 10) / 2;
-                    }
-                    else {
-                        atk = parseInt(atk, 10) + parseInt(v["pb"], 10);
-                        dc = parseInt(dc, 10) + parseInt(v["pb"], 10);
-                    };
-                    update["power_attack_mod"] = power_mod;
-                    update["power_attack_bonus"] = atk;
-                    update["power_save_dc"] = dc;
-                    var callback = function() {update_attacks("powers")};
-                    setAttrs(update, {silent: true}, callback);
-                });
+                };
             });
+
+            if(v["pb_type"] && v["pb_type"] === "die") {
+                atk = atk + "+" + v["pb"];
+                dc = dc + parseInt(v["pb"].substring(1), 10) / 2;
+            }
+            else {
+                atk = parseInt(atk, 10) + parseInt(v["pb"], 10);
+                dc = parseInt(dc, 10) + parseInt(v["pb"], 10);
+            };
+            update["power_attack_mod"] = power_mod;
+            update["power_attack_bonus"] = atk;
+            update["power_save_dc"] = dc;
+            var callback = function() {update_attacks("powers")};
+            setAttrs(update, {silent: true}, callback);
         });
     };
 
@@ -11230,6 +11620,7 @@
         clearset["jack_attr"] = "";
         clearset["death_save_bonus"] = "";
         clearset["weighttotal"] = "";
+        clearset["hiddenweighttotal"] = "";
         clearset["initiative_bonus"] = "";
         clearset["hit_dice"] = "";
         clearset["hit_dice_max"] = "";

--- a/StarWars5E/StarWars5E_HTML.html
+++ b/StarWars5E/StarWars5E_HTML.html
@@ -4327,8 +4327,9 @@
 <div class="container ship">
     <input class="tab-button ship-core" type="radio" name="attr_ship_tab" value="ship-core" checked="checked"><span data-i18n="core-u">CORE</span>
     <input class="tab-button ship-modifications" type="radio" name="attr_ship_tab" value="ship-modifications"><span data-i18n="modifications-u">MODIFICATIONS</span>
-    <input class="tab-button ship-options" type="radio" name="attr_ship_tab" value="ship-options"><span style="font-family: pictos">y</span>
-    <div class="page ship-options">
+    <input class="tab-button options" type="radio" name="attr_ship_tab" value="options"><span style="font-family: pictos">y</span>
+
+    <div class="page options">
         <div class="header">
             <div class="name-container">
                 <img src="https://s22.postimg.cc/jnlp8fqc1/Star_Wars_5_E_Logo_Shrunk.png" style="padding-bottom: 10px;">
@@ -4363,15 +4364,82 @@
             </div>
         </div>
         <div class="body">
-            <div class="row title">
-                <span data-i18n="ship-options-u">SHIP OPTIONS</span>
-                <div class="row">
-                    <span>SHEET TYPE:</span>
-                    <select name="attr_npc">
-                        <option value="0">PC</option>
-                        <option value="1">NPC</option>
-                        <option value="2">Ship</option>
-                    </select>
+            <div class="col">
+                <div class="general_options">
+                    <div class="version">
+                        <span data-i18n="version">v</span>
+                        <input type="text" name="attr_version">
+                    </div>
+                    <div class="row">
+                        <span>SHEET TYPE:</span>
+                        <select name="attr_npc">
+                            <option value="0">PC</option>
+                            <option value="1">NPC</option>
+                            <option value="2">Ship</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="roll-queries:-u">ROLL QUERIES:</span>
+                        <select name="attr_rtype">
+                            <option value="{{always=1}} {{r2=[[@{d20}" data-i18n="always-roll-adv">Always Roll Advantage</option>
+                            <option value="@{advantagetoggle}" data-i18n="toggle-roll-adv">Advantage Toggle</option>
+                            <option value="{{query=1}} ?{Advantage?|Normal Roll,&#123&#123normal=1&#125&#125 &#123&#123r2=[[0d20|Advantage,&#123&#123advantage=1&#125&#125 &#123&#123r2=[[@{d20}|Disadvantage,&#123&#123disadvantage=1&#125&#125 &#123&#123r2=[[@{d20}}" data-i18n="query-roll-adv">Query Advantage</option>
+                            <option value="{{normal=1}} {{r2=[[0d20" data-i18n="never-roll-adv">Never Roll Advantage</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="whisp-rolls-gm:-u">WHISPER ROLLS TO GM:</span>
+                        <select name="attr_wtype">
+                            <option value="" data-i18n="never-whisper-roll">Never Whisper Rolls</option>
+                            <option value="@{whispertoggle}" data-i18n="toggle-roll-whisper">Whisper Toggle</option>
+                            <option value="?{Whisper?|Public Roll,|Whisper Roll,/w gm }" data-i18n="query-whisper-roll">Query Whisper</option>
+                            <option value="/w gm " data-i18n="always-whisper-roll">Always Whisper Rolls</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="auto-dmg-roll:-u">AUTO DAMAGE ROLL:</span>
+                        <select class="dtype" name="attr_dtype">
+                            <option value="pick" data-i18n="never-roll-dmg">Don't Auto Roll Damage</option>
+                            <option value="full" data-i18n="always-roll-dmg">Auto Roll Damage & Crit</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="core-die-roll:-u">CORE DIE ROLL:</span>
+                        <input type="text" name="attr_core_die" value="1d20" placeholder="1d20" title="@{core_die}">
+                    </div>
+                    <div class="row">
+                        <input type="checkbox" name="attr_global_attack_mod_flag" value="1">
+                        <span data-i18n="show-global-attack-field-u">SHOW GLOBAL ATTACK MODIFIER FIELD</span>
+                    </div>
+                    <div class="row">
+                        <input type="checkbox" name="attr_global_damage_mod_flag" value="1">
+                        <span data-i18n="show-global-damage-field-u">SHOW GLOBAL DAMAGE MODIFIER FIELD</span>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="add-char-to-templates:-u">ADD CHARACTER NAME TO TEMPLATES:</span>
+                        <select class="dtype" name="attr_charname_output">
+                            <option value="{{charname=@{character_name}}}" data-i18n="on">On</option>
+                            <option value="charname=@{character_name}" selected="selected" data-i18n="off">Off</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="feats-traits-u">FEATURES AND TRAITS</span><span>:</span>
+                        <select name="attr_simpletraits">
+                            <option value="complex" data-i18n="compendium-compatible">Compendium Compatible</option>
+                            <option value="simple" data-i18n="simple">Simple</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <span data-i18n="ammo-tracking:-u">AMMO TRACKING:</span>
+                        <select name="attr_ammotracking">
+                            <option value="on" data-i18n="on">On</option>
+                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                        </select>
+                        <span data-i18n-title="api-required-title" data-i18n="api-required-u" title="Try it now with easy one click API installation available with your Pro subscription." style="color:#666; cursor:help;">(API REQUIRED)</span>
+                    </div>
+                    <div class="row title">
+                        <span data-i18n="general-opts-u">GENERAL OPTIONS</span>
+                    </div>
                 </div>
             </div>
         </div>
@@ -4461,6 +4529,22 @@
                             </div>
                             <div class="label">
                                 <span data-i18n="navcomputer_bonus-u">NAVCOMPUTER BONUS</span>
+                            </div>
+                        </div>
+                        <div class="insp-prof-container">
+                            <div class="value">
+                                <input type="number" name="attr_pb">
+                            </div>
+                            <div class="label">
+                                <span data-i18n="pilot_prof_bonus-u">PILOT PROF BONUS</span>
+                            </div>
+                        </div>
+                        <div class="insp-prof-container">
+                            <div class="value">
+                                <input type="number" value="0" name="attr_pilot_skill">
+                            </div>
+                            <div class="label">
+                                <span data-i18n="pilot_proficiency-u">PILOT INT(PILOT)</span>
                             </div>
                         </div>
                         <div class="saving-throw-container">
@@ -6303,92 +6387,218 @@
 
     on("change:acrobatics_prof change:acrobatics_type change:acrobatics_flat", function(eventinfo) {
         if(eventinfo.sourceType === "sheetworker") {return;};
-        update_skills(["acrobatics"]);
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                return;
+            }
+            else {
+                update_skills(["acrobatics"]);
+            }
+        });       
     });
 
     on("change:animal_handling_prof change:animal_handling_type change:animal_handling_flat", function(eventinfo) {
         if(eventinfo.sourceType === "sheetworker") {return;};
-        update_skills(["animal_handling"]);
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                return;
+            }
+            else {
+                update_skills(["animal_handling"]);
+            }
+        });   
     });
 
     on("change:technology_prof change:technology_type change:technology_flat", function(eventinfo) {
         if(eventinfo.sourceType === "sheetworker") {return;};
-        update_skills(["technology"]);
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                return;
+            }
+            else {
+                update_skills(["technology"]);
+            }
+        });   
     });
 
     on("change:athletics_prof change:athletics_type change:athletics_flat", function(eventinfo) {
         if(eventinfo.sourceType === "sheetworker") {return;};
-        update_skills(["athletics"]);
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                return;
+            }
+            else {
+                update_skills(["athletics"]);
+            }
+        });  
     });
 
     on("change:deception_prof change:deception_type change:deception_flat", function(eventinfo) {
         if(eventinfo.sourceType === "sheetworker") {return;};
-        update_skills(["deception"]);
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                return;
+            }
+            else {
+                update_skills(["deception"]); 
+            }
+        });  
     });
 
     on("change:lore_prof change:lore_type change:lore_flat", function(eventinfo) {
         if(eventinfo.sourceType === "sheetworker") {return;};
-        update_skills(["lore"]);
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                return;
+            }
+            else {
+                update_skills(["lore"]); 
+            }
+        });  
     });
 
     on("change:insight_prof change:insight_type change:insight_flat", function(eventinfo) {
         if(eventinfo.sourceType === "sheetworker") {return;};
-        update_skills(["insight"]);
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                return;
+            }
+            else {
+                update_skills(["insight"]); 
+            }
+        });  
     });
 
     on("change:intimidation_prof change:intimidation_type change:intimidation_flat", function(eventinfo) {
         if(eventinfo.sourceType === "sheetworker") {return;};
-        update_skills(["intimidation"]);
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                return;
+            }
+            else {
+                update_skills(["intimidation"]); 
+            }
+        });  
     });
 
     on("change:investigation_prof change:investigation_type change:investigation_flat", function(eventinfo) {
         if(eventinfo.sourceType === "sheetworker") {return;};
-        update_skills(["investigation"]);
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                return;
+            }
+            else {
+                update_skills(["investigation"]); 
+            }
+        });  
     });
 
     on("change:medicine_prof change:medicine_type change:medicine_flat", function(eventinfo) {
         if(eventinfo.sourceType === "sheetworker") {return;};
-        update_skills(["medicine"]);
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                return;
+            }
+            else {
+                update_skills(["medicine"]); 
+            }
+        });  
     });
 
     on("change:nature_prof change:nature_type change:nature_flat", function(eventinfo) {
         if(eventinfo.sourceType === "sheetworker") {return;};
-        update_skills(["nature"]);
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                return;
+            }
+            else {
+                update_skills(["nature"]); 
+            }
+        });  
     });
 
     on("change:perception_prof change:perception_type change:perception_flat", function(eventinfo) {
         if(eventinfo.sourceType === "sheetworker") {return;};
-        update_skills(["perception"]);
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                return;
+            }
+            else {
+                update_skills(["perception"]); 
+            }
+        });  
     });
 
     on("change:performance_prof change:performance_type change:performance_flat", function(eventinfo) {
         if(eventinfo.sourceType === "sheetworker") {return;};
-        update_skills(["performance"]);
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                return;
+            }
+            else {
+                update_skills(["performance"]); 
+            }
+        });  
     });
 
     on("change:persuasion_prof change:persuasion_type change:persuasion_flat", function(eventinfo) {
         if(eventinfo.sourceType === "sheetworker") {return;};
-        update_skills(["persuasion"]);
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                return;
+            }
+            else {
+                update_skills(["persuasion"]); 
+            }
+        });  
     });
 
     on("change:piloting_prof change:piloting_type change:piloting_flat", function(eventinfo) {
         if(eventinfo.sourceType === "sheetworker") {return;};
-        update_skills(["piloting"]);
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                return;
+            }
+            else {
+                update_skills(["piloting"]); 
+            }
+        });  
     });
 
     on("change:sleight_of_hand_prof change:sleight_of_hand_type change:sleight_of_hand_flat", function(eventinfo) {
         if(eventinfo.sourceType === "sheetworker") {return;};
-        update_skills(["sleight_of_hand"]);
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                return;
+            }
+            else {
+                update_skills(["sleight_of_hand"]); 
+            }
+        });  
     });
 
     on("change:stealth_prof change:stealth_type change:stealth_flat", function(eventinfo) {
         if(eventinfo.sourceType === "sheetworker") {return;};
-        update_skills(["stealth"]);
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                return;
+            }
+            else {
+                update_skills(["stealth"]
+            }
+        });  
     });
 
     on("change:survival_prof change:survival_type change:survival_flat", function(eventinfo) {
         if(eventinfo.sourceType === "sheetworker") {return;};
-        update_skills(["survival"]);
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                return;
+            }
+            else {
+                update_skills(["survival"]
+            }
+        });  
     });
 
     on("change:repeating_tool:toolname change:repeating_tool:toolbonus_base change:repeating_tool:toolattr_base change:repeating_tool:tool_mod", function(eventinfo) {
@@ -6751,11 +6961,18 @@
         });
     });
 
-    on("change:class change:custom_class change:cust_classname change:cust_hitdietype change:cust_powercasting_ability change:cust_powerslots change:cust_strength_save_prof change:cust_dexterity_save_prof change:cust_constitution_save_prof change:cust_intelligence_save_prof change:cust_wisdom_save_prof change:cust_charisma_save_prof change:subclass change:multiclass1 change:multiclass1_subclass change:multiclass2 change:multiclass2_subclass change:multiclass3 change:multiclass3_subclass" , function(eventinfo) {
+    on("change:class change:custom_class change:cust_classname change:cust_hitdietype change:cust_powercasting_ability change:cust_powerslots change:cust_strength_save_prof change:cust_dexterity_save_prof change:cust_constitution_save_prof change:cust_intelligence_save_prof change:cust_wisdom_save_prof change:cust_charisma_save_prof change:subclass change:multiclass1 change:multiclass1_subclass change:multiclass2 change:multiclass2_subclass change:multiclass3 change:multiclass3_subclass" , function(eventinfo) {        
         if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
             return;
         }
-        update_class();
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                return;
+            }
+            else {
+                update_class();
+            }
+        });
     });
 
     on("change:base_level change:multiclass1_flag change:multiclass1 change:multiclass1_lvl change:multiclass2_flag change:multiclass2 change:multiclass2_lvl change:multiclass3_flag change:multiclass3 change:multiclass3_lvl change:tech_fighter change:tech_infiltrator", function(eventinfo) {
@@ -6785,11 +7002,26 @@
         });
     });
 
+    on("change:pb", function(eventinfo) {
+        if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+            return;
+        }
+        getAttrs(["npc"], function(v) { 
+            if(v.npc === "2"){
+                update_pb();
+            }
+        });
+    });
+    
     on("change:pb_type change:pb_custom", function(eventinfo) {
         if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
             return;
         }
-        update_pb();
+        getAttrs(["npc"], function(v) { 
+            if(v.npc !== "2"){
+                update_pb();
+            }
+        });
     });
 
     on("change:dtype", function(eventinfo) {
@@ -9682,11 +9914,11 @@
     };
 
     var update_ac = function() {
-        getAttrs(["custom_ac_flag"], function(v) {
-            if(v.custom_ac_flag === "2") {
+        getAttrs(["custom_ac_flag","npc"], function(v) {
+            if(v.custom_ac_flag === "2" && v.npc !== "2") {
                 return;
             }
-            else if(v.custom_ac_flag === "1") {
+            else if(v.custom_ac_flag === "1" && v.npc !== "2") {
                 getAttrs(["custom_ac_base","custom_ac_part1","custom_ac_part2","strength_mod","dexterity_mod","constitution_mod","intelligence_mod","wisdom_mod","charisma_mod"], function(b) {
                     var base = isNaN(parseInt(b.custom_ac_base, 10)) === false ? parseInt(b.custom_ac_base, 10) : 10;
                     var part1attr = b.custom_ac_part1.toLowerCase();
@@ -10154,27 +10386,29 @@
 
     var update_pb = function() {
         callbacks = [];
-        getAttrs(["level","pb_type","pb_custom"], function(v) {
-            var update = {};
-            var pb = 2;
-            var lvl = parseInt(v["level"],10);
-            if(lvl < 5) {pb = "2"} else if(lvl < 9) {pb = "3"} else if(lvl < 13) {pb = "4"} else if(lvl < 17) {pb = "5"} else {pb = "6"}
-            var jack = Math.floor(pb/2);
-            if(v["pb_type"] === "die") {
-                update["jack"] = "d" + pb;
-                update["pb"] = "d" + pb*2;
-                update["pbd_safe"] = "cs0cf0";
-            }
-            else if(v["pb_type"] === "custom" && v["pb_custom"] && v["pb_custom"] != "") {
-                update["pb"] = v["pb_custom"]
-                update["jack"] = !isNaN(parseInt(v["pb_custom"],10)) ? Math.floor(parseInt(v["pb_custom"],10)/2) : jack;
-                update["pbd_safe"] = "";
-            }
-            else {
-                update["pb"] = pb;
-                update["jack"] = jack;
-                update["pbd_safe"] = "";
-            };
+        getAttrs(["level","pb_type","pb_custom","npc"], function(v) {
+            if(v.npc !== "2") {
+                var update = {};            
+                var pb = 2;
+                var lvl = parseInt(v["level"],10);
+                if(lvl < 5) {pb = "2"} else if(lvl < 9) {pb = "3"} else if(lvl < 13) {pb = "4"} else if(lvl < 17) {pb = "5"} else {pb = "6"}
+                var jack = Math.floor(pb/2);         
+                if(v["pb_type"] === "die") {
+                    update["jack"] = "d" + pb;
+                    update["pb"] = "d" + pb*2;
+                    update["pbd_safe"] = "cs0cf0";
+                }
+                else if(v["pb_type"] === "custom" && v["pb_custom"] && v["pb_custom"] != "") {
+                    update["pb"] = v["pb_custom"]
+                    update["jack"] = !isNaN(parseInt(v["pb_custom"],10)) ? Math.floor(parseInt(v["pb_custom"],10)/2) : jack;
+                    update["pbd_safe"] = "";
+                }
+                else {
+                    update["pb"] = pb;
+                    update["jack"] = jack;
+                    update["pbd_safe"] = "";
+                };
+            }          
             callbacks.push( function() {update_attacks("all");} );
             callbacks.push( function() {update_power_info();} );
             callbacks.push( function() {update_jack_attr();} );

--- a/StarWars5E/StarWars5E_HTML.html
+++ b/StarWars5E/StarWars5E_HTML.html
@@ -267,10 +267,11 @@
             <span data-i18n="gen-opts-u">GENERAL OPTIONS</span>
         </div>
         <div class="row">
+            <span>SHEET TYPE:</span>
             <select name="attr_npc">
                 <option value="0">PC</option>
-                <option value="1" >NPC</option>
-                <option value="2" >Ship</option>
+                <option value="1">NPC</option>
+                <option value="2">Ship</option>
             </select>
         <div class="row">
             <span data-i18n="roll-queries:-u">ROLL QUERIES:</span>
@@ -4087,10 +4088,11 @@
                     <input type="text" name="attr_version">
                 </div>
                 <div class="row">
+                    <span>SHEET TYPE:</span>
                     <select name="attr_npc">
                         <option value="0">PC</option>
-                        <option value="1" >NPC</option>
-                        <option value="2" >Ship</option>
+                        <option value="1">NPC</option>
+                        <option value="2">Ship</option>
                     </select>
                 </div>
                 <div class="row">

--- a/StarWars5E/StarWars5E_HTML.html
+++ b/StarWars5E/StarWars5E_HTML.html
@@ -4412,7 +4412,342 @@
             </div>
         </div>
         <div class="body">
-            
+            <div class="col col1">
+                <div class="attributes-container" style="margin-top: 10px;">
+                    <div class="attr-container">
+                        <button type="roll" name="roll_strength" value="@{wtype}&{template:simple} {{rname=^{strength-u}}} {{mod=@{strength_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{strength_mod}@{jack_attr}[STR]]]}} @{rtype}+@{strength_mod}@{jack_attr}[STR]]]}} @{charname_output}" data-i18n="strength-u">STRENGTH</button>
+                        <span class="attr" name="attr_strength_mod" title="@{strength_mod}">0</span>
+                        <div class="attr-mod">
+                            <input class="baseattr" type="text" name="attr_strength_base" title="@{strength}" value="10">
+                            <input type="hidden" name="attr_strength" value="10">
+                            <input class="attr-flag" type="hidden" name="attr_strength_flag" value="0">
+                            <span class="finalattr" name="attr_strength">
+                        </div>
+                    </div>
+                    <div class="attr-container">
+                        <button type="roll" name="roll_dexterity" value="@{wtype}&{template:simple} {{rname=^{dexterity-u}}} {{mod=@{dexterity_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{dexterity_mod}@{jack_attr}[DEX]]]}} @{rtype}+@{dexterity_mod}@{jack_attr}[DEX]]]}} @{charname_output}" data-i18n="dexterity-u">DEXTERITY</button>
+                        <span class="attr" name="attr_dexterity_mod" title="@{dexterity_mod}">0</span>
+                        <div class="attr-mod">
+                            <input class="baseattr" type="text" name="attr_dexterity_base" title="@{dexterity}" value="10">
+                            <input type="hidden" name="attr_dexterity" value="10">
+                            <input class="attr-flag" type="hidden" name="attr_dexterity_flag" value="0">
+                            <span class="finalattr" name="attr_dexterity">
+                        </div>
+                    </div>
+                    <div class="attr-container">
+                        <button type="roll" name="roll_constitution" value="@{wtype}&{template:simple} {{rname=^{constitution-u}}} {{mod=@{constitution_mod}@{jack_bonus}}} {{r1=[[@{d20}+@{constitution_mod}@{jack_attr}[CON]]]}} @{rtype}+@{constitution_mod}@{jack_attr}[CON]]]}} @{charname_output}" data-i18n="constitution-u">CONSTITUTION</button>
+                        <span class="attr" name="attr_constitution_mod" title="@{constitution_mod}">0</span>
+                        <div class="attr-mod">
+                            <input class="baseattr" type="text" name="attr_constitution_base" title="@{constitution}" value="10">
+                            <input type="hidden" name="attr_constitution" value="10">
+                            <input class="attr-flag" type="hidden" name="attr_constitution_flag" value="0">
+                            <span class="finalattr" name="attr_constitution">
+                        </div>
+                    </div>
+                </div>
+                <div class="skills-saves-container">
+                    <div class="insp-prof-container">
+                        <div class="value">
+                            <input type="number" name="attr_hyperdrive_class">
+                        </div>
+                        <div class="label">
+                            <span data-i18n="hyperdrive_class-u">HYPERDRIVE CLASS</span>
+                        </div>
+                    </div>
+                    <div class="insp-prof-container">
+                        <div class="value">
+                            <input type="number" name="attr_navcomputer_bonus">
+                        </div>
+                        <div class="label">
+                            <span data-i18n="navcomputer_bonus-u">NAVCOMPUTER BONUS</span>
+                        </div>
+                    </div>
+                    <div class="saving-throw-container">
+                        <div class="saving-throw">
+                            <input type="checkbox" name="attr_strength_save_prof" title="@{strength_save_prof}" value="(@{pb})">
+                            <span name="attr_strength_save_bonus" title="@{strength_save_bonus}">0</span>
+                            <button type="roll" name="roll_strength_save" value="@{wtype}&{template:simple} {{rname=^{strength-save-u}}} {{mod=@{strength_save_bonus}}} {{r1=[[@{d20}+@{strength_save_bonus}@{pbd_safe}]]}} @{rtype}+@{strength_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="strength">Strength</button>
+                        </div>
+                        <div class="saving-throw">
+                            <input type="checkbox" name="attr_dexterity_save_prof" title="@{dexterity_save_prof}" value="(@{pb})">
+                            <span name="attr_dexterity_save_bonus" title="@{dexterity_save_bonus}">0</span>
+                            <button type="roll" name="roll_dexterity_save" value="@{wtype}&{template:simple} {{rname=^{dexterity-save-u}}} {{mod=@{dexterity_save_bonus}}} {{r1=[[@{d20}+@{dexterity_save_bonus}@{pbd_safe}]]}} @{rtype}+@{dexterity_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="dexterity">Dexterity</button>
+                        </div>
+                        <div class="saving-throw">
+                            <input type="checkbox" name="attr_constitution_save_prof" title="@{constitution_save_prof}" value="(@{pb})">
+                            <span name="attr_constitution_save_bonus" title="@{constitution_save_bonus}">0</span>
+                            <button type="roll" name="roll_constitution_save" value="@{wtype}&{template:simple} {{rname=^{constitution-save-u}}} {{mod=@{constitution_save_bonus}}} {{r1=[[@{d20}+@{constitution_save_bonus}@{pbd_safe}]]}} @{rtype}+@{constitution_save_bonus}@{pbd_safe}]]}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="constitution">Constitution</button>
+                        </div>
+                        <input type="hidden" class="toggleflag" name="attr_global_save_mod_flag">
+                        <div class="hidden textarea globalattack">
+                            <span class="label" data-i18n="global-save-u">GLOBAL SAVE MODIFIER</span>
+                            <fieldset class="repeating_savemod">
+                                <div class="global-mod">
+                                    <input type="checkbox" name="attr_options-flag" class="options-flag" checked="checked" style="top: -15px;"><span>y</span>
+                                    <input type="checkbox" name="attr_global_save_active_flag" value="1" class="active-flag">
+                                    <div class="options">
+                                        <textarea type="textarea" name="attr_global_save_rollstring" placeholder="1d4[BLESS]" style="width: 125px;"></textarea>
+                                    </div>
+                                    <div class="display">
+                                        <span class="title" name="attr_global_save_rollstring"></span>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <div class="label">
+                            <span data-i18n="saving-throws-u">SAVING THROWS</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col col2">
+                <div class="ac-init-speed-container">
+                    <div class="ac">
+                        <input type="text" name="attr_ac">
+                        <span class="label pc-ac" data-i18n="armor-class-u">ARMOR CLASS</span>
+                    </div>
+                    <div class="speed">
+                            <input type="text" name="attr_ship_turnspeed">
+                            <span class="label" data-i18n="ship_turnspeed-u">TURNING SPEED</span>
+                        </div>
+                    <div class="speed">
+                        <input type="text" name="attr_ship_flyspeed">
+                        <span class="label" data-i18n="ship_flyspeed-u">FLYING SPEED</span>
+                    </div>
+                </div>
+                <div class="hp">
+                    <div class="top">
+                        <span data-i18n="hp-max-u">Hit Point Maximum</span>
+                        <input type="text" name="attr_hp_max" title="@{hp_max}">
+                    </div>
+                    <input type="number" name="attr_hp" title="@{hp}">
+                    <span class="label" data-i18n="hp-current-u">CURRENT HIT POINTS</span>
+                </div>
+                <div class="hp">
+                    <div class="top">
+                        <span data-i18n="ship-shield-max-u">Shield Point Maximum</span>
+                        <input type="text" style="width:120px" name="attr_ship_shield_max">
+                    </div>
+                    <input type="number" name="attr_ship_shield_points">
+                    <span class="label" data-i18n="ship-shield-u">CURRENT SHIELD POINTS</span>
+                </div>
+                <div class="hdice-dsaves-container" style="width: 242px;">
+                    <div class="subcontainer">
+                        <div class="top">
+                            <span data-i18n="total">Total</span>
+                            <input type="text" name="attr_hit_dice_max" title="@{hit_dice_max}">
+                        </div>
+                        <input type="number" name="attr_hit_dice" title="@{hit_dice}" style="margin-bottom: -6px;">
+                        <button type="roll" name="roll_hit_dice" value="@{wtype}&{template:simple} {{rname=^{hit-dice-u}}} {{mod=D@{hitdie_final}+[[@{constitution_mod}[CON]]]}} {{r1=[[1d@{hitdie_final}+[[@{constitution_mod}]][CON]]]}} {{normal=1}} @{charname_output}" data-i18n="hit-dice-u">HIT DICE</button>
+                    </div>
+                    <div class="subcontainer" >
+                        <div class="row-container" style="float:right;margin-top:20px">
+                            <span class="label" data-i18n="successes-u">SUCCESSES</span>
+                            <input type="checkbox" name="attr_deathsave_succ1">
+                            <input type="checkbox" name="attr_deathsave_succ2">
+                            <input type="checkbox" name="attr_deathsave_succ3">
+                        </div>
+                        <button type="roll" style="margin-top:16px;" name="roll_death_save" value="@{wtype}&{template:simple} {{rname=^{death-save-u}}} {{mod=@{death_save_bonus}}} {{r1=[[@{d20}+@{death_save_bonus}[MOD]@{globalsavingthrowbonus}]]}} {{normal=1}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="destruction-saves-u">DESTRUCTION SAVES</button>
+                    </div>
+                </div>
+            </div>
+            <div class="col col3">
+                <input type="hidden" class="ammoflag" name="attr_ammotracking">
+                <div class="attacks" style="position: relative;">
+                    <div class="top">
+                        <span class="label" style="width: 80px;" data-i18n="name-u">NAME</span>
+                        <span class="label" style="width: 30px;" data-i18n="atk-u">ATK</span>
+                        <span class="label" style="width: 70px;" data-i18n="dmg-type-u">DAMAGE/TYPE</span>
+                        <span class="label" style="width: 25px;" data-i18n="attacks-per-round-u">ATKS</span>
+                    </div>
+                    <fieldset class="repeating_attack">
+                        <div class="attack">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_atkname">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_atkflag" value="{{attack=1}}" checked="checked">
+                                    <span data-i18n="attack:-u">ATTACK:</span>
+                                    <select name="attr_atkattr_base">
+                                        <option value="@{strength_mod}" selected="selected" data-i18n="str-u">STR</option>
+                                        <option value="@{dexterity_mod}" data-i18n="dex-u">DEX</option>
+                                        <option value="@{constitution_mod}" data-i18n="con-u">CON</option>
+                                        <option value="@{intelligence_mod}" data-i18n="int-u">INT</option>
+                                        <option value="@{wisdom_mod}" data-i18n="wis-u">WIS</option>
+                                        <option value="@{charisma_mod}" data-i18n="cha-u">CHA</option>
+                                        <option value="power" data-i18n="power-u">POWER</option>
+                                        <option value="0">-</option>
+                                    </select>
+                                    <span>+</span>
+                                    <input type="text" class="num" name="attr_atkmod" placeholder="0">
+                                    <span>+</span>
+                                    <input type="checkbox" name="attr_atkprofflag" value="(@{pb})" checked="checked" style="margin-left: 3px;">
+                                    <span data-i18n="proficient-u">PROFICIENT</span>
+                                </div>
+                                <div class="row">
+                                    <span style="margin-left: 17px;" data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_atkrange" placeholder="Self (60-foot cone)" style="width: 170px;" data-i18n-placeholder="range-place">
+                                </div>
+                                <div class="row">
+                                    <span style="margin-left: 17px;" data-i18n="power-bonus:-u">POWER BONUS:</span>
+                                    <input type="text" class="num" name="attr_atkpower" placeholder="0">
+                                    <span data-i18n="crit-range-u">CRIT RANGE:</span>
+                                    <input type="text" class="num" name="attr_atkcritrange" value="20" placeholder="20">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_dmgflag" value="{{damage=1}} {{dmg1flag=1}}" checked="checked">
+                                    <span data-i18n="damage:-u">DAMAGE:</span>
+                                    <input type="text" name="attr_dmgbase" placeholder="1d6" style="width: 50px;">
+                                    <span>+</span>
+                                    <select name="attr_dmgattr">
+                                        <option value="@{strength_mod}" selected="selected" data-i18n="str-u">STR</option>
+                                        <option value="@{dexterity_mod}" data-i18n="dex-u">DEX</option>
+                                        <option value="@{constitution_mod}" data-i18n="con-u">CON</option>
+                                        <option value="@{intelligence_mod}" data-i18n="int-u">INT</option>
+                                        <option value="@{wisdom_mod}" data-i18n="wis-u">WIS</option>
+                                        <option value="@{charisma_mod}" data-i18n="cha-u">CHA</option>
+                                        <option value="power" data-i18n="power-u">POWER</option>
+                                        <option value="0">-</option>
+                                    </select>
+                                    <span>+</span>
+                                    <input type="text" class="num" name="attr_dmgmod" placeholder="0">
+                                </div>
+                                <div class="row">
+                                    <span style="margin-left: 17px;" data-i18n="type:-u">TYPE:</span>
+                                    <input type="text" name="attr_dmgtype" placeholder="Slashing" style="width: 50px;" data-i18n-placeholder="dmg-type-place">
+                                    <span data-i18n="crit:-u">CRIT:</span>
+                                    <input type="text" name="attr_dmgcustcrit" placeholder="1d6" style="width: 80px;">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_dmg2flag" value="{{damage=1}} {{dmg2flag=1}}">
+                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                    <input type="text" name="attr_dmg2base" placeholder="1d6" style="width: 50px;">
+                                    <span>+</span>
+                                    <select name="attr_dmg2attr">
+                                        <option value="@{strength_mod}" data-i18n="str-u">STR</option>
+                                        <option value="@{dexterity_mod}" data-i18n="dex-u">DEX</option>
+                                        <option value="@{constitution_mod}" data-i18n="con-u">CON</option>
+                                        <option value="@{intelligence_mod}" data-i18n="int-u">INT</option>
+                                        <option value="@{wisdom_mod}" data-i18n="wis-u">WIS</option>
+                                        <option value="@{charisma_mod}" data-i18n="cha-u">CHA</option>
+                                        <option value="power" data-i18n="power-u">POWER</option>
+                                        <option value="0" selected="selected">-</option>
+                                    </select>
+                                    <span>+</span>
+                                    <input type="text" class="num" name="attr_dmg2mod" placeholder="0">
+                                </div>
+                                <div class="row">
+                                    <span style="margin-left: 17px;" data-i18n="type:-u">TYPE:</span>
+                                    <input type="text" name="attr_dmg2type" placeholder="Slashing" style="width: 50px;" data-i18n-placeholder="dmg-type-place">
+                                    <span data-i18n="crit:-u">CRIT:</span>
+                                    <input type="text" name="attr_dmg2custcrit" placeholder="1d6" style="width: 80px;">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_saveflag" value="{{save=1}} {{saveattr=@{saveattr}}} {{savedesc=@{saveeffect}}} {{savedc=[[[[@{savedc}]][SAVE]]]}}">
+                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                    <select name="attr_saveattr">
+                                        <option value="Strength" selected="selected" data-i18n="str-u">STR</option>
+                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                        <option value="Constitution" data-i18n="con-u">CON</option>
+                                        <option value="Intelligence" data-i18n="int-u">INT</option>
+                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                    </select>
+                                    <span data-i18n="vs-dc:-u">VS DC:</span>
+                                    <select name="attr_savedc">
+                                        <option value="(@{power_save_dc})" selected="selected" data-i18n="power-u">POWER</option>
+                                        <option value="(@{strength_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="str-u">STR</option>
+                                        <option value="(@{dexterity_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="dex-u">DEX</option>
+                                        <option value="(@{constitution_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="con-u">CON</option>
+                                        <option value="(@{intelligence_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="int-u">INT</option>
+                                        <option value="(@{wisdom_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="wis-u">WIS</option>
+                                        <option value="(@{charisma_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="cha-u">CHA</option>
+                                        <option value="(@{saveflat})" data-i18n="flat-u">FLAT</option>
+                                    </select>
+                                    <input class="flatflag" type="hidden" name="attr_savedc">
+                                    <input class="num flat" type="text" name="attr_saveflat" placeholder="10" value="10">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="save-effect:-u">SAVE EFFECT:</span>
+                                    <input type="text" name="attr_saveeffect" placeholder="half damage" style="width: 160px;" data-i18n-placeholder="save-effect-place">
+                                </div>
+                                <div class="row ammo">
+                                    <span data-i18n="ammunition:-u">AMMUNITION:</span>
+                                    <input type="text" name="attr_ammo" placeholder="Arrows" style="width: 160px;" data-i18n-placeholder="ammunition-place">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="attacks-per-round:-u">ATK/ROUND:</span>
+                                    <input type="text" name="attr_atk_per_round" placeholder="1" style="width: 160px;">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                    <textarea name="attr_atk_desc" placeholder="Up to 2 creatures within 5 feet" data-i18n-placeholder="description-place"></textarea>
+                                </div>
+                            </div>
+                            <div class="display">
+                                <button type="roll" name="roll_attack" value="@{rollbase}">
+                                    <span name="attr_atkname" style="width: 70px;"></span>
+                                    <input type="text" name="attr_atkbonus" style="width: 35px; text-align: center;" value="">
+                                    <input type="text" name="attr_atkdmgtype" style="width: 75px;" value="">
+                                    <input type="text" name="attr_atk_per_round" style="width: 30px;" value="">
+                                </button>
+                            </div>
+                        </div>
+                        <input type="hidden" name="attr_rollbase">
+                        <input type="hidden" name="attr_rollbase_dmg">
+                        <input type="hidden" name="attr_rollbase_crit">
+                        <input type="hidden" name="attr_hldmg">
+                        <input type="hidden" name="attr_powerlevel">
+                        <input type="hidden" name="attr_itemid">
+                        <input type="hidden" name="attr_powerid">
+                        <input type="hidden" name="attr_power_innate">
+                        <input type="hidden" name="attr_versatile_alt">
+                        <button type="roll" name="roll_attack_dmg" style="display: none;" value="@{rollbase_dmg}"></button>
+                        <button type="roll" name="roll_attack_crit" style="display: none;" value="@{rollbase_crit}"></button>
+                    </fieldset>
+                    <input type="hidden" class="toggleflag" name="attr_global_attack_mod_flag">
+                    <div class="hidden textbox globalattack">
+                        <span class="label" data-i18n="global-attack-u">GLOBAL ATTACK MODIFIER</span>
+                        <fieldset class="repeating_tohitmod">
+                            <div class="global-mod">
+                                <input type="checkbox" name="attr_options-flag" class="options-flag" checked="checked" style="top: -15px;"><span>y</span>
+                                <input type="checkbox" name="attr_global_attack_active_flag" value="1" class="active-flag">
+                                <div class="options">
+                                    <textarea type="textarea" name="attr_global_attack_rollstring" placeholder="1d4[BLESS]"></textarea>
+                                </div>
+                                <div class="display">
+                                    <span class="title" name="attr_global_attack_rollstring"></span>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                    <input type="hidden" class="toggleflag" name="attr_global_damage_mod_flag">
+                    <div class="hidden textbox globalattack">
+                        <span class="label" data-i18n="global-damage-u">GLOBAL DAMAGE MODIFIER</span>
+                        <fieldset class="repeating_damagemod">
+                            <div class="global-mod">
+                                <input type="checkbox" name="attr_options-flag" class="options-flag" checked="checked" style="top: -15px;"><span>y</span>
+                                <input type="checkbox" name="attr_global_damage_active_flag" value="1" class="active-flag">
+                                <div class="options">
+                                    <textarea type="textarea" name="attr_global_damage_rollstring" placeholder="1d6[SNEAK ATTACK]"></textarea>
+                                    <div class="row" style="margin-bottom: 5px;">
+                                        <span style="display: inline; margin-left: 25px;" data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_global_damage_type" value="">
+                                    </div>
+                                </div>
+                                <div class="display" style="margin-bottom: 2px;">
+                                    <span class="title" name="attr_global_damage_rollstring" style="width: 110px; padding-right: 0px;"></span>
+                                    <span class="subheader" name="attr_global_damage_type" style="padding-right: 0px;"></span>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                    <span class="label" style="margin-top: 0px; position: absolute; bottom: 0px;" data-i18n="atk-powercasting-u">ATTACKS</span>
+                </div>
+            </div>
         </div>
     </div>
     <div class="page ship-modifications">

--- a/StarWars5E/StarWars5E_HTML.html
+++ b/StarWars5E/StarWars5E_HTML.html
@@ -4356,9 +4356,9 @@
                 </div>
                 <div class="sheet-row">
                     <span data-i18n="ship-credits-invested:-u">CREDITS INVESTED:</span>
-                    <input type="text" name="attr_ship_cr">
+                    <input type="number" style="width:90px" name="attr_ship_cr">
                     <span data-i18n="ship-credits-next-tier:-u">CREDITS NEEDED FOR NEXT TIER:</span>
-                    <input type="text" name="attr_ship_cr_next">
+                    <input type="number" style="width:90px" name="attr_ship_cr_next">
                 </div>
             </div>
         </div>
@@ -4405,9 +4405,9 @@
                 </div>
                 <div class="sheet-row">
                     <span data-i18n="ship-credits-invested:-u">CREDITS INVESTED:</span>
-                    <input type="text" name="attr_ship_cr">
+                    <input type="number" style="width:90px" name="attr_ship_cr">
                     <span data-i18n="ship-credits-next-tier:-u">CREDITS NEEDED FOR NEXT TIER:</span>
-                    <input type="text" name="attr_ship_cr_next">
+                    <input type="number" style="width:90px" name="attr_ship_cr_next">
                 </div>
             </div>
         </div>
@@ -4443,9 +4443,9 @@
                 </div>
                 <div class="sheet-row">
                     <span data-i18n="ship-credits-invested:-u">CREDITS INVESTED:</span>
-                    <input type="text" name="attr_ship_cr">
+                    <input type="number" style="width:90px" name="attr_ship_cr">
                     <span data-i18n="ship-credits-next-tier:-u">CREDITS NEEDED FOR NEXT TIER:</span>
-                    <input type="text" name="attr_ship_cr_next">
+                    <input type="number" style="width:90px" name="attr_ship_cr_next">
                 </div>
             </div>
         </div>

--- a/StarWars5E/StarWars5E_HTML.html
+++ b/StarWars5E/StarWars5E_HTML.html
@@ -4734,7 +4734,7 @@
                         <input type="hidden" class="inventoryflag" name="attr_simpletraits" value="complex">
                         <textarea class="sheet-simple" name="attr_features_and_traits" style="min-height: 260px; height: 260px;"></textarea>
                         <div class="complex" style="width: 475px;">
-                            <fieldset class="repeating_traits">
+                            <fieldset class="repeating_modifications">
                                 <div class="trait">
                                     <button type="roll" name="roll_output" class="output" value="@{wtype}&{template:traits} @{charname_output} {{name=@{name}}} {{source=@{source}: @{source_type}}} {{description=@{description}}}">w</button>
                                     <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
@@ -4747,13 +4747,13 @@
                                         <div class="row">
                                             <span data-i18n="source:-u">SOURCE:</span>
                                             <select name="attr_source">
-                                                <option selected="selected" data-i18n="modification">Modification</option>
+                                                <option selected="selected" data-i18n="upgrade">Upgrade</option>
                                                 <option data-i18n="other">Other</option>
                                             </select>
                                         </div>
                                         <div class="row">
-                                            <span data-i18n="source-type:-u">SOURCE TYPE:</span>
-                                            <input type="text" name="attr_source_type" style="width: 160px;" placeholder="Tier 1">
+                                            <span data-i18n="type:-u">TYPE:</span>
+                                            <input type="text" name="attr_source_type" style="width: 160px;" placeholder="Suite System">
                                         </div>
                                         <div class="row">
                                             <textarea name="attr_description" style="min-height: 200px; height: 200px;"></textarea>

--- a/StarWars5E/StarWars5E_HTML.html
+++ b/StarWars5E/StarWars5E_HTML.html
@@ -4755,8 +4755,8 @@
                                     <input type="checkbox" name="attr_atkflag" value="{{attack=1}}" checked="checked">
                                     <span data-i18n="attack:-u">ATTACK:</span>
                                     <select name="attr_atkattr_base">
-                                        <option value="@{strength_mod}" selected="selected" data-i18n="str-u">STR</option>
-                                        <option value="@{dexterity_mod}" data-i18n="dex-u">DEX</option>
+                                        <option value="@{strength_mod}" data-i18n="str-u">STR</option>
+                                        <option value="@{dexterity_mod}" selected="selected" data-i18n="dex-u">DEX</option>
                                         <option value="@{constitution_mod}" data-i18n="con-u">CON</option>
                                         <option value="@{intelligence_mod}" data-i18n="int-u">INT</option>
                                         <option value="@{wisdom_mod}" data-i18n="wis-u">WIS</option>
@@ -4766,9 +4766,7 @@
                                     </select>
                                     <span>+</span>
                                     <input type="text" class="num" name="attr_atkmod" placeholder="0">
-                                    <span>+</span>
-                                    <input type="checkbox" name="attr_atkprofflag" value="(@{pb})" checked="checked" style="margin-left: 3px;">
-                                    <span data-i18n="proficient-u">PROFICIENT</span>
+                                    <input type="hidden" name="attr_atkprofflag" value="">
                                 </div>
                                 <div class="row">
                                     <span style="margin-left: 17px;" data-i18n="range:-u">RANGE:</span>
@@ -4832,8 +4830,8 @@
                                     <input type="checkbox" name="attr_saveflag" value="{{save=1}} {{saveattr=@{saveattr}}} {{savedesc=@{saveeffect}}} {{savedc=[[[[@{savedc}]][SAVE]]]}}">
                                     <span data-i18n="saving-throw:-u">SAVING THROW:</span>
                                     <select name="attr_saveattr">
-                                        <option value="Strength" selected="selected" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                        <option value="Strength" data-i18n="str-u">STR</option>
+                                        <option value="Dexterity" selected="selected" data-i18n="dex-u">DEX</option>
                                         <option value="Constitution" data-i18n="con-u">CON</option>
                                         <option value="Intelligence" data-i18n="int-u">INT</option>
                                         <option value="Wisdom" data-i18n="wis-u">WIS</option>
@@ -4841,21 +4839,21 @@
                                     </select>
                                     <span data-i18n="vs-dc:-u">VS DC:</span>
                                     <select name="attr_savedc">
-                                        <option value="(@{power_save_dc})" selected="selected" data-i18n="power-u">POWER</option>
+                                        <option value="(@{power_save_dc})" data-i18n="power-u">POWER</option>
                                         <option value="(@{strength_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="str-u">STR</option>
                                         <option value="(@{dexterity_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="dex-u">DEX</option>
                                         <option value="(@{constitution_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="con-u">CON</option>
                                         <option value="(@{intelligence_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="int-u">INT</option>
                                         <option value="(@{wisdom_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="wis-u">WIS</option>
                                         <option value="(@{charisma_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="cha-u">CHA</option>
-                                        <option value="(@{saveflat})" data-i18n="flat-u">FLAT</option>
+                                        <option value="(@{saveflat})" selected="selected" data-i18n="flat-u">FLAT</option>
                                     </select>
-                                    <input class="flatflag" type="hidden" name="attr_savedc">
-                                    <input class="num flat" type="text" name="attr_saveflat" placeholder="10" value="10">
+                                    <input class="flatflag" type="hidden" name="attr_savedc" value="saveflat">
+                                    <input class="num flat" type="text" name="attr_saveflat" placeholder="8" value="8">
                                 </div>
                                 <div class="row">
                                     <span data-i18n="save-effect:-u">SAVE EFFECT:</span>
-                                    <input type="text" name="attr_saveeffect" placeholder="half damage" style="width: 160px;" data-i18n-placeholder="save-effect-place">
+                                    <input type="text" name="attr_saveeffect" placeholder="half damage" style="width: 160px;" data-i18n-placeholder="save-effect-place" value="half damage">
                                 </div>
                                 <div class="row ammo">
                                     <span data-i18n="ammunition:-u">AMMUNITION:</span>
@@ -4928,7 +4926,7 @@
                             </div>
                         </fieldset>
                     </div>
-                    <span class="label" style="margin-top: 0px; position: absolute; bottom: 0px;" data-i18n="atk-powercasting-u">ATTACKS</span>
+                    <span class="label" style="margin-top: 0px; position: absolute; bottom: 0px;" data-i18n="attacks-u">ATTACKS</span>
                 </div>
                 <div class="resources">
                     <div class="hdice-dsaves-container" style="width: 246px; margin-top: 10px;">
@@ -9382,9 +9380,11 @@
             attack_attribs.push("repeating_attack_" + attackid + "_itemid");
             attack_attribs.push("repeating_attack_" + attackid + "_ammo");
             attack_attribs.push("repeating_attack_" + attackid + "_global_damage_mod_field");
+            attack_attribs.push("npc");
         });
 
         getAttrs(attack_attribs, function(v) {
+            var isShipAttack = v.npc === "2";
             _.each(attack_array, function(attackid) {
                 console.log("UPDATING ATTACK: " + attackid);
                 var callbacks = [];
@@ -9447,6 +9447,9 @@
                 var dmgtype = v["repeating_attack_" + attackid + "_dmgtype"] ? v["repeating_attack_" + attackid + "_dmgtype"] + " " : "";
                 var dmg2type = v["repeating_attack_" + attackid + "_dmg2type"] ? v["repeating_attack_" + attackid + "_dmg2type"] + " " : "";
                 var pb = v["repeating_attack_" + attackid + "_atkprofflag"] && v["repeating_attack_" + attackid + "_atkprofflag"] != 0 && v.pb ? v.pb : 0;
+                if(isShipAttack) {
+                    pb = 0;
+                }
                 var atkmod = v["repeating_attack_" + attackid + "_atkmod"] && v["repeating_attack_" + attackid + "_atkmod"] != "" ? parseInt(v["repeating_attack_" + attackid + "_atkmod"],10) : 0;
                 var atkmag = v["repeating_attack_" + attackid + "_atkpower"] && v["repeating_attack_" + attackid + "_atkpower"] != "" ? parseInt(v["repeating_attack_" + attackid + "_atkpower"],10) : 0;
                 var dmgmag = isNaN(atkmag) === false && atkmag != 0 && ((v["repeating_attack_" + attackid + "_dmgflag"] && v["repeating_attack_" + attackid + "_dmgflag"] != 0) || (v["repeating_attack_" + attackid + "_dmg2flag"] && v["repeating_attack_" + attackid + "_dmg2flag"] != 0)) ? "+ " + atkmag + " Power Bonus" : "";

--- a/StarWars5E/StarWars5E_HTML.html
+++ b/StarWars5E/StarWars5E_HTML.html
@@ -4928,45 +4928,45 @@
                         <input type="hidden" name="attr_versatile_alt">
                         <button type="roll" name="roll_attack_dmg" style="display: none;" value="@{rollbase_dmg}"></button>
                         <button type="roll" name="roll_attack_crit" style="display: none;" value="@{rollbase_crit}"></button>
-                    </fieldset>
-                    <input type="hidden" class="toggleflag" name="attr_global_attack_mod_flag">
-                    <div class="hidden textbox globalattack">
-                        <span class="label" data-i18n="global-attack-u">GLOBAL ATTACK MODIFIER</span>
-                        <fieldset class="repeating_tohitmod">
-                            <div class="global-mod">
-                                <input type="checkbox" name="attr_options-flag" class="options-flag" checked="checked" style="top: -15px;"><span>y</span>
-                                <input type="checkbox" name="attr_global_attack_active_flag" value="1" class="active-flag">
-                                <div class="options">
-                                    <textarea type="textarea" name="attr_global_attack_rollstring" placeholder="1d4[BLESS]"></textarea>
-                                </div>
-                                <div class="display">
-                                    <span class="title" name="attr_global_attack_rollstring"></span>
-                                </div>
-                            </div>
-                        </fieldset>
-                    </div>
-                    <input type="hidden" class="toggleflag" name="attr_global_damage_mod_flag">
-                    <div class="hidden textbox globalattack">
-                        <span class="label" data-i18n="global-damage-u">GLOBAL DAMAGE MODIFIER</span>
-                        <fieldset class="repeating_damagemod">
-                            <div class="global-mod">
-                                <input type="checkbox" name="attr_options-flag" class="options-flag" checked="checked" style="top: -15px;"><span>y</span>
-                                <input type="checkbox" name="attr_global_damage_active_flag" value="1" class="active-flag">
-                                <div class="options">
-                                    <textarea type="textarea" name="attr_global_damage_rollstring" placeholder="1d6[SNEAK ATTACK]"></textarea>
-                                    <div class="row" style="margin-bottom: 5px;">
-                                        <span style="display: inline; margin-left: 25px;" data-i18n="type:-u">TYPE:</span>
-                                        <input type="text" name="attr_global_damage_type" value="">
-                                    </div>
-                                </div>
-                                <div class="display" style="margin-bottom: 2px;">
-                                    <span class="title" name="attr_global_damage_rollstring" style="width: 110px; padding-right: 0px;"></span>
-                                    <span class="subheader" name="attr_global_damage_type" style="padding-right: 0px;"></span>
-                                </div>
-                            </div>
-                        </fieldset>
-                    </div>
+                    </fieldset>                    
                     <span class="label" style="margin-top: 0px; position: absolute; bottom: 0px;" data-i18n="attacks-u">ATTACKS</span>
+                </div>
+                <input type="hidden" class="toggleflag" name="attr_global_attack_mod_flag">
+                <div class="hidden textbox globalattack">
+                    <span class="label" data-i18n="global-attack-u">GLOBAL ATTACK MODIFIER</span>
+                    <fieldset class="repeating_tohitmod">
+                        <div class="global-mod">
+                            <input type="checkbox" name="attr_options-flag" class="options-flag" checked="checked" style="top: -15px;"><span>y</span>
+                            <input type="checkbox" name="attr_global_attack_active_flag" value="1" class="active-flag">
+                            <div class="options">
+                                <textarea type="textarea" name="attr_global_attack_rollstring" placeholder="1d4[BLESS]"></textarea>
+                            </div>
+                            <div class="display">
+                                <span class="title" name="attr_global_attack_rollstring"></span>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <input type="hidden" class="toggleflag" name="attr_global_damage_mod_flag">
+                <div class="hidden textbox globalattack">
+                    <span class="label" data-i18n="global-damage-u">GLOBAL DAMAGE MODIFIER</span>
+                    <fieldset class="repeating_damagemod">
+                        <div class="global-mod">
+                            <input type="checkbox" name="attr_options-flag" class="options-flag" checked="checked" style="top: -15px;"><span>y</span>
+                            <input type="checkbox" name="attr_global_damage_active_flag" value="1" class="active-flag">
+                            <div class="options">
+                                <textarea type="textarea" name="attr_global_damage_rollstring" placeholder="1d6[SNEAK ATTACK]"></textarea>
+                                <div class="row" style="margin-bottom: 5px;">
+                                    <span style="display: inline; margin-left: 25px;" data-i18n="type:-u">TYPE:</span>
+                                    <input type="text" name="attr_global_damage_type" value="">
+                                </div>
+                            </div>
+                            <div class="display" style="margin-bottom: 2px;">
+                                <span class="title" name="attr_global_damage_rollstring" style="width: 110px; padding-right: 0px;"></span>
+                                <span class="subheader" name="attr_global_damage_type" style="padding-right: 0px;"></span>
+                            </div>
+                        </div>
+                    </fieldset>
                 </div>
                 <div class="resources">
                     <div class="hdice-dsaves-container" style="width: 246px; margin-top: 10px;">

--- a/StarWars5E/StarWars5E_HTML.html
+++ b/StarWars5E/StarWars5E_HTML.html
@@ -4326,7 +4326,6 @@
 
 <div class="container ship">
     <input class="tab-button ship-core" type="radio" name="attr_ship_tab" value="ship-core" checked="checked"><span data-i18n="core-u">CORE</span>
-    <input class="tab-button ship-modifications" type="radio" name="attr_ship_tab" value="ship-modifications"><span data-i18n="modifications-u">MODIFICATIONS</span>
     <input class="tab-button options" type="radio" name="attr_ship_tab" value="options"><span style="font-family: pictos">y</span>
 
     <div class="page options">
@@ -4632,7 +4631,7 @@
                                 <input type="checkbox" name="attr_deathsave_succ2">
                                 <input type="checkbox" name="attr_deathsave_succ3">
                             </div>
-                            <button type="roll" style="margin-top:16px;" name="roll_death_save" value="@{wtype}&{template:simple} {{rname=^{death-save-u}}} {{mod=@{death_save_bonus}}} {{r1=[[@{d20}+@{death_save_bonus}[MOD]@{globalsavingthrowbonus}]]}} {{normal=1}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="destruction-saves-u">DESTRUCTION SAVES</button>
+                            <button type="roll" style="margin-top:16px;" name="roll_death_save" value="@{wtype}&{template:simple} {{rname=^{destruction-save-u}}} {{mod=@{death_save_bonus}}} {{r1=[[@{d20}+@{death_save_bonus}[MOD]@{globalsavingthrowbonus}]]}} {{normal=1}} {{global=@{global_save_mod}}} @{charname_output}" data-i18n="destruction-saves-u">DESTRUCTION SAVES</button>
                         </div>
                     </div>
                 </div>
@@ -4730,6 +4729,47 @@
                             </div>
                         </div>
                         <span class="label" style="margin-top: 0px; position: absolute; bottom: 0px;" data-i18n="hidden-cargo-u">HIDDEN CARGO</span>
+                    </div>
+                    <div class="textbox traits" style="min-height: 260px; width:480px; display:inline-block;">
+                        <input type="hidden" class="inventoryflag" name="attr_simpletraits" value="complex">
+                        <textarea class="sheet-simple" name="attr_features_and_traits" style="min-height: 260px; height: 260px;"></textarea>
+                        <div class="complex" style="width: 475px;">
+                            <fieldset class="repeating_traits">
+                                <div class="trait">
+                                    <button type="roll" name="roll_output" class="output" value="@{wtype}&{template:traits} @{charname_output} {{name=@{name}}} {{source=@{source}: @{source_type}}} {{description=@{description}}}">w</button>
+                                    <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
+                                    <input class="display-flag" type="checkbox" name="attr_display_flag">
+                                    <div class="options">
+                                        <div class="row">
+                                            <span data-i18n="name:-u">NAME:</span>
+                                            <input type="text" name="attr_name" style="width: 120px;">
+                                        </div>
+                                        <div class="row">
+                                            <span data-i18n="source:-u">SOURCE:</span>
+                                            <select name="attr_source">
+                                                <option selected="selected" data-i18n="modification">Modification</option>
+                                                <option data-i18n="other">Other</option>
+                                            </select>
+                                        </div>
+                                        <div class="row">
+                                            <span data-i18n="source-type:-u">SOURCE TYPE:</span>
+                                            <input type="text" name="attr_source_type" style="width: 160px;" placeholder="Tier 1">
+                                        </div>
+                                        <div class="row">
+                                            <textarea name="attr_description" style="min-height: 200px; height: 200px;"></textarea>
+                                        </div>
+                                    </div>
+                                    <div class="display" style="margin-bottom: 2px;">
+                                        <span class="title" name="attr_name"></span>
+                                        <span class="subheader">
+                                            <span name="attr_source"></span><span>: </span><span name="attr_source_type"></span>
+                                        </span>
+                                        <span class="desc" name="attr_description"></span>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <span class="label" data-i18n="modifications-u" style="margin-top: 0px; position: absolute; bottom: 0px;">MODIFICATIONS</span>
                     </div>
                 </div>  
             </div>
@@ -5014,44 +5054,6 @@
                 </div>
             </div>
             
-        </div>
-    </div>
-    <div class="page ship-modifications">
-        <div class="header">
-            <div class="name-container">
-                <img src="https://s22.postimg.cc/jnlp8fqc1/Star_Wars_5_E_Logo_Shrunk.png" style="padding-bottom: 10px;">
-                <input type="text" name="attr_ship_name" style="width: 100%;">
-                <span class="label" data-i18n="ship-name-u">SHIP NAME</span>
-            </div>
-            <div class="header-info sheet-options">
-                <div class="sheet-row">
-                    <span data-i18n="ship-size:-u">SIZE:</span>
-                    <select class="hiding class" name="attr_ship_size">
-                        <option value="" data-i18n="choose">Choose</option>
-                        <option value="Tiny" data-i18n="tiny">Tiny</option>
-                        <option value="Small" data-i18n="small">Small</option>
-                        <option value="Medium" data-i18n="medium">Medium</option>
-                        <option value="Large" data-i18n="large">Large</option>
-                        <option value="Huge" data-i18n="huge">Huge</option>
-                        <option value="Gargantuan" data-i18n="gargantuan">Gargantuan</option>
-                    </select>
-                    <span data-i18n="ship-tier:-u">TIER:</span>
-                    <input type="number" class="class-level" style="width: 40px" name="attr_base_ship_tier" value="0">
-                </div>
-                <div class="sheet-row">
-                    <span data-i18n="ship-manufacturer:-u">MANUFACTURER/LINE/CLASS:</span>
-                    <input type="text">
-                </div>
-                <div class="sheet-row">
-                    <span data-i18n="ship-credits-invested:-u">CREDITS INVESTED:</span>
-                    <input type="number" style="width:90px" name="attr_ship_cr">
-                    <span data-i18n="ship-credits-next-tier:-u">CREDITS NEEDED FOR NEXT TIER:</span>
-                    <input type="number" style="width:90px" name="attr_ship_cr_next">
-                </div>
-            </div>
-        </div>
-        <div class="body">
-
         </div>
     </div>
 </div>

--- a/StarWars5E/StarWars5E_HTML.html
+++ b/StarWars5E/StarWars5E_HTML.html
@@ -267,9 +267,11 @@
             <span data-i18n="gen-opts-u">GENERAL OPTIONS</span>
         </div>
         <div class="row">
-        <input type="checkbox" name="attr_npc" value="1">
-            <span data-i18n="npc-u">NPC</span>
-        </div>
+            <select name="attr_npc">
+                <option value="0">PC</option>
+                <option value="1" >NPC</option>
+                <option value="2" >Ship</option>
+            </select>
         <div class="row">
             <span data-i18n="roll-queries:-u">ROLL QUERIES:</span>
             <select name="attr_rtype">
@@ -4085,8 +4087,11 @@
                     <input type="text" name="attr_version">
                 </div>
                 <div class="row">
-                    <input type="checkbox" name="attr_npc" value="1">
-                    <span data-i18n="npc-u">NPC</span>
+                    <select name="attr_npc">
+                        <option value="0">PC</option>
+                        <option value="1" >NPC</option>
+                        <option value="2" >Ship</option>
+                    </select>
                 </div>
                 <div class="row">
                     <span data-i18n="roll-queries:-u">ROLL QUERIES:</span>
@@ -4312,6 +4317,9 @@
 <input type="hidden" name="attr_drop_parent" accept="data-Parent">
 
 </div> <!-- licensecontainer div close -->
+
+<div class="container ship">
+</div>
 
 <!-- HIDDEN FIELDS -->
 <input type="hidden" name="attr_d20" value="1d20">

--- a/StarWars5E/StarWars5E_HTML.html
+++ b/StarWars5E/StarWars5E_HTML.html
@@ -6304,6 +6304,14 @@
         update_attacks("strength");
         update_tool("strength");
         update_power_info("strength");
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                update_ship_speeds();
+            }
+            else {
+                return;
+            }
+        }); 
     });
 
     on("change:dexterity_mod", function() {
@@ -6314,6 +6322,14 @@
         update_power_info("dexterity");
         update_ac();
         update_initiative();
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                update_ship_speeds();
+            }
+            else {
+                return;
+            }
+        }); 
     });
 
     on("change:constitution_mod", function() {
@@ -6321,6 +6337,14 @@
         update_attacks("constitution");
         update_tool("constitution");
         update_power_info("constitution");
+        getAttrs(["npc"], function(v) {
+            if(v.npc === "2") {
+                update_ship_speeds();
+            }
+            else {
+                return;
+            }
+        }); 
     });
 
     on("change:intelligence_mod", function() {
@@ -7289,6 +7313,7 @@
             return;
         }
         update_ac();
+        update_ship_speeds();
     });
 
     on("change:pilot_skill", function(eventinfo) {
@@ -10289,6 +10314,55 @@
             };
         });
         set_level();
+    };
+
+    var update_ship_speeds = function() {
+        getAttrs(["ship_size", "dexterity_mod", "constitution_mod", "strength_mod"], function(attributes) {
+            var update = {};
+            var baseTurningSpeed = 0;
+            var baseFlyingSpeed = 0;
+            switch(attributes.ship_size) {
+                case "Tiny":
+                    baseTurningSpeed = 300;
+                    baseFlyingSpeed = 400;
+                    break;
+                case "Small":
+                    baseTurningSpeed = 250;
+                    baseFlyingSpeed = 350;
+                    break;
+                case "Medium":
+                    baseTurningSpeed = 200;
+                    baseFlyingSpeed = 300;
+                    break;
+                case "Large":
+                    baseTurningSpeed = 150;
+                    baseFlyingSpeed = 250;
+                    break;
+                case "Huge":
+                    baseTurningSpeed = 100;
+                    baseFlyingSpeed = 200;
+                    break;
+                case "Gargantuan":
+                    baseTurningSpeed = 50;
+                    baseFlyingSpeed = 150;
+                    break;
+                default:
+                    baseTurningSpeed = 0;
+                    break;
+            }
+
+            update["ship_flyspeed"] = baseFlyingSpeed + 50 * (attributes.strength_mod - attributes.constitution_mod);
+            if(update["ship_flyspeed"] < 0) {
+                update["ship_flyspeed"] = 0;
+            }
+
+            update["ship_turnspeed"] = baseTurningSpeed - 50 * (attributes.dexterity_mod - attributes.constitution_mod);
+            if(update["ship_turnspeed"] < 50) {
+                update["ship_flyspeed"] = update["ship_flyspeed"] + (50 - update["ship_turnspeed"]);
+                update["ship_turnspeed"] = 50;
+            }
+            setAttrs(update, {silent: true});
+        });
     };
 
     var set_level = function() {

--- a/StarWars5E/StarWars5E_HTML.html
+++ b/StarWars5E/StarWars5E_HTML.html
@@ -4583,7 +4583,7 @@
                                 <input type="number" value="0" name="attr_pilot_skill">
                             </div>
                             <div class="label">
-                                <span data-i18n="pilot_proficiency-u">PILOT INT(PILOT)</span>
+                                <span data-i18n="pilot_proficiency-u">PILOT INT(PILOTING)</span>
                             </div>
                         </div>
                         <div class="saving-throw-container">

--- a/StarWars5E/sheet.json
+++ b/StarWars5E/sheet.json
@@ -1,8 +1,8 @@
 {
 	"html": "StarWars5E_HTML.html",
 	"css": "StarWars5E_CSS.css",
-	"authors": "Paul Lueders (Paul L. on Roll20.net)",
+	"authors": "Paul Lueders (Paul L. on Roll20.net), Alex Reeder",
 	"roll20userid": "2588855",
 	"preview": "StarWars5E_Shot.png",
-	"instructions": "Be sure to check out the [Star Wars 5E subreddit](https://www.reddit.com/r/sw5e) for new announcements on new releases and keep an eye out Compendium Compatibility. You can also contribute and help expand the [Star Wars 5E Sheet Wiki](https://wiki.roll20.net/StarWars5E-Sheet)"
+	"instructions": "Be sure to check out the [Star Wars 5E subreddit](https://www.reddit.com/r/sw5e) for new announcements on new releases and keep an eye out for Compendium Compatibility. You can also contribute and help expand the [Star Wars 5E Sheet Wiki](https://wiki.roll20.net/StarWars5E-Sheet)"
 }

--- a/StarWars5E/sheet.json
+++ b/StarWars5E/sheet.json
@@ -2,7 +2,7 @@
 	"html": "StarWars5E_HTML.html",
 	"css": "StarWars5E_CSS.css",
 	"authors": "Paul Lueders (Paul L. on Roll20.net), Alex Reeder",
-	"roll20userid": "2588855",
+	"roll20userid": "2588855, 3119863",
 	"preview": "StarWars5E_Shot.png",
 	"instructions": "Be sure to check out the [Star Wars 5E subreddit](https://www.reddit.com/r/sw5e) for new announcements on new releases and keep an eye out for Compendium Compatibility. You can also contribute and help expand the [Star Wars 5E Sheet Wiki](https://wiki.roll20.net/StarWars5E-Sheet)"
 }

--- a/StarWars5E/translation.json
+++ b/StarWars5E/translation.json
@@ -619,5 +619,6 @@
     "pilot_prof_bonus-u": "PILOT PROF BONUS",
     "pilot_proficiency-u": "PILOT INT(PILOT)",
     "attacks-u": "ATTACKS",
-    "modification": "Modification"
+    "modification": "Modification",
+    "upgrade": "Upgrade"
 }

--- a/StarWars5E/translation.json
+++ b/StarWars5E/translation.json
@@ -620,5 +620,15 @@
     "pilot_proficiency-u": "PILOT INT(PILOT)",
     "attacks-u": "ATTACKS",
     "modification": "Modification",
-    "upgrade": "Upgrade"
+    "upgrade": "Upgrade",
+    "deployments-u": "DEPLOYMENTS",
+    "deployment-u": "DEPLOYMENT",
+    "rank-u": "RANK",
+    "rank:-u": "RANK:",
+    "deployment:-u": "DEPLOYMENT:",
+    "gunner": "Gunner",
+    "mechanic": "Mechanic",
+    "coordinator": "Coordinator",
+    "operator": "Operator",
+    "pilot": "Pilot"
 }

--- a/StarWars5E/translation.json
+++ b/StarWars5E/translation.json
@@ -617,7 +617,7 @@
     "cargo-u": "CARGO",
     "hidden-cargo-u": "HIDDEN CARGO",
     "pilot_prof_bonus-u": "PILOT PROF BONUS",
-    "pilot_proficiency-u": "PILOT INT(PILOT)",
+    "pilot_proficiency-u": "PILOT INT(PILOTING)",
     "attacks-u": "ATTACKS",
     "modification": "Modification",
     "upgrade": "Upgrade",

--- a/StarWars5E/translation.json
+++ b/StarWars5E/translation.json
@@ -609,5 +609,10 @@
     "ship-shield-max-u": "Shield Point Maximum",
     "destruction-saves-u": "DESTRUCTION SAVES",
     "attacks-per-round:-u": "ATK/ROUND:",
-    "attacks-per-round-u": "ATKS"
+    "attacks-per-round-u": "ATKS",
+    "tier": "Tier",
+    "total-cargo-u": "TOTAL CARGO",
+    "total-hidden-cargo-u": "TOTAL HIDDEN CARGO",
+    "cargo-u": "CARGO",
+    "hidden-cargo-u": "HIDDEN CARGO"
 }

--- a/StarWars5E/translation.json
+++ b/StarWars5E/translation.json
@@ -600,5 +600,14 @@
     "ship-credits-invested:-u": "CREDITS INVESTED:",
     "ship-credits-next-tier:-u": "CREDITS NEEDED FOR NEXT TIER:",
     "modifications-u": "MODIFICATIONS",
-    "ship-options-u": "SHIP OPTIONS"
+    "ship-options-u": "SHIP OPTIONS",
+    "hyperdrive_class-u": "HYPERDRIVE CLASS",
+    "navcomputer_bonus-u": "NAVCOMPUTER BONUS",
+    "ship_flyspeed-u": "FLYING SPEED",
+    "ship_turnspeed-u": "TURNING SPEED",
+    "ship-shield-u": "CURRENT SHIELD POINTS",
+    "ship-shield-max-u": "Shield Point Maximum",
+    "destruction-saves-u": "DESTRUCTION SAVES",
+    "attacks-per-round:-u": "ATK/ROUND:",
+    "attacks-per-round-u": "ATKS"
 }

--- a/StarWars5E/translation.json
+++ b/StarWars5E/translation.json
@@ -563,7 +563,7 @@
 	"small": "Small",
 	"medium": "Medium",
 	"large": "Large",
-	"huge": "Huge",
+    "huge": "Huge",
 	"age": "Age:",
 	"gargantuan": "Gargantuan",
 	"step1-equipment": "Step 5: Equipment",
@@ -590,5 +590,15 @@
 	"clear-abilities": "Clear Assignment",
 	"use-charactermancer-for-new:-u": "USE LEVEL 1 CHARACTERMANCER FOR NEW CHARACTERS:",
 	"use-charactermancer-for-new-info": "With this option enabled all new characters will open with the Level 1 Roll20 Charactermancer. Disabling this option will start new characters directly on the character sheet disabling the Level 1 Charactermancer, which can still be manually run from the Settings tab of the character sheet.",
-	"feat-pre-check": "Look carefully! Prerequisites are not checked automatically."
+    "feat-pre-check": "Look carefully! Prerequisites are not checked automatically.",
+    "ship-name-u": "SHIP NAME",
+    "ship-tier:-u": "TIER:",
+    "ship-size:-u": "SIZE:",
+    "ship-manufacturer:-u": "MANUFACTURER/LINE/CLASS:",
+    "ship-line:-u": "LINE:",
+    "ship-class:-u": "CLASS:",
+    "ship-credits-invested:-u": "CREDITS INVESTED:",
+    "ship-credits-next-tier:-u": "CREDITS NEEDED FOR NEXT TIER:",
+    "modifications-u": "MODIFICATIONS",
+    "ship-options-u": "SHIP OPTIONS"
 }

--- a/StarWars5E/translation.json
+++ b/StarWars5E/translation.json
@@ -608,6 +608,7 @@
     "ship-shield-u": "CURRENT SHIELD POINTS",
     "ship-shield-max-u": "Shield Point Maximum",
     "destruction-saves-u": "DESTRUCTION SAVES",
+    "destruction-save-u": "DESTRUCTION SAVE",
     "attacks-per-round:-u": "ATK/ROUND:",
     "attacks-per-round-u": "ATKS",
     "tier": "Tier",
@@ -617,5 +618,6 @@
     "hidden-cargo-u": "HIDDEN CARGO",
     "pilot_prof_bonus-u": "PILOT PROF BONUS",
     "pilot_proficiency-u": "PILOT INT(PILOT)",
-    "attacks-u": "ATTACKS"
+    "attacks-u": "ATTACKS",
+    "modification": "Modification"
 }

--- a/StarWars5E/translation.json
+++ b/StarWars5E/translation.json
@@ -614,5 +614,7 @@
     "total-cargo-u": "TOTAL CARGO",
     "total-hidden-cargo-u": "TOTAL HIDDEN CARGO",
     "cargo-u": "CARGO",
-    "hidden-cargo-u": "HIDDEN CARGO"
+    "hidden-cargo-u": "HIDDEN CARGO",
+    "pilot_prof_bonus-u": "PILOT PROF BONUS",
+    "pilot_proficiency-u": "PILOT INT(PILOT)"
 }

--- a/StarWars5E/translation.json
+++ b/StarWars5E/translation.json
@@ -616,5 +616,6 @@
     "cargo-u": "CARGO",
     "hidden-cargo-u": "HIDDEN CARGO",
     "pilot_prof_bonus-u": "PILOT PROF BONUS",
-    "pilot_proficiency-u": "PILOT INT(PILOT)"
+    "pilot_proficiency-u": "PILOT INT(PILOT)",
+    "attacks-u": "ATTACKS"
 }


### PR DESCRIPTION
## Changes / Comments

* Added a sheet with type "Ship"
* Specific new fields added for ships:
    * Modifications (similar to Features)
    * Pilot proficiency
    * Pilot skill: INT(Piloting) with it's own specific field
    * Ship tier
    * Shield points
    * Abbreviated saving throws (STR, DEX, CON)
    * Abbreviated attributes (STR, DEX, CON)
    * Separate inventory for hidden cargo, with it's own total weight counter
    * Turning speed
    * Flying speed
* All new fields and any calculation changes do not affect NPC or PC type sheets.
## Roll20 Requests

*Include the name of the sheet you made changes to in the title.*

- If changes fix a bug or resolves a feature request, be sure to link to that issue. 
- For pull request that change multiple sheets please confirm these changes are intentional for all sheets. This will help us catch unintended submissions.
- When updating existing sheets if you are changing attribute names please note what steps you have taken, if any, to assist players in keeping their data.