### PR TITLE
RuneQuest:Rolepaying in Glorantha  version 04.03.2019

### DIFF
--- a/RunequestGQS/ReadMe.md
+++ b/RunequestGQS/ReadMe.md
@@ -34,6 +34,20 @@ To remove the experience checkbox from a skill add a - at the start of the name 
 
 STR and DEX minimums are not currently supported this maybe added in a future release.
 
+## Version 04.03.2019
+
+Tweaked CSS so skill names can be read when modifying repeating sections
+
+Added fields for coinage on the 2nd tab.  Currently this does not effect encumbrance.
+
+I added a bunch of new hit locations including all the location tables  at the start of the bestiary. 
+
+Added fields for individual weapons skill modifiers or occassion such as Bladesharp cast.
+
+I also added checkboxes with the heading Spells Cast for Vigor, Strength  and Glamour they handle all the fudges listed under the spells,such as skill category  increases, damage die steps and max enc.So don't add the stat bonuses in the mod fields of the characteristics.The bonuses are automatically added to stat rolls.A message appears under the stats  reminding you to add the bonus when doing resistance table rolls.  There is probabla better way of doing this but it would mean changing a lot of sheetworkers and/or adding a whole new column of mod fields
+
+
+
 ## Version 19.11.2018
 
 Disguise starting skill changed to 05

--- a/RunequestGQS/ReadMe.md
+++ b/RunequestGQS/ReadMe.md
@@ -42,9 +42,9 @@ Added fields for coinage on the 2nd tab.  Currently this does not effect encumbr
 
 I added a bunch of new hit locations including all the location tables  at the start of the bestiary. 
 
-Added fields for individual weapons skill modifiers or occassion such as Bladesharp cast.
+Added fields for individual weapons skill modifiers or occasions such as Bladesharp cast.
 
-I also added checkboxes with the heading Spells Cast for Vigor, Strength  and Glamour they handle all the fudges listed under the spells,such as skill category  increases, damage die steps and max enc.So don't add the stat bonuses in the mod fields of the characteristics.The bonuses are automatically added to stat rolls.A message appears under the stats  reminding you to add the bonus when doing resistance table rolls.  There is probabla better way of doing this but it would mean changing a lot of sheetworkers and/or adding a whole new column of mod fields
+I also added checkboxes with the heading Spells Cast for Vigor, Strength  and Glamour they handle all the fudges listed under the spells,such as skill category  increases, damage die steps and max enc.So don't add the stat bonuses in the mod fields of the characteristics.The bonuses are automatically added to stat rolls. A message appears under the stats  reminding you to add the bonus when doing resistance table rolls.  There is probably better way of doing this but it would mean changing a lot of sheetworkers and/or adding a whole new column of mod fields
 
 
 

--- a/RunequestGQS/RunequestGQS.css
+++ b/RunequestGQS/RunequestGQS.css
@@ -317,6 +317,15 @@ button[type="roll"] label, button[type="roll"] input {
     font-weight:700;
 }
 
+
+
+.sheet-buffMsg{
+	margin:15px 0px 0px 0px;
+	color:red;
+	font-size:x-small;
+	display:block;
+}
+
 .sheet-melee_wpns_labels label{
 	display:inline-block;
 	font-size:1em;
@@ -354,6 +363,29 @@ button[type="roll"] label, button[type="roll"] input {
 .sheet-rolltemplate-HL-Missle  .inlinerollresult.fullfail{
 	border:none;
 }
+
+
+.sheet-rolltemplate-HL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-HL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-HL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
+.sheet-rolltemplate-HL-Melee div.sheet-result {
+	text-align: center;
+	color: #000000;
+    background-color: #ffffff;
+}
+
 
 
 .sheet-rolltemplate-HL-Melee th {
@@ -408,6 +440,22 @@ button[type="roll"] label, button[type="roll"] input {
 
 
 
+
+.sheet-rolltemplate-FLL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-FLL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-FLL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
 .sheet-rolltemplate-FLL-Melee th {
 	text-align: center;
 	color: #ffffff;
@@ -431,6 +479,8 @@ button[type="roll"] label, button[type="roll"] input {
 .sheet-rolltemplate-FLL-Melee  .inlinerollresult.fullfail{
 	border:none;
 }
+
+
 
 
 .sheet-rolltemplate-WalkL-Missle th {
@@ -457,6 +507,24 @@ button[type="roll"] label, button[type="roll"] input {
 .sheet-rolltemplate-WalkL-Missle  .inlinerollresult.fullfail{
 	border:none;
 }
+
+
+.sheet-rolltemplate-WalkL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-WalkL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-WalkL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
+
 
 .sheet-rolltemplate-WalkL-Melee th {
 	text-align: center;
@@ -509,6 +577,23 @@ button[type="roll"] label, button[type="roll"] input {
 }
 
 
+
+.sheet-rolltemplate-NewtL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-NewtL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-NewtL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
+
 .sheet-rolltemplate-NewtL-Melee th {
 	text-align: center;
 	color: #ffffff;
@@ -532,6 +617,66 @@ button[type="roll"] label, button[type="roll"] input {
 .sheet-rolltemplate-NewtL-Melee .inlinerollresult.fullfail{
 	border:none;
 }
+
+
+
+
+.sheet-rolltemplate-RockL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-RockL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-RockL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
+.sheet-rolltemplate-RockL-Melee th {
+	text-align: center;
+	color: #ffffff;
+    background-color: #000000;
+}
+.sheet-rolltemplate-RockL-Melee table {
+    width: 230px;
+    padding: 2px;
+	border: 1px solid;
+    background-color: #ffffff;
+}
+
+.sheet-rolltemplate-RockL-Melee .inlinerollresult  {
+    background-color: transparent;
+    color: #000000;
+    border: none;
+}
+.sheet-rolltemplate-RockL-Melee .inlinerollresult.fullcrit{
+	border:none;
+}
+.sheet-rolltemplate-RockL-Melee .inlinerollresult.fullfail{
+	border:none;
+}
+
+
+
+.sheet-rolltemplate-ScorpL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-ScorpL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-ScorpL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
 
 
 .sheet-rolltemplate-ScorpL-Melee th {
@@ -585,6 +730,24 @@ button[type="roll"] label, button[type="roll"] input {
 }
 
 
+
+.sheet-rolltemplate-SprulPaL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-SprulPaL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-SprulPaL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
+
+
 .sheet-rolltemplate-SprulPaL-Melee th {
 	text-align: center;
 	color: #ffffff;
@@ -608,6 +771,544 @@ button[type="roll"] label, button[type="roll"] input {
 .sheet-rolltemplate-SprulPaL-Melee .inlinerollresult.fullfail{
 	border:none;
 }
+
+
+
+
+.sheet-rolltemplate-DragonL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-DragonL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-DragonL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
+
+
+
+.sheet-rolltemplate-DragonL-Melee .inlinerollresult  {
+    background-color: transparent;
+    color: #000000;
+    border: none;
+}
+.sheet-rolltemplate-DragonL-Melee .inlinerollresult.fullcrit{
+	border:none;
+}
+.sheet-rolltemplate-DragonL-Melee .inlinerollresult.fullfail{
+	border:none;
+}
+
+
+
+
+.sheet-rolltemplate-Dragonsnail1HL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-Dragonsnail1HL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-Dragonsnail1HL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
+
+.sheet-rolltemplate-Dragonsnail1HL-Melee .inlinerollresult  {
+    background-color: transparent;
+    color: #000000;
+    border: none;
+}
+.sheet-rolltemplate-Dragonsnail1HL-Melee .inlinerollresult.fullcrit{
+	border:none;
+}
+.sheet-rolltemplate-Dragonsnail1HL-Melee .inlinerollresult.fullfail{
+	border:none;
+}
+
+
+
+
+.sheet-rolltemplate-Dragonsnail2HL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-Dragonsnail2HL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-Dragonsnail2HL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
+
+.sheet-rolltemplate-Dragonsnail2HL-Melee .inlinerollresult  {
+    background-color: transparent;
+    color: #000000;
+    border: none;
+}
+.sheet-rolltemplate-Dragonsnail2HL-Melee .inlinerollresult.fullcrit{
+	border:none;
+}
+.sheet-rolltemplate-Dragonsnail2HL-Melee .inlinerollresult.fullfail{
+	border:none;
+}
+
+
+
+
+
+.sheet-rolltemplate-4leggedwingsL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-4leggedwingsL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-4leggedwingsL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
+
+.sheet-rolltemplate-4leggedwingsL-Melee .inlinerollresult  {
+    background-color: transparent;
+    color: #000000;
+    border: none;
+}
+.sheet-rolltemplate-4leggedwingsL-Melee .inlinerollresult.fullcrit{
+	border:none;
+}
+.sheet-rolltemplate-4leggedwingsL-Melee .inlinerollresult.fullfail{
+	border:none;
+}
+
+
+.sheet-rolltemplate-harpiesL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-harpiesL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-harpiesL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
+
+.sheet-rolltemplate-harpiesL-Melee .inlinerollresult  {
+    background-color: transparent;
+    color: #000000;
+    border: none;
+}
+.sheet-rolltemplate-harpiesL-Melee .inlinerollresult.fullcrit{
+	border:none;
+}
+.sheet-rolltemplate-harpiesL-Melee .inlinerollresult.fullfail{
+	border:none;
+}
+
+
+
+
+.sheet-rolltemplate-mammothL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-mammothL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-mammothL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
+
+.sheet-rolltemplate-mammothL-Melee .inlinerollresult  {
+    background-color: transparent;
+    color: #000000;
+    border: none;
+}
+.sheet-rolltemplate-mammothL-Melee .inlinerollresult.fullcrit{
+	border:none;
+}
+.sheet-rolltemplate-mammothL-Melee .inlinerollresult.fullfail{
+	border:none;
+}
+
+
+
+
+.sheet-rolltemplate-serpentL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-serpentL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-serpentL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
+
+.sheet-rolltemplate-serpentL-Melee .inlinerollresult  {
+    background-color: transparent;
+    color: #000000;
+    border: none;
+}
+.sheet-rolltemplate-serpentL-Melee .inlinerollresult.fullcrit{
+	border:none;
+}
+.sheet-rolltemplate-serpentL-Melee .inlinerollresult.fullfail{
+	border:none;
+}
+
+
+
+.sheet-rolltemplate-serpentWingsL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-serpentWingsL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-serpentWingsL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
+
+.sheet-rolltemplate-serpentWingsL-Melee .inlinerollresult  {
+    background-color: transparent;
+    color: #000000;
+    border: none;
+}
+.sheet-rolltemplate-serpentWingsL-Melee .inlinerollresult.fullcrit{
+	border:none;
+}
+.sheet-rolltemplate-serpentWingsL-Melee .inlinerollresult.fullfail{
+	border:none;
+}
+
+
+
+.sheet-rolltemplate-spiderL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-spiderL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-spiderL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
+
+.sheet-rolltemplate-spiderL-Melee .inlinerollresult  {
+    background-color: transparent;
+    color: #000000;
+    border: none;
+}
+.sheet-rolltemplate-spiderL-Melee .inlinerollresult.fullcrit{
+	border:none;
+}
+.sheet-rolltemplate-spiderL-Melee .inlinerollresult.fullfail{
+	border:none;
+}
+
+
+
+
+.sheet-rolltemplate-wyvernL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-wyvernL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-wyvernL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
+
+.sheet-rolltemplate-wyvernL-Melee .inlinerollresult  {
+    background-color: transparent;
+    color: #000000;
+    border: none;
+}
+.sheet-rolltemplate-wyvernL-Melee .inlinerollresult.fullcrit{
+	border:none;
+}
+.sheet-rolltemplate-wyvernL-Melee .inlinerollresult.fullfail{
+	border:none;
+}
+
+
+
+
+.sheet-rolltemplate-AnkylosaursL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-AnkylosaursL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-AnkylosaursL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
+
+
+
+.sheet-rolltemplate-AnkylosaursL-Melee div.sheet-result {
+	text-align: center;
+	color: #000000;
+    background-color: #ffffff;
+}
+.sheet-rolltemplate-AnkylosaursL-Melee div.sheet-skillRoll {
+    width: 230px;
+    padding: 2px;
+	border: 1px solid;
+	color:#ffffff;
+    background-color: #000000;
+}
+
+.sheet-rolltemplate-AnkylosaursL-Melee .inlinerollresult  {
+    background-color: transparent;
+    color: #000000;
+    border: none;
+}
+.sheet-rolltemplate-AnkylosaursL-Melee .inlinerollresult.fullcrit{
+	border:none;
+}
+.sheet-rolltemplate-AnkylosaursL-Melee .inlinerollresult.fullfail{
+	border:none;
+}
+
+
+
+
+.sheet-rolltemplate-BeetleL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-BeetleL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-BeetleL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
+
+.sheet-rolltemplate-BeetleL-Melee div.sheet-result {
+	text-align: center;
+	color: #000000;
+    background-color: #ffffff;
+}
+.sheet-rolltemplate-BeetleL-Melee div.sheet-skillRoll {
+    width: 230px;
+    padding: 2px;
+	border: 1px solid;
+	color:#ffffff;
+    background-color: #000000;
+}
+
+.sheet-rolltemplate-BeetleL-Melee .inlinerollresult  {
+    background-color: transparent;
+    color: #000000;
+    border: none;
+}
+.sheet-rolltemplate-BeetleL-Melee .inlinerollresult.fullcrit{
+	border:none;
+}
+.sheet-rolltemplate-BeetleL-Melee .inlinerollresult.fullfail{
+	border:none;
+}
+
+
+
+.sheet-rolltemplate-BirdsFlyingL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-BirdsFlyingL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-BirdsFlyingL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
+
+.sheet-rolltemplate-BirdsFlyingL-Melee div.sheet-result {
+	text-align: center;
+	color: #000000;
+    background-color: #ffffff;
+}
+.sheet-rolltemplate-BirdsFlyingL-Melee div.sheet-skillRoll {
+    width: 230px;
+    padding: 2px;
+	border: 1px solid;
+	color:#ffffff;
+    background-color: #000000;
+}
+
+.sheet-rolltemplate-BirdsFlyingL-Melee .inlinerollresult  {
+    background-color: transparent;
+    color: #000000;
+    border: none;
+}
+.sheet-rolltemplate-BirdsFlyingL-Melee .inlinerollresult.fullcrit{
+	border:none;
+}
+.sheet-rolltemplate-BirdsFlyingL-Melee .inlinerollresult.fullfail{
+	border:none;
+}
+
+
+
+.sheet-rolltemplate-BirdsRunningL-Melee div.sheet-loc_wrapper{
+	border: 1px solid black; 
+}
+
+.sheet-rolltemplate-BirdsRunningL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+.sheet-rolltemplate-BirdsRunningL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
+
+.sheet-rolltemplate-BirdsRunningL-Melee div.sheet-result {
+	text-align: center;
+	color: #000000;
+    background-color: #ffffff;
+}
+.sheet-rolltemplate-BirdsRunningL-Melee div.sheet-skillRoll {
+    width: 230px;
+    padding: 2px;
+	border: 1px solid;
+	color:#ffffff;
+    background-color: #000000;
+}
+
+.sheet-rolltemplate-BirdsRunningL-Melee .inlinerollresult  {
+    background-color: transparent;
+    color: #000000;
+    border: none;
+}
+.sheet-rolltemplate-BirdsRunningL-Melee .inlinerollresult.fullcrit{
+	border:none;
+}
+.sheet-rolltemplate-BirdsRunningL-Melee .inlinerollresult.fullfail{
+	border:none;
+}
+
+.sheet-rolltemplate-CentaurL-Melee div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
+
+.sheet-rolltemplate-CentaurL-Melee div.sheet-template_body{
+	background-color:white;
+	text-align:center
+}
+
+.sheet-rolltemplate-CentaurL-Melee div.sheet-result {
+	text-align: center;
+	color: #000000;
+    background-color: #ffffff;
+}
+.sheet-rolltemplate-CentaurL-Melee div.sheet-skillRoll {
+    width: 230px;
+    padding: 2px;
+	border: 1px solid;
+	color:#ffffff;
+    background-color: #000000;
+}
+
+.sheet-rolltemplate-CentaurL-Melee .inlinerollresult  {
+    background-color: transparent;
+    color: #000000;
+    border: none;
+}
+.sheet-rolltemplate-CentaurL-Melee .inlinerollresult.fullcrit{
+	border:none;
+}
+.sheet-rolltemplate-CentaurL-Melee .inlinerollresult.fullfail{
+	border:none;
+}
+
+
+.sheet-hitlocDrop{
+	font-size:x-small;
+	margin-top: 7px; 
+	height: 24px ; 
+	width: 130px
+}
+
+
+.sheet-rolltemplate-skillRoll div.sheet-template_header{
+	background-color:black;
+	color:white;
+	text-align:center; 	
+}
+
 
 
 .sheet-rolltemplate-skillRoll th {
@@ -651,6 +1352,36 @@ button[type="roll"] label, button[type="roll"] input {
 
 .sheet-rolltemplate-melee-roll .template_value{
 	text-align: right;
+}
+
+
+
+.repcontainer[data-groupname="repeating_melee2"]{
+													 
+    width:100%!important;
+}
+
+
+.repcontainer[data-groupname="repeating_missle2"]{
+													 
+    width:100%!important;
+}
+
+
+.repcontainer[data-groupname="repeating_mounts"]{
+													 
+    width:100%!important;
+}
+
+
+
+
+.repcontainer{
+	width:112%;
+}
+
+.itemcontrol {
+    margin-left: -33px;
 }
 
 
@@ -1054,31 +1785,6 @@ div.repcontrol.editmode button.repcontrol_edit::before
 
 
 
-.sheet-rolltemplate-RockL-Melee th {
-	text-align: center;
-	color: #ffffff;
-    background-color: #000000;
-}
-.sheet-rolltemplate-RockL-Melee table {
-    width: 230px;
-    padding: 2px;
-	border: 1px solid;
-    background-color: #ffffff;
-}
-
-.sheet-rolltemplate-RockL-Melee .inlinerollresult  {
-    background-color: transparent;
-    color: #000000;
-    border: none;
-}
-.sheet-rolltemplate-RockL-Melee .inlinerollresult.fullcrit{
-	border:none;
-}
-.sheet-rolltemplate-RockL-Melee .inlinerollresult.fullfail{
-	border:none;
-}
-
-
 /* Configuration Window 2*/
 .charsheet .sheet-cdiv2 {
     width:315px;
@@ -1180,7 +1886,7 @@ div.repcontrol.editmode button.repcontrol_edit::before
 .sheet-moon-image{
 	position:absolute;
 	top:148px;
-	left:119px;
+	left:110px;
 }
 
 
@@ -1604,13 +2310,14 @@ button[type=roll].sheet-d100_roll {
 	width:14px;
 	height:auto
 }
-
+ 
 .sheet-text_input{
 	border: none;
     box-shadow: none;
     border-bottom: 1px solid black;
     border-radius: 0;
 	display:inline-block;
+	outline:none;
 
 }	
 
@@ -1667,9 +2374,42 @@ button[type=roll].sheet-d100_roll {
 }
 
 
+.sheet-coins{
+		font-size:x-small;
+}
+
+input.sheet-coins{
+	width:33px;
+	text-align:center;	
+}
+
+input.sheet-goods{
+	width:95px;
+	text-align:center;	
+}
+
+.sheet-goods{
+		font-size:x-small;
+		width:100px;
+		text-align:center;
+
+}
+
 .repcontainer[data-groupname="repeating_melee2"] > .repitem {
     font-size:small!important;
 }
+
+
+.repcontrol[data-groupname="repeating_npcwpns"]{
+													 
+    width:394px!important;
+}
+
+
+.repeating_traits{
+	width:500px;
+}
+	
 
 .sheet-rune-pts{
 	display:inline-block;

--- a/RunequestGQS/RunequestGQS.html
+++ b/RunequestGQS/RunequestGQS.html
@@ -1,5 +1,6 @@
 <input type="text" style="display:none" value="0" name="attr_version" />
 <input type="text" style="display:none" value="0" name="attr_version" />
+<input type="text" style="display:none" value="0" name="attr_version" />
 <input type="text" style="display:none" value="0" name="attr_SetupDone2" />	
 <input type="checkbox" class="sheet-toggleFullSheet" name="attr_toggleFullSheet"  style="display: none">
 <div class="sheet-FullSheet">
@@ -21,7 +22,7 @@
 
 
 					</div>
-					<input style="color:red;border:none;background:none;padding 0px;font-weight: bold;;width:400px;" type="text" readonly name="attr_versionx" value ="Version 15.10.2018 (https://tinyurl.com/yb9tgmlv)" />
+					<input style="color:red;border:none;background:none;padding 0px;font-weight: bold;;width:400px;" type="text" readonly name="attr_versionx" value ="Version 19.11.2018 (https://tinyurl.com/yb9tgmlv)" />
 					
 					
 		</div>	
@@ -375,7 +376,10 @@
 								<input type="text" class="sheet-char_values" name="attr_basestr" value="0"/>
 								<input type="text" class="sheet-char_values" name="attr_modstr" value="0"/>
 								<input type="text" class="sheet-char_values" readonly name="attr_curstr" value="0"/>
-								<button type="roll" class="sheet-d100_roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{curstr}*5)]]}} {{fumble=[[{(101-(round((100-(@{curstr}*5))/20))),100}kl1]]}} {{crit=[[round(([[(@{curstr}*5)]])/20)+1]]}} {{special=[[round(([[(@{curstr}*5)]])/5)+1]]}}         {{success=[[(@{curstr}*5)]]}} {{roll=[[1d100]]}} {{skillname=STR}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button><button class="sheet-d100_roll" type="roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{curstr}*?{multiplier|5})]]}} {{fumble=[[{(101-(round((100-(@{curstr}*?{multiplier|5}))/20))),100}kl1]]}} {{crit=[[round(([[(@{curstr}*?{multiplier|5})]])/20)+1]]}} {{special=[[round(([[(@{curstr}*?{multiplier|5})]])/5)+1]]}}         {{success=[[(@{curstr}*?{multiplier|5})]]}} {{roll=[[1d100]]}} {{skillname=STR}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>	
+								<button type="roll" class="sheet-d100_roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[((@{curstr}+@{strBuff})*5)]]}} {{fumble=[[{(101-(round((100-((@{curstr}+@{strBuff})*5))/20))),100}kl1]]}} {{crit=[[round(([[((@{curstr}+@{strBuff})*5)]])/20)+1]]}} {{special=[[round(([[((@{curstr}+@{strBuff})*5)]])/5)+1]]}}         {{success=[[((@{curstr}+@{strBuff})*5)]]}} {{roll=[[1d100]]}} {{skillname=STR}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button><button class="sheet-d100_roll" type="roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[((@{curstr}+@{strBuff})*?{multiplier|5})]]}} {{fumble=[[{(101-(round((100-((@{curstr}+@{strBuff})*?{multiplier|5}))/20))),100}kl1]]}} {{crit=[[round(([[((@{curstr}+@{strBuff})*?{multiplier|5})]])/20)+1]]}} {{special=[[round(([[((@{curstr}+@{strBuff})*?{multiplier|5})]])/5)+1]]}}         {{success=[[((@{curstr}+@{strBuff})*?{multiplier|5})]]}} {{roll=[[1d100]]}} {{skillname=STR}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
+								<input name="attr_strBuff" value="0" style="display:none" />
+								<!--<input type="checkbox"  title="Strength Cast"  name="attr_strengthCast"  />-->
+								
 							</div>	
 							
 							<div>
@@ -384,7 +388,12 @@
 								<input type="text" class="sheet-char_values" name="attr_basecon" value="0"/>
 								<input type="text" class="sheet-char_values" name="attr_modcon" value="0"/>
 								<input type="text" class="sheet-char_values" readonly name="attr_curcon" value="0"/>
-								<button type="roll" class="sheet-d100_roll"   value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{curcon}*5)]]}} {{fumble=[[{(101-(round((100-(@{curcon}*5))/20))),100}kl1]]}} {{crit=[[round(([[(@{curcon}*5)]])/20)+1]]}} {{special=[[round(([[(@{curcon}*5)]])/5)+1]]}}         {{success=[[(@{curcon}*5)]]}} {{roll=[[1d100]]}} {{skillname=CON Roll}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button><button class="sheet-d100_roll" type="roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{curcon}*?{multiplier|5})]]}} {{fumble=[[{(101-(round((100-(@{curcon}*?{multiplier|5}))/20))),100}kl1]]}} {{crit=[[round(([[(@{curcon}*?{multiplier|5})]])/20)+1]]}} {{special=[[round(([[(@{curcon}*?{multiplier|5})]])/5)+1]]}}         {{success=[[(@{curcon}*?{multiplier|5})]]}} {{roll=[[1d100]]}} {{skillname=CON Roll}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>	
+								<button type="roll" class="sheet-d100_roll"   value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[((@{curcon}+@{conBuff})*5)]]}} {{fumble=[[{(101-(round((100-((@{curcon}+@{conBuff})*5))/20))),100}kl1]]}} {{crit=[[round(([[((@{curcon}+@{conBuff})*5)]])/20)+1]]}} {{special=[[round(([[((@{curcon}+@{conBuff})*5)]])/5)+1]]}}         {{success=[[((@{curcon}+@{conBuff})*5)]]}} {{roll=[[1d100]]}} {{skillname=CON}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" />
+								</button><button class="sheet-d100_roll" type="roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[((@{curcon}+@{conBuff})*?{multiplier|5})]]}} {{fumble=[[{(101-(round((100-((@{curcon}+@{conBuff})*?{multiplier|5}))/20))),100}kl1]]}} {{crit=[[round(([[((@{curcon}+@{conBuff})*?{multiplier|5})]])/20)+1]]}} {{special=[[round(([[((@{curcon}+@{conBuff})*?{multiplier|5})]])/5)+1]]}}         {{success=[[((@{curcon}+@{conBuff})*?{multiplier|5})]]}} {{roll=[[1d100]]}} {{skillname=CON}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
+                                                  
+								<input name="attr_conBuff" value="0" style="display:none" />
+								<!--<input type="checkbox"  title="Vigor Cast"  name="attr_vigorCast"  />-->
+								
 							</div>	
 
 							<div>
@@ -392,7 +401,7 @@
 								<input type="text" class="sheet-char_values" name="attr_basesiz" value="0" />
 								<input type="text" class="sheet-char_values" name="attr_modsiz" value="0"/>									
 								<input type="text" class="sheet-char_values" readonly name="attr_cursiz" value="0"/>
-								<button type="roll" class="sheet-d100_roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{cursiz}*5)]]}} {{fumble=[[{(101-(round((100-(@{cursiz}*5))/20))),100}kl1]]}} {{crit=[[round(([[(@{cursiz}*5)]])/20)+1]]}} {{special=[[round(([[(@{cursiz}*5)]])/5)+1]]}}         {{success=[[(@{cursiz}*5)]]}} {{roll=[[1d100]]}} {{skillname=SIZ Roll}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button><button class="sheet-d100_roll" type="roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{cursiz}*?{multiplier|5})]]}} {{fumble=[[{(101-(round((100-(@{cursiz}*?{multiplier|5}))/20))),100}kl1]]}}  {{crit=[[round(([[(@{cursiz}*?{multiplier|5})]])/20)+1]]}} {{special=[[round(([[(@{cursiz}*?{multiplier|5})]])/5)+1]]}}         {{success=[[(@{cursiz}*?{multiplier|5})]]}} {{roll=[[1d100]]}} {{skillname=SIZ Roll}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>	
+								<button type="roll" class="sheet-d100_roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{cursiz}*5)]]}} {{fumble=[[{(101-(round((100-(@{cursiz}*5))/20))),100}kl1]]}} {{crit=[[round(([[(@{cursiz}*5)]])/20)+1]]}} {{special=[[round(([[(@{cursiz}*5)]])/5)+1]]}}         {{success=[[(@{cursiz}*5)]]}} {{roll=[[1d100]]}} {{skillname=SIZ}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button><button class="sheet-d100_roll" type="roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{cursiz}*?{multiplier|5})]]}} {{fumble=[[{(101-(round((100-(@{cursiz}*?{multiplier|5}))/20))),100}kl1]]}}  {{crit=[[round(([[(@{cursiz}*?{multiplier|5})]])/20)+1]]}} {{special=[[round(([[(@{cursiz}*?{multiplier|5})]])/5)+1]]}}         {{success=[[(@{cursiz}*?{multiplier|5})]]}} {{roll=[[1d100]]}} {{skillname=SIZ}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>	
 							</div>	
 							
 							<div>
@@ -401,7 +410,7 @@
 								<input type="text" class="sheet-char_values" name="attr_baseint" value="0"/>	
 								<input type="text" class="sheet-char_values" name="attr_modint" value="0"/>									
 								<input type="text" class="sheet-char_values" readonly name="attr_curint" value="0"/>
-								<button type="roll" class="sheet-d100_roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{curint}*5)]]}} {{fumble=[[{(101-(round((100-(@{curint}*5))/20))),100}kl1]]}} {{crit=[[round(([[(@{curint}*5)]])/20)+1]]}} {{special=[[round(([[(@{curint}*5)]])/5)+1]]}}         {{success=[[(@{curint}*5)]]}} {{roll=[[1d100]]}} {{skillname=INT Roll}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button><button class="sheet-d100_roll" type="roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{curint}*?{multiplier|5})]]}} {{fumble=[[{(101-(round((100-(@{curint}*?{multiplier|5}))/20))),100}kl1]]}} {{crit=[[round(([[(@{curint}*?{multiplier|5})]])/20)+1]]}} {{special=[[round(([[(@{curint}*?{multiplier|5})]])/5)+1]]}}         {{success=[[(@{curint}*?{multiplier|5})]]}} {{roll=[[1d100]]}} {{skillname=INT Roll}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>	
+								<button type="roll" class="sheet-d100_roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{curint}*5)]]}} {{fumble=[[{(101-(round((100-(@{curint}*5))/20))),100}kl1]]}} {{crit=[[round(([[(@{curint}*5)]])/20)+1]]}} {{special=[[round(([[(@{curint}*5)]])/5)+1]]}}         {{success=[[(@{curint}*5)]]}} {{roll=[[1d100]]}} {{skillname=INT}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button><button class="sheet-d100_roll" type="roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{curint}*?{multiplier|5})]]}} {{fumble=[[{(101-(round((100-(@{curint}*?{multiplier|5}))/20))),100}kl1]]}} {{crit=[[round(([[(@{curint}*?{multiplier|5})]])/20)+1]]}} {{special=[[round(([[(@{curint}*?{multiplier|5})]])/5)+1]]}}         {{success=[[(@{curint}*?{multiplier|5})]]}} {{roll=[[1d100]]}} {{skillname=INT}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>	
 							</div>
 							
 							<div>
@@ -410,8 +419,8 @@
 								<input type="text" class="sheet-char_values" name="attr_basepow" value="0"/>
 								<input type="text" class="sheet-char_values" name="attr_modpow" value="0"/>									
 								<input type="text" class="sheet-char_values" readonly name="attr_curpow" value="0"/>
-								<button type="roll"  class="sheet-d100_roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{curpow}*5)]]}} {{fumble=[[{(101-(round((100-(@{curpow}*5))/20))),100}kl1]]}} {{crit=[[round(([[(@{curpow}*5)]])/20)+1]]}} {{special=[[round(([[(@{curpow}*5)]])/5)+1]]}}         {{success=[[(@{curpow}*5)]]}} {{roll=[[1d100]]}} {{skillname=POW Roll}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button><button class="sheet-d100_roll" type="roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{curpow}*?{multiplier|5})]]}} {{fumble=[[{(101-(round((100-(@{curpow}*?{multiplier|5}))/20))),100}kl1]]}} {{crit=[[round(([[(@{curpow}*?{multiplier|5})]])/20)+1]]}} {{special=[[round(([[(@{curpow}*?{multiplier|5})]])/5)+1]]}}         {{success=[[(@{curpow}*?{multiplier|5})]]}} {{roll=[[1d100]]}} {{skillname=POW Roll}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
-								<input type="checkbox"  name="attr_pow_check"/>								
+								<button type="roll"  class="sheet-d100_roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{curpow}*5)]]}} {{fumble=[[{(101-(round((100-(@{curpow}*5))/20))),100}kl1]]}} {{crit=[[round(([[(@{curpow}*5)]])/20)+1]]}} {{special=[[round(([[(@{curpow}*5)]])/5)+1]]}}         {{success=[[(@{curpow}*5)]]}} {{roll=[[1d100]]}} {{skillname=POW}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button><button class="sheet-d100_roll" type="roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{curpow}*?{multiplier|5})]]}} {{fumble=[[{(101-(round((100-(@{curpow}*?{multiplier|5}))/20))),100}kl1]]}} {{crit=[[round(([[(@{curpow}*?{multiplier|5})]])/20)+1]]}} {{special=[[round(([[(@{curpow}*?{multiplier|5})]])/5)+1]]}}         {{success=[[(@{curpow}*?{multiplier|5})]]}} {{roll=[[1d100]]}} {{skillname=POW}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
+								<input type="checkbox"  name="attr_pow_check" title="POW check"/>								
 							</div>
 
 							<div>
@@ -420,7 +429,7 @@
 								<input type="text" class="sheet-char_values" name="attr_basedex" value="0"/>	
 								<input type="text" class="sheet-char_values" name="attr_moddex" value="0"/>									
 								<input type="text" class="sheet-char_values" readonly name="attr_curdex" value="0"/>
-								<button type="roll" class="sheet-d100_roll"  value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{curdex}*5)]]}} {{fumble=[[{(101-(round((100-(@{curdex}*5))/20))),100}kl1]]}} {{crit=[[round(([[(@{curdex}*5)]])/20)+1]]}} {{special=[[round(([[(@{curdex}*5)]])/5)+1]]}}         {{success=[[(@{curdex}*5)]]}} {{roll=[[1d100]]}} {{skillname=DEX Roll}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button><button class="sheet-d100_roll" type="roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{curdex}*?{multiplier|5})]]}} {{fumble=[[{(101-(round((100-(@{curdex}*?{multiplier|5}))/20))),100}kl1]]}} {{crit=[[round(([[(@{curdex}*?{multiplier|5})]])/20)+1]]}} {{special=[[round(([[(@{curdex}*?{multiplier|5})]])/5)+1]]}}         {{success=[[(@{curdex}*?{multiplier|5})]]}} {{roll=[[1d100]]}} {{skillname=DEX Roll}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>	
+								<button type="roll" class="sheet-d100_roll"  value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{curdex}*5)]]}} {{fumble=[[{(101-(round((100-(@{curdex}*5))/20))),100}kl1]]}} {{crit=[[round(([[(@{curdex}*5)]])/20)+1]]}} {{special=[[round(([[(@{curdex}*5)]])/5)+1]]}}         {{success=[[(@{curdex}*5)]]}} {{roll=[[1d100]]}} {{skillname=DEX}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button><button class="sheet-d100_roll" type="roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{curdex}*?{multiplier|5})]]}} {{fumble=[[{(101-(round((100-(@{curdex}*?{multiplier|5}))/20))),100}kl1]]}} {{crit=[[round(([[(@{curdex}*?{multiplier|5})]])/20)+1]]}} {{special=[[round(([[(@{curdex}*?{multiplier|5})]])/5)+1]]}}         {{success=[[(@{curdex}*?{multiplier|5})]]}} {{roll=[[1d100]]}} {{skillname=DEX}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>	
 							</div>
 
 							<div>	
@@ -428,10 +437,13 @@
 								<input type="text" class="sheet-char_values" name="attr_basechr" value="0"/>	
 								<input type="text" class="sheet-char_values" name="attr_modchr" value="0"/>									
 								<input type="text" class="sheet-char_values" readonly name="attr_curchr" value="0"/>
-
-								<button type="roll" class="sheet-d100_roll"  value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{curchr}*5)]]}} {{fumble=[[{(101-(round((100-(@{curchr}*5))/20))),100}kl1]]}} {{crit=[[round(([[(@{curchr}*5)]])/20)+1]]}} {{special=[[round(([[(@{curchr}*5)]])/5)+1]]}}         {{success=[[(@{curchr}*5)]]}} {{roll=[[1d100]]}} {{skillname=chr Roll}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button><button class="sheet-d100_roll" type="roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{curchr}*?{multiplier|5})]]}} {{fumble=[[{(101-(round((100-(@{curchr}*?{multiplier|5}))/20))),100}kl1]]}} {{crit=[[round(([[(@{curchr}*?{multiplier|5})]])/20)+1]]}} {{special=[[round(([[(@{curchr}*?{multiplier|5})]])/5)+1]]}}         {{success=[[(@{curchr}*?{multiplier|5})]]}} {{roll=[[1d100]]}} {{skillname=chr Roll}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
+								<button type="roll" class="sheet-d100_roll"  value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[((@{curchr}+@{chrBuff})*5)]]}} {{fumble=[[{(101-(round((100-((@{curchr}+@{chrBuff})*5))/20))),100}kl1]]}} {{crit=[[round(([[((@{curchr}+@{chrBuff})*5)]])/20)+1]]}} {{special=[[round(([[((@{curchr}+@{chrBuff})*5)]])/5)+1]]}}         {{success=[[((@{curchr}+@{chrBuff})*5)]]}} {{roll=[[1d100]]}} {{skillname=CHR}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button><button class="sheet-d100_roll" type="roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[((@{curchr}+@{chrBuff})*?{multiplier|5})]]}} {{fumble=[[{(101-(round((100-((@{curchr}+@{chrBuff})*?{multiplier|5}))/20))),100}kl1]]}} {{crit=[[round(([[((@{curchr}+@{chrBuff})*?{multiplier|5})]])/20)+1]]}} {{special=[[round(([[((@{curchr}+@{chrBuff})*?{multiplier|5})]])/5)+1]]}}         {{success=[[((@{curchr}+@{chrBuff})*?{multiplier|5})]]}} {{roll=[[1d100]]}} {{skillname=CHR}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
+								<!--<input type="checkbox"  title="Glamour Cast"  name="attr_glamourCast"  />-->
+								<input name="attr_chrBuff" value="0" style="display:none" />
 							</div>
 						</div>	
+
+						
 						<div class='sheet-col' style="margin-right:1px;width:30%">
 							<div>
 								<div class="sheet-attribute_label">Dam. Bonus</div>
@@ -443,7 +455,7 @@
 							</div>
 							<div>
 								<div class="sheet-attribute_label">Move Rate</div>
-								<input style="width:50px;" type="text"  value="8" name="attr_move_rate" />	
+								<input style="width:50px;" type="text"  value="10" name="attr_move_rate" />	
 							</div>	
 							<div>
 								<div class="sheet-attribute_label">Dex SRM</div>
@@ -464,7 +476,7 @@
 						
 							</div>
 						</div>	
-						
+						<span class="buffMsg" name="attr_buffMsg" ></span><input style="display:none" type="text" readonly name="attr_buffMsg" />
 						<br />
 						<div class="sheet-header">Passions</div>
 						<div>
@@ -524,16 +536,31 @@
 								  </div>
 								</div>
 								<div>
-									<div style="display:inline;margin-left:21px;">
+									<div style="display:inline;margin-left:0px;">
 										<div class="sheet-input_label">Hit Location</div>
-										<select name="attr_creature_hit_location" style="margin-top: 7px; height: 24px ; width: 106px">
-										   <option value="HL-">Human</option>
-										   <option value="FLL-">Four-Legged</option>
+										<select class="hitlocDrop" name="attr_creature_hit_location" style="font-size:x-small;margin-top: 7px; height: 24px ; width: 130px">
+										   <option value="AnkylosaursL-">Ankylosaurs</option>
+										   <option value="BeetleL-">Beetle</option>
+										   <option value="BirdsFlyingL-">Birds, Flying</option>
+										   <option value="BirdsRunningL-">Birds, Running</option>
+										   <option value="CentaurL-">Centaur</option>
+										   <option value="DragonL-">Dragons/Manticore</option>
+											<option value="Dragonsnail1HL-">Dragonsnail 1 Head</option>
+											<option value="Dragonsnail2HL-">Dragonsnail 2 Heads</option>											
+											<option value="FLL-">Four-Legged</option>
+											<option value="4leggedwingsL-">Four-legged,Winged</option>
+											<option value="harpiesL-" >Harpy</option>										   
+										   <option value="HL-" selected>Human</option>
+										   <option value="mammothL-" >Mammoths/Mastodons</option>										   
 										   <option value="NewtL-">Newtling</option>
 										   <option value="RockL-">Rock Lizard</option>
+										   <option value="serpentL-">Serpent</option>
+										   <option value="serpentWingsL-">Serpent, Winged</option>
 										   <option value="ScorpL-">Scorpion Man</option>
+										   <option value="spiderL-">Spider, Giant</option>
 										   <option value="SprulPaL-">Sprul-Pa</option>										   
-										   <option value="WalkL-">Walktapus</option>			   
+										   <option value="WalkL-">Walktapus</option>
+											<option value="wyvernL-">Wyvern</option>
 										</select>
 										<input  name="attr_selected_wpn_type" value="Melee" style="display:none;" />
 									</div>
@@ -546,7 +573,7 @@
 										   <option value="1d10">1d10</option>
 										   <option value="1d8">1d8</option>			   			   
 										</select>
-										<button class="sheet-d100_roll" type="roll" value="&{template:@{creature_hit_location}@{selected_wpn_type}} {{roll=[[@{selected_die_roll}]]}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
+										<button style="margin-top:-7px" class="sheet-d100_roll" type="roll" value="&{template:@{creature_hit_location}@{selected_wpn_type}} {{roll=[[@{selected_die_roll}]]}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
 									</div>
 								</div>
 							</div>
@@ -588,7 +615,7 @@
 						<div>
 							<div class="sheet-input_label">Spirit Combat</div>
 							<input type="text" value="0" style="width:24px;margin-right:5px;" class="sheet-text_input" readonly name="attr_spirit_combat" /><button type="roll" class="sheet-d100_roll"  value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{spirit_combat})]]}} {{fumble=[[ceil(95+([[(@{spirit_combat})]])/20))]]}} {{crit=[[round(([[(@{spirit_combat})]])/20)+1]]}}  {{special=[[round(([[(@{spirit_combat})]])/5)+1]]}}    {{success=[[(@{spirit_combat})]]}} {{roll=[[1d100]]}} {{skillname=Spirit Combat}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" />
-							</button><button class="sheet-d100_roll" type="roll" style="margin-right:5px;" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[@{spirit_combat}]]}} {{fumble=[[ceil(95+(@{spirit_combat}+?{Mods|0})/20)]]}} {{crit=[[round((@{spirit_combat}+?{Mods|0})/20)+1]]}}  {{special=[[round((@{spirit_combat}+?{Mods|0})/5)+1]]}}    {{success=[[@{spirit_combat}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Spirit Combat}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button><div class="sheet-input_label">Damage</div><input type="text" value="" style="width:50px" class="sheet-text_input" readonly name="attr_sprt_cmbt_damage" /><button type="roll" class="sheet-d100_roll" value="[[@{sprt_cmbt_damage}]]"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
+							</button><button class="sheet-d100_roll" type="roll" style="margin-right:5px;" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[@{spirit_combat}]]}} {{fumble=[[ceil(95+(@{spirit_combat}+?{Mods|0})/20)]]}} {{crit=[[round((@{spirit_combat}+?{Mods|0})/20)+1]]}}  {{special=[[round((@{spirit_combat}+?{Mods|0})/5)+1]]}}    {{success=[[@{spirit_combat}+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Spirit Combat}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button><div class="sheet-input_label">Damage</div><input type="text" value="" style="width:70px" class="sheet-text_input" readonly name="attr_sprt_cmbt_damage" /><button type="roll" class="sheet-d100_roll" value="[[@{sprt_cmbt_damage}]]"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
 						</div>
 						<br />
 						<div class="sheet-header" >Spirit Magic</div>
@@ -598,6 +625,11 @@
 							 <button type="roll"  class="sheet-d100_roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{curpow}*5)]]}} {{fumble=[[ceil(95+([[(@{curpow}*5)]])/20))]]}} {{crit=[[round(([[(@{curpow}*5)]])/20)+1]]}} {{special=[[round(([[(@{curpow}*5)]])/5)+1]]}}         {{success=[[(@{curpow}*5)]]}} {{roll=[[1d100]]}} {{skillname=Spirit Magic}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button><button class="sheet-d100_roll" type="roll" value="&{template:skillRoll} {{name=@{character_name}}} {{skillvalue=[[(@{curpow}*5)]]}} {{fumble=[[ceil(95+([[(@{curpow}*5)+?{Mods|0}]])/20))]]}} {{crit=[[round(([[(@{curpow}*5)+?{Mods|0}]])/20)+1]]}} {{special=[[round(([[(@{curpow}*5)+?{Mods|0}]])/5)+1]]}}         {{success=[[(@{curpow}*5)+?{Mods|0}]]}} {{roll=[[1d100]]}} {{skillname=Spirit Magic}}"  ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button> 
 						</div>	
 						<textarea  name="attr_spirit_magic" class="sheet-magic_notes"></textarea> 
+						<div>
+							<div class="sheet-header" >Spells Cast:</div><span>Glamour <input type="checkbox"  name="attr_glamourCast"  /></span>
+							<span>Strength <input type="checkbox"  name="attr_strengthCast"  /></span>
+							<span>Vigor <input type="checkbox"  name="attr_vigorCast"  /></span>	
+						</div>			
 						<br />
 						<div class="sheet-header" style="display:inline-block">Rune Magic</div>
 						<textarea  name="attr_rune_magic" class="sheet-magic_notes"></textarea> 
@@ -639,7 +671,7 @@
 			<hr class="sheet-hr" />
 						<div class="sheet-header">Weapons</div>
 						<br />
-						<div style="margin-left:194px;margin-bottom:10px;">
+						<div style="margin-left:2px;margin-bottom:20px;">
 							<div>
 								<div CLASS="sheet-input_label">Modifiers</div>
 								
@@ -659,7 +691,8 @@
 							   <div style="margin-left:15px;">SR</div>
 							   <!--<div style="margin-left:14px;">STR/DEX</div>-->	   
 							   <div style="margin-left:43px;">%</div>
-							   <div style="margin-left:46px;">Damage</div>
+							   <div style="margin-left:16px;">Mod.</div>
+							   <div style="margin-left:38px;">Damage</div>
 							   <div style="margin-left:8px;">*</div>							   							   
 							   <div style="margin-left:7px;">Type</div>
 							   <div style="margin-left:8px;">Special</div>						   
@@ -688,6 +721,8 @@
 							  <input type="text" class="sheet-text_input sheet-percentiles"   style="width:22px" value="9" name="attr_wpndex" />--> 
 							  <input type="text"  class="sheet-text_input sheet-percentiles"  readonly style="display:none; width:30px;" value="0" name="attr_minmod" /> 							  
 							  <input type="text"  class="sheet-text_input sheet-percentiles" readonly name="attr_skillTotal" />					  
+							  <input type="text"  class="sheet-text_input sheet-percentiles" value="0" name="attr_skillWpnMod" />					  
+							 
 							  <!--
 							  <input type="text"  class="sheet-text_input sheet-percentiles"  name="attr_wpn_attk_value" />
 							  <input type="text"  class="sheet-text_input sheet-percentiles" disabled name="attr_wpn_attk_total" value="@{wpn_attk_value}+@{manipulation_mod}+@{enc_mod}+@{minmod}+@{gen_mod}" />-->
@@ -695,7 +730,7 @@
 											<button  type="roll" style="margin-right:0px;margin-left:0px;" class="sheet-d100_roll" value="@{melee_value}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
 											
 											
-											<textarea name="attr_melee_value" style="display:none">&{template:melee-roll2} {{name=@{character_name}}} {{tot=[[@{wpn_damage}+@{damagebonus}]]}}{{skillvalue=(@{skillTotal})}} {{fumble=[[{(101-(round((100-((@{skillTotal}*@{skillReduct})+@{skillMods}))/20))),100}kl1]]}}  {{crit=[[round([[ceil((@{skillTotal}*@{skillReduct}))+@{skillMods}]]/20)+1]]}} {{special=[[round(([[ceil((@{skillTotal}*@{skillReduct}))+@{skillMods}]])/5)+1]]}}   {{spclDam=[[@{spcldamage}+@{damagebonus}]]}}   {{crshDam=[[@{wpn_damage}+@{maxDb}+@{damagebonus}]]}}  {{critCrsh=[[@{critdamage}+@{maxDb}+@{damagebonus}]]}} {{critSI=[[@{critdamage}+@{damagebonus}]]}} {{type="[[@{wpn_spl}"]]}}  {{success=[[ceil(ceil((@{skillTotal}*@{skillReduct})))+@{skillMods}]]}} {{roll=[[1d100]]}} {{skillname=@{weapon_type}}} {{mntTogVal=[[@{mntTogVal}]]}} {{mntTot=[[@{wpn_damage}+@{mountDB}]]}} {{mntSpcl=[[@{spcldamage}+@{mountDB}]]}} {{mntCrit=[[@{critdamage}+@{mountDB}]]}}
+											<textarea name="attr_melee_value" style="display:none">&{template:melee-roll2} {{name=@{character_name}}} {{tot=[[@{wpn_damage}+@{damagebonus}]]}}{{skillvalue=(@{skillTotal})}} {{fumble=[[{(101-(round((100-((@{skillTotal}*@{skillReduct})+@{skillWpnMod}+@{skillMods}))/20))),100}kl1]]}}  {{crit=[[round([[ceil((@{skillTotal}*@{skillReduct}))+@{skillWpnMod}+@{skillMods}]]/20)+1]]}} {{special=[[round(([[ceil((@{skillTotal}*@{skillReduct}))+@{skillWpnMod}+@{skillMods}]])/5)+1]]}}   {{spclDam=[[@{spcldamage}+@{damagebonus}]]}}   {{crshDam=[[@{wpn_damage}+@{maxDb}+@{damagebonus}]]}}  {{critCrsh=[[@{critdamage}+@{maxDb}+@{damagebonus}]]}} {{critSI=[[@{critdamage}+@{damagebonus}]]}} {{type="[[@{wpn_spl}"]]}}  {{success=[[ceil(ceil((@{skillTotal}*@{skillReduct})))+@{skillWpnMod}+@{skillMods}]]}} {{roll=[[1d100]]}} {{skillname=@{weapon_type}}} {{mntTogVal=[[@{mntTogVal}]]}} {{mntTot=[[@{wpn_damage}+@{mountDB}]]}} {{mntSpcl=[[@{spcldamage}+@{mountDB}]]}} {{mntCrit=[[@{critdamage}+@{mountDB}]]}}
 										                                
 											
 											
@@ -745,8 +780,9 @@
 							   <div style="margin-left:54px;">Default</div>							   
 							   <!--<div style="margin-left:47px;">STR/DEX</div> -->
 							   <div style="margin-left:7px;">%</div>
-							   <div style="margin-left:48px;">Dmg.</div>
-							   <div style="margin-left:10px;">DB</div>
+							   <div style="margin-left:13px;">Mods.</div>							   
+							   <div style="margin-left:35px;">Dmg.</div>
+							   <div style="margin-left:11px;">DB</div>
 							   <div style="margin-left:3px;">Special</div>						   
 							   <div style="margin-left:8px;">Rng</div>		
 							   <div style="margin-left:4px;">Rate</div>		
@@ -764,14 +800,16 @@
 							  <input type="text"  class="sheet-text_input sheet-skillName" style="font-size:xx-small"  name="attr_skillName" />
 							  <input type="checkbox" style="margin-left:10px;margin-right:7px" name="attr_skillDefault" />	
 							 <input type="text"  style="display:none"  value="1" name="attr_skillReduct" />							  
-							  <input type="text"  class="sheet-text_input sheet-percentiles" readonly name="attr_skillTotal" />						  
+							  <input type="text"  class="sheet-text_input sheet-percentiles" readonly name="attr_skillTotal" />
+							  <input type="text"  class="sheet-text_input sheet-percentiles" value="0" name="attr_skillWpnMod" />				  
+							  
 							  <!--
 							  <input type="text"  class="sheet-text_input sheet-percentiles"  name="attr_wpn_attk_value" />
 							  <input type="text"  class="sheet-text_input sheet-percentiles" disabled name="attr_wpn_attk_total" value="@{wpn_attk_value}+@{manipulation_mod}+@{enc_mod}+@{minmod}+@{gen_mod}" />-->
 							  
 
 							  
-											<button  type="roll" style="margin-right:0px;margin-left:0px;" class="sheet-d100_roll" value="@{melee_value}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button><textarea name="attr_melee_value" style="display:none">&{template:melee-roll2} {{name=@{character_name}}} {{tot=[[@{wpn_damage}+@{wpnmdb}]]}}{{skillvalue=(@{skillTotal})}} {{fumble=[[{(101-(round((100-((@{skillTotal}*@{skillReduct})+@{skillMods}))/20))),100}kl1]]}} {{crit=[[round([[ceil((@{skillTotal}*@{skillReduct}))+@{skillMods}]]/20)+1]]}} {{special=[[round(([[ceil((@{skillTotal}*@{skillReduct}))+@{skillMods}]])/5)+1]]}}   {{spclDam=[[@{spcldamage}+@{wpnmdb}]]}}   {{crshDam=[[@{wpn_damage}+@{maxwpnmdb}+@{wpnmdb}]]}}  {{critCrsh=[[@{critdamage}+@{maxwpnmdb}+@{wpnmdb}]]}} {{critSI=[[@{critdamage}+@{wpnmdb}]]}} {{type="[[@{wpn_spl}"]]}}  {{success=[[ceil((@{skillTotal}*@{skillReduct}))+@{skillMods}]]}} {{roll=[[1d100]]}} {{mntTogVal=[[0]]}}  {{skillname=@{weapon_type}}} 
+											<button  type="roll" style="margin-right:0px;margin-left:0px;" class="sheet-d100_roll" value="@{melee_value}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button><textarea name="attr_melee_value" style="display:none">&{template:melee-roll2} {{name=@{character_name}}} {{tot=[[@{wpn_damage}+@{wpnmdb}]]}}{{skillvalue=(@{skillTotal})}} {{fumble=[[{(101-(round((100-((@{skillTotal}*@{skillReduct})+@{skillWpnMod}+@{skillMods}))/20))),100}kl1]]}} {{crit=[[round([[ceil((@{skillTotal}*@{skillReduct}))+@{skillWpnMod}+@{skillMods}]]/20)+1]]}} {{special=[[round(([[ceil((@{skillTotal}*@{skillReduct}))+@{skillWpnMod}+@{skillMods}]])/5)+1]]}}   {{spclDam=[[@{spcldamage}+@{wpnmdb}]]}}   {{crshDam=[[@{wpn_damage}+@{maxwpnmdb}+@{wpnmdb}]]}}  {{critCrsh=[[@{critdamage}+@{maxwpnmdb}+@{wpnmdb}]]}} {{critSI=[[@{critdamage}+@{wpnmdb}]]}} {{type="[[@{wpn_spl}"]]}}  {{success=[[ceil((@{skillTotal}*@{skillReduct}))+@{skillWpnMod}+@{skillMods}]]}} {{roll=[[1d100]]}} {{mntTogVal=[[0]]}}  {{skillname=@{weapon_type}}} 
 
 											&{template:@{creature_hit_location}Melee}} {{roll=[[@{selected_die_roll}]]}}</textarea>
 											
@@ -798,8 +836,10 @@
 										
 							  
 						   </div>
-						</fieldset>				
-			
+						</fieldset>		
+						<br />		
+						<br />		
+						<br />								
 		</div>
 		<div class="sheet-tab-contenta sheet-tab2a"><!--- Tab 2 start -->
 		<div >
@@ -899,7 +939,7 @@
 									<input  type="checkbox" style="display:none" checked class="sheet-check-toggle1" name="attr_sp_toggle1"  />
 									<div class="sheet-exp-toggle1">									
 										<input type="checkbox" name="attr_expCheck" />							
-									<div>	
+									</div>	
 								</fieldset>
 								<br />
 								<div class="sheet-skill_category">Manipulation</div>
@@ -1038,6 +1078,13 @@
 							<input class="sheet-text_input sheet-char_inputs sheet-percentiles" type="text" value="0" name="attr_equipment_weight"/>
 						</fieldset>	
 						<br />
+						<span class="coins"><b>Wheels (W)</b></span><input class="text_input char_inputs coins" value="0" type="text" name="attr_wheels"/>
+						<span class="coins"><b>Lunars (L)</b></span><input class="text_input char_inputs coins" value="0" type="text" name="attr_lunars"/>						
+						<span class="coins"><b>Clacks (C)</b></span><input class="text_input char_inputs coins" value="0" type="text" name="attr_clacks"/>												
+						<span class="coins"><b>Bolgs (B)</b></span><input class="text_input char_inputs coins" value="0" type="text" name="attr_bolgs"/>							
+						<span class="coins"><b>Goods (L)</b></span><input class="text_input char_inputs goods" value="0" type="text" name="attr_goods"/>							
+						<br />
+						<br />						
 						<span>Max Enc</span>
 						<input class="sheet-text_input sheet-char_inputs sheet-percentiles" value="0" type="text" name="attr_carry_max2"/>
 						<span style="margin-left:8px">Total Enc</span>								
@@ -1742,7 +1789,7 @@ THP 0/0
 					<div class="sheet-skill_category">CHARACTER INCOME</div>
 					<div>
 						<span style="width:86px;display:inline-block;">Base Income</span>
-						<input type="text" style="width:50px;" class="sheet-text_input" name="attr_income" /><span> Lunars<span> 						
+						<input type="text" style="width:50px;" class="sheet-text_input" name="attr_income" /><span> Lunars</span> 						
 					</div>
 					<div>
 						<span>Special Notes</span>
@@ -4105,32 +4152,8 @@ D20	    Result	       AP/HP
 								<span style="margin-left:308px;display:inline-block">								
 									<button  class="sheet-d100_roll"  type="roll" style="margin:0px;" value="@{whispSet} &{template:skillRoll} {{name=@{character_name}}}  {{skillvalue=[[?{Skill+Mods.|0}]]}} {{success=[[?{Skill+Mods.|0}]]}}  {{fumble=[[{(101-(round((100-(?{Skill+Mods.|0}))/20))),100}kl1]]}} {{crit=[[ceil(([[?{Skill+Mods.|0}]])/20)+1]]}} {{special=[[ceil(([[?{Skill+Mods.|0}]])/5)+1]]}}         {{roll=[[1d100]]}} {{skillname=Rune}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
 								</span> 								
-								<textarea  style="    font-size: xx-small;width: 368px;text-align: left;display: block;max-height: 35px;" type="text" name="attr_npc1_runes"></textarea>							
-	
-								<!---
-								<span style="display:inline-block">								
-									<div>
-										<input   class="sheet-value_display sheet-ally_skill"   type="text" name="attr_rune_name1a1" style="text-align:left;width:232px;font-size:x-small" value="rune" />
-										<input  class="sheet-value_display2" type="text" name="attr_rune_value1a1" value="0" />
-										<button  class="sheet-d100_roll"  type="roll" style="margin:0px;" value="@{whispSet} &{template:skillRoll} {{name=@{npc1_name}}}  {{skillvalue=[[@{rune_value1a1}]]}} {{success=[[@{rune_value1a1}+?{mods|0}]]}}  {{fumble=[[{(101-(round((100-(@{rune_value1a1}+?{mods|0}))/20))),100}kl1]]}} {{crit=[[ceil(([[@{rune_value1a1}+?{mods|0}]])/20)+1]]}} {{special=[[ceil(([[@{rune_value1a1}+?{mods|0}]])/5)+1]]}}         {{roll=[[1d100]]}} {{skillname=@{rune_name1a1}}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
-									</div>
-								</span>
-								
-								<span style="display:inline-block">									
-									<div>
-										<input   class="sheet-value_display sheet-ally_skill"  type="text" name="attr_rune_name1a2" style="text-align:left;width:232px;font-size:x-small" value="rune" />
-										<input  class="sheet-value_display2" type="text" name="attr_rune_value1a2" value="0" />
-										<button  class="sheet-d100_roll"  type="roll" style="margin:0px;" value="@{whispSet} &{template:skillRoll} {{name=@{npc1_name}}}  {{skillvalue=[[@{rune_value1a2}]]}} {{success=[[@{rune_value1a2}+?{mods|0}]]}}  {{fumble=[[{(101-(round((100-(@{rune_value1a2}+?{mods|0}))/20))),100}kl1]]}} {{crit=[[ceil(([[@{rune_value1a2}+?{mods|0}]])/20)+1]]}} {{special=[[ceil(([[@{rune_value1a2}+?{mods|0}]])/5)+1]]}}         {{roll=[[1d100]]}} {{skillname=@{rune_name1a2}}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
-									</div>
-								</span>
-								
-								<span style="display:inline-block">								
-									<div>
-										<input   class="sheet-value_display sheet-ally_skill"  type="text" name="attr_rune_name1a3" style="text-align:left;width:232px;" value="rune" />
-										<input  class="sheet-value_display2" type="text" name="attr_rune_value1a3" value="0" /><button  class="sheet-d100_roll"  type="roll" style="margin:0px;" value="@{whispSet} &{template:skillRoll} {{name=@{npc1_name}}}  {{skillvalue=[[@{rune_value1a3}]]}} {{success=[[@{rune_value1a3}+?{mods|0}]]}}  {{fumble=[[{(101-(round((100-(@{rune_value1a3}+?{mods|0}))/20))),100}kl1]]}} {{crit=[[ceil(([[@{rune_value1a3}+?{mods|0}]])/20)+1]]}} {{special=[[ceil(([[@{rune_value1a3}+?{mods|0}]])/5)+1]]}}         {{roll=[[1d100]]}} {{skillname=@{rune_name1a3}}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
-									</div>
-								</span>-->
-								
+								<textarea  style="    font-size: xx-small;width: 368px;text-align: left;display: block;min-height: 35px;height:75px" type="text" name="attr_npc1_runes"></textarea>							
+
 							</div><!--- end of runes -->
 							
 							
@@ -4148,7 +4171,7 @@ D20	    Result	       AP/HP
 										<button  class="sheet-d100_roll"  type="roll" style="margin:0px;" value="@{whispSet} &{template:skillRoll} {{name=@{character_name}}}  {{skillvalue=[[(@{npc1a_pow}*5)+@{magic_mod}]]}} {{success=[[(@{npc1a_pow}*5)+@{magic_mod}]]}}  {{fumble=[[{(101-(round((100-((@{npc1a_pow}*5)+@{magic_mod}))/20))),100}kl1]]}} {{crit=[[ceil(([[(@{npc1a_pow}*5)+@{magic_mod}]])/20)+1]]}} {{special=[[ceil(([[(@{npc1a_pow}*5)+@{magic_mod}]])/5)+1]]}}         {{roll=[[1d100]]}} {{skillname=Spirit Magic}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
 									</span>
 							</span> 
-							<textarea  style="    font-size: xx-small;width: 368px;text-align: left;display: block;max-height: 45px;" type="text" name="attr_npc1_spells"></textarea>							
+							<textarea  style="    font-size: xx-small;width: 368px;text-align: left;display: block;min-height: 45px;height:75px;" type="text" name="attr_npc1_spells"></textarea>							
 							<br>		
 
 							<span class="sheet-input_label">Passions:</span>
@@ -4157,7 +4180,7 @@ D20	    Result	       AP/HP
 									<button  class="sheet-d100_roll"  type="roll" style="margin:0px;" value="@{whispSet} &{template:skillRoll} {{name=@{character_name}}}  {{skillvalue=[[?{Skill+Mods.|0}]]}} {{success=[[?{Skill+Mods.|0}]]}}  {{fumble=[[{(101-(round((100-(?{Skill+Mods.|0}))/20))),100}kl1]]}} {{crit=[[ceil(([[?{Skill+Mods.|0}]])/20)+1]]}} {{special=[[ceil(([[?{Skill+Mods.|0}]])/5)+1]]}}         {{roll=[[1d100]]}} {{skillname=Passion}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
 									
 							</span> 
-							<textarea  style="font-size: xx-small;width: 368px;text-align: left;display: block;max-height: 35px;" type="text" name="attr_npc1_passions"></textarea>
+							<textarea  style="font-size: xx-small;width: 368px;text-align: left;display: block;min-height: 35px;height:75px;" type="text" name="attr_npc1_passions"></textarea>
 							<br>		
 							<span class="sheet-input_label">Skills:</span>
 							<span style="margin-left:315px;display:inline-block">								
@@ -4165,116 +4188,9 @@ D20	    Result	       AP/HP
 									<button  class="sheet-d100_roll"  type="roll" style="margin:0px;" value="@{whispSet} &{template:skillRoll} {{name=@{character_name}}}  {{skillvalue=[[?{Skill+Mods.|0}]]}} {{success=[[?{Skill+Mods.|0}]]}}  {{fumble=[[{(101-(round((100-(?{Skill+Mods.|0}))/20))),100}kl1]]}} {{crit=[[ceil(([[?{Skill+Mods.|0}]])/20)+1]]}} {{special=[[ceil(([[?{Skill+Mods.|0}]])/5)+1]]}}         {{roll=[[1d100]]}} {{skillname=Skill}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
 									
 							</span> 
-							<textarea  style="    font-size: xx-small;width: 368px;text-align: left;display: block;max-height: 45px;" type="text" name="attr_npc1_skills"></textarea>							
+							<textarea  style="    font-size: xx-small;width: 368px;text-align: left;display: block;min-height: 45px;height:75px;" type="text" name="attr_npc1_skills"></textarea>							
 
-							<!---
-							<div>	
-								<span style="display:inline-block">
-									<div style="margin-top:5px;display:inline-block" class="sheet-melee_wpns_labels">
-									   <div style="">Skill</div>
-									   <div style="margin-left:38px;">&#37;</div>   
-									</div>	
-									
-									<div>
-										<input   class="sheet-value_display sheet-ally_skill"   type="text" name="attr_skill_name1a1" style="text-align:left;width:232px;font-size:x-small" value="skill" />
-										<input  class="sheet-value_display2" type="text" name="attr_skill_value1a1" value="0" /><button  class="sheet-d100_roll"  type="roll" style="margin:0px;" value="&{template:skillRoll} {{name=@{npc1_name}}}  {{skillvalue=[[@{skill_value1a1}]]}} {{success=[[@{skill_value1a1}+?{mods|0}]]}}  {{fumble=[[{(101-(round((100-(@{skill_value1a1}+?{mods|0}))/20))),100}kl1]]}} {{crit=[[ceil(([[@{skill_value1a1}+?{mods|0}]])/20)+1]]}} {{special=[[ceil(([[@{skill_value1a1}+?{mods|0}]])/5)+1]]}}         {{roll=[[1d100]]}} {{skillname=@{skill_name1a1}}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
-									</div>
-								</span>
-								<span style="display:inline-block">
-									<div style="margin-top:5px;display:inline-block" class="sheet-melee_wpns_labels">
-									   <div style="">Skill</div>
-									   <div style="margin-left:38px;">&#37;</div>   
-									</div>	
-									
-									<div>
-										<input   class="sheet-value_display sheet-ally_skill"  type="text" name="attr_skill_name1a2" style="text-align:left;width:232px;font-size:x-small" value="skill" />
-										<input  class="sheet-value_display2" type="text" name="attr_skill_value1a2" value="0" /><button  class="sheet-d100_roll"  type="roll" style="margin:0px;" value="&{template:skillRoll} {{name=@{npc1_name}}}  {{skillvalue=[[@{skill_value1a2}]]}} {{success=[[@{skill_value1a2}+?{mods|0}]]}}  {{fumble=[[{(101-(round((100-(@{skill_value1a2}+?{mods|0}))/20))),100}kl1]]}} {{crit=[[ceil(([[@{skill_value1a2}+?{mods|0}]])/20)+1]]}} {{special=[[ceil(([[@{skill_value1a2}+?{mods|0}]])/5)+1]]}}         {{roll=[[1d100]]}} {{skillname=@{skill_name1a2}}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
-									</div>
-								</span>
-								<span style="display:inline-block">
-									<div style="margin-top:5px;display:inline-block" class="sheet-melee_wpns_labels">
-									   <div style="">Skill</div>
-									   <div style="margin-left:38px;">&#37;</div>   
-									</div>	
-									
-									<div>
-										<input   class="sheet-value_display sheet-ally_skill"  type="text" name="attr_skill_name1a3" style="text-align:left;width:232px;" value="skill" />
-										<input  class="sheet-value_display2" type="text" name="attr_skill_value1a3" value="0" /><button  class="sheet-d100_roll"  type="roll" style="margin:0px;" value="&{template:skillRoll} {{name=@{npc1_name}}}  {{skillvalue=[[@{skill_value1a3}]]}} {{success=[[@{skill_value1a3}+?{mods|0}]]}}  {{fumble=[[{(101-(round((100-(@{skill_value1a3}+?{mods|0}))/20))),100}kl1]]}} {{crit=[[ceil(([[@{skill_value1a3}+?{mods|0}]])/20)+1]]}} {{special=[[ceil(([[@{skill_value1a3}+?{mods|0}]])/5)+1]]}}         {{roll=[[1d100]]}} {{skillname=@{skill_name1a3}}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
-									</div>
-								</span>									
-							</div>
-							
-							<div>	
-								<span style="display:inline-block">
-									<div style="margin-top:5px;display:inline-block" class="sheet-melee_wpns_labels">
-									   <div style="">Skill</div>
-									   <div style="margin-left:38px;">&#37;</div>   
-									</div>	
-									
-									<div>
-										<input   class="sheet-value_display sheet-ally_skill"  type="text" name="attr_skill_name1a4" style="text-align:left;width:232px;" value="skill" />
-										<input  class="sheet-value_display2" type="text" name="attr_skill_value1a4" value="0" /><button  class="sheet-d100_roll"  type="roll" style="margin:0px;" value="&{template:skillRoll} {{name=@{npc1_name}}}  {{skillvalue=[[@{skill_value1a4}]]}} {{success=[[@{skill_value1a4}+?{mods|0}]]}}  {{fumble=[[{(101-(round((100-(@{skill_value1a4}+?{mods|0}))/20))),100}kl1]]}} {{crit=[[ceil(([[@{skill_value1a4}+?{mods|0}]])/20)+1]]}} {{special=[[ceil(([[@{skill_value1a4}+?{mods|0}]])/5)+1]]}}         {{roll=[[1d100]]}} {{skillname=@{skill_name1a4}}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
-									</div>
-								</span>
-								<span style="display:inline-block">
-									<div style="margin-top:5px;display:inline-block" class="sheet-melee_wpns_labels">
-									   <div style="">Skill</div>
-									   <div style="margin-left:38px;">&#37;</div>   
-									</div>	
-									
-									<div>
-										<input   class="sheet-value_display sheet-ally_skill"  type="text" name="attr_skill_name1a5" style="text-align:left;width:232px;" value="skill" />
-										<input  class="sheet-value_display2" type="text" name="attr_skill_value1a5" value="0" /><button  class="sheet-d100_roll"  type="roll" style="margin:0px;" value="&{template:skillRoll} {{name=@{npc1_name}}}  {{skillvalue=[[@{skill_value1a5}]]}} {{success=[[@{skill_value1a5}+?{mods|0}]]}}  {{fumble=[[{(101-(round((100-(@{skill_value1a5}+?{mods|0}))/20))),100}kl1]]}} {{crit=[[ceil(([[@{skill_value1a5}+?{mods|0}]])/20)+1]]}} {{special=[[ceil(([[@{skill_value1a5}+?{mods|0}]])/5)+1]]}}         {{roll=[[1d100]]}} {{skillname=@{skill_name1a5}}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
-									</div>
-								</span>
-								<span style="display:inline-block">
-									<div style="margin-top:5px;display:inline-block" class="sheet-melee_wpns_labels">
-									   <div style="">Skill</div>
-									   <div style="margin-left:38px;">&#37;</div>   
-									</div>	
-									
-									<div>
-										<input   class="sheet-value_display sheet-ally_skill"  type="text" name="attr_skill_name1a6" style="text-align:left;width:232px;" value="skill" />
-										<input  class="sheet-value_display2" type="text" name="attr_skill_value1a6" value="0" /><button  class="sheet-d100_roll"  type="roll" style="margin:0px;" value="&{template:skillRoll} {{name=@{npc1_name}}}  {{skillvalue=[[@{skill_value1a6}]]}} {{success=[[@{skill_value1a6}+?{mods|0}]]}}  {{fumble=[[{(101-(round((100-(@{skill_value1a6}+?{mods|0}))/20))),100}kl1]]}} {{crit=[[ceil(([[@{skill_value1a6}+?{mods|0}]])/20)+1]]}} {{special=[[ceil(([[@{skill_value1a6}+?{mods|0}]])/5)+1]]}}         {{roll=[[1d100]]}} {{skillname=@{skill_name1a6}}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
-									</div>
-								</span>									
-							</div>		
-							<div>
-									<span style="display:inline-block">
-									<div style="margin-top:5px;display:inline-block" class="sheet-melee_wpns_labels">
-									   <div style="">Skill</div>
-									   <div style="margin-left:38px;">&#37;</div>   
-									</div>	
-									
-									<div>
-										<input   class="sheet-value_display sheet-ally_skill"  type="text" name="attr_skill_name1a7" style="text-align:left;width:232px;" value="skill" />
-										<input  class="sheet-value_display2" type="text" name="attr_skill_value1a7" value="0" /><button  class="sheet-d100_roll"  type="roll" style="margin:0px;" value="&{template:skillRoll} {{name=@{npc1_name}}}  {{skillvalue=[[@{skill_value1a7}]]}} {{success=[[@{skill_value1a7}+?{mods|0}]]}}  {{fumble=[[{(101-(round((100-(@{skill_value1a7}+?{mods|0}))/20))),100}kl1]]}} {{crit=[[ceil(([[@{skill_value1a7}+?{mods|0}]])/20)+1]]}} {{special=[[ceil(([[@{skill_value1a7}+?{mods|0}]])/5)+1]]}}         {{roll=[[1d100]]}} {{skillname=@{skill_name1a7}}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
-									</div>
-								</span>
-								<span style="display:inline-block">
-									<div style="margin-top:5px;display:inline-block" class="sheet-melee_wpns_labels">
-									   <div style="">Skill</div>
-									   <div style="margin-left:38px;">&#37;</div>   
-									</div>	
-									
-									<div>
-										<input   class="sheet-value_display sheet-ally_skill"  type="text" name="attr_skill_name1a8" style="text-align:left;width:232px;" value="skill" />
-										<input  class="sheet-value_display2" type="text" name="attr_skill_value1a8" value="0" /><button  class="sheet-d100_roll"  type="roll" style="margin:0px;" value="&{template:skillRoll} {{name=@{npc1_name}}}  {{skillvalue=[[@{skill_value1a8}]]}} {{success=[[@{skill_value1a8}+?{mods|0}]]}}  {{fumble=[[{(101-(round((100-(@{skill_value1a8}+?{mods|0}))/20))),100}kl1]]}} {{crit=[[ceil(([[@{skill_value1a8}+?{mods|0}]])/20)+1]]}} {{special=[[ceil(([[@{skill_value1a8}+?{mods|0}]])/5)+1]]}}         {{roll=[[1d100]]}} {{skillname=@{skill_name1a8}}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
-									</div>
-								</span>
-								<span style="display:inline-block">
-									<div style="margin-top:5px;display:inline-block" class="sheet-melee_wpns_labels">
-									   <div style="">Skill</div>
-									   <div style="margin-left:38px;">&#37;</div>   
-									</div>	
-									
-									<div>
-										<input   class="sheet-value_display sheet-ally_skill"  type="text" name="attr_skill_name1a9" style="text-align:left;width:232px;" value="skill" />
-										<input  class="sheet-value_display2" type="text" name="attr_skill_value1a9" value="0" /><button  class="sheet-d100_roll"  type="roll" style="margin:0px;" value="&{template:skillRoll} {{name=@{npc1_name}}}  {{skillvalue=[[@{skill_value1a9}]]}} {{success=[[@{skill_value1a9}+?{mods|0}]]}}  {{fumble=[[{(101-(round((100-(@{skill_value1a9}+?{mods|0}))/20))),100}kl1]]}} {{crit=[[ceil(([[@{skill_value1a9}+?{mods|0}]])/20)+1]]}} {{special=[[ceil(([[@{skill_value1a9}+?{mods|0}]])/5)+1]]}}         {{roll=[[1d100]]}} {{skillname=@{skill_name1a9}}}" ><img class="sheet-d100_image" src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/RunequestGQS/luck.png" /></button>
-									</div>
-								</span>									
-							</div>							
-							-->							
+					
 							<br>							
 							<div style="margin-top:5px;" class="sheet-melee_wpns_labels">
 								<br />
@@ -4830,12 +4746,14 @@ wpn 3 HP 12
 			});
 
 			//Set Communication
-			on("change:curint change:curchr change:curpow", function() {
-				getAttrs(["version","curint", "curchr", "curpow"], function(pvalue) {
+			on("change:curint change:curchr change:curpow change:glamourCast", function() {
+				getAttrs(["version","curint", "curchr", "curpow","glamourCast"], function(pvalue) {
 					console.log("************ Start Communication Bonus ************");
 					console.log("curint value: " + pvalue.curint);
 					console.log("curchr value: " + pvalue.curchr);
 					console.log("curpow value: " + pvalue.curpow);
+					console.log("glamourCast value: " + pvalue.glamourCast);
+
 					
 					var curInt = parseInt(pvalue.curint);
 					var curPow = parseInt(pvalue.curpow);
@@ -4877,7 +4795,14 @@ wpn 3 HP 12
 					console.log("BonusMod value3: " + BonusMod);				
 
 					
+					if (pvalue.glamourCast==="on"){
+						BonusMod += 10;
+					}
+					
+					console.log("BonusMod value4: " + BonusMod);
+					
 					console.log("version "+pvalue.version);
+					
 					if (parseInt(pvalue.version)===0){
 						BonusMod = 0;
 					}
@@ -4940,11 +4865,11 @@ wpn 3 HP 12
 			});			
 			/////////////////////////////////////////////////
 			//Set Magic
-			on("change:curchr change:curpow ", function() {
-				getAttrs(["version","curchr", "curpow"], function(pvalue) {
+			on("change:curchr change:curpow change:glamourCast", function() {
+				getAttrs(["version","curchr", "curpow","glamourCast"], function(pvalue) {
 					console.log("************ Start Magic Bonus ************");
-					console.log("curpow value: " + pvalue.curint);
-					console.log("curchr value: " + pvalue.curpow);
+					console.log("curpow value: " + pvalue.curpow);
+					console.log("curchr value: " + pvalue.curchr);
 					
 					var curChr = parseInt(pvalue.curchr);
 					var curPow = parseInt(pvalue.curpow);
@@ -4977,6 +4902,19 @@ wpn 3 HP 12
 					console.log("BonusMod value3: " + BonusMod);				
 
 					
+					if (pvalue.glamourCast==="on"){
+					
+							if (curChr < 5) {
+								BonusMod = BonusMod+5;
+							}else if(curChr >= 9 && curChr <= 12){
+								BonusMod = BonusMod+5;
+							}else if(curChr >= 13){
+								BonusMod = BonusMod+10;
+							}					
+					}
+					console.log("BonusMod value4: " + BonusMod);				
+
+					
 					console.log("version "+pvalue.version);
 					if (parseInt(pvalue.version)===0){
 						BonusMod = 0;
@@ -4989,8 +4927,8 @@ wpn 3 HP 12
 			});					
 			
 			//Set Manipulation Bonus
-			on("change:curstr change:curint change:curdex change:curpow", function() {
-				getAttrs(["version","curint", "curstr", "curdex", "curpow"], function(pvalue) {
+			on("change:curstr change:curint change:curdex change:curpow change:strengthCast", function() {
+				getAttrs(["version","curint", "curstr", "curdex","strengthCast", "curpow"], function(pvalue) {
 					console.log("************ Start Manipulation Bonus ************");
 					console.log("curstr value: " + pvalue.curstr);
 					console.log("curint value: " + pvalue.curint);
@@ -5060,8 +4998,22 @@ wpn 3 HP 12
 					}else if (curPower >20){
 						BonusMod = BonusMod + 5+(Math.ceil((curPower-20)/4)*5);
 					}				
+   					console.log("before buff BonusMod value: " + BonusMod);
+
 				   
+					if (pvalue.strengthCast==="on"){
 					
+							if (curStrength < 5) {
+								BonusMod = BonusMod+5;
+							}else if(curStrength >= 9 && curStrength <= 12){
+								BonusMod = BonusMod+5;
+							}else if(curStrength >= 13){
+								BonusMod = BonusMod+10;
+							}					
+					}				   
+				   
+   					console.log("after buff BonusMod value: " + BonusMod);
+
 					console.log("version "+pvalue.version);
 					if (parseInt(pvalue.version)===0){
 						BonusMod = 0;
@@ -5199,8 +5151,8 @@ wpn 3 HP 12
 			
 			
 				//Set Damage Bonus
-			on("change:curstr change:cursiz", function() {
-				getAttrs(["curstr", "cursiz", "damagebonus"], function(pvalue) {
+			on("change:curstr change:cursiz change:strengthCast", function() {
+				getAttrs(["curstr", "cursiz","strengthCast","damagebonus"], function(pvalue) {
 					console.log("************ Start Damage Bonus ************");
 					console.log("curstr value: " + pvalue.curstr);
 					console.log("cursiz value: " + pvalue.cursiz);
@@ -5220,7 +5172,13 @@ wpn 3 HP 12
 					if (StplusSi < 13) {
 						console.log("-- Str+Siz is less than 13 --");
 						DBonus = "-1d4";
-						mDBonus = "-1d2";					
+						mDBonus = "-1d2";		
+						
+						if (pvalue.strengthCast==="on"){						
+							DBonus = "0";
+							mDBonus = "0";
+						}
+						
 						console.log("DBonus value: " + DBonus);
 						/*setAttrs({ damagebonus: DBonus,mdamagebonus: mDBonus,maxDb:maxDb1});*/
 					}
@@ -5228,6 +5186,14 @@ wpn 3 HP 12
 						console.log("-- Str+Siz is less than 25 --");
 						DBonus = "0";
 						mDBonus = "0";
+						
+						if (pvalue.strengthCast==="on"){						
+							DBonus = "1d4";
+							mDBonus = "1d2";
+							maxDb1=4;
+							maxDb2=2							
+						}						
+						
 						console.log("DBonus value: " + DBonus);
 						/*setAttrs({ damagebonus: DBonus,mdamagebonus: mDBonus,maxDb:maxDb1});*/
 					}
@@ -5238,6 +5204,15 @@ wpn 3 HP 12
 						console.log("DBonus value: " + DBonus);
 						maxDb1=4;
 						maxDb2=2
+						if (pvalue.strengthCast==="on"){						
+							DBonus = "1d6";
+							mDBonus = "1d3";
+							maxDb1=6;
+							maxDb2=3							
+						}												
+						
+						
+						
 						/*setAttrs({ damagebonus: DBonus,mdamagebonus: mDBonus,maxDb:maxDb1  });*/
 					}
 					else if (StplusSi < 41) {
@@ -5247,10 +5222,22 @@ wpn 3 HP 12
 						console.log("DBonus value: " + DBonus);
 						maxDb1=6;
 						maxDb2=3
+						
+						if (pvalue.strengthCast==="on"){						
+							DBonus = "2d6";
+							mDBonus = "1d6";
+							maxDb1=12;
+							maxDb2=6							
+						}							
+						
 						/*setAttrs({ damagebonus: DBonus,mdamagebonus: mDBonus,maxDb:maxDb1  });*/
 					}			
 					else { //StplusSi is greater than 
 						DBonusC = 2+Math.floor(parseFloat((StplusSi - 40) / 16));
+						if (pvalue.strengthCast==="on"){						
+							DBonusC += 1;
+						}						
+						
 						console.log("DBonusC value: " + DBonusC);
 
 						DBonus = DBonusC + "d6";
@@ -5330,12 +5317,67 @@ wpn 3 HP 12
 				});
 			});	
 			
+			
+			on("change:glamourCast change:strengthCast change:vigorCast", function() {
+				getAttrs(["glamourCast","strengthCast","vigorCast"], function(pvalue) {
+
+					
+					var buffStr = "";	
+
+					if (pvalue.strengthCast==="on"){
+						buffStr= buffStr+"+8 STR "
+						setAttrs({strBuff:8});
+					}else if(pvalue.strengthCast==="0"){
+						setAttrs({strBuff:0});
+					} 					
+					if (pvalue.glamourCast==="on"){
+						if (buffStr.length>0){
+							buffStr = buffStr+","
+						}
+						buffStr= buffStr+ " +8 CHR "
+						setAttrs({chrBuff:8});
+					} else if (pvalue.glamourCast==="0"){
+						setAttrs({chrBuff:0});						
+					}						
+
+					if (pvalue.vigorCast==="on"){
+						if (buffStr.length>0){
+							buffStr = buffStr+","
+						}					
+						buffStr= buffStr+" +3 CON "
+						setAttrs({conBuff:3});
+					} else if (pvalue.vigourCast==="0"){
+						setAttrs({conBuff:0});						
+					}	
+					if (buffStr.length>0){
+						buffStr = buffStr+" to resistance rolls only"
+					}					
+					console.log("*********** Updating Buff String");
+					console.log("buff "+buffStr);	
+					setAttrs({buffMsg:buffStr });
+				});
+			});	
+			
+			
+			
 				//Location Hit Points
 			//Set Hit Points
-			on("change:hp_max ", function() {
-				getAttrs(["hp_max"], function(pvalue) {
-					console.log("************ Start Location Hit Point Calculation ************");
+		                             
+			on("change:hp_max chnage:vigorCast", function() {
+				getAttrs(["hp_max","vigorCast"], function(pvalue) {
 					var HitPoints = parseInt(pvalue.hp_max);
+					console.log("************ Start Location Hit Point Calculation ************");
+					console.log("!!!!!!!!!! vigorCast "+pvalue.vigorCast);
+					
+					
+
+					var hpfudge =0;
+					if (pvalue.vigorCast==="on"){
+						
+						HitPoints = HitPoints-3;
+						hpfudge=1;
+						
+					}
 					console.log("hit points");
 					console.log(HitPoints);
 
@@ -5367,39 +5409,39 @@ wpn 3 HP 12
 					var LocPoints3 = 0; // Chest
 					
 					if (HitPoints < 7){
-						LocPoints1 = 2;
-						LocPoints2 = 1;
-						LocPoints3 = 3;					
+						LocPoints1 = 2+hpfudge;
+						LocPoints2 = 1+hpfudge;
+						LocPoints3 = 3+hpfudge;					
 					}
 					else if (HitPoints >= 7 && HitPoints <= 9){
-						LocPoints1 = 3;
-						LocPoints2 = 2;
-						LocPoints3 = 4;					
+						LocPoints1 = 3+hpfudge;
+						LocPoints2 = 2+hpfudge;
+						LocPoints3 = 4+hpfudge;					
 					}
 					else if (HitPoints >= 10 && HitPoints <= 12){
-						LocPoints1 = 4;
-						LocPoints2 = 3;
-						LocPoints3 = 5;					
+						LocPoints1 = 4+hpfudge;
+						LocPoints2 = 3+hpfudge;
+						LocPoints3 = 5+hpfudge;					
 					}
 					else if (HitPoints >= 13 && HitPoints <= 15){
-						LocPoints1 = 5;
-						LocPoints2 = 4;
-						LocPoints3 = 6;					
+						LocPoints1 = 5+hpfudge;
+						LocPoints2 = 4+hpfudge;
+						LocPoints3 = 6+hpfudge;					
 					}
 					else if (HitPoints >= 16 && HitPoints <= 18){
-						LocPoints1 = 6;
-						LocPoints2 = 5;
-						LocPoints3 = 7;					
+						LocPoints1 = 6+hpfudge;
+						LocPoints2 = 5+hpfudge;
+						LocPoints3 = 7+hpfudge;					
 					}
 					else if (HitPoints >= 19 && HitPoints <= 21){
-						LocPoints1 = 7;
-						LocPoints2 = 6;
-						LocPoints3 = 8;					
+						LocPoints1 = 7+hpfudge;
+						LocPoints2 = 6+hpfudge;
+						LocPoints3 = 8+hpfudge;					
 					}
 					else if (HitPoints > 21){
-						LocPoints1 = (7 + Math.ceil((HitPoints-21)/3));
-						LocPoints2 = (6 + Math.ceil((HitPoints-21)/3));
-						LocPoints3 = (8 + Math.ceil((HitPoints-21)/3));
+						LocPoints1 = (7 + Math.ceil((HitPoints-21)/3))+hpfudge;
+						LocPoints2 = (6 + Math.ceil((HitPoints-21)/3))+hpfudge;
+						LocPoints3 = (8 + Math.ceil((HitPoints-21)/3))+hpfudge;
 					}
 					
 					setAttrs({r_leg_max_hp: LocPoints1,l_leg_max_hp: LocPoints1,abd_max_hp: LocPoints1,chst_max_hp: LocPoints3,
@@ -5430,8 +5472,8 @@ wpn 3 HP 12
 			
 			
 		//Set Hit Points
-			on("change:curcon change:curpow change:cursiz ", function() {
-				getAttrs(["curcon", "cursiz","curpow","hp","lhp_loss","thp_loss"], function(pvalue) {
+			on("change:curcon change:curpow change:cursiz  change:vigorCast", function() {
+				getAttrs(["curcon", "cursiz","curpow","hp","lhp_loss","thp_loss","vigorCast"], function(pvalue) {
 					console.log("************ Start Hit Point Calculation ************");
 					console.log("curcon value: " + pvalue.curcon);
 					console.log("cursiz value: " + pvalue.cursiz);
@@ -5487,8 +5529,10 @@ wpn 3 HP 12
 						HitPoints += (3 + Math.ceil((charPow-20)/4));
 					}
 
-
 					
+					if (pvalue.vigorCast==="on"){
+						HitPoints +=3;
+					}
 					
 					CurHitPoints = HitPoints-THpLoss-LHpLoss;
 								
@@ -6620,11 +6664,11 @@ console.log("111111111 swim_mod2 "+swim_mod);
 			});
 		})		
 
-			on("change:curstr change:curcon", function() {
-				getAttrs(["curstr","curcon"], function(pvalue) {		
+			on("change:curstr change:curcon change:strBuff change:conBuff", function() {
+				getAttrs(["curstr","curcon","conBuff","strBuff"], function(pvalue) {		
 					
-					var cStr = parseInt(pvalue.curstr);
-					var cCon = parseInt(pvalue.curcon);
+					var cStr = parseInt(pvalue.curstr)+parseInt(pvalue.strBuff);
+					var cCon = parseInt(pvalue.curcon)+parseInt(pvalue.conBuff);
 					
 					var enc = Math.ceil((cStr+cCon)/2);
 					if (enc > cStr){
@@ -8097,8 +8141,8 @@ console.log("111111111 swim_mod2 "+swim_mod);
 			});	
 			
 			//spirit combat damage
-			on("change:curpow change:curchr", function() {
-				getAttrs(["curpow","curchr"], function(pvalue) {
+			on("change:curpow change:curchr change:glamourCast", function() {
+				getAttrs(["curpow","curchr","glamourCast"], function(pvalue) {
 
 					
 					var charPow = parseInt(pvalue.curpow);
@@ -8107,18 +8151,53 @@ console.log("111111111 swim_mod2 "+swim_mod);
 					var sprtCbtDam = "";
 					console.log("!!!!!!!!!!! "+(charPow+charChr));
 					if (charPow+charChr < 13){
-						sprtCbtDam = "1D3"; <!-- 2-12-->
+						 <!-- 2-12-->
+						if (pvalue.glamourCast==="on"){	
+							sprtCbtDam = "1D6";
+						}else{
+							sprtCbtDam = "1D3";
+						}
+						
 					} else if (charPow+charChr < 25){
-						sprtCbtDam = "1D6"; <!-- 13-24 -->
+						<!-- 13-24 -->
+						if (pvalue.glamourCast==="on"){	
+							sprtCbtDam = "1D6+1";
+						}else{
+							sprtCbtDam = "1D6";
+						}
+						
 					} else if (charPow+charChr < 33){
-						sprtCbtDam = "1D6+1"; <!-- 25-32-->
+					
+						<!-- 25-32-->
+						if (pvalue.glamourCast==="on"){	
+							sprtCbtDam = "1D6+3";
+						}else{
+							sprtCbtDam = "1D6+1";
+						}						
+
 					} else if (charPow+charChr < 41){
-						sprtCbtDam = "1D6+3"; <!-- 33-40-->					
+						<!-- 33-40-->						
+						if (pvalue.glamourCast==="on"){	
+							sprtCbtDam = "2D6+3";
+						}else{
+							sprtCbtDam = "1D6+3";
+						}						
+						
 					} else if (charPow+charChr < 57){
-						sprtCbtDam = "2D6+3"; <!-- 41- 56 -->					
+						<!-- 41- 56 -->	
+						if (pvalue.glamourCast==="on"){	
+							sprtCbtDam = "3D6+3";
+						}else{
+							sprtCbtDam = "2D6+3";
+						}												
+						
+
 					} else {
 					
 						var val = (2 + Math.ceil(((charPow+charChr)-56)/16));
+						if (pvalue.glamourCast==="on"){	
+							val =+ 1;
+						}						
 						sprtCbtDam = val+"D6+"+(val+2);				
 					}				
 									
@@ -8916,22 +8995,25 @@ console.log("111111111 swim_mod2 "+swim_mod);
 </rolltemplate>
 
 
+
+
+
+
 <rolltemplate class="sheet-rolltemplate-HL-Melee">
-	<table class="skillRoll" style="border 1px black">
-		<tr><th colspan="2">Human Hit location roll</th></tr>
-		<tr>
-		<td>{{roll}}&nbsp;</td>
-		{{#rollBetween() roll 1 4}}<td class="template_label">Hit on the Left Leg</td>{{/rollBetween() roll 1 4}}
-		{{#rollBetween() roll 5 8}}<td class="template_label">Hit on the Right Leg</td>{{/rollBetween() roll 5 8}}
-		{{#rollBetween() roll 9 11}}<td class="template_label">Hit on the  Abdomen</td>{{/rollBetween() roll 9 11}}
-				{{#rollTotal() roll 12}}
-					<td class="template_value">Hit on the Chest</td>
-				{{/rollTotal() roll 12}}
-		{{#rollBetween() roll 13 15}}<td class="template_label">Hit on the Right Arm</td>{{/rollBetween() roll 13 15}}
-		{{#rollBetween() roll 16 18}}<td class="template_label">Hit on the Left Arm</td>{{/rollBetween() roll 16 18}}
-		{{#rollBetween() roll 19 20}}<td class="template_label">Hit on the Head</td>{{/rollBetween() roll 19 20}}
-		</tr>
-	</table>
+	<div class="loc_wrapper">
+		<div class="template_header">Human Hit location roll</div>
+	    <div class="template_body" ><span>{{roll}}&nbsp;</span>
+		<span class="template_label">
+			{{#rollBetween() roll 1 4}}Hit on the Left Leg{{/rollBetween() roll 1 4}}
+			{{#rollBetween() roll 5 8}}Hit on the Right Leg{{/rollBetween() roll 5 8}}
+			{{#rollBetween() roll 9 11}}Hit on the  Abdomen{{/rollBetween() roll 9 11}}
+			{{#rollTotal() roll 12}}Hit on the Chest{{/rollTotal() roll 12}}
+			{{#rollBetween() roll 13 15}}Hit on the Right Arm{{/rollBetween() roll 13 15}}
+			{{#rollBetween() roll 16 18}}Hit on the Left Arm{{/rollBetween() roll 16 18}}
+			{{#rollBetween() roll 19 20}}Hit on the Head{{/rollBetween() roll 19 20}}
+		</span>
+		</div>
+	</div>
 </rolltemplate>
 
 
@@ -8972,118 +9054,124 @@ console.log("111111111 swim_mod2 "+swim_mod);
 </rolltemplate>
 
 <rolltemplate class="sheet-rolltemplate-FLL-Melee">
-	<table class="skillRoll" style="border 1px black">
-		<tr><th colspan="2">Four-legged Hit location roll</th></tr>
-		<tr>
-	    <td>{{roll}}&nbsp;</td>		
-		{{#rollBetween() roll 1 2}}<td class="template_label">Hit on the RH Leg</td>{{/rollBetween() roll 1 2}}
-		{{#rollBetween() roll 3 4}}<td class="template_label">Hit on the LH Leg</td>{{/rollBetween() roll 3 4}}
-		{{#rollBetween() roll 5 7}}<td class="template_label">Hit on the  Hind Q</td>{{/rollBetween() roll 5 7}}
-		{{#rollBetween() roll 8 10}}<td class="template_label">Hit on the Fore Q</td>{{/rollBetween() roll 8 10}}
-		{{#rollBetween() roll 11 13}}<td class="template_label">Hit on the RF Leg</td>{{/rollBetween() roll 11 13}}
-		{{#rollBetween() roll 14 16}}<td class="template_label">Hit on the LF Leg</td>{{/rollBetween() roll 14 16}}
-		{{#rollBetween() roll 17 20}}<td class="template_label">Hit on the Head</td>{{/rollBetween() roll 17 20}}		
-		</tr>
-	</table>
-</rolltemplate>
-
-
-<rolltemplate class="sheet-rolltemplate-NewtL-Missle">
-	<table class="skillRoll" style="border 1px black">
-		<tr><th colspan="2">Newtling Missle Hit location roll</th></tr>
-		<tr>
-		<td>{{roll}}&nbsp;</td>
-		{{#rollTotal() roll 1}}<td class="template_label">Hit on the Tail</td>{{/rollTotal() roll 1}}		
-		{{#rollBetween() roll 2 4}}<td class="template_label">Hit on the R Leg</td>{{/rollBetween() roll 2 4}}
-		{{#rollBetween() roll 5 7}}<td class="template_label">Hit on the L Leg</td>{{/rollBetween() roll 5 7}}
-		{{#rollBetween() roll 8 11}}<td class="template_label">Hit on the  Abdomen</td>{{/rollBetween() roll 8 11}}
-		{{#rollBetween() roll 12 15}}<td class="template_label">Hit on the Chest</td>{{/rollBetween() roll 12 15}}
-		{{#rollBetween() roll 16 17}}<td class="template_label">Hit on the R Arm</td>{{/rollBetween() roll 16 17}}
-		{{#rollBetween() roll 18 19}}<td class="template_label">Hit on the L Arm</td>{{/rollBetween() roll 18 19}}
-		{{#rollTotal() roll 20}}<td class="template_label">Hit on the Head</td>{{/rollTotal() roll 20}}		
-		</tr>
-	</table>
-</rolltemplate>
-
-<rolltemplate class="sheet-rolltemplate-SprulPaL-Melee">
-	<div class="sheet-HitLoc">
-	<table class="skillRoll" style="border 1px black">
-		<tr><th colspan="2">Sprul-Pa Hit location roll</th></tr>
-		<tr>
-		<td>{{roll}}&nbsp;</td>
-		{{#rollBetween() roll 1 4}}<td class="template_label">Hit on the R Leg</td>{{/rollBetween() roll 1 4}}		
-		{{#rollBetween() roll 5 8}}<td class="template_label">Hit on the L Leg</td>{{/rollBetween() roll 5 8}}
-		{{#rollBetween() roll 9 11}}<td class="template_label">Hit on the  Abdomen</td>{{/rollBetween() roll 9 11}}
-		{{#rollTotal() roll 12}}<td class="template_label">Hit on the Chest</td>{{/rollTotal() roll 12}}
-		{{#rollTotal() roll 13}}<td class="template_label">Hit on the Lower R Arm</td>{{/rollTotal() roll 13}}
-		{{#rollTotal() roll 14}}<td class="template_label">Hit on the Lower L Arm</td>{{/rollTotal() roll 14}}		
-		{{#rollBetween() roll 15 16}}<td class="template_label">Hit on the Upper R Arm</td>{{/rollBetween() roll 15 16}}
-		{{#rollBetween() roll 17 18}}<td class="template_label">Hit on the Upper L Arm</td>{{/rollBetween() roll 17 18}}		
-		{{#rollBetween() roll 19 20}}<td class="template_label">Hit on the Head</td>{{/rollBetween() roll 19 20}}		
-		
-		</tr>
-	</table>
+	<div class="loc_wrapper">		
+		<div class="template_header">Four-legged Hit location roll</div>
+		<div class="template_body" ><span>{{roll}}&nbsp;</span>
+			<span class="template_label">
+				{{#rollBetween() roll 1 2}}Hit on the RH Leg{{/rollBetween() roll 1 2}}
+				{{#rollBetween() roll 3 4}}Hit on the LH Leg{{/rollBetween() roll 3 4}}
+				{{#rollBetween() roll 5 7}}Hit on the  Hind Q{{/rollBetween() roll 5 7}}
+				{{#rollBetween() roll 8 10}}Hit on the Fore Q{{/rollBetween() roll 8 10}}
+				{{#rollBetween() roll 11 13}}Hit on the RF Leg{{/rollBetween() roll 11 13}}
+				{{#rollBetween() roll 14 16}}Hit on the LF Leg{{/rollBetween() roll 14 16}}
+				{{#rollBetween() roll 17 20}}Hit on the Head{{/rollBetween() roll 17 20}}		
+			</span>
+		</div>
 	</div>
 </rolltemplate>
 
+
+
+<rolltemplate class="sheet-rolltemplate-SprulPaL-Melee">
+	<div class="loc_wrapper">
+		<div class="template_header">Sprul-Pa Hit location roll</div>
+		<div class="template_body" ><span>{{roll}}&nbsp;</span>		
+			<span class="template_label">
+				{{#rollBetween() roll 1 4}}Hit on the R Leg{{/rollBetween() roll 1 4}}		
+				{{#rollBetween() roll 5 8}}Hit on the L Leg{{/rollBetween() roll 5 8}}
+				{{#rollBetween() roll 9 11}}Hit on the  Abdomen{{/rollBetween() roll 9 11}}
+				{{#rollTotal() roll 12}}Hit on the Chest{{/rollTotal() roll 12}}
+				{{#rollTotal() roll 13}}Hit on the Lower R Arm{{/rollTotal() roll 13}}
+				{{#rollTotal() roll 14}}Hit on the Lower L Arm{{/rollTotal() roll 14}}		
+				{{#rollBetween() roll 15 16}}Hit on the Upper R Arm{{/rollBetween() roll 15 16}}
+				{{#rollBetween() roll 17 18}}Hit on the Upper L Arm{{/rollBetween() roll 17 18}}		
+				{{#rollBetween() roll 19 20}}Hit on the Head{{/rollBetween() roll 19 20}}		
+			</span>
+		</div>
+	</div>
+</rolltemplate>
+
+<rolltemplate class="sheet-rolltemplate-NewtL-Missle">
+	<div class="loc_wrapper">
+		<div class="template_header">Newtling Missle Hit location roll</div>
+		<div class="template_body" ><span>{{roll}}&nbsp;</span>
+			<span class="template_label">
+				{{#rollTotal() roll 1}}Hit on the Tail{{/rollTotal() roll 1}}		
+				{{#rollBetween() roll 2 4}}Hit on the R Leg{{/rollBetween() roll 2 4}}
+				{{#rollBetween() roll 5 7}}Hit on the L Leg{{/rollBetween() roll 5 7}}
+				{{#rollBetween() roll 8 11}}Hit on the  Abdomen{{/rollBetween() roll 8 11}}
+				{{#rollBetween() roll 12 15}}Hit on the Chest{{/rollBetween() roll 12 15}}
+				{{#rollBetween() roll 16 17}}Hit on the R Arm{{/rollBetween() roll 16 17}}
+				{{#rollBetween() roll 18 19}}Hit on the L Arm{{/rollBetween() roll 18 19}}
+				{{#rollTotal() roll 20}}Hit on the Head{{/rollTotal() roll 20}}		
+			</span>
+		</div>
+	</div>
+</rolltemplate>
+
+
+
 <rolltemplate class="sheet-rolltemplate-NewtL-Melee">
-	<table class="skillRoll" style="border 1px black">
-		<tr><th colspan="2">Newtling Hit location roll</th></tr>
-		<tr>
-		<td>{{roll}}&nbsp;</td>
-		{{#rollBetween() roll 1 2}}<td class="template_label">Hit on the Tail</td>{{/rollBetween() roll 1 2}}		
-		{{#rollBetween() roll 3 5}}<td class="template_label">Hit on the R Leg</td>{{/rollBetween() roll 3 5}}
-		{{#rollBetween() roll 6 8}}<td class="template_label">Hit on the L Leg</td>{{/rollBetween() roll 6 8}}
-		{{#rollBetween() roll 9 11}}<td class="template_label">Hit on the  Abdomen</td>{{/rollBetween() roll 9 11}}
-		{{#rollTotal() roll 12}}<td class="template_label">Hit on the Chest</td>{{/rollTotal() roll 12}}
-		{{#rollBetween() roll 13 15}}<td class="template_label">Hit on the R Arm</td>{{/rollBetween() roll 13 15}}
-		{{#rollBetween() roll 16 18}}<td class="template_label">Hit on the L Arm</td>{{/rollBetween() roll 16 18}}
-		{{#rollBetween() roll 19 20}}<td class="template_label">Hit on the Head</td>{{/rollBetween() roll 19 20}}		
-		</tr>
-	</table>
+	<div class="loc_wrapper">
+		<div class="template_header">Newtling Hit location roll</div>
+		<div class="template_body" ><span>{{roll}}&nbsp;</span>
+			<span class="template_label">
+			{{#rollBetween() roll 1 2}}Hit on the Tail{{/rollBetween() roll 1 2}}		
+			{{#rollBetween() roll 3 5}}Hit on the R Leg{{/rollBetween() roll 3 5}}
+			{{#rollBetween() roll 6 8}}Hit on the L Leg{{/rollBetween() roll 6 8}}
+			{{#rollBetween() roll 9 11}}Hit on the  Abdomen{{/rollBetween() roll 9 11}}
+			{{#rollTotal() roll 12}}Hit on the Chest{{/rollTotal() roll 12}}
+			{{#rollBetween() roll 13 15}}Hit on the R Arm{{/rollBetween() roll 13 15}}
+			{{#rollBetween() roll 16 18}}Hit on the L Arm{{/rollBetween() roll 16 18}}
+			{{#rollBetween() roll 19 20}}Hit on the Head{{/rollBetween() roll 19 20}}
+			</span>
+		</div>
+	</div>
 </rolltemplate>
 
 	<rolltemplate class="sheet-rolltemplate-RockL-Melee">
-		<table class="skillRoll" style="border 1px black">
-			<tr><th colspan="2">Rock Lizard Hit location roll</th></tr>
-			<tr>
-			<td>{{roll}}&nbsp;</td>
-			{{#rollBetween() roll 1 3}}<td class="template_label">Hit on the Tail</td>{{/rollBetween() roll 1 3}}		
-			{{#rollBetween() roll 4 5}}<td class="template_label">Hit on the R Leg</td>{{/rollBetween() roll 4 5}}
-			{{#rollBetween() roll 6 7}}<td class="template_label">Hit on the L Leg</td>{{/rollBetween() roll 6 7}}
-			{{#rollBetween() roll 8 11}}<td class="template_label">Hit on the  HQ</td>{{/rollBetween() roll 8 11}}
-			{{#rollBetween() roll 12 15}}<td class="template_label">Hit on the  FQ</td>{{/rollBetween() roll 12 15}}
-			{{#rollTotal() roll 16}}<td class="template_label">Hit on the R Fore Leg</td>{{/rollTotal() roll 16}}
-			{{#rollTotal() roll 17}}<td class="template_label">Hit on the R Fore Leg</td>{{/rollTotal() roll 17}}
-			{{#rollBetween() roll 18 20}}<td class="template_label">Hit on the Head</td>{{/rollBetween() roll 18 20}}		
-			</tr>
-		</table>
+		<div class="loc_wrapper">
+			<div class="template_header">Rock Lizard Hit location roll</div>
+			<div class="template_body" ><span>{{roll}}&nbsp;</span>
+				<span class="template_label">
+					{{#rollBetween() roll 1 3}}<td class="template_label">Hit on the Tail</td>{{/rollBetween() roll 1 3}}		
+					{{#rollBetween() roll 4 5}}<td class="template_label">Hit on the R Leg</td>{{/rollBetween() roll 4 5}}
+					{{#rollBetween() roll 6 7}}<td class="template_label">Hit on the L Leg</td>{{/rollBetween() roll 6 7}}
+					{{#rollBetween() roll 8 11}}<td class="template_label">Hit on the  HQ</td>{{/rollBetween() roll 8 11}}
+					{{#rollBetween() roll 12 15}}<td class="template_label">Hit on the  FQ</td>{{/rollBetween() roll 12 15}}
+					{{#rollTotal() roll 16}}<td class="template_label">Hit on the R Fore Leg</td>{{/rollTotal() roll 16}}
+					{{#rollTotal() roll 17}}<td class="template_label">Hit on the R Fore Leg</td>{{/rollTotal() roll 17}}
+					{{#rollBetween() roll 18 20}}<td class="template_label">Hit on the Head</td>{{/rollBetween() roll 18 20}}		
+				</span>	
+			</div>
+		</div>
 	</rolltemplate>
 
 
 
 <rolltemplate class="sheet-rolltemplate-WalkL-Melee">
-	<table class="skillRoll" style="border 1px black">
-		<tr><th colspan="2">Walktapus Hit location roll</th></tr>
-		<tr>
-		<td>{{roll}}&nbsp;</td>
-		{{#rollBetween() roll 1 2}}<td class="template_label">Hit on the R Leg</td>{{/rollBetween() roll 1 2}}
-		{{#rollBetween() roll 3 4}}<td class="template_label">Hit on the L Leg</td>{{/rollBetween() roll 3 4}}
-		{{#rollTotal() roll 5}}<td class="template_label">Hit on the  Abdomen</td>{{/rollTotal() roll 5}}
-		{{#rollTotal() roll 6}}<td class="template_label">Hit on the  Chest</td>{{/rollTotal() roll 6}}		
-		{{#rollBetween() roll 7 8}}<td class="template_label">Hit on the R Arm</td>{{/rollBetween() roll 7 8}}
-		{{#rollBetween() roll 9 10}}<td class="template_label">Hit on the L Arm</td>{{/rollBetween() roll 9 10}}
-		{{#rollTotal() roll 11}}<td class="template_label">Hit on the  Tentacle 1</td>{{/rollTotal() roll 11}}
-		{{#rollTotal() roll 12}}<td class="template_label">Hit on the  Tentacle 2</td>{{/rollTotal() roll 12}}				
-		{{#rollTotal() roll 13}}<td class="template_label">Hit on the  Tentacle 3</td>{{/rollTotal() roll 13}}				
-		{{#rollTotal() roll 14}}<td class="template_label">Hit on the  Tentacle 4</td>{{/rollTotal() roll 14}}
-		{{#rollTotal() roll 15}}<td class="template_label">Hit on the  Tentacle 5</td>{{/rollTotal() roll 15}}
-		{{#rollTotal() roll 16}}<td class="template_label">Hit on the  Tentacle 6</td>{{/rollTotal() roll 16}}				
-		{{#rollTotal() roll 17}}<td class="template_label">Hit on the  Tentacle 7</td>{{/rollTotal() roll 17}}				
-		{{#rollTotal() roll 18}}<td class="template_label">Hit on the  Tentacle 8</td>{{/rollTotal() roll 18}}				
-		{{#rollBetween() roll 19 20}}<td class="template_label">Hit on Head</td>{{/rollBetween() roll 19 20}}		
-		</tr>
-	</table>
+	<div class="loc_wrapper">
+		<div class="template_header">Walktapus Hit location roll</div>
+		<div class="template_body" ><span>{{roll}}&nbsp;</span>
+		<span class="template_label">		
+			{{#rollBetween() roll 1 2}}Hit on the R Leg{{/rollBetween() roll 1 2}}
+			{{#rollBetween() roll 3 4}}Hit on the L Leg{{/rollBetween() roll 3 4}}
+			{{#rollTotal() roll 5}}Hit on the  Abdomen{{/rollTotal() roll 5}}
+			{{#rollTotal() roll 6}}Hit on the  Chest{{/rollTotal() roll 6}}		
+			{{#rollBetween() roll 7 8}}Hit on the R Arm{{/rollBetween() roll 7 8}}
+			{{#rollBetween() roll 9 10}}Hit on the L Arm{{/rollBetween() roll 9 10}}
+			{{#rollTotal() roll 11}}Hit on the  Tentacle 1{{/rollTotal() roll 11}}
+			{{#rollTotal() roll 12}}Hit on the  Tentacle 2{{/rollTotal() roll 12}}				
+			{{#rollTotal() roll 13}}Hit on the  Tentacle 3{{/rollTotal() roll 13}}				
+			{{#rollTotal() roll 14}}Hit on the  Tentacle 4{{/rollTotal() roll 14}}
+			{{#rollTotal() roll 15}}Hit on the  Tentacle 5{{/rollTotal() roll 15}}
+			{{#rollTotal() roll 16}}Hit on the  Tentacle 6{{/rollTotal() roll 16}}				
+			{{#rollTotal() roll 17}}Hit on the  Tentacle 7{{/rollTotal() roll 17}}				
+			{{#rollTotal() roll 18}}Hit on the  Tentacle 8{{/rollTotal() roll 18}}				
+			{{#rollBetween() roll 19 20}}Hit on Head{{/rollBetween() roll 19 20}}		
+			</span>
+		</div>
+	</div>
 </rolltemplate>
 
 <rolltemplate class="sheet-rolltemplate-WalkL-Missle">
@@ -9136,25 +9224,307 @@ console.log("111111111 swim_mod2 "+swim_mod);
 </rolltemplate>
 
 <rolltemplate class="sheet-rolltemplate-ScorpL-Melee">
-	<table class="skillRoll" style="border 1px black">
-		<tr><th colspan="2">Scorpion Man Hit location roll</th></tr>
-		<tr>
-	    <td>{{roll}}&nbsp;</td>
-		{{#rollTotal() roll 1}}<td class="template_label">Hit on the  RH Leg</td>{{/rollTotal() roll 1}}		
-		{{#rollTotal() roll 2}}<td class="template_label">Hit on the  RC Leg</td>{{/rollTotal() roll 2}}
-		{{#rollBetween() roll 3 4}}<td class="template_label">Hit on the  RF Leg</td>{{/rollBetween() roll 3 4}}
-		{{#rollTotal() roll 5}}<td class="template_label">Hit on the  LH Leg</td>{{/rollTotal() roll 5}}
-		{{#rollTotal() roll 6}}<td class="template_label">Hit on the  LC Leg</td>{{/rollTotal() roll 6}}		
-		{{#rollBetween() roll 7 8}}<td class="template_label">Hit on the  LF Leg</td>{{/rollBetween() roll 7 8}}		
-		{{#rollBetween() roll 9 10}}<td class="template_label">Hit on the  Tail</td>{{/rollBetween() roll 9 10}}		
-		{{#rollBetween() roll 11 12}}<td class="template_label">Hit on the  Thorax</td>{{/rollBetween() roll 11 12}}		
-		{{#rollBetween() roll 13 14}}<td class="template_label">Hit on the  Chest</td>{{/rollBetween() roll 13 14}}		
-		{{#rollBetween() roll 15 16}}<td class="template_label">Hit on the  R Arm</td>{{/rollBetween() roll 15 16}}		
-		{{#rollBetween() roll 17 18}}<td class="template_label">Hit on the  L Arm</td>{{/rollBetween() roll 17 18}}		
-		{{#rollBetween() roll 19 20}}<td class="template_label">Hit on the  Head</td>{{/rollBetween() roll 19 20}}		
+		<div class="loc_wrapper">
+		<div class="template_header">Scorpion Man Hit location roll</div>
+		<div class="template_body" ><span>{{roll}}&nbsp;</span>		
+			<span class="template_label">			
+			{{#rollTotal() roll 1}}Hit on the  RH Leg{{/rollTotal() roll 1}}		
+			{{#rollTotal() roll 2}}Hit on the  RC Leg{{/rollTotal() roll 2}}
+			{{#rollBetween() roll 3 4}}Hit on the  RF Leg{{/rollBetween() roll 3 4}}
+			{{#rollTotal() roll 5}}Hit on the  LH Leg{{/rollTotal() roll 5}}
+			{{#rollTotal() roll 6}}Hit on the  LC Leg{{/rollTotal() roll 6}}		
+			{{#rollBetween() roll 7 8}}Hit on the  LF Leg{{/rollBetween() roll 7 8}}		
+			{{#rollBetween() roll 9 10}}Hit on the  Tail{{/rollBetween() roll 9 10}}		
+			{{#rollBetween() roll 11 12}}Hit on the  Thorax{{/rollBetween() roll 11 12}}		
+			{{#rollBetween() roll 13 14}}Hit on the  Chest{{/rollBetween() roll 13 14}}		
+			{{#rollBetween() roll 15 16}}Hit on the  R Arm{{/rollBetween() roll 15 16}}		
+			{{#rollBetween() roll 17 18}}Hit on the  L Arm{{/rollBetween() roll 17 18}}		
+			{{#rollBetween() roll 19 20}}Hit on the  Head{{/rollBetween() roll 19 20}}		
+			</span>
+		</div>
+	</div>
+</rolltemplate>
 
-		</tr>
-	</table>
+<rolltemplate class="sheet-rolltemplate-AnkylosaursL-Melee">
+	<div class="skillRoll" style="border 1px black">
+		<div style="text-align:center">Ankylosaurs Hit location roll</div>
+		<div class="result">
+			<span>{{roll}}&nbsp;</span>
+			
+			{{#rollBetween() roll 1 3}}<span class="template_label">Hit on the  Tail</span>{{/rollBetween() roll 1 3}}		
+			{{#rollBetween() roll 4 5}}<span class="template_label">Hit on the  RH Leg</span>{{/rollBetween() roll 4 5}}		
+			{{#rollBetween() roll 6 7}}<span class="template_label">Hit on the  LH Leg</span>{{/rollBetween() roll 6 7}}
+			{{#rollBetween() roll 8 11}}<span class="template_label">Hit on the  HQ</span>{{/rollBetween() roll 8 11}}
+			{{#rollBetween() roll 12 15}}<span class="template_label">Hit on the  FQ Leg</span>{{/rollBetween() roll 12 15}}
+			{{#rollTotal() roll 16}}<span class="template_label">Hit on the  LH Leg</span>{{/rollTotal() roll 16}}
+			{{#rollTotal() roll 17}}<span class="template_label">Hit on the  LH Leg</span>{{/rollTotal() roll 17}}
+			{{#rollBetween() roll 18 20}}<span class="template_label">Hit on the  FQ Leg</span>{{/rollBetween() roll 18 20}}		
+
+		</div>
+	</div>
+</rolltemplate>
+
+
+
+<rolltemplate class="sheet-rolltemplate-BeetleL-Melee">
+	<div class="skillRoll" style="border 1px black">
+		<div style="text-align:center">Beetle Hit location roll</div>
+		<div class="result">
+			<span>{{roll}}&nbsp;</span>
+			{{#rollTotal() roll 1}}<span class="template_label">Hit on the  RH Leg</span>{{/rollTotal() roll 1}}
+			{{#rollTotal() roll 2}}<span class="template_label">Hit on the  RC Leg</span>{{/rollTotal() roll 2}}
+			{{#rollTotal() roll 3}}<span class="template_label">Hit on the  LH Leg</span>{{/rollTotal() roll 3}}			
+			{{#rollTotal() roll 4}}<span class="template_label">Hit on the  LC Leg</span>{{/rollTotal() roll 4}}
+			{{#rollBetween() roll 5 8}}<span class="template_label">Hit on the  Abdomen</span>{{/rollBetween() roll 5 8}}					
+			{{#rollBetween() roll 9 12}}<span class="template_label">Hit on the  Thorax</span>{{/rollBetween() roll 9 12}}
+			{{#rollBetween() roll 13 14}}<span class="template_label">Hit on the  RF Leg</span>{{/rollBetween() roll 13 14}}			
+			{{#rollBetween() roll 15 16}}<span class="template_label">Hit on the  LF Leg</span>{{/rollBetween() roll 15 16}}						
+			{{#rollBetween() roll 17 20}}<span class="template_label">Hit on the  RF Leg</span>{{/rollBetween() roll 17 20}}			
+
+		</div>
+	</div>
+</rolltemplate>
+
+
+
+
+<rolltemplate class="sheet-rolltemplate-BirdsFlyingL-Melee">
+	<div class="skillRoll" style="border 1px black">
+		<div style="text-align:center">Birds,Flying Hit location roll</div>
+		<div class="result">
+			<span>{{roll}}&nbsp;</span>
+			{{#rollTotal() roll 1}}<span class="template_label">Hit on Tail</span>{{/rollTotal() roll 1}}
+			{{#rollBetween() roll 2 4}}<span class="template_label">Hit on the  RH Leg</span>{{/rollBetween() roll 2 4}}		
+			{{#rollBetween() roll 5 7}}<span class="template_label">Hit on the  LH Leg</span>{{/rollBetween() roll 5 7}}		
+			{{#rollBetween() roll 8 9}}<span class="template_label">Hit on the  Abdomen</span>{{/rollBetween() roll 8 9}}
+			{{#rollBetween() roll 10 12}}<span class="template_label">Hit on the  Chest</span>{{/rollBetween() roll 10 12}}
+			{{#rollBetween() roll 13 14}}<span class="template_label">Hit on the  Right Wing</span>{{/rollBetween() roll 13 14}}			
+			{{#rollBetween() roll 15 16}}<span class="template_label">Hit on the  Left Wing</span>{{/rollBetween() roll 15 16}}
+			{{#rollBetween() roll 17 20}}<span class="template_label">Hit on the  Head</span>{{/rollBetween() roll 17 20}}				
+		</div>
+	</div>
+</rolltemplate>
+
+
+<rolltemplate class="sheet-rolltemplate-BirdsRunningL-Melee">
+	<div class="skillRoll" style="border 1px black">
+		<div style="text-align:center">Birds,Running Hit location roll</div>
+		<div class="result">
+			<span>{{roll}}&nbsp;</span>
+			{{#rollBetween() roll 1 4}}<span class="template_label">Hit on the  Right Leg</span>{{/rollBetween() roll 1 4}}		
+			{{#rollBetween() roll 5 8}}<span class="template_label">Hit on the  Left Leg</span>{{/rollBetween() roll 5 8}}		
+			{{#rollBetween() roll 9 10}}<span class="template_label">Hit on the  Abdomen</span>{{/rollBetween() roll 9 10}}
+			{{#rollBetween() roll 11 13}}<span class="template_label">Hit on the  Chest</span>{{/rollBetween() roll 11 13}}
+			{{#rollBetween() roll 14 15}}<span class="template_label">Hit on the  Right Wing</span>{{/rollBetween() roll 14 15}}			
+			{{#rollBetween() roll 16 17}}<span class="template_label">Hit on the  Left Wing</span>{{/rollBetween() roll 16 17}}
+			{{#rollBetween() roll 18 20}}<span class="template_label">Hit on the  Head</span>{{/rollBetween() roll 18 20}}				
+		</div>
+	</div>
+</rolltemplate>
+
+
+<rolltemplate class="sheet-rolltemplate-CentaurL-Melee">
+	<div style="border: 1px solid black ">
+		<div class="template_header" >Centaur Hit location roll</div>
+	    <div class="template_body" ><span>{{roll}}&nbsp;</span>
+			<span class="template_label">
+				{{#rollBetween() roll 1 2}}Hit on the  RH Leg{{/rollBetween() roll 1 2}}
+				{{#rollBetween() roll 3 4}}Hit on the  LH Leg{{/rollBetween() roll 3 4}}
+				{{#rollBetween() roll 5 6}}Hit on the  HQ{{/rollBetween() roll 5 6}}
+				{{#rollBetween() roll 7 8}}Hit on the  FQ{{/rollBetween() roll 7 8}}
+				{{#rollBetween() roll 9 10}}Hit on the RF Leg{{/rollBetween() roll 9 10}}
+				{{#rollBetween() roll 11 12}}Hit on the  LF Leg{{/rollBetween() roll 11 12}}		
+				{{#rollBetween() roll 13 14}}Hit on the  Chest{{/rollBetween() roll 13 14}}				
+				{{#rollBetween() roll 15 16}}Hit on the  R Arm{{/rollBetween() roll 15 16}}				
+				{{#rollBetween() roll 17 18}}Hit on the  L Arm{{/rollBetween() roll 17 18}}						
+				{{#rollBetween() roll 19 20}}Hit on the  Head{{/rollBetween() roll 19 20}}
+			</span>	
+		</div>
+	</div>
+</rolltemplate>
+
+
+
+<rolltemplate class="sheet-rolltemplate-DragonL-Melee">
+	<div style="border: 1px solid black ">
+		<div class="template_header" >Dragon/Manticore Hit location roll</div>
+	    <div class="template_body" ><span>{{roll}}&nbsp;</span>
+			<span class="template_label">
+				{{#rollBetween() roll 1 2}}Hit on the  Tail{{/rollBetween() roll 1 2}}
+				{{#rollBetween() roll 3 4}}Hit on the  RH Leg{{/rollBetween() roll 3 4}}
+				{{#rollBetween() roll 5 6}}Hit on the  LH Leg{{/rollBetween() roll 5 6}}
+				{{#rollBetween() roll 7 8}}Hit on the  HQ{{/rollBetween() roll 7 8}}
+				{{#rollBetween() roll 9 10}}Hit on the FQ{{/rollBetween() roll 9 10}}
+				{{#rollBetween() roll 11 12}}Hit on the  R Wing{{/rollBetween() roll 11 12}}		
+				{{#rollBetween() roll 13 14}}Hit on the  L Wing{{/rollBetween() roll 13 14}}				
+				{{#rollBetween() roll 15 16}}Hit on the  RF Leg{{/rollBetween() roll 15 16}}				
+				{{#rollBetween() roll 17 18}}Hit on the  LF Leg{{/rollBetween() roll 17 18}}						
+				{{#rollBetween() roll 19 20}}Hit on the  Head{{/rollBetween() roll 19 20}}
+			</span>	
+		</div>
+	</div>
+</rolltemplate>
+
+
+
+<rolltemplate class="sheet-rolltemplate-Dragonsnail1HL-Melee">
+	<div style="border: 1px solid black ">
+		<div class="template_header" >Dragonsnail 1 head Hit location roll</div>
+	    <div class="template_body" ><span>{{roll}}&nbsp;</span>
+			<span class="template_label">
+				{{#rollBetween() roll 1 8}}Hit on the  Shell{{/rollBetween() roll 1 8}}
+				{{#rollBetween() roll 9 14}}Hit on the  Forebody{{/rollBetween() roll 9 14}}
+				{{#rollBetween() roll 15 20}}Hit on the  Head{{/rollBetween() roll 15 20}}
+			</span>	
+		</div>
+	</div>
+</rolltemplate>
+
+<rolltemplate class="sheet-rolltemplate-Dragonsnail2HL-Melee">
+	<div style="border: 1px solid black ">
+		<div class="template_header" >Dragonsnail 2 head Hit location roll</div>
+	    <div class="template_body" ><span>{{roll}}&nbsp;</span>
+			<span class="template_label">
+				{{#rollBetween() roll 1 7}}Hit on the  Shell{{/rollBetween() roll 1 7}}
+				{{#rollBetween() roll 8 12}}Hit on the  Forebody{{/rollBetween() roll 8 12}}
+				{{#rollBetween() roll 13 16}}Hit on the  R Head{{/rollBetween() roll 13 16}}
+				{{#rollBetween() roll 17 20}}Hit on the  L Head{{/rollBetween() roll 17 20}}				
+			</span>	
+		</div>
+	</div>
+</rolltemplate>
+
+
+
+<rolltemplate class="sheet-rolltemplate-4leggedwingsL-Melee">
+	<div style="border: 1px solid black ">
+		<div class="template_header" >Four-legged, Winged Hit location roll</div>
+	    <div class="template_body" ><span>{{roll}}&nbsp;</span>
+			<span class="template_label">
+				{{#rollBetween() roll 1 3}}Hit on the  RH Leg{{/rollBetween() roll 1 3}}
+				{{#rollBetween() roll 4 6}}Hit on the  LH Leg{{/rollBetween() roll 4 6}}
+				{{#rollBetween() roll 7 9}}Hit on the  HQ{{/rollBetween() roll 7 9}}
+				{{#rollTotal() roll 10}}Hit on the  FQ{{/rollTotal() roll 10}}				
+				{{#rollBetween() roll 11 12}}Hit on the R Wing{{/rollBetween() roll 11 12}}
+				{{#rollBetween() roll 13 14}}Hit on the L Wing{{/rollBetween() roll 13 14}}
+				{{#rollBetween() roll 15 16}}Hit on the RF Leg{{/rollBetween() roll 15 16}}
+				{{#rollBetween() roll 17 18}}Hit on the  LF Leg{{/rollBetween() roll 17 18}}		
+				{{#rollBetween() roll 19 20}}Hit on the  Head{{/rollBetween() roll 19 20}}
+			</span>	
+		</div>
+	</div>
+</rolltemplate>
+
+
+
+
+<rolltemplate class="sheet-rolltemplate-harpiesL-Melee">
+	<div style="border: 1px solid black ">
+		<div class="template_header" >Harpy Hit location roll</div>
+	    <div class="template_body" ><span>{{roll}}&nbsp;</span>
+			<span class="template_label">
+				{{#rollBetween() roll 1 2}}Hit on the  R Leg{{/rollBetween() roll 1 2}}
+				{{#rollBetween() roll 3 4}}Hit on the  L Leg{{/rollBetween() roll 3 4}}
+				{{#rollBetween() roll 5 7}}Hit on the  Abdomen{{/rollBetween() roll 5 7}}
+				{{#rollBetween() roll 8 9}}Hit on the  Chest{{/rollBetween() roll 8 9}}				
+				{{#rollBetween() roll 10 13}}Hit on the R Wing{{/rollBetween() roll 10 13}}
+				{{#rollBetween() roll 14 17}}Hit on the L Wing{{/rollBetween() roll 14 17}}
+				{{#rollBetween() roll 18 20}}Hit on the  Head{{/rollBetween() roll 18 20}}
+			</span>	
+		</div>
+	</div>
+</rolltemplate>
+
+<rolltemplate class="sheet-rolltemplate-mammothL-Melee">
+	<div style="border: 1px solid black ">
+		<div class="template_header" >Mammoth/Mastadon Hit location roll</div>
+	    <div class="template_body" ><span>{{roll}}&nbsp;</span>
+			<span class="template_label">
+				{{#rollBetween() roll 1 2}}Hit on the  RH Leg{{/rollBetween() roll 1 2}}
+				{{#rollBetween() roll 3 4}}Hit on the  LH Leg{{/rollBetween() roll 3 4}}
+				{{#rollBetween() roll 5 7}}Hit on the  HQ{{/rollBetween() roll 5 7}}
+				{{#rollBetween() roll 8 10}}Hit on the  FQ{{/rollBetween() roll 8 10}}
+				{{#rollBetween() roll 11 13}}Hit on the RF Leg{{/rollBetween() roll 11 13}}
+				{{#rollBetween() roll 14 16}}Hit on the  LF Leg{{/rollBetween() roll 14 16}}	
+				{{#rollTotal() roll 17}}Hit on the  Trunk{{/rollTotal() roll 17}}								
+				{{#rollBetween() roll 18 20}}Hit on the  Head{{/rollBetween() roll 18 20}}
+			</span>	
+		</div>
+	</div>
+</rolltemplate>
+
+
+
+<rolltemplate class="sheet-rolltemplate-serpentL-Melee">
+	<div style="border: 1px solid black ">
+		<div class="template_header" >Serpent Hit location roll</div>
+	    <div class="template_body" ><span>{{roll}}&nbsp;</span>
+			<span class="template_label">
+				{{#rollBetween() roll 1 6}}Hit on the Tail{{/rollBetween() roll 1 6}}
+				{{#rollBetween() roll 7 14}}Hit on the  Body{{/rollBetween() roll 7 14}}
+				{{#rollBetween() roll 15 20}}Hit on the Head{{/rollBetween() roll 15 20}}
+			</span>	
+		</div>
+	</div>
+</rolltemplate>
+
+
+<rolltemplate class="sheet-rolltemplate-serpentWingsL-Melee">
+	<div style="border: 1px solid black ">
+		<div class="template_header" >Serpent , Winged Hit location roll</div>
+	    <div class="template_body" ><span>{{roll}}&nbsp;</span>
+			<span class="template_label">
+				{{#rollBetween() roll 1 4}}Hit on the Tail{{/rollBetween() roll 1 4}}
+				{{#rollBetween() roll 5 8}}Hit on the  Abdomen{{/rollBetween() roll 5 8}}
+				{{#rollBetween() roll 9 12}}Hit on the  Chest{{/rollBetween() roll 9 12}}	
+				{{#rollBetween() roll 13 14}}Hit on the R Wing{{/rollBetween() roll 13 14}}
+				{{#rollBetween() roll 15 16}}Hit on the L Wing{{/rollBetween() roll 15 16}}				
+				{{#rollBetween() roll 17 20}}Hit on the Head{{/rollBetween() roll 17 20}}
+			</span>	
+		</div>
+	</div>
+</rolltemplate>
+
+
+
+<rolltemplate class="sheet-rolltemplate-spiderL-Melee">
+	<div style="border: 1px solid black ">
+		<div class="template_header" >Spider, Giant Hit location roll</div>
+	    <div class="template_body" ><span>{{roll}}&nbsp;</span>
+			<span class="template_label">
+				{{#rollTotal() roll 1}}Hit on the  RH Leg{{/rollTotal() roll 1}}				
+				{{#rollTotal() roll 2}}Hit on the  LH Leg{{/rollTotal() roll 2}}				
+				{{#rollTotal() roll 3}}Hit on the  RCR Leg{{/rollTotal() roll 3}}				
+				{{#rollTotal() roll 4}}Hit on the  LCR Leg{{/rollTotal() roll 4}}
+				{{#rollBetween() roll 5 8}}Hit on the Abdomen{{/rollBetween() roll 5 8}}
+				{{#rollBetween() roll 9 10}}Hit on the RCF Leg{{/rollBetween() roll 9 10}}
+				{{#rollBetween() roll 11 12}}Hit on the LCF Leg{{/rollBetween() roll 11 12}}
+				{{#rollBetween() roll 13 14}}Hit on the RF Leg{{/rollBetween() roll 13 14}}
+				{{#rollBetween() roll 15 16}}Hit on the LF leg{{/rollBetween() roll 15 16}}
+				{{#rollBetween() roll 17 20}}Hit on the Head{{/rollBetween() roll 17 20}}				
+			</span>	
+		</div>
+	</div>
+</rolltemplate>
+
+
+
+<rolltemplate class="sheet-rolltemplate-wyvernL-Melee">
+	<div style="border: 1px solid black ">
+		<div class="template_header" >Wyvern Hit location roll</div>
+	    <div class="template_body" ><span>{{roll}}&nbsp;</span>
+			<span class="template_label">
+				{{#rollTotal() roll 1}}Hit on the  Tail{{/rollTotal() roll 1}}				
+				{{#rollBetween() roll 2 4}}Hit on the R Leg{{/rollBetween() roll 2 4}}				
+				{{#rollBetween() roll 5 7}}Hit on the L Leg{{/rollBetween() roll 5 7}}
+				{{#rollBetween() roll 8 9}}Hit on the Abdomen{{/rollBetween() roll 8 9}}
+				{{#rollBetween() roll 10 12}}Hit on the Chest{{/rollBetween() roll 10 12}}
+				{{#rollBetween() roll 13 14}}Hit on the R Wing{{/rollBetween() roll 13 14}}
+				{{#rollBetween() roll 15 16}}Hit on the L Wing{{/rollBetween() roll 15 16}}
+				{{#rollBetween() roll 17 20}}Hit on the Head{{/rollBetween() roll 17 20}}				
+			</span>	
+		</div>
+	</div>
 </rolltemplate>
 
 


### PR DESCRIPTION
## Changes / Comments

Tweaked CSS so skill names can be read when modifying repeating sections

Added fields for coinage on the 2nd tab.  Currently this does not effect encumbrance.

I added a bunch of new hit locations including all the location tables  at the start of the bestiary. 


Added fields for individual weapons skill modifiers or occasion such as Bladesharp cast as per request  
[https://app.roll20.net/forum/post/7170823/runequest-roleplaying-in-glorantha-feature-request-weapons-skill-mod/?pageforid=7170823#post-7170823](url)

I also added checkboxes with the heading Spells Cast for Vigor, Strength  and Glamour they handle all the fudges listed under the spells,such as skill category  increases, damage die steps and max enc.So don't add the stat bonuses in the mod fields of the characteristics.The bonuses are automatically added to stat rolls.A message appears under the stats  reminding you to add the bonus when doing resistance table rolls.  There is probably better way of doing this but it would mean changing a lot of sheetworkers and/or adding a whole new column of mod fields.

Removed a lot of tables in Hit location roll templates


## Roll20 Requests

.