### PR TITLE
Minor fixes to Wraith20 and new Werewolf 2e

### DIFF
--- a/CWOD-Wr20/translation.json
+++ b/CWOD-Wr20/translation.json
@@ -88,5 +88,6 @@
 	"thorns-u":"Thorns",
 	"angst-u":"Angst",
 	"psychewillpower-u":"Psyche Willpower",
-	"darkpassions-u":"Dark Passions"
+	"darkpassions-u":"Dark Passions",
+	"persuasion-u":"Persuasion"
 }

--- a/WerewolfTheForsaken2e/WerewolfTheForsaken2e.css
+++ b/WerewolfTheForsaken2e/WerewolfTheForsaken2e.css
@@ -271,6 +271,8 @@ input.sheet-blank:checked ~ input.sheet-empty
 	border-bottom: 1px black solid;
 	height: 1em;
 	width: 3em !important;
+	-moz-appearance: textfield;
+	padding: 0px;
 }
 .charsheet .sheet-hbspace{
 	display: block;

--- a/WerewolfTheForsaken2e/WerewolfTheForsaken2e.html
+++ b/WerewolfTheForsaken2e/WerewolfTheForsaken2e.html
@@ -1383,7 +1383,7 @@
     </fieldset>
 </div><div class="sheet-col">
     <h3>Rites</h3>
-    <fieldset class="repeating-rites">
+    <fieldset class="repeating_rites">
         <div class="sheet-gift">
         <h4>Name:</h4>
         <input type="text" name="attr_ritename">

--- a/WerewolfTheForsaken2e/WerewolfTheForsaken2e.html
+++ b/WerewolfTheForsaken2e/WerewolfTheForsaken2e.html
@@ -1072,7 +1072,7 @@
     <h4>Stamina(+2):</h4>
     <input type="number" name="attr_urshulstamina">
     <br>
-    <h4>Manipulation(+1):</h4>
+    <h4>Manipulation(-1):</h4>
     <input type="number" name="attr_urshulmanipulation">
     <br>
     </div>
@@ -1114,7 +1114,7 @@
     <h4>Stamina(+1):</h4>
     <input type="number" name="attr_urhanstamina">
     <br>
-    <h4>Manipulation(+1):</h4>
+    <h4>Manipulation(-1):</h4>
     <input type="number" name="attr_urhanmanipulation">
     <br>
     </div>

--- a/WerewolfTheForsaken2e/WerewolfTheForsaken2e.html
+++ b/WerewolfTheForsaken2e/WerewolfTheForsaken2e.html
@@ -1390,12 +1390,14 @@
 
         <input type="checkbox" class="sheet-expander sheet-facets" name="attr_giftexpander">
         <span></span>
-        <select name="attr_ritetype">
-    <option value="wolf">Wolf</option>
-    <option value="pack">Pack</option></select><div class="sheet-facets">
-    <div class="sheet-skillnote">Details</div>
-    <textarea name="attr_ritedetails"></textarea>
-</div>
+            <div class="sheet-facets">
+                <select name="attr_ritetype">
+                    <option value="wolf">Wolf</option>
+                    <option value="pack">Pack</option>
+                </select>
+                <div class="sheet-skillnote">Details</div>
+                <textarea name="attr_ritedetails"></textarea>
+            </div>
     </div>
     </fieldset>
 </div>


### PR DESCRIPTION
## Changes / Comments
- Fixed the repeating rites section on the Werewolf sheet(accidentally wrote "repeating-" instead of "repeating_")
- Moved Rites type selector into the collapsing section of the repeating rite fieldset, to preserve space
- Fixed the number inputs in Firefox on the Werewolf sheet
- Fixed the Manipulation labels on 2 forms for the Werewolf sheet(put +1 instead of -1)
- Adding Persuasion to the translation files for the Wraith sheet