### PR TITLE
7th Sea 2e update 3-7-19

### DIFF
--- a/7th Sea 2e/7th Sea 2e.html
+++ b/7th Sea 2e/7th Sea 2e.html
@@ -1,54 +1,70 @@
+
 <div class="sheet-topbar">
     <table style="width:830px;">
         <tr>
-            <td>Name</td>
+            <td><b>NAME</b></td>
             <td><input type="text" class="sheet-heading_1" name="attr_character_name"/></td>
-            <td>Nation</td>
+            <td><b>NATION</b></td>
             <td><input type="text" class="sheet-text_1" name="attr_nation"/></td>
             <th rowspan="2">
-            <!-- ==== hero Tracker ==== -->
+            <!-- ==== hero Point Up/Down ==== -->
                 <div>
                     <input type="checkbox" class="sheet-heroup" name="attr_hero_up" value="1"><span></span><br>
                     <input type="checkbox" class="sheet-herodown" name="attr_hero_down" value="1"><span></span>
                 </div>
             </th>
+            <!-- ==== hero Points ==== -->
             <th rowspan="2">
-                <input type="number" class="sheet-hero" name="attr_hero" value="0" checked/>
+                 <div class="sheet-hero">
+                    <input type="radio" class="sheet-hero sheet-zerohero" name="attr_hero" value="0" checked/>
+                    <input type="radio" class="sheet-hero sheet-onehero" name="attr_hero" value="1" />
+                    <input type="radio" class="sheet-hero sheet-twohero" name="attr_hero" value="2" />
+                    <input type="radio" class="sheet-hero sheet-threehero" name="attr_hero" value="3" />
+                    <input type="radio" class="sheet-hero sheet-fourhero" name="attr_hero" value="4" />
+                    <input type="radio" class="sheet-hero sheet-fivehero" name="attr_hero" value="5" />
+                    <input type="radio" class="sheet-hero sheet-sixhero" name="attr_hero" value="6" />
+                    <input type="radio" class="sheet-hero sheet-sevenhero" name="attr_hero" value="7" />
+                    <input type="radio" class="sheet-hero sheet-eighthero" name="attr_hero" value="8" />
+                    <input type="radio" class="sheet-hero sheet-ninehero" name="attr_hero" value="9" />
+                    <span class="sheet-hero sheet-zerohero"></span>
+                    <span class="sheet-hero sheet-onehero"></span>
+                    <span class="sheet-hero sheet-twohero"></span>
+                    <span class="sheet-hero sheet-threehero"></span>
+                    <span class="sheet-hero sheet-fourhero"></span>
+                    <span class="sheet-hero sheet-fivehero"></span>
+                    <span class="sheet-hero sheet-sixhero"></span>
+                    <span class="sheet-hero sheet-sevenhero"></span>
+                    <span class="sheet-hero sheet-eighthero"></span>
+                    <span class="sheet-hero sheet-ninehero"></span>
+                </div>
             </th>
         </tr>
         <tr>
-            <td>Player</td>
+            <td><b>PLAYER</b></td>
             <td><input type="text" class="sheet-text_1" name="attr_player_name"/></td>
-            <td>Religion</td>
+            <td><b>RELIGION</b></td>
             <td><input type="text" class="sheet-text_1" name="attr_Religion"/></td>
         </tr>
     </table>
-    <br>
-    <!-- -->
-    <table style="width:810px;">
+        <!-- Wounds -->
+        <!-- Wounds -->
+    <table align="center" style="width:810px;">
         <tr>
-            <th><input type="checkbox" class="sheet-wound" name="attr_wound1" value="1"/><span></span></th>
-            <th><input type="checkbox" class="sheet-wound" name="attr_wound2" value="2"/><span></span></th>
-            <th><input type="checkbox" class="sheet-wound" name="attr_wound3" value="3"/><span></span></th>
-            <th><input type="checkbox" class="sheet-wound" name="attr_wound4" value="4"/><span></span></th>
-            <th><input type="checkbox" class="sheet-wound sheet-drama" name="attr_wound5" value="5"/><span></span></th>
-            <th><input type="checkbox" class="sheet-wound" name="attr_wound6" value="6"/><span></span></th>
-            <th><input type="checkbox" class="sheet-wound" name="attr_wound7" value="7"/><span></span></th>
-            <th><input type="checkbox" class="sheet-wound" name="attr_wound8" value="8"/><span></span></th>
-            <th><input type="checkbox" class="sheet-wound" name="attr_wound9" value="9"/><span></span></th>
-            <th><input type="checkbox" class="sheet-wound sheet-drama" name="attr_wound10" value="10"/><span></span></th>
-            <th><input type="checkbox" class="sheet-wound" name="attr_wound11" value="11"/><span></span></th>
-            <th><input type="checkbox" class="sheet-wound" name="attr_wound12" value="12"/><span></span></th>
-            <th><input type="checkbox" class="sheet-wound" name="attr_wound13" value="13"/><span></span></th>
-            <th><input type="checkbox" class="sheet-wound" name="attr_wound14" value="14"/><span></span></th>
-            <th><input type="checkbox" class="sheet-wound sheet-drama" name="attr_wound" value="15"/><span></span></th>
-            <th><input type="checkbox" class="sheet-wound" name="attr_wound16" value="16"/><span></span></th>
-            <th><input type="checkbox" class="sheet-wound" name="attr_wound17" value="17"/><span></span></th>
-            <th><input type="checkbox" class="sheet-wound" name="attr_wound18" value="18"/><span></span></th>
-            <th><input type="checkbox" class="sheet-wound" name="attr_wound19" value="19"/><span></span></th>
-            <th><input type="checkbox" class="sheet-wound sheet-drama" name="attr_wound20" value="20"/><span></span></th>
+            <td><label>Wounds</label>
+            <input type="number" class="sheet-text_1" name="attr_wounds" value="0"/> out of <input type="number" class="sheet-text_1" name="attr_wounds_max" value="20" /></td>
+            <td><label>Dramatic Wounds</label>
+              <input type="number" class="sheet-text_1" name="attr_dramatic_wounds" value="0"/> out of <input type="number" class="sheet-text_1" name="attr_dramatic_wounds_max" value="4" />
+              <!-- These attributes are used for the "health" bar - they count down from the max --
+              <input type="number" class="sheet-hidden" name="attr_health" value="@{wounds_max}-@{wounds}"/>
+              <input type="number" class="sheet-hidden" name="attr_health_max" value="@{wounds_max}"/>
+              <input type="number" class="sheet-hidden" name="attr_dramatic_health" value="@{dramatic_wounds_max}-@{dramatic_wounds}"/>
+              <input type="number" class="sheet-hidden" name="attr_dramatic_health_max" value="@{dramatic_wounds_max}"/>
+-->
+            </td>
         </tr>
     </table>
+
+        
 </div>
 <br>
 <input type="radio" class="sheet-tab sheet-tab1" name="attr_core-tab" value="1" title="Traits and Skills" checked="checked"/> 
@@ -57,89 +73,92 @@
 <span class="sheet-tab sheet-tab2" style='line-height: 20px;'>Details</span>
 <input type="radio" class="sheet-tab sheet-tab3" name="attr_core-tab" value="3" title="Story" /> 
 <span class="sheet-tab sheet-tab3" style='line-height: 20px;'><div class="sheet-smaller">Story</div></span>
+<input type="radio" class="sheet-tab sheet-tab4" name="attr_core-tab" value="4" title="Ship" /> 
+<span class="sheet-tab sheet-tab4" style='line-height: 20px;'><div class="sheet-smaller">Ship</div></span>
 <input type="radio" class="sheet-tab sheet-tab99" name="attr_core-tab" value="99" title="All" />
 <span class="sheet-tab sheet-tab99" style='line-height: 20px;'>All</span>  
-<button type="roll" class="sheet-button_dice" name="roll_3_more" value="&{template:trait} {{name= Plus 3 Dice }} {{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}">Plus 3</button>
-<button type="roll" class="sheet-button_dice" name="roll_4_more" value="&{template:trait} {{name= Plus 4 Dice }} {{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}">Plus 4</button>
 <br><br>
 <div class="sheet-section sheet-section-1">
-	<div class='sheet-2colrow'>
+    <br></br>
+    <div class='sheet-2colrow'>
     	<div class='sheet-col'>
-            <img src="http://i.imgur.com/975VTit.gif" style="max-height: 100px;" />
+            <img src=<a href="https://imgur.com/z3tKWhV"><img src="https://i.imgur.com/z3tKWhV.png" title="source: imgur.com"/></a>
             <h4>Traits</h4>
+            <br>
             <table>
                 <tr>
-                    <td><button type="roll" class="sheet-trait_button" name="roll_brawn" value="&{template:trait} {{name= Brawn}} @{brawn}">Brawn</button></td>
+                    <td><button type="roll" class="sheet-trait_button" name="roll_brawn" value="/em takes a Brawn Risk\n/r (@{brawn}-?{penalty?|0}+?{bonus?|0})d@{d10}sd">Brawn</button></td>
                     <th>
                         <input type="radio" class="sheet-normal sheet-zip" name="attr_brawn" value="0"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_brawn" value="{{1= [[1d@{d@{d10}}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_brawn" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_brawn" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_brawn" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_brawn" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_brawn" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_brawn" value="2" checked/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_brawn" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_brawn" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_brawn" value="5"/><span></span>
                     </th>
                 </tr>
                 <tr>
-                    <td><button type="roll" class="sheet-trait_button" name="roll_finesse" value="&{template:trait} {{name= Finesse}} @{finesse}">Finesse</button></td>
+                    <td><button type="roll" class="sheet-trait_button" name="roll_finesse" value="/em takes a Finesse Risk\n/r (@{finesse}-?{penalty?|0}+?{bonus?|0})d@{d10}sd">Finesse</button></td>
                     <th>
                         <input type="radio" class="sheet-normal sheet-zip" name="attr_finesse" value="0"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_finesse" value="{{1= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_finesse" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_finesse" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_finesse" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_finesse" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_finesse" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_finesse" value="2" checked/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_finesse" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_finesse" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_finesse" value="5"/><span></span>
                     </th>
                 </tr>
                 <tr>
-                    <td><button type="roll" class="sheet-trait_button" name="roll_Resolve" value="&{template:trait} {{name= Resolve}} @{resolve}">Resolve</button></td>
+                    <td><button type="roll" class="sheet-trait_button" name="roll_resolve" value="/em takes a Resolve Risk\n/r (@{resolve}-?{penalty?|0}+?{bonus?|0})d@{d10}sd">Resolve</button></td>
                     <th>
                         <input type="radio" class="sheet-normal sheet-zip" name="attr_resolve" value="0"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_resolve" value="{{1= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_resolve" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_resolve" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_resolve" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_resolve" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_resolve" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_resolve" value="2" checked/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_resolve" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_resolve" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_resolve" value="5"/><span></span>
                     </th>
                 </tr>
                 <tr>
-                    <td><button type="roll" class="sheet-trait_button" name="roll_Wits" value="&{template:trait} {{name= Wits}} @{wits}">Wits</button></td>
+                    <td><button type="roll" class="sheet-trait_button" name="roll_wits" value="/em takes a Wits Risk\n/r (@{wits}-?{penalty?|0}+?{bonus?|0})d@{d10}sd">Wits</button></td>
                     <th>
                         <input type="radio" class="sheet-normal sheet-zip" name="attr_wits" value="0"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_wits" value="{{1= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_wits" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_wits" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_wits" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_wits" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_wits" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_wits" value="2" checked/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_wits" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_wits" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_wits" value="5"/><span></span>
                     </th>
                 </tr>
                 <tr>
-                    <td><button type="roll" class="sheet-trait_button" name="roll_Panache" value="&{template:trait} {{name= Panache}} @{panache}">Panache</button></td>
+                    <td><button type="roll" class="sheet-trait_button" name="roll_panache" value="/em takes a Panache Risk\n/r (@{panache}-?{penalty?|0}+?{bonus?|0})d@{d10}sd">Panache</button></td>
                     <th>
                         <input type="radio" class="sheet-normal sheet-zip" name="attr_panache" value="0"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_panache" value="{{1= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_panache" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_panache" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_panache" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_panache" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_panache" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_panache" value="2" checked/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_panache" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_panache" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_panache" value="5"/><span></span>
                     </th>
                     </th>
                 </tr>
             </table>
+            <br>
+            <br>
             <h4>Advantages</h4>
+            <br>
             <table>
                 <tr>
                     <td style="width:60px"></td>
-                    <td style="width:210px">Name</td>
-                    <td style="width:60px">Cost</td>
+                    <td style="width:270px"></td>
                     <th style="width:60px">*</th>
                 </tr>
             </table>
             <fieldset class="repeating_advantage">
                 <table>
                     <tr>
-                        <td style="width:60px"><button type="roll" class="sheet-button_show" name="roll_advantage_show" value="&{template:show} {{name= @{advantage_name} }} {{cost= @{advantage_cost} }} {{note= @{advantage_notes} }}">Show</button></td>
-                        <td style="width:210px"><input type="text" class="sheet-text_1" name="attr_advantage_name"/></td>
-                        <td style="width:60px"><input type="number" class="sheet-number_1" name="attr_advantage_cost"/></td>
+                        <td style="width:60px"><button type="roll" class="sheet-button_show" name="roll_advantage_show" value="&{template:show} {{name= @{advantage_name} }} {{note= @{advantage_notes} }}">Show</button></td>
+                        <td style="width:270px"><input type="text" class="sheet-text_1" name="attr_advantage_name"/></td>
                         <th style="width:60px"><input type="checkbox" class="sheet-checkbox_3" name="attr_advantage_hider" value="1" checked/><span></span></th>
                     </tr>
                     <tr>
@@ -154,468 +173,417 @@
             </fieldset>
 		</div>
         <div class='sheet-col'>
-            <h4>d10 Type</h4>
-            <input type="radio" class="sheet-" name="attr_d10" value="10" checked/><span>Normal</span>
-            <input type="radio" class="sheet-" name="attr_d10" value="10!"/><span>Exploding</span>
+            <h4>Dice</h4>
+            <p></p>
+            <input type="radio" class="sheet-" name="attr_d10" value="10" checked/><span>&nbsp;Normal&nbsp;&nbsp;&nbsp;&nbsp;</span>
+            <input type="radio" class="sheet-" name="attr_d10" value="10!"/><span>&nbsp;Exploding&nbsp;&nbsp;&nbsp;</span>
+            <button type="roll" class="sheet-skill_button" name="roll_1_more" value="/roll 1d@{d10}">Reroll</button>
+            <p></p>
+            <button type="roll" class="sheet-button_dice" name="roll_2_more" value="/roll 2d@{d10}">Plus 2 Dice</button>
+            <button type="roll" class="sheet-button_dice" name="roll_3_more" value="/roll 3d@{d10}">Plus 3 Dice</button>
+            <button type="roll" class="sheet-button_dice" name="roll_4_more" value="/roll 4d@{d10}">Plus 4 Dice</button>
+            <br>
+            <br>
             <h4>Skills</h4>
             <table>
                 <tr>
                     <th></th>
-                    <th class="sheet-small">Trait</th>
-                    <th class="sheet-small">Rank</th>
-                    <th class="sheet-small">Extra<br>Die</th>
+                    <th class="sheet-small">TRAIT</th>
+                    <th class="sheet-small">RANK</th>
                     <th class="sheet-small">Reroll</th>
                 </tr>
                 <tr>
-                    <td><button type="roll" class="sheet-skill_button" name="roll_Aim" value="&{template:skill} {{name= Aim}} @{aim}  @{aim_boost} @{aim_reroll} \\n @{aim_trait}">Aim</button></td>
+                    <td><button type="roll" class="sheet-skill_button" name="roll_Aim" value="/em takes an Aim Risk\n/roll { (@{aim}+@{aim_trait}-?{penalty?|0}+?{bonus?|0})d@{d10}sd, @{aim_reroll}d@{d10}  }">Aim</button></td>
                     <td>
                         <select class="sheet-select_1" name="attr_aim_trait" >
                             <option value="">None</option>
-                            <option value="&{template:trait} {{name= Brawn}} @{brawn}">Brawn</option>
-                            <option value="&{template:trait} {{name= Finesse}} @{finesse}">Finesse</option>
-                            <option value="&{template:trait} {{name= Resolve}} @{resolve}">Resolve</option>
-                            <option value="&{template:trait} {{name= Wits}} @{wits}">Wits</option>
-                            <option value="&{template:trait} {{name= Panache}} @{panache}">Panache</option>
+                            <option value="@{brawn}">Brawn</option>
+                            <option value="@{finesse}">Finesse</option>
+                            <option value="@{resolve}">Resolve</option>
+                            <option value="@{wits}">Wits</option>
+                            <option value="@{panache}">Panache</option>
                         </select>
                     </td>
                     <th>
                         <input type="radio" class="sheet-normal sheet-zip" name="attr_aim" value="0" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_aim" value="{{1= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_aim" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_aim" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_aim" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_aim" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_aim" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_aim" value="2"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_aim" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_aim" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_aim" value="5"/><span></span>
                     </th>
-                    <th><input type="checkbox" class="sheet-checkbox_1" name="attr_aim_boost" value="{{boost= [[1d@{d10}]]}}" /><span></span></th>
-                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_aim_reroll" value="{{reroll= [[1d@{d10}]]}}" /><span></span></th>
+                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_aim_reroll" value="1" /><span></span></th>
                 </tr>
                 <tr>
-                    <td><button type="roll" class="sheet-skill_button" name="roll_athletics" value="&{template:skill} {{name= Athletics}} @{athletics} @{athletics_reroll} @{athletics_boost} \\n @{athletics_trait} ">Athletics</button></td>
+                    <td><button type="roll" class="sheet-skill_button" name="roll_athletics" value="/em takes an Athletics Risk\n/roll { (@{athletics}+@{athletics_trait}-?{penalty?|0}+?{bonus?|0})d@{d10}sd, @{athletics_reroll}d@{d10}  }">Athletics</button></td>
                     <td>
                         <select class="sheet-select_1" name="attr_athletics_trait" >
                             <option value="">None</option>
-                            <option value="&{template:trait} {{name= Brawn}} @{brawn}">Brawn</option>
-                            <option value="&{template:trait} {{name= Finesse}} @{finesse}">Finesse</option>
-                            <option value="&{template:trait} {{name= Resolve}} @{resolve}">Resolve</option>
-                            <option value="&{template:trait} {{name= Wits}} @{wits}">Wits</option>
-                            <option value="&{template:trait} {{name= Panache}} @{panache}">Panache</option>
+                            <option value="@{brawn}">Brawn</option>
+                            <option value="@{finesse}">Finesse</option>
+                            <option value="@{resolve}">Resolve</option>
+                            <option value="@{wits}">Wits</option>
+                            <option value="@{panache}">Panache</option>
                         </select>
                     </td>
                     <th>
-                        <input type="radio" class="sheet-normal sheet-zip" name="attr_athletics" value="0" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_athletics" value="{{1= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_athletics" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_athletics" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_athletics" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_athletics" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                    <input type="radio" class="sheet-normal sheet-zip" name="attr_athletics" value="0" checked/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_athletics" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_athletics" value="2"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_athletics" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_athletics" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_athletics" value="5"/><span></span>                    
                     </th>
-                    <th><input type="checkbox" class="sheet-checkbox_1" name="attr_athletics_boost" value="{{boost= [[1d@{d10}]]}}" /><span></span></th>
-                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_athletics_reroll" value="{{reroll= [[1d@{d10}]]}}" /><span></span></th>
+                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_athletics_reroll" value="1" /><span></span></th>
                 </tr>
                 <tr>
-                    <td><button type="roll" class="sheet-skill_button" name="roll_brawl" value="&{template:skill} {{name= Brawl}} @{brawl} @{brawl_reroll} @{brawl_boost} \\n @{brawl_trait} ">Brawl</button></td>
+                    <td><button type="roll" class="sheet-skill_button" name="roll_brawl" value="/em takes a Brawl Risk\n/roll { (@{brawl}+@{brawl_trait}-?{penalty?|0}+?{bonus?|0})d@{d10}sd, @{brawl_reroll}d@{d10}  }">Brawl</button></td>
                     <td>
                         <select class="sheet-select_1" name="attr_brawl_trait" >
                             <option value="">None</option>
-                            <option value="&{template:trait} {{name= Brawn}} @{brawn}">Brawn</option>
-                            <option value="&{template:trait} {{name= Finesse}} @{finesse}">Finesse</option>
-                            <option value="&{template:trait} {{name= Resolve}} @{resolve}">Resolve</option>
-                            <option value="&{template:trait} {{name= Wits}} @{wits}">Wits</option>
-                            <option value="&{template:trait} {{name= Panache}} @{panache}">Panache</option>
+                            <option value="@{brawn}">Brawn</option>
+                            <option value="@{finesse}">Finesse</option>
+                            <option value="@{resolve}">Resolve</option>
+                            <option value="@{wits}">Wits</option>
+                            <option value="@{panache}">Panache</option>
                         </select>
                     </td>
                     <th>
-                        <input type="radio" class="sheet-normal sheet-zip" name="attr_brawl" value="0" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_brawl" value="{{1= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_brawl" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_brawl" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_brawl" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_brawl" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                    <input type="radio" class="sheet-normal sheet-zip" name="attr_brawl" value="0" checked/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_brawl" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_brawl" value="2"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_brawl" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_brawl" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_brawl" value="5"/><span></span>                    
                     </th>
-                    <th><input type="checkbox" class="sheet-checkbox_1" name="attr_brawl_boost" value="{{boost= [[1d@{d10}]]}}" /><span></span></th>
-                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_brawl_reroll" value="{{reroll= [[1d@{d10}]]}}" /><span></span></th>
+                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_brawl_reroll" value="1" /><span></span></th>
                 </tr>
                 <tr>
-                    <td><button type="roll" class="sheet-skill_button" name="roll_convince" value="&{template:skill} {{name= Convince}} @{convince} @{convince_reroll} @{convince_boost} \\n @{convince_trait} ">Convince</button></td>
+                    <td><button type="roll" class="sheet-skill_button" name="roll_convince" value="/em takes a Convince Risk\n/roll { (@{convince}+@{convince_trait}-?{penalty?|0}+?{bonus?|0})d@{d10}sd, @{convince_reroll}d@{d10}  }">Convince</button></td>
                     <td>
                         <select class="sheet-select_1" name="attr_convince_trait" >
                             <option value="">None</option>
-                            <option value="&{template:trait} {{name= Brawn}} @{brawn}">Brawn</option>
-                            <option value="&{template:trait} {{name= Finesse}} @{finesse}">Finesse</option>
-                            <option value="&{template:trait} {{name= Resolve}} @{resolve}">Resolve</option>
-                            <option value="&{template:trait} {{name= Wits}} @{wits}">Wits</option>
-                            <option value="&{template:trait} {{name= Panache}} @{panache}">Panache</option>
+                            <option value="@{brawn}">Brawn</option>
+                            <option value="@{finesse}">Finesse</option>
+                            <option value="@{resolve}">Resolve</option>
+                            <option value="@{wits}">Wits</option>
+                            <option value="@{panache}">Panache</option>
                         </select>
                     </td>
                     <th>
-                        <input type="radio" class="sheet-normal sheet-zip" name="attr_convince" value="0" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_convince" value="{{1= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_convince" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_convince" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_convince" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_convince" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                    <input type="radio" class="sheet-normal sheet-zip" name="attr_convince" value="0" checked/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_convince" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_convince" value="2"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_convince" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_convince" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_convince" value="5"/><span></span>                    
                     </th>
-                    <th><input type="checkbox" class="sheet-checkbox_1" name="attr_convince_boost" value="{{boost= [[1d@{d10}]]}}" /><span></span></th>
-                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_convince_reroll" value="{{reroll= [[1d@{d10}]]}}" /><span></span></th>
+                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_convince_reroll" value="1" /><span></span></th>
                 </tr>
                 <tr>
-                    <td><button type="roll" class="sheet-skill_button" name="roll_empathy" value="&{template:skill} {{name= Empathy}} @{empathy} @{empathy_reroll} @{empathy_boost} \\n @{empathy_trait} ">Empathy</button></td>
+                    <td><button type="roll" class="sheet-skill_button" name="roll_empathy" value="/em takes an Empathy Risk\n/roll { (@{empathy}+@{empathy_trait}-?{penalty?|0}+?{bonus?|0})d@{d10}sd, @{empathy_reroll}d@{d10}  }">Empathy</button></td>
                     <td>
                         <select class="sheet-select_1" name="attr_empathy_trait" >
                             <option value="">None</option>
-                            <option value="&{template:trait} {{name= Brawn}} @{brawn}">Brawn</option>
-                            <option value="&{template:trait} {{name= Finesse}} @{finesse}">Finesse</option>
-                            <option value="&{template:trait} {{name= Resolve}} @{resolve}">Resolve</option>
-                            <option value="&{template:trait} {{name= Wits}} @{wits}">Wits</option>
-                            <option value="&{template:trait} {{name= Panache}} @{panache}">Panache</option>
+                            <option value="@{brawn}">Brawn</option>
+                            <option value="@{finesse}">Finesse</option>
+                            <option value="@{resolve}">Resolve</option>
+                            <option value="@{wits}">Wits</option>
+                            <option value="@{panache}">Panache</option>
                         </select>
                     </td>
                     <th>
-                        <input type="radio" class="sheet-normal sheet-zip" name="attr_empathy" value="0" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_empathy" value="{{1= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_empathy" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_empathy" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_empathy" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_empathy" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                    <input type="radio" class="sheet-normal sheet-zip" name="attr_empathy" value="0" checked/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_empathy" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_empathy" value="2"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_empathy" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_empathy" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_empathy" value="5"/><span></span>                    
                     </th>
-                    <th><input type="checkbox" class="sheet-checkbox_1" name="attr_empathy_boost" value="{{boost= [[1d@{d10}]]}}" /><span></span></th>
-                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_empathy_reroll" value="{{reroll= [[1d@{d10}]]}}" /><span></span></th>
+                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_empathy_reroll" value="1" /><span></span></th>
                 </tr>
                 <tr>
-                    <td><button type="roll" class="sheet-skill_button" name="roll_hide" value="&{template:skill} {{name= Hide}} @{hide} @{hide_reroll} @{hide_boost} \\n @{hide_trait} ">Hide</button></td>
+                    <td><button type="roll" class="sheet-skill_button" name="roll_hide" value="/em takes a Hide Risk\n/roll { (@{hide}+@{hide_trait}-?{penalty?|0}+?{bonus?|0})d@{d10}sd, @{hide_reroll}d@{d10}  }">Hide</button></td>
                     <td>
                         <select class="sheet-select_1" name="attr_hide_trait" >
                             <option value="">None</option>
-                            <option value="&{template:trait} {{name= Brawn}} @{brawn}">Brawn</option>
-                            <option value="&{template:trait} {{name= Finesse}} @{finesse}">Finesse</option>
-                            <option value="&{template:trait} {{name= Resolve}} @{resolve}">Resolve</option>
-                            <option value="&{template:trait} {{name= Wits}} @{wits}">Wits</option>
-                            <option value="&{template:trait} {{name= Panache}} @{panache}">Panache</option>
+                            <option value="@{brawn}">Brawn</option>
+                            <option value="@{finesse}">Finesse</option>
+                            <option value="@{resolve}">Resolve</option>
+                            <option value="@{wits}">Wits</option>
+                            <option value="@{panache}">Panache</option>
                         </select>
                     </td>
                     <th>
-                        <input type="radio" class="sheet-normal sheet-zip" name="attr_hide" value="0" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_hide" value="{{1= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_hide" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_hide" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_hide" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_hide" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                    <input type="radio" class="sheet-normal sheet-zip" name="attr_hide" value="0" checked/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_hide" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_hide" value="2"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_hide" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_hide" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_hide" value="5"/><span></span>                    
                     </th>
-                    <th><input type="checkbox" class="sheet-checkbox_1" name="attr_hide_boost" value="{{boost= [[1d@{d10}]]}}" /><span></span></th>
-                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_hide_reroll" value="{{reroll= [[1d@{d10}]]}}" /><span></span></th>
+                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_hide_reroll" value="1" /><span></span></th>
                 </tr>
                 <tr>
-                    <td><button type="roll" class="sheet-skill_button" name="roll_intimidate" value="&{template:skill} {{name= Intimidate}} @{intimidate}  @{intimidate_reroll} @{intimidate_boost} \\n @{intimidate_trait} ">Intimidate</button></td>
+                    <td><button type="roll" class="sheet-skill_button" name="roll_intimidate" value="/em takes an Intimidate Risk\n/roll { (@{intimidate}+@{intimidate_trait}-?{penalty?|0}+?{bonus?|0})d@{d10}sd, @{intimidate_reroll}d@{d10}  }">Intimidate</button></td>
                     <td>
                         <select class="sheet-select_1" name="attr_intimidate_trait" >
                             <option value="">None</option>
-                            <option value="&{template:trait} {{name= Brawn}} @{brawn}">Brawn</option>
-                            <option value="&{template:trait} {{name= Finesse}} @{finesse}">Finesse</option>
-                            <option value="&{template:trait} {{name= Resolve}} @{resolve}">Resolve</option>
-                            <option value="&{template:trait} {{name= Wits}} @{wits}">Wits</option>
-                            <option value="&{template:trait} {{name= Panache}} @{panache}">Panache</option>
+                            <option value="@{brawn}">Brawn</option>
+                            <option value="@{finesse}">Finesse</option>
+                            <option value="@{resolve}">Resolve</option>
+                            <option value="@{wits}">Wits</option>
+                            <option value="@{panache}">Panache</option>
                         </select>
                     </td>
                     <th>
-                        <input type="radio" class="sheet-normal sheet-zip" name="attr_intimidate" value="0" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_intimidate" value="{{1= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_intimidate" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_intimidate" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_intimidate" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_intimidate" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                    <input type="radio" class="sheet-normal sheet-zip" name="attr_intimidate" value="0" checked/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_intimidate" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_intimidate" value="2"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_intimidate" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_intimidate" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_intimidate" value="5"/><span></span>                    
                     </th>
-                    <th><input type="checkbox" class="sheet-checkbox_1" name="attr_intimidate_boost" value="{{boost= [[1d@{d10}]]}}" /><span></span></th>
-                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_intimidate_reroll" value="{{reroll= [[1d@{d10}]]}}" /><span></span></th>
+                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_intimidate_reroll" value="1" /><span></span></th>
                 </tr>
                 <tr>
-                    <td><button type="roll" class="sheet-skill_button" name="roll_notice" value="&{template:skill} {{name= Notice}} @{notice} @{notice_reroll} @{notice_boost} \\n @{notice_trait} ">Notice</button></td>
+                    <td><button type="roll" class="sheet-skill_button" name="roll_notice" value="/em takes a Notice Risk\n/roll { (@{notice}+@{notice_trait}-?{penalty?|0}+?{bonus?|0})d@{d10}sd, @{notice_reroll}d@{d10}  }">Notice</button></td>
                     <td>
                         <select class="sheet-select_1" name="attr_notice_trait" >
                             <option value="">None</option>
-                            <option value="&{template:trait} {{name= Brawn}} @{brawn}">Brawn</option>
-                            <option value="&{template:trait} {{name= Finesse}} @{finesse}">Finesse</option>
-                            <option value="&{template:trait} {{name= Resolve}} @{resolve}">Resolve</option>
-                            <option value="&{template:trait} {{name= Wits}} @{wits}">Wits</option>
-                            <option value="&{template:trait} {{name= Panache}} @{panache}">Panache</option>
+                            <option value="@{brawn}">Brawn</option>
+                            <option value="@{finesse}">Finesse</option>
+                            <option value="@{resolve}">Resolve</option>
+                            <option value="@{wits}">Wits</option>
+                            <option value="@{panache}">Panache</option>
                         </select>
                     </td>
                     <th>
-                        <input type="radio" class="sheet-normal sheet-zip" name="attr_notice" value="0" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_notice" value="{{1= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_notice" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_notice" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_notice" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_notice" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                    <input type="radio" class="sheet-normal sheet-zip" name="attr_notice" value="0" checked/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_notice" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_notice" value="2"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_notice" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_notice" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_notice" value="5"/><span></span>                    
                     </th>
-                    <th><input type="checkbox" class="sheet-checkbox_1" name="attr_notice_boost" value="{{boost= [[1d@{d10}]]}}" /><span></span></th>
-                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_notice_reroll" value="{{reroll= [[1d@{d10}]]}}" /><span></span></th>
+                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_notice_reroll" value="1" /><span></span></th>
                 </tr>
                 <tr>
-                    <td><button type="roll" class="sheet-skill_button" name="roll_perform" value="&{template:skill} {{name= Perform}} @{perform} @{perform_reroll} @{perform_boost} \\n @{perform_trait} ">Perform</button></td>
+                    <td><button type="roll" class="sheet-skill_button" name="roll_perform" value="/em takes a Perform Risk\n/roll { (@{perform}+@{perform_trait}-?{penalty?|0}+?{bonus?|0})d@{d10}sd, @{perform_reroll}d@{d10}  }">Perform</button></td>
                     <td>
                         <select class="sheet-select_1" name="attr_perform_trait" >
                             <option value="">None</option>
-                            <option value="&{template:trait} {{name= Brawn}} @{brawn}">Brawn</option>
-                            <option value="&{template:trait} {{name= Finesse}} @{finesse}">Finesse</option>
-                            <option value="&{template:trait} {{name= Resolve}} @{resolve}">Resolve</option>
-                            <option value="&{template:trait} {{name= Wits}} @{wits}">Wits</option>
-                            <option value="&{template:trait} {{name= Panache}} @{panache}">Panache</option>
+                            <option value="@{brawn}">Brawn</option>
+                            <option value="@{finesse}">Finesse</option>
+                            <option value="@{resolve}">Resolve</option>
+                            <option value="@{wits}">Wits</option>
+                            <option value="@{panache}">Panache</option>
                         </select>
                     </td>
                     <th>
-                        <input type="radio" class="sheet-normal sheet-zip" name="attr_perform" value="0" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_perform" value="{{1= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_perform" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_perform" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_perform" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_perform" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                    <input type="radio" class="sheet-normal sheet-zip" name="attr_perform" value="0" checked/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_perform" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_perform" value="2"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_perform" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_perform" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_perform" value="5"/><span></span>                    
                     </th>
-                    <th><input type="checkbox" class="sheet-checkbox_1" name="attr_perform_boost" value="{{boost= [[1d@{d10}]]}}" /><span></span></th>
-                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_perform_reroll" value="{{reroll= [[1d@{d10}]]}}" /><span></span></th>
+                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_perform_reroll" value="1" /><span></span></th>
                 </tr>
                 <tr>
-                    <td><button type="roll" class="sheet-skill_button" name="roll_ride" value="&{template:skill} {{name= Ride}} @{ride} @{ride_reroll} @{ride_boost} \\n @{ride_trait} ">Ride</button></td>
+                    <td><button type="roll" class="sheet-skill_button" name="roll_ride" value="/em takes a Ride Risk\n/roll { (@{ride}+@{ride_trait}-?{penalty?|0}+?{bonus?|0})d@{d10}sd, @{ride_reroll}d@{d10}  }">Ride</button></td>
                     <td>
                         <select class="sheet-select_1" name="attr_ride_trait" >
                             <option value="">None</option>
-                            <option value="&{template:trait} {{name= Brawn}} @{brawn}">Brawn</option>
-                            <option value="&{template:trait} {{name= Finesse}} @{finesse}">Finesse</option>
-                            <option value="&{template:trait} {{name= Resolve}} @{resolve}">Resolve</option>
-                            <option value="&{template:trait} {{name= Wits}} @{wits}">Wits</option>
-                            <option value="&{template:trait} {{name= Panache}} @{panache}">Panache</option>
+                            <option value="@{brawn}">Brawn</option>
+                            <option value="@{finesse}">Finesse</option>
+                            <option value="@{resolve}">Resolve</option>
+                            <option value="@{wits}">Wits</option>
+                            <option value="@{panache}">Panache</option>
                         </select>
                     </td>
                     <th>
-                        <input type="radio" class="sheet-normal sheet-zip" name="attr_ride" value="0" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_ride" value="{{1= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_ride" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_ride" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_ride" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_ride" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                    <input type="radio" class="sheet-normal sheet-zip" name="attr_ride" value="0" checked/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_ride" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_ride" value="2"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_ride" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_ride" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_ride" value="5"/><span></span>                    
                     </th>
-                    <th><input type="checkbox" class="sheet-checkbox_1" name="attr_ride_boost" value="{{boost= [[1d@{d10}]]}}" /><span></span></th>
-                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_ride_reroll" value="{{reroll= [[1d@{d10}]]}}" /><span></span></th>
+                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_ride_reroll" value="1" /><span></span></th>
                 </tr>
                 <tr>
-                    <td><button type="roll" class="sheet-skill_button" name="roll_sailing" value="&{template:skill} {{name= Sailing}} @{sailing}  @{sailing_reroll} @{sailing_boost} \\n @{sailing_trait} ">Sailing</button></td>
+                    <td><button type="roll" class="sheet-skill_button" name="roll_sailing" value="/em takes a Sailing Risk\n/roll { (@{sailing}+@{sailing_trait}-?{penalty?|0}+?{bonus?|0})d@{d10}sd, @{sailing_reroll}d@{d10}  }">Sailing</button></td>
                     <td>
                         <select class="sheet-select_1" name="attr_sailing_trait" >
                             <option value="">None</option>
-                            <option value="&{template:trait} {{name= Brawn}} @{brawn}">Brawn</option>
-                            <option value="&{template:trait} {{name= Finesse}} @{finesse}">Finesse</option>
-                            <option value="&{template:trait} {{name= Resolve}} @{resolve}">Resolve</option>
-                            <option value="&{template:trait} {{name= Wits}} @{wits}">Wits</option>
-                            <option value="&{template:trait} {{name= Panache}} @{panache}">Panache</option>
+                            <option value="@{brawn}">Brawn</option>
+                            <option value="@{finesse}">Finesse</option>
+                            <option value="@{resolve}">Resolve</option>
+                            <option value="@{wits}">Wits</option>
+                            <option value="@{panache}">Panache</option>
                         </select>
                     </td>
                     <th>
-                        <input type="radio" class="sheet-normal sheet-zip" name="attr_sailing" value="0" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_sailing" value="{{1= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_sailing" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_sailing" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_sailing" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_sailing" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                    <input type="radio" class="sheet-normal sheet-zip" name="attr_sailing" value="0" checked/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_sailing" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_sailing" value="2"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_sailing" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_sailing" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_sailing" value="5"/><span></span>                    
                     </th>
-                    <th><input type="checkbox" class="sheet-checkbox_1" name="attr_sailing_boost" value="{{boost= [[1d@{d10}]]}}" /><span></span></th>
-                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_sailing_reroll" value="{{reroll= [[1d@{d10}]]}}" /><span></span></th>
+                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_sailing_reroll" value="1" /><span></span></th>
                 </tr>
                 <tr>
-                    <td><button type="roll" class="sheet-skill_button" name="roll_scholarship" value="&{template:skill} {{name= Scholarship}} @{scholarship} @{scholarship_reroll} @{scholarship_boost} \\n @{scholarship_trait} ">Scholarship</button></td>
+                    <td><button type="roll" class="sheet-skill_button" name="roll_scholarship" value="/em takes a Scholarship Risk\n/roll { (@{scholarship}+@{scholarship_trait}-?{penalty?|0}+?{bonus?|0})d@{d10}sd, @{scholarship_reroll}d@{d10}  }">Scholarship</button></td>
                     <td>
                         <select class="sheet-select_1" name="attr_scholarship_trait" >
                             <option value="">None</option>
-                            <option value="&{template:trait} {{name= Brawn}} @{brawn}">Brawn</option>
-                            <option value="&{template:trait} {{name= Finesse}} @{finesse}">Finesse</option>
-                            <option value="&{template:trait} {{name= Resolve}} @{resolve}">Resolve</option>
-                            <option value="&{template:trait} {{name= Wits}} @{wits}">Wits</option>
-                            <option value="&{template:trait} {{name= Panache}} @{panache}">Panache</option>
+                            <option value="@{brawn}">Brawn</option>
+                            <option value="@{finesse}">Finesse</option>
+                            <option value="@{resolve}">Resolve</option>
+                            <option value="@{wits}">Wits</option>
+                            <option value="@{panache}">Panache</option>
                         </select>
                     </td>
                     <th>
-                        <input type="radio" class="sheet-normal sheet-zip" name="attr_scholarship" value="0" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_scholarship" value="{{1= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_scholarship" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_scholarship" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_scholarship" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_scholarship" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                    <input type="radio" class="sheet-normal sheet-zip" name="attr_scholarship" value="0" checked/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_scholarship" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_scholarship" value="2"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_scholarship" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_scholarship" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_scholarship" value="5"/><span></span>                    
                     </th>
-                    <th><input type="checkbox" class="sheet-checkbox_1" name="attr_scholarship_boost" value="{{boost= [[1d@{d10}]]}}" /><span></span></th>
-                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_scholarship_reroll" value="{{reroll= [[1d@{d10}]]}}" /><span></span></th>
+                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_scholarship_reroll" value="1" /><span></span></th>
                 </tr>
                 <tr>
-                    <td><button type="roll" class="sheet-skill_button" name="roll_tempt" value="&{template:skill} {{name= Tempt}} @{tempt} @{tempt_reroll} @{tempt_boost} \\n @{tempt_trait} ">Tempt</button></td>
+                    <td><button type="roll" class="sheet-skill_button" name="roll_tempt" value="/em takes a Tempt Risk\n/roll { (@{tempt}+@{tempt_trait}-?{penalty?|0}+?{bonus?|0})d@{d10}sd, @{tempt_reroll}d@{d10}  }">Tempt</button></td>
                     <td>
                         <select class="sheet-select_1" name="attr_tempt_trait" >
                             <option value="">None</option>
-                            <option value="&{template:trait} {{name= Brawn}} @{brawn}">Brawn</option>
-                            <option value="&{template:trait} {{name= Finesse}} @{finesse}">Finesse</option>
-                            <option value="&{template:trait} {{name= Resolve}} @{resolve}">Resolve</option>
-                            <option value="&{template:trait} {{name= Wits}} @{wits}">Wits</option>
-                            <option value="&{template:trait} {{name= Panache}} @{panache}">Panache</option>
+                            <option value="@{brawn}">Brawn</option>
+                            <option value="@{finesse}">Finesse</option>
+                            <option value="@{resolve}">Resolve</option>
+                            <option value="@{wits}">Wits</option>
+                            <option value="@{panache}">Panache</option>
                         </select>
                     </td>
                     <th>
-                        <input type="radio" class="sheet-normal sheet-zip" name="attr_tempt" value="0" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_tempt" value="{{1= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_tempt" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_tempt" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_tempt" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_tempt" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                    <input type="radio" class="sheet-normal sheet-zip" name="attr_tempt" value="0" checked/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_tempt" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_tempt" value="2"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_tempt" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_tempt" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_tempt" value="5"/><span></span>                    
                     </th>
-                    <th><input type="checkbox" class="sheet-checkbox_1" name="attr_tempt_boost" value="{{boost= [[1d@{d10}]]}}" /><span></span></th>
-                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_tempt_reroll" value="{{reroll= [[1d@{d10}]]}}" /><span></span></th>
+                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_tempt_reroll" value="1" /><span></span></th>
                 </tr>
                 <tr>
-                    <td><button type="roll" class="sheet-skill_button" name="roll_theft" value="&{template:skill} {{name= Theft}} @{theft} @{theft_reroll} @{theft_boost}\\n @{theft_trait} ">Theft</button></td>
+                    <td><button type="roll" class="sheet-skill_button" name="roll_theft" value="/em takes a Theft Risk\n/roll { (@{theft}+@{theft_trait}-?{penalty?|0}+?{bonus?|0})d@{d10}sd, @{theft_reroll}d@{d10}  }">Theft</button></td>
                     <td>
                         <select class="sheet-select_1" name="attr_theft_trait" >
                             <option value="">None</option>
-                            <option value="&{template:trait} {{name= Brawn}} @{brawn}">Brawn</option>
-                            <option value="&{template:trait} {{name= Finesse}} @{finesse}">Finesse</option>
-                            <option value="&{template:trait} {{name= Resolve}} @{resolve}">Resolve</option>
-                            <option value="&{template:trait} {{name= Wits}} @{wits}">Wits</option>
-                            <option value="&{template:trait} {{name= Panache}} @{panache}">Panache</option>
+                            <option value="@{brawn}">Brawn</option>
+                            <option value="@{finesse}">Finesse</option>
+                            <option value="@{resolve}">Resolve</option>
+                            <option value="@{wits}">Wits</option>
+                            <option value="@{panache}">Panache</option>
                         </select>
                     </td>
                     <th>
-                        <input type="radio" class="sheet-normal sheet-zip" name="attr_theft" value="0" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_theft" value="{{1= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_theft" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_theft" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_theft" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_theft" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                    <input type="radio" class="sheet-normal sheet-zip" name="attr_theft" value="0" checked/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_theft" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_theft" value="2"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_theft" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_theft" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_theft" value="5"/><span></span>                    
                     </th>
-                    <th><input type="checkbox" class="sheet-checkbox_1" name="attr_theft_boost" value="{{boost= [[1d@{d10}]]}}" /><span></span></th>
-                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_theft_reroll" value="{{reroll= [[1d@{d10}]]}}" /><span></span></th>
+                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_theft_reroll" value="1" /><span></span></th>
                 </tr>
                 <tr>
-                    <td><button type="roll" class="sheet-skill_button" name="roll_warfare" value="&{template:skill} {{name= Warfare}} @{warfare} @{warfare_reroll} @{warfare_boost}\\n @{warfare_trait} ">Warfare</button></td>
+                    <td><button type="roll" class="sheet-skill_button" name="roll_warfare" value="/em takes a Warfare Risk\n/roll { (@{warfare}+@{warfare_trait}-?{penalty?|0}+?{bonus?|0})d@{d10}sd, @{warfare_reroll}d@{d10}  }">Warfare</button></td>
                     <td>
                         <select class="sheet-select_1" name="attr_warfare_trait" >
                             <option value="">None</option>
-                            <option value="&{template:trait} {{name= Brawn}} @{brawn}">Brawn</option>
-                            <option value="&{template:trait} {{name= Finesse}} @{finesse}">Finesse</option>
-                            <option value="&{template:trait} {{name= Resolve}} @{resolve}">Resolve</option>
-                            <option value="&{template:trait} {{name= Wits}} @{wits}">Wits</option>
-                            <option value="&{template:trait} {{name= Panache}} @{panache}">Panache</option>
+                            <option value="@{brawn}">Brawn</option>
+                            <option value="@{finesse}">Finesse</option>
+                            <option value="@{resolve}">Resolve</option>
+                            <option value="@{wits}">Wits</option>
+                            <option value="@{panache}">Panache</option>
                         </select>
                     </td>
                     <th>
-                        <input type="radio" class="sheet-normal sheet-zip" name="attr_warfare" value="0" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_warfare" value="{{1= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_warfare" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_warfare" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_warfare" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_warfare" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                    <input type="radio" class="sheet-normal sheet-zip" name="attr_warfare" value="0" checked/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_warfare" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_warfare" value="2"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_warfare" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_warfare" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_warfare" value="5"/><span></span>                    
                     </th>
-                    <th><input type="checkbox" class="sheet-checkbox_1" name="attr_warfare_boost" value="{{boost= [[1d@{d10}]]}}" /><span></span></th>
-                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_warfare_reroll" value="{{reroll= [[1d@{d10}]]}}" /><span></span></th>
+                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_warfare_reroll" value="1" /><span></span></th>
                 </tr>
                 <tr>
-                    <td><button type="roll" class="sheet-skill_button" name="roll_weaponry" value="&{template:skill} {{name= Weaponry}} @{weaponry} @{weaponry_reroll} @{weaponry_boost}\\n @{weaponry_trait} ">Weaponry</button></td>
+                    <td><button type="roll" class="sheet-skill_button" name="roll_weaponry" value="/em takes a Weaponry Risk\n/roll { (@{weaponry}+@{weaponry_trait}-?{penalty?|0}+?{bonus?|0})d@{d10}sd, @{weaponry_reroll}d@{d10}  }">Weaponry</button></td>
                     <td>
                         <select class="sheet-select_1" name="attr_weaponry_trait" >
                             <option value="">None</option>
-                            <option value="&{template:trait} {{name= Brawn}} @{brawn}">Brawn</option>
-                            <option value="&{template:trait} {{name= Finesse}} @{finesse}">Finesse</option>
-                            <option value="&{template:trait} {{name= Resolve}} @{resolve}">Resolve</option>
-                            <option value="&{template:trait} {{name= Wits}} @{wits}">Wits</option>
-                            <option value="&{template:trait} {{name= Panache}} @{panache}">Panache</option>
+                            <option value="@{brawn}">Brawn</option>
+                            <option value="@{finesse}">Finesse</option>
+                            <option value="@{resolve}">Resolve</option>
+                            <option value="@{wits}">Wits</option>
+                            <option value="@{panache}">Panache</option>
                         </select>
                     </td>
                     <th>
-                        <input type="radio" class="sheet-normal sheet-zip" name="attr_weaponry" value="0" checked/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_weaponry" value="{{1= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_weaponry" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_weaponry" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_weaponry" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}"/><span></span>
-                        <input type="radio" class="sheet-normal" name="attr_weaponry" value="{{1= [[1d@{d10}]]}}{{2= [[1d@{d10}]]}}{{3= [[1d@{d10}]]}}{{4= [[1d@{d10}]]}}{{5= [[1d@{d10}]]}}"/><span></span>
+                    <input type="radio" class="sheet-normal sheet-zip" name="attr_weaponry" value="0" checked/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_weaponry" value="1"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_weaponry" value="2"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_weaponry" value="3"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_weaponry" value="4"/><span></span>
+                        <input type="radio" class="sheet-normal" name="attr_weaponry" value="5"/><span></span>                    
                     </th>
-                    <th><input type="checkbox" class="sheet-checkbox_1" name="attr_weaponry_boost" value="{{boost= [[1d@{d10}]]}}" /><span></span></th>
-                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_weaponry_reroll" value="{{reroll= [[1d@{d10}]]}}" /><span></span></th>
+                    <th><input type="checkbox" class="sheet-checkbox_2" name="attr_weaponry_reroll" value="1" /><span></span></th>
                 </tr>
             </table>
+        <br>
         </div>
     </div>
 </div>
 
 <div class="sheet-section sheet-section-2">
     <div class='sheet-2colrow'>
+        <br>
 		<div class='sheet-col'>
-            <img src="http://i.imgur.com/975VTit.gif" style="max-height: 100px;" />
-            <h4>Appearance</h4>
-            <textarea class="sheet-textarea_1" name="attr_Appearance"></textarea>
-            <h4>Reputation</h4>
-            <fieldset class="repeating_Reputation">
-                <table style="width:390px">
-                    <tr>
-                        <td style="width:60px"><button type="roll" class="sheet-skill_button" name="roll_Reputation_show" value="&{template:show} {{name= @{Reputation_name} }} {{score= @{Reputation_score} }} {{note= @{Reputation_notes} }}">Reputation</button></td>
-                        <td style="width:210px"><input type="text" class="sheet-text_1" name="attr_Reputation_name"/></td>
-                            <td style="width:60px"><input type="number" class="sheet-number_1" name="attr_Reputation_score"/></td>
-                        <th style="width:60px"><input type="checkbox" class="sheet-checkbox_3" name="attr_Reputation_hider" value="1" checked/><span></span></th>
-                    </tr>
-                    <tr>
-                        <td colspan="4">
-                            <input type="checkbox" class="sheet-hider sheet-hidden" name="attr_Reputation_hider" value="1" checked/>
-                            <div class="sheet-hold">
-                                <textarea class="sheet-textarea_1" name="attr_Reputation_notes"></textarea>
-                            </div>
-                        </td>
-                    </tr>
-                </table>
-            </fieldset>
-            <h4>Languages</h4>
-            <textarea class="sheet-textarea_1" name="attr_Languages"></textarea>
-            <h4>Secret Society</h4>
+            <h4>Backgrounds</h4>
             <table style="width:390px">
                 <tr>
-                    <td style="width:60px"><button type="roll" class="sheet-skill_button" name="roll_SecretSociety_show" value="&{template:show} {{name= @{SecretSociety_name} }} {{note= @{SecretSociety_notes} }}">Show</button></td>
-                    <td style="width:210px"><input type="text" class="sheet-text_1" name="attr_SecretSociety_name"/></td>
-                    <th style="width:60px"><input type="checkbox" class="sheet-checkbox_3" name="attr_SecretSociety_hider" value="1" checked/><span></span></th>
+                    <td style="width:60px"><button type="roll" class="sheet-skill_button" name="roll_background1_show" value="&{template:show} {{name= @{background1_name} }} {{note= @{background1_notes} }}">Show</button></td>
+                    <td style="width:210px"><input type="text" class="sheet-text_1" name="attr_background1_name"/></td>
+                    <th style="width:60px"><input type="checkbox" class="sheet-checkbox_3" name="attr_background1_hider" value="1" checked/><span></span></th>
                 </tr>
                 <tr>
                     <td colspan="3">
-                        <input type="checkbox" class="sheet-hider sheet-hidden" name="attr_SecretSociety_hider" value="1" checked/>
+                        <input type="checkbox" class="sheet-hider sheet-hidden" name="attr_background1_hider" value="1" checked/>
                         <div class="sheet-hold">
-                            <textarea class="sheet-textarea_1" name="attr_SecretSociety_notes"></textarea>
+                            <textarea class="sheet-textarea_1" name="attr_background1_notes"></textarea>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="width:60px"><button type="roll" class="sheet-skill_button" name="roll_background2_show" value="&{template:show} {{name= @{background2_name} }} {{note= @{background2_notes} }}">Show</button></td>
+                    <td style="width:210px"><input type="text" class="sheet-text_1" name="attr_background2_name"/></td>
+                    <th style="width:60px"><input type="checkbox" class="sheet-checkbox_3" name="attr_background2_hider" value="1" checked/><span></span></th>
+                </tr>
+                <tr>
+                    <td colspan="3">
+                        <input type="checkbox" class="sheet-hider sheet-hidden" name="attr_background2_hider" value="1" checked/>
+                        <div class="sheet-hold">
+                            <textarea class="sheet-textarea_1" name="attr_background2_notes"></textarea>
                         </div>
                     </td>
                 </tr>
             </table>
-            <h4>Wealth</h4>
-            <table style="width:390px">
-                <tr>
-                    <td style="width:60px"><button type="roll" class="sheet-skill_button" name="roll_Wealth_show" value="&{template:show} {{name= @{Wealth_name} }} {{wealth= @{Wealth_Rating} }} {{note= @{Wealth_notes} }}">Profession</button></td>
-                    <td style="width:210px"><input type="text" class="sheet-text_1" name="attr_Wealth_name"/></td>
-                    <td style="width:60px"><input type="number" class="sheet-number_1" name="attr_Wealth_Rating"/></td>
-                    <th style="width:60px"><input type="checkbox" class="sheet-checkbox_3" name="attr_Wealth_hider" value="1" checked/><span></span></th>
-                </tr>
-                <tr>
-                    <td colspan="4">
-                        <input type="checkbox" class="sheet-hider sheet-hidden" name="attr_Wealth_hider" value="1" checked/>
-                        <div class="sheet-hold">
-                            <textarea class="sheet-textarea_1" name="attr_Wealth_notes"></textarea>
-                        </div>
-                    </td>
-                </tr>
-            </table>
-            <h4>Corruption</h4>
-            <div>
-                <input type="radio" class="sheet-normal sheet-zip" name="attr_Corruption" value="0" checked/><span></span>
-                <input type="radio" class="sheet-normal" name="attr_Corruption" value="1"/><span></span>/
-                <input type="radio" class="sheet-normal" name="attr_Corruption" value="2"/><span></span>
-                <input type="radio" class="sheet-normal" name="attr_Corruption" value="3"/><span></span>/
-                <input type="radio" class="sheet-normal" name="attr_Corruption" value="4"/><span></span>
-                <input type="radio" class="sheet-normal" name="attr_Corruption" value="5"/><span></span>
-                <input type="radio" class="sheet-normal" name="attr_Corruption" value="6"/><span></span>/
-                <input type="radio" class="sheet-normal" name="attr_Corruption" value="7"/><span></span>
-                <input type="radio" class="sheet-normal" name="attr_Corruption" value="8"/><span></span>
-                <input type="radio" class="sheet-normal" name="attr_Corruption" value="9"/><span></span>
-                <input type="radio" class="sheet-normal" name="attr_Corruption" value="10"/><span></span>
-            </div>
-            <textarea class="sheet-textarea_1" name="attr_Corruption_notes"></textarea>
-        </div>
-        <div class='sheet-col'>
+            <br>
             <h4>Arcana</h4>
             <table style="width:390px">
                 <tr>
@@ -645,12 +613,61 @@
                     </td>
                 </tr>
             </table>
+            <br>
+            <h4>Reputation</h4>
+            <fieldset class="repeating_Reputation">
+                <table style="width:390px">
+                    <tr>
+                        <td style="width:60px"><button type="roll" class="sheet-skill_button" name="roll_Reputation_show" value="&{template:show} {{name= @{Reputation_name} }} {{score= @{Reputation_score} }} {{note= @{Reputation_notes} }}">Reputation</button></td>
+                        <td style="width:210px"><input type="text" class="sheet-text_1" name="attr_Reputation_name"/></td>
+                            <td style="width:60px"><input type="number" class="sheet-number_1" name="attr_Reputation_score"/></td>
+                        <th style="width:60px"><input type="checkbox" class="sheet-checkbox_3" name="attr_Reputation_hider" value="1" checked/><span></span></th>
+                    </tr>
+                    <tr>
+                        <td colspan="4">
+                            <input type="checkbox" class="sheet-hider sheet-hidden" name="attr_Reputation_hider" value="1" checked/>
+                            <div class="sheet-hold">
+                                <textarea class="sheet-textarea_1" name="attr_Reputation_notes"></textarea>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </fieldset>
+            <br>
+            <h4>Wealth</h4>
+            <table style="width:390px">
+                <tr>
+                    <td style="width:60px"><button type="roll" class="sheet-skill_button" name="roll_Wealth_show" value="&{template:show} {{name= @{Wealth_name} }} {{wealth= @{Wealth_Rating} }} {{note= @{Wealth_notes} }}">Profession</button></td>
+                    <td style="width:210px"><input type="text" class="sheet-text_1" name="attr_Wealth_name"/></td>
+                    <td style="width:60px"><input type="number" class="sheet-number_1" name="attr_Wealth_Rating"/></td>
+                    <th style="width:60px"><input type="checkbox" class="sheet-checkbox_3" name="attr_Wealth_hider" value="1" checked/><span></span></th>
+                </tr>
+                <tr>
+                    <td colspan="4">
+                        <input type="checkbox" class="sheet-hider sheet-hidden" name="attr_Wealth_hider" value="1" checked/>
+                        <div class="sheet-hold">
+                            <textarea class="sheet-textarea_1" name="attr_Wealth_notes"></textarea>
+                        </div>
+                    </td>
+                </tr>
+            </table>
+            <br>
+        </div>
+        <div class='sheet-col'>
+
             <h4>Sorcery</h4>
             <fieldset class="repeating_Sorcery">
                 <table style="width:390px">
                     <tr>
+                        <td style="width:60px"><span></span></td>
+                        <td style="width:210px"></td>
+                            <td class="sheet-small" style="width:60px">Rank</td>
+                        <th style="width:60px"><span></span></th>
+                    </tr>
+                    <tr>
                         <td style="width:60px"><button type="roll" class="sheet-button_show" name="roll_Sorcery_show" value="&{template:show} {{name= @{Sorcery_name} }} {{note= @{Sorcery_notes} }}">Sorcery</button></td>
-                        <td style="width:210px"><input type="text" class="sheet-text_1" name="attr_Sorcery_name"/></td>
+                         <td style="width:210px"><input type="text" class="sheet-text_1" name="attr_Sorcery_name"/></td>
+                            <td style="width:60px"><input type="number" class="sheet-number_1" name="attr_Sorcery_rank"/></td>
                         <th style="width:60px"><input type="checkbox" class="sheet-checkbox_3" name="attr_Sorcery_hider" value="1" checked/><span></span></th>
                     </tr>
                     <tr>
@@ -663,7 +680,8 @@
                     </tr>
                 </table>
             </fieldset>
-            <h4>Dueling</h4>
+            <br>
+            <h4>Dueling Style Bonus</h4>
             <fieldset class="repeating_Dueling">
                 <table style="width:390px">
                     <tr>
@@ -681,72 +699,275 @@
                     </tr>
                 </table>
             </fieldset>
-        </div>
-    </div>
-</div>
-
-<div class="sheet-section sheet-section-3">
-    <div class='sheet-2colrow'>
-    	<div class='sheet-col'>
-            <img src="http://i.imgur.com/975VTit.gif" style="max-height: 100px;" />
-            <h4>Religous Beliefs</h4>
-            <fieldset class="repeating_religion"> 
-                <table style="width:100%">
+            <br>
+            <h4>Secret Society</h4>
+            <fieldset class="repeating_SecretSociety">
+                <table style="width:390px">
                     <tr>
-                        <td><textarea wrap="soft" class="sheet-textarea_1" alue="" name="attr_Religous_note" style="width:99%;" placeholder="Religous Notes" /></textarea></td>
+                        <td style="width:60px"><span></span></td>
+                        <td style="width:210px"></td>
+                            <td class="sheet-small" style="width:60px">Favor</td>
+                        <th style="width:60px"><span></span></th>
+                    </tr>
+                    <tr>
+                        <td style="width:60px"><button type="roll" class="sheet-skill_button" name="roll_Society_show" value="&{template:show} {{name= @{Society_name} }} {{score= @{Favor_score} }} {{note= @{Society_notes} }}">Society</button></td>
+                        <td style="width:210px"><input type="text" class="sheet-text_1" name="attr_Society_name"/></td>
+                            <td style="width:60px"><input type="number" class="sheet-number_1" name="attr_Favor_score"/></td>
+                        <th style="width:60px"><input type="checkbox" class="sheet-checkbox_3" name="attr_Society_hider" value="1" checked/><span></span></th>
+                    </tr>
+                    <tr>
+                        <td colspan="4">
+                            <input type="checkbox" class="sheet-hider sheet-hidden" name="attr_Society_hider" value="1" checked/>
+                            <div class="sheet-hold">
+                                <textarea class="sheet-textarea_1" name="attr_Society_notes"></textarea>
+                            </div>
+                        </td>
                     </tr>
                 </table>
             </fieldset>
+            <br>
+            <h4>Languages</h4>
+            <p></p>
+            <textarea class="sheet-textarea_1" name="attr_Languages"></textarea>
+            <br>
+            <h4>Corruption</h4>
+            <p></p>
+            <div>
+                <input type="radio" class="sheet-normal sheet-zip" name="attr_Corruption" value="0" checked><span></span>
+                <input type="radio" class="sheet-normal" name="attr_Corruption" value="1"><span><b>/&nbsp;&nbsp;</b></span>
+                
+                <input type="radio" class="sheet-normal" name="attr_Corruption" value="2"><span></span>
+                <input type="radio" class="sheet-normal" name="attr_Corruption" value="3"><span><b>/&nbsp;&nbsp;</b></span>
+                <input type="radio" class="sheet-normal" name="attr_Corruption" value="4"><span></span>
+                <input type="radio" class="sheet-normal" name="attr_Corruption" value="5"><span></span>
+                <input type="radio" class="sheet-normal" name="attr_Corruption" value="6"><span><b>/&nbsp;&nbsp;</b></span>
+                <input type="radio" class="sheet-normal" name="attr_Corruption" value="7"><span></span>
+                <input type="radio" class="sheet-normal" name="attr_Corruption" value="8"><span></span>
+                <input type="radio" class="sheet-normal" name="attr_Corruption" value="9"><span></span>
+                <input type="radio" class="sheet-normal" name="attr_Corruption" value="10"><span></span>
+            </div>
         </div>
-        <div class="sheet-col">
-            <h5>Character History</h5>
-            <textarea wrap="soft" class="sheet-textarea_1" value="" name="attr_character_history" style="width:99%;height:140px;" placeholder="Character History" /></textarea>
         </div>
-    </div>
-    <div class="sheet-tabbed-panel">
+        <div class="sheet-tabbed-panel">
         <div class="sheet-row-panel">
-            <h4>Contacts</h4>
+            <h4>Connections</h4>
             <div class="body">
                 <fieldset class="repeating_contacts"> 
                     <table style="width:100%">
                         <tr>
-                            <td><h5>Name</h5></td>
-                            <td><h5>Location</h5></td>
-                        </tr>
-                        <tr>
                             <td><div class="sheet-ability"><input class="sheet-text_1" type="text" value="" name="attr_contact_name"placeholder="Contact Name" /></div></td>
+                            <td><div class="sheet-ability"><input class="sheet-text_1" type="text" value="" name="attr_contact_relation"placeholder="Relation" /></div></td>
                             <td><div class="sheet-ability"><input class="sheet-text_1" type="text" value="" name="attr_contact_location" placeholder="Country, City"/></div></td>
-                        </tr>
-                        <tr>
-                            <td colspan="2"><textarea class="sheet-textarea_1" wrap="soft" value="" name="attr_Contact_details" style="width:99%" placeholder="Contact Details" /></textarea></td>
+                            <td style="width:60px"><input type="number" class="sheet-number_1" name="attr_Favor_score" placeholder="0"/></td>
                         </tr>
                     </table>
                 </fieldset>
             </div>
         </div>
     </div>
+    <br><br>
+    </div>
+
+</div>
+
+<div class="sheet-section sheet-section-3">
     <div class="sheet-tabbed-panel">
+        <br>
         <div class="sheet-row">
-            <h4>Recent History</h4>
-            <fieldset class="repeating_recenthistory"> 
-                <table style="width:100%">
+            <h4>Stories</h4>
+            <fieldset class="repeating_stories"> 
+                <table style="width:98%">
                     <tr>
-                        <td><h5>Event</h5></td>
-                        <td><h5>Date</h5></td>
+                        <td><div class="sheet-ability"><input class="sheet-text_2" type="text" name="attr_story_description" placeholder="Story" /></div></td>
+                        <td><div class="sheet-ability"><input class="sheet-text_3" type="text" name="attr_story_steps" placeholder="Steps"/><span></span></div></td>
+                        <td><div class="sheet-ability"><input class="sheet-text_1" type="text" name="attr_story_reward" placeholder="Reward"/></div></td>
+                        <th style="width:60px"><input type="checkbox" class="sheet-checkbox_3" name="attr_story_hider" value="1" checked/><span></span></th>
                     </tr>
                     <tr>
-                        <td><input type="text" class="sheet-text_1" value="" name="attr_event_name" placeholder="Event Name" /></td>
-                        <td><input type="text" class="sheet-text_1" value="" name="attr_event_date" placeholder="Event Date"/></td>
-                    </tr>
-                    <tr>
-                        <td colspan="2"><textarea class="sheet-textarea_1" wrap="soft" value="" name="attr_event_details" style="width:99%" placeholder="Event Details" /></textarea></td>
+                        <td colspan="4">
+                            <input type="checkbox" class="sheet-hider sheet-hidden" name="attr_story_hider" value="1" checked/>
+                            <div class="sheet-hold">
+                                <textarea class="sheet-textarea_1" name="attr_story_notes"></textarea>
+                            </div>
+                        </td>
                     </tr>
                 </table>            
             </fieldset>
+            <br>
         </div>
     </div>
 </div>
-    
+
+<div class="sheet-section sheet-section-4">
+    <div class="sheet-tabbed-panel">
+        <br>
+        <div class="sheet-row">
+            <table style="width:830px;">
+                <tr>
+                    <td><b>SHIP'S NAME</b></td>
+                    <td><input type="text" class="sheet-heading_1" name="attr_ship_name"/></td>
+                    <td><b>CLASS</b></td>
+                    <td><input type="text" class="sheet-text_1" name="attr_ship_nation"/></td>
+                </tr>
+                <tr>
+                    <td><b>CAPTAIN</b></td>
+                    <td><input type="text" class="sheet-text_1" name="attr_Captain_name"/></td>
+                    <td><b>ORIGIN</b></td>
+                    <td><input type="text" class="sheet-text_1" name="attr_origin"/></td>
+                </tr>
+                <!-- Hits -->
+                <tr>
+                    <td><B>HITS</B></td>
+                    <td><input type="number" class="sheet-text_1" name="attr_hits" value="0"/> out of <input type="number" class="sheet-text_1" name="attr_hits_max" value="20" /></td>
+                    <td><B>CRITICAL HITS</B></td>
+                    <td><input type="number" class="sheet-heading_1" name="attr_critical_hits" value="0"/> out of <input type="number" class="sheet-text_1" name="attr_critical_hits_max" value="4" />
+                        <!-- These attributes are used for the "health" bar - they count down from the max --
+                        <input type="number" class="sheet-hidden" name="attr_ship_health" value="@{hits_max}-@{hits}"/>
+                        <input type="number" class="sheet-hidden" name="attr_ship_health_max" value="@{hits_max}"/>
+                        <input type="number" class="sheet-hidden" name="attr_ship_critical_health" value="@{critical_hits_max}-@{critical_hits}"/>
+                        <input type="number" class="sheet-hidden" name="attr_ship_critical_health_max" value="@{critcial_hits_max}"/>
+                        -->
+                    </td>
+                </tr>
+            </table>
+        </div>
+        <br>
+        <div class="sheet-newtoggel" style="text-align:left">
+            <input type="checkbox" name="attr_ship-toggle" class="arrow" value="1"/><span></span><b><I>&nbsp;&nbsp;Expanded Ship Details</I></b>
+            <div class="sheet-details-togglepanel">
+                <table style="width:100%">
+                    <tr>
+                        <th><input type="number" type="number" name="attr_Class_rank" placeholder="1"/></th>
+                        <th><input type="number" type="number" name="attr_Crew_rank" placeholder="0"/></th> 
+                        <th><input type="number" type="number" name="attr_Cargo_rank" placeholder="0"/></th>
+                        <th><input type="number" type="number" name="attr_Sail_rank" placeholder="0"/></th>
+                        <th><input type="number" type="number" name="attr_Guns_rank" placeholder="0"/></th>
+                        <th><input type="number" type="number" name="attr_Treasury" placeholder="0"/></th>
+                    </tr>
+                    <tr>
+                        <th>Class</th>
+                        <th>Crew</th> 
+                        <th>Cargo</th>
+                        <th>Sail</th>
+                        <th>Guns</th>
+                        <th>Treasury</th>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        <BR>
+        </div>
+        <div class='sheet-2colrow'>
+    	    <div class='sheet-col'>
+                <h4>Backgrounds</h4>
+                <fieldset class="repeating_ShipBackgrounds">
+                <table style="width:390px">
+                    <tr>
+                        <td style="width:60px"><button type="roll" class="sheet-skill_button" name="roll_Ship_Background_show" value="&{template:show} {{name= @{Ship_Background_name} }} {{note= @{Ship_Background_notes} }}">Background</button></td>
+                        <td style="width:210px"><input type="text" class="sheet-text_1" name="attr_Ship_Background_name"/></td>
+                        <th style="width:60px"><input type="checkbox" class="sheet-checkbox_3" name="attr_Ship_Background_hider" value="1" checked/><span></span></th>
+                    </tr>
+                    <tr>
+                        <td colspan="3">
+                            <input type="checkbox" class="sheet-hider sheet-hidden" name="attr_Ship_Background_hider" value="1" checked/>
+                            <div class="sheet-hold">
+                                <textarea class="sheet-textarea_1" name="attr_Ship_Background_notes"></textarea>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </fieldset>
+            <br>
+                <h4>Special Features</h4>
+                <fieldset class="repeating_ShipFeatures">
+                <table style="width:390px">
+                    <tr>
+                        <td style="width:60px"><button type="roll" class="sheet-skill_button" name="roll_Ship_Feature_show" value="&{template:show} {{name= @{Ship_Feature_name} }} {{note= @{Ship_Feature_notes} }}">Feature</button></td>
+                        <td style="width:210px"><input type="text" class="sheet-text_1" name="attr_Ship_Feature_name"/></td>
+                        <th style="width:60px"><input type="checkbox" class="sheet-checkbox_3" name="attr_Ship_Feature_hider" value="1" checked/><span></span></th>
+                    </tr>
+                    <tr>
+                        <td colspan="3">
+                            <input type="checkbox" class="sheet-hider sheet-hidden" name="attr_Ship_Featured_hider" value="1" checked/>
+                            <div class="sheet-hold">
+                                <textarea class="sheet-textarea_1" name="attr_Ship_Feature_notes"></textarea>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </fieldset>
+            <br>
+            <h4>Adventures</h4>
+            <fieldset class="repeating_Sorcery">
+                <table style="width:390px">
+                    <tr>
+                        <td style="width:60px"><button type="roll" class="sheet-skill_button" name="roll_Ship_Adventure_show" value="&{template:show} {{name= @{Ship_Adventure_name} }} {{note= @{Ship_Adventure_notes} }}">Adventure</button></td>
+                        <td style="width:210px"><input type="text" class="sheet-text_1" name="attr_Ship_Adventure_name"/></td>
+                        <th style="width:60px"><input type="checkbox" class="sheet-checkbox_3" name="attr_Ship_Adventure_hider" value="1" checked/><span></span></th>
+                    </tr>
+                    <tr>
+                        <td colspan="3">
+                            <input type="checkbox" class="sheet-hider sheet-hidden" name="attr_Ship_Adventure_hider" value="1" checked/>
+                            <div class="sheet-hold">
+                                <textarea class="sheet-textarea_1" name="attr_Ship_Adventure_notes"></textarea>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </fieldset>
+            <br>
+        </div>
+        <div class='sheet-col'>
+            <h4>Crew</h4>
+                <table style="width:98%">
+                        <tr>
+                            <th>Position</th>
+                            <th>Name</th>
+                        </tr>
+                        <tr>
+                            <td>Lieutenant/First Mate</td>
+                            <td><input class="sheet-text_1" type="text" value="" name="attr_lieutenant"placeholder="Lieutenant/First Mate" /></td>
+                        </tr>
+                        <tr>
+                            <td>Master of Sail</td>
+                            <td><input class="sheet-text_1" type="text" value="" name="attr_master"placeholder="Master of Sail" /></td>
+                        </tr>
+                        <tr>
+                            <td>Boatswan</td>
+                            <td><input class="sheet-text_1" type="text" value="" name="attr_boatswan"placeholder="Boatswan" /></td>
+                        </tr>
+                        <tr>
+                            <td>Master Gunner</td>
+                            <td><input class="sheet-text_1" type="text" value="" name="attr_gunner"placeholder="Master Gunner" /></td>
+                        </tr>
+                        <tr>
+                            <td>Surgeon/Doctor</td>
+                            <td><input class="sheet-text_1" type="text" value="" name="attr_doctor"placeholder="Surgeon/Doctor" /></td>
+                        </tr>
+                        <tr>
+                            <td>Crew</td>
+                            <td><input type="number" type="number" value="" name="attr_Crew_rank" placeholder="0"/></td>
+                        </tr>
+                        <tr>
+                            <td>Treasury</td>
+                            <td><input type="number" type="number" value="" name="attr_Treasury" placeholder="0"/></td>
+                        </tr>
+                    </table>
+                <br>
+                <h4>Cargo</h4>
+                    <fieldset class="repeating_Sorcery">
+                    <table style="width:390px">
+                        <tr>
+                            <td><input class="sheet-text_1" type="text" value="" name="attr_cargo1" placeholder="Cargo" /></td>
+                            <td><input class="sheet-text_1" type="number" value="" name="attr_cargo1_value" placeholder="0" /></td>
+                        </tr>
+                    </table>
+                    </fieldset>
+                    <br>
+                </div>
+
+    </div>
+
 </div>
 
 <div class="sheet-section sheet-section-4">
@@ -756,67 +977,9 @@
 <div class="sheet-section sheet-section-5">
     
 </div>
+
 <!-- rolltemplate -->
 <div class="sheet-hidden">
-    <rolltemplate class="sheet-rolltemplate-trait">
-    	<table>
-            <tr>
-                <th colspan="5">{{name}}</th>
-            </tr>
-            <tr>
-                {{#1}}
-                <th><div class="sheet-skill_number">{{1}}</div></th>
-                {{/1}}
-                {{#2}}
-                <th><div class="sheet-skill_number">{{2}}</div></th>
-                {{/2}}
-                {{#3}}
-                <th><div class="sheet-skill_number">{{3}}</div></th>
-                {{/3}}
-                {{#4}}
-                <th><div class="sheet-skill_number">{{4}}</div></th>
-                {{/4}}
-                {{#5}}
-                <th><div class="sheet-skill_number">{{5}}</div></th>
-                {{/5}}
-            </tr>
-    	</table>
-    </rolltemplate>
-    <rolltemplate class="sheet-rolltemplate-skill">
-        <table>
-            <tr>
-                <th colspan="5">{{name}}</th>
-            </tr>
-            <tr>
-                {{#1}}
-                <th><div class="sheet-skill_number">{{1}}</div></th>
-                {{/1}}
-                {{#2}}
-                <th><div class="sheet-skill_number">{{2}}</div></th>
-                {{/2}}
-                {{#3}}
-                <th><div class="sheet-skill_number">{{3}}</div></th>
-                {{/3}}
-                {{#4}}
-                <th><div class="sheet-skill_number">{{4}}</div></th>
-                {{/4}}
-                {{#5}}
-                <th><div class="sheet-skill_number">{{5}}</div></th>
-                {{/5}}
-            </tr>
-                {{#boost}}
-            <tr>
-                <th colspan="5">Bonus Die<div class="sheet-bonus">{{boost}}</div></th>
-            </tr>
-                {{/boost}}
-                {{#reroll}}
-            <tr>
-                <th colspan="5">Reroll<div class="sheet-reroll">{{reroll}}</div></th>
-            </tr>
-                {{/reroll}}
-    	</table>
-    </rolltemplate>
-    
     <rolltemplate class="sheet-rolltemplate-show">
         <table>
             <tr>
@@ -846,21 +1009,31 @@
     	</table>
     </rolltemplate>
 </div>
-<!-- Sheet Worker Scripts -->
+
+<!-- Sheet Worker Scripts: Hero Point Dial -->
 <script type="text/worker">
     //hero Switches
 on("change:hero_up", function() {
     getAttrs(["hero_up", "hero"], function(values) {
         setAttrs({
-            hero: values.hero + 1
+            hero: Math.max(Math.min(parseInt(values.hero, 10) + 1, 9), 0)
         });
     });
 });
+
 on("change:hero_down", function() {
     getAttrs(["hero_down", "hero"], function(values) {
         setAttrs({
-            hero: values.hero - 1
+            hero: Math.max(Math.min(parseInt(values.hero, 10) - 1, 9), 0)
         });
+    });
+});
+
+on("change:wounds change:dramatic_wounds", function() {
+    console.log("wounds changed");
+    getAttrs(["wounds", "dramatic_wounds"], function(values) {
+        let newDramaticWounds = Math.max(Math.floor(parseInt(values.wounds/5)), parseInt(values.dramatic_wounds));
+        setAttrs({dramatic_wounds: newDramaticWounds});
     });
 });
 </script>


### PR DESCRIPTION
Update by Tom Harrison (Blusponge) and Matt Levy

## Changes / Comments
UPDATES include: 
– Updated color scheme and logo
– Include Backgrounds and Arcana info
– Removed Roll Template for better representation of the system’s die roll (easier for sorting raises)
– Internal die roll formula changes 
– Ship record includes support for Expanded Ship Rules PDF
– Minor formatting and content changes to all pages
– Hero Points counter goes to 9
– Wound/Dramatic Wound tracker update





## Roll20 Requests

*Include the name of the sheet you made changes to in the title.*

- If changes fix a bug or resolves a feature request, be sure to link to that issue. 
- For pull request that change multiple sheets please confirm these changes are intentional for all sheets. This will help us catch unintended submissions.
- When updating existing sheets if you are changing attribute names please note what steps you have taken, if any, to assist players in keeping their data.