### PR TITLE
D&D 5e - DEV 1977 - Spell Attack hot fix

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -7282,7 +7282,7 @@
             });
             uses_string = uses_string.replace(/half_level/g, Math.floor(classlevel/2));
             return uses_string.replace(/level/g, classlevel);
-        };
+        };//
         var category = page.data["Category"];
         var callbacks = [];
         var update = {};
@@ -7450,7 +7450,7 @@
                 (page.data[`${attr}`]) ? update[`repeating_spell-${lvl}_${id}_${suffix}`] = page.data[`${attr}`] : false;
             });
 
-           ["Add Casting Modifier", "Casting Time", "Concentration", "Damage Type", "Damage", "Duration", "Healing", "Material", "Range", "Ritual", "Save", "Save Success", "School", "Secondary Damage", "Secondary Damage Type", "Spell Attack", "Target"].forEach((attr) => {
+           ["Add Casting Modifier", "Casting Time", "Concentration", "Damage Type", "Damage", "Duration", "Healing", "Material", "Range", "Ritual", "Save", "Save Success", "School", "Secondary Damage", "Secondary Damage Type", "Target"].forEach((attr) => {
                 if(page.data[`${attr}`]) {
                     //Adjust the array entry to match the attribute name in the HTML
                     const name           = (attr === "Add Casting Modifier") ? "dmgmod" : (attr === "Material") ? `comp_materials` : (attr.includes("Secondary Damage")) ? attr.split("Secondary ")[0] + "2" : attr;
@@ -7474,6 +7474,10 @@
                 });
             };
 
+            if (page.data["Spell Attack"]) {
+                update[`repeating_spell-${lvl}_${id}_spellattack`] = page.data[`Spell Attack`];
+            };
+
             if(page.data["Damage"] || page.data["Healing"]) {
                 update[`repeating_spell-${lvl}_${id}_spelloutput`] = "ATTACK";
                 if(!existing.spellattackid) callbacks.push(() => {create_attack_from_spell(lvl, id, currentData.character_id);} );
@@ -7490,7 +7494,7 @@
             update[`repeating_spell-${lvl}_${id}_options-flag`] = "0"; 
         };
         if(category === "Monsters") {
-            console.log(`%c MONSTERS: ${page.name}`, "color: purple; font-weight:16px;");
+            console.log(`%c MONSTERS: ${page.name}`, "color: purple; font-weight:14px;");
             update["npc"] = "1";
             update["npc_options-flag"] = "0";
             if(page.name && page.name != "") {update["npc_name"] = page.name};


### PR DESCRIPTION
## Changes / Comments


* Spell Attacks are not getting set. This will fix that.



## Roll20 Requests

*Include the name of the sheet you made changes to in the title.*

- If changes fix a bug or resolves a feature request, be sure to link to that issue. 
- For pull request that change multiple sheets please confirm these changes are intentional for all sheets. This will help us catch unintended submissions.
- When updating existing sheets if you are changing attribute names please note what steps you have taken, if any, to assist players in keeping their data.