### PR TITLE
Call of Cthulhu 7th Ed. - Size fix

### DIFF
--- a/Call_of_Cthulhu_7th_Ed/coc_7th_ed.css
+++ b/Call_of_Cthulhu_7th_Ed/coc_7th_ed.css
@@ -1,7 +1,6 @@
 .charsheet {
     background-color: #888888;
     border: 2px solid black;
-    width: 840px;
     color:black;
 }
 


### PR DESCRIPTION
## Changes / Comments

A couple of users have mentioned that the sheet appears tiny to them. I have not made out yet if its from personal settings or something done wrong by me, but removing the Sheet's set-width seems to fix that. As it was added by me recently, I do not see its removal creating any problems.