### PR TITLE
[LowFantasyGaming] sheet.json & Readme edit

### DIFF
--- a/Low Fantasy Gaming/ReadMe.md
+++ b/Low Fantasy Gaming/ReadMe.md
@@ -1,9 +1,15 @@
 # Low Fantasy Gaming Character Sheet
 
-This is a character sheet for use on Roll20.net with Low Fantasy Gaming. 
+This is a character sheet for use on Roll20.net with Low Fantasy Gaming.
 
 ## Features
 This version of the sheet incorporates roll templates and autocalculates hit and damage values. It does not require access to features of the Dev server or the API.
+
+**Attribute clarifications:**
+
+* GS = Great Success
+* TF = Terrible Failure
+(Low Fantasy Gaming page 42, "Degrees of Success or Failure")
 
 ### Changelog
 * 12 June 2016 original version.

--- a/Low Fantasy Gaming/sheet.json
+++ b/Low Fantasy Gaming/sheet.json
@@ -4,5 +4,5 @@
     "authors": "Stephen J Grodzicki,Davemania",
     "roll20userid": "76",
     "preview": "LFGSheet.png",
-    "instructions": "This sheet is for Low Fantasy Gaming.\n* [Sheet Readme](https://github.com/Roll20/roll20-character-sheets/blob/master/Low%20Fantasy%20Gaming/ReadMe.md)\n* [Game Homepage]()https://lowfantasygaming.com/"
+    "instructions": "This sheet is for Low Fantasy Gaming.\n* [Sheet Readme](https://github.com/Roll20/roll20-character-sheets/blob/master/Low%20Fantasy%20Gaming/ReadMe.md)\n* [Game Homepage](https://lowfantasygaming.com/)"
 }

--- a/Low Fantasy Gaming/sheet.json
+++ b/Low Fantasy Gaming/sheet.json
@@ -4,5 +4,5 @@
     "authors": "Stephen J Grodzicki,Davemania",
     "roll20userid": "76",
     "preview": "LFGSheet.png",
-    "instructions": "This sheet is Low Fantasy Gaming."
+    "instructions": "This sheet is for Low Fantasy Gaming.\n* [Sheet Readme](https://github.com/Roll20/roll20-character-sheets/blob/master/Low%20Fantasy%20Gaming/ReadMe.md)\n* [Game Homepage]()https://lowfantasygaming.com/"
 }


### PR DESCRIPTION
## Changes / Comments

* Added link to sheet Readme and game's homepage on the `Sheet instruction`-section.
* Readme mention of two uncommon abbrevations


## Other 
@dedurrett If more info is added to the Readme later, it will be easier to find for the average user.

Is it fine if I include in the Readme  what the **TF** and **GS** stats means? 