### PR TITLE
[Ryuutama]: styling tweaks

### DIFF
--- a/Ryuutama/Ryuutama.css
+++ b/Ryuutama/Ryuutama.css
@@ -241,7 +241,7 @@ input.sheet-overburdenPenalty {
     border-radius: 4px;
     padding-left: 5px;
     width: 250px;
-    font-size: 15px;
+    font-size: 14px;
     height: 20px;
     font-family: cursive;
 }
@@ -305,7 +305,7 @@ inpur.sheet-radioChoice6:checked + span.sheet-radioChoice6 {
 
 /* High Level Tabs */
 input.sheet-tab {
-    width: 100px;
+    width: 150px;
     height: 40px;
     cursor: pointer;
 	position: relative;
@@ -322,12 +322,12 @@ span.sheet-tab {
 	font-weight: bold;
 	border-radius: 4px;
 	font-family: cursive;
-	width: 160px;
+	width: 150px;
     height: 40px;
     cursor: pointer;
 	position: relative;
 	vertical-align: middle;
-	margin-left: -100px;
+	margin-left: -150px;
     line-height: 40px;
 }
 

--- a/Ryuutama/sheet.json
+++ b/Ryuutama/sheet.json
@@ -1,8 +1,8 @@
 {
   "html": "Ryuutama.html",
   "css": "Ryuutama.css",
-  "authors": "King Puff",
-  "roll20userid": "665159",
+  "authors": "King Puff, Jose Velazquez",
+  "roll20userid": "665159, 665811",
   "preview": "Ryuutama.png",
   "instructions": "This character sheet represents player characters for the Ryuutama system. It does not provide details about classes, skills, or mechanics, but does an intuitive dice roller that automatically takes into account benefits from class, type, weather, condition, and terrain and the penalties associated with being overburdened and suffering from conditional status effects. The sheet contains a tab for inputting meta information about characters, a tab for tracking experience points and statistics (derived attributes are automatically calculated but can be overridden), a tab for inputting class, type, weapon mastery, and skills/spells, and a tab for inventory management that automatically tracks current and maximum item and water capacity."
 }


### PR DESCRIPTION
## Changes / Comments
Fixing up a few of the tabs that were wrapping poorly and were only clickable on the left side. Also made some text a tiny bit smaller to also no longer wrap and partially cover the input below it.



## Roll20 Requests

*Include the name of the sheet(s) you made changes to in the title.*

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- Is this a bug fix?
- Does this add functional enhancements (new features or extending existing features) ?
- Does this add or change functional aesthetics (such as layout or color scheme) ? 
- Are you intentionally changing more that one sheet? If so, which ones ?
- If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
