### PR TITLE
[Ryuutama] Adding a windows font

### DIFF
--- a/Ryuutama/Ryuutama.css
+++ b/Ryuutama/Ryuutama.css
@@ -1,5 +1,5 @@
 * {
-    font-family: fantasy;
+    font-family: fantasy, 'Palatino Linotype', cursive;
 }
 
 textarea {
@@ -243,7 +243,7 @@ input.sheet-overburdenPenalty {
     width: 250px;
     font-size: 15px;
     height: 20px;
-    font-family: cursive;
+    font-family: 'Palatino Linotype', cursive;
 }
 
 .sheet-loweredHeaderLabel {
@@ -321,7 +321,7 @@ span.sheet-tab {
 	color: black;
 	font-weight: bold;
 	border-radius: 4px;
-	font-family: cursive;
+	font-family: 'Palatino Linotype', cursive;
 	width: 160px;
     height: 40px;
     cursor: pointer;


### PR DESCRIPTION
## Changes / Comments

The default font is a Mac font and it looks good there, but on Windows it defaults to Comic Sans, which doesn't look as good. So adding an extra font that will hopefully make it look better on Windows machines, with the Comic Sans as additional backup if that Win Font isn't installed.


## Roll20 Requests

*Include the name of the sheet(s) you made changes to in the title.*

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- Is this a bug fix?
- Does this add functional enhancements (new features or extending existing features) ?
- Does this add or change functional aesthetics (such as layout or color scheme) ? 
- Are you intentionally changing more that one sheet? If so, which ones ?
- If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
