### PR TITLE
D&D 5e - UC 13 - Mancer Level up Fix single spell selection

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -13806,6 +13806,7 @@
             });
             getCompendiumPage(getNames, function(data) {
                 var nextGet = [];
+                if (getNames.length === 1) { data = {0:data} }; //Fix single spell selections failing.
                 _.each(data, function(page, index) {
                     var pagedata = false;
                     _.each(pageArray, function(arrayData) {
@@ -16342,6 +16343,7 @@
             });
             getCompendiumPage(getNames, function(data) {
                 var nextGet = [];
+                if (getNames.length === 1) { data = {0:data} }; //Fix single spell selections failing.
                 _.each(data, function(page, index) {
                     var pagedata = false;
                     _.each(pageArray, function(arrayData) {


### PR DESCRIPTION
## Changes / Comments

* Fix the issue where Paladins could not level from 1 -> 2 due to a single spell select.


## Roll20 Requests

*Include the name of the sheet(s) you made changes to in the title.*

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- Is this a bug fix?
- Does this add functional enhancements (new features or extending existing features) ?
- Does this add or change functional aesthetics (such as layout or color scheme) ? 
- Are you intentionally changing more that one sheet? If so, which ones ?
- If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
