### PR TITLE
D&D 5e - UC 78 - Deprecated NPC Spell Text

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -775,7 +775,7 @@
             <div class="row actiontitle">
                 <span class="title red" style="font-weight: normal; text-align: left;" data-i18n="spells">Spells</span>
             </div>
-            <div class="warning"><span>THIS SECTION IS NOW NO LONGER SUPPORTED. PLEASE TRANSFER ANY SPELLS LISTED HERE INTO THE NEW SPELLS BY LEVEL SECTION, AVAILABLE AFTER SELECTING THE 'SPELLCASTING NPC' OPTION FROM THE NPC OPTIONS ABOVE. FOR MODULE USERS, THIS SHEET WILL BE UPDATED IN AN UPCOMING PATCH.</span></div>
+            <div class="warning"><span style="color:#d06300;">THIS SECTION IS SCHEDULED TO BE REMOVED ON <u>19 APRIL 2019</u>. PLEASE TRANSFER ANY SPELLS LISTED HERE INTO THE NEW SPELLS BY LEVEL SECTION, AVAILABLE AFTER SELECTING THE 'SPELLCASTING NPC' OPTION FROM THE NPC OPTIONS ABOVE. IF THIS REMOVAL WOULD BE A HARDSHIP FOR YOU PLEASE REPLY ON THE STICKIED POST IN THE CHARACTER SHEET & COMPENDIUM FORUM</span></div>
             <div class="spell-container">
                 <fieldset class="repeating_spell-npc">
                     <div class="spell">


### PR DESCRIPTION
## Changes / Comments

* Update the old NPC Spells text to inform users of its intended removal.

## Roll20 Requests

*Include the name of the sheet(s) you made changes to in the title.*

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- Is this a bug fix?
- Does this add functional enhancements (new features or extending existing features) ?
- Does this add or change functional aesthetics (such as layout or color scheme) ? 
- Are you intentionally changing more that one sheet? If so, which ones ?
- If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
