### PR TITLE
5e D&D - UC 26 - Fixed Encode Thoughts in Level+

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -15440,6 +15440,7 @@
             getCompendiumQuery(queries, (data) => {
                 let byLevel = {};
                 _.each(data, (spell) => {
+                    let classes = [];
                     if (spell.data.Classes) {
                         classes = spell.data.Classes;
                     //Ravinca introduced Spells without Classes

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -11126,10 +11126,12 @@
         var additionalList = {};
         var blobs = getRelevantBlobs(mancerdata, "1", "l1");
 
-        //Collect expanded spell lists
+        //First look through all Blobs for any blob.Spells
         _.each(blobs.all, function(blob) {
             if(blob.Spells) {
                 var spells = JSON.parse(blob.Spells);
+                //Examine each spell to determine if it is "Extended List". "Extended List" adds to the classes spell list.
+                //Ravnica Guilds backgrounds such as Dimir Operative are examples of this
                 _.each(spells, function(spell) {
                     if(spell["Expanded List"]) {
                         expandedList[spell.Level] = expandedList[spell.Level] ? expandedList[spell.Level].concat(spell["Expanded List"]) : spell["Expanded List"];
@@ -11137,9 +11139,12 @@
                 });
             }
         });
+        //Look through blobs.sorted.
         _.each(blobs.sorted, function(sectionblobs, section) {
+            //Subclass needs to be changed to class.
             var parentsection = section.replace("sub", "");
             additionalList[parentsection] = additionalList[parentsection] || []
+            //Examine eaach blob for "Additional Spell List"
             _.each(sectionblobs, function(blob) {
                 if(blob["Additional Spell List"]) {
                     additionalList[parentsection].push(blob["Additional Spell List"]);
@@ -11150,18 +11155,24 @@
         _.each(blobs.sorted, function(sectionblobs, section) {
             var parentsection = section.replace("sub", "");
             _.each(sectionblobs, function(blob) {
+                //Looks through the blobs for Spells attribute
+                //class.Spells contains the information for how many spells are choosen at each level & Prepared spells to be selected based on ability modifer + 1
+                //[subclass, background, race}.Spells will contain KNOWN, CHOSEN, or EXPANDED LIST for extra spells granted by these sections
                 if(blob.Spells) {
                     var spells = JSON.parse(blob.Spells);
                     allSpells[parentsection] = allSpells[parentsection] || {known: [], choices: []}
                     _.each(spells, function(spell) {
                         var numSpells = 0;
                         expandedList[spell.Level] = expandedList[spell.Level] || [];
+                        //class.Spells will contain Prepared and Choose.
+                        //These are used to populate the number of selects needed for each spell lists on the Spells slide
                         if(spell.Prepared) {
                             numSpells = Math.max(stats.totals[spell.Prepared.split("+")[0].toLowerCase()].mod, 0) + parseInt(spell.Prepared.split("+")[1]);
                         }
                         if(spell.Choose) {
                             numSpells = parseInt(spell.Choose);
                         }
+                        //If Spells are to be Chosen or Prepared add them to a class list, expand the list, and set the Ability modifier & Level
                         if(numSpells > 0) {
                             _.times(numSpells, function(n) {
                                 var thisspell = {Level: parseInt(spell.Level)};
@@ -11172,6 +11183,7 @@
                                 allSpells[parentsection].choices.push(thisspell);
                             });
                         }
+                        //Add any spells that are already known from sections such as Forge Domain Cleric starts with identify & searing smite
                         _.each(spell.Known, function(known) {
                             var thisspell = {Name: known, Level: parseInt(spell.Level)};
                             thisspell.Ability = spell.Ability ? spell.Ability : classAbility;
@@ -15425,17 +15437,35 @@
                 });
             }
             setCharmancerText(update);
-            getCompendiumQuery(queries, function(data) {
-                var byLevel = {};
-                _.each(data, function(spell) {
-                    if(spell.data.Classes) {
-                        byLevel[spell.data.Level] = byLevel[spell.data.Level] || [];
-                        byLevel[spell.data.Level].push({
-                            name: spell.name,
-                            classes: spell.data.Classes.split(",").map(x => x.trim()),
-                            level: parseInt(spell.data.Level)
+            getCompendiumQuery(queries, (data) => {
+                let byLevel = {};
+                _.each(data, (spell) => {
+                    if (spell.data.Classes) {
+                        classes = spell.data.Classes;
+                    //Ravinca introduced Spells without Classes
+                    } else {
+                      ["class1", "class2", "class3", "class4"].forEach(levelclass => {
+                            //Get the class name out of values & confirm its a spellcaster using data Spellcasting Ability
+                            const name = (mancerdata["lp-levels"].values[`${levelclass}`]) ? mancerdata["lp-levels"].values[`${levelclass}`].split("Classes:")[1] : false;
+                            const ability = (mancerdata["lp-levels"].data[`${levelclass}`] && mancerdata["lp-levels"].data[`${levelclass}`]["Spellcasting Ability"]) ? mancerdata["lp-levels"].data[`${levelclass}`]["Spellcasting Ability"] : false;
+                            if (name && ability) {
+                                //Spell casters have thier class name pushed to the array above
+                                classes.push(name);
+                            };
                         });
-                    }
+
+                       if (classes.length > 0) {
+                            classes = classes.join(', ');
+                       };
+                    };
+
+                    /* This will set the information for populating the spell list */
+                    byLevel[spell.data.Level] = byLevel[spell.data.Level] || [];
+                    byLevel[spell.data.Level].push({
+                        name: spell.name,
+                        classes: classes.split(",").map(x => x.trim()),
+                        level: parseInt(spell.data.Level)
+                    });
                 });
                 addSpellSections(byLevel, {
                     newspells: newspells,

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -15448,7 +15448,13 @@
                       ["class1", "class2", "class3", "class4"].forEach(levelclass => {
                             //Get the class name out of values & confirm its a spellcaster using data Spellcasting Ability
                             const name = (mancerdata["lp-levels"].values[`${levelclass}`]) ? mancerdata["lp-levels"].values[`${levelclass}`].split("Classes:")[1] : false;
-                            const ability = (mancerdata["lp-levels"].data[`${levelclass}`] && mancerdata["lp-levels"].data[`${levelclass}`]["Spellcasting Ability"]) ? mancerdata["lp-levels"].data[`${levelclass}`]["Spellcasting Ability"] : false;
+                            const ability = 
+                                //Check if the class has a Spellcasting Ability attribute
+                                (mancerdata["lp-levels"].data[`${levelclass}`] && mancerdata["lp-levels"].data[`${levelclass}`]["Spellcasting Ability"]) ? true : 
+                                //Check if the subclass has a Spellcasting Ability attribute
+                                (mancerdata["lp-levels"].data[`${levelclass}_subclass`] && mancerdata["lp-levels"].data[`${levelclass}_subclass`]["Spellcasting Ability"]) ? true :
+                                //Set to false if the class is not a spellcaster
+                                false;
                             if (name && ability) {
                                 //Spell casters have thier class name pushed to the array above
                                 classes.push(name);
@@ -15461,12 +15467,14 @@
                     };
 
                     /* This will set the information for populating the spell list */
-                    byLevel[spell.data.Level] = byLevel[spell.data.Level] || [];
-                    byLevel[spell.data.Level].push({
-                        name: spell.name,
-                        classes: classes.split(",").map(x => x.trim()),
-                        level: parseInt(spell.data.Level)
-                    });
+                    if (classes.length > 0) {
+                        byLevel[spell.data.Level] = byLevel[spell.data.Level] || [];
+                        byLevel[spell.data.Level].push({
+                            name: spell.name,
+                            classes: classes.split(",").map(x => x.trim()),
+                            level: parseInt(spell.data.Level)
+                        });
+                    };
                 });
                 addSpellSections(byLevel, {
                     newspells: newspells,


### PR DESCRIPTION
## Changes / Comments

* Encode Thoughts was not being displayed on Level Up. 
* Also added comments to the Mancer code.


## Roll20 Requests

*Include the name of the sheet(s) you made changes to in the title.*

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- Is this a bug fix?
- Does this add functional enhancements (new features or extending existing features) ?
- Does this add or change functional aesthetics (such as layout or color scheme) ? 
- Are you intentionally changing more that one sheet? If so, which ones ?
- If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
