### PR TITLE
D&D 5e - UC 330 & 371 - Fix #4890

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -8441,53 +8441,56 @@
         });
     };
 
-    var create_resource_from_item = function(itemid) {
-        var update = {};
-        var newrowid = generateRowID();
+    const create_resource_from_item = (itemid) => {
+        const newrowid = generateRowID();
+        let update     = {};
 
-        getAttrs(["other_resource_name"], function(x) {
-            if(!x.other_resource_name || x.other_resource_name == "") {
-                update["repeating_inventory_" + itemid + "_itemresourceid"] = "other_resource";
+        getAttrs(["other_resource_name"], (v) => {
+            //Use other_resource if it is empty
+            if (!v.other_resource_name || v.other_resource_name == "") {
+                update[`repeating_inventory_${itemid}_itemresourceid`] = "other_resource";
                 setAttrs(update, {}, update_resource_from_item(itemid, "other_resource", true));
-            }
-            else {
-                getSectionIDs("repeating_resource", function(idarray) {
-                    if(idarray.length == 0) {
-                        update["repeating_inventory_" + itemid + "_itemresourceid"] = newrowid + "_resource_left";
-                        setAttrs(update, {}, update_resource_from_item(itemid, newrowid + "_resource_left", true));
-                    }
-                    else {
-                        var resource_names = [];
-                        _.each(idarray, function(currentID, i) {
-                            resource_names.push("repeating_resource_" + currentID + "_resource_left_name");
-                            resource_names.push("repeating_resource_" + currentID + "_resource_right_name");
-                        });
-
-                        getAttrs(resource_names, function(y) {
-                            var existing = false;
-                            _.each(idarray, function(currentID, i) {
-                                if((!y["repeating_resource_" + currentID + "_resource_left_name"] || y["repeating_resource_" + currentID + "_resource_left_name"] === "") && existing == false) {
-                                    update["repeating_inventory_" + itemid + "_itemresourceid"] = currentID + "_resource_left";
-                                    setAttrs(update, {}, update_resource_from_item(itemid, currentID + "_resource_left", true));
-                                    existing = true;
-                                }
-                                else if((!y["repeating_resource_" + currentID + "_resource_right_name"] || y["repeating_resource_" + currentID + "_resource_right_name"] === "") && existing == false) {
-                                    update["repeating_inventory_" + itemid + "_itemresourceid"] = currentID + "_resource_right";
-                                    setAttrs(update, {}, update_resource_from_item(itemid, currentID + "_resource_right", true));
-                                    existing = true;
-                                };
+            //If other_resource is populated look through the repeating sections for an empty spot
+            } else {
+                getSectionIDs(`repeating_resource`, (idarray) => {
+                    if (idarray.length == 0) {
+                        update[`repeating_inventory_${itemid}_itemresourceid`] = `${newrowid}_resource_left`;
+                        setAttrs(update, {}, update_resource_from_item(itemid, `${newrowid}_resource_left`, true));
+                    } else {
+                        let array = [];
+                        _.each(idarray, (currentID, i) => {
+                            ["left", "right"].forEach(side => {
+                                array.push(`repeating_resource_${currentID}_resource_${side}`);
+                                array.push(`repeating_resource_${currentID}_resource_${side}_name`);
+                                array.push(`repeating_resource_${currentID}_resource_${side}_max`);
                             });
-                            if(!existing) {
-                                update["repeating_inventory_" + itemid + "_itemresourceid"] = newrowid + "_resource_left";
-                                setAttrs(update, {}, update_resource_from_item(itemid, newrowid + "_resource_left", true));
-                            }
                         });
+                        getAttrs(array, (y) => {
+                            let existing = false;
+                           _.each(idarray, (currentID, i) => {
+                                ["left", "right"].forEach(side => {
+                                    const Name  = y[`repeating_resource_${currentID}_resource_${side}_name`] || false;
+                                    const Value = y[`repeating_resource_${currentID}_resource_${side}`] || false;
+                                    const Max   = y[`repeating_resource_${currentID}_resource_${side}_max`] || false;
 
+                                    //If Name, Value, & Max are empty and existing === false then populate a resource there
+                                    if ((!Name && !Value && !Max) && existing === false) {
+                                        update[`repeating_inventory_${itemid}_itemresourceid`] = `${currentID}_resource_${side}`;
+                                        setAttrs(update, {}, update_resource_from_item(itemid, `${currentID}_resource_${side}`, true));
+                                        existing = true;
+                                    };
+                                });
+                            });
+                           //If nothing is empty then generatae a new row
+                            if(!existing) {
+                                update[`repeating_inventory_${itemid}_itemresourceid`] = `${newrowid}_resource_left`;
+                                setAttrs(update, {}, update_resource_from_item(itemid, `${newrowid}_resource_left`, true));
+                            };
+                        });
                     };
                 });
             };
         });
-
     };
 
     var update_resource_from_item = function(itemid, resourceid, newresource) {
@@ -9155,36 +9158,42 @@
         removeRepeatingRow("repeating_attack_" + attackid);
     };
 
-    var remove_resource = function(id) {
-        var update = {};
-        getAttrs([id + "_itemid"], function(v) {
-            var itemid = v[id + "_itemid"];
-            if(itemid) {
-                update["repeating_inventory_" + itemid + "_useasresource"] = 0;
-                update["repeating_inventory_" + itemid + "_itemresourceid"] = "";
+    const remove_resource = (id) => {
+        const attr = (id === "other_resource") ? id : `repeating_resource_${id}_itemid`;
+        let update = {};
+        getAttrs([`${attr}`], (v) => {
+            const itemid = v[`${attr}`];
+            //Uncheck Use As A Resource in inventory for an item if its resource row is deleted
+            if (itemid) {
+                update[`repeating_inventory_${itemid}_useasresource`]  = 0;
+                update[`repeating_inventory_${itemid}_itemresourceid`] = "";
             };
-            if(id == "other_resource") {
-                update["other_resource"] = "";
-                update["other_resource_name"] = "";
+            if (id == "other_resource") {
+                update["other_resource"]        = "";
+                update["other_resource_name"]   = "";
                 update["other_resource_itemid"] = "";
                 setAttrs(update, {silent: true});
-            }
-            else {
-                var baseid = id.replace("repeating_resource_", "").substring(0,20);
-                var resource_names = ["repeating_resource_" + baseid + "_resource_left_name", "repeating_resource_" + baseid + "_resource_right_name"];
-                getAttrs(resource_names, function(v) {
-                    if((id.indexOf("left") > -1 && !v["repeating_resource_" + baseid + "_resource_right_name"]) || (id.indexOf("right") > -1 && !v["repeating_resource_" + baseid + "_resource_left_name"])) {
-                        removeRepeatingRow("repeating_resource_" + baseid);
-                    }
-                    else {
-                        update["repeating_resource_" + id.replace("repeating_resource_", "")] = "";
-                        update["repeating_resource_" + id.replace("repeating_resource_", "") + "_name"] = "";
+            } else {
+                const currentID = id.replace("repeating_resource_", "").substring(0,20);
+                const side  = (id.includes("left")) ? `right` : `left`;
+                //Get the inputs for the opposite side to see if they are empty. 
+                //If they are empty delete the entire row. Otherwise set the side that was the source of this event to empty strings
+                getAttrs([`repeating_resource_${currentID}_resource_${side}`, `repeating_resource_${currentID}_resource_${side}_name`, `repeating_resource_${currentID}_resource_${side}_max`], (v) => {
+                    const Name  = v[`repeating_resource_${currentID}_resource_${side}_name`] || false;
+                    const Value = v[`repeating_resource_${currentID}_resource_${side}`] || false;
+                    const Max   = v[`repeating_resource_${currentID}_resource_${side}_max`] || false;
+                    if (!Name && !Value && !Max) {
+                        removeRepeatingRow(`repeating_resource_${currentID}`);
+                    } else {
+                        update[`repeating_resource_${id}`]        = "";
+                        update[`repeating_resource_${id}_name`]   = "";
+                        update[`repeating_resource_${id}_max`]    = "";
+                        update[`repeating_resource_${id}_itemid`] = "";
                     };
                     setAttrs(update, {silent: true});
                 });
-
             };
-        });
+        }); 
     };
 
     const update_weight = function() {

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -6412,29 +6412,25 @@
         });
     });
 
-    on("change:other_resource change:other_resource_name change:repeating_resource:resource_left change:repeating_resource:resource_left_name change:repeating_resource:resource_right change:repeating_resource:resource_right_name", function(eventinfo) {
-
-        if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
-            return;
-        }
-
-        var resourceid = eventinfo.sourceAttribute;
-        if(eventinfo.sourceAttribute.indexOf("other") > -1) {
-            resourceid = "other_resource";
-        }
-        else if(eventinfo.sourceAttribute.substring(eventinfo.sourceAttribute.length - 5) == "_name") {
-            resourceid = eventinfo.sourceAttribute.substring(0, eventinfo.sourceAttribute.length - 5);
-        };
-
-        getAttrs([resourceid, resourceid + "_name", resourceid + "_itemid"], function(v) {
-            if(!v[resourceid + "_name"]) {
-                remove_resource(resourceid);
-            }
-            else if(v[resourceid + "_itemid"] && v[resourceid + "_itemid"] != ""){
-                update_item_from_resource(resourceid, v[resourceid + "_itemid"]);
-            };
+    ['other_resource','repeating_resource:resource_left','repeating_resource:resource_right'].forEach(attr => {
+        on(`change:${attr} change:${attr}_name`, (eventinfo) => {
+            if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {return;}
+            const resourceid = (eventinfo.sourceAttribute.includes("_name")) ? eventinfo.sourceAttribute.slice(0, -5) : eventinfo.sourceAttribute;
+            getAttrs([`${resourceid}_itemid`], (v) => {
+                const value = eventinfo.newValue;
+                //Update repeating_inventory if an itemid is associated with a resource
+                if (v[`${resourceid}_itemid`] && v[`${resourceid}_itemid`] != "") {
+                    const itemid = v[`${resourceid}_itemid`];
+                    let update = {};
+                    if (eventinfo.sourceAttribute.includes("_name")) {
+                        update[`repeating_inventory_${itemid}_itemname`]  = eventinfo.newValue;
+                    } else {
+                        update[`repeating_inventory_${itemid}_itemcount`] = eventinfo.newValue;
+                    };
+                    setAttrs(update, {silent: true}, () => {update_weight()});
+                };
+            });
         });
-
     });
 
     on("change:repeating_inventory:itemweight change:repeating_inventory:itemcount change:cp change:sp change:ep change:gp change:pp change:encumberance_setting change:size change:carrying_capacity_mod", function() {
@@ -6720,21 +6716,21 @@
         update_passive_perception();
     });
 
-    on("remove:repeating_inventory", function(eventinfo) {
-        var itemid = eventinfo.sourceAttribute.substring(20, 40);
-        var attackids = eventinfo.removedInfo && eventinfo.removedInfo["repeating_inventory_" + itemid + "_itemattackid"] ? eventinfo.removedInfo["repeating_inventory_" + itemid + "_itemattackid"] : undefined;
-        var resourceid = eventinfo.removedInfo && eventinfo.removedInfo["repeating_inventory_" + itemid + "_itemresourceid"] ? eventinfo.removedInfo["repeating_inventory_" + itemid + "_itemresourceid"] : undefined;
+    on("remove:repeating_inventory", (eventinfo) => {
+        const itemid     = eventinfo.sourceAttribute.substring(20, 40);
+        const attackids  = (eventinfo.removedInfo && eventinfo.removedInfo[`repeating_inventory_${itemid}_itemattackid`]) ? eventinfo.removedInfo[`repeating_inventory_${itemid}_itemattackid`] : undefined;
+        const resourceid = (eventinfo.removedInfo && eventinfo.removedInfo[`repeating_inventory_${itemid}_itemresourceid`]) ? eventinfo.removedInfo[`repeating_inventory_${itemid}_itemresourceid`] : undefined;
 
-        if(attackids) {
-            _.each(attackids.split(","), function(value) { remove_attack(value); });
-        }
-        if(resourceid) {
+        if (attackids) {
+            _.each(attackids.split(","), (value) => { remove_attack(value); });
+        };
+        if (resourceid) {
             remove_resource(resourceid);
-        }
+        };
 
-        if(eventinfo.removedInfo && eventinfo.removedInfo["repeating_inventory_" + itemid + "_itemmodifiers"]) {
-            check_itemmodifiers(eventinfo.removedInfo["repeating_inventory_" + itemid + "_itemmodifiers"]);
-        }
+        if (eventinfo.removedInfo && eventinfo.removedInfo[`repeating_inventory_${itemid}_itemmodifiers`]) {
+            check_itemmodifiers(eventinfo.removedInfo[`repeating_inventory_${itemid}_itemmodifiers`]);
+        };
 
         update_weight();
     });
@@ -8526,14 +8522,6 @@
         });
     };
 
-    var update_item_from_resource = function(resourceid, itemid) {
-        var update = {};
-        getAttrs([resourceid, resourceid + "_name"], function(v) {
-            update["repeating_inventory_" + itemid + "_itemcount"] = v[resourceid];
-            update["repeating_inventory_" + itemid + "_itemname"] = v[resourceid + "_name"];
-            setAttrs(update, {silent: true}, function() {update_weight()});
-        });
-    };
 
     const create_attack_from_spell = function(lvl, spellid, character_id) {
         let update   = {};

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -6716,21 +6716,21 @@
         update_passive_perception();
     });
 
-    on("remove:repeating_inventory", (eventinfo) => {
-        const itemid     = eventinfo.sourceAttribute.substring(20, 40);
-        const attackids  = (eventinfo.removedInfo && eventinfo.removedInfo[`repeating_inventory_${itemid}_itemattackid`]) ? eventinfo.removedInfo[`repeating_inventory_${itemid}_itemattackid`] : undefined;
-        const resourceid = (eventinfo.removedInfo && eventinfo.removedInfo[`repeating_inventory_${itemid}_itemresourceid`]) ? eventinfo.removedInfo[`repeating_inventory_${itemid}_itemresourceid`] : undefined;
+    on("remove:repeating_inventory", function(eventinfo) {
+        var itemid = eventinfo.sourceAttribute.substring(20, 40);
+        var attackids = eventinfo.removedInfo && eventinfo.removedInfo["repeating_inventory_" + itemid + "_itemattackid"] ? eventinfo.removedInfo["repeating_inventory_" + itemid + "_itemattackid"] : undefined;
+        var resourceid = eventinfo.removedInfo && eventinfo.removedInfo["repeating_inventory_" + itemid + "_itemresourceid"] ? eventinfo.removedInfo["repeating_inventory_" + itemid + "_itemresourceid"] : undefined;
 
-        if (attackids) {
-            _.each(attackids.split(","), (value) => { remove_attack(value); });
-        };
-        if (resourceid) {
+        if(attackids) {
+            _.each(attackids.split(","), function(value) { remove_attack(value); });
+        }
+        if(resourceid) {
             remove_resource(resourceid);
-        };
+        }
 
-        if (eventinfo.removedInfo && eventinfo.removedInfo[`repeating_inventory_${itemid}_itemmodifiers`]) {
-            check_itemmodifiers(eventinfo.removedInfo[`repeating_inventory_${itemid}_itemmodifiers`]);
-        };
+        if(eventinfo.removedInfo && eventinfo.removedInfo["repeating_inventory_" + itemid + "_itemmodifiers"]) {
+            check_itemmodifiers(eventinfo.removedInfo["repeating_inventory_" + itemid + "_itemmodifiers"]);
+        }
 
         update_weight();
     });


### PR DESCRIPTION
## Changes / Comments

* Refactored & optimize how resources & repeating inventory work together
* Remove the code that was force deleting the field if a name wasn't present
* Remove update_item_from_resource function. Nothing else uses this function so the code was integrated in the change events
* Fixed a bug that were not apparent with the changes above.
* Removing Item or a Resource will update the opposite.


## Roll20 Requests

*Include the name of the sheet(s) you made changes to in the title.*

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- Is this a bug fix?
- Does this add functional enhancements (new features or extending existing features) ?
- Does this add or change functional aesthetics (such as layout or color scheme) ? 
- Are you intentionally changing more that one sheet? If so, which ones ?
- If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
