### PR TITLE
Das_Schwarze_Auge_5 Fixed: Each Parrying Weapons can now have its own range

### DIFF
--- a/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.html
@@ -7157,7 +7157,7 @@
 						<td class="padding-1"><input style="width: 3em;" type="number" name="attr_ParierwaffeTP1_2" value="0"></td>
 						<td class="padding-1"><input style="width: 3em;" type="number" name="attr_ParierwaffeATMod1" value="0"></td>
 						<td class="padding-1"><input style="width: 3em;" type="number" name="attr_ParierwaffePAMod1" value="0"></td>
-						<td class="padding-1"><select name="attr_ReichweiteNKWaffe4" style="width: 5em">
+						<td class="padding-1"><select name="attr_ReichweiteParierwaffe1" style="width: 5em">
 								<option value="1" data-i18n="kurz">kurz</option>
 								<option value="2" data-i18n="mittel">mittel</option>
 								<option value="3" data-i18n="lang">lang</option>
@@ -7196,7 +7196,7 @@
 						<td class="padding-1"><input style="width: 3em;" type="number" name="attr_ParierwaffeTP2_2" value="0"></td>
 						<td class="padding-1"><input style="width: 3em;" type="number" name="attr_ParierwaffeATMod2" value="0"></td>
 						<td class="padding-1"><input style="width: 3em;" type="number" name="attr_ParierwaffePAMod2" value="0"></td>
-						<td class="padding-1"><select name="attr_ReichweiteNKWaffe4" style="width: 5em">
+						<td class="padding-1"><select name="attr_ReichweiteParierwaffe2" style="width: 5em">
 								<option value="1" data-i18n="kurz">kurz</option>
 								<option value="2" data-i18n="mittel">mittel</option>
 								<option value="3" data-i18n="lang">lang</option>
@@ -7235,7 +7235,7 @@
 						<td class="padding-1"><input style="width: 3em;" type="number" name="attr_ParierwaffeTP3_2" value="0"></td>
 						<td class="padding-1"><input style="width: 3em;" type="number" name="attr_ParierwaffeATMod3" value="0"></td>
 						<td class="padding-1"><input style="width: 3em;" type="number" name="attr_ParierwaffePAMod3" value="0"></td>
-						<td class="padding-1"><select name="attr_ReichweiteNKWaffe4" style="width: 5em">
+						<td class="padding-1"><select name="attr_ReichweiteParierwaffe3" style="width: 5em">
 								<option value="1" data-i18n="kurz">kurz</option>
 								<option value="2" data-i18n="mittel">mittel</option>
 								<option value="3" data-i18n="lang">lang</option>
@@ -7274,7 +7274,7 @@
 						<td class="padding-1"><input style="width: 3em;" type="number" name="attr_ParierwaffeTP4_2" value="0"></td>
 						<td class="padding-1"><input style="width: 3em;" type="number" name="attr_ParierwaffeATMod4" value="0"></td>
 						<td class="padding-1"><input style="width: 3em;" type="number" name="attr_ParierwaffePAMod4" value="0"></td>
-						<td class="padding-1"><select name="attr_ReichweiteNKWaffe4" style="width: 5em">
+						<td class="padding-1"><select name="attr_ReichweiteParierwaffe4" style="width: 5em">
 								<option value="1" data-i18n="kurz">kurz</option>
 								<option value="2" data-i18n="mittel">mittel</option>
 								<option value="3" data-i18n="lang">lang</option>


### PR DESCRIPTION
## Changes / Comments
Bugfix for Das_Schwarze_Auge_5 character sheet:
- Each parrying weapon now has its own attribute for range, instead of using the fourth weapons range
  - Before it was not possible to correctly enter the range attribute for each parrying weapon as all had the same backing attribute (attr_ReichweiteNKWaffe4) instead of their own field.
  - Now all parrying weapons use their own attribute created in the same naming scheme as the other attributes
  - No other changes are necessary, as the fields are not used for auto calculation of values