### PR TITLE
Forbidden Lands v1.1 small update

### DIFF
--- a/Forbidden_Lands/Forbidden_Lands.css
+++ b/Forbidden_Lands/Forbidden_Lands.css
@@ -61,6 +61,13 @@ hr.sheet-horizontal-rule::before { /* Not really supposed to work, but does */
   padding: 22px 2px 0px 0px;
 }
 
+.sheet-footer {
+  font-size: 0.95em;
+  display: block;
+  text-align: right;
+  margin: -15px 0 0 -10px;
+}
+
 .sheet-label {
   font-weight: bold;
 }

--- a/Forbidden_Lands/Forbidden_Lands.htm
+++ b/Forbidden_Lands/Forbidden_Lands.htm
@@ -1,4 +1,5 @@
-<!--v1.0 4/9/19'-->
+<!--4/14/19'-->
+<input type="hidden" name="attr_version" value="1.1">
 
 <!--tabs-->
 <input class="tab character" name="attr_tab" title="Character" type="radio" value="1" checked/>
@@ -461,7 +462,7 @@
                     <button class="dice-pool api-button" type="roll" name="roll_the_dice" value="!forl [[(@{skill})d6]] [[(@{attribute})d6]] [[(@{gear})d6]] [[(@{artifact_die_eight})d8+(@{artifact_die_ocho})d8+(@{artifact_die_ten})d10+(@{artifact_die_twelve})d12]] --Character|@{character_name} --Roll|@{current_preset} @{include_with_roll}" data-i18n-title="roll-dice" title="Roll the Dice!"><span class="small-caps" data-i18n="roll"> Roll </span></button>
                 </div>
                 <div class="grid-item">
-                    <button class="dice-pool" type="roll" name="roll_d66" value="&{template:forbiddenlands} {{character_name=@{selected|character_name}}} {{character_id=@{selected|character_id}}} {{name=D66 Roll}} {{subtitle}} {{free-text}}  {{skill-die-one=[[ 1 ]] }} {{skill-roll-one=[[ 1d6 ]] }} {{skill-die-two=[[ 1 ]] }} {{skill-roll-two=[[ 1d6 ]] }} {{footer}}" data-i18n-title="roll-dice-66" title="Roll d66!"><span class="small-caps"> D</span>66 </button>
+                    <button class="dice-pool" type="roll" name="roll_d66" value="&{template:forbiddenlands} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=D66 Roll}} {{subtitle}} {{free-text}}  {{skill-die-one=[[ 1 ]] }} {{skill-roll-one=[[ 1d6 ]] }} {{skill-die-two=[[ 1 ]] }} {{skill-roll-two=[[ 1d6 ]] }} {{footer}}" data-i18n-title="roll-dice-66" title="Roll d66!"><span class="small-caps"> D</span>66 </button>
                 </div>
             </div>
         </div>
@@ -559,7 +560,7 @@
                     </select>
                 </div>
                 <div class="consumables-box6">
-                    <button type="roll" name="roll_food" title="%{food}" value="&{template:forbiddenlands} {{character_name=@{selected|character_name}}} {{character_id=@{selected|character_id}}} {{name=Consumable}} @{food}"></button>
+                    <button type="roll" name="roll_food" title="%{food}" value="&{template:forbiddenlands} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Consumable}} @{food}"></button>
                 </div>
                 <div class="consumables-box7">
                     <span class="header-h1" data-i18n="water">Water</span>
@@ -574,7 +575,7 @@
                     </select>
                 </div>
                 <div class="consumables-box9">
-                    <button type="roll" name="roll_water" title="%{water}" value="&{template:forbiddenlands} {{character_name=@{selected|character_name}}} {{character_id=@{selected|character_id}}} {{name=Consumable}} @{water}"></button>
+                    <button type="roll" name="roll_water" title="%{water}" value="&{template:forbiddenlands} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Consumable}} @{water}"></button>
                 </div>
                 <div class="consumables-box10">
                     <span class="header-h1" data-i18n="arrows">Arrows</span>
@@ -589,7 +590,7 @@
                     </select>
                 </div>
                 <div class="consumables-box12">
-                    <button type="roll" name="roll_arrows" title="%{arrows}" value="&{template:forbiddenlands} {{character_name=@{selected|character_name}}} {{character_id=@{selected|character_id}}} {{name=Consumable}} @{arrows}"></button>
+                    <button type="roll" name="roll_arrows" title="%{arrows}" value="&{template:forbiddenlands} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Consumable}} @{arrows}"></button>
                 </div>
                 <div class="consumables-box13">
                     <span class="header-h1" data-i18n="torches">Torches</span>
@@ -604,7 +605,7 @@
                     </select>
                 </div>
                 <div class="consumables-box15">
-                    <button type="roll" name="roll_torches" title="%{torches}" value="&{template:forbiddenlands} {{character_name=@{selected|character_name}}} {{character_id=@{selected|character_id}}} {{name=Consumable}} @{torches}"></button>
+                    <button type="roll" name="roll_torches" title="%{torches}" value="&{template:forbiddenlands} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{name=Consumable}} @{torches}"></button>
                 </div>
             </div>    
         </div>
@@ -945,6 +946,8 @@
         </div>
     </div>
 </div>
+
+<label class="footer">v.<span name="attr_version"></span></label>
 
 <!-- Roll Templates -->
 <rolltemplate class="sheet-rolltemplate-forbiddenlands">
@@ -1906,7 +1909,6 @@ on("sheet:opened change:armor1_equiped change:armor1_damage change:armor1_bonus 
 });
 
 </script>
-
 
 <!--
 ------------- i18n-tags generated with ACSI V0.32 (Automated Character Sheet Internationalizer)-------------


### PR DESCRIPTION
- removed "selected|..." from sheet rolls.  Rolls can now be made from the sheet regardless if a token is linked and/or selected.
- added a version attribute to the sheet.  Currently only used as a visual indicator, but could be used from version checking later if needed.