### PR TITLE
D&D 5e - UC 382 & 386 - Fix class saving throws

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -9436,14 +9436,11 @@
     };
 
     const update_class = () => {
-        //console.log(`%c Update class:`, "color:purple; font-size:14px;");
         getAttrs(["class", "base_level","custom_class","cust_hitdietype","cust_spellcasting_ability","cust_strength_save_prof","cust_dexterity_save_prof","cust_constitution_save_prof","cust_intelligence_save_prof","cust_wisdom_save_prof","cust_charisma_save_prof", "npc"], (v) => {
-            if(v.npc && v.npc == "1") {
-                return;
-            }
+            if (v.npc && v.npc == "1") { return; }
             const abilites = ["Strength", "Dexterity", "Constitution", "Intelligence", "Wisdom", "Charisma"];
             //Custom Classes
-            if(v.custom_class && v.custom_class != "0") {
+            if (v.custom_class && v.custom_class != "0") {
                 update = {};
                 update["hitdietype"] = v.cust_hitdietype;
                 update["spellcasting_ability"] = v.cust_spellcasting_ability;
@@ -9468,15 +9465,16 @@
                     update = {};
                     page.forEach((list) => {
                         if (list.data && 'Category' in list.data && list.data[`Category`] === "Classes") {
-                            update["hitdietype"] = list.data["Hit Die"].slice(1);
+                            update["hitdietype"]           = list.data["Hit Die"].slice(1);
                             update["spellcasting_ability"] = (list.data["Spellcasting Ability"]) ? `@{${list.data["Spellcasting Ability"].toLowerCase()}_mod}+` : "0*";
-
                             abilites.forEach((save) => {
                                 const ability = save.toLowerCase();
                                 update[`${ability}_save_prof`] = (list.data["data-Saving Throws"].indexOf(`${save}`) > -1) ? "(@{pb})" : 0;
+                                update_save(ability);
                             });
                         };
                     });
+
                     setAttrs(update, {silent: true});
                     //Update Spell info to change or remove casting attributes in Spells
                     update_spell_info();

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -13691,7 +13691,7 @@
         var silentset = {};
         var silentattrs = ["class_resource_name", "class_resource", "class_resource_max", "other_resource_name", "other_resource", "other_resource_max", "other_resource_itemid", "class", "class_display", "subclass", "hitdietype", "hitdie_final", "race", "subrace", "race_display", "custom_class", "cust_classname"];
         var clearset = {};
-        var clearattrs = ["hp", "hp_max", "size", "speed", "gp", "alignment", "global_damage_mod_flag", "spellcasting_ability", "cust_hitdietype", "cust_spellslots", "cust_spellcasting_ability", "ac", "jack_bonsu", "jack_attr", "death_save_bonus", "weighttotal", "initiative_bonus", "hit_dice", "hit_dice_max", "pb", "jack", "caster_level", "spell_attack_mod", "spell_attack_bonus", "spell_save_dc", "passive_wisdom", "custom_ac_base", "custom_ac_part1", "custom_ac_part2", "custom_ac_shield", "background", "global_ac_mod_flag", "global_attack_mod_flag", "global_save_mod_flag", "global_skill_mod_flag"];
+        var clearattrs = ["hp", "hp_max", "size", "speed", "gp", "alignment", "global_damage_mod_flag", "spellcasting_ability", "cust_hitdietype", "cust_spellslots", "cust_spellcasting_ability", "ac", "jack_bonus", "jack_attr", "death_save_bonus", "weighttotal", "initiative_bonus", "hit_dice", "hit_dice_max", "pb", "jack", "caster_level", "spell_attack_mod", "spell_attack_bonus", "spell_save_dc", "passive_wisdom", "custom_ac_base", "custom_ac_part1", "custom_ac_part2", "custom_ac_shield", "background", "global_ac_mod_flag", "global_attack_mod_flag", "global_save_mod_flag", "global_skill_mod_flag"];
         var classname = "";
         var set = {gp: 0};
         var allDrops = [];


### PR DESCRIPTION
## Changes / Comments

* Added update_save(ability); to allow for saves to be updated.
* fixed jack_bonsu to jack_bonus

## Roll20 Requests

*Include the name of the sheet(s) you made changes to in the title.*

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- Is this a bug fix?
- Does this add functional enhancements (new features or extending existing features) ?
- Does this add or change functional aesthetics (such as layout or color scheme) ? 
- Are you intentionally changing more that one sheet? If so, which ones ?
- If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
