### PR TITLE
[Cypher by Roll20] add missing i18n equipment tag

### DIFF
--- a/Cypher Systems by Roll20/cypher_systems_by_roll20.html
+++ b/Cypher Systems by Roll20/cypher_systems_by_roll20.html
@@ -725,7 +725,7 @@
                 </div>
                 <input type="checkbox" name="attr_expand_equipment" value="1" class="pseudocheck expand" data-i18n-title="click-expand" title="Click to expand or reduce this section" /><span></span>
                 <div class="subblock wide">
-                    <span class="title dotted">equipment</span>
+                    <span class="title dotted" data-i18n="equipment">equipment</span>
                     <div class="inblock toppad">
                         <div class="line">
                             <label class="inlcontent">

--- a/Cypher Systems by Roll20/translation.json
+++ b/Cypher Systems by Roll20/translation.json
@@ -86,7 +86,7 @@
     , "misc:": "Misc:"
     , "use-api": "API buttons"
     , "use-api-title": "Show API buttons in chat roll template. Requires a Pro account, with the Cypher Systems by Roll20 API Companion Script, activated in the current game."
-    , "equipment": "Equipment"
+    , "equipment": "equipment"
     , "task-difficulty": "Task difficulty"
     , "roll-eff": "ROLL EFF."
     , "roll-effort": "Roll Effort"


### PR DESCRIPTION
## Changes / Comments
* add missing i18n equipment tag, and change it to lowercase as is mentioned in html(doesn't appear on rest of the sheet)

## Comments
* [forum mention](https://app.roll20.net/forum/post/7345592/cypher-systems-by-roll20/?pageforid=7394385#post-7394385)

@NathaTerrien