### PR TITLE
D&D 5e - UC 405 - Fix Saves & Hit die for SRD

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -9463,18 +9463,16 @@
             } else {
                 getCompendiumPage(v.class, (page) => {
                     update = {};
-                    page.forEach((list) => {
-                        if (list.data && 'Category' in list.data && list.data[`Category`] === "Classes") {
-                            update["hitdietype"]           = list.data["Hit Die"].slice(1);
-                            update["spellcasting_ability"] = (list.data["Spellcasting Ability"]) ? `@{${list.data["Spellcasting Ability"].toLowerCase()}_mod}+` : "0*";
-                            abilites.forEach((save) => {
-                                const ability = save.toLowerCase();
-                                update[`${ability}_save_prof`] = (list.data["data-Saving Throws"].indexOf(`${save}`) > -1) ? "(@{pb})" : 0;
-                                update_save(ability);
-                            });
-                        };
-                    });
-
+                    const classData = (page.length === undefined || page.length === 1) ? page : page[0];
+                    if (classData.data && 'Category' in classData.data && classData.data[`Category`] === "Classes") {
+                        update["hitdietype"]           = classData.data["Hit Die"].slice(1);
+                        update["spellcasting_ability"] = (classData.data["Spellcasting Ability"]) ? `@{${classData.data["Spellcasting Ability"].toLowerCase()}_mod}+` : "0*";
+                        abilites.forEach((save) => {
+                            const ability = save.toLowerCase();
+                            update[`${ability}_save_prof`] = (classData.data["data-Saving Throws"].indexOf(`${save}`) > -1) ? "(@{pb})" : 0;
+                            update_save(ability);
+                        });
+                    };
                     setAttrs(update, {silent: true});
                     //Update Spell info to change or remove casting attributes in Spells
                     update_spell_info();


### PR DESCRIPTION
## Changes / Comments


* SRD was not loading hit die and saves on class select change



## Roll20 Requests

*Include the name of the sheet(s) you made changes to in the title.*

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- Is this a bug fix?
- Does this add functional enhancements (new features or extending existing features) ?
- Does this add or change functional aesthetics (such as layout or color scheme) ? 
- Are you intentionally changing more that one sheet? If so, which ones ?
- If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
