### PR TITLE
[DSA4.1] Sheet Worker Scripts for Stats & Derived Stats, Gifts and Meta-Talents

### DIFF
--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
@@ -66,6 +66,10 @@ Confirmed Critical Failure: #b39797 (a red)
     display: none;
 }
 
+.charsheet .sheet-section-info * {
+	text-align: left;
+}
+
 /* Headings */
 .charsheet h1,
 .charsheet h2,
@@ -173,6 +177,20 @@ input[type=number]::-webkit-outer-spin-button {
     border-color: #806940;
     border-width: 0.1em;
     font-weight: bold;
+}
+
+/* Selectable text has to go into <input> */
+.charsheet input[type="text"].sheet-selectable-text {
+    background-color: inherit;
+    border: none;
+    color: inherit;
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: inherit;
+    padding-bottom: inherit;
 }
 
 .charsheet .sheet-activation-items input[type="checkbox"] {

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
@@ -150,6 +150,31 @@ input[type=number]::-webkit-outer-spin-button {
     font-weight: bold;
 }
 
+.charsheet input[type="text"]:read-only,
+.charsheet input[type="number"]:read-only {
+    background-color: #bf9e60;
+    border-style: solid;
+    border-color: #806940;
+    border-width: 0.1em;
+    font-weight: bold;
+}
+
+.charsheet input[type="number"]:-moz-read-only {
+    background-color: #bf9e60;
+    border-style: solid;
+    border-color: #806940;
+    border-width: 0.1em;
+    font-weight: bold;
+}
+
+.charsheet input[type="text"]:-moz-read-only {
+    background-color: #bf9e60;
+    border-style: solid;
+    border-color: #806940;
+    border-width: 0.1em;
+    font-weight: bold;
+}
+
 .charsheet .sheet-activation-items input[type="checkbox"] {
     margin: 0.1em 0.3em 0.1em 0em;
 }
@@ -227,6 +252,28 @@ The solution: convert the <input>s to type="text" and make them look like normal
     vertical-align: bottom;
 }
 
+.charsheet input[type="text"]:read-only.sheet-stat-immutable {
+    background-color: #e6be74;
+    border-style: hidden;
+    box-shadow: none;
+    cursor: auto;
+    font-family: serif;
+    padding: 0;
+    width: 2.5em;
+    vertical-align: bottom;
+}
+
+.charsheet input[type="text"]:-moz-read-only.sheet-stat-immutable {
+    background-color: #e6be74;
+    border-style: hidden;
+    box-shadow: none;
+    cursor: auto;
+    font-family: serif;
+    padding: 0;
+    width: 2.5em;
+    vertical-align: bottom;
+}
+
 .charsheet input[type="text"]:disabled.sheet-stat-immutable-version {
     width: 7em;
 }
@@ -236,9 +283,25 @@ The solution: convert the <input>s to type="text" and make them look like normal
     text-align: left;
 }
 
+.charsheet th > input[type="text"]:read-only.sheet-stat-immutable {
+    text-align: left;
+}
+
+.charsheet th > input[type="text"]:-moz-read-only.sheet-stat-immutable {
+    text-align: left;
+}
+
 /* Align text right to match other table cells */
 .charsheet td > input[type="text"]:disabled.sheet-stat-immutable {
-    text-align: right;
+    text-align: center;
+}
+
+.charsheet td > input[type="text"]:read-only.sheet-stat-immutable {
+    text-align: center;
+}
+
+.charsheet td > input[type="text"]:-moz-read-only.sheet-stat-immutable {
+    text-align: center;
 }
 
 /* Style draggable UI buttons */
@@ -460,7 +523,8 @@ The solution: convert the <input>s to type="text" and make them look like normal
 .charsheet input.sheet-tab83:checked ~ div.sheet-section-Orte,
 .charsheet input.sheet-tab10:checked ~ div.sheet-section-config,
 .charsheet input.sheet-tab101:checked ~ div.sheet-section-config1,
-.charsheet input.sheet-tab102:checked ~ div.sheet-section-config2 {
+.charsheet input.sheet-tab102:checked ~ div.sheet-section-config2,
+.charsheet input.sheet-tab11:checked ~ div.sheet-section-info {
     border-color: #806940;
     border-style: solid;
     border-width: 0.2em 0 0.2em 0;
@@ -529,7 +593,8 @@ The solution: convert the <input>s to type="text" and make them look like normal
 .charsheet input.sheet-tab99:checked + span.sheet-tab99,
 .charsheet input.sheet-tab10:checked + span.sheet-tab10,
 .charsheet input.sheet-tab101:checked + span.sheet-tab101,
-.charsheet input.sheet-tab102:checked + span.sheet-tab102 {
+.charsheet input.sheet-tab102:checked + span.sheet-tab102,
+.charsheet input.sheet-tab11:checked + span.sheet-tab11 {
     background-color: #bf9e60;
     border-color: #806940;
     color: #000000;
@@ -1485,4 +1550,3 @@ The solution: convert the <input>s to type="text" and make them look like normal
     font-weight: inherit;
     color: #000000;
 }
-

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -254,7 +254,6 @@
                 <td>INI-Basiswert</td>
                 <td><input type="text" class="sheet-stat-immutable" name="attr_INIBasis" value="0" readonly="readonly"></td>
                 <td><input name="attr_INIZugeK" style="width: 2em;" type="number" value="0"></td>
-                <td><input type="text" class="sheet-stat-immutable" name="attr_INI_max" value="0" readonly="readonly"></td>
                 <td>&nbsp;</td>
             </tr>
             <tr>
@@ -11163,7 +11162,7 @@
                         <input class="sheet-stat-immutable" disabled="disabled" type="text" name="attr_GS_Wert" style="width: 2em" value="@{GS}">
                     </th>
                     <th>IB
-                        <input class="sheet-stat-immutable" disabled="true" type="text" name="attr_INIBasis2" style="width: 3em" value="@{INI_max}">
+                        <input class="sheet-stat-immutable" readonly="readonly" type="text" name="attr_INIBasis2" style="width: 3em" value="0">
                     </th>
                     <th>BE <input class="sheet-stat-immutable" disabled="disabled" type="text" name="attr_Ges_BE_Anzeige" value="@{BE_TaW}" style="width: 2em">
                     </th>
@@ -15616,11 +15615,11 @@ on("sheet:opened change:wound_kopf change:wound_ra change:wound_la change:wound_
             'mr_max': Math.round((+v.mu_basis + +v.kl_basis + +v.ko_basis) / 5) + +v.mrzugek,
             'ueberanstrengung_max': +v.ko_basis,
             'inibasis': Math.round((+v.mu_basis + +v.mu_basis + +v.in_basis + +v.ge_basis) / 5),
-            'ini_max': Math.round((+v.mu_basis + +v.mu_basis + +v.in_basis + +v.ge_basis) / 5) + +v.inizugek - wundeKopf - wundeBauch - wundeLB - wundeRB,
             'atbasis': Math.round(((+v.mu_basis + +v.ge_basis + +v.kk_basis) / 5) - wundeBauch - wundeRA - wundeLA - wundeRB - wundeLB),
             'pabasis': Math.round(((+v.in_basis + +v.ge_basis + +v.kk_basis) / 5) - wundeBrust - wundeBauch - wundeRA - wundeLA - wundeRB - wundeLB),
             'fkbasis': Math.round(((+v.in_basis + +v.ff_basis + +v.kk_basis) / 5) - wundeBrust - wundeBauch - wundeRA - wundeLA - wundeRB - wundeLB)
         };
+        update['inibasis2'] = update['inibasis'] + +v.inizugek - wundeKopf - wundeBauch - wundeLB - wundeRB;
         let GS = {
             'Basis': +v.gs_basis,
             'Mod': +v.gs_mod,

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -12814,7 +12814,7 @@
     </div>
 
 
-    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20190418"></b>
+    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20190418"><input type="hidden" class="sheet-stat-immutable sheet-stat-immutable-version" readonly="readonly" name="attr_data_version" value="20171014"></b>
     <br><b>Autoren: Gereon Heinemann (Original), Patrick Gebhardt, Steven 'Kreuvf' Koenig, apehead.</b>
     <br><b>Dank an: G V., Kai, SepDepp</b>
     </table>

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -6197,60 +6197,72 @@
                 <option value=" ">Offen würfeln</option>
                 <option value="/w GM ">Nur zu Meister würfeln</option>
             </select>
-            <br><b style="display: inline-block; font-size:90%; width: 2.5em">SE</b>
-            <b style="display: inline-block; font-size:90%; width: 15.25em;">Talent</b>
-            <b style="display: inline-block; font-size:90%; width: 15.25em;">Eigenschaften</b>
-            <b style="display: inline-block; font-size:90%; width: 3.25em;">TaW</b>
-            <b style="display: inline-block; font-size:90%; width: 3em;">Probe</b>
-            <br>
+
+            <table>
+                <tr>
+                    <th style="width: 23em">Gabe (+ Zusatz)</th>
+                    <th style="width: 15.25em;">Eigenschaften</th>
+                    <th style="width: 3.25em;">TaW</th>
+                    <th style="width: 3em;">Probe</th>
+                </tr>
+            </table>
             <fieldset class="repeating_GabenTalente">
-                <input type="checkbox" name="attr_SE" style="width: 2em">
-                <select name="attr_TalentName" class="atype" style="width: 14em;">
-                    <option>---</option>
-                    <option>Empathie</option>
-                    <option>Gefahreninstinkt</option>
-                    <option>Geräuschhexerei</option>
-                    <option>Kräfteschub/Talentschub</option>
-                    <option>Magiegespür</option>
-                    <option>Prophezeien</option>
-                    <option>Tierempathie</option>
-                    <option>Zwergennase</option>
-                </select>
-                <select name="attr_Eigenschaft1" class="sheet-talent-eigenschaft">
-                    <option>---</option>
-                    <option value="@{MU}">MU</option>
-                    <option value="@{KL}">KL</option>
-                    <option value="@{IN}">IN</option>
-                    <option value="@{CH}">CH</option>
-                    <option value="@{FF}">FF</option>
-                    <option value="@{GE}">GE</option>
-                    <option value="@{KO}">KO</option>
-                    <option value="@{KK}">KK</option>
-                </select>
-                <select name="attr_Eigenschaft2" class="sheet-talent-eigenschaft">
-                    <option>---</option>
-                    <option value="@{MU}">MU</option>
-                    <option value="@{KL}">KL</option>
-                    <option value="@{IN}">IN</option>
-                    <option value="@{CH}">CH</option>
-                    <option value="@{FF}">FF</option>
-                    <option value="@{GE}">GE</option>
-                    <option value="@{KO}">KO</option>
-                    <option value="@{KK}">KK</option>
-                </select>
-                <select name="attr_Eigenschaft3" class="sheet-talent-eigenschaft">
-                    <option>---</option>
-                    <option value="@{MU}">MU</option>
-                    <option value="@{KL}">KL</option>
-                    <option value="@{IN}">IN</option>
-                    <option value="@{CH}">CH</option>
-                    <option value="@{FF}">FF</option>
-                    <option value="@{GE}">GE</option>
-                    <option value="@{KO}">KO</option>
-                    <option value="@{KK}">KK</option>
-                </select>
-                <input type="number" name="attr_TaW" style="width: 3em;">
-                <button type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=@{TalentName}}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW}]]}} {{stat1=[[@{Eigenschaft1}]]}} {{stat2=[[@{Eigenschaft2}]]}} {{stat3=[[@{Eigenschaft3}]]}} {{Talent=[[ { [[{0d1 + @{TaW} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft1}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft2}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft3}, 0d1}kh1, 0d1 + @{TaW}}dh1]]}}"></button>
+                <span style="display: inline-block; width: 23em">
+                    <select name="attr_Name_Gabe" class="atype" style="width: 10em;">
+                        <option value="nothing">---</option>
+                        <option value="empathie">Empathie</option>
+                        <option value="gefahreninstinkt">Gefahreninstinkt</option>
+                        <option value="geraeuschhexerei">Geräuschhexerei</option>
+                        <option value="kraefteschub/talentschub">Kräfteschub/Talentschub</option>
+                        <option value="magiegespuer">Magiegespür</option>
+                        <option value="prophezeien">Prophezeien</option>
+                        <option value="tierempathie">Tierempathie</option>
+                        <option value="zwergennase">Zwergennase</option>
+                    </select>
+                     (<input type="text" name="attr_Name_Gabe_Zusatz" style="width: 10em;"/>)
+                </span><span style="display: inline-block; width: 15.25em">
+                    <select name="attr_Eigenschaft1" class="sheet-talent-eigenschaft">
+                        <option value="nothing">---</option>
+                        <option value="mu">MU</option>
+                        <option value="kl">KL</option>
+                        <option value="in">IN</option>
+                        <option value="ch">CH</option>
+                        <option value="ff">FF</option>
+                        <option value="ge">GE</option>
+                        <option value="ko">KO</option>
+                        <option value="kk">KK</option>
+                    </select>
+                    <select name="attr_Eigenschaft2" class="sheet-talent-eigenschaft">
+                        <option value="nothing">---</option>
+                        <option value="mu">MU</option>
+                        <option value="kl">KL</option>
+                        <option value="in">IN</option>
+                        <option value="ch">CH</option>
+                        <option value="ff">FF</option>
+                        <option value="ge">GE</option>
+                        <option value="ko">KO</option>
+                        <option value="kk">KK</option>
+                    </select>
+                    <select name="attr_Eigenschaft3" class="sheet-talent-eigenschaft">
+                        <option value="nothing">---</option>
+                        <option value="mu">MU</option>
+                        <option value="kl">KL</option>
+                        <option value="in">IN</option>
+                        <option value="ch">CH</option>
+                        <option value="ff">FF</option>
+                        <option value="ge">GE</option>
+                        <option value="ko">KO</option>
+                        <option value="kk">KK</option>
+                    </select>
+                </span><span style="display: inline-block; width: 3.25em">
+                    <input type="number" name="attr_TaW" style="width: 3em;" value="3">
+                    <input type="hidden" name="attr_hiddenEigenschaft1" value="0">
+                    <input type="hidden" name="attr_hiddenEigenschaft2" value="0">
+                    <input type="hidden" name="attr_hiddenEigenschaft3" value="0">
+                    <input type="hidden" name="attr_Name_Gabe_Anzeige" value="">
+                </span><span style="display: inline-block; width: 3em">
+                <button type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=@{Name_Gabe_Anzeige}}} {{mod=[[?{Erleichterung (-) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW}]]}} {{stat1=[[@{hiddenEigenschaft1}]]}} {{stat2=[[@{hiddenEigenschaft2}]]}} {{stat3=[[@{hiddenEigenschaft3}]]}} {{Talent=[[ { [[{0d1 + @{TaW} - (?{Erleichterung (-) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft1}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft2}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft3}, 0d1}kh1, 0d1 + @{TaW}}dh1]]}}"></button>
+                </span>
             </fieldset>
         </div>
 
@@ -15518,6 +15530,42 @@ on("sheet:opened change:wound_kopf change:wound_ra change:wound_la change:wound_
     }); 
 });
 
+on("change:repeating_gabenTalente:Name_Gabe change:repeating_gabenTalente:Name_Gabe_Zusatz", function(eventInfo) {
+    getAttrs(["repeating_gabenTalente_Name_Gabe", "repeating_gabenTalente_Name_Gabe_Zusatz"], function(v) {
+        let gabe = v.repeating_gabenTalente_Name_Gabe;
+        let gabeZusatz = v.repeating_gabenTalente_Name_Gabe_Zusatz;
+        let gaben = {
+            "empathie": [ ["mu", "in", "in"], "Empathie" ],
+            "gefahreninstinkt": [ ["kl", "in", "in"], "Gefahreninstinkt" ],
+            "geraeuschhexerei": [ ["in", "ch", "ko"], "Geräuschhexerei" ],
+            "kraefteschub/talentschub": [ ["mu", "in", "ko"], "Kräfteschub/Talentschub" ],
+            "magiegespuer": [ ["mu", "in", "in"], "Magiegespür" ],
+            "prophezeien": [ ["in", "in", "ch"], "Prophezeien" ],
+            "tierempathie": [ ["mu", "in", "ch"], "Tierempathie" ],
+            "zwergennase": [ ["in", "in", "ff"], "Zwergennase" ]
+        };
+        if (gabe != "nothing") {
+            let update = {
+                'repeating_gabenTalente_eigenschaft1': gaben[gabe][0][0],
+                'repeating_gabenTalente_eigenschaft2': gaben[gabe][0][1],
+                'repeating_gabenTalente_eigenschaft3': gaben[gabe][0][2],
+                'repeating_gabenTalente_Name_Gabe_Anzeige': gaben[gabe][1]
+            };
+            if (gabeZusatz != "") {
+                update['repeating_gabenTalente_Name_Gabe_Anzeige'] += " (" + gabeZusatz + ")";
+            }
+            setAttrs(update);
+        } else {
+            setAttrs({
+                'repeating_gabenTalente_eigenschaft1': "nothing",
+                'repeating_gabenTalente_eigenschaft2': "nothing",
+                'repeating_gabenTalente_eigenschaft3': "nothing",
+                'repeating_gabenTalente_Name_Gabe_Anzeige': "Keine Gabe gewählt"
+            });
+        }
+    });
+});
+
 on("change:repeating_metatalente:Name_Metatalent change:repeating_metatalente:Name_Metatalent_Eigen", function(eventInfo) {
     getAttrs(["repeating_metatalente_Name_Metatalent", "repeating_metatalente_Name_Metatalent_Eigen"], function(v) {
         let metatalent = v.repeating_metatalente_Name_Metatalent;
@@ -15551,6 +15599,17 @@ on("change:repeating_metatalente:Name_Metatalent change:repeating_metatalente:Na
     });
 });
 
+on("change:repeating_gabenTalente:eigenschaft1 change:repeating_gabenTalente:eigenschaft2 change:repeating_gabenTalente:eigenschaft3", function(eventInfo) {
+    getAttrs(["repeating_gabenTalente_eigenschaft1", "repeating_gabenTalente_eigenschaft2", "repeating_gabenTalente_eigenschaft3", "mu", "kl", "in", "ch", "ff", "ge", "ko", "kk"], function(v) {
+            let attributes = {"mu": +v.mu, "kl": +v.kl, "in": +v.in, "ch": +v.ch, "ff": +v.ff, "ge": +v.ge, "ko": +v.ko, "kk": +v.kk};
+            setAttrs({
+                'repeating_gabenTalente_hiddeneigenschaft1': attributes[v.repeating_gabenTalente_eigenschaft1] || 0,
+                'repeating_gabenTalente_hiddeneigenschaft2': attributes[v.repeating_gabenTalente_eigenschaft2] || 0,
+                'repeating_gabenTalente_hiddeneigenschaft3': attributes[v.repeating_gabenTalente_eigenschaft3] || 0
+            });
+    });
+});
+
 on("change:repeating_metatalente:eigenschaft1 change:repeating_metatalente:eigenschaft2 change:repeating_metatalente:eigenschaft3", function(eventInfo) {
     getAttrs(["repeating_metatalente_eigenschaft1", "repeating_metatalente_eigenschaft2", "repeating_metatalente_eigenschaft3", "mu", "kl", "in", "ch", "ff", "ge", "ko", "kk"], function(v) {
             let attributes = {"mu": +v.mu, "kl": +v.kl, "in": +v.in, "ch": +v.ch, "ff": +v.ff, "ge": +v.ge, "ko": +v.ko, "kk": +v.kk};
@@ -15567,6 +15626,19 @@ on("change:mu change:kl change:in change:ch change:ff change:ge change:ko change
     getAttrs(["mu", "kl", "in", "ch", "ff", "ge", "ko", "kk"], function(v) {
         let attributes = {"mu": +v.mu, "kl": +v.kl, "in": +v.in, "ch": +v.ch, "ff": +v.ff, "ge": +v.ge, "ko": +v.ko, "kk": +v.kk};
         let update = {};
+
+        // Aktualisiere Gaben
+        getSectionIDs("gaben", function(idarray) {
+             _.each(idarray, function(currentID, i) {
+                getAttrs(["repeating_gabenTalente_" + currentID + "_eigenschaften"], function(v) {
+                    update["repeating_gabenTalente_" + currentID + "_hiddeneigenschaft1"] = attributes[v["repeating_gabenTalente_" + currentID + "_eigenschaft1"]];
+                    update["repeating_gabenTalente_" + currentID + "_hiddeneigenschaft2"] = attributes[v["repeating_gabenTalente_" + currentID + "_eigenschaft2"]];
+                    update["repeating_gabenTalente_" + currentID + "_hiddeneigenschaft3"] = attributes[v["repeating_gabenTalente_" + currentID + "_eigenschaft3"]];
+                    setAttrs(update);
+                });
+            });
+        });
+
         // Aktualisiere Metatalente
         getSectionIDs("metatalente", function(idarray) {
              _.each(idarray, function(currentID, i) {

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -31,8 +31,8 @@
     <input type="radio" name="attr_tab" class="sheet-tab sheet-tab10" value="10" title="Konfiguration">
     <span class="sheet-tab sheet-tab10">Konfiguration</span>
     
-    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab11" value="11" title="Updates">
-    <span class="sheet-tab sheet-tab11">Updates</span>
+    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab11" value="11" title="Infos">
+    <span class="sheet-tab sheet-tab11">Infos</span>
     
     <div class="sheet-section sheet-section-Allgemein">
         <table>
@@ -6206,7 +6206,7 @@
                     <th style="width: 3em;">Probe</th>
                 </tr>
             </table>
-            <fieldset class="repeating_GabenTalente">
+            <fieldset class="repeating_Gaben">
                 <span style="display: inline-block; width: 23em">
                     <select name="attr_Name_Gabe" class="atype" style="width: 10em;">
                         <option value="nothing">---</option>
@@ -6263,56 +6263,6 @@
                 </span><span style="display: inline-block; width: 3em">
                 <button type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=@{Name_Gabe_Anzeige}}} {{mod=[[?{Erleichterung (-) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW}]]}} {{stat1=[[@{hiddenEigenschaft1}]]}} {{stat2=[[@{hiddenEigenschaft2}]]}} {{stat3=[[@{hiddenEigenschaft3}]]}} {{Talent=[[ { [[{0d1 + @{TaW} - (?{Erleichterung (-) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft1}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft2}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft3}, 0d1}kh1, 0d1 + @{TaW}}dh1]]}}"></button>
                 </span>
-            </fieldset>
-            <h3>ALTE DATEN</h3>
-            <fieldset class="repeating_AlteGaben">
-                <input type="checkbox" name="attr_SE" style="width: 2em">
-                <select name="attr_TalentName" class="atype" style="width: 14em;">
-                    <option>---</option>
-                    <option>Empathie</option>
-                    <option>Gefahreninstinkt</option>
-                    <option>Geräuschhexerei</option>
-                    <option>Kräfteschub/Talentschub</option>
-                    <option>Magiegespür</option>
-                    <option>Prophezeien</option>
-                    <option>Tierempathie</option>
-                    <option>Zwergennase</option>
-                </select>
-                <select name="attr_Eigenschaft1" class="sheet-talent-eigenschaft">
-                    <option>---</option>
-                    <option value="@{MU}">MU</option>
-                    <option value="@{KL}">KL</option>
-                    <option value="@{IN}">IN</option>
-                    <option value="@{CH}">CH</option>
-                    <option value="@{FF}">FF</option>
-                    <option value="@{GE}">GE</option>
-                    <option value="@{KO}">KO</option>
-                    <option value="@{KK}">KK</option>
-                </select>
-                <select name="attr_Eigenschaft2" class="sheet-talent-eigenschaft">
-                    <option>---</option>
-                    <option value="@{MU}">MU</option>
-                    <option value="@{KL}">KL</option>
-                    <option value="@{IN}">IN</option>
-                    <option value="@{CH}">CH</option>
-                    <option value="@{FF}">FF</option>
-                    <option value="@{GE}">GE</option>
-                    <option value="@{KO}">KO</option>
-                    <option value="@{KK}">KK</option>
-                </select>
-                <select name="attr_Eigenschaft3" class="sheet-talent-eigenschaft">
-                    <option>---</option>
-                    <option value="@{MU}">MU</option>
-                    <option value="@{KL}">KL</option>
-                    <option value="@{IN}">IN</option>
-                    <option value="@{CH}">CH</option>
-                    <option value="@{FF}">FF</option>
-                    <option value="@{GE}">GE</option>
-                    <option value="@{KO}">KO</option>
-                    <option value="@{KK}">KK</option>
-                </select>
-                <input type="number" name="attr_TaW" style="width: 3em;">
-                <button type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=@{TalentName}}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW}]]}} {{stat1=[[@{Eigenschaft1}]]}} {{stat2=[[@{Eigenschaft2}]]}} {{stat3=[[@{Eigenschaft3}]]}} {{Talent=[[ { [[{0d1 + @{TaW} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft1}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft2}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft3}, 0d1}kh1, 0d1 + @{TaW}}dh1]]}}"></button>
             </fieldset>
         </div>
 
@@ -12860,7 +12810,64 @@
     </div>
     
     <div class="sheet-section sheet-section-info" align="center">
-        Hier findest du alle Informationen zu Updates und <i>alten</i> Werten, sprich Werten, die durch Updates ersetzt wurden.
+        <h3>Infos zum Charakterbogen</h3>
+        <p>Dieser Charakterbogen wird weiterentwickelt. Dabei bleibt es nicht aus, dass alte Daten nicht mehr ohne Weiteres in den veränderten Bogen passen. Wenn es nötig wird, werden die alten Daten automatisch im Hintergrund umgewandelt. Da es aber immer zu Fehlern kommen kann, stehen für jeden Versionssprung hier weiterhin die alten Daten (inklusive ihrer Funktionalität) zur Verfügung. So wird sichergestellt, dass keine Daten verlorengehen und das Spiel weitergehen kann.</p>
+        <p>Videos zu einzelnen Updates: <br />
+            <input type="text" class="sheet-selectable-text" style="width: 45em" value="https://www.youtube.com/watch?v=l2SCwz51T9g&list=PLGBXxa8pcNCqzNe4CrKvy-_QgjfgLDOZ-" />
+        </p>
+
+        <h4>Update auf Version 20190425</h4>
+        <p>Gaben und Metatalente wurden verändert, sodass eine Migration der alten Daten notwendig wurde. Spalten für spezielle Erfahrungen (SE) wurden entfernt, da diese ausschließlich für die Steigerung relevant sind, Steigerungen aber seitens Roll20 nicht im Charakterbogen umgesetzt sein dürfen. Um die Information dauerhafter zu speichern, empfiehlt es sich die Notizen zu benutzen. Spezielle Erfahrungen in Metatalenten sind darüber hinaus nicht regelkonform.</p>
+        <h5>Gaben</h5>
+        <fieldset class="repeating_GabenTalente">
+            <input type="checkbox" name="attr_SE" style="width: 2em">
+            <select name="attr_TalentName" class="atype" style="width: 14em;">
+                <option>---</option>
+                <option>Empathie</option>
+                <option>Gefahreninstinkt</option>
+                <option>Geräuschhexerei</option>
+                <option>Kräfteschub/Talentschub</option>
+                <option>Magiegespür</option>
+                <option>Prophezeien</option>
+                <option>Tierempathie</option>
+                <option>Zwergennase</option>
+            </select>
+            <select name="attr_Eigenschaft1" class="sheet-talent-eigenschaft">
+                <option>---</option>
+                <option value="@{MU}">MU</option>
+                <option value="@{KL}">KL</option>
+                <option value="@{IN}">IN</option>
+                <option value="@{CH}">CH</option>
+                <option value="@{FF}">FF</option>
+                <option value="@{GE}">GE</option>
+                <option value="@{KO}">KO</option>
+                <option value="@{KK}">KK</option>
+            </select>
+            <select name="attr_Eigenschaft2" class="sheet-talent-eigenschaft">
+                <option>---</option>
+                <option value="@{MU}">MU</option>
+                <option value="@{KL}">KL</option>
+                <option value="@{IN}">IN</option>
+                <option value="@{CH}">CH</option>
+                <option value="@{FF}">FF</option>
+                <option value="@{GE}">GE</option>
+                <option value="@{KO}">KO</option>
+                <option value="@{KK}">KK</option>
+            </select>
+            <select name="attr_Eigenschaft3" class="sheet-talent-eigenschaft">
+                <option>---</option>
+                <option value="@{MU}">MU</option>
+                <option value="@{KL}">KL</option>
+                <option value="@{IN}">IN</option>
+                <option value="@{CH}">CH</option>
+                <option value="@{FF}">FF</option>
+                <option value="@{GE}">GE</option>
+                <option value="@{KO}">KO</option>
+                <option value="@{KK}">KK</option>
+            </select>
+            <input type="number" name="attr_TaW" style="width: 3em;">
+            <button type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=@{TalentName}}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW}]]}} {{stat1=[[@{Eigenschaft1}]]}} {{stat2=[[@{Eigenschaft2}]]}} {{stat3=[[@{Eigenschaft3}]]}} {{Talent=[[ { [[{0d1 + @{TaW} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft1}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft2}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft3}, 0d1}kh1, 0d1 + @{TaW}}dh1]]}}"></button>
+        </fieldset>
     </div>
 
 
@@ -15580,10 +15587,10 @@ on("sheet:opened change:wound_kopf change:wound_ra change:wound_la change:wound_
     }); 
 });
 
-on("change:repeating_gabenTalente:Name_Gabe change:repeating_gabenTalente:Name_Gabe_Zusatz", function(eventInfo) {
-    getAttrs(["repeating_gabenTalente_Name_Gabe", "repeating_gabenTalente_Name_Gabe_Zusatz"], function(v) {
-        let gabe = v.repeating_gabenTalente_Name_Gabe;
-        let gabeZusatz = v.repeating_gabenTalente_Name_Gabe_Zusatz;
+on("change:repeating_Gaben:Name_Gabe change:repeating_Gaben:Name_Gabe_Zusatz", function(eventInfo) {
+    getAttrs(["repeating_Gaben_Name_Gabe", "repeating_Gaben_Name_Gabe_Zusatz"], function(v) {
+        let gabe = v.repeating_Gaben_Name_Gabe;
+        let gabeZusatz = v.repeating_Gaben_Name_Gabe_Zusatz;
         let gaben = {
             "empathie": [ ["mu", "in", "in"], "Empathie" ],
             "gefahreninstinkt": [ ["kl", "in", "in"], "Gefahreninstinkt" ],
@@ -15596,18 +15603,18 @@ on("change:repeating_gabenTalente:Name_Gabe change:repeating_gabenTalente:Name_G
         };
         if (gabe != "nothing") {
             let update = {
-                'repeating_gabenTalente_eigenschaft1': gaben[gabe][0][0],
-                'repeating_gabenTalente_eigenschaft2': gaben[gabe][0][1],
-                'repeating_gabenTalente_eigenschaft3': gaben[gabe][0][2],
-                'repeating_gabenTalente_Name_Gabe_Anzeige': gaben[gabe][1]
+                'repeating_Gaben_eigenschaft1': gaben[gabe][0][0],
+                'repeating_Gaben_eigenschaft2': gaben[gabe][0][1],
+                'repeating_Gaben_eigenschaft3': gaben[gabe][0][2],
+                'repeating_Gaben_Name_Gabe_Anzeige': gaben[gabe][1]
             };
             if (gabeZusatz != "") {
-                update['repeating_gabenTalente_Name_Gabe_Anzeige'] += " (" + gabeZusatz + ")";
+                update['repeating_Gaben_Name_Gabe_Anzeige'] += " (" + gabeZusatz + ")";
             }
             setAttrs(update);
         } else {
             setAttrs({
-                'repeating_gabenTalente_Name_Gabe_Anzeige': "Keine Gabe gewählt"
+                'repeating_Gaben_Name_Gabe_Anzeige': "Keine Gabe gewählt"
             });
         }
     });
@@ -15646,13 +15653,13 @@ on("change:repeating_metatalente:Name_Metatalent change:repeating_metatalente:Na
     });
 });
 
-on("change:repeating_gabenTalente:eigenschaft1 change:repeating_gabenTalente:eigenschaft2 change:repeating_gabenTalente:eigenschaft3", function(eventInfo) {
-    getAttrs(["repeating_gabenTalente_eigenschaft1", "repeating_gabenTalente_eigenschaft2", "repeating_gabenTalente_eigenschaft3", "mu", "kl", "in", "ch", "ff", "ge", "ko", "kk"], function(v) {
+on("change:repeating_Gaben:eigenschaft1 change:repeating_Gaben:eigenschaft2 change:repeating_Gaben:eigenschaft3", function(eventInfo) {
+    getAttrs(["repeating_Gaben_eigenschaft1", "repeating_Gaben_eigenschaft2", "repeating_Gaben_eigenschaft3", "mu", "kl", "in", "ch", "ff", "ge", "ko", "kk"], function(v) {
             let attributes = {"mu": +v.mu, "kl": +v.kl, "in": +v.in, "ch": +v.ch, "ff": +v.ff, "ge": +v.ge, "ko": +v.ko, "kk": +v.kk};
             setAttrs({
-                'repeating_gabenTalente_hiddeneigenschaft1': attributes[v.repeating_gabenTalente_eigenschaft1] || 0,
-                'repeating_gabenTalente_hiddeneigenschaft2': attributes[v.repeating_gabenTalente_eigenschaft2] || 0,
-                'repeating_gabenTalente_hiddeneigenschaft3': attributes[v.repeating_gabenTalente_eigenschaft3] || 0
+                'repeating_Gaben_hiddeneigenschaft1': attributes[v.repeating_Gaben_eigenschaft1] || 0,
+                'repeating_Gaben_hiddeneigenschaft2': attributes[v.repeating_Gaben_eigenschaft2] || 0,
+                'repeating_Gaben_hiddeneigenschaft3': attributes[v.repeating_Gaben_eigenschaft3] || 0
             });
     });
 });
@@ -15677,10 +15684,10 @@ on("change:mu change:kl change:in change:ch change:ff change:ge change:ko change
         // Aktualisiere Gaben
         getSectionIDs("gaben", function(idarray) {
              _.each(idarray, function(currentID, i) {
-                getAttrs(["repeating_gabenTalente_" + currentID + "_eigenschaften"], function(v) {
-                    update["repeating_gabenTalente_" + currentID + "_hiddeneigenschaft1"] = attributes[v["repeating_gabenTalente_" + currentID + "_eigenschaft1"]];
-                    update["repeating_gabenTalente_" + currentID + "_hiddeneigenschaft2"] = attributes[v["repeating_gabenTalente_" + currentID + "_eigenschaft2"]];
-                    update["repeating_gabenTalente_" + currentID + "_hiddeneigenschaft3"] = attributes[v["repeating_gabenTalente_" + currentID + "_eigenschaft3"]];
+                getAttrs(["repeating_Gaben_" + currentID + "_eigenschaften"], function(v) {
+                    update["repeating_Gaben_" + currentID + "_hiddeneigenschaft1"] = attributes[v["repeating_Gaben_" + currentID + "_eigenschaft1"]];
+                    update["repeating_Gaben_" + currentID + "_hiddeneigenschaft2"] = attributes[v["repeating_Gaben_" + currentID + "_eigenschaft2"]];
+                    update["repeating_Gaben_" + currentID + "_hiddeneigenschaft3"] = attributes[v["repeating_Gaben_" + currentID + "_eigenschaft3"]];
                     setAttrs(update);
                 });
             });
@@ -15769,7 +15776,7 @@ function migrate20171014to20190425 () {
     console.log("Migrating sheet data from version 20171014 to 20190425 ...");
     let migrationFinished = 0;
 
-    getSectionIDs("AlteGaben", function(idarray) {
+    getSectionIDs("GabenTalente", function(idarray) {
         if(idarray.length == 0) {
             console.log("Migration: No gifts found, nothing to migrate.");
             migrationFinished = 1;
@@ -15807,20 +15814,20 @@ function migrate20171014to20190425 () {
             for(var i=0; i < idarray.length; i++) {
                 getAttrs(
                     [
-                        "repeating_AlteGaben_" + idarray[i] + "_TalentName",
-                        "repeating_AlteGaben_" + idarray[i] + "_Eigenschaft1",
-                        "repeating_AlteGaben_" + idarray[i] + "_Eigenschaft2",
-                        "repeating_AlteGaben_" + idarray[i] + "_Eigenschaft3",
-                        "repeating_AlteGaben_" + idarray[i] + "_TaW",
-                        "repeating_AlteGaben_" + idarray[i] + "_SE",
+                        "repeating_GabenTalente_" + idarray[i] + "_TalentName",
+                        "repeating_GabenTalente_" + idarray[i] + "_Eigenschaft1",
+                        "repeating_GabenTalente_" + idarray[i] + "_Eigenschaft2",
+                        "repeating_GabenTalente_" + idarray[i] + "_Eigenschaft3",
+                        "repeating_GabenTalente_" + idarray[i] + "_TaW",
+                        "repeating_GabenTalente_" + idarray[i] + "_SE",
                         "mu", "kl", "in", "ch", "ff", "ge", "ko", "kk"
                     ], function(v) {
                         console.log(v);
                         let update = {};
                         let newrow = generateRowID();
                         let current = Object.keys(v)[0].split("_")[2];
-                        let prefixNew = "repeating_GabenTalente_" + newrow;
-                        let prefixOld = "repeating_AlteGaben_" + current;
+                        let prefixNew = "repeating_Gaben_" + newrow;
+                        let prefixOld = "repeating_GabenTalente_" + current;
 
                         // Gather data
                         // Updating the name will set the stats automatically

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -15829,102 +15829,201 @@ function migrate20171014to20190425 () {
     console.log("Migrating sheet data from version 20171014 to 20190425 ...");
     let migrationFinished = 0;
 
-    getSectionIDs("GabenTalente", function(idarray) {
-        if(idarray.length == 0) {
-            console.log("Migration: No gifts found, nothing to migrate.");
-            migrationFinished = 1;
-        } else {
-            console.log("Migration: Found old gifts, continuing ...");
-            let conversion = {
-                "@{MU}": "mu",
-                "@{KL}": "kl",
-                "@{IN}": "in",
-                "@{CH}": "ch",
-                "@{FF}": "ff",
-                "@{GE}": "ge",
-                "@{KO}": "ko",
-                "@{KK}": "kk",
-                "---": "nothing",
-                "Empathie": "empathie",
-                "Gefahreninstinkt": "gefahreninstinkt",
-                "Geräuschhexerei": "geraeuschhexerei",
-                "Kräfteschub/Talentschub": "kraefteschub/talentschub",
-                "Magiegespür": "magiegespuer",
-                "Prophezeien": "prophezeien",
-                "Tierempathie": "tierempathie",
-                "Zwergennase": "zwergennase",
-            };
-            let gaben = {
-                "empathie": [ ["mu", "in", "in"], "Empathie" ],
-                "gefahreninstinkt": [ ["kl", "in", "in"], "Gefahreninstinkt" ],
-                "geraeuschhexerei": [ ["in", "ch", "ko"], "Geräuschhexerei" ],
-                "kraefteschub/talentschub": [ ["mu", "in", "ko"], "Kräfteschub/Talentschub" ],
-                "magiegespuer": [ ["mu", "in", "in"], "Magiegespür" ],
-                "prophezeien": [ ["in", "in", "ch"], "Prophezeien" ],
-                "tierempathie": [ ["mu", "in", "ch"], "Tierempathie" ],
-                "zwergennase": [ ["in", "in", "ff"], "Zwergennase" ]
-            };
-            for(var i=0; i < idarray.length; i++) {
-                getAttrs(
-                    [
-                        "repeating_GabenTalente_" + idarray[i] + "_TalentName",
-                        "repeating_GabenTalente_" + idarray[i] + "_Eigenschaft1",
-                        "repeating_GabenTalente_" + idarray[i] + "_Eigenschaft2",
-                        "repeating_GabenTalente_" + idarray[i] + "_Eigenschaft3",
-                        "repeating_GabenTalente_" + idarray[i] + "_TaW",
-                        "repeating_GabenTalente_" + idarray[i] + "_SE",
-                        "mu", "kl", "in", "ch", "ff", "ge", "ko", "kk"
-                    ], function(v) {
-                        console.log(v);
-                        let update = {};
-                        let newrow = generateRowID();
-                        let current = Object.keys(v)[0].split("_")[2];
-                        let prefixNew = "repeating_Gaben_" + newrow;
-                        let prefixOld = "repeating_GabenTalente_" + current;
+    getSectionIDs("GabenTalente", function(gabenIDs) {
+        getSectionIDs("MetaTalente", function(metatalenteIDs) {
+            // GIFTS MIGRATION
+            if(gabenIDs.length == 0) {
+                console.log("Migration: No gifts found, nothing to migrate.");
+                migrationFinished += 1;
+            } else {
+                console.log("Migration: Found old gifts, continuing ...");
+                let conversion = {
+                    "@{MU}": "mu",
+                    "@{KL}": "kl",
+                    "@{IN}": "in",
+                    "@{CH}": "ch",
+                    "@{FF}": "ff",
+                    "@{GE}": "ge",
+                    "@{KO}": "ko",
+                    "@{KK}": "kk",
+                    "---": "nothing",
+                    "Empathie": "empathie",
+                    "Gefahreninstinkt": "gefahreninstinkt",
+                    "Geräuschhexerei": "geraeuschhexerei",
+                    "Kräfteschub/Talentschub": "kraefteschub/talentschub",
+                    "Magiegespür": "magiegespuer",
+                    "Prophezeien": "prophezeien",
+                    "Tierempathie": "tierempathie",
+                    "Zwergennase": "zwergennase",
+                };
+                let gaben = {
+                    "empathie": [ ["mu", "in", "in"], "Empathie" ],
+                    "gefahreninstinkt": [ ["kl", "in", "in"], "Gefahreninstinkt" ],
+                    "geraeuschhexerei": [ ["in", "ch", "ko"], "Geräuschhexerei" ],
+                    "kraefteschub/talentschub": [ ["mu", "in", "ko"], "Kräfteschub/Talentschub" ],
+                    "magiegespuer": [ ["mu", "in", "in"], "Magiegespür" ],
+                    "prophezeien": [ ["in", "in", "ch"], "Prophezeien" ],
+                    "tierempathie": [ ["mu", "in", "ch"], "Tierempathie" ],
+                    "zwergennase": [ ["in", "in", "ff"], "Zwergennase" ]
+                };
+                for(var i=0; i < gabenIDs.length; i++) {
+                    getAttrs(
+                        [
+                            "repeating_GabenTalente_" + gabenIDs[i] + "_TalentName",
+                            "repeating_GabenTalente_" + gabenIDs[i] + "_Eigenschaft1",
+                            "repeating_GabenTalente_" + gabenIDs[i] + "_Eigenschaft2",
+                            "repeating_GabenTalente_" + gabenIDs[i] + "_Eigenschaft3",
+                            "repeating_GabenTalente_" + gabenIDs[i] + "_TaW",
+                            "repeating_GabenTalente_" + gabenIDs[i] + "_SE",
+                            "mu", "kl", "in", "ch", "ff", "ge", "ko", "kk"
+                        ], function(v) {
+                            console.log(v);
+                            let update = {};
+                            let newrow = generateRowID();
+                            let current = Object.keys(v)[0].split("_")[2];
+                            let prefixNew = "repeating_Gaben_" + newrow;
+                            let prefixOld = "repeating_GabenTalente_" + current;
 
-                        // Gather data
-                        // Updating the name will set the stats automatically
-                        // To prevent overwriting of custom stats check that the RAW stats are used
-                        // Need to check that the three correct ones are used, order irrelevant
-                        // Comparison made easy by taking all three stats, sorting them alphabetically and then concatenating them into one string -> simple string comparison will reveal whether the same stats are used (order not important)
-                        let gabeStats = gaben[conversion[v[prefixOld + "_TalentName"]]][0].sort().join("");
-                        let gabeStatsOld = [conversion[v[prefixOld + "_Eigenschaft1"]], conversion[v[prefixOld + "_Eigenschaft2"]], conversion[v[prefixOld + "_Eigenschaft3"]]].sort().join("");
-                        if(gabeStats == gabeStatsOld) {
-                            update[prefixNew + "_Name_Gabe"] = conversion[v[prefixOld + "_TalentName"]];
-                            update[prefixNew + "_Name_Gabe_Zusatz"] = "";
-                        } else {
-                            update[prefixNew + "_Name_Gabe_Zusatz"] = "urspr. " + v[prefixOld + "_TalentName"] + "; Eigenschaften für Probe aber nicht Standard. ";
-                            console.log("Migration: Found old " + v[prefixOld + "_TalentName"] + " containing non-standard stats. No predefined gift set. Old data preserved.");
-                        }
-                        if(v[prefixOld + "_SE"] == "on") {
-                            update[prefixNew + "_Name_Gabe_Zusatz"] += "[x] SE";
-                            console.log("Migration: Found old " + v[prefixOld + "_TalentName"] + " marked as having a special experience (SE). This data will no longer be kept in the character sheet as it is only relevant for character advancement. Old data preserved. Please move to notes.");
-                        } else {
-                            update[prefixNew + "_Name_Gabe_Zusatz"] += "[ ] SE";
-                        }
-                        update[prefixNew + "_Name_Gabe_Anzeige"] = conversion[v[prefixOld + "_TalentName"]];
-                        update[prefixNew + "_Eigenschaft1"] = conversion[v[prefixOld + "_Eigenschaft1"]];
-                        update[prefixNew + "_Eigenschaft2"] = conversion[v[prefixOld + "_Eigenschaft2"]];
-                        update[prefixNew + "_Eigenschaft3"] = conversion[v[prefixOld + "_Eigenschaft3"]];
-                        update[prefixNew + "_hiddenEigenschaft1"] = v[conversion[v[prefixOld + "_Eigenschaft1"]]];
-                        update[prefixNew + "_hiddenEigenschaft2"] = v[conversion[v[prefixOld + "_Eigenschaft2"]]];
-                        update[prefixNew + "_hiddenEigenschaft3"] = v[conversion[v[prefixOld + "_Eigenschaft3"]]];
-                        update[prefixNew + "_TaW"] = parseInt(v[prefixOld + "_TaW"]);
-                        console.log(update);
+                            // Gather data
+                            // Updating the name will set the stats automatically
+                            // To prevent overwriting of custom stats check that the RAW stats are used
+                            // Need to check that the three correct ones are used, order irrelevant
+                            // Comparison made easy by taking all three stats, sorting them alphabetically and then concatenating them into one string -> simple string comparison will reveal whether the same stats are used (order not important)
+                            let gabeStats = gaben[conversion[v[prefixOld + "_TalentName"]]][0].sort().join("");
+                            let gabeStatsOld = [conversion[v[prefixOld + "_Eigenschaft1"]], conversion[v[prefixOld + "_Eigenschaft2"]], conversion[v[prefixOld + "_Eigenschaft3"]]].sort().join("");
+                            if(gabeStats == gabeStatsOld) {
+                                update[prefixNew + "_Name_Gabe"] = conversion[v[prefixOld + "_TalentName"]];
+                                update[prefixNew + "_Name_Gabe_Zusatz"] = "";
+                            } else {
+                                update[prefixNew + "_Name_Gabe_Zusatz"] = "urspr. " + v[prefixOld + "_TalentName"] + "; Eigenschaften für Probe aber nicht Standard. ";
+                                console.log("Migration: Found old " + v[prefixOld + "_TalentName"] + " containing non-standard stats. No predefined gift set. Old data preserved.");
+                            }
+                            if(v[prefixOld + "_SE"] == "on") {
+                                update[prefixNew + "_Name_Gabe_Zusatz"] += "[x] SE";
+                                console.log("Migration: Found old " + v[prefixOld + "_TalentName"] + " marked as having a special experience (SE). This data will no longer be kept in the character sheet as it is only relevant for character advancement. Old data preserved. Please move to notes.");
+                            } else {
+                                update[prefixNew + "_Name_Gabe_Zusatz"] += "[ ] SE";
+                            }
+                            update[prefixNew + "_Name_Gabe_Anzeige"] = conversion[v[prefixOld + "_TalentName"]];
+                            update[prefixNew + "_Eigenschaft1"] = conversion[v[prefixOld + "_Eigenschaft1"]];
+                            update[prefixNew + "_Eigenschaft2"] = conversion[v[prefixOld + "_Eigenschaft2"]];
+                            update[prefixNew + "_Eigenschaft3"] = conversion[v[prefixOld + "_Eigenschaft3"]];
+                            update[prefixNew + "_hiddenEigenschaft1"] = v[conversion[v[prefixOld + "_Eigenschaft1"]]];
+                            update[prefixNew + "_hiddenEigenschaft2"] = v[conversion[v[prefixOld + "_Eigenschaft2"]]];
+                            update[prefixNew + "_hiddenEigenschaft3"] = v[conversion[v[prefixOld + "_Eigenschaft3"]]];
+                            update[prefixNew + "_TaW"] = parseInt(v[prefixOld + "_TaW"]);
+                            console.log(update);
 
-                        // Create new row
-                        setAttrs(update);
-                    });
+                            // Create new row
+                            setAttrs(update);
+                        });
+                }
+                migrationFinished += 1;
             }
-            migrationFinished = 1;
-        }
-        if (migrationFinished === 1) {
-            let dataVersionNew = "20190425";
-            setAttrs({ "data_version": dataVersionNew });
-            console.log("Migration: Data version updated to character sheet version (" + dataVersionNew + "). Migration complete.");
-        } else {
-            console.log("Migration: Migration appears to be incomplete. See console/log for further hints. Data version not updated to character sheet version.");
-        }
+
+            // META-TALENTS MIGRATION
+            if(metatalenteIDs.length == 0) {
+                console.log("Migration: No meta-talents found, nothing to migrate.");
+                migrationFinished += 2;
+            } else {
+                console.log("Migration: Found old meta-talents, continuing ...");
+                let conversion = {
+                    "@{MU}": "mu",
+                    "@{KL}": "kl",
+                    "@{IN}": "in",
+                    "@{CH}": "ch",
+                    "@{FF}": "ff",
+                    "@{GE}": "ge",
+                    "@{KO}": "ko",
+                    "@{KK}": "kk",
+                    "---": "nothing",
+                    "Ansitzjagd": "ansitzjagd",
+                    "Hetzjagd": "hetzjagd",
+                    "Kräutersuchen": "kraeutersuchen",
+                    "Nahrungsammeln": "nahrungsammeln",
+                    "Pirschjagd": "pirschjagd",
+                    "Speerfischen": "speerfischen",
+                    "Tierfallenstellen": "tierfallenstellen",
+                    "Wachehalten": "wachehalten"
+                };
+                let metatalente = {
+                    "nothing": [ ["---", "---", "---"], "nothing" ],
+                    "ansitzjagd": [ ["mu", "in", "ge"], "Ansitzjagd" ],
+                    "hetzjagd": [ ["mu", "in", "ge"], "Hetzjagd" ],
+                    "kraeutersuchen": [ ["mu", "in", "ff"], "Kräutersuchen" ],
+                    "nahrungsammeln": [ ["mu", "in", "ff"], "Nahrungsammeln" ],
+                    "pirschjagd": [ ["mu", "in", "ge"], "Pirschjagd" ],
+                    "speerfischen": [ ["mu", "in", "ge"], "Speerfischen" ],
+                    "tierfallenstellen": [ ["kl", "in", "ff"], "Tierfallenstellen" ],
+                    "wachehalten": [ ["mu", "in", "ko"], "Wachehalten" ]
+                };
+                for(var i=0; i < metatalenteIDs.length; i++) {
+                    getAttrs(
+                        [
+                            "repeating_MetaTalente_" + metatalenteIDs[i] + "_TalentName",
+                            "repeating_MetaTalente_" + metatalenteIDs[i] + "_Eigenschaft1",
+                            "repeating_MetaTalente_" + metatalenteIDs[i] + "_Eigenschaft2",
+                            "repeating_MetaTalente_" + metatalenteIDs[i] + "_Eigenschaft3",
+                            "repeating_MetaTalente_" + metatalenteIDs[i] + "_TaW",
+                            "repeating_MetaTalente_" + metatalenteIDs[i] + "_SE",
+                            "mu", "kl", "in", "ch", "ff", "ge", "ko", "kk"
+                        ], function(v) {
+                            console.log(v);
+                            let update = {};
+                            let newrow = generateRowID();
+                            let current = Object.keys(v)[0].split("_")[2];
+                            let prefixNew = "repeating_Metatalente201904_" + newrow;
+                            let prefixOld = "repeating_MetaTalente_" + current;
+
+                            // Gather data
+                            // Updating the name will set the stats automatically
+                            // To prevent overwriting of custom stats check that the RAW stats are used
+                            // Need to check that the three correct ones are used, order irrelevant
+                            // Comparison made easy by taking all three stats, sorting them alphabetically and then concatenating them into one string -> simple string comparison will reveal whether the same stats are used (order not important)
+                            let metatalentStats = metatalente[conversion[v[prefixOld + "_TalentName"]]][0].sort().join("");
+                            let metatalentStatsOld = [conversion[v[prefixOld + "_Eigenschaft1"]], conversion[v[prefixOld + "_Eigenschaft2"]], conversion[v[prefixOld + "_Eigenschaft3"]]].sort().join("");
+                            if(metatalentStats == metatalentStatsOld) {
+                                update[prefixNew + "_Name_Metatalent"] = conversion[v[prefixOld + "_TalentName"]];
+                                update[prefixNew + "_Name_Metatalent_Eigen"] = "";
+                            } else {
+                                update[prefixNew + "_Name_Metatalent_Eigen"] = "urspr. " + v[prefixOld + "_TalentName"] + "; Eigenschaften für Probe aber nicht Standard. ";
+                                console.log("Migration: Found old " + v[prefixOld + "_TalentName"] + " containing non-standard stats. No predefined meta-talent set. Old data preserved.");
+                            }
+                            if(v[prefixOld + "_SE"] == "on") {
+                                update[prefixNew + "_Name_Metatalent_Eigen"] += "[x] SE";
+                                console.log("Migration: Found old " + v[prefixOld + "_TalentName"] + " marked as having a special experience (SE). This data will no longer be kept in the character sheet as SEs for metatalents are not RAW and they are only relevant for character advancement. Old data preserved. Please move to notes.");
+                            } else {
+                                update[prefixNew + "_Name_Metatalent_Eigen"] += "[ ] SE";
+                            }
+                            update[prefixNew + "_Name_Metatalent_Anzeige"] = conversion[v[prefixOld + "_TalentName"]];
+                            update[prefixNew + "_Eigenschaft1"] = conversion[v[prefixOld + "_Eigenschaft1"]];
+                            update[prefixNew + "_Eigenschaft2"] = conversion[v[prefixOld + "_Eigenschaft2"]];
+                            update[prefixNew + "_Eigenschaft3"] = conversion[v[prefixOld + "_Eigenschaft3"]];
+                            update[prefixNew + "_hiddenEigenschaft1"] = v[conversion[v[prefixOld + "_Eigenschaft1"]]];
+                            update[prefixNew + "_hiddenEigenschaft2"] = v[conversion[v[prefixOld + "_Eigenschaft2"]]];
+                            update[prefixNew + "_hiddenEigenschaft3"] = v[conversion[v[prefixOld + "_Eigenschaft3"]]];
+                            update[prefixNew + "_TaW"] = parseInt(v[prefixOld + "_TaW"]);
+                            console.log(update);
+
+                            // Create new row
+                            setAttrs(update);
+                        });
+                }
+                migrationFinished += 2;
+            }
+            // FINISHING
+            if (migrationFinished === 1) {
+                console.log("Migration: Gifts migrated to new version, but there seems to be a problem with meta-talents. See console/log for further hints. Data version not updated to character sheet version.");
+            } else if (migrationFinished === 2) {
+                console.log("Migration: Meta-talents migrated to new version, but there seems to be a problem with gifts. See console/log for further hints. Data version not updated to character sheet version.");
+            } else if (migrationFinished === 3) {
+                let dataVersionNew = "20190425";
+                setAttrs({ "data_version": dataVersionNew });
+                console.log("Migration: Data version updated to character sheet version (" + dataVersionNew + "). Migration complete.");
+            } else {
+                console.log("Migration: Migration appears to be incomplete. See console/log for further hints. Data version not updated to character sheet version.");
+            }
+        });
     });
 }
 

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -6279,7 +6279,7 @@
                     <th style="width: 3em;">Probe</th>
                 </tr>
             </table>
-            <fieldset class="repeating_Metatalente">
+            <fieldset class="repeating_Metatalente201904">
                 <span style="display: inline-block; width: 23em">
                     <select name="attr_Name_Metatalent" class="atype" style="width: 10em;">
                         <option value="ansitzjagd">Ansitzjagd</option>
@@ -12868,6 +12868,56 @@
             <input type="number" name="attr_TaW" style="width: 3em;">
             <button type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=@{TalentName}}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW}]]}} {{stat1=[[@{Eigenschaft1}]]}} {{stat2=[[@{Eigenschaft2}]]}} {{stat3=[[@{Eigenschaft3}]]}} {{Talent=[[ { [[{0d1 + @{TaW} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft1}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft2}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft3}, 0d1}kh1, 0d1 + @{TaW}}dh1]]}}"></button>
         </fieldset>
+        <h5>Metatalente</h5>
+        <fieldset class="repeating_MetaTalente">
+            <input type="checkbox" name="attr_SE" style="width: 2em">
+            <select name="attr_TalentName" class="atype" style="width: 14em;">
+                <option>---</option>
+                <option>Pirschjagd</option>
+                <option>Ansitzjagd</option>
+                <option>Hetzjagd</option>
+                <option>Speerfischen</option>
+                <option>Tierfallenstellen</option>
+                <option>Nahrungsammeln</option>
+                <option>Kräutersuchen</option>
+                <option>Wachehalten</option>
+            </select>
+            <select name="attr_Eigenschaft1" class="sheet-talent-eigenschaft">
+                <option>---</option>
+                <option value="@{MU}">MU</option>
+                <option value="@{KL}">KL</option>
+                <option value="@{IN}">IN</option>
+                <option value="@{CH}">CH</option>
+                <option value="@{FF}">FF</option>
+                <option value="@{GE}">GE</option>
+                <option value="@{KO}">KO</option>
+                <option value="@{KK}">KK</option>
+            </select>
+            <select name="attr_Eigenschaft2" class="sheet-talent-eigenschaft">
+                <option>---</option>
+                <option value="@{MU}">MU</option>
+                <option value="@{KL}">KL</option>
+                <option value="@{IN}">IN</option>
+                <option value="@{CH}">CH</option>
+                <option value="@{FF}">FF</option>
+                <option value="@{GE}">GE</option>
+                <option value="@{KO}">KO</option>
+                <option value="@{KK}">KK</option>
+            </select>
+            <select name="attr_Eigenschaft3" class="sheet-talent-eigenschaft">
+                <option>---</option>
+                <option value="@{MU}">MU</option>
+                <option value="@{KL}">KL</option>
+                <option value="@{IN}">IN</option>
+                <option value="@{CH}">CH</option>
+                <option value="@{FF}">FF</option>
+                <option value="@{GE}">GE</option>
+                <option value="@{KO}">KO</option>
+                <option value="@{KK}">KK</option>
+            </select>
+            <input type="number" name="attr_TaW" style="width: 3em;">
+            <button type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=@{TalentName}}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW}]]}} {{stat1=[[@{Eigenschaft1}]]}} {{stat2=[[@{Eigenschaft2}]]}} {{stat3=[[@{Eigenschaft3}]]}} {{Talent=[[ { [[{0d1 + @{TaW} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft1}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft2}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft3}, 0d1}kh1, 0d1 + @{TaW}}dh1]]}}"></button>
+        </fieldset>
     </div>
 
 
@@ -15624,10 +15674,10 @@ on("change:repeating_Gaben:Name_Gabe change:repeating_Gaben:Name_Gabe_Zusatz", f
     });
 });
 
-on("change:repeating_metatalente:Name_Metatalent change:repeating_metatalente:Name_Metatalent_Eigen", function(eventInfo) {
-    getAttrs(["repeating_metatalente_Name_Metatalent", "repeating_metatalente_Name_Metatalent_Eigen"], function(v) {
-        let metatalent = v.repeating_metatalente_Name_Metatalent;
-        let metatalentEigen = v.repeating_metatalente_Name_Metatalent_Eigen;
+on("change:repeating_Metatalente201904:Name_Metatalent change:repeating_Metatalente201904:Name_Metatalent_Eigen", function(eventInfo) {
+    getAttrs(["repeating_Metatalente201904_Name_Metatalent", "repeating_Metatalente201904_Name_Metatalent_Eigen"], function(v) {
+        let metatalent = v.repeating_Metatalente201904_Name_Metatalent;
+        let metatalentEigen = v.repeating_Metatalente201904_Name_Metatalent_Eigen;
         let metatalente = {
             "ansitzjagd": [ ["mu", "in", "ge"], "Ansitzjagd" ],
             "hetzjagd": [ ["mu", "in", "ge"], "Hetzjagd" ],
@@ -15640,10 +15690,10 @@ on("change:repeating_metatalente:Name_Metatalent change:repeating_metatalente:Na
         };
         if (metatalent != "nothing")  {
             setAttrs({
-                'repeating_metatalente_eigenschaft1': metatalente[metatalent][0][0],
-                'repeating_metatalente_eigenschaft2': metatalente[metatalent][0][1],
-                'repeating_metatalente_eigenschaft3': metatalente[metatalent][0][2],
-                'repeating_metatalente_Name_Metatalent_Anzeige': metatalente[metatalent][1]
+                'repeating_Metatalente201904_eigenschaft1': metatalente[metatalent][0][0],
+                'repeating_Metatalente201904_eigenschaft2': metatalente[metatalent][0][1],
+                'repeating_Metatalente201904_eigenschaft3': metatalente[metatalent][0][2],
+                'repeating_Metatalente201904_Name_Metatalent_Anzeige': metatalente[metatalent][1]
             });
         } else {
             let update = {};
@@ -15668,13 +15718,13 @@ on("change:repeating_Gaben:eigenschaft1 change:repeating_Gaben:eigenschaft2 chan
     });
 });
 
-on("change:repeating_metatalente:eigenschaft1 change:repeating_metatalente:eigenschaft2 change:repeating_metatalente:eigenschaft3", function(eventInfo) {
-    getAttrs(["repeating_metatalente_eigenschaft1", "repeating_metatalente_eigenschaft2", "repeating_metatalente_eigenschaft3", "mu", "kl", "in", "ch", "ff", "ge", "ko", "kk"], function(v) {
+on("change:repeating_Metatalente201904:eigenschaft1 change:repeating_Metatalente201904:eigenschaft2 change:repeating_Metatalente201904:eigenschaft3", function(eventInfo) {
+    getAttrs(["repeating_Metatalente201904_eigenschaft1", "repeating_Metatalente201904_eigenschaft2", "repeating_Metatalente201904_eigenschaft3", "mu", "kl", "in", "ch", "ff", "ge", "ko", "kk"], function(v) {
             let attributes = {"mu": +v.mu, "kl": +v.kl, "in": +v.in, "ch": +v.ch, "ff": +v.ff, "ge": +v.ge, "ko": +v.ko, "kk": +v.kk};
             setAttrs({
-                'repeating_metatalente_hiddeneigenschaft1': attributes[v.repeating_metatalente_eigenschaft1] || 0,
-                'repeating_metatalente_hiddeneigenschaft2': attributes[v.repeating_metatalente_eigenschaft2] || 0,
-                'repeating_metatalente_hiddeneigenschaft3': attributes[v.repeating_metatalente_eigenschaft3] || 0
+                'repeating_Metatalente201904_hiddeneigenschaft1': attributes[v.repeating_Metatalente201904_eigenschaft1] || 0,
+                'repeating_Metatalente201904_hiddeneigenschaft2': attributes[v.repeating_Metatalente201904_eigenschaft2] || 0,
+                'repeating_Metatalente201904_hiddeneigenschaft3': attributes[v.repeating_Metatalente201904_eigenschaft3] || 0
             });
     });
 });
@@ -15698,12 +15748,12 @@ on("change:mu change:kl change:in change:ch change:ff change:ge change:ko change
         });
 
         // Aktualisiere Metatalente
-        getSectionIDs("metatalente", function(idarray) {
+        getSectionIDs("metatalente201904", function(idarray) {
              _.each(idarray, function(currentID, i) {
-                getAttrs(["repeating_metatalente_" + currentID + "_eigenschaft1", "repeating_metatalente_" + currentID + "_eigenschaft2", "repeating_metatalente_" + currentID + "_eigenschaft3"], function(v) {
-                    update["repeating_metatalente_" + currentID + "_hiddeneigenschaft1"] = attributes[v["repeating_metatalente_" + currentID + "_eigenschaft1"]];
-                    update["repeating_metatalente_" + currentID + "_hiddeneigenschaft2"] = attributes[v["repeating_metatalente_" + currentID + "_eigenschaft2"]];
-                    update["repeating_metatalente_" + currentID + "_hiddeneigenschaft3"] = attributes[v["repeating_metatalente_" + currentID + "_eigenschaft3"]];
+                getAttrs(["repeating_Metatalente201904_" + currentID + "_eigenschaft1", "repeating_Metatalente201904_" + currentID + "_eigenschaft2", "repeating_Metatalente201904_" + currentID + "_eigenschaft3"], function(v) {
+                    update["repeating_Metatalente201904_" + currentID + "_hiddeneigenschaft1"] = attributes[v["repeating_Metatalente201904_" + currentID + "_eigenschaft1"]];
+                    update["repeating_Metatalente201904_" + currentID + "_hiddeneigenschaft2"] = attributes[v["repeating_Metatalente201904_" + currentID + "_eigenschaft2"]];
+                    update["repeating_Metatalente201904_" + currentID + "_hiddeneigenschaft3"] = attributes[v["repeating_Metatalente201904_" + currentID + "_eigenschaft3"]];
                     setAttrs(update);
                 });
             });

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -6272,10 +6272,11 @@
                     <select name="attr_Name_Metatalent" class="atype" style="width: 10em;">
                         <option value="ansitzjagd">Ansitzjagd</option>
                         <option value="hetzjagd">Hetzjagd</option>
+                        <option value="kraeutersuchen">Kräutersuchen</option>
+                        <option value="nahrungsammeln">Nahrungsammeln</option>
+                        <option value="pirschjagd">Pirschjagd</option>
                         <option value="speerfischen">Speerfischen</option>
                         <option value="tierfallenstellen">Tierfallenstellen</option>
-                        <option value="nahrungsammeln">Nahrungsammeln</option>
-                        <option value="kraeutersuchen">Kräutersuchen</option>
                         <option value="wachehalten">Wachehalten</option>
                         <option value="nothing" selected>Eigenes</option>
                     </select>
@@ -15513,13 +15514,22 @@ on("change:repeating_metatalente:Name_Metatalent change:repeating_metatalente:Na
     getAttrs(["repeating_metatalente_Name_Metatalent", "repeating_metatalente_Name_Metatalent_Eigen"], function(v) {
         let metatalent = v.repeating_metatalente_Name_Metatalent;
         let metatalentEigen = v.repeating_metatalente_Name_Metatalent_Eigen;
-        let metaTalente = {"pirschjagd":"mu/in/ge","ansitzjagd":"mu/in/ge","hetzjagd":"mu/in/ge","speerfischen":"mu/in/ge","tierfallenstellen":"kl/in/ff","nahrungsammeln":"mu/in/ff","kraeutersuchen":"mu/in/ff","wachehalten":"mu/in/ko"};
+        let metatalente = {
+            "ansitzjagd": [ ["mu", "in", "ge"], "Ansitzjagd" ],
+            "hetzjagd": [ ["mu", "in", "ge"], "Hetzjagd" ],
+            "kraeutersuchen": [ ["mu", "in", "ff"], "Kräutersuchen" ],
+            "nahrungsammeln": [ ["mu", "in", "ff"], "Nahrungsammeln" ],
+            "pirschjagd": [ ["mu", "in", "ge"], "Pirschjagd" ],
+            "speerfischen": [ ["mu", "in", "ge"], "Speerfischen" ],
+            "tierfallenstellen": [ ["kl", "in", "ff"], "Tierfallenstellen" ],
+            "wachehalten": [ ["mu", "in", "ko"], "Wachehalten" ]
+        };
         if (metatalent != "nothing")  {
             setAttrs({
-                'repeating_metatalente_eigenschaft1': metaTalente[metatalent].split("/")[0],
-                'repeating_metatalente_eigenschaft2': metaTalente[metatalent].split("/")[1],
-                'repeating_metatalente_eigenschaft3': metaTalente[metatalent].split("/")[2],
-                'repeating_metatalente_Name_Metatalent_Anzeige': metatalent.charAt(0).toUpperCase() + metatalent.slice(1)
+                'repeating_metatalente_eigenschaft1': metatalente[metatalent][0][0],
+                'repeating_metatalente_eigenschaft2': metatalente[metatalent][0][1],
+                'repeating_metatalente_eigenschaft3': metatalente[metatalent][0][2],
+                'repeating_metatalente_Name_Metatalent_Anzeige': metatalente[metatalent][1]
             });
         } else {
             let update = {};

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -948,7 +948,7 @@
                 <input class="sheet-talent-zweihandschwerter sheet-default-hide" type="checkbox" name="attr_talent_zweihandschwerter" value="1">
                 <div class="sheet-talent">
                     <div class="sheet-talent-cell sheet-talent-name">Zweihandschwerter/-säbel</div>
-                    <div class="sheet-talent-cell sheet-talent-stf">D</div>
+                    <div class="sheet-talent-cell sheet-talent-stf">E</div>
                     <div class="sheet-talent-cell sheet-talent-ebe">BE−2</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_zweihandschwerter">
                     <input type="number" class="sheet-talent-at" name="attr_AT_zweihandschwerter">

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -31,6 +31,9 @@
     <input type="radio" name="attr_tab" class="sheet-tab sheet-tab10" value="10" title="Konfiguration">
     <span class="sheet-tab sheet-tab10">Konfiguration</span>
     
+    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab11" value="11" title="Updates">
+    <span class="sheet-tab sheet-tab11">Updates</span>
+    
     <div class="sheet-section sheet-section-Allgemein">
         <table>
             <tr>
@@ -130,55 +133,55 @@
                 <td><button type="roll" name="Mut" value="@{gm_roll_opt} &{template:DSA-Eigenschaft} {{name=Mut}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{ew=[[@{MU}]]}} {{Probe=[[{@{MU} - (?{Erleichterung (−) oder Erschwernis (+)|0}) - 1d20cs1cf20, @{MU} + 0d1}dh1]]}}"> <span>Mut</span></button></td>
                 <td><input type="number" style="width: 4em" name="attr_MU_Basis" min="0" value="8"></td>
                 <td><input type="number" style="width: 4em" name="attr_MU_Mod" min="-99" max="99" value="0"></td>
-                <td><input type="text" class="sheet-stat-immutable" disabled="true" name="attr_MU" value="(@{MU_Basis} + @{MU_Mod} - @{wound_Kopf})"></td>
+                <td><input type="text" class="sheet-stat-immutable" readonly="readonly" name="attr_MU" value="0"></td>
             </tr>
             <tr>
                 <td><button type="roll" name="Klugheit" value="@{gm_roll_opt} &{template:DSA-Eigenschaft} {{name=Klugheit}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{ew=[[@{KL}]]}} {{Probe=[[{@{KL} - (?{Erleichterung (−) oder Erschwernis (+)|0}) - 1d20cs1cf20, @{KL} + 0d1}dh1]]}}{"> <span>Klugheit</span></button></td>
                 <td><input type="number" style="width: 4em" name="attr_KL_Basis" min="0" value="8"></td>
                 <td><input type="number" style="width: 4em" name="attr_KL_Mod" min="-99" max="99" value="0"></td>
-                <td><input type="text" class="sheet-stat-immutable" disabled="true" name="attr_KL" value="(@{KL_Basis} + @{KL_Mod} - @{wound_Kopf})"></td>
+                <td><input type="text" class="sheet-stat-immutable" readonly="readonly" name="attr_KL" value="0"></td>
             </tr>
             <tr>
                 <td><button type="roll" name="Intuition" value="@{gm_roll_opt} &{template:DSA-Eigenschaft} {{name=Intuition}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{ew=[[@{IN}]]}} {{Probe=[[{@{IN} - (?{Erleichterung (−) oder Erschwernis (+)|0}) - 1d20cs1cf20, @{IN} + 0d1}dh1]]}}"> <span>Intuition</span></button></td>
                 <td><input type="number" style="width: 4em" name="attr_IN_Basis" min="0" value="8"></td>
                 <td><input type="number" style="width: 4em" name="attr_IN_Mod" min="-99" max="99" value="0"></td>
-                <td><input type="text" class="sheet-stat-immutable" disabled="true" name="attr_IN" value="(@{IN_Basis} + @{IN_Mod} - @{wound_Kopf})"></td>
+                <td><input type="text" class="sheet-stat-immutable" readonly="readonly" name="attr_IN" value="0"></td>
             </tr>
             <tr>
                 <td><button type="roll" name="Charisma" value="@{gm_roll_opt} &{template:DSA-Eigenschaft} {{name=Charisma}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{ew=[[@{CH}]]}} {{Probe=[[{@{CH} - (?{Erleichterung (−) oder Erschwernis (+)|0}) - 1d20cs1cf20, @{CH} + 0d1}dh1]]}}"> <span>Charisma</span></button></td>
                 <td><input type="number" style="width: 4em" name="attr_CH_Basis" min="0" value="8"></td>
                 <td><input type="number" style="width: 4em" name="attr_CH_Mod" min="-99" max="99" value="0"></td>
-                <td><input type="text" class="sheet-stat-immutable" disabled="true" name="attr_CH" value="(@{CH_Basis} + @{CH_Mod})"></td>
+                <td><input type="text" class="sheet-stat-immutable" readonly="readonly" name="attr_CH" value="0"></td>
             </tr>
             <tr>
                 <td><button type="roll" name="Fingerfertigkeit" value="@{gm_roll_opt} &{template:DSA-Eigenschaft} {{name=Fingerfertigkeit}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{ew=[[@{FF}]]}} {{Probe=[[{@{FF} - (?{Erleichterung (−) oder Erschwernis (+)|0}) - 1d20cs1cf20, @{FF} + 0d1}dh1]]}}"> <span>Fingerfertigkeit</span></button></td>
                 <td><input type="number" style="width: 4em" name="attr_FF_Basis" min="0" value="8"></td>
                 <td><input type="number" style="width: 4em" name="attr_FF_Mod" min="-99" max="99" value="0"></td>
-                <td><input type="text" class="sheet-stat-immutable" disabled="true" name="attr_FF" value="(@{FF_Basis} + @{FF_Mod} - @{wound_RA} - @{wound_LA})"></td>
+                <td><input type="text" class="sheet-stat-immutable" readonly="readonly" name="attr_FF" value="0"></td>
             </tr>
             <tr>
                 <td><button type="roll" name="Gewandheit" value="@{gm_roll_opt} &{template:DSA-Eigenschaft} {{name=Gewandtheit}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{ew=[[@{GE}]]}} {{Probe=[[{@{GE} - (?{Erleichterung (−) oder Erschwernis (+)|0}) - 1d20cs1cf20, @{GE} + 0d1}dh1]]}}"> <span>Gewandtheit</span></button></td>
                 <td><input type="number" style="width: 4em" name="attr_GE_Basis" min="0" value="8"></td>
                 <td><input type="number" style="width: 4em" name="attr_GE_Mod" min="-99" max="99" value="0"></td>
-                <td><input type="text" class="sheet-stat-immutable" disabled="true" name="attr_GE" value="(@{GE_Basis} + @{GE_Mod} - @{wound_RB} - @{wound_LB})"></td>
+                <td><input type="text" class="sheet-stat-immutable" readonly="readonly" name="attr_GE" value="0"></td>
             </tr>
             <tr>
                 <td><button type="roll" name="Konstitution" value="@{gm_roll_opt} &{template:DSA-Eigenschaft} {{name=Konstitution}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{ew=[[@{KO}]]}} {{Probe=[[{@{KO} - (?{Erleichterung (−) oder Erschwernis (+)|0}) - 1d20cs1cf20, @{KO} + 0d1}dh1]]}}"> <span>Konstitution</span></button></td>
                 <td><input type="number" style="width: 4em" name="attr_KO_Basis" min="0" value="8"></td>
                 <td><input type="number" style="width: 4em" name="attr_KO_Mod" min="-99" max="99" value="0"></td>
-                <td><input type="text" class="sheet-stat-immutable" disabled="true" name="attr_KO" value="(@{KO_Basis} + @{KO_Mod} - @{wound_Brust} - @{wound_Bauch})"></td>
+                <td><input type="text" class="sheet-stat-immutable" readonly="readonly" name="attr_KO" value="0"></td>
             </tr>
             <tr>
                 <td><button type="roll" name="Koerperkraft" value="@{gm_roll_opt} &{template:DSA-Eigenschaft} {{name=Körperkraft}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{ew=[[@{KK}]]}} {{Probe=[[{@{KK} - (?{Erleichterung (−) oder Erschwernis (+)|0}) - 1d20cs1cf20, @{KK} + 0d1}dh1]]}}"> <span>Körperkraft</span></button></td>
                 <td><input type="number" style="width: 4em" name="attr_KK_Basis" min="0" value="8"></td>
                 <td><input type="number" style="width: 4em" name="attr_KK_Mod" min="-99" max="99" value="0"></td>
-                <td><input type="text" class="sheet-stat-immutable" disabled="true" name="attr_KK" value="(@{KK_Basis} + @{KK_Mod} - @{wound_Brust} - @{wound_Bauch} - @{wound_RA} - @{wound_LA})"></td>
+                <td><input type="text" class="sheet-stat-immutable" readonly="readonly" name="attr_KK" value="0"></td>
             </tr>
             <tr>
                 <td>Geschwindigkeit</td>
                 <td><input type="number" style="width: 4em" name="attr_GS_Basis" min="1" max="99" value="8"></td>
                 <td><input type="number" style="width: 4em" name="attr_GS_Mod" min="-99" max="99" value="0"></td>
-                <td><input type="text" class="sheet-stat-immutable" disabled="true" name="attr_GS" value="(@{GS_Basis} + @{GS_Mod} + (floor((@{GE_Basis} + @{GE_Mod} + 100)/111)-1) + (ceil((@{GE_Basis} + @{GE_Mod} + 100)/115)-1) - @{wound_Bauch} - (@{wound_RB}/2 - @{wound_LB}/2))"></td>
+                <td><input type="text" class="sheet-stat-immutable" readonly="readonly" name="attr_GS" value="0"></td>
                 <td>&nbsp;</td>
             </tr>
         </table>
@@ -194,90 +197,90 @@
             <th>Aktuell</th>
             <tr>
                 <td>Lebensenergie</td>
-                <td><input type="text" class="sheet-stat-immutable" name="attr_LEGrundW" value="round(@{KO_Basis} + (@{KK_Basis}/2) + 0.05)" disabled="true"></td>
-                <td><input type="number" name="attr_LEZugeK" style="width: 3em;" value="0"></td>
-                <td><input type="text" class="sheet-stat-immutable" name="attr_LE_max" value="(@{LEGrundW} + @{LEZugeK})" disabled="true"></td>
-                <td><input type="number" name="attr_LEAktuell" style="width: 3em" value="0"></td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_LEGrundW" value="0" readonly="readonly"></td>
+                <td><input type="number" name="attr_LEZugeK" style="width: 2em;" value="0"></td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_LE_max" value="0" readonly="readonly"></td>
+                <td><input type="number" name="attr_LEAktuell" style="width: 2em" value="0"></td>
             </tr>
             <tr>
                 <td>Ausdauer</td>
-                <td><input type="text" class="sheet-stat-immutable" name="attr_AusGrundW" value="round((@{MU_Basis} + @{KO_Basis} + @{GE_Basis})/2 + 0.05)" disabled="true"></td>
-                <td><input type="number" name="attr_AusZugeK" style="width: 3em;" value="0"></td>
-                <td><input type="text" class="sheet-stat-immutable" name="attr_Aus_max" value="@{AusGrundW} + @{AusZugeK}" disabled="true"></td>
-                <td><input type="number" name="attr_AusAktuell" style="width: 3em" value="@{Aus_max}"></td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_AusGrundW" value="0" readonly="readonly"></td>
+                <td><input type="number" name="attr_AusZugeK" style="width: 2em;" value="0"></td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_Aus_max" value="0" readonly="readonly"></td>
+                <td><input type="number" name="attr_AusAktuell" style="width: 2em" value="@{Aus_max}"></td>
             </tr>
             <tr class="sheet-hideable-exhaustion">
-                <td>Erschöpfung</td>
-                <td><input type="text" class="sheet-stat-immutable" name="attr_erschoepfung_basis" value="@{KO_Basis}" disabled="true"></td>
-                <td><input type="number" name="attr_erschoepfung_mod" style="width: 3em;" value="0" min="-2" max="2"></td>
-                <td><input type="text" class="sheet-stat-immutable" name="attr_erschoepfung_max" value="(@{erschoepfung_basis}) + (@{erschoepfung_mod})" disabled="true"></td>
-                <td><input type="number" name="attr_erschoepfung" style="width: 3em" value="0" min="0"></td>
+                <td>Ersch&ouml;pfung</td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_erschoepfung_basis" value="0" readonly="readonly"></td>
+                <td><input type="number" name="attr_erschoepfung_mod" style="width: 2em;" value="0" min="-2" max="2"></td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_erschoepfung_max" value="0" readonly="readonly"></td>
+                <td><input type="number" name="attr_erschoepfung" style="width: 2em" value="0" min="0"></td>
             </tr>
             <tr class="sheet-hideable-overstrain">
-                <td>Überanstrengung</td>
+                <td>&Uuml;beranstrengung</td>
                 <td>&nbsp;</td>
                 <td>&nbsp;</td>
-                <td><input type="text" class="sheet-stat-immutable" name="attr_ueberanstrengung_max" value="@{KO_Basis}" disabled="true"></td>
-                <td><input type="number" name="attr_ueberanstrengung" style="width: 3em" value="0" min="0"></td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_ueberanstrengung_max" value="0" readonly="readonly"></td>
+                <td><input type="number" name="attr_ueberanstrengung" style="width: 2em" value="0" min="0"></td>
             </tr>
             <tr class="sheet-hideable-ae">
                 <td>Astralenergie</td>
-                <td><input type="text" class="sheet-stat-immutable" name="attr_ASPGrundW" value="round((@{MU_Basis} + @{IN_Basis} + @{CH_Basis})/2 + 0.05)" disabled="true"></td>
-                <td><input type="number" name="attr_ASPZugeK" style="width: 3em;" value="0"></td>
-                <td><input type="text" class="sheet-stat-immutable" name="attr_ASP_max" value="@{ASPGrundW} + @{ASPZugeK}" disabled="true"></td>
-                <td><input type="number" name="attr_ASPAktuell" style="width: 3em" value="@{ASP_max}"></td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_ASPGrundW" value="0" readonly="readonly"></td>
+                <td><input type="number" name="attr_ASPZugeK" style="width: 2em;" value="0"></td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_ASP_max" value="0" readonly="readonly"></td>
+                <td><input type="number" name="attr_ASPAktuell" style="width: 2em" value="@{ASP_max}"></td>
             </tr>
             <tr class="sheet-hideable-ke">
                 <td>Karmaenergie</td>
                 <td>
-                    <select name="attr_KEGrundW" class="atype" style="width: 3em;">
+                    <select name="attr_KEGrundW" class="atype" style="width: 4em;">
                         <option value="">---</option>
                         <option value="12">12</option>
                         <option value="24">24</option>
                     </select>
                 </td>
-                <td><input type="number" name="attr_KEZugeK" style="width: 3em;" value="0"></td>
-                <td><input type="text" class="sheet-stat-immutable" name="attr_KE_max" value="@{KEGrundW} + @{KEZugeK}" disabled="true"></td>
-                <td><input type="number" name="attr_KEAktuell" style="width: 3em" value="@{KE_max}"></td>
+                <td><input type="number" name="attr_KEZugeK" style="width: 2em;" value="0"></td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_KE_max" value="0" readonly="readonly"></td>
+                <td><input type="number" name="attr_KEAktuell" style="width: 2em" value="@{KE_max}"></td>
             </tr>
             <tr>
                 <td>Magieresistenz</td>
-                <td><input type="text" class="sheet-stat-immutable" name="attr_MRGrundW" value="round((@{MU_Basis} + @{MU_Mod} + @{KL_Basis} + @{KL_Mod} + @{KO_Basis} + @{KO_Mod})/5)" disabled="true"></td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_MRGrundW" value="0" readonly="readonly"></td>
                 <td><input type="number" name="attr_MRZugeK" style="width: 3em;" value="-4"></td>
-                <td><input type="text" class="sheet-stat-immutable" name="attr_MR_max" value="@{MRGrundW} + @{MRZugeK}" disabled="true"></td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_MR_max" value="0" readonly="readonly"></td>
                 <td>&nbsp;</td>
             </tr>
             <tr>
                 <td>INI-Basiswert</td>
-                <td><input type="text" class="sheet-stat-immutable" name="attr_INIBasis" value="round((@{MU_Basis} + @{MU_Mod} + @{MU_Basis} + @{MU_Mod} + @{IN_Basis} + @{IN_Mod} + @{GE_Basis} + @{GE_Mod})/5)" disabled="true"></td>
-                <td><input name="attr_INIZugeK" style="width: 3em;" type="number" value="0"></td>
-                <td><input type="text" class="sheet-stat-immutable" name="attr_INI_max" value="(@{INIBasis} + @{INIZugeK} - @{wound_Kopf} - @{wound_Bauch} - @{wound_LB} - @{wound_RB})" disabled="true"></td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_INIBasis" value="0" readonly="readonly"></td>
+                <td><input name="attr_INIZugeK" style="width: 2em;" type="number" value="0"></td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_INI_max" value="0" readonly="readonly"></td>
                 <td>&nbsp;</td>
             </tr>
             <tr>
                 <td>AT-Basiswert</td>
-                <td><input type="text" class="sheet-stat-immutable" name="attr_ATBasis" value="round(((@{MU_Basis} + @{MU_Mod} + @{GE_Basis} + @{GE_Mod} + @{KK_Basis} + @{KK_Mod})/5) - @{wound_Bauch} - @{wound_RA} - @{wound_LA} - @{wound_RB} - @{wound_LB})" disabled="true"></td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_ATBasis" value="0" readonly="readonly"></td>
                 <td><input type="number" class="sheet-invisible"></td>
                 <td>&nbsp;</td>
                 <td>&nbsp;</td>
             </tr>
             <tr>
                 <td>PA-Basiswert</td>
-                <td><input type="text" class="sheet-stat-immutable" name="attr_PABasis" value="round(((@{IN_Basis} + @{IN_Mod} + @{GE_Basis} + @{GE_Mod} + @{KK_Basis} + @{KK_Mod})/5) - @{wound_Brust} - @{wound_Bauch} - @{wound_RA} - @{wound_LA} - @{wound_RB} - @{wound_LB})" disabled="true"></td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_PABasis" value="0" readonly="readonly"></td>
                 <td><input type="number" class="sheet-invisible"></td>
                 <td>&nbsp;</td>
                 <td>&nbsp;</td>
             </tr>
             <tr>
                 <td>FK-Basiswert</td>
-                <td><input type="text" class="sheet-stat-immutable" name="attr_FKBasis" value="round(((@{IN_Basis} + @{IN_Mod} + @{FF_Basis} + @{FF_Mod} + @{KK_Basis} + @{KK_Mod})/5) - @{wound_Brust} - @{wound_Bauch} - @{wound_RA} - @{wound_LA} - @{wound_RB} - @{wound_LB})" disabled="true"></td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_FKBasis" value="0" readonly="readonly"></td>
                 <td><input type="number" class="sheet-invisible"></td>
                 <td>&nbsp;</td>
                 <td>&nbsp;</td>
             </tr>
             <tr>
                 <td>Wundschwelle</td>
-                <td><input type="text" class="sheet-stat-immutable" name="attr_Wundschwelle" value="ceil((@{KO_Basis}/2) + @{Eisern})" disabled="true"></td>
+                <td><input type="text" class="sheet-stat-immutable" name="attr_Wundschwelle" value="0" readonly="readonly"></td>
                 <td><input type="number" class="sheet-invisible"></td>
                 <td>&nbsp;</td>
                 <td>&nbsp;</td>
@@ -300,7 +303,7 @@
             </tr>
             <tr>
                 <td>Verfügbar</td>
-                <td><input type="text" class="sheet-stat-immutable" disabled="true" name="attr_AP_verfuegbar" style="width: 5em;" min="0" value="(@{AP_gesamt} - @{AP_ausgegeben})"></td>
+                <td><input type="text" class="sheet-stat-immutable" readonly="readonly" name="attr_AP_verfuegbar" style="width: 5em;" min="0" value="0"></td>
                 <td><input type="number" class="sheet-invisible" style="width: 0em;"></td>
             </tr>
         </table>
@@ -633,15 +636,15 @@
         <br>
         <table align="center">
             <tr>
-                <th>MU: <input type="text" class="sheet-stat-immutable" name="attr_MU2" disabled="true" value="@{MU}"></th>
-                <th>KL: <input type="text" class="sheet-stat-immutable" name="attr_KL2" disabled="true" value="@{KL}"></th>
-                <th>IN: <input type="text" class="sheet-stat-immutable" name="attr_IN2" disabled="true" value="@{IN}"></th>
-                <th>CH: <input type="text" class="sheet-stat-immutable" name="attr_CH2" disabled="true" value="@{CH}"></th>
-                <th>FF: <input type="text" class="sheet-stat-immutable" name="attr_FF2" disabled="true" value="@{FF}"></th>
-                <th>GE: <input type="text" class="sheet-stat-immutable" name="attr_GE2" disabled="true" value="@{GE}"></th>
-                <th>KO: <input type="text" class="sheet-stat-immutable" name="attr_KO2" disabled="true" value="@{KO}"></th>
-                <th>KK: <input type="text" class="sheet-stat-immutable" name="attr_KK2" disabled="true" value="@{KK}"></th>
-                <th>BE: <input type="text" class="sheet-stat-immutable" name="attr_BE_TaW" disabled="true" value="(@{Ges_BE} + @{BE_Last})"></th>
+                <th>MU: <input type="text" class="sheet-stat-immutable" name="attr_MU2" readonly="readonly" value="0"></th>
+                <th>KL: <input type="text" class="sheet-stat-immutable" name="attr_KL2" readonly="readonly" value="0"></th>
+                <th>IN: <input type="text" class="sheet-stat-immutable" name="attr_IN2" readonly="readonly" value="0"></th>
+                <th>CH: <input type="text" class="sheet-stat-immutable" name="attr_CH2" readonly="readonly" value="0"></th>
+                <th>FF: <input type="text" class="sheet-stat-immutable" name="attr_FF2" readonly="readonly" value="0"></th>
+                <th>GE: <input type="text" class="sheet-stat-immutable" name="attr_GE2" readonly="readonly" value="0"></th>
+                <th>KO: <input type="text" class="sheet-stat-immutable" name="attr_KO2" readonly="readonly" value="0"></th>
+                <th>KK: <input type="text" class="sheet-stat-immutable" name="attr_KK2" readonly="readonly" value="0"></th>
+                <th>BE: <input type="text" class="sheet-stat-immutable" name="attr_BE_TaW" disabled="disabled" value="(@{Ges_BE} + @{BE_Last})"></th>
             </tr>
         </table>
         <br>
@@ -6257,59 +6260,65 @@
                 <option value="/w GM ">Nur zu Meister würfeln</option>
             </select>
             <br><b style="display: inline-block; font-size:90%; width: 2.5em">SE</b>
-            <b style="display: inline-block; font-size:90%; width: 15.25em;">Talent</b>
+            <b style="display: inline-block; font-size:90%; width: 23em;">Talent (Offiziell / Eigenes)</b>
             <b style="display: inline-block; font-size:90%; width: 15.25em;">Eigenschaften</b>
             <b style="display: inline-block; font-size:90%; width: 3.25em;">TaW</b>
             <b style="display: inline-block; font-size:90%; width: 3em;">Probe</b>
             <br>
             <fieldset class="repeating_MetaTalente">
-                <input type="checkbox" name="attr_SE" style="width: 2em">
-                <select name="attr_TalentName" class="atype" style="width: 14em;">
-                    <option>---</option>
-                    <option>Pirschjagd</option>
-                    <option>Ansitzjagd</option>
-                    <option>Hetzjagd</option>
-                    <option>Speerfischen</option>
-                    <option>Tierfallenstellen</option>
-                    <option>Nahrungsammeln</option>
-                    <option>Kräutersuchen</option>
-                    <option>Wachehalten</option>
+                <input type="checkbox" name="attr_SE" style="width: 2em" />
+                <select name="attr_TalentName" class="atype" style="width: 10em;">
+                    <option value="nothing">---</option>
+                    <option value="pirschjagd">Pirschjagd</option>
+                    <option value="ansitzjagd">Ansitzjagd</option>
+                    <option value="hetzjagd">Hetzjagd</option>
+                    <option value="speerfischen">Speerfischen</option>
+                    <option value="tierfallenstellen">Tierfallen aufstellen</option>
+                    <option value="nahrungsammeln">Nahrungsammeln</option>
+                    <option value="kraeutersuchen">Kr&auml;utersuchen</option>
+                    <option value="wachehalten">Wachehalten</option>
                 </select>
+                &nbsp;/&nbsp;
+                <input type="text" name="attr_eigenerMetaname" style="width: 10em;"/>
                 <select name="attr_Eigenschaft1" class="sheet-talent-eigenschaft">
-                    <option>---</option>
-                    <option value="@{MU}">MU</option>
-                    <option value="@{KL}">KL</option>
-                    <option value="@{IN}">IN</option>
-                    <option value="@{CH}">CH</option>
-                    <option value="@{FF}">FF</option>
-                    <option value="@{GE}">GE</option>
-                    <option value="@{KO}">KO</option>
-                    <option value="@{KK}">KK</option>
+                    <option value="nothing">---</option>
+                    <option value="mu">MU</option>
+                    <option value="kl">KL</option>
+                    <option value="in">IN</option>
+                    <option value="ch">CH</option>
+                    <option value="ff">FF</option>
+                    <option value="ge">GE</option>
+                    <option value="ko">KO</option>
+                    <option value="kk">KK</option>
                 </select>
                 <select name="attr_Eigenschaft2" class="sheet-talent-eigenschaft">
-                    <option>---</option>
-                    <option value="@{MU}">MU</option>
-                    <option value="@{KL}">KL</option>
-                    <option value="@{IN}">IN</option>
-                    <option value="@{CH}">CH</option>
-                    <option value="@{FF}">FF</option>
-                    <option value="@{GE}">GE</option>
-                    <option value="@{KO}">KO</option>
-                    <option value="@{KK}">KK</option>
+                    <option value="nothing">---</option>
+                    <option value="mu">MU</option>
+                    <option value="kl">KL</option>
+                    <option value="in">IN</option>
+                    <option value="ch">CH</option>
+                    <option value="ff">FF</option>
+                    <option value="ge">GE</option>
+                    <option value="ko">KO</option>
+                    <option value="kk">KK</option>
                 </select>
                 <select name="attr_Eigenschaft3" class="sheet-talent-eigenschaft">
-                    <option>---</option>
-                    <option value="@{MU}">MU</option>
-                    <option value="@{KL}">KL</option>
-                    <option value="@{IN}">IN</option>
-                    <option value="@{CH}">CH</option>
-                    <option value="@{FF}">FF</option>
-                    <option value="@{GE}">GE</option>
-                    <option value="@{KO}">KO</option>
-                    <option value="@{KK}">KK</option>
+                    <option value="nothing">---</option>
+                    <option value="mu">MU</option>
+                    <option value="kl">KL</option>
+                    <option value="in">IN</option>
+                    <option value="ch">CH</option>
+                    <option value="ff">FF</option>
+                    <option value="ge">GE</option>
+                    <option value="ko">KO</option>
+                    <option value="kk">KK</option>
                 </select>
-                <input type="number" name="attr_TaW" style="width: 3em;">
-                <button type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=@{TalentName}}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW}]]}} {{stat1=[[@{Eigenschaft1}]]}} {{stat2=[[@{Eigenschaft2}]]}} {{stat3=[[@{Eigenschaft3}]]}} {{Talent=[[ { [[{0d1 + @{TaW} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft1}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft2}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft3}, 0d1}kh1, 0d1 + @{TaW}}dh1]]}}"></button>
+                <input type="number" name="attr_TaW" style="width: 3em;" value=0>
+                <input type="hidden" name="attr_hiddenEigenschaft1">
+                <input type="hidden" name="attr_hiddenEigenschaft2">
+                <input type="hidden" name="attr_hiddenEigenschaft3">
+                <input type="hidden" name="attr_realName">
+                <button type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=@{realName}}} {{mod=[[?{Erleichterung (-) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW}]]}} {{stat1=[[@{hiddenEigenschaft1}]]}} {{stat2=[[@{hiddenEigenschaft2}]]}} {{stat3=[[@{hiddenEigenschaft3}]]}} {{Talent=[[ { [[{0d1 + @{TaW} - (?{Erleichterung (-) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft1}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft2}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft3}, 0d1}kh1, 0d1 + @{TaW}}dh1]]}}"></button>
             </fieldset>
         </div>
     </div>
@@ -12607,25 +12616,25 @@
                     </td>
                     <tr>
                         <td align="center">
-                            <input type="number" disabled="true" name="attr_wound_Kopf" value="(@{wound_Kopf1} + @{wound_Kopf2})">
+                            <input type="number" readonly="readonly" name="attr_wound_Kopf" value="0">
                         </td>
                         <td align="center">
-                            <input type="number" disabled="true" name="attr_wound_Brust" value="(@{wound_Brust1} + @{wound_Brust2})">
+                            <input type="number" readonly="readonly" name="attr_wound_Brust" value="0">
                         </td>
                         <td align="center">
-                            <input type="number" disabled="true" name="attr_wound_Bauch" value="(@{wound_Bauch1} + @{wound_Bauch2})">
+                            <input type="number" readonly="readonly" name="attr_wound_Bauch" value="0">
                         </td>
                         <td align="center">
-                            <input type="number" disabled="true" name="attr_wound_RA" value="(@{wound_RA1} + @{wound_RA2})">
+                            <input type="number" readonly="readonly" name="attr_wound_RA" value="0">
                         </td>
                         <td align="center">
-                            <input type="number" disabled="true" name="attr_wound_LA" value="(@{wound_LA1} + @{wound_LA2})">
+                            <input type="number" readonly="readonly" name="attr_wound_LA" value="0">
                         </td>
                         <td align="center">
-                            <input type="number" disabled="true" name="attr_wound_RB" value="(@{wound_RB1} + @{wound_RB2})">
+                            <input type="number" readonly="readonly" name="attr_wound_RB" value="0">
                         </td>
                         <td align="center">
-                            <input type="number" disabled="true" name="attr_wound_LB" value="(@{wound_LB1} + @{wound_LB2})">
+                            <input type="number" readonly="readonly" name="attr_wound_LB" value="0">
                         </td>
                     </tr>
             </table>
@@ -12781,9 +12790,13 @@
             </div>
         </div>
     </div>
+    
+    <div class="sheet-section sheet-section-info" align="center">
+        Hier findest du alle Informationen zu Updates und <i>alten</i> Werten, sprich Werten, die durch Updates ersetzt wurden.
+    </div>
 
 
-    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="true" name="attr_character_sheet_version" value="20171014"></b>
+    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20171014"></b>
     <br><b>Autoren: Gereon Heinemann (Original), Patrick Gebhardt, Steven 'Kreuvf' Koenig.</b>
     <br><b>Dank an: G V., Kai, SepDepp</b>
     </table>
@@ -15446,4 +15459,151 @@ on("sheet:opened change:fkw_aktiv1 change:fkw_aktiv2 change:fkw_aktiv3 change:fk
 		);
 	}
 );
-</script>
+
+on("sheet:opened change:wound_kopf change:wound_ra change:wound_la change:wound_rb change:wound_lb change:wound_brust change:wound_bauch change:mu_basis change:mu_mod change:kl_basis change:kl_mod change:in_basis change:in_mod change:ch_basis change:ch_mod change:ff_basis change:ff_mod change:ge_basis change:ge_mod change:ko_basis change:ko_mod change:kk_basis change:kk_mod change:gs_basis change:gs_mod change:erschoepfung_mod change:eisern change:aspzugek change:auszugek change:lezugek change:mrzugek change:inizugek", function(eventInfo) {
+    getAttrs(["wound_kopf", "wound_ra", "wound_la", "wound_rb", "wound_lb", "wound_brust", "wound_bauch", "mu_basis", "mu_mod", "kl_basis", "kl_mod", "in_basis", "in_mod", "ch_basis", "ch_mod", "ff_basis", "ff_mod", "ge_basis", "ge_mod", "ko_basis", "ko_mod", "kk_basis", "kk_mod", "gs_basis", "gs_mod", "erschoepfung_mod", "eisern", "aspzugek", "auszugek", "lezugek", "mrzugek", "inizugek"], function(v) {
+        let wundeKopf = +v.wound_kopf || 0;
+        let wundeRA = +v.wound_ra || 0;
+        let wundeLA = +v.wound_la || 0;
+        let wundeRB = +v.wound_rb || 0;
+        let wundeLB = +v.wound_lb || 0;
+        let wundeBrust = +v.wound_brust || 0;
+        let wundeBauch = +v.wound_bauch || 0;
+        // Attribute setzen
+        setAttrs({
+            mu: +v.mu_basis + +v.mu_mod - +wundeKopf,
+            mu2: +v.mu_basis + +v.mu_mod - +wundeKopf,
+            kl: +v.kl_basis + +v.kl_mod - +wundeKopf,
+            kl2: +v.kl_basis + +v.kl_mod - +wundeKopf,
+            in: +v.in_basis + +v.in_mod - +wundeKopf,
+            in2: +v.in_basis + +v.in_mod - +wundeKopf,
+            ch: +v.ch_basis + +v.ch_mod,
+            ch2: +v.ch_basis + +v.ch_mod,
+            ff: +v.ff_basis + +v.ff_mod - +wundeRA - +wundeLA,
+            ff2: +v.ff_basis + +v.ff_mod - +wundeRA - +wundeLA,
+            ge: +v.ge_basis + +v.ge_mod - +wundeLB - +wundeRB,
+            ge2: +v.ge_basis + +v.ge_mod - +wundeLB - +wundeRB,
+            ko: +v.ko_basis + +v.ko_mod - +wundeBrust - +wundeBauch,
+            ko2: +v.ko_basis + +v.ko_mod - +wundeBrust - +wundeBauch,
+            kk: +v.kk_basis + +v.kk_mod - +wundeBrust - +wundeBauch - +wundeRA - +wundeLA,
+            kk2: +v.kk_basis + +v.kk_mod - +wundeBrust - +wundeBauch - +wundeRA - +wundeLA
+        }); 
+        // Abgeleitete werte setzen
+        setAttrs({
+           gs: +v.gs_basis + +v.gs_mod + Math.floor(((+v.ge_basis + +v.ge_mod + 100) / 111) - 1) + Math.ceil(((+v.ge_basis + +v.ge_mod + 100)/115) - 1) - +wundeBauch - (+wundeRB / 2 - +wundeLB / 2),
+           erschoepfung_basis: +v.ko_basis,
+           erschoepfung_max: +v.ko_basis + +v.erschoepfung_mod,
+           wundschwelle: Math.ceil(+v.ko_basis + +v.eisern),
+           aspgrundw: Math.round((+v.mu_basis + +v.in_basis + +v.ch_basis) / 2 + 0.05),
+           asp_max: Math.round((+v.mu_basis + +v.in_basis + +v.ch_basis) / 2 + 0.05) + +v.aspzugek,
+           ausgrundw: Math.round((+v.mu_basis + +v.ko_basis + +v.ge_basis) / 2 + 0.05),
+           aus_max: Math.round((+v.mu_basis + +v.ko_basis + +v.ge_basis) / 2 + 0.05) + +v.auszugek,
+           legrundw: Math.round((+v.ko_basis + +v.kk_basis) / 2 + 0.05),
+           le_max: Math.round((+v.ko_basis + +v.kk_basis) / 2 + 0.05) + +v.lezugek,
+           mrgrundw: Math.round((+v.mu_basis + +v.mu_mod + +v.kl_basis + +v.kl_mod + +v.ko_basis + +v.ko_mod) / 5),
+           mr_max: Math.round((+v.mu_basis + +v.mu_mod + +v.kl_basis + +v.kl_mod + +v.ko_basis + +v.ko_mod) / 5) + +v.mrzugek,
+           ueberanstrengung_max: +v.ko_basis,
+           inibasis: Math.round((+v.mu_basis + +v.mu_mod + +v.mu_basis + +v.mu_mod + +v.in_basis + +v.in_mod + +v.ge_basis + +v.ge_mod) / 5),
+           ini_max: Math.round((+v.mu_basis + +v.mu_mod + +v.mu_basis + +v.mu_mod + +v.in_basis + +v.in_mod + +v.ge_basis + +v.ge_mod) / 5) + +v.inizugek - +wundeKopf - +wundeBauch - +wundeLB - +wundeRB,
+           atbasis: Math.round(((+v.mu_basis + +v.mu_mod + +v.ge_basis + +v.ge_mod + +v.kk_basis + +v.kk_mod) / 5) - +wundeBauch - +wundeRA - +wundeLA - +wundeRB - +wundeLB),
+           pabasis: Math.round(((+v.in_basis + +v.in_mod + +v.ge_basis + +v.ge_mod + +v.kk_basis + +v.kk_mod) / 5) - +wundeBrust - +wundeBauch - +wundeRA - +wundeLA - +wundeRB - +wundeLB),
+           fkbasis: Math.round(((+v.in_basis + +v.in_mod + +v.ff_basis + +v.ff_mod + +v.kk_basis + +v.kk_mod) / 5) - +wundeBrust - +wundeBauch - +wundeRA - +wundeLA - +wundeRB - +wundeLB)
+        });
+    }); 
+});
+
+on("change:repeating_metatalente:talentname", function(eventInfo) {
+    getAttrs(["repeating_metatalente_talentname"], function(v) {
+        let talentName = v.repeating_metatalente_talentname; 
+        let metaTalente = {"pirschjagd":"mu/in/ge","ansitzjagd":"mu/in/ge","hetzjagd":"mu/in/ge","speerfischen":"mu/in/ge","tierfallenstellen":"kl/in/ff","nahrungsammeln":"mu/in/ff","kraeutersuchen":"mu/in/ff","wachehalten":"mu/in/ko"};
+        if (talentName != "nothing")  {
+            setAttrs({
+                'repeating_metatalente_eigenschaft1': metaTalente[talentName].split("/")[0],
+                'repeating_metatalente_eigenschaft2': metaTalente[talentName].split("/")[1],
+                'repeating_metatalente_eigenschaft3': metaTalente[talentName].split("/")[2],
+                'repeating_metatalente_eigenerMetaname': "",
+                'repeating_metatalente_realName': talentName.charAt(0).toUpperCase() + talentName.slice(1)
+            });
+        } else {
+            setAttrs({
+                'repeating_metatalente_eigenschaft1': "nothing",
+                'repeating_metatalente_eigenschaft2': "nothing",
+                'repeating_metatalente_eigenschaft3': "nothing"
+            });
+        }
+    });
+});
+
+on("change:repeating_metatalente:eigenschaft1 change:repeating_metatalente:eigenschaft2 change:repeating_metatalente:eigenschaft3", function(eventInfo) {
+    getAttrs(["repeating_metatalente_eigenschaft1", "repeating_metatalente_eigenschaft2", "repeating_metatalente_eigenschaft3", "mu", "kl", "in", "ch", "ff", "ge", "ko", "kk"], function(v) {
+            let attributes = {"mu": +v.mu, "kl": +v.kl, "in": +v.in, "ch": +v.ch, "ff": +v.ff, "ge": +v.ge, "ko": +v.ko, "kk": +v.kk};
+            setAttrs({
+                'repeating_metatalente_hiddeneigenschaft1': attributes[v.repeating_metatalente_eigenschaft1] || 0,
+                'repeating_metatalente_hiddeneigenschaft2': attributes[v.repeating_metatalente_eigenschaft2] || 0,
+                'repeating_metatalente_hiddeneigenschaft3': attributes[v.repeating_metatalente_eigenschaft3] || 0
+            });
+    });
+});
+
+on("change:mu change:kl change:in change:ch change:ff change:ge change:ko change:kk", function(eventInfo) {
+    // Aktualisiere Talentwerte
+    getAttrs(["mu", "kl", "in", "ch", "ff", "ge", "ko", "kk"], function(v) {
+        let attributes = {"mu": +v.mu, "kl": +v.kl, "in": +v.in, "ch": +v.ch, "ff": +v.ff, "ge": +v.ge, "ko": +v.ko, "kk": +v.kk};
+        let update = {};
+        // Aktualisiere Metatalente
+        getSectionIDs("metatalente", function(idarray) {
+             _.each(idarray, function(currentID, i) {
+                getAttrs(["repeating_metatalente_" + currentID + "_eigenschaft1", "repeating_metatalente_" + currentID + "_eigenschaft2", "repeating_metatalente_" + currentID + "_eigenschaft3"], function(v) {
+                    update["repeating_metatalente_" + currentID + "_hiddeneigenschaft1"] = attributes[v["repeating_metatalente_" + currentID + "_eigenschaft1"]];
+                    update["repeating_metatalente_" + currentID + "_hiddeneigenschaft2"] = attributes[v["repeating_metatalente_" + currentID + "_eigenschaft2"]];
+                    update["repeating_metatalente_" + currentID + "_hiddeneigenschaft3"] = attributes[v["repeating_metatalente_" + currentID + "_eigenschaft3"]];
+                    setAttrs(update);
+                });
+            });
+        });
+    });
+});
+
+on("change:repeating_metatalente:eigenerMetaname", function(eventInfo) {
+    getAttrs(["repeating_metatalente_eigenerMetaname"], function(v) {
+        let talentName = v.repeating_metatalente_eigenerMetaname; 
+        if (talentName != "") {
+            setAttrs({
+                'repeating_metatalente_talentname': "nothing",
+                'repeating_metatalente_realName': talentName.charAt(0).toUpperCase() + talentName.slice(1)
+            });
+        }
+    });
+});
+
+on("change:ap_gesamt change:ap_ausgegeben", function(eventInfo) {
+    getAttrs(["ap_gesamt", "ap_ausgegeben"], function(v) {
+        setAttrs({
+            ap_verfuegbar: +v.ap_gesamt - +v.ap_ausgegeben
+        });
+    });
+});
+
+on("change:wound_kopf1 change:wound_kopf2 change:wound_brust1 change:wound_brust2 change:wound_bauch1 change:wound_bauch2 change:wound_ra1 change:wound_ra2 change:wound_la1 change:wound_la2 change:wound_rb1 change:wound_rb2 change:wound_lb1 change:wound_lb2", function(eventInfo) {
+    getAttrs(["wound_kopf1", "wound_kopf2", "wound_brust1", "wound_brust2", "wound_bauch1", "wound_bauch2", "wound_ra1", "wound_ra2", "wound_la1", "wound_la2", "wound_rb1", "wound_rb2", "wound_lb1", "wound_lb2"], function(v) {
+        setAttrs({
+            wound_kopf: +v.wound_kopf1 + +v.wound_kopf2,
+            wound_brust: +v.wound_brust1 + +v.wound_brust2,
+            wound_bauch: +v.wound_bauch1 + +v.wound_bauch2,
+            wound_ra: +v.wound_ra1 + +v.wound_ra2,
+            wound_la: +v.wound_la1 + +v.wound_la2,
+            wound_rb: +v.wound_rb1 + +v.wound_rb2,
+            wound_lb: +v.wound_lb1 + +v.wound_lb2
+        });
+    });
+});
+
+on("change:kegrundw change:kezugek", function(eventInfo) {
+    getAttrs(["kegrundw", "kezugek"], function(v) {
+        setAttrs({
+            ke_max: +v.kegrundw + +v.kezugek
+        });
+    });
+});
+
+</script> 

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -15688,7 +15688,7 @@ on("change:mu change:kl change:in change:ch change:ff change:ge change:ko change
         // Aktualisiere Gaben
         getSectionIDs("gaben", function(idarray) {
              _.each(idarray, function(currentID, i) {
-                getAttrs(["repeating_Gaben_" + currentID + "_eigenschaften"], function(v) {
+                getAttrs(["repeating_Gaben_" + currentID + "_eigenschaft1", "repeating_Gaben_" + currentID + "_eigenschaft2", "repeating_Gaben_" + currentID + "_eigenschaft3"], function(v) {
                     update["repeating_Gaben_" + currentID + "_hiddeneigenschaft1"] = attributes[v["repeating_Gaben_" + currentID + "_eigenschaft1"]];
                     update["repeating_Gaben_" + currentID + "_hiddeneigenschaft2"] = attributes[v["repeating_Gaben_" + currentID + "_eigenschaft2"]];
                     update["repeating_Gaben_" + currentID + "_hiddeneigenschaft3"] = attributes[v["repeating_Gaben_" + currentID + "_eigenschaft3"]];

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -15557,9 +15557,6 @@ on("change:repeating_gabenTalente:Name_Gabe change:repeating_gabenTalente:Name_G
             setAttrs(update);
         } else {
             setAttrs({
-                'repeating_gabenTalente_eigenschaft1': "nothing",
-                'repeating_gabenTalente_eigenschaft2': "nothing",
-                'repeating_gabenTalente_eigenschaft3': "nothing",
                 'repeating_gabenTalente_Name_Gabe_Anzeige': "Keine Gabe gewählt"
             });
         }

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -6200,7 +6200,7 @@
 
             <table>
                 <tr>
-                    <th style="width: 23em">Gabe (+ Zusatz)</th>
+                    <th style="width: 23em">Gabe + Zusatz/Eigene Gabe</th>
                     <th style="width: 15.25em;">Eigenschaften</th>
                     <th style="width: 3.25em;">TaW</th>
                     <th style="width: 3em;">Probe</th>
@@ -6209,7 +6209,6 @@
             <fieldset class="repeating_Gaben">
                 <span style="display: inline-block; width: 23em">
                     <select name="attr_Name_Gabe" class="atype" style="width: 10em;">
-                        <option value="nothing">---</option>
                         <option value="empathie">Empathie</option>
                         <option value="gefahreninstinkt">Gefahreninstinkt</option>
                         <option value="geraeuschhexerei">Geräuschhexerei</option>
@@ -6218,8 +6217,9 @@
                         <option value="prophezeien">Prophezeien</option>
                         <option value="tierempathie">Tierempathie</option>
                         <option value="zwergennase">Zwergennase</option>
+                        <option value="nothing" selected>Eigene</option>
                     </select>
-                     (<input type="text" name="attr_Name_Gabe_Zusatz" style="width: 10em;"/>)
+                    <input type="text" name="attr_Name_Gabe_Zusatz" style="width: 10em;"/>
                 </span><span style="display: inline-block; width: 15.25em">
                     <select name="attr_Eigenschaft1" class="sheet-talent-eigenschaft">
                         <option value="nothing">---</option>
@@ -6259,7 +6259,7 @@
                     <input type="hidden" name="attr_hiddenEigenschaft1" value="0">
                     <input type="hidden" name="attr_hiddenEigenschaft2" value="0">
                     <input type="hidden" name="attr_hiddenEigenschaft3" value="0">
-                    <input type="hidden" name="attr_Name_Gabe_Anzeige" value="">
+                    <input type="hidden" name="attr_Name_Gabe_Anzeige" value="Eigene Gabe">
                 </span><span style="display: inline-block; width: 3em">
                 <button type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=@{Name_Gabe_Anzeige}}} {{mod=[[?{Erleichterung (-) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW}]]}} {{stat1=[[@{hiddenEigenschaft1}]]}} {{stat2=[[@{hiddenEigenschaft2}]]}} {{stat3=[[@{hiddenEigenschaft3}]]}} {{Talent=[[ { [[{0d1 + @{TaW} - (?{Erleichterung (-) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft1}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft2}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft3}, 0d1}kh1, 0d1 + @{TaW}}dh1]]}}"></button>
                 </span>
@@ -15613,9 +15613,13 @@ on("change:repeating_Gaben:Name_Gabe change:repeating_Gaben:Name_Gabe_Zusatz", f
             }
             setAttrs(update);
         } else {
-            setAttrs({
-                'repeating_Gaben_Name_Gabe_Anzeige': "Keine Gabe gewählt"
-            });
+            let update = {};
+            if(gabeZusatz !== "") {
+                update['repeating_Gaben_Name_Gabe_Anzeige'] = gabeZusatz;
+            } else {
+                update['repeating_Gaben_Name_Gabe_Anzeige'] = "Eigene Gabe";
+            }
+            setAttrs(update);
         }
     });
 });

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -12814,7 +12814,7 @@
     </div>
 
 
-    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20171014"></b>
+    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20190418"></b>
     <br><b>Autoren: Gereon Heinemann (Original), Patrick Gebhardt, Steven 'Kreuvf' Koenig, apehead.</b>
     <br><b>Dank an: G V., Kai, SepDepp</b>
     </table>

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -12815,7 +12815,7 @@
             <input type="text" class="sheet-selectable-text" style="width: 45em" value="https://www.youtube.com/watch?v=l2SCwz51T9g&list=PLGBXxa8pcNCqzNe4CrKvy-_QgjfgLDOZ-" />
         </p>
 
-        <h4>Update auf Version 20190425</h4>
+        <h4>Update auf Version 20190427</h4>
         <p>Gaben und Metatalente wurden verändert, sodass eine Migration der alten Daten notwendig wurde. Spalten für spezielle Erfahrungen (SE) wurden entfernt, da diese ausschließlich für die Steigerung relevant sind, Steigerungen aber seitens Roll20 nicht im Charakterbogen umgesetzt sein dürfen. Um die Information dauerhafter zu speichern, empfiehlt es sich die Notizen zu benutzen. Spezielle Erfahrungen in Metatalenten sind darüber hinaus nicht regelkonform.</p>
         <h5>Gaben</h5>
         <fieldset class="repeating_GabenTalente">
@@ -12920,7 +12920,7 @@
     </div>
 
 
-    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20190418"><input type="hidden" class="sheet-stat-immutable sheet-stat-immutable-version" readonly="readonly" name="attr_data_version" value="20171014"></b>
+    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20190427"><input type="hidden" class="sheet-stat-immutable sheet-stat-immutable-version" readonly="readonly" name="attr_data_version" value="20171014"></b>
     <br><b>Autoren: Gereon Heinemann (Original), Patrick Gebhardt, Steven 'Kreuvf' Koenig, apehead.</b>
     <br><b>Dank an: G V., Kai, SepDepp</b>
     </table>
@@ -15796,7 +15796,7 @@ Always try to migrate as much data as possible
 
 Relevant character sheet versions
 * 20171014: last version before sheet worker scripts conversion
-* 20190425: new repeating sections for meta-talents and gifts
+* 20190427: new repeating sections for meta-talents and gifts
 */
 function migrationCheck() {
     getAttrs(["character_sheet_version", "data_version"], function(v) {
@@ -15811,7 +15811,7 @@ function migrationCheck() {
             console.log("Character sheet version (" + sheetVersion + ") is newer than data version (" + dataVersion + "). Having a closer look at the data version ...");
             // This needs to be adapted/replaced by a better system
             if(dataVersion === 20171014) {
-                migrate20171014to20190425();
+                migrate20171014to20190427();
             } else {
                 console.log("The data version does not indicate the need to migrate old data to new formats. Nothing done.");
             }
@@ -15822,11 +15822,11 @@ function migrationCheck() {
 }
 
 /*
-## From version 20171014 to 20190425
+## From version 20171014 to 20190427
 * Gifts and meta-talents were changed
 */
-function migrate20171014to20190425 () {
-    console.log("Migrating sheet data from version 20171014 to 20190425 ...");
+function migrate20171014to20190427 () {
+    console.log("Migrating sheet data from version 20171014 to 20190427 ...");
     let migrationFinished = 0;
 
     getSectionIDs("GabenTalente", function(gabenIDs) {
@@ -16028,7 +16028,7 @@ function migrate20171014to20190425 () {
             } else if (migrationFinished === 2) {
                 console.log("Migration: Meta-talents migrated to new version, but there seems to be a problem with gifts. See console/log for further hints. Data version not updated to character sheet version.");
             } else if (migrationFinished === 3) {
-                let dataVersionNew = "20190425";
+                let dataVersionNew = "20190427";
                 setAttrs({ "data_version": dataVersionNew });
                 console.log("Migration: Data version updated to character sheet version (" + dataVersionNew + "). Migration complete.");
             } else {

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -12797,7 +12797,7 @@
 
 
     <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20171014"></b>
-    <br><b>Autoren: Gereon Heinemann (Original), Patrick Gebhardt, Steven 'Kreuvf' Koenig.</b>
+    <br><b>Autoren: Gereon Heinemann (Original), Patrick Gebhardt, Steven 'Kreuvf' Koenig, apehead.</b>
     <br><b>Dank an: G V., Kai, SepDepp</b>
     </table>
 </div>

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -347,7 +347,7 @@
 
         <table align="center">
             <tr>
-                <th>Tragkraft in U: <input class="sheet-stat-immutable" style="width: 4em" disabled="true" name="attr_Tragkraft" value="(40 * @{KK})" data-formula="(40 * @{KK})" type="text"></th>
+                <th>Tragkraft in U: <input class="sheet-stat-immutable" style="width: 4em" disabled="disabled" name="attr_Tragkraft" value="(40 * @{KK})" type="text"></th>
                 <th>Last in U: <input name="attr_Last" min="0" value="320" style="width: 5em; margin-right: 1em" type="number"></th>
                 <th>Behinderung aus Last: <input style="width: 4em" name="attr_BE_Last" min="0" value="0" type="number"></th>
             </tr>
@@ -410,10 +410,10 @@
                 <input type="number" name="attr_Kreuzer" min="0" value="0"><br>Kreuzer</span>
                     </td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Geld_Mittelreich" style="width: 7em;" value="(@{Dukaten}*10) + (@{Silber}*1) + (@{Heller}*0.1) + (@{Kreuzer}*0.01)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Geld_Mittelreich" style="width: 7em;" value="(@{Dukaten}*10) + (@{Silber}*1) + (@{Heller}*0.1) + (@{Kreuzer}*0.01)"><br></span>
                     </td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Gewicht_Mittelreich" style="width: 7em;" value="(@{Dukaten}*25) + (@{Silber}*5) + (@{Heller}*5) + (@{Kreuzer}*5)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Gewicht_Mittelreich" style="width: 7em;" value="(@{Dukaten}*25) + (@{Silber}*5) + (@{Heller}*5) + (@{Kreuzer}*5)"><br></span>
                     </td>
                 </tr>
                 <tr align="center">
@@ -429,10 +429,10 @@
                     </td>
                     <td></td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Geld_Kalifat" style="width: 7em;" value="(@{Marawedi}*20) + (@{Zechine}*2) + (@{Muwlat}*0.05)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Geld_Kalifat" style="width: 7em;" value="(@{Marawedi}*20) + (@{Zechine}*2) + (@{Muwlat}*0.05)"><br></span>
                     </td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Gewicht_Kalifat" style="width: 7em;" value="(@{Marawedi}*50) + (@{Zechine}*10) + (@{Muwlat}*2.5)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Gewicht_Kalifat" style="width: 7em;" value="(@{Marawedi}*50) + (@{Zechine}*10) + (@{Muwlat}*2.5)"><br></span>
                     </td>
                 </tr>
                 <tr align="center">
@@ -450,10 +450,10 @@
                 <input type="number" name="attr_Dirham" min="0" value="0"><br>Dirham</span>
                     </td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Geld_AlAnfa" style="width: 7em;" value="(@{Dublone}*20) + (@{Oreal}*1) + (@{K_Oreal}*0.5) + (@{Dirham}*0.01)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Geld_AlAnfa" style="width: 7em;" value="(@{Dublone}*20) + (@{Oreal}*1) + (@{K_Oreal}*0.5) + (@{Dirham}*0.01)"><br></span>
                     </td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Gewicht_AlAnfa" style="width: 7em;" value="(@{Dublone}*50) + (@{Oreal}*5) + (@{K_Oreal}*2.5) + (@{Dirham}*3)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Gewicht_AlAnfa" style="width: 7em;" value="(@{Dublone}*50) + (@{Oreal}*5) + (@{K_Oreal}*2.5) + (@{Dirham}*3)"><br></span>
                     </td>
                 </tr>
                 <tr align="center">
@@ -465,10 +465,10 @@
                     <td></td>
                     <td></td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Geld_Amazonen" style="width: 7em;" value="(@{Amazonenkrone}*12)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Geld_Amazonen" style="width: 7em;" value="(@{Amazonenkrone}*12)"><br></span>
                     </td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Gewicht_Amazonen" style="width: 7em;" value="(@{Amazonenkrone}*30)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Gewicht_Amazonen" style="width: 7em;" value="(@{Amazonenkrone}*30)"><br></span>
                     </td>
                 </tr>
                 <tr align="center">
@@ -484,10 +484,10 @@
                     </td>
                     <td></td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Geld_Bornland" style="width: 7em;" value="(@{Batzen}*10) + (@{Groschen}*1) + (@{Deut}*0.1)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Geld_Bornland" style="width: 7em;" value="(@{Batzen}*10) + (@{Groschen}*1) + (@{Deut}*0.1)"><br></span>
                     </td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Gewicht_Bornland" style="width: 7em;" value="(@{Batzen}*25) + (@{Groschen}*5) + (@{Deut}*5)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Gewicht_Bornland" style="width: 7em;" value="(@{Batzen}*25) + (@{Groschen}*5) + (@{Deut}*5)"><br></span>
                     </td>
                 </tr>
                 <tr align="center">
@@ -499,10 +499,10 @@
                     <td></td>
                     <td></td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Geld_Horasreich" style="width: 7em;" value="(@{Horasdor}*200)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Geld_Horasreich" style="width: 7em;" value="(@{Horasdor}*200)"><br></span>
                     </td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Gewicht_Horasreich" style="width: 7em;" value="(@{Horasdor}*500)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Gewicht_Horasreich" style="width: 7em;" value="(@{Horasdor}*500)"><br></span>
                     </td>
                 </tr>
                 <tr align="center">
@@ -514,10 +514,10 @@
                     <td></td>
                     <td></td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Geld_Meridiana" style="width: 7em;" value="(@{Krone}*10)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Geld_Meridiana" style="width: 7em;" value="(@{Krone}*10)"><br></span>
                     </td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Gewicht_Meridiana" style="width: 7em;" value="(@{Krone}*20)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Gewicht_Meridiana" style="width: 7em;" value="(@{Krone}*20)"><br></span>
                     </td>
                 </tr>
                 <tr align="center">
@@ -533,10 +533,10 @@
                     </td>
                     <td></td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Geld_Valiusa" style="width: 7em;" value="(@{Witten}*10) + (@{Stueber}*1) + (@{Flindrich}*0.1)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Geld_Valiusa" style="width: 7em;" value="(@{Witten}*10) + (@{Stueber}*1) + (@{Flindrich}*0.1)"><br></span>
                     </td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Gewicht_Valiusa" style="width: 7em;" value="(@{Witten}*25) + (@{Stueber}*5) + (@{Flindrich}*5)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Gewicht_Valiusa" style="width: 7em;" value="(@{Witten}*25) + (@{Stueber}*5) + (@{Flindrich}*5)"><br></span>
                     </td>
                 </tr>
                 <tr align="center">
@@ -552,10 +552,10 @@
                     </td>
                     <td></td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Geld_Xeraanien" style="width: 7em;" value="(@{Borbaradstaler}*7) + (@{Zholvari}*1) + (@{Splitter}*0.14)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Geld_Xeraanien" style="width: 7em;" value="(@{Borbaradstaler}*7) + (@{Zholvari}*1) + (@{Splitter}*0.14)"><br></span>
                     </td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Gewicht_Xeraanien" style="width: 7em;" value="(@{Borbaradstaler}*17) + (@{Zholvari}*5) + (@{Splitter}*3)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Gewicht_Xeraanien" style="width: 7em;" value="(@{Borbaradstaler}*17) + (@{Zholvari}*5) + (@{Splitter}*3)"><br></span>
                     </td>
                 </tr>
                 <tr align="center">
@@ -571,10 +571,10 @@
                     </td>
                     <td></td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Geld_Zwerge" style="width: 7em;" value="(@{Auromox}*12) + (@{Arganbrox}*2) + (@{Atebrox}*0.2)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Geld_Zwerge" style="width: 7em;" value="(@{Auromox}*12) + (@{Arganbrox}*2) + (@{Atebrox}*0.2)"><br></span>
                     </td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Gewicht_Zwerge" style="width: 7em;" value="(@{Auromox}*25) + (@{Arganbrox}*10) + (@{Atebrox}*10)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Gewicht_Zwerge" style="width: 7em;" value="(@{Auromox}*25) + (@{Arganbrox}*10) + (@{Atebrox}*10)"><br></span>
                     </td>
                 </tr>
                 <tr align="center">
@@ -588,10 +588,10 @@
                     <td></td>
                     <td></td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Geld_Nostragast" style="width: 7em;" value="(@{NostrischeKrone}*5) + (@{Andrataler}*5)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Geld_Nostragast" style="width: 7em;" value="(@{NostrischeKrone}*5) + (@{Andrataler}*5)"><br></span>
                     </td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Gewicht_Nostragast" style="width: 7em;" value="(@{NostrischeKrone}*5) + (@{Andrataler}*5)"><br></span>
+                <input type="number" disabled="disabled" name="attr_Gewicht_Nostragast" style="width: 7em;" value="(@{NostrischeKrone}*5) + (@{Andrataler}*5)"><br></span>
                     </td>
                 </tr>
                 <tr align="center">
@@ -601,10 +601,10 @@
                     <td></td>
                     <td></td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_Geld_gesamt" style="width: 7em;" value="@{Geld_Mittelreich} + @{Geld_Kalifat} + @{Geld_AlAnfa} + @{Geld_Amazonen} + @{Geld_Bornland} + @{Geld_Horasreich} + @{Geld_Meridiana} + @{Geld_Valiusa} + @{Geld_Xeraanien} + @{Geld_Zwerge} + @{Geld_Nostragast}"><br></span>
+                <input type="number" disabled="disabled" name="attr_Geld_gesamt" style="width: 7em;" value="@{Geld_Mittelreich} + @{Geld_Kalifat} + @{Geld_AlAnfa} + @{Geld_Amazonen} + @{Geld_Bornland} + @{Geld_Horasreich} + @{Geld_Meridiana} + @{Geld_Valiusa} + @{Geld_Xeraanien} + @{Geld_Zwerge} + @{Geld_Nostragast}"><br></span>
                     </td>
                     <td><span class="sheet-table-data sheet-center sheet-small-label">
-                <input type="number" disabled="true" name="attr_GeldGewicht_gesamt" style="width: 7em;" value="@{Gewicht_Mittelreich} + @{Gewicht_Kalifat} + @{Gewicht_AlAnfa} + @{Gewicht_Amazonen} + @{Gewicht_Bornland} + @{Gewicht_Horasreich} + @{Gewicht_Meridiana} + @{Gewicht_Valiusa} + @{Gewicht_Xeraanien} + @{Gewicht_Zwerge} + @{Gewicht_Nostragast}"><br></span>
+                <input type="number" disabled="disabled" name="attr_GeldGewicht_gesamt" style="width: 7em;" value="@{Gewicht_Mittelreich} + @{Gewicht_Kalifat} + @{Gewicht_AlAnfa} + @{Gewicht_Amazonen} + @{Gewicht_Bornland} + @{Gewicht_Horasreich} + @{Gewicht_Meridiana} + @{Gewicht_Valiusa} + @{Gewicht_Xeraanien} + @{Gewicht_Zwerge} + @{Gewicht_Nostragast}"><br></span>
                     </td>
 
             </table>
@@ -677,8 +677,8 @@
                     <div class="sheet-talent-cell sheet-talent-stf">C</div>
                     <div class="sheet-talent-cell sheet-talent-ebe">BE−5</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_armbrust">
-                    <input type="number" class="sheet-talent-at" name="attr_AT_armbrust" disabled="true" value="@{FKBasis} + @{TaW_armbrust}">
-                    <input type="text" class="sheet-talent-pa" disabled="true" value="-">
+                    <input type="number" class="sheet-talent-at" name="attr_AT_armbrust" disabled="disabled" value="@{FKBasis} + @{TaW_armbrust}">
+                    <input type="text" class="sheet-talent-pa" disabled="disabled" value="-">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_armbrust" min="-4" value="0">
                     <br>
                 </div>
@@ -688,8 +688,8 @@
                     <div class="sheet-talent-cell sheet-talent-stf">D</div>
                     <div class="sheet-talent-cell sheet-talent-ebe">-</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_belagerungswaffen">
-                    <input type="number" class="sheet-talent-at" name="attr_AT_belagerungswaffen" disabled="true" value="@{FKBasis} + @{TaW_belagerungswaffen}">
-                    <input type="text" class="sheet-talent-pa" disabled="true" value="-">
+                    <input type="number" class="sheet-talent-at" name="attr_AT_belagerungswaffen" disabled="disabled" value="@{FKBasis} + @{TaW_belagerungswaffen}">
+                    <input type="text" class="sheet-talent-pa" disabled="disabled" value="-">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_belagerungswaffen" min="-4" value="0">
                     <br>
                 </div>
@@ -699,8 +699,8 @@
                     <div class="sheet-talent-cell sheet-talent-stf">D</div>
                     <div class="sheet-talent-cell sheet-talent-ebe">BE−5</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_blasrohr">
-                    <input type="number" class="sheet-talent-at" name="attr_AT_blasrohr" disabled="true" value="@{FKBasis} + @{TaW_Blasrohr}">
-                    <input type="text" class="sheet-talent-pa" disabled="true" value="-">
+                    <input type="number" class="sheet-talent-at" name="attr_AT_blasrohr" disabled="disabled" value="@{FKBasis} + @{TaW_Blasrohr}">
+                    <input type="text" class="sheet-talent-pa" disabled="disabled" value="-">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_blasrohr" min="-4" value="0">
                     <br>
                 </div>
@@ -710,8 +710,8 @@
                     <div class="sheet-talent-cell sheet-talent-stf">E</div>
                     <div class="sheet-talent-cell sheet-talent-ebe">BE−3</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_bogen">
-                    <input type="number" class="sheet-talent-at" name="attr_AT_bogen" disabled="true" value="@{FKBasis} + @{TaW_Bogen}">
-                    <input type="text" class="sheet-talent-pa" disabled="true" value="-">
+                    <input type="number" class="sheet-talent-at" name="attr_AT_bogen" disabled="disabled" value="@{FKBasis} + @{TaW_Bogen}">
+                    <input type="text" class="sheet-talent-pa" disabled="disabled" value="-">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_bogen" min="-4" value="0">
                     <br>
                 </div>
@@ -721,8 +721,8 @@
                     <div class="sheet-talent-cell sheet-talent-stf">D</div>
                     <div class="sheet-talent-cell sheet-talent-ebe">BE−2</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_diskus">
-                    <input type="number" class="sheet-talent-at" name="attr_AT_diskus" disabled="true" value="@{FKBasis} + @{TaW_Diskus}">
-                    <input type="text" class="sheet-talent-pa" disabled="true" value="-">
+                    <input type="number" class="sheet-talent-at" name="attr_AT_diskus" disabled="disabled" value="@{FKBasis} + @{TaW_Diskus}">
+                    <input type="text" class="sheet-talent-pa" disabled="disabled" value="-">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_diskus" min="-4" value="0">
                     <br>
                 </div>
@@ -809,8 +809,8 @@
                     <div class="sheet-talent-cell sheet-talent-stf">E</div>
                     <div class="sheet-talent-cell sheet-talent-ebe">BE−1</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_peitsche">
-                    <input type="number" class="sheet-talent-at" name="attr_AT_peitsche" disabled="true" value="@{ATbasis} + @{TaW_peitsche}">
-                    <input type="text" class="sheet-talent-pa" disabled="true" value="-">
+                    <input type="number" class="sheet-talent-at" name="attr_AT_peitsche" disabled="disabled" value="@{ATbasis} + @{TaW_peitsche}">
+                    <input type="text" class="sheet-talent-pa" disabled="disabled" value="-">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_peitsche" min="-4" value="0">
                     <br>
                 </div>
@@ -853,8 +853,8 @@
                     <div class="sheet-talent-cell sheet-talent-stf">E</div>
                     <div class="sheet-talent-cell sheet-talent-ebe">BE−2</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schleuder">
-                    <input type="number" class="sheet-talent-at" name="attr_AT_schleuder" disabled="true" value="@{FKBasis} + @{TaW_schleuder}">
-                    <input type="text" class="sheet-talent-pa" disabled="true" value="-">
+                    <input type="number" class="sheet-talent-at" name="attr_AT_schleuder" disabled="disabled" value="@{FKBasis} + @{TaW_schleuder}">
+                    <input type="text" class="sheet-talent-pa" disabled="disabled" value="-">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schleuder" min="-4" value="0">
                     <br>
                 </div>
@@ -897,8 +897,8 @@
                     <div class="sheet-talent-cell sheet-talent-stf">D</div>
                     <div class="sheet-talent-cell sheet-talent-ebe">BE−2</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_wurfbeile">
-                    <input type="number" class="sheet-talent-at" name="attr_AT_wurfbeile" disabled="true" value="@{FKBasis} + @{TaW_wurfbeile}">
-                    <input type="text" class="sheet-talent-pa" disabled="true" value="-">
+                    <input type="number" class="sheet-talent-at" name="attr_AT_wurfbeile" disabled="disabled" value="@{FKBasis} + @{TaW_wurfbeile}">
+                    <input type="text" class="sheet-talent-pa" disabled="disabled" value="-">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_wurfbeile" min="-4" value="0">
                     <br>
                 </div>
@@ -908,8 +908,8 @@
                     <div class="sheet-talent-cell sheet-talent-stf">C</div>
                     <div class="sheet-talent-cell sheet-talent-ebe">BE−3</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_wurfmesser">
-                    <input type="number" class="sheet-talent-at" name="attr_AT_wurfmesser" disabled="true" value="@{FKBasis} + @{TaW_wurfmesser}">
-                    <input type="text" class="sheet-talent-pa" disabled="true" value="-">
+                    <input type="number" class="sheet-talent-at" name="attr_AT_wurfmesser" disabled="disabled" value="@{FKBasis} + @{TaW_wurfmesser}">
+                    <input type="text" class="sheet-talent-pa" disabled="disabled" value="-">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_wurfmesser" min="-4" value="0">
                     <br>
                 </div>
@@ -919,8 +919,8 @@
                     <div class="sheet-talent-cell sheet-talent-stf">C</div>
                     <div class="sheet-talent-cell sheet-talent-ebe">BE−2</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_wurfspeere">
-                    <input type="number" class="sheet-talent-at" name="attr_AT_wurfspeere" disabled="true" value="@{FKBasis} + @{TaW_wurfspeere}">
-                    <input type="text" class="sheet-talent-pa" disabled="true" value="-">
+                    <input type="number" class="sheet-talent-at" name="attr_AT_wurfspeere" disabled="disabled" value="@{FKBasis} + @{TaW_wurfspeere}">
+                    <input type="text" class="sheet-talent-pa" disabled="disabled" value="-">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_wurfspeere" min="-4" value="0">
                     <br>
                 </div>
@@ -3590,7 +3590,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Garethi" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Garethi}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_garethi}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_garethi} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_garethi}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_garethi}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_garethi}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_garethi}}dh1]]}}"> <span>Garethi</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_garethi">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_garethi" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_garethi" disabled="true" value="18">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_garethi" disabled="disabled" value="18">
                     <br>
                 </div>
                 <input class="sheet-talent-bosparano sheet-default-hide" type="checkbox" name="attr_talent_bosparano" value="1">
@@ -3598,7 +3598,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Bosparano" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Bosparano}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_bosparano}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_bosparano} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_bosparano}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_bosparano}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_bosparano}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_bosparano}}dh1]]}}"> <span>Bosparano</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_bosparano">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_bosparano" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_bosparano" disabled="true" value="21">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_bosparano" disabled="disabled" value="21">
                     <br>
                 </div>
                 <input class="sheet-talent-aureliani sheet-default-hide" type="checkbox" name="attr_talent_aureliani" value="1">
@@ -3606,7 +3606,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Aureliani" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Aureliani}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_aureliani}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_aureliani} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_aureliani}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_aureliani}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_aureliani}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_aureliani}}dh1]]}}"> <span>Aureliani</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_aureliani">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_aureliani" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_aureliani" disabled="true" value="21">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_aureliani" disabled="disabled" value="21">
                     <br>
                 </div>
                 <input class="sheet-talent-zyklopaisch sheet-default-hide" type="checkbox" name="attr_talent_zyklopaisch" value="1">
@@ -3614,7 +3614,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Zyklopaisch" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Zyklopäisch}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_zyklopaisch}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_zyklopaisch} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_zyklopaisch}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_zyklopaisch}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_zyklopaisch}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_zyklopaisch}}dh1]]}}"> <span>Zyklopäisch</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_zyklopaisch">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_zyklopaisch" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_zyklopaisch" disabled="true" value="18">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_zyklopaisch" disabled="disabled" value="18">
                     <br>
                 </div>
                 <input class="sheet-talent-tulamidya sheet-default-hide" type="checkbox" name="attr_talent_tulamidya" value="1">
@@ -3622,7 +3622,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Tulamidya" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Tulamidya}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_tulamidya}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_tulamidya} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_tulamidya}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_tulamidya}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_tulamidya}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_tulamidya}}dh1]]}}"> <span>Tulamidya</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_tulamidya">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_tulamidya" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_tulamidya" disabled="true" value="18">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_tulamidya" disabled="disabled" value="18">
                     <br>
                 </div>
                 <input class="sheet-talent-urtulamidya sheet-default-hide" type="checkbox" name="attr_talent_urtulamidya" value="1">
@@ -3630,7 +3630,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Ur-Tulamidya" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Ur-Tulamidya}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_urtulamidya}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_urtulamidya} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_urtulamidya}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_urtulamidya}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_urtulamidya}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_urtulamidya}}dh1]]}}"> <span>Ur-Tulamidya</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_urtulamidya">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_urtulamidya" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_urtulamidya" disabled="true" value="21">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_urtulamidya" disabled="disabled" value="21">
                     <br>
                 </div>
                 <input class="sheet-talent-zelemja sheet-default-hide" type="checkbox" name="attr_talent_zelemja" value="1">
@@ -3638,7 +3638,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Zelemja" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Zelemja}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_zelemja}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_zelemja} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_zelemja}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_zelemja}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_zelemja}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_zelemja}}dh1]]}}"> <span>Zelemja</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_zelemja">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_zelemja" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_zelemja" disabled="true" value="18">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_zelemja" disabled="disabled" value="18">
                     <br>
                 </div>
                 <input class="sheet-talent-alaani sheet-default-hide" type="checkbox" name="attr_talent_alaani" value="1">
@@ -3646,7 +3646,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Alaani" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Alaani}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_alaani}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_alaani} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_alaani}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_alaani}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_alaani}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_alaani}}dh1]]}}"> <span>Alaani</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_alaani">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_alaani" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_alaani" disabled="true" value="21">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_alaani" disabled="disabled" value="21">
                     <br>
                 </div>
                 <input class="sheet-talent-zhulchammaqra sheet-default-hide" type="checkbox" name="attr_talent_zhulchammaqra" value="1">
@@ -3654,7 +3654,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Zhulchammaqra" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Zhulchammaqra}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_zhulchammaqra}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_zhulchammaqra} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_zhulchammaqra}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_zhulchammaqra}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_zhulchammaqra}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_zhulchammaqra}}dh1]]}}"> <span>Zhulchammaqra</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_zhulchammaqra">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_zhulchammaqra" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_zhulchammaqra" disabled="true" value="15">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_zhulchammaqra" disabled="disabled" value="15">
                     <br>
                 </div>
                 <input class="sheet-talent-ferkina sheet-default-hide" type="checkbox" name="attr_talent_ferkina" value="1">
@@ -3662,7 +3662,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Ferkina" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Ferkina}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_ferkina}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_ferkina} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_ferkina}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_ferkina}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_ferkina}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_ferkina}}dh1]]}}"> <span>Ferkina</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_ferkina">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_ferkina" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_ferkina" disabled="true" value="16">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_ferkina" disabled="disabled" value="16">
                     <br>
                 </div>
                 <input class="sheet-talent-ruuz sheet-default-hide" type="checkbox" name="attr_talent_ruuz" value="1">
@@ -3670,7 +3670,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Ruuz" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Ruuz}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_ruuz}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_ruuz} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_ruuz}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_ruuz}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_ruuz}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_ruuz}}dh1]]}}"> <span>Ruuz</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_ruuz">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_ruuz" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_ruuz" disabled="true" value="18">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_ruuz" disabled="disabled" value="18">
                     <br>
                 </div>
                 <input class="sheet-talent-alteskemi sheet-default-hide" type="checkbox" name="attr_talent_alteskemi" value="1">
@@ -3678,7 +3678,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="AltesKemi" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Altes Kemi}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_alteskemi}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_alteskemi} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_alteskemi}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_alteskemi}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_alteskemi}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_alteskemi}}dh1]]}}"> <span>Altes Kemi</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_alteskemi">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_alteskemi" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_alteskemi" disabled="true" value="18">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_alteskemi" disabled="disabled" value="18">
                     <br>
                 </div>
                 <input class="sheet-talent-rabensprache sheet-default-hide" type="checkbox" name="attr_talent_rabensprache" value="1">
@@ -3686,7 +3686,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Rabensprache" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Rabensprache}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_rabensprache}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_rabensprache} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_rabensprache}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_rabensprache}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_rabensprache}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_rabensprache}}dh1]]}}"> <span>Rabensprache</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_rabensprache">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_rabensprache" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_rabensprache" disabled="true" value="15">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_rabensprache" disabled="disabled" value="15">
                     <br>
                 </div>
                 <input class="sheet-talent-thorwalsch sheet-default-hide" type="checkbox" name="attr_talent_thorwalsch" value="1">
@@ -3694,7 +3694,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Thorwalsch" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Thorwalsch}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_thorwalsch}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_thorwalsch} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_thorwalsch}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_thorwalsch}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_thorwalsch}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_thorwalsch}}dh1]]}}"> <span>Thorwalsch</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_thorwalsch">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_thorwalsch" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_thorwalsch" disabled="true" value="18">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_thorwalsch" disabled="disabled" value="18">
                     <br>
                 </div>
                 <input class="sheet-talent-hjaldingsch sheet-default-hide" type="checkbox" name="attr_talent_hjaldingsch" value="1">
@@ -3702,7 +3702,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Hjaldinsch" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Hjaldingsch}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_hjaldingsch}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_hjaldingsch} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_hjaldingsch}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_hjaldingsch}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_hjaldingsch}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_hjaldingsch}}dh1]]}}"> <span>Hjaldingsch</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_hjaldingsch">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_hjaldingsch" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_hjaldingsch" disabled="true" value="18">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_hjaldingsch" disabled="disabled" value="18">
                     <br>
                 </div>
                 <input class="sheet-talent-isdira sheet-default-hide" type="checkbox" name="attr_talent_isdira" value="1">
@@ -3710,7 +3710,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Isdira" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Isdira}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_isdira}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_isdira} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_isdira}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_isdira}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_isdira}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_isdira}}dh1]]}}"> <span>Isdira</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_isdira">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_isdira" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_isdira" disabled="true" value="21">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_isdira" disabled="disabled" value="21">
                     <br>
                 </div>
                 <input class="sheet-talent-asdharia sheet-default-hide" type="checkbox" name="attr_talent_asdharia" value="1">
@@ -3718,7 +3718,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Asdharia" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Asdharia}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_asdharia}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_asdharia} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_asdharia}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_asdharia}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_asdharia}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_asdharia}}dh1]]}}"> <span>Asdharia</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_asdharia">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_asdharia" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_asdharia" disabled="true" value="24">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_asdharia" disabled="disabled" value="24">
                     <br>
                 </div>
                 <input class="sheet-talent-rogolan sheet-default-hide" type="checkbox" name="attr_talent_rogolan" value="1">
@@ -3726,7 +3726,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Rogolan" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Rogogan}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_rogolan}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_rogolan} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_rogolan}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_rogolan}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_rogolan}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_rogolan}}dh1]]}}"> <span>Rogolan</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_rogolan">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_rogolan" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_rogolan" disabled="true" value="21">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_rogolan" disabled="disabled" value="21">
                     <br>
                 </div>
                 <input class="sheet-talent-angram sheet-default-hide" type="checkbox" name="attr_talent_angram" value="1">
@@ -3734,7 +3734,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Angram" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Angram}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_angram}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_angram} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_angram}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_angram}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_angram}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_angram}}dh1]]}}"> <span>Angram</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_angram">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_angram" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_angram" disabled="true" value="21">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_angram" disabled="disabled" value="21">
                     <br>
                 </div>
                 <input class="sheet-talent-ologhaijan sheet-default-hide" type="checkbox" name="attr_talent_ologhaijan" value="1">
@@ -3742,7 +3742,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Ologhaijan" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Ologhaijan}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_ologhaijan}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_ologhaijan} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_ologhaijan}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_ologhaijan}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_ologhaijan}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_ologhaijan}}dh1]]}}"> <span>Ologhaijan</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_ologhaijan">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_ologhaijan" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_ologhaijan" disabled="true" value="15">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_ologhaijan" disabled="disabled" value="15">
                     <br>
                 </div>
                 <input class="sheet-talent-oloarkh sheet-default-hide" type="checkbox" name="attr_talent_oloarkh" value="1">
@@ -3750,7 +3750,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Oloarkh" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Oloarkh}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_oloarkh}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_oloarkh} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_oloarkh}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_oloarkh}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_oloarkh}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_oloarkh}}dh1]]}}"> <span>Oloarkh</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_oloarkh">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_oloarkh" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_oloarkh" disabled="true" value="10">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_oloarkh" disabled="disabled" value="10">
                     <br>
                 </div>
                 <input class="sheet-talent-mahrisch sheet-default-hide" type="checkbox" name="attr_talent_mahrisch" value="1">
@@ -3758,7 +3758,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Mahrisch" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Mahrisch}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_mahrisch}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_mahrisch} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_mahrisch}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_mahrisch}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_mahrisch}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_mahrisch}}dh1]]}}"> <span>Mahrisch</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_mahrisch">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_mahrisch" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_mahrisch" disabled="true" value="20">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_mahrisch" disabled="disabled" value="20">
                     <br>
                 </div>
                 <input class="sheet-talent-rissoal sheet-default-hide" type="checkbox" name="attr_talent_rissoal" value="1">
@@ -3766,7 +3766,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Rissoal" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Rissoal}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_rissoal}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_rissoal} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_rissoal}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_rissoal}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_rissoal}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_rissoal}}dh1]]}}"> <span>Rissoal</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_rissoal">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_rissoal" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_rissoal" disabled="true" value="20">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_rissoal" disabled="disabled" value="20">
                     <br>
                 </div>
                 <input class="sheet-talent-drachisch sheet-default-hide" type="checkbox" name="attr_talent_drachisch" value="1">
@@ -3774,7 +3774,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Drachisch" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Drachisch}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_drachisch}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_drachisch} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_drachisch}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_drachisch}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_drachisch}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_drachisch}}dh1]]}}"> <span>Drachisch</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_drachisch">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_drachisch" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_drachisch" disabled="true" value="21">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_drachisch" disabled="disabled" value="21">
                     <br>
                 </div>
                 <input class="sheet-talent-goblinisch sheet-default-hide" type="checkbox" name="attr_talent_goblinisch" value="1">
@@ -3782,7 +3782,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Goblinisch" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Goblinisch}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_goblinisch}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_goblinisch} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_goblinisch}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_goblinisch}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_goblinisch}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_goblinisch}}dh1]]}}"> <span>Goblinisch</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_goblinisch">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_goblinisch" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_goblinisch" disabled="true" value="12">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_goblinisch" disabled="disabled" value="12">
                     <br>
                 </div>
                 <input class="sheet-talent-grolmisch sheet-default-hide" type="checkbox" name="attr_talent_grolmisch" value="1">
@@ -3790,7 +3790,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Grolmisch" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Grolmisch}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_grolmisch}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_grolmisch} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_grolmisch}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_grolmisch}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_grolmisch}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_grolmisch}}dh1]]}}"> <span>Grolmisch</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_grolmisch">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_grolmisch" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_grolmisch" disabled="true" value="17">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_grolmisch" disabled="disabled" value="17">
                     <br>
                 </div>
                 <input class="sheet-talent-koboldisch sheet-default-hide" type="checkbox" name="attr_talent_koboldisch" value="1">
@@ -3798,7 +3798,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Koboldisch" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Koboldisch}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_koboldisch}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_koboldisch} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_koboldisch}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_koboldisch}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_koboldisch}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_koboldisch}}dh1]]}}"> <span>Koboldisch</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_koboldisch">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_koboldisch" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_koboldisch" disabled="true" value="15">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_koboldisch" disabled="disabled" value="15">
                     <br>
                 </div>
                 <input class="sheet-talent-molochisch sheet-default-hide" type="checkbox" name="attr_talent_molochisch" value="1">
@@ -3806,7 +3806,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Molochisch" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Molochisch}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_molochisch}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_molochisch} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_molochisch}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_molochisch}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_molochisch}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_molochisch}}dh1]]}}"> <span>Molochisch</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_molochisch">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_molochisch" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_molochisch" disabled="true" value="17">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_molochisch" disabled="disabled" value="17">
                     <br>
                 </div>
                 <input class="sheet-talent-neckergesang sheet-default-hide" type="checkbox" name="attr_talent_neckergesang" value="1">
@@ -3814,7 +3814,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Neckergesang" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Neckergesang}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_neckergesang}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_neckergesang} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_neckergesang}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_neckergesang}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_neckergesang}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_neckergesang}}dh1]]}}"> <span>Neckergesang</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_neckergesang">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_neckergesang" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_neckergesang" disabled="true" value="18">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_neckergesang" disabled="disabled" value="18">
                     <br>
                 </div>
                 <input class="sheet-talent-nujuka sheet-default-hide" type="checkbox" name="attr_talent_nujuka" value="1">
@@ -3822,7 +3822,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Nujuka" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Nujuka}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_nujuka}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_nujuka} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_nujuka}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_nujuka}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_nujuka}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_nujuka}}dh1]]}}"> <span>Nujuka</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_nujuka">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_nujuka" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_nujuka" disabled="true" value="15">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_nujuka" disabled="disabled" value="15">
                     <br>
                 </div>
                 <input class="sheet-talent-rssahh sheet-default-hide" type="checkbox" name="attr_talent_rssahh" value="1">
@@ -3830,7 +3830,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Rssahh" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Rssahh}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_rssahh}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_rssahh} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_rssahh}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_rssahh}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_rssahh}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_rssahh}}dh1]]}}"> <span>Rssahh</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_rssahh">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_rssahh" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_rssahh" disabled="true" value="18">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_rssahh" disabled="disabled" value="18">
                     <br>
                 </div>
                 <input class="sheet-talent-trollisch sheet-default-hide" type="checkbox" name="attr_talent_trollisch" value="1">
@@ -3838,7 +3838,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Trollisch" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Trollisch}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_trollisch}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_trollisch} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_trollisch}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_trollisch}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_trollisch}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_trollisch}}dh1]]}}"> <span>Trollisch</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_trollisch">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_trollisch" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_trollisch" disabled="true" value="15">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_trollisch" disabled="disabled" value="15">
                     <br>
                 </div>
                 <input class="sheet-talent-waldmenschensprache sheet-default-hide" type="checkbox" name="attr_talent_waldmenschensprache" value="1">
@@ -3846,7 +3846,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Waldmenschen-Sprache" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Waldmenschen-Sprachen}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_waldmenschensprache}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_waldmenschensprache} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_waldmenschensprache}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_waldmenschensprache}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_waldmenschensprache}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_waldmenschensprache}}dh1]]}}"> <span>Waldmenschen-Sprachen</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_waldmenschensprache">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_waldmenschensprache" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_waldmenschensprache" disabled="true" value="15">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_waldmenschensprache" disabled="disabled" value="15">
                     <br>
                 </div>
                 <input class="sheet-talent-zlit sheet-default-hide" type="checkbox" name="attr_talent_zlit" value="1">
@@ -3854,7 +3854,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="ZLit" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Z'Lit}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_zlit}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_zlit} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_zlit}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_zlit}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_zlit}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_zlit}}dh1]]}}"> <span>Z'Lit</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_zlit">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_zlit" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_zlit" disabled="true" value="17">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_zlit" disabled="disabled" value="17">
                     <br>
                 </div>
                 <input class="sheet-talent-zhayad sheet-default-hide" type="checkbox" name="attr_talent_zhayad" value="1">
@@ -3862,7 +3862,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Zhayad" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Zhayad}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_zhayad}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_zhayad} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_zhayad}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_zhayad}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_zhayad}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_zhayad}}dh1]]}}"> <span>Zhayad</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_zhayad">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_zhayad" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_zhayad" disabled="true" value="15">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_zhayad" disabled="disabled" value="15">
                     <br>
                 </div>
                 <input class="sheet-talent-atak sheet-default-hide" type="checkbox" name="attr_talent_atak" value="1">
@@ -3870,7 +3870,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Atak" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Atak}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_atak}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_atak} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_atak}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_atak}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_atak}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_atak}}dh1]]}}"> <span>Atak</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_atak">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_atak" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_atak" disabled="true" value="12">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_atak" disabled="disabled" value="12">
                     <br>
                 </div>
                 <input class="sheet-talent-fuchsisch sheet-default-hide" type="checkbox" name="attr_talent_fuchsisch" value="1">
@@ -3878,7 +3878,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Fuchsisch" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Füchsisch}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_fuchsisch}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{TaW_fuchsisch} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_fuchsisch}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_fuchsisch}, 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_fuchsisch}, 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{TaW_fuchsisch}}dh1]]}}"> <span>Füchsisch</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_fuchsisch">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_fuchsisch" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_fuchsisch" disabled="true" value="12">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_fuchsisch" disabled="disabled" value="12">
                     <br>
                 </div>
 
@@ -3963,7 +3963,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="AltesAlaani" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Altes Alaani}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_altesalaani}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_altesalaani} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_altesalaani}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_altesalaani}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_altesalaani}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_altesalaani}}dh1]]}}"> <span>Altes Alaani</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_altesalaani">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_altesalaani" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_altesalaani" disabled="true" value="18">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_altesalaani" disabled="disabled" value="18">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-alteskemi sheet-default-hide" type="checkbox" name="attr_talent_schrift_alteskemi" value="1">
@@ -3971,7 +3971,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="AltesKemiSchrift" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Altes Kemi}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_alteskemi}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_alteskemi} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_alteskemi}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_alteskemi}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_alteskemi}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_alteskemi}}dh1]]}}"> <span>Altes Kemi</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_alteskemi">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_alteskemi" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_alteskemi" disabled="true" value="21">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_alteskemi" disabled="disabled" value="21">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-amulashtra sheet-default-hide" type="checkbox" name="attr_talent_schrift_amulashtra" value="1">
@@ -3979,7 +3979,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Amulashtra" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Amulashtra}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_amulashtra}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_amulashtra} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_amulashtra}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_amulashtra}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_amulashtra}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_amulashtra}}dh1]]}}"> <span>Amulashtra</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_amulashtra">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_amulashtra" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_amulashtra" disabled="true" value="17">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_amulashtra" disabled="disabled" value="17">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-angram sheet-default-hide" type="checkbox" name="attr_talent_schrift_angram" value="1">
@@ -3987,7 +3987,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Angram" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Angram}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_angram}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_angram} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_angram}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_angram}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_angram}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_angram}}dh1]]}}"> <span>Angram</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_angram">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_angram" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_angram" disabled="true" value="21">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_angram" disabled="disabled" value="21">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-arkanil sheet-default-hide" type="checkbox" name="attr_talent_schrift_arkanil" value="1">
@@ -3995,7 +3995,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Arkanil" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Arkanil}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_arkanil}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_arkanil} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_arkanil}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_arkanil}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_arkanil}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_arkanil}}dh1]]}}"> <span>Arkanil</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_arkanil">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_arkanil" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_arkanil" disabled="true" value="24">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_arkanil" disabled="disabled" value="24">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-chrmk sheet-default-hide" type="checkbox" name="attr_talent_schrift_chrmk" value="1">
@@ -4003,7 +4003,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Chrmk" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Chrmk}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_chrmk}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_chrmk} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_chrmk}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_chrmk}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_chrmk}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_chrmk}}dh1]]}}"> <span>Chrmk</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_chrmk">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_chrmk" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_chrmk" disabled="true" value="18">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_chrmk" disabled="disabled" value="18">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-chuchas sheet-default-hide" type="checkbox" name="attr_talent_schrift_chuchas" value="1">
@@ -4011,7 +4011,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Chuchas" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Chuchas}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_chuchas}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_chuchas} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_chuchas}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_chuchas}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_chuchas}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_chuchas}}dh1]]}}"> <span>Chuchas</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_chuchas">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_chuchas" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_chuchas" disabled="true" value="24">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_chuchas" disabled="disabled" value="24">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-drakhardzinken sheet-default-hide" type="checkbox" name="attr_talent_schrift_drakhardzinken" value="1">
@@ -4019,7 +4019,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Drakhard-Zinken" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Drakhardzinken}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_drakhardzinken}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_drakhardzinken} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_drakhardzinken}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_drakhardzinken}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_drakhardzinken}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_drakhardzinken}}dh1]]}}"> <span>Drakhard-Zinken</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_drakhardzinken">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_drakhardzinken" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_drakhardzinken" disabled="true" value="9">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_drakhardzinken" disabled="disabled" value="9">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-draknedglyphen sheet-default-hide" type="checkbox" name="attr_talent_schrift_draknedglyphen" value="1">
@@ -4027,7 +4027,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Drakned-Glyphen" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Drakned-Glyphen}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_draknedglyphen}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_draknedglyphen} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_draknedglyphen}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_draknedglyphen}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_draknedglyphen}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_draknedglyphen}}dh1]]}}"> <span>Drakned-Glyphen</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_draknedglyphen">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_draknedglyphen" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_draknedglyphen" disabled="true" value="15">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_draknedglyphen" disabled="disabled" value="15">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-glyphenvonunau sheet-default-hide" type="checkbox" name="attr_talent_schrift_glyphenvonunau" value="1">
@@ -4035,7 +4035,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="GlyphenvonUnau" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Geheiligte Glyphen von Unau}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_glyphenvonunau}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_glyphenvonunau} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_glyphenvonunau}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_glyphenvonunau}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_glyphenvonunau}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_glyphenvonunau}}dh1]]}}"> <span>Geheiligte Glyphen von Unau</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_glyphenvonunau">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_glyphenvonunau" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_glyphenvonunau" disabled="true" value="13">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_glyphenvonunau" disabled="disabled" value="13">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-gimaril sheet-default-hide" type="checkbox" name="attr_talent_schrift_gimaril" value="1">
@@ -4043,7 +4043,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Gimaril" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Gimaril}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_gimaril}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_gimaril} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_gimaril}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_gimaril}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_gimaril}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_gimaril}}dh1]]}}"> <span>Gimaril</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_gimaril">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_gimaril" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_gimaril" disabled="true" value="10">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_gimaril" disabled="disabled" value="10">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-gjalskisch sheet-default-hide" type="checkbox" name="attr_talent_schrift_gjalskisch" value="1">
@@ -4051,7 +4051,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Gjalskisch" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Gjalskisch}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_gjalskisch}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_gjalskisch} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_gjalskisch}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_gjalskisch}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_gjalskisch}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_gjalskisch}}dh1]]}}"> <span>Gjalskisch</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_gjalskisch">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_gjalskisch" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_gjalskisch" disabled="true" value="14">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_gjalskisch" disabled="disabled" value="14">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-hjaldingscherunen sheet-default-hide" type="checkbox" name="attr_talent_schrift_hjaldingscherunen" value="1">
@@ -4059,7 +4059,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="HjaldingscheRunen" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Hjaldingsche Runen}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_hjaldingscherunen}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_hjaldingscherunen} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_hjaldingscherunen}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_hjaldingscherunen}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_hjaldingscherunen}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_hjaldingscherunen}}dh1]]}}"> <span>Hjaldingsche Runen</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_hjaldingscherunen">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_hjaldingscherunen" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_hjaldingscherunen" disabled="true" value="16">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_hjaldingscherunen" disabled="disabled" value="16">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-imperialezeichen sheet-default-hide" type="checkbox" name="attr_talent_schrift_imperialezeichen" value="1">
@@ -4067,7 +4067,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="ImperialeZeichen" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Imperiale Zeichen}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_imperialezeichen}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_imperialezeichen} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_imperialezeichen}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_imperialezeichen}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_imperialezeichen}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_imperialezeichen}}dh1]]}}"> <span>Imperiale Zeichen</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_imperialezeichen">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_imperialezeichen" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_imperialezeichen" disabled="true" value="12">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_imperialezeichen" disabled="disabled" value="12">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-isdira sheet-default-hide" type="checkbox" name="attr_talent_schrift_isdira" value="1">
@@ -4075,7 +4075,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Isdira-Asdharia" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Isdira/Asdharia}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_isdira}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_isdira} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_isdira}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_isdira}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_isdira}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_isdira}}dh1]]}}"> <span>Isdira/Asdharia</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_isdira">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_isdira" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_isdira" disabled="true" value="18">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_isdira" disabled="disabled" value="18">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-kuslikerzeichen sheet-default-hide" type="checkbox" name="attr_talent_schrift_kuslikerzeichen" value="1">
@@ -4083,7 +4083,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="KuslikerZeichen" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Kusliker Zeichen}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_kuslikerzeichen}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_kuslikerzeichen} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_kuslikerzeichen}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_kuslikerzeichen}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_kuslikerzeichen}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_kuslikerzeichen}}dh1]]}}"> <span>Kusliker Zeichen</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_kuslikerzeichen">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_kuslikerzeichen" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_kuslikerzeichen" disabled="true" value="10">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_kuslikerzeichen" disabled="disabled" value="10">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-mahrischeglyphen sheet-default-hide" type="checkbox" name="attr_talent_schrift_mahrischeglyphen" value="1">
@@ -4091,7 +4091,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="MahrischeGlyphen" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Mahrische Glyphen}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_mahrischeglyphen}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_mahrischeglyphen} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_mahrischeglyphen}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_mahrischeglyphen}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_mahrischeglyphen}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_mahrischeglyphen}}dh1]]}}"> <span>Mahrische Glyphen</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_mahrischeglyphen">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_mahrischeglyphen" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_mahrischeglyphen" disabled="true" value="15">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_mahrischeglyphen" disabled="disabled" value="15">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-nanduria sheet-default-hide" type="checkbox" name="attr_talent_schrift_nanduria" value="1">
@@ -4099,7 +4099,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Nanduria" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Nanduria}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_nanduria}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_nanduria} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_nanduria}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_nanduria}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_nanduria}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_nanduria}}dh1]]}}"> <span>Nanduria</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_nanduria">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_nanduria" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_nanduria" disabled="true" value="10">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_nanduria" disabled="disabled" value="10">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-rogolan sheet-default-hide" type="checkbox" name="attr_talent_schrift_rogolan" value="1">
@@ -4107,7 +4107,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Rogolan" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Rogolan}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_rogolan}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_rogolan} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_rogolan}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_rogolan}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_rogolan}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_rogolan}}dh1]]}}"> <span>Rogolan</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_rogolan">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_rogolan" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_rogolan" disabled="true" value="11">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_rogolan" disabled="disabled" value="11">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-troll sheet-default-hide" type="checkbox" name="attr_talent_schrift_troll" value="1">
@@ -4115,7 +4115,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="TrollischeRaumbilderschrift" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Trollische 'Raumbilderschrift'}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_troll}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_troll} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_troll}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_troll}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_troll}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_troll}}dh1]]}}"> <span>Trollische 'Raumbilderschrift'</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_troll">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_troll" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_troll" disabled="true" value="24">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_troll" disabled="disabled" value="24">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-tulamidya sheet-default-hide" type="checkbox" name="attr_talent_schrift_tulamidya" value="1">
@@ -4123,7 +4123,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="TulamidyaSchrift" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Tulamidya}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_tulamidya}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_tulamidya} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_tulamidya}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_tulamidya}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_tulamidya}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_tulamidya}}dh1]]}}"> <span>Tulamidya</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_tulamidya">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_tulamidya" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_tulamidya" disabled="true" value="14">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_tulamidya" disabled="disabled" value="14">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-urtulamidya sheet-default-hide" type="checkbox" name="attr_talent_schrift_urtulamidya" value="1">
@@ -4131,7 +4131,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="Ur-TulamidyaSchrift" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Ur-Tulamidya}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_urtulamidya}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_urtulamidya} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_urtulamidya}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_urtulamidya}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_urtulamidya}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_urtulamidya}}dh1]]}}"> <span>Ur-Tulamidya</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_urtulamidya">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_urtulamidya" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_urtulamidya" disabled="true" value="16">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_urtulamidya" disabled="disabled" value="16">
                     <br>
                 </div>
                 <input class="sheet-talent-schrift-zhayad sheet-default-hide" type="checkbox" name="attr_talent_schrift_zhayad" value="1">
@@ -4139,7 +4139,7 @@
                     <div class="sheet-talent-cell sheet-talent-name"><button name="ZhayadSchrift" type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=Zhayad}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW_schrift_zhayad}]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{KL}]]}} {{stat3=[[@{FF}]]}} {{Talent=[[ { [[{0d1 + @{TaW_schrift_zhayad} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_zhayad}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_zhayad}, 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW_schrift_zhayad}, 0d1}kh1]] - @{FF}, 0d1}kh1, 0d1 + @{TaW_schrift_zhayad}}dh1]]}}"> <span>Zhayad</span></button></div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_schrift_zhayad">
                     <input type="number" class="sheet-talent-taw" name="attr_TaW_schrift_zhayad" min="-4" value="0">
-                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_zhayad" disabled="true" value="18">
+                    <input type="text" class="sheet-talent-komp sheet-stat-immutable" name="attr_Komp_schrift_zhayad" disabled="disabled" value="18">
                     <br>
                 </div>
                 <div align="left">
@@ -10292,7 +10292,7 @@
                             <input type="number" name="attr_NKW1_Schwellenwert" min="1" value="4" style="width: 2.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_NKW1_SB" style="width: 2.5em;" disabled="true" value="floor((abs(@{KK} - @{NKW1_SchwellenwertKK}))/@{NKW1_Schwellenwert})*((@{KK} - @{NKW1_SchwellenwertKK} + 0.01)/abs(@{KK} - @{NKW1_SchwellenwertKK} + 0.01))">
+                            <input type="number" name="attr_NKW1_SB" style="width: 2.5em;" disabled="disabled" value="floor((abs(@{KK} - @{NKW1_SchwellenwertKK}))/@{NKW1_Schwellenwert})*((@{KK} - @{NKW1_SchwellenwertKK} + 0.01)/abs(@{KK} - @{NKW1_SchwellenwertKK} + 0.01))">
                         </td>
                         <td>
                             <input type="number" name="attr_NKWschaden1_1" min="0" value="1" style="width: 2.5em;">
@@ -10308,10 +10308,10 @@
                             <input type="number" name="attr_NKW1PAMod" min="-20" value="0" style="width: 3em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_NKW1AT" disabled="true" value="@{NKW_AT_typ1} + @{NKW1ATMod} + @{NKW1_Spez}" style="width: 3em;">
+                            <input type="number" name="attr_NKW1AT" disabled="disabled" value="@{NKW_AT_typ1} + @{NKW1ATMod} + @{NKW1_Spez}" style="width: 3em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_NKW1PA" disabled="true" value="@{NKW_PA_typ1} + @{NKW1PAMod} + @{NKW1_Spez}" style="width: 3em;">
+                            <input type="number" name="attr_NKW1PA" disabled="disabled" value="@{NKW_PA_typ1} + @{NKW1PAMod} + @{NKW1_Spez}" style="width: 3em;">
                         </td>
                         <td>
                             <input type="text" name="attr_ReichweiteNKW1" style="width: 3em;">
@@ -10388,7 +10388,7 @@
                             <input type="number" name="attr_NKW2_Schwellenwert" min="1" value="4" style="width: 2.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_NKW2_SB" style="width: 2.5em;" disabled="true" value="floor((abs(@{KK} - @{NKW2_SchwellenwertKK}))/@{NKW2_Schwellenwert})*((@{KK} - @{NKW2_SchwellenwertKK} + 0.01)/abs(@{KK} - @{NKW2_SchwellenwertKK} + 0.01))">
+                            <input type="number" name="attr_NKW2_SB" style="width: 2.5em;" disabled="disabled" value="floor((abs(@{KK} - @{NKW2_SchwellenwertKK}))/@{NKW2_Schwellenwert})*((@{KK} - @{NKW2_SchwellenwertKK} + 0.01)/abs(@{KK} - @{NKW2_SchwellenwertKK} + 0.01))">
                         </td>
                         <td>
                             <input type="number" name="attr_NKWschaden2_1" min="0" value="1" style="width: 2.5em;">
@@ -10404,10 +10404,10 @@
                             <input type="number" name="attr_NKW2PAMod" min="-20" value="0" style="width: 3em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_NKW2AT" disabled="true" value="@{NKW_AT_typ2} + @{NKW2ATMod} + @{NKW2_Spez}" style="width: 3em;">
+                            <input type="number" name="attr_NKW2AT" disabled="disabled" value="@{NKW_AT_typ2} + @{NKW2ATMod} + @{NKW2_Spez}" style="width: 3em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_NKW2PA" disabled="true" value="@{NKW_PA_typ2} + @{NKW2PAMod} + @{NKW2_Spez}" style="width: 3em;">
+                            <input type="number" name="attr_NKW2PA" disabled="disabled" value="@{NKW_PA_typ2} + @{NKW2PAMod} + @{NKW2_Spez}" style="width: 3em;">
                         </td>
                         <td>
                             <input type="text" name="attr_ReichweiteNKW2" style="width: 3em;">
@@ -10484,7 +10484,7 @@
                             <input type="number" name="attr_NKW3_Schwellenwert" min="1" value="4" style="width: 2.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_NKW3_SB" style="width: 2.5em;" disabled="true" value="floor((abs(@{KK} - @{NKW3_SchwellenwertKK}))/@{NKW3_Schwellenwert})*((@{KK} - @{NKW3_SchwellenwertKK} + 0.01)/abs(@{KK} - @{NKW3_SchwellenwertKK} + 0.01))">
+                            <input type="number" name="attr_NKW3_SB" style="width: 2.5em;" disabled="disabled" value="floor((abs(@{KK} - @{NKW3_SchwellenwertKK}))/@{NKW3_Schwellenwert})*((@{KK} - @{NKW3_SchwellenwertKK} + 0.01)/abs(@{KK} - @{NKW3_SchwellenwertKK} + 0.01))">
                         </td>
                         <td>
                             <input type="number" name="attr_NKWschaden3_1" min="0" value="1" style="width: 2.5em;">
@@ -10500,10 +10500,10 @@
                             <input type="number" name="attr_NKW3PAMod" min="-20" value="0" style="width: 3em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_NKW3AT" disabled="true" value="@{NKW_AT_typ3} + @{NKW3ATMod} + @{NKW3_Spez}" style="width: 3em;">
+                            <input type="number" name="attr_NKW3AT" disabled="disabled" value="@{NKW_AT_typ3} + @{NKW3ATMod} + @{NKW3_Spez}" style="width: 3em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_NKW3PA" disabled="true" value="@{NKW_PA_typ3} + @{NKW3PAMod} + @{NKW3_Spez}" style="width: 3em;">
+                            <input type="number" name="attr_NKW3PA" disabled="disabled" value="@{NKW_PA_typ3} + @{NKW3PAMod} + @{NKW3_Spez}" style="width: 3em;">
                         </td>
                         <td>
                             <input type="text" name="attr_ReichweiteNKW3" style="width: 3em;">
@@ -10580,7 +10580,7 @@
                             <input type="number" name="attr_NKW4_Schwellenwert" min="1" value="4" style="width: 2.5em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_NKW4_SB" style="width: 2.5em;" disabled="true" value="floor((abs(@{KK} - @{NKW4_SchwellenwertKK}))/@{NKW4_Schwellenwert})*((@{KK} - @{NKW4_SchwellenwertKK} + 0.01)/abs(@{KK} - @{NKW4_SchwellenwertKK} + 0.01))">
+                            <input type="number" name="attr_NKW4_SB" style="width: 2.5em;" disabled="disabled" value="floor((abs(@{KK} - @{NKW4_SchwellenwertKK}))/@{NKW4_Schwellenwert})*((@{KK} - @{NKW4_SchwellenwertKK} + 0.01)/abs(@{KK} - @{NKW4_SchwellenwertKK} + 0.01))">
                         </td>
                         <td>
                             <input type="number" name="attr_NKWschaden4_1" min="0" value="1" style="width: 2.5em;">
@@ -10596,10 +10596,10 @@
                             <input type="number" name="attr_NKW4PAMod" min="-20" value="0" style="width: 3em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_NKW4AT" disabled="true" value="@{NKW_AT_typ4} + @{NKW4ATMod} + @{NKW4_Spez}" style="width: 3em;">
+                            <input type="number" name="attr_NKW4AT" disabled="disabled" value="@{NKW_AT_typ4} + @{NKW4ATMod} + @{NKW4_Spez}" style="width: 3em;">
                         </td>
                         <td>
-                            <input type="number" name="attr_NKW4PA" disabled="true" value="@{NKW_PA_typ4} + @{NKW4PAMod} + @{NKW4_Spez}" style="width: 3em;">
+                            <input type="number" name="attr_NKW4PA" disabled="disabled" value="@{NKW_PA_typ4} + @{NKW4PAMod} + @{NKW4_Spez}" style="width: 3em;">
                         </td>
                         <td>
                             <input type="text" name="attr_ReichweiteNKW4" style="width: 3em;">
@@ -10666,7 +10666,7 @@
                             <input type="number" name="attr_FKWMunition1Anzahl" min="0" value="0">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKWFK1" value="@{FKWtyp1} + @{FKW1_Spez}" disabled="true">
+                            <input type="number" name="attr_FKWFK1" value="@{FKWtyp1} + @{FKW1_Spez}" disabled="disabled">
                         </td>
                         <td>
                             <input type="text" name="attr_FKWLadezeit1" style="width: 3em;" min="1" value="3">
@@ -10744,7 +10744,7 @@
                             <input type="number" name="attr_FKWMunition2Anzahl" min="0" value="0">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKWFK2" value="@{FKWtyp2} + @{FKW2_Spez}" disabled="true">
+                            <input type="number" name="attr_FKWFK2" value="@{FKWtyp2} + @{FKW2_Spez}" disabled="disabled">
                         </td>
                         <td>
                             <input type="text" name="attr_FKWLadezeit2" style="width: 3em;" min="1" value="3">
@@ -10822,7 +10822,7 @@
                             <input type="number" name="attr_FKWMunition3Anzahl" min="0" value="0">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKWFK3" value="@{FKWtyp3} + @{FKW3_Spez}" disabled="true">
+                            <input type="number" name="attr_FKWFK3" value="@{FKWtyp3} + @{FKW3_Spez}" disabled="disabled">
                         </td>
                         <td>
                             <input type="text" name="attr_FKWLadezeit3" style="width: 3em;" min="1" value="3">
@@ -10900,7 +10900,7 @@
                             <input type="number" name="attr_FKWMunition4Anzahl" min="0" value="0">
                         </td>
                         <td>
-                            <input type="number" name="attr_FKWFK4" value="@{FKWtyp4} + @{FKW4_Spez}" disabled="true">
+                            <input type="number" name="attr_FKWFK4" value="@{FKWtyp4} + @{FKW4_Spez}" disabled="disabled">
                         </td>
                         <td>
                             <input type="text" name="attr_FKWLadezeit4" style="width: 3em;" min="1" value="3">
@@ -11121,34 +11121,34 @@
                 <tr align="center">
                     <td>
                         <td>
-                            <input type="number" disabled="true" name="attr_Ges_RS_Ko" value="@{RSAktiv1} * @{RS_Ko1} + @{RSAktiv2} * @{RS_Ko2} + @{RSAktiv3} * @{RS_Ko3} + @{RSAktiv4} * @{RS_Ko4}">
+                            <input type="number" disabled="disabled" name="attr_Ges_RS_Ko" value="@{RSAktiv1} * @{RS_Ko1} + @{RSAktiv2} * @{RS_Ko2} + @{RSAktiv3} * @{RS_Ko3} + @{RSAktiv4} * @{RS_Ko4}">
                         </td>
                         <td>
-                            <input type="number" disabled="true" name="attr_Ges_RS_Br" value="@{RSAktiv1} * @{RS_Br1} + @{RSAktiv2} * @{RS_Br2} + @{RSAktiv3} * @{RS_Br3} + @{RSAktiv4} * @{RS_Br4}">
+                            <input type="number" disabled="disabled" name="attr_Ges_RS_Br" value="@{RSAktiv1} * @{RS_Br1} + @{RSAktiv2} * @{RS_Br2} + @{RSAktiv3} * @{RS_Br3} + @{RSAktiv4} * @{RS_Br4}">
                         </td>
                         <td>
-                            <input type="number" disabled="true" name="attr_Ges_RS_Ru" value="@{RSAktiv1} * @{RS_Ru1} + @{RSAktiv2} * @{RS_Ru2} + @{RSAktiv3} * @{RS_Ru3} + @{RSAktiv4} * @{RS_Ru4}">
+                            <input type="number" disabled="disabled" name="attr_Ges_RS_Ru" value="@{RSAktiv1} * @{RS_Ru1} + @{RSAktiv2} * @{RS_Ru2} + @{RSAktiv3} * @{RS_Ru3} + @{RSAktiv4} * @{RS_Ru4}">
                         </td>
                         <td>
-                            <input type="number" disabled="true" name="attr_Ges_RS_Ba" value="@{RSAktiv1} * @{RS_Ba1} + @{RSAktiv2} * @{RS_Ba2} + @{RSAktiv3} * @{RS_Ba3} + @{RSAktiv4} * @{RS_Ba4}">
+                            <input type="number" disabled="disabled" name="attr_Ges_RS_Ba" value="@{RSAktiv1} * @{RS_Ba1} + @{RSAktiv2} * @{RS_Ba2} + @{RSAktiv3} * @{RS_Ba3} + @{RSAktiv4} * @{RS_Ba4}">
                         </td>
                         <td>
-                            <input type="number" disabled="true" name="attr_Ges_RS_LA" value="@{RSAktiv1} * @{RS_LA1} + @{RSAktiv2} * @{RS_LA2} + @{RSAktiv3} * @{RS_LA3} + @{RSAktiv4} * @{RS_LA4}">
+                            <input type="number" disabled="disabled" name="attr_Ges_RS_LA" value="@{RSAktiv1} * @{RS_LA1} + @{RSAktiv2} * @{RS_LA2} + @{RSAktiv3} * @{RS_LA3} + @{RSAktiv4} * @{RS_LA4}">
                         </td>
                         <td>
-                            <input type="number" disabled="true" name="attr_Ges_RS_RA" value="@{RSAktiv1} * @{RS_RA1} + @{RSAktiv2} * @{RS_RA2} + @{RSAktiv3} * @{RS_RA3} + @{RSAktiv4} * @{RS_RA4}">
+                            <input type="number" disabled="disabled" name="attr_Ges_RS_RA" value="@{RSAktiv1} * @{RS_RA1} + @{RSAktiv2} * @{RS_RA2} + @{RSAktiv3} * @{RS_RA3} + @{RSAktiv4} * @{RS_RA4}">
                         </td>
                         <td>
-                            <input type="number" disabled="true" name="attr_Ges_RS_LB" value="@{RSAktiv1} * @{RS_LB1} + @{RSAktiv2} * @{RS_LB2} + @{RSAktiv3} * @{RS_LB3} + @{RSAktiv4} * @{RS_LB4}">
+                            <input type="number" disabled="disabled" name="attr_Ges_RS_LB" value="@{RSAktiv1} * @{RS_LB1} + @{RSAktiv2} * @{RS_LB2} + @{RSAktiv3} * @{RS_LB3} + @{RSAktiv4} * @{RS_LB4}">
                         </td>
                         <td>
-                            <input type="number" disabled="true" name="attr_Ges_RS_RB" value="@{RSAktiv1} * @{RS_RB1} + @{RSAktiv2} * @{RS_RB2} + @{RSAktiv3} * @{RS_RB3} + @{RSAktiv4} * @{RS_RB4}">
+                            <input type="number" disabled="disabled" name="attr_Ges_RS_RB" value="@{RSAktiv1} * @{RS_RB1} + @{RSAktiv2} * @{RS_RB2} + @{RSAktiv3} * @{RS_RB3} + @{RSAktiv4} * @{RS_RB4}">
                         </td>
                         <td>
-                            <input type="number" disabled="true" name="attr_Ges_BE" value="round(@{RSAktiv1} * @{RS_gBE1} + @{RSAktiv2} * @{RS_gBE2} + @{RSAktiv3} * @{RS_gBE3} + @{RSAktiv4} * @{RS_gBE4})">
+                            <input type="number" disabled="disabled" name="attr_Ges_BE" value="round(@{RSAktiv1} * @{RS_gBE1} + @{RSAktiv2} * @{RS_gBE2} + @{RSAktiv3} * @{RS_gBE3} + @{RSAktiv4} * @{RS_gBE4})">
                         </td>
                         <td>
-                            <input type="number" disabled="true" name="attr_Ges_Gewicht" value="@{RSAktiv1} * @{RSGew1} + @{RSAktiv2} * @{RSGew2} + @{RSAktiv3} * @{RSGew3} + @{RSAktiv4} * @{RSGew4}">
+                            <input type="number" disabled="disabled" name="attr_Ges_Gewicht" value="@{RSAktiv1} * @{RSGew1} + @{RSAktiv2} * @{RSGew2} + @{RSAktiv3} * @{RSGew3} + @{RSAktiv4} * @{RSGew4}">
                         </td>
                         <td>
                 </tr>
@@ -11160,12 +11160,12 @@
             <table align="center">
                 <tr>
                     <th>GS
-                        <input class="sheet-stat-immutable" disabled="true" type="text" name="attr_GS_Wert" style="width: 2em" value="@{GS}">
+                        <input class="sheet-stat-immutable" disabled="disabled" type="text" name="attr_GS_Wert" style="width: 2em" value="@{GS}">
                     </th>
                     <th>IB
                         <input class="sheet-stat-immutable" disabled="true" type="text" name="attr_INIBasis2" style="width: 3em" value="@{INI_max}">
                     </th>
-                    <th>BE <input class="sheet-stat-immutable" disabled="true" type="text" name="attr_Ges_BE_Anzeige" value="@{BE_TaW}" style="width: 2em">
+                    <th>BE <input class="sheet-stat-immutable" disabled="disabled" type="text" name="attr_Ges_BE_Anzeige" value="@{BE_TaW}" style="width: 2em">
                     </th>
                     <th><button name="Initiative" type="roll" value="@{gm_roll_opt} &{template:DSA-Initiative} {{char=@{Name}}} {{mod=[[?{Bonus (+) oder Malus (−)|0}d1cs0cf2]]}} {{dice=[[@{INI_dice_count}]]}} {{IB=[[@{INIBasis2}]]}} {{be=[[@{BE_TaW}]]}} {{ini=[[(@{INI_dice_count}d6 + @{INIBasis2} - @{BE_TaW} + [[?{Bonus (+) oder Malus (−)|0}d1cs0cf2]])&{tracker}]]}}"> <span>Initiative</span></button> mit <select type="number" name="attr_INI_dice_count" style="width: 4em">
                 <option value="1" selected="selected">1</option>
@@ -11198,40 +11198,40 @@
                 </tr>
                 <tr class="sheet-hideable-melee-weapon-1">
                     <td><span name="attr_NKWname1"></span></td>
-                    <td><input type="text" class="sheet-stat-immutable" name="attr_AT_NKW1" disabled="true" value="@{NKW1AT}"></td>
-                    <td><input type="text" class="sheet-stat-immutable" name="attr_PA_NKW1" disabled="true" value="@{NKW1PA}"></td>
+                    <td><input type="text" class="sheet-stat-immutable" name="attr_AT_NKW1" disabled="disabled" value="@{NKW1AT}"></td>
+                    <td><input type="text" class="sheet-stat-immutable" name="attr_PA_NKW1" disabled="disabled" value="@{NKW1PA}"></td>
                     <td><span name="attr_NKWschaden1_1"></span>W6 + <span name="attr_NKWschaden1_2"></span></td>
-                    <td><input type="text" class="sheet-stat-immutable" name="attr_NKW1_SB" disabled="true" value="floor((abs(@{KK} - @{NKW1_SchwellenwertKK}))/@{NKW1_Schwellenwert})*((@{KK} - @{NKW1_SchwellenwertKK} + 0.01)/abs(@{KK} - @{NKW1_SchwellenwertKK} + 0.01))"></td>
+                    <td><input type="text" class="sheet-stat-immutable" name="attr_NKW1_SB" disabled="disabled" value="floor((abs(@{KK} - @{NKW1_SchwellenwertKK}))/@{NKW1_Schwellenwert})*((@{KK} - @{NKW1_SchwellenwertKK} + 0.01)/abs(@{KK} - @{NKW1_SchwellenwertKK} + 0.01))"></td>
                     <td><span name="attr_ReichweiteNKW1"></span></td>
                     <td><span name="attr_INIModNKW1"></span></td>
                     <td><input type="number" name="attr_BFAktuellNKW1" value="@{BFStartNKW1}"></td>
                 </tr>
                 <tr class="sheet-hideable-melee-weapon-2">
                     <td><span name="attr_NKWname2"></span></td>
-                    <td><input type="text" class="sheet-stat-immutable" name="attr_AT_NKW2" disabled="true" value="@{NKW2AT}"></td>
-                    <td><input type="text" class="sheet-stat-immutable" name="attr_PA_NKW2" disabled="true" value="@{NKW2PA}"></td>
+                    <td><input type="text" class="sheet-stat-immutable" name="attr_AT_NKW2" disabled="disabled" value="@{NKW2AT}"></td>
+                    <td><input type="text" class="sheet-stat-immutable" name="attr_PA_NKW2" disabled="disabled" value="@{NKW2PA}"></td>
                     <td><span name="attr_NKWschaden2_1"></span>W6 + <span name="attr_NKWschaden2_2"></span></td>
-                    <td><input type="text" class="sheet-stat-immutable" name="attr_NKW2_SB" disabled="true" value="floor((abs(@{KK} - @{NKW2_SchwellenwertKK}))/@{NKW2_Schwellenwert})*((@{KK} - @{NKW2_SchwellenwertKK} + 0.01)/abs(@{KK} - @{NKW2_SchwellenwertKK} + 0.01))"></td>
+                    <td><input type="text" class="sheet-stat-immutable" name="attr_NKW2_SB" disabled="disabled" value="floor((abs(@{KK} - @{NKW2_SchwellenwertKK}))/@{NKW2_Schwellenwert})*((@{KK} - @{NKW2_SchwellenwertKK} + 0.01)/abs(@{KK} - @{NKW2_SchwellenwertKK} + 0.01))"></td>
                     <td><span name="attr_ReichweiteNKW2"></span></td>
                     <td><span name="attr_INIModNKW2"></span></td>
                     <td><input type="number" name="attr_BFAktuellNKW2" value="@{BFStartNKW2}"></td>
                 </tr>
                 <tr class="sheet-hideable-melee-weapon-3">
                     <td><span name="attr_NKWname3"></span></td>
-                    <td><input type="text" class="sheet-stat-immutable" name="attr_AT_NKW3" disabled="true" value="@{NKW3AT}"></td>
-                    <td><input type="text" class="sheet-stat-immutable" name="attr_PA_NKW3" disabled="true" value="@{NKW3PA}"></td>
+                    <td><input type="text" class="sheet-stat-immutable" name="attr_AT_NKW3" disabled="disabled" value="@{NKW3AT}"></td>
+                    <td><input type="text" class="sheet-stat-immutable" name="attr_PA_NKW3" disabled="disabled" value="@{NKW3PA}"></td>
                     <td><span name="attr_NKWschaden3_1"></span>W6 + <span name="attr_NKWschaden3_2"></span></td>
-                    <td><input type="text" class="sheet-stat-immutable" name="attr_NKW3_SB" disabled="true" value="floor((abs(@{KK} - @{NKW3_SchwellenwertKK}))/@{NKW3_Schwellenwert})*((@{KK} - @{NKW3_SchwellenwertKK} + 0.01)/abs(@{KK} - @{NKW3_SchwellenwertKK} + 0.01))"></td>
+                    <td><input type="text" class="sheet-stat-immutable" name="attr_NKW3_SB" disabled="disabled" value="floor((abs(@{KK} - @{NKW3_SchwellenwertKK}))/@{NKW3_Schwellenwert})*((@{KK} - @{NKW3_SchwellenwertKK} + 0.01)/abs(@{KK} - @{NKW3_SchwellenwertKK} + 0.01))"></td>
                     <td><span name="attr_ReichweiteNKW3"></span></td>
                     <td><span name="attr_INIModNKW3"></span></td>
                     <td><input type="number" name="attr_BFAktuellNKW3" value="@{BFStartNKW3}"></td>
                 </tr>
                 <tr class="sheet-hideable-melee-weapon-4">
                     <td><span name="attr_NKWname4"></span></td>
-                    <td><input type="text" class="sheet-stat-immutable" name="attr_AT_NKW4" disabled="true" value="@{NKW4AT}"></td>
-                    <td><input type="text" class="sheet-stat-immutable" name="attr_PA_NKW4" disabled="true" value="@{NKW4PA}"></td>
+                    <td><input type="text" class="sheet-stat-immutable" name="attr_AT_NKW4" disabled="disabled" value="@{NKW4AT}"></td>
+                    <td><input type="text" class="sheet-stat-immutable" name="attr_PA_NKW4" disabled="disabled" value="@{NKW4PA}"></td>
                     <td><span name="attr_NKWschaden4_1"></span>W6 + <span name="attr_NKWschaden4_2"></span></td>
-                    <td><input type="text" class="sheet-stat-immutable" name="attr_NKW4_SB" disabled="true" value="floor((abs(@{KK} - @{NKW4_SchwellenwertKK}))/@{NKW4_Schwellenwert})*((@{KK} - @{NKW4_SchwellenwertKK} + 0.01)/abs(@{KK} - @{NKW4_SchwellenwertKK} + 0.01))"></td>
+                    <td><input type="text" class="sheet-stat-immutable" name="attr_NKW4_SB" disabled="disabled" value="floor((abs(@{KK} - @{NKW4_SchwellenwertKK}))/@{NKW4_Schwellenwert})*((@{KK} - @{NKW4_SchwellenwertKK} + 0.01)/abs(@{KK} - @{NKW4_SchwellenwertKK} + 0.01))"></td>
                     <td><span name="attr_ReichweiteNKW4"></span></td>
                     <td><span name="attr_INIModNKW4"></span></td>
                     <td><input type="number" name="attr_BFAktuellNKW4" value="@{BFStartNKW4}"></td>
@@ -11444,29 +11444,29 @@
                 </tr>
                 <tr>
                     <td>Kopf</td>
-                    <td colspan="2" class="sheet-table-armour-zones-center-cell"><input type="text" name="attr_Ges_RS_Ko_Anzeige" class="sheet-stat-immutable" disabled="true" value="@{Ges_RS_Ko}"></td>
+                    <td colspan="2" class="sheet-table-armour-zones-center-cell"><input type="text" name="attr_Ges_RS_Ko_Anzeige" class="sheet-stat-immutable" disabled="disabled" value="@{Ges_RS_Ko}"></td>
                     <td></td>
                 </tr>
                 <tr>
                     <td>Brust</td>
-                    <td><input type="text" name="attr_Ges_RS_Br_Anzeige" class="sheet-stat-immutable" disabled="true" value="@{Ges_RS_Br}"></td>
-                    <td rowspan="2"><input type="text" name="attr_Ges_RS_Ru_Anzeige" class="sheet-stat-immutable" disabled="true" value="@{Ges_RS_Ru}"></td>
+                    <td><input type="text" name="attr_Ges_RS_Br_Anzeige" class="sheet-stat-immutable" disabled="disabled" value="@{Ges_RS_Br}"></td>
+                    <td rowspan="2"><input type="text" name="attr_Ges_RS_Ru_Anzeige" class="sheet-stat-immutable" disabled="disabled" value="@{Ges_RS_Ru}"></td>
                     <td rowspan="2" class="sheet-table-armour-zones-right-cell">Rücken</td>
                 </tr>
                 <tr>
                     <td>Bauch</td>
-                    <td><input type="text" name="attr_Ges_RS_Ba_Anzeige" class="sheet-stat-immutable" disabled="true" value="@{Ges_RS_Ba}"></td>
+                    <td><input type="text" name="attr_Ges_RS_Ba_Anzeige" class="sheet-stat-immutable" disabled="disabled" value="@{Ges_RS_Ba}"></td>
                 </tr>
                 <tr>
                     <td>Arm (links)</td>
-                    <td><input type="text" name="attr_Ges_RS_LA_Anzeige" class="sheet-stat-immutable" disabled="true" value="@{Ges_RS_LA}"></td>
-                    <td><input type="text" name="attr_Ges_RS_RA_Anzeige" class="sheet-stat-immutable" disabled="true" value="@{Ges_RS_RA}"></td>
+                    <td><input type="text" name="attr_Ges_RS_LA_Anzeige" class="sheet-stat-immutable" disabled="disabled" value="@{Ges_RS_LA}"></td>
+                    <td><input type="text" name="attr_Ges_RS_RA_Anzeige" class="sheet-stat-immutable" disabled="disabled" value="@{Ges_RS_RA}"></td>
                     <td class="sheet-table-armour-zones-right-cell">Arm (rechts)</td>
                 </tr>
                 <tr>
                     <td>Bein (links)</td>
-                    <td><input type="text" name="attr_Ges_RS_LB_Anzeige" class="sheet-stat-immutable" disabled="true" value="@{Ges_RS_LB}"></td>
-                    <td><input type="text" name="attr_Ges_RS_RB_Anzeige" class="sheet-stat-immutable" disabled="true" value="@{Ges_RS_RB}"></td>
+                    <td><input type="text" name="attr_Ges_RS_LB_Anzeige" class="sheet-stat-immutable" disabled="disabled" value="@{Ges_RS_LB}"></td>
+                    <td><input type="text" name="attr_Ges_RS_RB_Anzeige" class="sheet-stat-immutable" disabled="disabled" value="@{Ges_RS_RB}"></td>
                     <td class="sheet-table-armour-zones-right-cell">Bein (rechts)</td>
                 </tr>
             </table>
@@ -11477,12 +11477,12 @@
             <table align="center">
                 <tr>
                     <th>GS
-                        <input class="sheet-stat-immutable" disabled="true" type="text" name="attr_GS_Wert" style="width: 2em" value="@{GS}">
+                        <input class="sheet-stat-immutable" disabled="disabled" type="text" name="attr_GS_Wert" style="width: 2em" value="@{GS}">
                     </th>
                     <th>IB
-                        <input class="sheet-stat-immutable" disabled="true" type="text" name="attr_INIBasis2" style="width: 3em" value="@{INI_max}">
+                        <input class="sheet-stat-immutable" readonly="readonly" type="text" name="attr_INIBasis2" style="width: 3em" value="0">
                     </th>
-                    <th>BE <input class="sheet-stat-immutable" disabled="true" type="text" name="attr_Ges_BE_Anzeige" value="@{BE_TaW}" style="width: 2em">
+                    <th>BE <input class="sheet-stat-immutable" disabled="disabled" type="text" name="attr_Ges_BE_Anzeige" value="@{BE_TaW}" style="width: 2em">
                     </th>
                     <th><button name="Initiative" type="roll" value="&{template:DSA-Initiative} {{char=@{Name}}} {{mod=[[?{Bonus (+) oder Malus (−)|0}d1cs0cf2]]}} {{dice=[[@{INI_dice_count}]]}} {{IB=[[@{INIBasis2}]]}} {{be=[[@{BE_TaW}]]}} {{ini=[[(@{INI_dice_count}d6 + @{INIBasis2} - @{BE_TaW} + [[?{Bonus (+) oder Malus (−)|0}d1cs0cf2]])&{tracker}]]}}"> <span>Initiative</span></button> mit <select type="number" name="attr_INI_dice_count" style="width: 4em">
                 <option value="1" selected="selected">1</option>
@@ -11516,7 +11516,7 @@
                     <td><span name="attr_FKWname1"></span></td>
                     <td><span name="attr_FKWMunition1"></span></td>
                     <td>&nbsp;(<input type="number" name="attr_FKWMunition1Anzahl" min="0" value="0">)</td>
-                    <td><input class="sheet-stat-immutable" type="text" name="attr_FKWFK1" value="@{FKWtyp1} + @{FKW1_Spez}" disabled="true"></td>
+                    <td><input class="sheet-stat-immutable" type="text" name="attr_FKWFK1" value="@{FKWtyp1} + @{FKW1_Spez}" disabled="disabled"></td>
                     <td><span name="attr_FKWLadezeit1"></span></td>
                     <td><span name="attr_FKWSchaden1_1"></span>W6 + <span name="attr_FKWSchaden1_2"></span></td>
                     <td><span name="attr_FKW1_RW1"></span>/<span name="attr_FKW1_RW2"></span>/<span name="attr_FKW1_RW3"></span>/<span name="attr_FKW1_RW4"></span>/<span name="attr_FKW1_RW5"></span></td>
@@ -11526,7 +11526,7 @@
                     <td><span name="attr_FKWname2"></span></td>
                     <td><span name="attr_FKWMunition2"></span></td>
                     <td>&nbsp;(<input type="number" name="attr_FKWMunition2Anzahl" min="0" value="0">)</td>
-                    <td><input class="sheet-stat-immutable" type="text" name="attr_FKWFK2" value="@{FKWtyp2} + @{FKW2_Spez}" disabled="true"></td>
+                    <td><input class="sheet-stat-immutable" type="text" name="attr_FKWFK2" value="@{FKWtyp2} + @{FKW2_Spez}" disabled="disabled"></td>
                     <td><span name="attr_FKWLadezeit2"></span></td>
                     <td><span name="attr_FKWSchaden2_1"></span>W6 + <span name="attr_FKWSchaden2_2"></span></td>
                     <td><span name="attr_FKW2_RW1"></span>/<span name="attr_FKW2_RW2"></span>/<span name="attr_FKW2_RW3"></span>/<span name="attr_FKW2_RW4"></span>/<span name="attr_FKW2_RW5"></span></td>
@@ -11536,7 +11536,7 @@
                     <td><span name="attr_FKWname3"></span></td>
                     <td><span name="attr_FKWMunition3"></span></td>
                     <td>&nbsp;(<input type="number" name="attr_FKWMunition3Anzahl" min="0" value="0">)</td>
-                    <td><input class="sheet-stat-immutable" type="text" name="attr_FKWFK3" value="@{FKWtyp3} + @{FKW3_Spez}" disabled="true"></td>
+                    <td><input class="sheet-stat-immutable" type="text" name="attr_FKWFK3" value="@{FKWtyp3} + @{FKW3_Spez}" disabled="disabled"></td>
                     <td><span name="attr_FKWLadezeit3"></span></td>
                     <td><span name="attr_FKWSchaden3_1"></span>W6 + <span name="attr_FKWSchaden3_2"></span></td>
                     <td><span name="attr_FKW3_RW1"></span>/<span name="attr_FKW3_RW2"></span>/<span name="attr_FKW3_RW3"></span>/<span name="attr_FKW3_RW4"></span>/<span name="attr_FKW3_RW5"></span></td>
@@ -11546,7 +11546,7 @@
                     <td><span name="attr_FKWname4"></span></td>
                     <td><span name="attr_FKWMunition4"></span></td>
                     <td>&nbsp;(<input type="number" name="attr_FKWMunition4Anzahl" min="0" value="0">)</td>
-                    <td><input class="sheet-stat-immutable" type="text" name="attr_FKWFK4" value="@{FKWtyp4} + @{FKW4_Spez}" disabled="true"></td>
+                    <td><input class="sheet-stat-immutable" type="text" name="attr_FKWFK4" value="@{FKWtyp4} + @{FKW4_Spez}" disabled="disabled"></td>
                     <td><span name="attr_FKWLadezeit4"></span></td>
                     <td><span name="attr_FKWSchaden4_1"></span>W6 + <span name="attr_FKWSchaden4_2"></span></td>
                     <td><span name="attr_FKW4_RW1"></span>/<span name="attr_FKW4_RW2"></span>/<span name="attr_FKW4_RW3"></span>/<span name="attr_FKW4_RW4"></span>/<span name="attr_FKW4_RW5"></span></td>
@@ -11564,7 +11564,7 @@
                     <th><span class="sheet-abbr" title="Sämtliche Einstellungen inklusive Modifikatoren und Ansagen werden aus dem Fernkampfrechner übernommen.">Fernkampfangriff</span></th>
                 </tr>
                 <tr>
-                    <td><input type="hidden" name="attr_FK_Aktiv" style="width: 4em" value="((@{FKWFK1}) * @{FKW_Aktiv1}) + ((@{FKWFK2}) * @{FKW_Aktiv2}) + ((@{FKWFK3}) * @{FKW_Aktiv3}) + ((@{FKWFK4}) * @{FKW_Aktiv4})" disabled="true"><button name="FK" type="roll" value="@{gm_roll_opt} &{template:DSA-Fernkampf-AT} {{name=Fernkampfangriff}} {{mod=[[(@{fkr_erschwernis_gesamt}) - (@{fkr_erschwernis_ansage_gesamt})]]}} {{ansage=[[@{fkr_erschwernis_ansage_gesamt}]]}} {{modansage=[[@{fkr_erschwernis_gesamt}]]}} {{wert=[[(@{FK_Aktiv})]]}} {{eff_wert=[[(@{FK_Aktiv}) - (@{fkr_erschwernis_gesamt})]]}} {{eff_wert_ohne_kampfgetuemmel=[[(@{FK_Aktiv}) - (@{fkr_erschwernis_ohne_kampfgetuemmel})]]}} {{ZieleKampfgetuemmel=[[@{fkr_kampfgetuemmel_ziele}]]}} {{wurf=[[1d20cs1cf20]]}} {{pruefwurf=[[1d20cs1cf20]]}}"> <span>Attacke</span></button>
+                    <td><input type="hidden" name="attr_FK_Aktiv" style="width: 4em" value="((@{FKWFK1}) * @{FKW_Aktiv1}) + ((@{FKWFK2}) * @{FKW_Aktiv2}) + ((@{FKWFK3}) * @{FKW_Aktiv3}) + ((@{FKWFK4}) * @{FKW_Aktiv4})" disabled="disabled"><button name="FK" type="roll" value="@{gm_roll_opt} &{template:DSA-Fernkampf-AT} {{name=Fernkampfangriff}} {{mod=[[(@{fkr_erschwernis_gesamt}) - (@{fkr_erschwernis_ansage_gesamt})]]}} {{ansage=[[@{fkr_erschwernis_ansage_gesamt}]]}} {{modansage=[[@{fkr_erschwernis_gesamt}]]}} {{wert=[[(@{FK_Aktiv})]]}} {{eff_wert=[[(@{FK_Aktiv}) - (@{fkr_erschwernis_gesamt})]]}} {{eff_wert_ohne_kampfgetuemmel=[[(@{FK_Aktiv}) - (@{fkr_erschwernis_ohne_kampfgetuemmel})]]}} {{ZieleKampfgetuemmel=[[@{fkr_kampfgetuemmel_ziele}]]}} {{wurf=[[1d20cs1cf20]]}} {{pruefwurf=[[1d20cs1cf20]]}}"> <span>Attacke</span></button>
                     </td>
                 </tr>
                 <tr>
@@ -11845,29 +11845,29 @@
                 </tr>
                 <tr>
                     <td>Kopf</td>
-                    <td colspan="2" class="sheet-table-armour-zones-center-cell"><input type="text" name="attr_Ges_RS_Ko_Anzeige" class="sheet-stat-immutable" disabled="true" value="@{Ges_RS_Ko}"></td>
+                    <td colspan="2" class="sheet-table-armour-zones-center-cell"><input type="text" name="attr_Ges_RS_Ko_Anzeige" class="sheet-stat-immutable" disabled="disabled" value="@{Ges_RS_Ko}"></td>
                     <td></td>
                 </tr>
                 <tr>
                     <td>Brust</td>
-                    <td><input type="text" name="attr_Ges_RS_Br_Anzeige" class="sheet-stat-immutable" disabled="true" value="@{Ges_RS_Br}"></td>
-                    <td rowspan="2"><input type="text" name="attr_Ges_RS_Ru_Anzeige" class="sheet-stat-immutable" disabled="true" value="@{Ges_RS_Ru}"></td>
+                    <td><input type="text" name="attr_Ges_RS_Br_Anzeige" class="sheet-stat-immutable" disabled="disabled" value="@{Ges_RS_Br}"></td>
+                    <td rowspan="2"><input type="text" name="attr_Ges_RS_Ru_Anzeige" class="sheet-stat-immutable" disabled="disabled" value="@{Ges_RS_Ru}"></td>
                     <td rowspan="2" class="sheet-table-armour-zones-right-cell">Rücken</td>
                 </tr>
                 <tr>
                     <td>Bauch</td>
-                    <td><input type="text" name="attr_Ges_RS_Ba_Anzeige" class="sheet-stat-immutable" disabled="true" value="@{Ges_RS_Ba}"></td>
+                    <td><input type="text" name="attr_Ges_RS_Ba_Anzeige" class="sheet-stat-immutable" disabled="disabled" value="@{Ges_RS_Ba}"></td>
                 </tr>
                 <tr>
                     <td>Arm (links)</td>
-                    <td><input type="text" name="attr_Ges_RS_LA_Anzeige" class="sheet-stat-immutable" disabled="true" value="@{Ges_RS_LA}"></td>
-                    <td><input type="text" name="attr_Ges_RS_RA_Anzeige" class="sheet-stat-immutable" disabled="true" value="@{Ges_RS_RA}"></td>
+                    <td><input type="text" name="attr_Ges_RS_LA_Anzeige" class="sheet-stat-immutable" disabled="disabled" value="@{Ges_RS_LA}"></td>
+                    <td><input type="text" name="attr_Ges_RS_RA_Anzeige" class="sheet-stat-immutable" disabled="disabled" value="@{Ges_RS_RA}"></td>
                     <td class="sheet-table-armour-zones-right-cell">Arm (rechts)</td>
                 </tr>
                 <tr>
                     <td>Bein (links)</td>
-                    <td><input type="text" name="attr_Ges_RS_LB_Anzeige" class="sheet-stat-immutable" disabled="true" value="@{Ges_RS_LB}"></td>
-                    <td><input type="text" name="attr_Ges_RS_RB_Anzeige" class="sheet-stat-immutable" disabled="true" value="@{Ges_RS_RB}"></td>
+                    <td><input type="text" name="attr_Ges_RS_LB_Anzeige" class="sheet-stat-immutable" disabled="disabled" value="@{Ges_RS_LB}"></td>
+                    <td><input type="text" name="attr_Ges_RS_RB_Anzeige" class="sheet-stat-immutable" disabled="disabled" value="@{Ges_RS_RB}"></td>
                     <td class="sheet-table-armour-zones-right-cell">Bein (rechts)</td>
                 </tr>
             </table>
@@ -12496,7 +12496,7 @@
             <th><b>TP</b></th>
         </tr>
         <tr>
-            <td><input type="text" disabled="true" name="attr_Raufen" value="Raufen" style="width: 10em;"></td>
+            <td><input type="text" disabled="disabled" name="attr_Raufen" value="Raufen" style="width: 10em;"></td>
             <td><select type="text" name="attr_TechnikNameRA"  style="width: 8em;">
                 <option>---</option>
                 <option>Biss</option>
@@ -12533,7 +12533,7 @@
             <td><button type="roll" value="@{gm_roll_opt} &{template:DSA-Kampf-Treffer} {{damage=[[@{TP_RA}]]}}">TP(a)</button></td>
         </tr>
         <tr>
-            <td><input type="text" disabled="true" name="attr_Ringen" value="Ringen" style="width: 10em;"></td>
+            <td><input type="text" disabled="disabled" name="attr_Ringen" value="Ringen" style="width: 10em;"></td>
             <td><select type="text" name="attr_TechnikNameRI"  style="width: 8em;">
                 <option>---</option>
                 <option>Griff</option>
@@ -12792,19 +12792,19 @@
             <div class="sheet-hide">
                 <!-- Comfort Attributes (= to shorten rolls) -->
                 AT-Wert aus aktiver Waffe (bei Wahl mehrerer aktiver Waffen wird addiert!)
-                <input type="number" name="attr_AT_Aktiv" disabled="true" value="((@{AT_NKW1}) * @{NKW_Aktiv1}) + ((@{AT_NKW2}) * @{NKW_Aktiv2}) + ((@{AT_NKW3}) * @{NKW_Aktiv3}) + ((@{AT_NKW4}) * @{NKW_Aktiv4})">
+                <input type="number" name="attr_AT_Aktiv" disabled="disabled" value="((@{AT_NKW1}) * @{NKW_Aktiv1}) + ((@{AT_NKW2}) * @{NKW_Aktiv2}) + ((@{AT_NKW3}) * @{NKW_Aktiv3}) + ((@{AT_NKW4}) * @{NKW_Aktiv4})">
 
                 Anzahl an W6 aus aktiver Waffe (bei Wahl mehrerer aktiver Waffen wird addiert!)
-                <input type="number" name="attr_TP_W_Aktiv" disabled="true" value="@{NKW_Aktiv1} * @{NKWschaden1_1} + @{NKW_Aktiv2} * @{NKWschaden2_1} + @{NKW_Aktiv3} * @{NKWschaden3_1} + @{NKW_Aktiv4} * @{NKWschaden4_1}">
+                <input type="number" name="attr_TP_W_Aktiv" disabled="disabled" value="@{NKW_Aktiv1} * @{NKWschaden1_1} + @{NKW_Aktiv2} * @{NKWschaden2_1} + @{NKW_Aktiv3} * @{NKWschaden3_1} + @{NKW_Aktiv4} * @{NKWschaden4_1}">
 
                 Schadensbonus aus aktiver Waffe inkl. TP/KK (bei Wahl mehrerer aktiver Waffen wird addiert!)
-                <input type="number" name="attr_TP_Bonus_Aktiv" disabled="true" value="@{NKW_Aktiv1} * (@{NKWschaden1_2} + @{NKW1_SB}) + @{NKW_Aktiv2} * (@{NKWschaden2_2} + @{NKW2_SB}) + @{NKW_Aktiv3} * (@{NKWschaden3_2} + @{NKW3_SB}) + @{NKW_Aktiv4} * (@{NKWschaden4_2} + @{NKW4_SB})">
+                <input type="number" name="attr_TP_Bonus_Aktiv" disabled="disabled" value="@{NKW_Aktiv1} * (@{NKWschaden1_2} + @{NKW1_SB}) + @{NKW_Aktiv2} * (@{NKWschaden2_2} + @{NKW2_SB}) + @{NKW_Aktiv3} * (@{NKWschaden3_2} + @{NKW3_SB}) + @{NKW_Aktiv4} * (@{NKWschaden4_2} + @{NKW4_SB})">
 
                 PA-Wert aus aktiver Waffe (bei Wahl mehrerer aktiver Waffen wird addiert!)
-                <input type="number" name="attr_PA_Aktiv" disabled="true" value="((@{PA_NKW1}) * @{NKW_Aktiv1}) + ((@{PA_NKW2}) * @{NKW_Aktiv2}) + ((@{PA_NKW3}) * @{NKW_Aktiv3}) + ((@{PA_NKW4}) * @{NKW_Aktiv4})">
+                <input type="number" name="attr_PA_Aktiv" disabled="disabled" value="((@{PA_NKW1}) * @{NKW_Aktiv1}) + ((@{PA_NKW2}) * @{NKW_Aktiv2}) + ((@{PA_NKW3}) * @{NKW_Aktiv3}) + ((@{PA_NKW4}) * @{NKW_Aktiv4})">
 
                 Ausweichen-Wert für den Kampf (quasi deaktiviert im Zuge der Umstellung auf das WdS-System zum Ausweichen)
-                <input type="number" name="attr_Ausweichen_Kampf" disabled="true" value="@{PABasis} - @{BE_TaW}">
+                <input type="number" name="attr_Ausweichen_Kampf" disabled="disabled" value="@{PABasis} - @{BE_TaW}">
             </div>
         </div>
     </div>

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -636,14 +636,14 @@
         <br>
         <table align="center">
             <tr>
-                <th>MU: <input type="text" class="sheet-stat-immutable" name="attr_MU2" readonly="readonly" value="0"></th>
-                <th>KL: <input type="text" class="sheet-stat-immutable" name="attr_KL2" readonly="readonly" value="0"></th>
-                <th>IN: <input type="text" class="sheet-stat-immutable" name="attr_IN2" readonly="readonly" value="0"></th>
-                <th>CH: <input type="text" class="sheet-stat-immutable" name="attr_CH2" readonly="readonly" value="0"></th>
-                <th>FF: <input type="text" class="sheet-stat-immutable" name="attr_FF2" readonly="readonly" value="0"></th>
-                <th>GE: <input type="text" class="sheet-stat-immutable" name="attr_GE2" readonly="readonly" value="0"></th>
-                <th>KO: <input type="text" class="sheet-stat-immutable" name="attr_KO2" readonly="readonly" value="0"></th>
-                <th>KK: <input type="text" class="sheet-stat-immutable" name="attr_KK2" readonly="readonly" value="0"></th>
+                <th>MU: <input type="text" class="sheet-stat-immutable" name="attr_MU" readonly="readonly" value="0"></th>
+                <th>KL: <input type="text" class="sheet-stat-immutable" name="attr_KL" readonly="readonly" value="0"></th>
+                <th>IN: <input type="text" class="sheet-stat-immutable" name="attr_IN" readonly="readonly" value="0"></th>
+                <th>CH: <input type="text" class="sheet-stat-immutable" name="attr_CH" readonly="readonly" value="0"></th>
+                <th>FF: <input type="text" class="sheet-stat-immutable" name="attr_FF" readonly="readonly" value="0"></th>
+                <th>GE: <input type="text" class="sheet-stat-immutable" name="attr_GE" readonly="readonly" value="0"></th>
+                <th>KO: <input type="text" class="sheet-stat-immutable" name="attr_KO" readonly="readonly" value="0"></th>
+                <th>KK: <input type="text" class="sheet-stat-immutable" name="attr_KK" readonly="readonly" value="0"></th>
                 <th>BE: <input type="text" class="sheet-stat-immutable" name="attr_BE_TaW" disabled="disabled" value="(@{Ges_BE} + @{BE_Last})"></th>
             </tr>
         </table>
@@ -6335,14 +6335,14 @@
         <br>
         <table align="center">
             <tr>
-                <th>MU: <input type="text" class="sheet-stat-immutable" name="attr_MU2" disabled="true" value="@{MU}"></th>
-                <th>KL: <input type="text" class="sheet-stat-immutable" name="attr_KL2" disabled="true" value="@{KL}"></th>
-                <th>IN: <input type="text" class="sheet-stat-immutable" name="attr_IN2" disabled="true" value="@{IN}"></th>
-                <th>CH: <input type="text" class="sheet-stat-immutable" name="attr_CH2" disabled="true" value="@{CH}"></th>
-                <th>FF: <input type="text" class="sheet-stat-immutable" name="attr_FF2" disabled="true" value="@{FF}"></th>
-                <th>GE: <input type="text" class="sheet-stat-immutable" name="attr_GE2" disabled="true" value="@{GE}"></th>
-                <th>KO: <input type="text" class="sheet-stat-immutable" name="attr_KO2" disabled="true" value="@{KO}"></th>
-                <th>KK: <input type="text" class="sheet-stat-immutable" name="attr_KK2" disabled="true" value="@{KK}"></th>
+                <th>MU: <input type="text" class="sheet-stat-immutable" name="attr_MU" disabled="true" value="@{MU}"></th>
+                <th>KL: <input type="text" class="sheet-stat-immutable" name="attr_KL" disabled="true" value="@{KL}"></th>
+                <th>IN: <input type="text" class="sheet-stat-immutable" name="attr_IN" disabled="true" value="@{IN}"></th>
+                <th>CH: <input type="text" class="sheet-stat-immutable" name="attr_CH" disabled="true" value="@{CH}"></th>
+                <th>FF: <input type="text" class="sheet-stat-immutable" name="attr_FF" disabled="true" value="@{FF}"></th>
+                <th>GE: <input type="text" class="sheet-stat-immutable" name="attr_GE" disabled="true" value="@{GE}"></th>
+                <th>KO: <input type="text" class="sheet-stat-immutable" name="attr_KO" disabled="true" value="@{KO}"></th>
+                <th>KK: <input type="text" class="sheet-stat-immutable" name="attr_KK" disabled="true" value="@{KK}"></th>
                 <th>BE: <input type="text" class="sheet-stat-immutable" name="attr_BE_TaW" disabled="true" value="(@{Ges_BE} + @{BE_Last})"></th>
             </tr>
         </table>
@@ -15472,21 +15472,13 @@ on("sheet:opened change:wound_kopf change:wound_ra change:wound_la change:wound_
         // Attribute setzen
         setAttrs({
             mu: +v.mu_basis + +v.mu_mod - +wundeKopf,
-            mu2: +v.mu_basis + +v.mu_mod - +wundeKopf,
             kl: +v.kl_basis + +v.kl_mod - +wundeKopf,
-            kl2: +v.kl_basis + +v.kl_mod - +wundeKopf,
             in: +v.in_basis + +v.in_mod - +wundeKopf,
-            in2: +v.in_basis + +v.in_mod - +wundeKopf,
             ch: +v.ch_basis + +v.ch_mod,
-            ch2: +v.ch_basis + +v.ch_mod,
             ff: +v.ff_basis + +v.ff_mod - +wundeRA - +wundeLA,
-            ff2: +v.ff_basis + +v.ff_mod - +wundeRA - +wundeLA,
             ge: +v.ge_basis + +v.ge_mod - +wundeLB - +wundeRB,
-            ge2: +v.ge_basis + +v.ge_mod - +wundeLB - +wundeRB,
             ko: +v.ko_basis + +v.ko_mod - +wundeBrust - +wundeBauch,
-            ko2: +v.ko_basis + +v.ko_mod - +wundeBrust - +wundeBauch,
-            kk: +v.kk_basis + +v.kk_mod - +wundeBrust - +wundeBauch - +wundeRA - +wundeLA,
-            kk2: +v.kk_basis + +v.kk_mod - +wundeBrust - +wundeBauch - +wundeRA - +wundeLA
+            kk: +v.kk_basis + +v.kk_mod - +wundeBrust - +wundeBauch - +wundeRA - +wundeLA
         }); 
         // Abgeleitete werte setzen
         setAttrs({

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -6335,15 +6335,15 @@
         <br>
         <table align="center">
             <tr>
-                <th>MU: <input type="text" class="sheet-stat-immutable" name="attr_MU" disabled="true" value="@{MU}"></th>
-                <th>KL: <input type="text" class="sheet-stat-immutable" name="attr_KL" disabled="true" value="@{KL}"></th>
-                <th>IN: <input type="text" class="sheet-stat-immutable" name="attr_IN" disabled="true" value="@{IN}"></th>
-                <th>CH: <input type="text" class="sheet-stat-immutable" name="attr_CH" disabled="true" value="@{CH}"></th>
-                <th>FF: <input type="text" class="sheet-stat-immutable" name="attr_FF" disabled="true" value="@{FF}"></th>
-                <th>GE: <input type="text" class="sheet-stat-immutable" name="attr_GE" disabled="true" value="@{GE}"></th>
-                <th>KO: <input type="text" class="sheet-stat-immutable" name="attr_KO" disabled="true" value="@{KO}"></th>
-                <th>KK: <input type="text" class="sheet-stat-immutable" name="attr_KK" disabled="true" value="@{KK}"></th>
-                <th>BE: <input type="text" class="sheet-stat-immutable" name="attr_BE_TaW" disabled="true" value="(@{Ges_BE} + @{BE_Last})"></th>
+                <th>MU: <input type="text" class="sheet-stat-immutable" name="attr_MU" readonly="readonly" value="0"></th>
+                <th>KL: <input type="text" class="sheet-stat-immutable" name="attr_KL" readonly="readonly" value="0"></th>
+                <th>IN: <input type="text" class="sheet-stat-immutable" name="attr_IN" readonly="readonly" value="0"></th>
+                <th>CH: <input type="text" class="sheet-stat-immutable" name="attr_CH" readonly="readonly" value="0"></th>
+                <th>FF: <input type="text" class="sheet-stat-immutable" name="attr_FF" readonly="readonly" value="0"></th>
+                <th>GE: <input type="text" class="sheet-stat-immutable" name="attr_GE" readonly="readonly" value="0"></th>
+                <th>KO: <input type="text" class="sheet-stat-immutable" name="attr_KO" readonly="readonly" value="0"></th>
+                <th>KK: <input type="text" class="sheet-stat-immutable" name="attr_KK" readonly="readonly" value="0"></th>
+                <th>BE: <input type="text" class="sheet-stat-immutable" name="attr_BE_TaW" disabled="disabled" value="(@{Ges_BE} + @{BE_Last})"></th>
             </tr>
         </table>
         <br>
@@ -12554,7 +12554,7 @@
             <br>
             <td colspan="2" align="right">Wundschwelle</td>
             <td>
-                <input name="attr_Wundschwelle" style="width: 5em;" type="number" disabled="true" value="ceil((@{KO_Basis}/2) + @{Eisern})">
+                <input name="attr_Wundschwelle" style="width: 5em;" type="number" value="0" readonly="readonly">
             </td>
             <td colspan="2" align="right">Eisern?
                 <input type="checkbox" name="attr_Eisern" Value="2">

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -6264,6 +6264,56 @@
                 <button type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=@{Name_Gabe_Anzeige}}} {{mod=[[?{Erleichterung (-) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW}]]}} {{stat1=[[@{hiddenEigenschaft1}]]}} {{stat2=[[@{hiddenEigenschaft2}]]}} {{stat3=[[@{hiddenEigenschaft3}]]}} {{Talent=[[ { [[{0d1 + @{TaW} - (?{Erleichterung (-) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft1}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft2}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft3}, 0d1}kh1, 0d1 + @{TaW}}dh1]]}}"></button>
                 </span>
             </fieldset>
+            <h3>ALTE DATEN</h3>
+            <fieldset class="repeating_AlteGaben">
+                <input type="checkbox" name="attr_SE" style="width: 2em">
+                <select name="attr_TalentName" class="atype" style="width: 14em;">
+                    <option>---</option>
+                    <option>Empathie</option>
+                    <option>Gefahreninstinkt</option>
+                    <option>Geräuschhexerei</option>
+                    <option>Kräfteschub/Talentschub</option>
+                    <option>Magiegespür</option>
+                    <option>Prophezeien</option>
+                    <option>Tierempathie</option>
+                    <option>Zwergennase</option>
+                </select>
+                <select name="attr_Eigenschaft1" class="sheet-talent-eigenschaft">
+                    <option>---</option>
+                    <option value="@{MU}">MU</option>
+                    <option value="@{KL}">KL</option>
+                    <option value="@{IN}">IN</option>
+                    <option value="@{CH}">CH</option>
+                    <option value="@{FF}">FF</option>
+                    <option value="@{GE}">GE</option>
+                    <option value="@{KO}">KO</option>
+                    <option value="@{KK}">KK</option>
+                </select>
+                <select name="attr_Eigenschaft2" class="sheet-talent-eigenschaft">
+                    <option>---</option>
+                    <option value="@{MU}">MU</option>
+                    <option value="@{KL}">KL</option>
+                    <option value="@{IN}">IN</option>
+                    <option value="@{CH}">CH</option>
+                    <option value="@{FF}">FF</option>
+                    <option value="@{GE}">GE</option>
+                    <option value="@{KO}">KO</option>
+                    <option value="@{KK}">KK</option>
+                </select>
+                <select name="attr_Eigenschaft3" class="sheet-talent-eigenschaft">
+                    <option>---</option>
+                    <option value="@{MU}">MU</option>
+                    <option value="@{KL}">KL</option>
+                    <option value="@{IN}">IN</option>
+                    <option value="@{CH}">CH</option>
+                    <option value="@{FF}">FF</option>
+                    <option value="@{GE}">GE</option>
+                    <option value="@{KO}">KO</option>
+                    <option value="@{KK}">KK</option>
+                </select>
+                <input type="number" name="attr_TaW" style="width: 3em;">
+                <button type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=@{TalentName}}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW}]]}} {{stat1=[[@{Eigenschaft1}]]}} {{stat2=[[@{Eigenschaft2}]]}} {{stat3=[[@{Eigenschaft3}]]}} {{Talent=[[ { [[{0d1 + @{TaW} - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft1}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft2}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{Eigenschaft3}, 0d1}kh1, 0d1 + @{TaW}}dh1]]}}"></button>
+            </fieldset>
         </div>
 
         <div class="sheet-section sheet-section-Meta">
@@ -15678,6 +15728,148 @@ on("change:kegrundw change:kezugek", function(eventInfo) {
             ke_max: +v.kegrundw + +v.kezugek
         });
     });
+});
+
+/*
+# Old Data Conversion
+Always try to migrate as much data as possible
+
+Relevant character sheet versions
+* 20171014: last version before sheet worker scripts conversion
+* 20190425: new repeating sections for meta-talents and gifts
+*/
+function migrationCheck() {
+    getAttrs(["character_sheet_version", "data_version"], function(v) {
+        console.log("Checking versions before attempting data migration ...");
+        
+        let dataVersion = parseInt(v["data_version"]);
+        let sheetVersion = parseInt(v["character_sheet_version"]);
+
+        if(sheetVersion == dataVersion) {
+            console.log("Character sheet version (" + sheetVersion + ") matches data version (" + dataVersion + "). Nothing to do.");
+        } else if(sheetVersion > dataVersion) {
+            console.log("Character sheet version (" + sheetVersion + ") is newer than data version (" + dataVersion + "). Having a closer look at the data version ...");
+            // This needs to be adapted/replaced by a better system
+            if(dataVersion === 20171014) {
+                migrate20171014to20190425();
+            } else {
+                console.log("The data version does not indicate the need to migrate old data to new formats. Nothing done.");
+            }
+        } else if (sheetVersion < dataVersion) {
+            console.log("Character sheet version (" + sheetVersion + ") is older than data version (" + dataVersion + "). Version numbers inconsistent, stopping to prevent unwanted effects. Please fix your version number(s).");
+        }
+    });
+}
+
+/*
+## From version 20171014 to 20190425
+* Gifts and meta-talents were changed
+*/
+function migrate20171014to20190425 () {
+    console.log("Migrating sheet data from version 20171014 to 20190425 ...");
+    let migrationFinished = 0;
+
+    getSectionIDs("AlteGaben", function(idarray) {
+        if(idarray.length == 0) {
+            console.log("Migration: No gifts found, nothing to migrate.");
+            migrationFinished = 1;
+        } else {
+            console.log("Migration: Found old gifts, continuing ...");
+            let conversion = {
+                "@{MU}": "mu",
+                "@{KL}": "kl",
+                "@{IN}": "in",
+                "@{CH}": "ch",
+                "@{FF}": "ff",
+                "@{GE}": "ge",
+                "@{KO}": "ko",
+                "@{KK}": "kk",
+                "---": "nothing",
+                "Empathie": "empathie",
+                "Gefahreninstinkt": "gefahreninstinkt",
+                "Geräuschhexerei": "geraeuschhexerei",
+                "Kräfteschub/Talentschub": "kraefteschub/talentschub",
+                "Magiegespür": "magiegespuer",
+                "Prophezeien": "prophezeien",
+                "Tierempathie": "tierempathie",
+                "Zwergennase": "zwergennase",
+            };
+            let gaben = {
+                "empathie": [ ["mu", "in", "in"], "Empathie" ],
+                "gefahreninstinkt": [ ["kl", "in", "in"], "Gefahreninstinkt" ],
+                "geraeuschhexerei": [ ["in", "ch", "ko"], "Geräuschhexerei" ],
+                "kraefteschub/talentschub": [ ["mu", "in", "ko"], "Kräfteschub/Talentschub" ],
+                "magiegespuer": [ ["mu", "in", "in"], "Magiegespür" ],
+                "prophezeien": [ ["in", "in", "ch"], "Prophezeien" ],
+                "tierempathie": [ ["mu", "in", "ch"], "Tierempathie" ],
+                "zwergennase": [ ["in", "in", "ff"], "Zwergennase" ]
+            };
+            for(var i=0; i < idarray.length; i++) {
+                getAttrs(
+                    [
+                        "repeating_AlteGaben_" + idarray[i] + "_TalentName",
+                        "repeating_AlteGaben_" + idarray[i] + "_Eigenschaft1",
+                        "repeating_AlteGaben_" + idarray[i] + "_Eigenschaft2",
+                        "repeating_AlteGaben_" + idarray[i] + "_Eigenschaft3",
+                        "repeating_AlteGaben_" + idarray[i] + "_TaW",
+                        "repeating_AlteGaben_" + idarray[i] + "_SE",
+                        "mu", "kl", "in", "ch", "ff", "ge", "ko", "kk"
+                    ], function(v) {
+                        console.log(v);
+                        let update = {};
+                        let newrow = generateRowID();
+                        let current = Object.keys(v)[0].split("_")[2];
+                        let prefixNew = "repeating_GabenTalente_" + newrow;
+                        let prefixOld = "repeating_AlteGaben_" + current;
+
+                        // Gather data
+                        // Updating the name will set the stats automatically
+                        // To prevent overwriting of custom stats check that the RAW stats are used
+                        // Need to check that the three correct ones are used, order irrelevant
+                        // Comparison made easy by taking all three stats, sorting them alphabetically and then concatenating them into one string -> simple string comparison will reveal whether the same stats are used (order not important)
+                        let gabeStats = gaben[conversion[v[prefixOld + "_TalentName"]]][0].sort().join("");
+                        let gabeStatsOld = [conversion[v[prefixOld + "_Eigenschaft1"]], conversion[v[prefixOld + "_Eigenschaft2"]], conversion[v[prefixOld + "_Eigenschaft3"]]].sort().join("");
+                        if(gabeStats == gabeStatsOld) {
+                            update[prefixNew + "_Name_Gabe"] = conversion[v[prefixOld + "_TalentName"]];
+                            update[prefixNew + "_Name_Gabe_Zusatz"] = "";
+                        } else {
+                            update[prefixNew + "_Name_Gabe_Zusatz"] = "urspr. " + v[prefixOld + "_TalentName"] + "; Eigenschaften für Probe aber nicht Standard. ";
+                            console.log("Migration: Found old " + v[prefixOld + "_TalentName"] + " containing non-standard stats. No predefined gift set. Old data preserved.");
+                        }
+                        if(v[prefixOld + "_SE"] == "on") {
+                            update[prefixNew + "_Name_Gabe_Zusatz"] += "[x] SE";
+                            console.log("Migration: Found old " + v[prefixOld + "_TalentName"] + " marked as having a special experience (SE). This data will no longer be kept in the character sheet as it is only relevant for character advancement. Old data preserved. Please move to notes.");
+                        } else {
+                            update[prefixNew + "_Name_Gabe_Zusatz"] += "[ ] SE";
+                        }
+                        update[prefixNew + "_Name_Gabe_Anzeige"] = conversion[v[prefixOld + "_TalentName"]];
+                        update[prefixNew + "_Eigenschaft1"] = conversion[v[prefixOld + "_Eigenschaft1"]];
+                        update[prefixNew + "_Eigenschaft2"] = conversion[v[prefixOld + "_Eigenschaft2"]];
+                        update[prefixNew + "_Eigenschaft3"] = conversion[v[prefixOld + "_Eigenschaft3"]];
+                        update[prefixNew + "_hiddenEigenschaft1"] = v[conversion[v[prefixOld + "_Eigenschaft1"]]];
+                        update[prefixNew + "_hiddenEigenschaft2"] = v[conversion[v[prefixOld + "_Eigenschaft2"]]];
+                        update[prefixNew + "_hiddenEigenschaft3"] = v[conversion[v[prefixOld + "_Eigenschaft3"]]];
+                        update[prefixNew + "_TaW"] = parseInt(v[prefixOld + "_TaW"]);
+                        console.log(update);
+
+                        // Create new row
+                        setAttrs(update);
+                    });
+            }
+            migrationFinished = 1;
+        }
+        if (migrationFinished === 1) {
+            let dataVersionNew = "20190425";
+            setAttrs({ "data_version": dataVersionNew });
+            console.log("Migration: Data version updated to character sheet version (" + dataVersionNew + "). Migration complete.");
+        } else {
+            console.log("Migration: Migration appears to be incomplete. See console/log for further hints. Data version not updated to character sheet version.");
+        }
+    });
+}
+
+on("sheet:opened", function() {
+    migrationCheck();
 });
 
 </script>

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -15475,38 +15475,46 @@ on("sheet:opened change:wound_kopf change:wound_ra change:wound_la change:wound_
         let wundeLB = +v.wound_lb || 0;
         let wundeBrust = +v.wound_brust || 0;
         let wundeBauch = +v.wound_bauch || 0;
-        // Attribute setzen
-        setAttrs({
-            mu: +v.mu_basis + +v.mu_mod - +wundeKopf,
-            kl: +v.kl_basis + +v.kl_mod - +wundeKopf,
-            in: +v.in_basis + +v.in_mod - +wundeKopf,
-            ch: +v.ch_basis + +v.ch_mod,
-            ff: +v.ff_basis + +v.ff_mod - +wundeRA - +wundeLA,
-            ge: +v.ge_basis + +v.ge_mod - +wundeLB - +wundeRB,
-            ko: +v.ko_basis + +v.ko_mod - +wundeBrust - +wundeBauch,
-            kk: +v.kk_basis + +v.kk_mod - +wundeBrust - +wundeBauch - +wundeRA - +wundeLA
-        }); 
-        // Abgeleitete werte setzen
-        setAttrs({
-           gs: +v.gs_basis + +v.gs_mod + Math.floor(((+v.ge_basis + +v.ge_mod + 100) / 111) - 1) + Math.ceil(((+v.ge_basis + +v.ge_mod + 100)/115) - 1) - +wundeBauch - (+wundeRB / 2 - +wundeLB / 2),
-           erschoepfung_basis: +v.ko_basis,
-           erschoepfung_max: +v.ko_basis + +v.erschoepfung_mod,
-           wundschwelle: Math.ceil(((+v.ko_basis) / 2)) + +v.eisern,
-           aspgrundw: Math.round((+v.mu_basis + +v.in_basis + +v.ch_basis) / 2 + 0.05),
-           asp_max: Math.round((+v.mu_basis + +v.in_basis + +v.ch_basis) / 2 + 0.05) + +v.aspzugek,
-           ausgrundw: Math.round((+v.mu_basis + +v.ko_basis + +v.ge_basis) / 2 + 0.05),
-           aus_max: Math.round((+v.mu_basis + +v.ko_basis + +v.ge_basis) / 2 + 0.05) + +v.auszugek,
-           legrundw: Math.round((+v.ko_basis + +v.kk_basis) / 2 + 0.05),
-           le_max: Math.round((+v.ko_basis + +v.kk_basis) / 2 + 0.05) + +v.lezugek,
-           mrgrundw: Math.round((+v.mu_basis + +v.mu_mod + +v.kl_basis + +v.kl_mod + +v.ko_basis + +v.ko_mod) / 5),
-           mr_max: Math.round((+v.mu_basis + +v.mu_mod + +v.kl_basis + +v.kl_mod + +v.ko_basis + +v.ko_mod) / 5) + +v.mrzugek,
-           ueberanstrengung_max: +v.ko_basis,
-           inibasis: Math.round((+v.mu_basis + +v.mu_mod + +v.mu_basis + +v.mu_mod + +v.in_basis + +v.in_mod + +v.ge_basis + +v.ge_mod) / 5),
-           ini_max: Math.round((+v.mu_basis + +v.mu_mod + +v.mu_basis + +v.mu_mod + +v.in_basis + +v.in_mod + +v.ge_basis + +v.ge_mod) / 5) + +v.inizugek - +wundeKopf - +wundeBauch - +wundeLB - +wundeRB,
-           atbasis: Math.round(((+v.mu_basis + +v.mu_mod + +v.ge_basis + +v.ge_mod + +v.kk_basis + +v.kk_mod) / 5) - +wundeBauch - +wundeRA - +wundeLA - +wundeRB - +wundeLB),
-           pabasis: Math.round(((+v.in_basis + +v.in_mod + +v.ge_basis + +v.ge_mod + +v.kk_basis + +v.kk_mod) / 5) - +wundeBrust - +wundeBauch - +wundeRA - +wundeLA - +wundeRB - +wundeLB),
-           fkbasis: Math.round(((+v.in_basis + +v.in_mod + +v.ff_basis + +v.ff_mod + +v.kk_basis + +v.kk_mod) / 5) - +wundeBrust - +wundeBauch - +wundeRA - +wundeLA - +wundeRB - +wundeLB)
-        });
+        let update = {
+            'MU': +v.mu_basis + +v.mu_mod - wundeKopf,
+            'KL': +v.kl_basis + +v.kl_mod - wundeKopf,
+            'IN': +v.in_basis + +v.in_mod - wundeKopf,
+            'CH': +v.ch_basis + +v.ch_mod,
+            'FF': +v.ff_basis + +v.ff_mod - wundeRA - wundeLA,
+            'GE': +v.ge_basis + +v.ge_mod - wundeLB - wundeRB,
+            'KO': +v.ko_basis + +v.ko_mod - wundeBrust - wundeBauch,
+            'KK': +v.kk_basis + +v.kk_mod - wundeBrust - wundeBauch - wundeRA - wundeLA,
+            'erschoepfung_basis': +v.ko_basis,
+            'erschoepfung_max': +v.ko_basis + +v.erschoepfung_mod,
+            'wundschwelle': Math.ceil((+v.ko_basis) / 2) + +v.eisern,
+            'aspgrundw': Math.ceil((+v.mu_basis + +v.in_basis + +v.ch_basis) / 2),
+            'asp_max': Math.ceil((+v.mu_basis + +v.in_basis + +v.ch_basis) / 2) + +v.aspzugek,
+            'ausgrundw': Math.ceil((+v.mu_basis + +v.ko_basis + +v.ge_basis) / 2),
+            'aus_max': Math.ceil((+v.mu_basis + +v.ko_basis + +v.ge_basis) / 2) + +v.auszugek,
+            'legrundw': Math.ceil((+v.ko_basis + +v.kk_basis) / 2),
+            'le_max': Math.ceil((+v.ko_basis + +v.kk_basis) / 2) + +v.lezugek,
+            'mrgrundw': Math.round((+v.mu_basis + +v.kl_basis + +v.ko_basis) / 5),
+            'mr_max': Math.round((+v.mu_basis + +v.kl_basis + +v.ko_basis) / 5) + +v.mrzugek,
+            'ueberanstrengung_max': +v.ko_basis,
+            'inibasis': Math.round((+v.mu_basis + +v.mu_basis + +v.in_basis + +v.ge_basis) / 5),
+            'ini_max': Math.round((+v.mu_basis + +v.mu_basis + +v.in_basis + +v.ge_basis) / 5) + +v.inizugek - wundeKopf - wundeBauch - wundeLB - wundeRB,
+            'atbasis': Math.round(((+v.mu_basis + +v.ge_basis + +v.kk_basis) / 5) - wundeBauch - wundeRA - wundeLA - wundeRB - wundeLB),
+            'pabasis': Math.round(((+v.in_basis + +v.ge_basis + +v.kk_basis) / 5) - wundeBrust - wundeBauch - wundeRA - wundeLA - wundeRB - wundeLB),
+            'fkbasis': Math.round(((+v.in_basis + +v.ff_basis + +v.kk_basis) / 5) - wundeBrust - wundeBauch - wundeRA - wundeLA - wundeRB - wundeLB)
+        };
+        let GS = {
+            'Basis': +v.gs_basis,
+            'Mod': +v.gs_mod,
+            'GE-Einfluss': 0,
+            'Wunden': wundeBauch - (wundeRB / 2) - (wundeLB / 2)
+        };
+        if (update['GE'] < 11) {
+            GS['GE-Einfluss'] = -1;
+        } else if (update['GE'] > 15) {
+            GS['GE-Einfluss'] = 1;
+        }
+        update['GS'] = GS['Basis'] + GS['Mod'] + GS['GE-Einfluss'] + GS['Wunden'];
+        setAttrs(update);
     }); 
 });
 

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -15598,4 +15598,5 @@ on("change:kegrundw change:kezugek", function(eventInfo) {
     });
 });
 
-</script> 
+</script>
+

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -6259,66 +6259,71 @@
                 <option value=" ">Offen würfeln</option>
                 <option value="/w GM ">Nur zu Meister würfeln</option>
             </select>
-            <br><b style="display: inline-block; font-size:90%; width: 2.5em">SE</b>
-            <b style="display: inline-block; font-size:90%; width: 23em;">Talent (Offiziell / Eigenes)</b>
-            <b style="display: inline-block; font-size:90%; width: 15.25em;">Eigenschaften</b>
-            <b style="display: inline-block; font-size:90%; width: 3.25em;">TaW</b>
-            <b style="display: inline-block; font-size:90%; width: 3em;">Probe</b>
-            <br>
-            <fieldset class="repeating_MetaTalente">
-                <input type="checkbox" name="attr_SE" style="width: 2em" />
-                <select name="attr_TalentName" class="atype" style="width: 10em;">
-                    <option value="nothing">---</option>
-                    <option value="pirschjagd">Pirschjagd</option>
-                    <option value="ansitzjagd">Ansitzjagd</option>
-                    <option value="hetzjagd">Hetzjagd</option>
-                    <option value="speerfischen">Speerfischen</option>
-                    <option value="tierfallenstellen">Tierfallen aufstellen</option>
-                    <option value="nahrungsammeln">Nahrungsammeln</option>
-                    <option value="kraeutersuchen">Kr&auml;utersuchen</option>
-                    <option value="wachehalten">Wachehalten</option>
-                </select>
-                &nbsp;/&nbsp;
-                <input type="text" name="attr_eigenerMetaname" style="width: 10em;"/>
-                <select name="attr_Eigenschaft1" class="sheet-talent-eigenschaft">
-                    <option value="nothing">---</option>
-                    <option value="mu">MU</option>
-                    <option value="kl">KL</option>
-                    <option value="in">IN</option>
-                    <option value="ch">CH</option>
-                    <option value="ff">FF</option>
-                    <option value="ge">GE</option>
-                    <option value="ko">KO</option>
-                    <option value="kk">KK</option>
-                </select>
-                <select name="attr_Eigenschaft2" class="sheet-talent-eigenschaft">
-                    <option value="nothing">---</option>
-                    <option value="mu">MU</option>
-                    <option value="kl">KL</option>
-                    <option value="in">IN</option>
-                    <option value="ch">CH</option>
-                    <option value="ff">FF</option>
-                    <option value="ge">GE</option>
-                    <option value="ko">KO</option>
-                    <option value="kk">KK</option>
-                </select>
-                <select name="attr_Eigenschaft3" class="sheet-talent-eigenschaft">
-                    <option value="nothing">---</option>
-                    <option value="mu">MU</option>
-                    <option value="kl">KL</option>
-                    <option value="in">IN</option>
-                    <option value="ch">CH</option>
-                    <option value="ff">FF</option>
-                    <option value="ge">GE</option>
-                    <option value="ko">KO</option>
-                    <option value="kk">KK</option>
-                </select>
-                <input type="number" name="attr_TaW" style="width: 3em;" value=0>
-                <input type="hidden" name="attr_hiddenEigenschaft1">
-                <input type="hidden" name="attr_hiddenEigenschaft2">
-                <input type="hidden" name="attr_hiddenEigenschaft3">
-                <input type="hidden" name="attr_realName">
-                <button type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=@{realName}}} {{mod=[[?{Erleichterung (-) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW}]]}} {{stat1=[[@{hiddenEigenschaft1}]]}} {{stat2=[[@{hiddenEigenschaft2}]]}} {{stat3=[[@{hiddenEigenschaft3}]]}} {{Talent=[[ { [[{0d1 + @{TaW} - (?{Erleichterung (-) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft1}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft2}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft3}, 0d1}kh1, 0d1 + @{TaW}}dh1]]}}"></button>
+            <table>
+                <tr>
+                    <th style="width: 23em">Talent</th>
+                    <th style="width: 15.25em;">Eigenschaften</th>
+                    <th style="width: 3.25em;">TaW</th>
+                    <th style="width: 3em;">Probe</th>
+                </tr>
+            </table>
+            <fieldset class="repeating_Metatalente">
+                <span style="display: inline-block; width: 23em">
+                    <select name="attr_Name_Metatalent" class="atype" style="width: 10em;">
+                        <option value="ansitzjagd">Ansitzjagd</option>
+                        <option value="hetzjagd">Hetzjagd</option>
+                        <option value="speerfischen">Speerfischen</option>
+                        <option value="tierfallenstellen">Tierfallenstellen</option>
+                        <option value="nahrungsammeln">Nahrungsammeln</option>
+                        <option value="kraeutersuchen">Kräutersuchen</option>
+                        <option value="wachehalten">Wachehalten</option>
+                        <option value="nothing" selected>Eigenes</option>
+                    </select>
+                     / 
+                    <input type="text" name="attr_Name_Metatalent_Eigen" style="width: 10em;"/>
+                </span><span style="display: inline-block; width: 15.25em">
+                    <select name="attr_Eigenschaft1" class="sheet-talent-eigenschaft">
+                        <option value="nothing">---</option>
+                        <option value="mu">MU</option>
+                        <option value="kl">KL</option>
+                        <option value="in">IN</option>
+                        <option value="ch">CH</option>
+                        <option value="ff">FF</option>
+                        <option value="ge">GE</option>
+                        <option value="ko">KO</option>
+                        <option value="kk">KK</option>
+                    </select>
+                    <select name="attr_Eigenschaft2" class="sheet-talent-eigenschaft">
+                        <option value="nothing">---</option>
+                        <option value="mu">MU</option>
+                        <option value="kl">KL</option>
+                        <option value="in">IN</option>
+                        <option value="ch">CH</option>
+                        <option value="ff">FF</option>
+                        <option value="ge">GE</option>
+                        <option value="ko">KO</option>
+                        <option value="kk">KK</option>
+                    </select>
+                    <select name="attr_Eigenschaft3" class="sheet-talent-eigenschaft">
+                        <option value="nothing">---</option>
+                        <option value="mu">MU</option>
+                        <option value="kl">KL</option>
+                        <option value="in">IN</option>
+                        <option value="ch">CH</option>
+                        <option value="ff">FF</option>
+                        <option value="ge">GE</option>
+                        <option value="ko">KO</option>
+                        <option value="kk">KK</option>
+                    </select>
+                </span><span style="display: inline-block; width: 3.25em">
+                    <input type="number" name="attr_TaW" style="width: 3em;" value=0>
+                    <input type="hidden" name="attr_hiddenEigenschaft1">
+                    <input type="hidden" name="attr_hiddenEigenschaft2">
+                    <input type="hidden" name="attr_hiddenEigenschaft3">
+                    <input type="hidden" name="attr_Name_Metatalent_Anzeige">
+                </span><span style="display: inline-block; width: 3em">
+                    <button type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=@{Name_Metatalent_Anzeige}}} {{mod=[[?{Erleichterung (-) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW}]]}} {{stat1=[[@{hiddenEigenschaft1}]]}} {{stat2=[[@{hiddenEigenschaft2}]]}} {{stat3=[[@{hiddenEigenschaft3}]]}} {{Talent=[[ { [[{0d1 + @{TaW} - (?{Erleichterung (-) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft1}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft2}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft3}, 0d1}kh1, 0d1 + @{TaW}}dh1]]}}"></button>
+                </span>
             </fieldset>
         </div>
     </div>
@@ -15504,24 +15509,26 @@ on("sheet:opened change:wound_kopf change:wound_ra change:wound_la change:wound_
     }); 
 });
 
-on("change:repeating_metatalente:talentname", function(eventInfo) {
-    getAttrs(["repeating_metatalente_talentname"], function(v) {
-        let talentName = v.repeating_metatalente_talentname; 
+on("change:repeating_metatalente:Name_Metatalent change:repeating_metatalente:Name_Metatalent_Eigen", function(eventInfo) {
+    getAttrs(["repeating_metatalente_Name_Metatalent", "repeating_metatalente_Name_Metatalent_Eigen"], function(v) {
+        let metatalent = v.repeating_metatalente_Name_Metatalent;
+        let metatalentEigen = v.repeating_metatalente_Name_Metatalent_Eigen;
         let metaTalente = {"pirschjagd":"mu/in/ge","ansitzjagd":"mu/in/ge","hetzjagd":"mu/in/ge","speerfischen":"mu/in/ge","tierfallenstellen":"kl/in/ff","nahrungsammeln":"mu/in/ff","kraeutersuchen":"mu/in/ff","wachehalten":"mu/in/ko"};
-        if (talentName != "nothing")  {
+        if (metatalent != "nothing")  {
             setAttrs({
-                'repeating_metatalente_eigenschaft1': metaTalente[talentName].split("/")[0],
-                'repeating_metatalente_eigenschaft2': metaTalente[talentName].split("/")[1],
-                'repeating_metatalente_eigenschaft3': metaTalente[talentName].split("/")[2],
-                'repeating_metatalente_eigenerMetaname': "",
-                'repeating_metatalente_realName': talentName.charAt(0).toUpperCase() + talentName.slice(1)
+                'repeating_metatalente_eigenschaft1': metaTalente[metatalent].split("/")[0],
+                'repeating_metatalente_eigenschaft2': metaTalente[metatalent].split("/")[1],
+                'repeating_metatalente_eigenschaft3': metaTalente[metatalent].split("/")[2],
+                'repeating_metatalente_Name_Metatalent_Anzeige': metatalent.charAt(0).toUpperCase() + metatalent.slice(1)
             });
         } else {
-            setAttrs({
-                'repeating_metatalente_eigenschaft1': "nothing",
-                'repeating_metatalente_eigenschaft2': "nothing",
-                'repeating_metatalente_eigenschaft3': "nothing"
-            });
+            let update = {};
+            if (metatalentEigen != "") {
+                update['repeating_metatalent_Name_Metatalent_Anzeige'] = metatalentEigen;
+            } else {
+                update['repeating_metatalent_Name_Metatalent_Anzeige'] = "Eigenes Metatalent";
+            }
+            setAttrs(update);
         }
     });
 });
@@ -15553,18 +15560,6 @@ on("change:mu change:kl change:in change:ch change:ff change:ge change:ko change
                 });
             });
         });
-    });
-});
-
-on("change:repeating_metatalente:eigenerMetaname", function(eventInfo) {
-    getAttrs(["repeating_metatalente_eigenerMetaname"], function(v) {
-        let talentName = v.repeating_metatalente_eigenerMetaname; 
-        if (talentName != "") {
-            setAttrs({
-                'repeating_metatalente_talentname': "nothing",
-                'repeating_metatalente_realName': talentName.charAt(0).toUpperCase() + talentName.slice(1)
-            });
-        }
     });
 });
 

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -6317,11 +6317,11 @@
                         <option value="kk">KK</option>
                     </select>
                 </span><span style="display: inline-block; width: 3.25em">
-                    <input type="number" name="attr_TaW" style="width: 3em;" value=0>
-                    <input type="hidden" name="attr_hiddenEigenschaft1">
-                    <input type="hidden" name="attr_hiddenEigenschaft2">
-                    <input type="hidden" name="attr_hiddenEigenschaft3">
-                    <input type="hidden" name="attr_Name_Metatalent_Anzeige">
+                    <input type="number" name="attr_TaW" style="width: 3em;" value="0">
+                    <input type="hidden" name="attr_hiddenEigenschaft1" value="0">
+                    <input type="hidden" name="attr_hiddenEigenschaft2" value="0">
+                    <input type="hidden" name="attr_hiddenEigenschaft3" value="0">
+                    <input type="hidden" name="attr_Name_Metatalent_Anzeige" value="Eigenes Metatalent">
                 </span><span style="display: inline-block; width: 3em">
                     <button type="roll" value="@{gm_roll_opt} &{template:DSA-Talente} {{name=@{Name_Metatalent_Anzeige}}} {{mod=[[?{Erleichterung (-) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{TaW}]]}} {{stat1=[[@{hiddenEigenschaft1}]]}} {{stat2=[[@{hiddenEigenschaft2}]]}} {{stat3=[[@{hiddenEigenschaft3}]]}} {{Talent=[[ { [[{0d1 + @{TaW} - (?{Erleichterung (-) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft1}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft2}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (-) oder Erschwernis (+)|0}) - @{TaW}, 0d1}kh1]] - @{hiddenEigenschaft3}, 0d1}kh1, 0d1 + @{TaW}}dh1]]}}"></button>
                 </span>

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -15857,6 +15857,7 @@ function migrate20171014to20190425 () {
                     "Zwergennase": "zwergennase",
                 };
                 let gaben = {
+                    "nothing": [ ["---", "---", "---"], "nothing" ],
                     "empathie": [ ["mu", "in", "in"], "Empathie" ],
                     "gefahreninstinkt": [ ["kl", "in", "in"], "Gefahreninstinkt" ],
                     "geraeuschhexerei": [ ["in", "ch", "ko"], "Geräuschhexerei" ],
@@ -15878,6 +15879,7 @@ function migrate20171014to20190425 () {
                             "mu", "kl", "in", "ch", "ff", "ge", "ko", "kk"
                         ], function(v) {
                             console.log(v);
+                            let defaultTaW = 3;
                             let update = {};
                             let newrow = generateRowID();
                             let current = Object.keys(v)[0].split("_")[2];
@@ -15911,7 +15913,11 @@ function migrate20171014to20190425 () {
                             update[prefixNew + "_hiddenEigenschaft1"] = v[conversion[v[prefixOld + "_Eigenschaft1"]]];
                             update[prefixNew + "_hiddenEigenschaft2"] = v[conversion[v[prefixOld + "_Eigenschaft2"]]];
                             update[prefixNew + "_hiddenEigenschaft3"] = v[conversion[v[prefixOld + "_Eigenschaft3"]]];
-                            update[prefixNew + "_TaW"] = parseInt(v[prefixOld + "_TaW"]);
+                            if(v[prefixOld + "_TaW"] === "") {
+                                update[prefixNew + "_TaW"] = defaultTaW;
+                            } else {
+                                update[prefixNew + "_TaW"] = parseInt(v[prefixOld + "_TaW"]);
+                            }
                             console.log(update);
 
                             // Create new row
@@ -15969,6 +15975,7 @@ function migrate20171014to20190425 () {
                             "mu", "kl", "in", "ch", "ff", "ge", "ko", "kk"
                         ], function(v) {
                             console.log(v);
+                            let defaultTaW = 0;
                             let update = {};
                             let newrow = generateRowID();
                             let current = Object.keys(v)[0].split("_")[2];
@@ -16002,7 +16009,11 @@ function migrate20171014to20190425 () {
                             update[prefixNew + "_hiddenEigenschaft1"] = v[conversion[v[prefixOld + "_Eigenschaft1"]]];
                             update[prefixNew + "_hiddenEigenschaft2"] = v[conversion[v[prefixOld + "_Eigenschaft2"]]];
                             update[prefixNew + "_hiddenEigenschaft3"] = v[conversion[v[prefixOld + "_Eigenschaft3"]]];
-                            update[prefixNew + "_TaW"] = parseInt(v[prefixOld + "_TaW"]);
+                            if(v[prefixOld + "_TaW"] === "") {
+                                update[prefixNew + "_TaW"] = defaultTaW;
+                            } else {
+                                update[prefixNew + "_TaW"] = parseInt(v[prefixOld + "_TaW"]);
+                            }
                             console.log(update);
 
                             // Create new row

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -15485,7 +15485,7 @@ on("sheet:opened change:wound_kopf change:wound_ra change:wound_la change:wound_
            gs: +v.gs_basis + +v.gs_mod + Math.floor(((+v.ge_basis + +v.ge_mod + 100) / 111) - 1) + Math.ceil(((+v.ge_basis + +v.ge_mod + 100)/115) - 1) - +wundeBauch - (+wundeRB / 2 - +wundeLB / 2),
            erschoepfung_basis: +v.ko_basis,
            erschoepfung_max: +v.ko_basis + +v.erschoepfung_mod,
-           wundschwelle: Math.ceil(+v.ko_basis + +v.eisern),
+           wundschwelle: Math.ceil(((+v.ko_basis) / 2)) + +v.eisern,
            aspgrundw: Math.round((+v.mu_basis + +v.in_basis + +v.ch_basis) / 2 + 0.05),
            asp_max: Math.round((+v.mu_basis + +v.in_basis + +v.ch_basis) / 2 + 0.05) + +v.aspzugek,
            ausgrundw: Math.round((+v.mu_basis + +v.ko_basis + +v.ge_basis) / 2 + 0.05),

--- a/Das_Schwarze_Auge_4-1/formulas.md
+++ b/Das_Schwarze_Auge_4-1/formulas.md
@@ -20,37 +20,14 @@ The stat value (`@{MU}`) is increased (easy) or decreased (difficult) by the mod
 
 Therefore, the first part is grouped with the roll `@{MU} + 0d1` and the highest value of both is dropped. In the above example, 14 would be higher than 12 and dropped, so that the result would be 12. When the check result is less than the stat value, the second part would be higher and dropped. The same is true for negative results (failures). Automatic successes (1) and failures (20) are handled by the roll template. Since stat values of 20 and higher are possible (and negative modifiers as well), the roll template currently does not show the resulting points in the case of automatic failures. The reasoning behind this is that the result would be non-negative, suggest success to the player and might confuse newbies. It should be noted that automatic success/failures in stat checks are an optional rule according to WdS, p. 7.
 
-## Speed (Geschwindigkeit/GS)
-`(@{GS_Basis} + @{GS_Mod} + (floor((@{GE_Basis} + @{GE_Mod} + 100)/111)-1) + (ceil((@{GE_Basis} + @{GE_Mod} + 100)/115)-1) - @{wound_Bauch} - (@{wound_RB}/2 - @{wound_LB}/2))`
-
-The GS stat is 8 by default and modified by certain advantages/disadvantages (which are not currently respected) and certain wounds. Additionally, the agility stat (GE) influences the speed: GE less than 11 reduces the GS by one, GE greater than 15 increases the GS by one. The above formula contains some magic values to accomplish the correct behaviour.
-
-`floor((@{GE_Basis} + @{GE_Mod} + 100)/111)-1`
-
-`@{GE_Basis}` and `@{GE_Mod}` represent the current agility without wound effects. The trick to get this term to be -1 for GE less than 11 lies within floor(). floor() always rounds down. So, 0.999 gets rounded to 0. GE less than 11 also means GE less than or equal to 10 and with GE = 10, the fraction `110/111` will be rounded down to 0. The `-1` after the `floor(...)` makes the whole term become -1.
-
-`ceil((@{GE_Basis} + @{GE_Mod} + 100)/115)-1`
-
-Same situation as before, but this time using ceil() to always round up. Until GE = 15, the `ceil(...)` is 1 and the `-1` afterwards reduces it to zero cancelling out any effect. Starting with GE = 16, the `ceil(...)` is 2 and the whole term +1.
-
 ## Life Energy (Lebensenergie/LE), Stamina (Ausdauer/AU) and Astral Energy (Astralenergie/AE)
-LE: `round(@{KO_Basis} + (@{KK_Basis}/2) + 0.05)`
-
-AU: `round((@{MU_Basis} + @{KO_Basis} + @{GE_Basis})/2 + 0.05)`
-
-AE: `round((@{MU_Basis} + @{IN_Basis} + @{CH_Basis})/2 + 0.05)`
-
-These formulas are quite straightforward implementations of the official rules with one small change: Prior to rounding, 0.05 is added as a safeguard to ensure that .5 is correctly rounded up by making it 0.55. Not sure, if this is really necessary.
-
 It is important to note that the base values of the stats are used here (`_Basis`). This prevents these base values to change upon temporary effects such as wounds, spells or disease. A side effect of this is that the "Mod" column on the "Grundwerte" tab must not be mistaken for the "Mod" column on the official PDF character sheet which takes boni/mali from the character generation. In its current form, this character sheet assumes that the value entered under `Basis` is the value of the current stat with all permanent modifications already factored in.
 
 ## Magic Resistance (Magieresistenz/MR)
-`round((@{MU_Basis} + @{MU_Mod} + @{KL_Basis} + @{KL_Mod} + @{KO_Basis} + @{KO_Mod})/5)`
-
-Since stats are positive integers and are divided by 5, the first decimal place always is an even number (.0, .2, .4, .6 or .8). Therefore, no safeguard is needed. Temporary modifiers without wounds are applied. No source is yet known for this behaviour and therefore, this will likely change in a future release.
+No temporary stat modifiers or wounds are applied.
 
 ## Initiative/Attack/Parry/Long Range Base Values (INI/AT/PA/FK-Basiswert)
-Analog to Magic Resistance, but wound effects are honoured for Attack/Parry/Long Range base values. No source is yet known for the application of temporary modifiers and therefore, this will likely change in a future release.
+Wound effects are honoured for Attack/Parry/Long Range base values. No temporary stat modifiers are applied.
 
 ## 3d20 Checks
 Four cases have to be distinguished in order to determine the result of a roll:

--- a/Das_Schwarze_Auge_4-1/sheet.json
+++ b/Das_Schwarze_Auge_4-1/sheet.json
@@ -1,7 +1,7 @@
 {
 	"html": "dsa4_1_character_sheet_roll20.html",
 	"css": "dsa4_1_character_sheet_roll20.css",
-	"authors": "Gereon Heinemann, Patrick Gebhardt (gebhardthbs@web.de), Kai, Steven 'Kreuvf' Koenig (webmaster@kreuvf.de)",
+	"authors": "Gereon Heinemann, Patrick Gebhardt (gebhardthbs@web.de), Kai, Steven 'Kreuvf' Koenig (webmaster@kreuvf.de), apehead",
 	"roll20userid": "584207,592673,879287,1411023 ",
 	"preview": "dsa4_1_character_sheet_roll20.png",
 	"instructions": "Charakterbogen für das &quot;Das Schwarze Auge&quot;-Regelwerk 4.1"


### PR DESCRIPTION
This PR marks the beginning of the conversion to sheet worker scripts. Basic stats and derived stats are now calculated via sheet worker scripts. Also, meta-talents received an overhaul. For other minor things, see below.

* **New features**
  * Fill in meta-talent and gift stats automatically (034c130)
  * Meta-talents, gifts, stats and derived stats use sheet worker scripts now (034c130, 68cd766, 64c1892, 046c050, b999a5c, 41cadf5, 26f8cc8, 0e50f75, f547692, 6f7f087, a4f8423)
  * Support for custom gifts (d91ff2d)
  * Version number for sheet data to be able to distinguish between the current character sheet version and the data version (969f110)
  * Migration of old gifts data (557a5e1, 8928533, de389c0) and old meta-talents data (97ab820, de389c0)
  * Tab for accessing old data manually (034c130, 6822821)
* **Style**
  * Make pseudo-columns of meta-talents align properly (b999a5c)
  * Sort meta-talents alphabetically ("Custom" is last, though) (41cadf5)
* **Fixes**
  * Temporary modifiers of stats do no longer affect magic resistance, initiative, attack/parry/long range base values (0e50f75)
  * Give correct cost column for two-hand swords/sabres (156c98a)
  * Improve HTML validity a bit (6a23fd9)
* **Removed attributes**
  * Duplicates of stats `MU2`, `KL2`, `IN2`, `CH2`, `FF2`, `GE2`, `KO2`, `KK2` were unused and had the same value as the corresponding attributes `MU`, `KL`, `IN`, `CH`, `FF`, `GE`, `KO`, `KK`; no side-effects expected (68cd766)
  * `INI_max` was removed for several reasons (c824268)
    * Quirks due to not being the `|max` value of (the non-existant) `INI` attribute
    * Misleading naming

### Thanks
I would not have done that if not for the basic work from ap3h3ad. Thank you very much.
