### PR TITLE
Exalted 3rd edition Bug Fix for Evasion Specialization Field

### DIFF
--- a/Exalted 3/Ex3-Sheet.html
+++ b/Exalted 3/Ex3-Sheet.html
@@ -2148,7 +2148,7 @@ TAS=TAS||function(){"use strict";var e="0.2.4",n=1457098091,t={debug:{key:"debug
                             <input type="hidden" value="(@{dexterity} + @{dodge})" disabled="disabled" name="attr_evasion-root">
                             <input type="hidden" value="(@{evasion-root} + 1)" disabled="disabled" name="attr_evasion-root-s">
                             <input type="hidden" value="(ceil(@{evasion-root} / 2) - abs(@{armor-mobility}) - abs(@{wound-penalty}))" disabled="disabled" name="attr_evasion-base">
-                            <input type="hidden" value="(ceil(@{evasion-root-s} / 2) - abs(@{armor-mobility}) - abc(@{wound-penalty}))" disabled="disabled" name="attr_evasion-base-s">
+                            <input type="hidden" value="(ceil(@{evasion-root-s} / 2) - abs(@{armor-mobility}) - abs(@{wound-penalty}))" disabled="disabled" name="attr_evasion-base-s">
                             <input type="number" value="(@{evasion-base} + abs(@{evasion-base})) / 2" disabled="disabled" style="width:27px;margin-right:2px" data-i18n-title="evasion-without-specialty" title="Evasion without specialty" name="attr_evasion"><input type="number" value="(@{evasion-base-s} + abs(@{evasion-base-s})) / 2" disabled="disabled" style="width:27px" data-i18n-title="evasion-with-specialty" title="Evasion with specialty" name="attr_evasion-specialty">
                         </div>
                         <div class="sheet-table-cell sheet-text-right"><span data-i18n="resolve">Resolve</span>:</div>


### PR DESCRIPTION
Field would calculate the would penalty wrong (Would add the wound penalty instead of subtract it)
Bug caused by incorrect function call in math ('abc' instead of 'abs')

## Changes / Comments

- Is this a bug fix? [Yes]
- Does this add functional enhancements (new features or extending existing features) ? [No]
- Does this add or change functional aesthetics (such as layout or color scheme) ? [No]
- Are you intentionally changing more that one sheet? If so, which ones ? [No]
- If changing or removing attributes, what steps have you taken, if any, to preserve player data ? [No attributes changed or removed]
- If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ? [ Sheet is existing]

## Roll20 Requests

*Include the name of the sheet(s) you made changes to in the title.*

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- Is this a bug fix?
- Does this add functional enhancements (new features or extending existing features) ?
- Does this add or change functional aesthetics (such as layout or color scheme) ? 
- Are you intentionally changing more that one sheet? If so, which ones ?
- If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
