### PR TITLE
D&D5e- UC-471 - fix sleight of hand bug

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -7553,7 +7553,7 @@
                 const array = (page.data[`${attr}`]) ? page.data[`${attr}`].split(", ") : [];
                 _.each(array, (entry) => {
                     const kv        = (entry.indexOf("-") > -1) ? entry.split(" ") : entry.split(" +");
-                    const attribute = (attr === "Saving Throws") ? kv[0].toLowerCase() + "_save" : kv[0].toLowerCase().replace(" ", '_');
+                    const attribute = (attr === "Saving Throws") ? kv[0].toLowerCase() + "_save" : kv[0].toLowerCase().split(' ').join('_');
                     update[`npc_${attribute}_base`] = parseInt(kv[1], 10);
                 });
                 (attr === "Saving Throws") ? callbacks.push(() => {update_npc_saves();} ) : callbacks.push(() => {update_npc_skills();} );


### PR DESCRIPTION
## Changes / Comments


* .replace wasn't replacing all of the spaces. Using a split & join instead.



## Roll20 Requests

*Include the name of the sheet(s) you made changes to in the title.*

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- Is this a bug fix?
- Does this add functional enhancements (new features or extending existing features) ?
- Does this add or change functional aesthetics (such as layout or color scheme) ? 
- Are you intentionally changing more that one sheet? If so, which ones ?
- If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
