### PR TITLE
[Call of Cthulhu 7th Ed] Adding ''NPC Sheet'' and minor additions.

### DIFF
--- a/Call_of_Cthulhu_7th_Ed/coc_7th_ed.css
+++ b/Call_of_Cthulhu_7th_Ed/coc_7th_ed.css
@@ -38,7 +38,7 @@ div[class="repcontainer editmode"] ~ div[class^="repcontrol"] button[class="btn 
 .charsheet .repcontrol_edit,
 .charsheet .repcontrol_del {
     display: block;
-    background: #000;
+    background: #7c746a;
     color: white;
     box-shadow:none;
     font-size:0.7em;

--- a/Call_of_Cthulhu_7th_Ed/coc_7th_ed.css
+++ b/Call_of_Cthulhu_7th_Ed/coc_7th_ed.css
@@ -2,6 +2,7 @@
     background-color: #888888;
     border: 2px solid black;
     color:black;
+    width: 840px;
 }
 
 .dummy{
@@ -31,6 +32,26 @@ div[class^="repcontrol"] {
 div[class="repcontainer editmode"] ~ div[class^="repcontrol"] button[class="btn repcontrol_add"] {
   display: inline-block!important;
   visibility: hidden;
+}
+
+.charsheet .repcontrol_add,
+.charsheet .repcontrol_edit,
+.charsheet .repcontrol_del {
+    display: block;
+    background: #000;
+    color: white;
+    box-shadow:none;
+    font-size:0.7em;
+    height:2.2em;
+}
+
+/* -------------------------------------------------------------------------- */
+
+input.sheet-hide:checked ~ div.sheet-2colrow,
+input.sheet-hide:checked ~ div.sheet-3colrow,
+input.sheet-hide:checked ~ div.sheet-section,
+input.sheet-hide:checked ~ h4.sheet-section-head {
+    display: none;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/Call_of_Cthulhu_7th_Ed/coc_7th_ed.html
+++ b/Call_of_Cthulhu_7th_Ed/coc_7th_ed.html
@@ -3,7 +3,7 @@
     <input class="sheet-HideConfig" type="checkbox" checked name="attr_is_config"/><span class="sheet-is-config"><span style='font-family:"Pictos";'>y</span></span>
     <div class="sheet-config" style="text-align:left">
         <div style="text-align:left"><b>Era Selection</b></div>
-	    <input type="checkbox" style="display:none" lass="sheet-showskills" name="attr_showskills" value="7"><span style="display:none">Invictuss</span>
+	    <input type="checkbox" style="display:none" lass="sheet-showskills" name="attr_showskills" value="7"><span style="display:none">Invictus</span>
 	    <input type="checkbox" style="display:none" lass="sheet-showskills" name="attr_showskills" value="1"><span style="display:none">Dark Ages</span>
 	    <input type="checkbox" style="display:none" class="sheet-showskills" name="attr_showskills" value="5"><span style="display:none">Old West</span>
 	    <input type="checkbox" style="display:none" class="sheet-showskills" name="attr_showskills" value="2" checked="checked"><span style="display:none">1920's</span>

--- a/Call_of_Cthulhu_7th_Ed/coc_7th_ed.html
+++ b/Call_of_Cthulhu_7th_Ed/coc_7th_ed.html
@@ -34,11 +34,15 @@
 	    <div>
 	        <input type="checkbox" class="sheet-toggledr" name="attr_toggledr" value="1">Common Dice Rolls
 	        <input type="checkbox" class="sheet-togglearmor" name="attr_togglearmor" value="1">Armor
-	        <input type="checkbox" class="sheet-togglecompanions" name="attr_togglecompanions" value="1">Companions & Mounts
+	    </div>
+	    <div>
+	        <input type="checkbox" class="sheet-togglecompanions" name="attr_togglecompanions" value="1">NPCs(Companions,Mounts,etc)
+	        <input type="checkbox" class="sheet-hide" name="attr_sheet-hide">Hide Sheet
 	    </div>
     </div>
 </div>
 
+<input type="checkbox" style="display:none" class="sheet-hide" name="attr_sheet-hide">
 <!------------------------- Char Info and Characteristics ------------------------->
 <div class='sheet-2colrow'>
     <div class='sheet-col'>
@@ -3733,7 +3737,9 @@
     <input type="checkbox" style="display:none" class="sheet-showskills" name="attr_showskills" value="3">
     <input type="checkbox" style="display:none" class="sheet-showskills" name="attr_showskills" value="6">
     <input type="checkbox" style="display:none" class="sheet-showskills" name="attr_showskills" value="4">
+    <input type="checkbox" style="display:none" class="sheet-hide" name="attr_sheet-hide">
     <h4 class="section-head" data-i18n="combat-u">Combat</h4>
+    <input type="checkbox" style="display:none" class="sheet-hide" name="attr_sheet-hide">
     <div class="section">
 
 <!------------------------- Invictus Combat ------------------------->
@@ -4688,7 +4694,7 @@
     </div>
 </div>
 
-<!------------------------- Companions ------------------------->
+<!------------------------- Companions (NPCs)------------------------->
 <div class='sheet-colrow'>
     <input type="checkbox" class="sheet-togglecompanions" style="display:none" name="attr_togglecompanions" value="1">
     <div class="sheet-companions">
@@ -4700,7 +4706,7 @@
         <input type="checkbox" style="display:none" class="sheet-showskills" name="attr_showskills" value="3">
         <input type="checkbox" style="display:none" class="sheet-showskills" name="attr_showskills" value="6">
         <input type="checkbox" style="display:none" class="sheet-showskills" name="attr_showskills" value="4">
-    <h4 class="section-head" data-i18n="companions&mounts-u">Companions & Mounts</h4>
+    <h4 class="section-head" data-i18n="companions&mounts-u">NPCs</h4>
 		<div class="sheet-section">
 		    <fieldset class="repeating_minion">
 		        <div class="sheet-row">

--- a/Call_of_Cthulhu_7th_Ed/sheet.json
+++ b/Call_of_Cthulhu_7th_Ed/sheet.json
@@ -4,36 +4,22 @@
 	"authors": "Aqua Alex, Matthew Carpenter, Roric, Orp",
 	"roll20userid": "1048758, 103705, 1466905, 2559057",
 	"preview": "coc_7th_ed.png",
-	"instructions": "You may note the absence of hard and extreme values.  These have been moved into the roll button itself.  When you use the roll button you will see, in the chat log, a roll \"vs standard value/hard value/extreme value.\"  Compare the appropriate threshold to your result to determine success.  For weapon skill select one of the listed skills to base your weapon skill check on.  You may select up to the tenth custom skill as the base skill.  For weapon damages you may specify a \"+0\", \"+1/2db\" or \"+db.\"  Use this to include your damage bonus in the damage roll or not.\n\n In support of Pulp Cthulhu a checkbox in the Hit Points section allows for the Pulp Cthulhu rules variant of doubling hit points. \n\n Aqua Alex: (1)removed the need for the js file and created a Workerscript to enable autocalculation of Damage Bonus and Build even for people without a Pro account.\n (2) added calculation of move\n (3) BONUS/PENALTY Dice rolls - Grey Button is for current Roll template (it rolls normal, 1 bonus, 2 bonus, 1 penalty, 2 penalty dice and shows all results), Green button is for new smaller (only normal roll) template.",
+	"instructions": "You may note the absence of hard and extreme values.  These have been moved into the roll button itself.  When you use the roll button you will see, in the chat log, a roll \"vs standard value/hard value/extreme value.\"  Compare the appropriate threshold to your result to determine success.  For weapon skill select one of the listed skills to base your weapon skill check on.  You may select up to the tenth custom skill as the base skill.  For weapon damages you may specify a \"+0\", \"+1/2db\" or \"+db.\"  Use this to include your damage bonus in the damage roll or not.\n\n Aqua Alex: \n (1)removed the need for the js file and created a Workerscript to enable autocalculation of Damage Bonus and Build even for people without a Pro account.\n (2) added calculation of move\n (3) BONUS/PENALTY Dice rolls - Purple-Grey Button is for current Roll template (it rolls normal, 1 bonus, 2 bonus, 1 penalty, 2 penalty dice and shows all results), Green button is for new smaller (only normal roll) template. \n\n The in-game option \"NPCs\" enables a section where player companions or Keeper NPCs can be recorded. \n\n The in-game option to \"Hide Sheet\", when enabled, hides all Major Sheet Sections, apart from Common Dice Rolls, Talents, and NPCs, in order to simulate a clean NPC sheet for Keeper's use.",
 	"useroptions": [
-		{
-			"attribute": "showskills",
-			"displayname": "Dark Ages ",
-			"type": "checkbox",
-			"value": "1",
-			"description": "Cthulhu Dark Ages Character Sheet (Skill and Bouts of Madness Changes Unfinished)"
-		},
-		{
-			"attribute": "showskills",
-			"displayname": "Classic 1920's",
-			"type": "checkbox",
-			"value": "2",
-			"description": "Call of Cthulhu Character Sheet for the 1920's",
-			"checked": "checked"
-		},
-		{
-			"attribute": "showskills",
-			"displayname": "Modern Era ",
-			"type": "checkbox",
-			"value": "3",
-			"description": "Cthulhu Now Character Sheet (Skill Changes Unfinished)"
-		},
-		{
-			"attribute": "showskills",
-			"displayname": "End Times ",
-			"type": "checkbox",
-			"value": "4",
-			"description": "Cthulhu End Times Character Sheet (Skill Changes Unfinished)"
+		{  
+			"attribute":"showskills",
+			"displayname":"Era",
+			"type":"select",
+			"options":[  
+				"Invictus|7",
+				"Dark Ages|1",
+				"Down Darker Trails|5",
+				"1920s|2"
+				"Modern|3"
+				"Icarus|6"
+				"End Times|4"
+			],
+			"default":"1920s"
 		},
 		{
 			"attribute": "showpulp",

--- a/Call_of_Cthulhu_7th_Ed/translation.json
+++ b/Call_of_Cthulhu_7th_Ed/translation.json
@@ -239,7 +239,7 @@
 	"Other Skill #8": "Other Skill #8",
 	"Other Skill #9": "Other Skill #9",
 	"Other Skill #10": "Other Skill #10",
-	"companions&mounts-u": "Companions & Mounts",
+	"companions&mounts-u": "NPCs",
 	"san-u": "SAN",
 	"HP-z": "HP",
 	"armor-z": "Armor",


### PR DESCRIPTION
## Changes / Comments
• Changed Companions and Mounts to NPCs.
• Added Option to Hide all Major Sheet Sections, apart from Companions, Common Dice Rolls and Talents. (This comes in handy when running a game and want an ''NPC'' sheet.).
• Changed Add/Edit/Del Buttons appearance.
• Set Sheet Width to 840px.
• Changed sheet.json format to display Default Sheet options in Select style, and added minor info about the sheet.


## Roll20 Requests

*Include the name of the sheet(s) you made changes to in the title.*

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- Is this a bug fix?
- Does this add functional enhancements (new features or extending existing features) ?
- Does this add or change functional aesthetics (such as layout or color scheme) ? 
- Are you intentionally changing more that one sheet? If so, which ones ?
- If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
