### PR TITLE
D&D 5e - uc-533 - fix cantrip display

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -8779,7 +8779,7 @@
 
                 //used in _atkdmgtype display
                 const dmgmag = (isNaN(atkmag) === false && atkmag != 0 && ((v[`${repeating_attack}_dmgflag`] && v[`${repeating_attack}_dmgflag`] != 0) || (v[`${repeating_attack}_dmg2flag`] && v[`${repeating_attack}_dmg2flag`] != 0))) ? `+ ${atkmag} Magic Bonus` : "";
-                
+
                //ATTACK checkbox inside settings for the repeating attack
                 const atkflag = v[`${repeating_attack}_atkflag`] || 0;
                 if (atkflag != 0) {
@@ -8821,12 +8821,13 @@
                 if (dmgflag1 != 0) {
                     if (spellattack === true && dmgbase.indexOf("[[round((@{level} + 1) / 6 + 0.5)]]") > -1) {
                         // SPECIAL CANTRIP DAMAGE
-                        dmgdiestring = Math.round(((parseInt(v["level"], 10) + 1) / 6) + 0.5).toString()
+                        dmgdiestring = Math.round(((parseInt(v["level"], 10) + 1) / 6) + 0.5).toString();
                         dmg = dmgdiestring + dmgbase.substring(dmgbase.lastIndexOf("d"));
+                        //select & input to the right of damage
                         if (dmgattr + dmgmod != 0) {
-                            dmg = dmg + "+" + (dmgattr + dmgmod);
+                            dmg += `+${(dmgattr + dmgmod)}`;
                         }
-                        dmg += dmg + " " + dmgtype;
+                        dmg += ` ${dmgtype}`;
                     } else {
                         if (dmgbase === 0 && (dmgattr + dmgmod === 0)) {
                             dmg = 0;
@@ -8859,6 +8860,7 @@
                     dmg2 = dmg2 + " " + dmg2type;
                 };
                 update[`${repeating_attack}_atkdmgtype`] = (dmgflag1 != 0 && dmgflag2 != 0) ? `${dmg} + ${dmg2}${dmgmag} `:`${dmg}${dmg2}${dmgmag} `;
+                console.log(`%c atk dmg type: ${update[`${repeating_attack}_atkdmgtype`]}`, "color:green;font-size:16px;");
 
                 //Build ROLL TEMPLATE with below variables
                 //ATTACK checkbox inside settings for the repeating attack

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -8860,7 +8860,6 @@
                     dmg2 = dmg2 + " " + dmg2type;
                 };
                 update[`${repeating_attack}_atkdmgtype`] = (dmgflag1 != 0 && dmgflag2 != 0) ? `${dmg} + ${dmg2}${dmgmag} `:`${dmg}${dmg2}${dmgmag} `;
-                console.log(`%c atk dmg type: ${update[`${repeating_attack}_atkdmgtype`]}`, "color:green;font-size:16px;");
 
                 //Build ROLL TEMPLATE with below variables
                 //ATTACK checkbox inside settings for the repeating attack


### PR DESCRIPTION
## Changes / Comments


### Bug fix
* Cantrips had the wrong display


## Roll20 Requests

*Include the name of the sheet(s) you made changes to in the title.*

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- Is this a bug fix?
- Does this add functional enhancements (new features or extending existing features) ?
- Does this add or change functional aesthetics (such as layout or color scheme) ? 
- Are you intentionally changing more that one sheet? If so, which ones ?
- If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
