### PR TITLE
D&D3.5 Roll Template Bug Fix

### DIFF
--- a/D&D_3-5/charsheet_3-5.css
+++ b/D&D_3-5/charsheet_3-5.css
@@ -757,7 +757,7 @@ input, select {
 	text-align: left;
 }
  .sheet-rolltemplate-DnD35StdRoll th {
-    /*color: rgb(45, 126, 107);         /* teal color */
+    /*color: rgb(45, 126, 107); */        /* teal color */
 	padding-left: 5px;
 	line-height: 1.6em;          /* a little extra vertical spacing of the lines in the header to help the name/title stand out. */
 	font-size: 1.2em;            /* the name is slightly larger than the rest */
@@ -912,7 +912,7 @@ font-style: italic;
  .sheet-rolltemplate-DnD35Initiative th {
 	color: rgb(204, 153, 51);         /* golden color */
 	padding-left: 5px;
-	/*line-height: 1.6em;          /* a little extra vertical spacing of the lines in the header to help the name/title stand out. */
+	/*line-height: 1.6em; */      /* a little extra vertical spacing of the lines in the header to help the name/title stand out. */
 	font-size: 1.2em;            /* the name is slightly larger than the rest */
 	text-align: left;
 	font-family: "Arial", Helvetica, sans-serif;


### PR DESCRIPTION
Re-add closing comment tags to fix the CSS files so the StdRoll and Initiative roll templates work again.
(was broken with the encoding/line ending fix.)

## Changes / Comments

Note: Was edited within the GitHub web file edit utility to try and prevent changing any of the encoding fixes.  It looks like that added a newline to the end of the file; don't know if that is a bad thing or not and I have no idea how to fix it if it is.

## Roll20 Requests

*Include the name of the sheet(s) you made changes to in the title.*

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- Is this a bug fix?
- Does this add functional enhancements (new features or extending existing features) ?
- Does this add or change functional aesthetics (such as layout or color scheme) ? 
- Are you intentionally changing more that one sheet? If so, which ones ?
- If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
