### PR TITLE
 [SIFRP] Fixed rolls from new sheet.

### DIFF
--- a/A Song of Ice and Fire/SIFRPNew.html
+++ b/A Song of Ice and Fire/SIFRPNew.html
@@ -95,10 +95,10 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_will-roll'
-                                    value='&{template:sofai} {{input= @{character_name} rolls [[ ( [[ ?{Dice|1} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh?{Dice}sd + ?{Modifier|0} ]]}}'><label
+                                    value='&{template:sofai} {{input= @{character_name} rolls [[ ( [[ ?{Dice|1} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + ?{Penalty Dice|0} ]] ) + ?{Modifier|0} ]] }}'><label
                                         style="vertical-align: middle;">Custom Roll</label></button>
                             </div>
-                        </div>
+						</div>
                     </div>
                     <div class="sheet-col sheet-Custom">
                             <div style="height: 50px !important;">
@@ -162,7 +162,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_agility-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Agility!** \n\n [[ ( [[ @{agility} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh@{agility}sd - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Agility!** \n\n [[ ( [[ @{agility} + ?{Bonus Dice|0}]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Agility</label></button>
                             </div>
                         </div>
@@ -181,7 +181,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_agilityAcrobatics"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Agility (Acrobatics)!** \n\n [[ ( [[ @{agility} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{agilityAcrobatics}]] )d6kh@{agility}sd - @{injuries} - @{fatigue} ]] }}">Acrobatics</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Agility (Acrobatics)!** \n\n [[ ( [[ @{agility} + @{agilityAcrobatics} + ?{Bonus Dice|0} ]] )d6dl( [[ @{agilityAcrobatics} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Acrobatics</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -190,7 +190,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_agilityBalance"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Agility (Balance)!** \n\n [[ ( [[ @{agility} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{agilityBalance}]] )d6kh@{agility}sd - @{injuries} - @{fatigue} ]] }}">Balance</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Agility (Balance)!** \n\n [[ ( [[ @{agility} + @{agilityBalance} + ?{Bonus Dice|0} ]] )d6dl( [[ @{agilityBalance} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] }}">Balance</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -199,7 +199,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_agilityContortions"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Agility (Contortions)!** \n\n [[ ( [[ @{agility} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{agilityContortions}]] )d6kh@{agility}sd - @{injuries} - @{fatigue} ]] }}">Contortions</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Agility (Contortions)!** \n\n [[ ( [[ @{agility} + @{agilityContortions} + ?{Bonus Dice|0} ]] )d6dl( [[ @{agilityContortions} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Contortions</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -208,7 +208,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_agilityDodge"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Agility (Dodge)!** \n\n [[ ( [[ @{agility} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{agilityDodge}]] )d6kh@{agility}sd - @{injuries} - @{fatigue} ]] }}">Dodge</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Agility (Dodge)!** \n\n [[ ( [[ @{agility} + @{agilityDodge} + ?{Bonus Dice|0} ]] )d6dl( [[ @{agilityDodge} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Dodge</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -217,7 +217,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_agilityQuickness"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Agility (Quickness)!** \n\n [[ ( [[ @{agility} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{agilityQuickness}]] )d6kh@{agility}sd - @{injuries} - @{fatigue} ]] }}">Quickness</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Agility (Quickness)!** \n\n [[ ( [[ @{agility} + @{agilityQuickness} + ?{Bonus Dice|0} ]] )d6dl( [[ @{agilityQuickness} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Quickness</button>
                                 </div>
                             </div>
                         </div>
@@ -240,7 +240,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_animalhandling-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Animal Handling!** \n\n [[ ( [[ @{animalhandling} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh@{animalhandling}sd - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Animal Handling!** \n\n [[ ( [[ @{animalhandling} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Animal Handling</label></button>
                             </div>
                         </div>
@@ -259,7 +259,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_animalhandlingCharm"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Animal Handling (Charm)!** \n\n [[ ( [[ @{animalhandling} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{animalhandlingCharm}]] )d6kh@{animalhandling}sd - @{injuries} - @{fatigue} ]] }}">Charm</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Animal Handling (Charm)!** \n\n [[ ( [[ @{animalhandling} + @{animalhandlingCharm} + ?{Bonus Dice|0} ]] )d6dl( [[ @{animalhandlingCharm} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Charm</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -268,7 +268,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_animalhandlingDrive"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Animal Handling (Drive)!** \n\n [[ ( [[ @{animalhandling} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{animalhandlingDrive}]] )d6kh@{animalhandling}sd - @{injuries} - @{fatigue} ]] }}">Drive</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Animal Handling (Drive)!** \n\n [[ ( [[ @{animalhandling} + @{animalhandlingDrive} + ?{Bonus Dice|0} ]] )d6dl( [[ @{animalhandlingDrive} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Drive</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -277,7 +277,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_animalhandlingRide"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Animal Handling (Ride)!** \n\n [[ ( [[ @{animalhandling} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{animalhandlingRide}]] )d6kh@{animalhandling}sd - @{injuries} - @{fatigue} ]] }}">Ride</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Animal Handling (Ride)!** \n\n [[ ( [[ @{animalhandling} + @{animalhandlingRide} + ?{Bonus Dice|0} ]] )d6dl( [[ @{animalhandlingRide} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Ride</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -286,7 +286,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_animalhandlingTrain"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Animal Handling (Train)!** \n\n [[ ( [[ @{animalhandling} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{animalhandlingTrain}]] )d6kh@{animalhandling}sd - @{injuries} - @{fatigue} ]] }}">Train</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Animal Handling (Train)!** \n\n [[ ( [[ @{animalhandling} + @{animalhandlingTrain} + ?{Bonus Dice|0} ]] )d6dl( [[ @{animalhandlingTrain} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Train</button>
                                 </div>
                             </div>
                         </div>
@@ -309,7 +309,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_athletics-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Athletics!** \n\n [[ ( [[ @{athletics} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh@{athletics}sd - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Athletics!** \n\n [[ ( [[ @{athletics} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Athletics</label></button>
                             </div>
                         </div>
@@ -328,7 +328,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_athleticsClimb"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Climb)!** \n\n [[ ( [[ @{athletics} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{athleticsClimb}]] )d6kh@{athletics}sd - @{injuries} - @{fatigue} ]] }}">Climb</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Climb)!** \n\n [[ ( [[ @{athletics} + @{athleticsClimb} + ?{Bonus Dice|0} ]] )d6dl( [[ @{athleticsClimb} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Climb</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -337,7 +337,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_athleticsJump"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Jump)!** \n\n [[ ( [[ @{athletics} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{athleticsJump}]] )d6kh@{athletics}sd - @{injuries} - @{fatigue} ]] }}">Jump</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Jump)!** \n\n [[ ( [[ @{athletics} + @{athleticsJump} + ?{Bonus Dice|0} ]] )d6dl( [[ @{athleticsJump} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Jump</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -346,7 +346,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_athleticsRun"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Run)!** \n\n [[ ( [[ @{athletics} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{athleticsRun}]] )d6kh@{athletics}sd - @{injuries} - @{fatigue} ]] }}">Run</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Run)!** \n\n [[ ( [[ @{athletics} + @{athleticsRun} + ?{Bonus Dice|0} ]] )d6dl( [[ @{athleticsRun} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Run</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -355,7 +355,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_athleticsStrength"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Strength)!** \n\n [[ ( [[ @{athletics} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{athleticsStrength}]] )d6kh@{athletics}sd - @{injuries} - @{fatigue} ]] }}">Strength</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Strength)!** \n\n [[ ( [[ @{athletics} + @{athleticsStrength} + ?{Bonus Dice|0} ]] )d6dl( [[ @{athleticsStrength} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Strength</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -364,7 +364,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_athleticsSwim"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Swim)!** \n\n [[ ( [[ @{athletics} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{athleticsSwim}]] )d6kh@{athletics}sd - @{injuries} - @{fatigue} ]] }}">Swim</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Swim)!** \n\n [[ ( [[ @{athletics} + @{athleticsSwim} + ?{Bonus Dice|0} ]] )d6dl( [[ @{athleticsSwim} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Swim</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -373,7 +373,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_athleticsThrow"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Throw)!** \n\n [[ ( [[ @{athletics} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{athleticsThrow}]] )d6kh@{athletics}sd - @{injuries} - @{fatigue} ]] }}">Throw</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Throw)!** \n\n [[ ( [[ @{athletics} + @{athleticsThrow} + ?{Bonus Dice|0} ]] )d6dl( [[ @{athleticsThrow} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Throw</button>
                                 </div>
                             </div>
                         </div>
@@ -397,7 +397,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_awareness-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Awareness!** \n\n [[ ( [[ @{awareness} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh@{awareness}sd - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Awareness!** \n\n [[ ( [[ @{awareness} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Awareness</label></button>
                             </div>
                         </div>
@@ -416,7 +416,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_awarenessEmpathy"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Awareness (Empathy)!** \n\n [[ ( [[ @{awareness} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{awarenessEmpathy}]] )d6kh@{awareness}sd - @{injuries} - @{fatigue} ]] }}">Empathy</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Awareness (Empathy)!** \n\n [[ ( [[ @{awareness} + @{awarenessEmpathy} + ?{Bonus Dice|0} ]] )d6dl( [[ @{awarenessEmpathy} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Empathy</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -425,7 +425,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_awarenessNotice"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Awareness (Notice)!** \n\n [[ ( [[ @{awareness} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{awarenessNotice}]] )d6kh@{awareness}sd - @{injuries} - @{fatigue} ]] }}">Notice</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Awareness (Notice)!** \n\n [[ ( [[ @{awareness} + @{awarenessNotice} + ?{Bonus Dice|0} ]] )d6dl( [[ @{awarenessNotice} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Notice</button>
                                 </div>
                             </div>
                         </div>
@@ -448,7 +448,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_cunning-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Cunning!** \n\n [[ ( [[ @{cunning} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh@{cunning}sd - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Cunning!** \n\n [[ ( [[ @{cunning} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Cunning</label></button>
                             </div>
                         </div>
@@ -467,7 +467,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_cunningDecipher"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Cunning (Decipher)!** \n\n [[ ( [[ @{cunning} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{cunningDecipher}]] )d6kh@{cunning}sd - @{injuries} - @{fatigue} ]] }}">Decipher</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Cunning (Decipher)!** \n\n [[ ( [[ @{cunning} + @{cunningDecipher} + ?{Bonus Dice|0} ]] )d6dl( [[ @{cunningDecipher} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Decipher</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -476,7 +476,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_cunningLogic"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Cunning (Logic)!** \n\n [[ ( [[ @{cunning} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{cunningLogic}]] )d6kh@{cunning}sd - @{injuries} - @{fatigue} ]] }}">Logic</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Cunning (Logic)!** \n\n [[ ( [[ @{cunning} + @{cunningLogic} + ?{Bonus Dice|0} ]] )d6dl( [[ @{cunningLogic} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Logic</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -485,7 +485,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_cunningMemory"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Cunning (Memory)!** \n\n [[ ( [[ @{cunning} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{cunningMemory}]] )d6kh@{cunning}sd - @{injuries} - @{fatigue} ]] }}">Memory</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Cunning (Memory)!** \n\n [[ ( [[ @{cunning} + @{cunningMemory} + ?{Bonus Dice|0} ]] )d6dl( [[ @{cunningMemory} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Memory</button>
                                 </div>
                             </div>
                         </div>
@@ -508,7 +508,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_deception-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Deception!** \n\n [[ ( [[ @{deception} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh@{deception}sd - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Deception!** \n\n [[ ( [[ @{deception} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Deception</label></button>
                             </div>
                         </div>
@@ -527,7 +527,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_deceptionAct"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Deception (Act)!** \n\n [[ ( [[ @{deception} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{deceptionAct}]] )d6kh@{deception}sd - @{injuries} - @{fatigue} ]] }}">Act</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Deception (Act)!** \n\n [[ ( [[ @{deception} + @{deceptionAct} + ?{Bonus Dice|0} ]] )d6dl( [[ @{deceptionAct} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Act</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -536,7 +536,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_deceptionBluff"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Deception (Bluff)!** \n\n [[ ( [[ @{deception} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{deceptionBluff}]] )d6kh@{deception}sd - @{injuries} - @{fatigue} ]] }}">Bluff</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Deception (Bluff)!** \n\n [[ ( [[ @{deception} + @{deceptionBluff} + ?{Bonus Dice|0} ]] )d6dl( [[ @{deceptionBluff} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Bluff</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -545,7 +545,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_deceptionCheat"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Deception (Cheat)!** \n\n [[ ( [[ @{deception} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{deceptionCheat}]] )d6kh@{deception}sd - @{injuries} - @{fatigue} ]] }}">Cheat</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Deception (Cheat)!** \n\n [[ ( [[ @{deception} + @{deceptionCheat} + ?{Bonus Dice|0} ]] )d6dl( [[ @{deceptionCheat} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Cheat</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -554,7 +554,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_deceptionDisguise"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Deception (Disguise)!** \n\n [[ ( [[ @{deception} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{deceptionDisguise}]] )d6kh@{deception}sd - @{injuries} - @{fatigue} ]] }}">Disguise</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Deception (Disguise)!** \n\n [[ ( [[ @{deception} + @{deceptionDisguise} + ?{Bonus Dice|0} ]] )d6dl( [[ @{deceptionDisguise} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Disguise</button>
                                 </div>
                             </div>
                         </div>
@@ -577,7 +577,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_endurance-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Endurance!** \n\n [[ ( [[ @{endurance} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh@{endurance}sd - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Endurance!** \n\n [[ ( [[ @{endurance} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Endurance</label></button>
                             </div>
                         </div>
@@ -596,7 +596,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_enduranceResilience"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Endurance (Resilience)!** \n\n [[ ( [[ @{endurance} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{enduranceResilience}]] )d6kh@{endurance}sd - @{injuries} - @{fatigue} ]] }}">Resilience</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Endurance (Resilience)!** \n\n [[ ( [[ @{endurance} + @{enduranceResilience} + ?{Bonus Dice|0} ]] )d6dl( [[ @{enduranceResilience} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Resilience</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -605,7 +605,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_enduranceStamina"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Endurance (Stamina)!** \n\n [[ ( [[ @{endurance} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{enduranceStamina}]] )d6kh@{endurance}sd - @{injuries} - @{fatigue} ]] }}">Stamina</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Endurance (Stamina)!** \n\n [[ ( [[ @{endurance} + @{enduranceStamina} + ?{Bonus Dice|0} ]] )d6dl( [[ @{enduranceStamina} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Stamina</button>
                                 </div>
                             </div>
                         </div>
@@ -628,7 +628,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_fighting-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Fighting!** \n\n [[ ( [[ @{fighting} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh@{fighting}sd - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Fighting!** \n\n [[ ( [[ @{fighting} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Fighting</label></button>
                             </div>
                         </div>
@@ -647,7 +647,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_fightingAxes"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Axes)!** \n\n [[ ( [[ @{fighting} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{fightingAxes}]] )d6kh@{fighting}sd - @{injuries} - @{fatigue} ]] }}">Axes</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Axes)!** \n\n [[ ( [[ @{fighting} + @{fightingAxes} + ?{Bonus Dice|0} ]] )d6dl( [[ @{fightingAxes} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Axes</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -656,7 +656,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_fightingBludgeons"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Bludgeons)!** \n\n [[ ( [[ @{fighting} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{fightingBludgeons}]] )d6kh@{fighting}sd - @{injuries} - @{fatigue} ]] }}">Bludgeons</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Bludgeons)!** \n\n [[ ( [[ @{fighting} + @{fightingBludgeons} + ?{Bonus Dice|0} ]] )d6dl( [[ @{fightingBludgeons} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Bludgeons</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -665,7 +665,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_fightingBrawling"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Brawling)!** \n\n [[ ( [[ @{fighting} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{fightingBrawling}]] )d6kh@{fighting}sd - @{injuries} - @{fatigue} ]] }}">Brawling</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Brawling)!** \n\n [[ ( [[ @{fighting} + @{fightingBrawling} + ?{Bonus Dice|0} ]] )d6dl( [[ @{fightingBrawling} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Brawling</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -674,7 +674,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_fightingFencing"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Fencing)!** \n\n [[ ( [[ @{fighting} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{fightingFencing}]] )d6kh@{fighting}sd - @{injuries} - @{fatigue} ]] }}">Fencing</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Fencing)!** \n\n [[ ( [[ @{fighting} + @{fightingFencing} + ?{Bonus Dice|0} ]] )d6dl( [[ @{fightingFencing} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Fencing</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -683,7 +683,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_fightingLongBlades"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Long Blades)!** \n\n [[ ( [[ @{fighting} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{fightingLongBlades}]] )d6kh@{fighting}sd - @{injuries} - @{fatigue} ]] }}">Long
+                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Long Blades)!** \n\n [[ ( [[ @{fighting} + @{fightingLongBlades} + ?{Bonus Dice|0} ]] )d6dl( [[ @{fightingLongBlades} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Long
                                         Blades</button>
                                 </div>
                             </div>
@@ -693,7 +693,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_fightingPolearms"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Polearms)!** \n\n [[ ( [[ @{fighting} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{fightingPolearms}]] )d6kh@{fighting}sd - @{injuries} - @{fatigue} ]] }}">Polearms</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Polearms)!** \n\n [[ ( [[ @{fighting} + @{fightingPolearms} + ?{Bonus Dice|0} ]] )d6dl( [[ @{fightingPolearms} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Polearms</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -702,7 +702,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_fightingShields"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Shields)!** \n\n [[ ( [[ @{fighting} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{fightingShields}]] )d6kh@{fighting}sd - @{injuries} - @{fatigue} ]] }}">Shields</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Shields)!** \n\n [[ ( [[ @{fighting} + @{fightingShields} + ?{Bonus Dice|0} ]] )d6dl( [[ @{fightingShields} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Shields</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -711,7 +711,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_fightingShortBlades"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Short Blades)!** \n\n [[ ( [[ @{fighting} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{fightingShortBlades}]] )d6kh@{fighting}sd - @{injuries} - @{fatigue} ]] }}">Short
+                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Short Blades)!** \n\n [[ ( [[ @{fighting} + @{fightingShortBlades} + ?{Bonus Dice|0} ]] )d6dl( [[ @{fightingShortBlades} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Short
                                         Blades</button>
                                 </div>
                             </div>
@@ -721,7 +721,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_fightingSpears"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Spears)!** \n\n [[ ( [[ @{fighting} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{fightingSpears}]] )d6kh@{fighting}sd - @{injuries} - @{fatigue} ]] }}">Spears</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Spears)!** \n\n [[ ( [[ @{fighting} + @{fightingSpears} + ?{Bonus Dice|0} ]] )d6dl( [[ @{fightingSpears} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Spears</button>
                                 </div>
                             </div>
                         </div>
@@ -744,7 +744,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_healing-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Healing!** \n\n [[ ( [[ @{healing} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh@{healing}sd - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Healing!** \n\n [[ ( [[ @{healing} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Healing</label></button>
                             </div>
                         </div>
@@ -763,7 +763,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_healingDiagnose"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Healing (Diagnose)!** \n\n [[ ( [[ @{healing} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{healingDiagnose}]] )d6kh@{healing}sd - @{injuries} - @{fatigue} ]] }}">Diagnose</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Healing (Diagnose)!** \n\n [[ ( [[ @{healing} + @{healingDiagnose} + ?{Bonus Dice|0} ]] )d6dl( [[ @{healingDiagnose} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Diagnose</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -772,7 +772,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_healingTreatAilment"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Healing(Treat Ailment)!** \n\n [[ ( [[ @{healing} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{healingTreatAilment}]] )d6kh@{healing}sd - @{injuries} - @{fatigue} ]] }}">Treat
+                                        value="&{template:sofai} {{input=**@{character_name} tests Healing(Treat Ailment)!** \n\n [[ ( [[ @{healing} + @{healingTreatAilment} + ?{Bonus Dice|0} ]] )d6dl( [[ @{healingTreatAilment} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Treat
                                         Ailment</button>
                                 </div>
                             </div>
@@ -782,7 +782,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_healingTreatInjury"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Healing (Treat Injury)!** \n\n [[ ( [[ @{healing} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{healingTreatInjury}]] )d6kh@{healing}sd - @{injuries} - @{fatigue} ]] }}">Treat
+                                        value="&{template:sofai} {{input=**@{character_name} tests Healing (Treat Injury)!** \n\n [[ ( [[ @{healing} + @{healingTreatInjury} + ?{Bonus Dice|0} ]] )d6dl( [[ @{healingTreatInjury} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Treat
                                         Injury</button>
                                 </div>
                             </div>
@@ -813,7 +813,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_language-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Language!** \n\n [[ ( [[ @{language} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh@{language}sd - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Language!** \n\n [[ ( [[ @{language} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Language</label></button>
                             </div>
                         </div>
@@ -836,7 +836,7 @@
                                 <div class="sheet-row">
                                     <div class="sheet-item" style="width: 15%;"></div>
                                     <div class="sheet-item" style="width: 85%;"> <button type='roll' class='sheet-specialtyRoll' name='attr_languageRe-roll'
-                                        value='&{template:sofai} {{input=**@{character_name} tests Language (@{languageKnown})!** \n\n [[ ( [[ @{language} + @{knownLanguageRank} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh@{language}sd - @{injuries} - @{fatigue} ]] }}'><label
+                                        value='&{template:sofai} {{input=**@{character_name} tests Language (@{languageKnown})!** \n\n [[ ( [[ @{language} + @{knownLanguageRank} + ?{Bonus Dice|0} ]] )d6dl( [[ @{language} + @{knownLanguageRank} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
                                             style="vertical-align: middle;">Roll</label></button></div>
                                 </div>
                                 <br/>
@@ -848,6 +848,7 @@
                 <div style="height: 4px;">&emsp;</div>
 
                 <!-- Knowledge -->
+
                 <div class="sheet-2colrow">
                     <div class="sheet-col sheet-characteristics">
                         <div class="sheet-2colrow">
@@ -860,7 +861,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_knowledge-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Knowledge!** \n\n [[ ( [[ @{knowledge} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh@{knowledge}sd - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Knowledge!** \n\n [[ ( [[ @{language} + @{languageX} + ?{Bonus Dice|0} ]] )d6dl( [[ @{languageX} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Knowledge</label></button>
                             </div>
                         </div>
@@ -879,7 +880,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_knowledgeEducation"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Knowledge (Education)!** \n\n [[ ( [[ @{knowledge} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{knowledgeEducation}]] )d6kh@{knowledge}sd - @{injuries} - @{fatigue} ]] }}">Education</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Knowledge (Education)!** \n\n [[ ( [[ @{language} + @{languageEducation} + ?{Bonus Dice|0} ]] )d6dl( [[ @{languageEducation} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Education</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -888,7 +889,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_knowledgeResearch"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Knowledge (Research)!** \n\n [[ ( [[ @{knowledge} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{knowledgeResearch}]] )d6kh@{knowledge}sd - @{injuries} - @{fatigue} ]] }}">Research</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Knowledge (Research)!** \n\n [[ ( [[ @{language} + @{languageResearch} + ?{Bonus Dice|0} ]] )d6dl( [[ @{languageResearch} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Research</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -897,7 +898,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_knowledgeStreetwise"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Knowledge (Streetwise)!** \n\n [[ ( [[ @{knowledge} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{knowledgeStreetwise}]] )d6kh@{knowledge}sd - @{injuries} - @{fatigue} ]] }}">Streetwise</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Knowledge (Streetwise)!** \n\n [[ ( [[ @{language} + @{languageStreetwise} + ?{Bonus Dice|0} ]] )d6dl( [[ @{languageStreetwise} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Streetwise</button>
                                 </div>
                             </div>
                         </div>
@@ -920,7 +921,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_marksmanship-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Marksmanship!** \n\n [[ ( [[ @{marksmanship} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh@{marksmanship}sd - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Marksmanship!** \n\n [[ ( [[ @{marksmanship} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Marksman- ship</label></button>
                             </div>
                         </div>
@@ -939,7 +940,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_marksmanshipBows"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Marksmanship (Bows)!** \n\n [[ ( [[ @{marksmanship} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{marksmanshipBows}]] )d6kh@{marksmanship}sd - @{injuries} - @{fatigue} ]] }}">Bows</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Marksmanship (Bows)!** \n\n [[ ( [[ @{marksmanship} + @{marksmanshipBows} + ?{Bonus Dice|0} ]] )d6dl( [[ @{marksmanshipBows} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Bows</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -948,7 +949,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_marksmanshipCrossbows"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Marksmanship (Crossbows)!** \n\n [[ ( [[ @{marksmanship} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{marksmanshipCrossbows}]] )d6kh@{marksmanship}sd - @{injuries} - @{fatigue} ]] }}">Crossbows</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Marksmanship (Crossbows)!** \n\n [[ ( [[ @{marksmanship} + @{marksmanshipCrossbows} + ?{Bonus Dice|0} ]] )d6dl( [[ @{marksmanshipCrossbows} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Crossbows</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -957,7 +958,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_marksmanshipSiege"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Marksmanship (Siege)!** \n\n [[ ( [[ @{marksmanship} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{marksmanshipSiege}]] )d6kh@{marksmanship}sd - @{injuries} - @{fatigue} ]] }}">Siege</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Marksmanship (Siege)!** \n\n [[ ( [[ @{marksmanship} + @{marksmanshipSiege} + ?{Bonus Dice|0} ]] )d6dl( [[ @{marksmanshipSiege} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Siege</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -966,7 +967,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_marksmanshipThrown"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Marksmanship (Thrown)!** \n\n [[ ( [[ @{marksmanship} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{marksmanshipThrown}]] )d6kh@{marksmanship}sd - @{injuries} - @{fatigue} ]] }}">Thrown</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Marksmanship (Thrown)!** \n\n [[ ( [[ @{marksmanship} + @{marksmanshipThrown} + ?{Bonus Dice|0} ]] )d6dl( [[ @{marksmanshipThrown} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Thrown</button>
                                 </div>
                             </div>
                         </div>
@@ -989,7 +990,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_persuasion-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Persuasion!** \n\n [[ ( [[ @{persuasion} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh@{persuasion}sd - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Persuasion!** \n\n [[ ( [[ @{persuasion} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Persuasion</label></button>
                             </div>
                         </div>
@@ -1008,7 +1009,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_persuasionBargain"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Bargain)!** \n\n [[ ( [[ @{persuasion} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{persuasionBargain}]] )d6kh@{persuasion}sd - @{injuries} - @{fatigue} ]] }}">Bargain</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Bargain)!** \n\n [[ ( [[ @{persuasion} + @{persuasionBargain} + ?{Bonus Dice|0} ]] )d6dl( [[ @{persuasionBargain} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Bargain</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1017,7 +1018,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_persuasionCharm"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Charm)!** \n\n [[ ( [[ @{persuasion} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{persuasionCharm}]] )d6kh@{persuasion}sd - @{injuries} - @{fatigue} ]] }}">Charm</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Charm)!** \n\n [[ ( [[ @{persuasion} + @{persuasionCharm} + ?{Bonus Dice|0} ]] )d6dl( [[ @{persuasionCharm} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Charm</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1026,7 +1027,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_persuasionConvince"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Convince)!** \n\n [[ ( [[ @{persuasion} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{persuasionConvince}]] )d6kh@{persuasion}sd - @{injuries} - @{fatigue} ]] }}">Convince</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Convince)!** \n\n [[ ( [[ @{persuasion} + @{persuasionConvince} + ?{Bonus Dice|0} ]] )d6dl( [[ @{persuasionConvince} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Convince</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1035,7 +1036,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_persuasionIncite"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Incite)!** \n\n [[ ( [[ @{persuasion} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{persuasionIncite}]] )d6kh@{persuasion}sd - @{injuries} - @{fatigue} ]] }}">Incite</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Incite)!** \n\n [[ ( [[ @{persuasion} + @{persuasionIncite} + ?{Bonus Dice|0} ]] )d6dl( [[ @{persuasionIncite} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Incite</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1044,7 +1045,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_persuasionIntimidate"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Intimidate)!** \n\n [[ ( [[ @{persuasion} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{persuasionIntimidate}]] )d6kh@{persuasion}sd - @{injuries} - @{fatigue} ]] }}">Intimidate</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Intimidate)!** \n\n [[ ( [[ @{persuasion} + @{persuasionIntimidate} + ?{Bonus Dice|0} ]] )d6dl( [[ @{persuasionIntimidate} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Intimidate</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1053,7 +1054,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_persuasionSeduce"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Seduce)!** \n\n [[ ( [[ @{persuasion} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{persuasionSeduce}]] )d6kh@{persuasion}sd - @{injuries} - @{fatigue} ]] }}">Seduce</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Seduce)!** \n\n [[ ( [[ @{persuasion} + @{persuasionSeduce} + ?{Bonus Dice|0} ]] )d6dl( [[ @{persuasionSeduce} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Seduce</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1062,7 +1063,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_persuasionTaunt"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Taunt)!** \n\n [[ ( [[ @{persuasion} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{persuasionTaunt}]] )d6kh@{persuasion}sd - @{injuries} - @{fatigue} ]] }}">Taunt</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Taunt)!** \n\n [[ ( [[ @{persuasion} + @{persuasionTaunt} + ?{Bonus Dice|0} ]] )d6dl( [[ @{persuasionTaunt} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Taunt</button>
                                 </div>
                             </div>
                         </div>
@@ -1086,7 +1087,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_status-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Status!** \n\n [[ ( [[ @{status} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh@{status}sd - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Status!** \n\n [[ ( [[ @{status} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
                                         class="sheet-statusRoll">Status</label></button>
                             </div>
                         </div>
@@ -1105,7 +1106,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_statusBreeding"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Status (Breeding)!** \n\n [[ ( [[ @{status} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{statusBreeding}]] )d6kh@{status}sd - @{injuries} - @{fatigue} ]] }}">Breeding</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Status (Breeding)!** \n\n [[ ( [[ @{status} + @{statusBreeding} + ?{Bonus Dice|0} ]] )d6dl( [[ @{statusBreeding} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Breeding</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1114,7 +1115,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_statusReputation"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Status (Reputation)!** \n\n [[ ( [[ @{status} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{statusReputation}]] )d6kh@{status}sd - @{injuries} - @{fatigue} ]] }}">Reputation</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Status (Reputation)!** \n\n [[ ( [[ @{status} + @{statusReputation} + ?{Bonus Dice|0} ]] )d6dl( [[ @{statusReputation} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Reputation</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1123,7 +1124,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_statusStewardship"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Status (Stewardship)!** \n\n [[ ( [[ @{status} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{statusStewardship}]] )d6kh@{status}sd - @{injuries} - @{fatigue} ]] }}">Stewardship</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Status (Stewardship)!** \n\n [[ ( [[ @{status} + @{statusStewardship} + ?{Bonus Dice|0} ]] )d6dl( [[ @{statusStewardship} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Stewardship</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1132,7 +1133,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_statusTournaments"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Status (Tournaments)!** \n\n [[ ( [[ @{status} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{statusTournaments}]] )d6kh@{status}sd - @{injuries} - @{fatigue} ]] }}">Tournaments</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Status (Tournaments)!** \n\n [[ ( [[ @{status} + @{statusTournaments} + ?{Bonus Dice|0} ]] )d6dl( [[ @{statusTournaments} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Tournaments</button>
                                 </div>
                             </div>
                         </div>
@@ -1155,7 +1156,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_stealth-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Stealth!** \n\n [[ ( [[ @{stealth} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh@{stealth}sd - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Stealth!** \n\n [[ ( [[ @{stealth} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Stealth</label></button>
                             </div>
                         </div>
@@ -1174,7 +1175,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_stealthBlendIn"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Stealth (Blend In)!** \n\n [[ ( [[ @{stealth} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{stealthBlendIn}]] )d6kh@{stealth}sd - @{injuries} - @{fatigue} ]] }}">Blend
+                                        value="&{template:sofai} {{input=**@{character_name} tests Stealth (Blend In)!** \n\n [[ ( [[ @{stealth} + @{stealthBlendIn} + ?{Bonus Dice|0} ]] )d6dl( [[ @{stealthBlendIn} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Blend
                                         In</button>
                                 </div>
                             </div>
@@ -1184,7 +1185,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_stealthSneak"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Stealth (Sneak)!** \n\n [[ ( [[ @{stealth} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{stealthSneak}]] )d6kh@{stealth}sd - @{injuries} - @{fatigue} ]] }}">Sneak</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Stealth (Sneak)!** \n\n [[ ( [[ @{stealth} + @{stealthSneak} + ?{Bonus Dice|0} ]] )d6dl( [[ @{stealthSneak} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Sneak</button>
                                 </div>
                             </div>
                         </div>
@@ -1207,7 +1208,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_survival-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Survival!** \n\n [[ ( [[ @{survival} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh@{survival}sd - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Survival!** \n\n [[ ( [[ @{survival} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Survival</label></button>
                             </div>
                         </div>
@@ -1226,7 +1227,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_survivalForage"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Survival (Forage)!** \n\n [[ ( [[ @{survival} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{survivalForage}]] )d6kh@{survival}sd - @{injuries} - @{fatigue} ]] }}">Forage</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Survival (Forage)!** \n\n [[ ( [[ @{survival} + @{survivalForage} + ?{Bonus Dice|0} ]] )d6dl( [[ @{survivalForage} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Forage</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1235,7 +1236,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_survivalHunt"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Survival (Hunt)!** \n\n [[ ( [[ @{survival} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{survivalHunt}]] )d6kh@{survival}sd - @{injuries} - @{fatigue} ]] }}">Hunt</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Survival (Hunt)!** \n\n [[ ( [[ @{survival} + @{survivalHunt} + ?{Bonus Dice|0} ]] )d6dl( [[ @{survivalHunt} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Hunt</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1244,7 +1245,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_survivalOrientation"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Survival (Orientation)!** \n\n [[ ( [[ @{survival} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{survivalOrientation}]] )d6kh@{survival}sd - @{injuries} - @{fatigue} ]] }}">Orientation</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Survival (Orientation)!** \n\n [[ ( [[ @{survival} + @{survivalOrientation} + ?{Bonus Dice|0} ]] )d6dl( [[ @{survivalOrientation} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Orientation</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1253,7 +1254,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_survivalTrack"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Survival (Track)!** \n\n [[ ( [[ @{survival} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{survivalTrack}]] )d6kh@{survival}sd - @{injuries} - @{fatigue} ]] }}">Track</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Survival (Track)!** \n\n [[ ( [[ @{survival} + @{survivalTrack} + ?{Bonus Dice|0} ]] )d6dl( [[ @{survivalTrack} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Track</button>
                                 </div>
                             </div>
                         </div>
@@ -1276,7 +1277,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_thievery-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Thievery!** \n\n [[ ( [[ @{thievery} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh@{thievery}sd - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Thievery!** \n\n [[ ( [[ @{thievery} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Thievery</label></button>
                             </div>
                         </div>
@@ -1295,7 +1296,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_thieveryPickLock"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Thievery (Pick Lock)!** \n\n [[ ( [[ @{thievery} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{thieveryPickLock}]] )d6kh@{thievery}sd - @{injuries} - @{fatigue} ]] }}">Pick
+                                        value="&{template:sofai} {{input=**@{character_name} tests Thievery (Pick Lock)!** \n\n [[ ( [[ @{thievery} + @{thieveryPickLock} + ?{Bonus Dice|0} ]] )d6dl( [[ @{thieveryPickLock} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Pick
                                         Lock</button>
                                 </div>
                             </div>
@@ -1305,7 +1306,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_thieverySleightOfHand"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Thievery (Sleight of Hand)!** \n\n [[ ( [[ @{thievery} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{thieverySleightOfHand}]] )d6kh@{thievery}sd - @{injuries} - @{fatigue} ]] }}">Sleight
+                                        value="&{template:sofai} {{input=**@{character_name} tests Thievery (Sleight of Hand)!** \n\n [[ ( [[ @{thievery} + @{thieverySleightOfHand} + ?{Bonus Dice|0} ]] )d6dl( [[ @{thieverySleightOfHand} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Sleight
                                         of Hand</button>
                                 </div>
                             </div>
@@ -1315,7 +1316,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_thieverySteal"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Thievery (Steal)!** \n\n [[ ( [[ @{thievery} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{thieverySteal}]] )d6kh@{thievery}sd - @{injuries} - @{fatigue} ]] }}">Steal</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Thievery (Steal)!** \n\n [[ ( [[ @{thievery} + @{thieverySteal} + ?{Bonus Dice|0} ]] )d6dl( [[ @{thieverySteal} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Steal</button>
                                 </div>
                             </div>
                         </div>
@@ -1338,7 +1339,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_warfare-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Warfare!** \n\n [[ ( [[ @{warfare} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh@{warfare}sd - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Warfare!** \n\n [[ ( [[ @{warfare} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Warfare</label></button>
                             </div>
                         </div>
@@ -1357,7 +1358,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_warfareCommand"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Warfare (Command)!** \n\n [[ ( [[ @{warfare} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{warfareCommand}]] )d6kh@{warfare}sd - @{injuries} - @{fatigue} ]] }}">Command</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Warfare (Command)!** \n\n [[ ( [[ @{warfare} + @{warfareCommand} + ?{Bonus Dice|0} ]] )d6dl( [[ @{warfareCommand} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Command</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1366,7 +1367,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_warfareStrategy"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Warfare (Strategy)!** \n\n [[ ( [[ @{warfare} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{warfareStrategy}]] )d6kh@{warfare}sd - @{injuries} - @{fatigue} ]] }}">Strategy</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Warfare (Strategy)!** \n\n [[ ( [[ @{warfare} + @{warfareStrategy} + ?{Bonus Dice|0} ]] )d6dl( [[ @{warfareStrategy} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Strategy</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1375,7 +1376,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_warfareTactics"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Warfare (Tactics)!** \n\n [[ ( [[ @{warfare} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{warfareTactics}]] )d6kh@{warfare}sd - @{injuries} - @{fatigue} ]] }}">Tactics</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Warfare (Tactics)!** \n\n [[ ( [[ @{warfare} + @{warfareTactics} + ?{Bonus Dice|0} ]] )d6dl( [[ @{warfareTactics} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Tactics</button>
                                 </div>
                             </div>
                         </div>
@@ -1398,7 +1399,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_will-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Will!** \n\n [[ ( [[ @{will} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0}]] )d6kh@{will}sd - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Will!** \n\n [[ ( [[ @{will} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Will</label></button>
                             </div>
                         </div>
@@ -1417,7 +1418,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_willCourage"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Will (Courage)!** \n\n [[ ( [[ @{will} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{willCourage}]] )d6kh@{will}sd - @{injuries} - @{fatigue} ]] }}">Courage</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Will (Courage)!** \n\n [[ ( [[ @{will} + @{willCourage} + ?{Bonus Dice|0} ]] )d6dl( [[ @{willCourage} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Courage</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1426,7 +1427,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_willCoordinate"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Will (Coordinate)!** \n\n [[ ( [[ @{will} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{willCoordinate}]] )d6kh@{will}sd - @{injuries} - @{fatigue} ]] }}">Coordinate</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Will (Coordinate)!** \n\n [[ ( [[ @{will} + @{willCoordinate} + ?{Bonus Dice|0} ]] )d6dl( [[ @{willCoordinate} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Coordinate</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1435,7 +1436,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_willDedication"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Will (Dedication)!** \n\n [[ ( [[ @{will} - @{wounds} + ?{Bonus Dice|0} - ?{Penalty Dice|0} + @{willDedication}]] )d6kh@{will}sd - @{injuries} - @{fatigue} ]] }}">Dedication</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Will (Dedication)!** \n\n [[ ( [[ @{will} + @{willDedication} + ?{Bonus Dice|0} ]] )d6dl( [[ @{willDedication} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Dedication</button>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Change to Alex Ott's sheet for A Song of Ice and Fire RPG to fix https://github.com/Roll20/roll20-character-sheets/issues/5183
Changed the roll for all roll buttons on the core section of the sheet.
By the rules all forms of -D turn Test dice into Bonus dice, and this change causes the roll buttons to respect this, rather than removing bonus dice, which is the current behavour.

##Changes / Comments
Restructured the rolls to look like this:
`[[ ( [[ ?{Dice|1} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + ?{Penalty Dice|0} ]] ) + ?{Modifier|0} ]]`
Should now be rolling `([Test dice] + [Bonus dice]d6dl([Bonus dice] + [Penalty dice]) - [Modifier]`

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
