### PR TITLE
Shadowrun5thEdition: Use 'repeating_spell' to attach sheet worker listener

### DIFF
--- a/Shadowrun5thEdition/Shadowrun5thEdition.html
+++ b/Shadowrun5thEdition/Shadowrun5thEdition.html
@@ -3948,7 +3948,7 @@
 	    });
 
 	//PC SPELLS/PREPS/RITUALS
-	  	['repeating_spells','repeating_preps','repeating_ritual'].forEach(field => {
+	  	['repeating_spell','repeating_preps','repeating_ritual'].forEach(field => {
 	        // Attach listener
 	        on(`change:${field}`, (eventInfo) => {
 	        	const source = eventInfo.sourceAttribute;


### PR DESCRIPTION
## Changes / Comments

Use 'repeating_spell' to attach listener, since repeating section is named 'repeating_spell' in the character sheet. This fixes the trigger and changes to dicepool modifier will now be included into rolls correctly (cc @clevett).

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
