### PR TITLE
[SFRPG (Alex Ott)] Fix to sheet rolls not working

### DIFF
--- a/A Song of Ice and Fire/SIFRPNew.html
+++ b/A Song of Ice and Fire/SIFRPNew.html
@@ -95,7 +95,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_will-roll'
-                                    value='&{template:sofai} {{input= @{character_name} rolls [[ ( [[ ?{Dice|1} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + ?{Penalty Dice|0} ]] ) + ?{Modifier|0} ]] }}'><label
+                                    value='&{template:sofai} {{input= @{character_name} rolls [[ ( [[ ?{Dice|1} + ?{Bonus Dice|0} ]] )d6dl [[ ?{Bonus Dice|0} + ?{Penalty Dice|0} ]] + ?{Modifier|0} ]] }}'><label
                                         style="vertical-align: middle;">Custom Roll</label></button>
                             </div>
 						</div>
@@ -162,7 +162,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_agility-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Agility!** \n\n [[ ( [[ @{agility} + ?{Bonus Dice|0}]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Agility!** \n\n [[ ( [[ @{agility} + ?{Bonus Dice|0}]] )d6dl[[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Agility</label></button>
                             </div>
                         </div>
@@ -181,7 +181,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_agilityAcrobatics"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Agility (Acrobatics)!** \n\n [[ ( [[ @{agility} + @{agilityAcrobatics} + ?{Bonus Dice|0} ]] )d6dl( [[ @{agilityAcrobatics} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Acrobatics</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Agility (Acrobatics)!** \n\n [[ ( [[ @{agility} + @{agilityAcrobatics} + ?{Bonus Dice|0} ]] )d6dl[[ @{agilityAcrobatics} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Acrobatics</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -190,7 +190,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_agilityBalance"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Agility (Balance)!** \n\n [[ ( [[ @{agility} + @{agilityBalance} + ?{Bonus Dice|0} ]] )d6dl( [[ @{agilityBalance} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] }}">Balance</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Agility (Balance)!** \n\n [[ ( [[ @{agility} + @{agilityBalance} + ?{Bonus Dice|0} ]] )d6dl[[ @{agilityBalance} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] }}">Balance</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -199,7 +199,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_agilityContortions"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Agility (Contortions)!** \n\n [[ ( [[ @{agility} + @{agilityContortions} + ?{Bonus Dice|0} ]] )d6dl( [[ @{agilityContortions} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Contortions</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Agility (Contortions)!** \n\n [[ ( [[ @{agility} + @{agilityContortions} + ?{Bonus Dice|0} ]] )d6dl[[ @{agilityContortions} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Contortions</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -208,7 +208,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_agilityDodge"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Agility (Dodge)!** \n\n [[ ( [[ @{agility} + @{agilityDodge} + ?{Bonus Dice|0} ]] )d6dl( [[ @{agilityDodge} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Dodge</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Agility (Dodge)!** \n\n [[ ( [[ @{agility} + @{agilityDodge} + ?{Bonus Dice|0} ]] )d6dl[[ @{agilityDodge} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Dodge</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -217,7 +217,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_agilityQuickness"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Agility (Quickness)!** \n\n [[ ( [[ @{agility} + @{agilityQuickness} + ?{Bonus Dice|0} ]] )d6dl( [[ @{agilityQuickness} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Quickness</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Agility (Quickness)!** \n\n [[ ( [[ @{agility} + @{agilityQuickness} + ?{Bonus Dice|0} ]] )d6dl[[ @{agilityQuickness} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Quickness</button>
                                 </div>
                             </div>
                         </div>
@@ -240,7 +240,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_animalhandling-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Animal Handling!** \n\n [[ ( [[ @{animalhandling} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Animal Handling!** \n\n [[ ( [[ @{animalhandling} + ?{Bonus Dice|0} ]] )d6dl[[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Animal Handling</label></button>
                             </div>
                         </div>
@@ -259,7 +259,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_animalhandlingCharm"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Animal Handling (Charm)!** \n\n [[ ( [[ @{animalhandling} + @{animalhandlingCharm} + ?{Bonus Dice|0} ]] )d6dl( [[ @{animalhandlingCharm} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Charm</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Animal Handling (Charm)!** \n\n [[ ( [[ @{animalhandling} + @{animalhandlingCharm} + ?{Bonus Dice|0} ]] )d6dl[[ @{animalhandlingCharm} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Charm</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -268,7 +268,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_animalhandlingDrive"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Animal Handling (Drive)!** \n\n [[ ( [[ @{animalhandling} + @{animalhandlingDrive} + ?{Bonus Dice|0} ]] )d6dl( [[ @{animalhandlingDrive} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Drive</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Animal Handling (Drive)!** \n\n [[ ( [[ @{animalhandling} + @{animalhandlingDrive} + ?{Bonus Dice|0} ]] )d6dl[[ @{animalhandlingDrive} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Drive</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -277,7 +277,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_animalhandlingRide"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Animal Handling (Ride)!** \n\n [[ ( [[ @{animalhandling} + @{animalhandlingRide} + ?{Bonus Dice|0} ]] )d6dl( [[ @{animalhandlingRide} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Ride</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Animal Handling (Ride)!** \n\n [[ ( [[ @{animalhandling} + @{animalhandlingRide} + ?{Bonus Dice|0} ]] )d6dl[[ @{animalhandlingRide} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Ride</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -286,7 +286,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_animalhandlingTrain"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Animal Handling (Train)!** \n\n [[ ( [[ @{animalhandling} + @{animalhandlingTrain} + ?{Bonus Dice|0} ]] )d6dl( [[ @{animalhandlingTrain} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Train</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Animal Handling (Train)!** \n\n [[ ( [[ @{animalhandling} + @{animalhandlingTrain} + ?{Bonus Dice|0} ]] )d6dl[[ @{animalhandlingTrain} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Train</button>
                                 </div>
                             </div>
                         </div>
@@ -309,7 +309,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_athletics-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Athletics!** \n\n [[ ( [[ @{athletics} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Athletics!** \n\n [[ ( [[ @{athletics} + ?{Bonus Dice|0} ]] )d6dl[[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Athletics</label></button>
                             </div>
                         </div>
@@ -328,7 +328,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_athleticsClimb"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Climb)!** \n\n [[ ( [[ @{athletics} + @{athleticsClimb} + ?{Bonus Dice|0} ]] )d6dl( [[ @{athleticsClimb} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Climb</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Climb)!** \n\n [[ ( [[ @{athletics} + @{athleticsClimb} + ?{Bonus Dice|0} ]] )d6dl[[ @{athleticsClimb} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Climb</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -337,7 +337,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_athleticsJump"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Jump)!** \n\n [[ ( [[ @{athletics} + @{athleticsJump} + ?{Bonus Dice|0} ]] )d6dl( [[ @{athleticsJump} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Jump</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Jump)!** \n\n [[ ( [[ @{athletics} + @{athleticsJump} + ?{Bonus Dice|0} ]] )d6dl[[ @{athleticsJump} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Jump</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -346,7 +346,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_athleticsRun"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Run)!** \n\n [[ ( [[ @{athletics} + @{athleticsRun} + ?{Bonus Dice|0} ]] )d6dl( [[ @{athleticsRun} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Run</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Run)!** \n\n [[ ( [[ @{athletics} + @{athleticsRun} + ?{Bonus Dice|0} ]] )d6dl[[ @{athleticsRun} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Run</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -355,7 +355,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_athleticsStrength"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Strength)!** \n\n [[ ( [[ @{athletics} + @{athleticsStrength} + ?{Bonus Dice|0} ]] )d6dl( [[ @{athleticsStrength} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Strength</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Strength)!** \n\n [[ ( [[ @{athletics} + @{athleticsStrength} + ?{Bonus Dice|0} ]] )d6dl[[ @{athleticsStrength} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Strength</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -364,7 +364,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_athleticsSwim"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Swim)!** \n\n [[ ( [[ @{athletics} + @{athleticsSwim} + ?{Bonus Dice|0} ]] )d6dl( [[ @{athleticsSwim} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Swim</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Swim)!** \n\n [[ ( [[ @{athletics} + @{athleticsSwim} + ?{Bonus Dice|0} ]] )d6dl[[ @{athleticsSwim} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Swim</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -373,7 +373,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_athleticsThrow"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Throw)!** \n\n [[ ( [[ @{athletics} + @{athleticsThrow} + ?{Bonus Dice|0} ]] )d6dl( [[ @{athleticsThrow} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Throw</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Athletics (Throw)!** \n\n [[ ( [[ @{athletics} + @{athleticsThrow} + ?{Bonus Dice|0} ]] )d6dl[[ @{athleticsThrow} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Throw</button>
                                 </div>
                             </div>
                         </div>
@@ -397,7 +397,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_awareness-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Awareness!** \n\n [[ ( [[ @{awareness} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Awareness!** \n\n [[ ( [[ @{awareness} + ?{Bonus Dice|0} ]] )d6dl[[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Awareness</label></button>
                             </div>
                         </div>
@@ -416,7 +416,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_awarenessEmpathy"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Awareness (Empathy)!** \n\n [[ ( [[ @{awareness} + @{awarenessEmpathy} + ?{Bonus Dice|0} ]] )d6dl( [[ @{awarenessEmpathy} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Empathy</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Awareness (Empathy)!** \n\n [[ ( [[ @{awareness} + @{awarenessEmpathy} + ?{Bonus Dice|0} ]] )d6dl[[ @{awarenessEmpathy} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Empathy</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -425,7 +425,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_awarenessNotice"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Awareness (Notice)!** \n\n [[ ( [[ @{awareness} + @{awarenessNotice} + ?{Bonus Dice|0} ]] )d6dl( [[ @{awarenessNotice} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Notice</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Awareness (Notice)!** \n\n [[ ( [[ @{awareness} + @{awarenessNotice} + ?{Bonus Dice|0} ]] )d6dl[[ @{awarenessNotice} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Notice</button>
                                 </div>
                             </div>
                         </div>
@@ -448,7 +448,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_cunning-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Cunning!** \n\n [[ ( [[ @{cunning} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Cunning!** \n\n [[ ( [[ @{cunning} + ?{Bonus Dice|0} ]] )d6dl[[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Cunning</label></button>
                             </div>
                         </div>
@@ -467,7 +467,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_cunningDecipher"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Cunning (Decipher)!** \n\n [[ ( [[ @{cunning} + @{cunningDecipher} + ?{Bonus Dice|0} ]] )d6dl( [[ @{cunningDecipher} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Decipher</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Cunning (Decipher)!** \n\n [[ ( [[ @{cunning} + @{cunningDecipher} + ?{Bonus Dice|0} ]] )d6dl[[ @{cunningDecipher} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Decipher</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -476,7 +476,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_cunningLogic"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Cunning (Logic)!** \n\n [[ ( [[ @{cunning} + @{cunningLogic} + ?{Bonus Dice|0} ]] )d6dl( [[ @{cunningLogic} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Logic</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Cunning (Logic)!** \n\n [[ ( [[ @{cunning} + @{cunningLogic} + ?{Bonus Dice|0} ]] )d6dl[[ @{cunningLogic} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Logic</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -485,7 +485,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_cunningMemory"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Cunning (Memory)!** \n\n [[ ( [[ @{cunning} + @{cunningMemory} + ?{Bonus Dice|0} ]] )d6dl( [[ @{cunningMemory} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Memory</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Cunning (Memory)!** \n\n [[ ( [[ @{cunning} + @{cunningMemory} + ?{Bonus Dice|0} ]] )d6dl[[ @{cunningMemory} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Memory</button>
                                 </div>
                             </div>
                         </div>
@@ -508,7 +508,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_deception-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Deception!** \n\n [[ ( [[ @{deception} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Deception!** \n\n [[ ( [[ @{deception} + ?{Bonus Dice|0} ]] )d6dl[[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Deception</label></button>
                             </div>
                         </div>
@@ -527,7 +527,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_deceptionAct"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Deception (Act)!** \n\n [[ ( [[ @{deception} + @{deceptionAct} + ?{Bonus Dice|0} ]] )d6dl( [[ @{deceptionAct} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Act</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Deception (Act)!** \n\n [[ ( [[ @{deception} + @{deceptionAct} + ?{Bonus Dice|0} ]] )d6dl[[ @{deceptionAct} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Act</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -536,7 +536,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_deceptionBluff"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Deception (Bluff)!** \n\n [[ ( [[ @{deception} + @{deceptionBluff} + ?{Bonus Dice|0} ]] )d6dl( [[ @{deceptionBluff} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Bluff</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Deception (Bluff)!** \n\n [[ ( [[ @{deception} + @{deceptionBluff} + ?{Bonus Dice|0} ]] )d6dl[[ @{deceptionBluff} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Bluff</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -545,7 +545,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_deceptionCheat"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Deception (Cheat)!** \n\n [[ ( [[ @{deception} + @{deceptionCheat} + ?{Bonus Dice|0} ]] )d6dl( [[ @{deceptionCheat} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Cheat</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Deception (Cheat)!** \n\n [[ ( [[ @{deception} + @{deceptionCheat} + ?{Bonus Dice|0} ]] )d6dl[[ @{deceptionCheat} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Cheat</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -554,7 +554,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_deceptionDisguise"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Deception (Disguise)!** \n\n [[ ( [[ @{deception} + @{deceptionDisguise} + ?{Bonus Dice|0} ]] )d6dl( [[ @{deceptionDisguise} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Disguise</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Deception (Disguise)!** \n\n [[ ( [[ @{deception} + @{deceptionDisguise} + ?{Bonus Dice|0} ]] )d6dl[[ @{deceptionDisguise} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Disguise</button>
                                 </div>
                             </div>
                         </div>
@@ -577,7 +577,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_endurance-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Endurance!** \n\n [[ ( [[ @{endurance} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Endurance!** \n\n [[ ( [[ @{endurance} + ?{Bonus Dice|0} ]] )d6dl[[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Endurance</label></button>
                             </div>
                         </div>
@@ -596,7 +596,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_enduranceResilience"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Endurance (Resilience)!** \n\n [[ ( [[ @{endurance} + @{enduranceResilience} + ?{Bonus Dice|0} ]] )d6dl( [[ @{enduranceResilience} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Resilience</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Endurance (Resilience)!** \n\n [[ ( [[ @{endurance} + @{enduranceResilience} + ?{Bonus Dice|0} ]] )d6dl[[ @{enduranceResilience} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Resilience</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -605,7 +605,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_enduranceStamina"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Endurance (Stamina)!** \n\n [[ ( [[ @{endurance} + @{enduranceStamina} + ?{Bonus Dice|0} ]] )d6dl( [[ @{enduranceStamina} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Stamina</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Endurance (Stamina)!** \n\n [[ ( [[ @{endurance} + @{enduranceStamina} + ?{Bonus Dice|0} ]] )d6dl[[ @{enduranceStamina} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Stamina</button>
                                 </div>
                             </div>
                         </div>
@@ -628,7 +628,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_fighting-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Fighting!** \n\n [[ ( [[ @{fighting} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Fighting!** \n\n [[ ( [[ @{fighting} + ?{Bonus Dice|0} ]] )d6dl[[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Fighting</label></button>
                             </div>
                         </div>
@@ -647,7 +647,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_fightingAxes"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Axes)!** \n\n [[ ( [[ @{fighting} + @{fightingAxes} + ?{Bonus Dice|0} ]] )d6dl( [[ @{fightingAxes} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Axes</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Axes)!** \n\n [[ ( [[ @{fighting} + @{fightingAxes} + ?{Bonus Dice|0} ]] )d6dl[[ @{fightingAxes} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Axes</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -656,7 +656,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_fightingBludgeons"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Bludgeons)!** \n\n [[ ( [[ @{fighting} + @{fightingBludgeons} + ?{Bonus Dice|0} ]] )d6dl( [[ @{fightingBludgeons} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Bludgeons</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Bludgeons)!** \n\n [[ ( [[ @{fighting} + @{fightingBludgeons} + ?{Bonus Dice|0} ]] )d6dl[[ @{fightingBludgeons} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Bludgeons</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -665,7 +665,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_fightingBrawling"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Brawling)!** \n\n [[ ( [[ @{fighting} + @{fightingBrawling} + ?{Bonus Dice|0} ]] )d6dl( [[ @{fightingBrawling} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Brawling</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Brawling)!** \n\n [[ ( [[ @{fighting} + @{fightingBrawling} + ?{Bonus Dice|0} ]] )d6dl[[ @{fightingBrawling} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Brawling</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -674,7 +674,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_fightingFencing"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Fencing)!** \n\n [[ ( [[ @{fighting} + @{fightingFencing} + ?{Bonus Dice|0} ]] )d6dl( [[ @{fightingFencing} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Fencing</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Fencing)!** \n\n [[ ( [[ @{fighting} + @{fightingFencing} + ?{Bonus Dice|0} ]] )d6dl[[ @{fightingFencing} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Fencing</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -683,7 +683,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_fightingLongBlades"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Long Blades)!** \n\n [[ ( [[ @{fighting} + @{fightingLongBlades} + ?{Bonus Dice|0} ]] )d6dl( [[ @{fightingLongBlades} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Long
+                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Long Blades)!** \n\n [[ ( [[ @{fighting} + @{fightingLongBlades} + ?{Bonus Dice|0} ]] )d6dl[[ @{fightingLongBlades} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Long
                                         Blades</button>
                                 </div>
                             </div>
@@ -693,7 +693,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_fightingPolearms"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Polearms)!** \n\n [[ ( [[ @{fighting} + @{fightingPolearms} + ?{Bonus Dice|0} ]] )d6dl( [[ @{fightingPolearms} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Polearms</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Polearms)!** \n\n [[ ( [[ @{fighting} + @{fightingPolearms} + ?{Bonus Dice|0} ]] )d6dl[[ @{fightingPolearms} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Polearms</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -702,7 +702,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_fightingShields"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Shields)!** \n\n [[ ( [[ @{fighting} + @{fightingShields} + ?{Bonus Dice|0} ]] )d6dl( [[ @{fightingShields} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Shields</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Shields)!** \n\n [[ ( [[ @{fighting} + @{fightingShields} + ?{Bonus Dice|0} ]] )d6dl[[ @{fightingShields} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Shields</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -711,7 +711,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_fightingShortBlades"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Short Blades)!** \n\n [[ ( [[ @{fighting} + @{fightingShortBlades} + ?{Bonus Dice|0} ]] )d6dl( [[ @{fightingShortBlades} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Short
+                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Short Blades)!** \n\n [[ ( [[ @{fighting} + @{fightingShortBlades} + ?{Bonus Dice|0} ]] )d6dl[[ @{fightingShortBlades} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Short
                                         Blades</button>
                                 </div>
                             </div>
@@ -721,7 +721,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_fightingSpears"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Spears)!** \n\n [[ ( [[ @{fighting} + @{fightingSpears} + ?{Bonus Dice|0} ]] )d6dl( [[ @{fightingSpears} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Spears</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Fighting (Spears)!** \n\n [[ ( [[ @{fighting} + @{fightingSpears} + ?{Bonus Dice|0} ]] )d6dl[[ @{fightingSpears} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Spears</button>
                                 </div>
                             </div>
                         </div>
@@ -744,7 +744,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_healing-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Healing!** \n\n [[ ( [[ @{healing} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Healing!** \n\n [[ ( [[ @{healing} + ?{Bonus Dice|0} ]] )d6dl[[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Healing</label></button>
                             </div>
                         </div>
@@ -763,7 +763,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_healingDiagnose"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Healing (Diagnose)!** \n\n [[ ( [[ @{healing} + @{healingDiagnose} + ?{Bonus Dice|0} ]] )d6dl( [[ @{healingDiagnose} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Diagnose</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Healing (Diagnose)!** \n\n [[ ( [[ @{healing} + @{healingDiagnose} + ?{Bonus Dice|0} ]] )d6dl[[ @{healingDiagnose} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Diagnose</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -772,7 +772,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_healingTreatAilment"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Healing(Treat Ailment)!** \n\n [[ ( [[ @{healing} + @{healingTreatAilment} + ?{Bonus Dice|0} ]] )d6dl( [[ @{healingTreatAilment} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Treat
+                                        value="&{template:sofai} {{input=**@{character_name} tests Healing(Treat Ailment)!** \n\n [[ ( [[ @{healing} + @{healingTreatAilment} + ?{Bonus Dice|0} ]] )d6dl[[ @{healingTreatAilment} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Treat
                                         Ailment</button>
                                 </div>
                             </div>
@@ -782,7 +782,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_healingTreatInjury"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Healing (Treat Injury)!** \n\n [[ ( [[ @{healing} + @{healingTreatInjury} + ?{Bonus Dice|0} ]] )d6dl( [[ @{healingTreatInjury} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Treat
+                                        value="&{template:sofai} {{input=**@{character_name} tests Healing (Treat Injury)!** \n\n [[ ( [[ @{healing} + @{healingTreatInjury} + ?{Bonus Dice|0} ]] )d6dl[[ @{healingTreatInjury} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Treat
                                         Injury</button>
                                 </div>
                             </div>
@@ -813,7 +813,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_language-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Language!** \n\n [[ ( [[ @{language} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Language!** \n\n [[ ( [[ @{language} + ?{Bonus Dice|0} ]] )d6dl[[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Language</label></button>
                             </div>
                         </div>
@@ -836,7 +836,7 @@
                                 <div class="sheet-row">
                                     <div class="sheet-item" style="width: 15%;"></div>
                                     <div class="sheet-item" style="width: 85%;"> <button type='roll' class='sheet-specialtyRoll' name='attr_languageRe-roll'
-                                        value='&{template:sofai} {{input=**@{character_name} tests Language (@{languageKnown})!** \n\n [[ ( [[ @{language} + @{knownLanguageRank} + ?{Bonus Dice|0} ]] )d6dl( [[ @{language} + @{knownLanguageRank} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
+                                        value='&{template:sofai} {{input=**@{character_name} tests Language (@{languageKnown})!** \n\n [[ ( [[ @{language} + @{knownLanguageRank} + ?{Bonus Dice|0} ]] )d6dl[[ @{language} + @{knownLanguageRank} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}'><label
                                             style="vertical-align: middle;">Roll</label></button></div>
                                 </div>
                                 <br/>
@@ -861,7 +861,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_knowledge-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Knowledge!** \n\n [[ ( [[ @{language} + @{languageX} + ?{Bonus Dice|0} ]] )d6dl( [[ @{languageX} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Knowledge!** \n\n [[ ( [[ @{language} + @{languageX} + ?{Bonus Dice|0} ]] )d6dl[[ @{languageX} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Knowledge</label></button>
                             </div>
                         </div>
@@ -880,7 +880,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_knowledgeEducation"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Knowledge (Education)!** \n\n [[ ( [[ @{language} + @{languageEducation} + ?{Bonus Dice|0} ]] )d6dl( [[ @{languageEducation} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Education</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Knowledge (Education)!** \n\n [[ ( [[ @{language} + @{languageEducation} + ?{Bonus Dice|0} ]] )d6dl[[ @{languageEducation} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Education</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -889,7 +889,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_knowledgeResearch"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Knowledge (Research)!** \n\n [[ ( [[ @{language} + @{languageResearch} + ?{Bonus Dice|0} ]] )d6dl( [[ @{languageResearch} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Research</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Knowledge (Research)!** \n\n [[ ( [[ @{language} + @{languageResearch} + ?{Bonus Dice|0} ]] )d6dl[[ @{languageResearch} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Research</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -898,7 +898,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_knowledgeStreetwise"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Knowledge (Streetwise)!** \n\n [[ ( [[ @{language} + @{languageStreetwise} + ?{Bonus Dice|0} ]] )d6dl( [[ @{languageStreetwise} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Streetwise</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Knowledge (Streetwise)!** \n\n [[ ( [[ @{language} + @{languageStreetwise} + ?{Bonus Dice|0} ]] )d6dl[[ @{languageStreetwise} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Streetwise</button>
                                 </div>
                             </div>
                         </div>
@@ -921,7 +921,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_marksmanship-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Marksmanship!** \n\n [[ ( [[ @{marksmanship} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Marksmanship!** \n\n [[ ( [[ @{marksmanship} + ?{Bonus Dice|0} ]] )d6dl[[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Marksman- ship</label></button>
                             </div>
                         </div>
@@ -940,7 +940,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_marksmanshipBows"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Marksmanship (Bows)!** \n\n [[ ( [[ @{marksmanship} + @{marksmanshipBows} + ?{Bonus Dice|0} ]] )d6dl( [[ @{marksmanshipBows} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Bows</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Marksmanship (Bows)!** \n\n [[ ( [[ @{marksmanship} + @{marksmanshipBows} + ?{Bonus Dice|0} ]] )d6dl[[ @{marksmanshipBows} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Bows</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -949,7 +949,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_marksmanshipCrossbows"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Marksmanship (Crossbows)!** \n\n [[ ( [[ @{marksmanship} + @{marksmanshipCrossbows} + ?{Bonus Dice|0} ]] )d6dl( [[ @{marksmanshipCrossbows} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Crossbows</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Marksmanship (Crossbows)!** \n\n [[ ( [[ @{marksmanship} + @{marksmanshipCrossbows} + ?{Bonus Dice|0} ]] )d6dl[[ @{marksmanshipCrossbows} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Crossbows</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -958,7 +958,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_marksmanshipSiege"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Marksmanship (Siege)!** \n\n [[ ( [[ @{marksmanship} + @{marksmanshipSiege} + ?{Bonus Dice|0} ]] )d6dl( [[ @{marksmanshipSiege} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Siege</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Marksmanship (Siege)!** \n\n [[ ( [[ @{marksmanship} + @{marksmanshipSiege} + ?{Bonus Dice|0} ]] )d6dl[[ @{marksmanshipSiege} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Siege</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -967,7 +967,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_marksmanshipThrown"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Marksmanship (Thrown)!** \n\n [[ ( [[ @{marksmanship} + @{marksmanshipThrown} + ?{Bonus Dice|0} ]] )d6dl( [[ @{marksmanshipThrown} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Thrown</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Marksmanship (Thrown)!** \n\n [[ ( [[ @{marksmanship} + @{marksmanshipThrown} + ?{Bonus Dice|0} ]] )d6dl[[ @{marksmanshipThrown} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Thrown</button>
                                 </div>
                             </div>
                         </div>
@@ -990,7 +990,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_persuasion-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Persuasion!** \n\n [[ ( [[ @{persuasion} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Persuasion!** \n\n [[ ( [[ @{persuasion} + ?{Bonus Dice|0} ]] )d6dl[[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Persuasion</label></button>
                             </div>
                         </div>
@@ -1009,7 +1009,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_persuasionBargain"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Bargain)!** \n\n [[ ( [[ @{persuasion} + @{persuasionBargain} + ?{Bonus Dice|0} ]] )d6dl( [[ @{persuasionBargain} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Bargain</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Bargain)!** \n\n [[ ( [[ @{persuasion} + @{persuasionBargain} + ?{Bonus Dice|0} ]] )d6dl[[ @{persuasionBargain} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Bargain</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1018,7 +1018,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_persuasionCharm"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Charm)!** \n\n [[ ( [[ @{persuasion} + @{persuasionCharm} + ?{Bonus Dice|0} ]] )d6dl( [[ @{persuasionCharm} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Charm</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Charm)!** \n\n [[ ( [[ @{persuasion} + @{persuasionCharm} + ?{Bonus Dice|0} ]] )d6dl[[ @{persuasionCharm} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Charm</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1027,7 +1027,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_persuasionConvince"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Convince)!** \n\n [[ ( [[ @{persuasion} + @{persuasionConvince} + ?{Bonus Dice|0} ]] )d6dl( [[ @{persuasionConvince} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Convince</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Convince)!** \n\n [[ ( [[ @{persuasion} + @{persuasionConvince} + ?{Bonus Dice|0} ]] )d6dl[[ @{persuasionConvince} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Convince</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1036,7 +1036,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_persuasionIncite"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Incite)!** \n\n [[ ( [[ @{persuasion} + @{persuasionIncite} + ?{Bonus Dice|0} ]] )d6dl( [[ @{persuasionIncite} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Incite</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Incite)!** \n\n [[ ( [[ @{persuasion} + @{persuasionIncite} + ?{Bonus Dice|0} ]] )d6dl[[ @{persuasionIncite} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Incite</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1045,7 +1045,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_persuasionIntimidate"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Intimidate)!** \n\n [[ ( [[ @{persuasion} + @{persuasionIntimidate} + ?{Bonus Dice|0} ]] )d6dl( [[ @{persuasionIntimidate} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Intimidate</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Intimidate)!** \n\n [[ ( [[ @{persuasion} + @{persuasionIntimidate} + ?{Bonus Dice|0} ]] )d6dl[[ @{persuasionIntimidate} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Intimidate</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1054,7 +1054,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_persuasionSeduce"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Seduce)!** \n\n [[ ( [[ @{persuasion} + @{persuasionSeduce} + ?{Bonus Dice|0} ]] )d6dl( [[ @{persuasionSeduce} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Seduce</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Seduce)!** \n\n [[ ( [[ @{persuasion} + @{persuasionSeduce} + ?{Bonus Dice|0} ]] )d6dl[[ @{persuasionSeduce} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Seduce</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1063,7 +1063,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_persuasionTaunt"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Taunt)!** \n\n [[ ( [[ @{persuasion} + @{persuasionTaunt} + ?{Bonus Dice|0} ]] )d6dl( [[ @{persuasionTaunt} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Taunt</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Persuasion (Taunt)!** \n\n [[ ( [[ @{persuasion} + @{persuasionTaunt} + ?{Bonus Dice|0} ]] )d6dl[[ @{persuasionTaunt} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Taunt</button>
                                 </div>
                             </div>
                         </div>
@@ -1087,7 +1087,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_status-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Status!** \n\n [[ ( [[ @{status} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Status!** \n\n [[ ( [[ @{status} + ?{Bonus Dice|0} ]] )d6dl[[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}'><label
                                         class="sheet-statusRoll">Status</label></button>
                             </div>
                         </div>
@@ -1106,7 +1106,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_statusBreeding"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Status (Breeding)!** \n\n [[ ( [[ @{status} + @{statusBreeding} + ?{Bonus Dice|0} ]] )d6dl( [[ @{statusBreeding} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Breeding</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Status (Breeding)!** \n\n [[ ( [[ @{status} + @{statusBreeding} + ?{Bonus Dice|0} ]] )d6dl[[ @{statusBreeding} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Breeding</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1115,7 +1115,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_statusReputation"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Status (Reputation)!** \n\n [[ ( [[ @{status} + @{statusReputation} + ?{Bonus Dice|0} ]] )d6dl( [[ @{statusReputation} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Reputation</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Status (Reputation)!** \n\n [[ ( [[ @{status} + @{statusReputation} + ?{Bonus Dice|0} ]] )d6dl[[ @{statusReputation} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Reputation</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1124,7 +1124,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_statusStewardship"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Status (Stewardship)!** \n\n [[ ( [[ @{status} + @{statusStewardship} + ?{Bonus Dice|0} ]] )d6dl( [[ @{statusStewardship} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Stewardship</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Status (Stewardship)!** \n\n [[ ( [[ @{status} + @{statusStewardship} + ?{Bonus Dice|0} ]] )d6dl[[ @{statusStewardship} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Stewardship</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1133,7 +1133,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_statusTournaments"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Status (Tournaments)!** \n\n [[ ( [[ @{status} + @{statusTournaments} + ?{Bonus Dice|0} ]] )d6dl( [[ @{statusTournaments} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Tournaments</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Status (Tournaments)!** \n\n [[ ( [[ @{status} + @{statusTournaments} + ?{Bonus Dice|0} ]] )d6dl[[ @{statusTournaments} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Tournaments</button>
                                 </div>
                             </div>
                         </div>
@@ -1156,7 +1156,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_stealth-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Stealth!** \n\n [[ ( [[ @{stealth} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Stealth!** \n\n [[ ( [[ @{stealth} + ?{Bonus Dice|0} ]] )d6dl[[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Stealth</label></button>
                             </div>
                         </div>
@@ -1175,7 +1175,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_stealthBlendIn"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Stealth (Blend In)!** \n\n [[ ( [[ @{stealth} + @{stealthBlendIn} + ?{Bonus Dice|0} ]] )d6dl( [[ @{stealthBlendIn} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Blend
+                                        value="&{template:sofai} {{input=**@{character_name} tests Stealth (Blend In)!** \n\n [[ ( [[ @{stealth} + @{stealthBlendIn} + ?{Bonus Dice|0} ]] )d6dl[[ @{stealthBlendIn} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Blend
                                         In</button>
                                 </div>
                             </div>
@@ -1185,7 +1185,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_stealthSneak"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Stealth (Sneak)!** \n\n [[ ( [[ @{stealth} + @{stealthSneak} + ?{Bonus Dice|0} ]] )d6dl( [[ @{stealthSneak} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Sneak</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Stealth (Sneak)!** \n\n [[ ( [[ @{stealth} + @{stealthSneak} + ?{Bonus Dice|0} ]] )d6dl[[ @{stealthSneak} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Sneak</button>
                                 </div>
                             </div>
                         </div>
@@ -1208,7 +1208,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_survival-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Survival!** \n\n [[ ( [[ @{survival} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Survival!** \n\n [[ ( [[ @{survival} + ?{Bonus Dice|0} ]] )d6dl[[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Survival</label></button>
                             </div>
                         </div>
@@ -1227,7 +1227,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_survivalForage"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Survival (Forage)!** \n\n [[ ( [[ @{survival} + @{survivalForage} + ?{Bonus Dice|0} ]] )d6dl( [[ @{survivalForage} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Forage</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Survival (Forage)!** \n\n [[ ( [[ @{survival} + @{survivalForage} + ?{Bonus Dice|0} ]] )d6dl[[ @{survivalForage} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Forage</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1236,7 +1236,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_survivalHunt"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Survival (Hunt)!** \n\n [[ ( [[ @{survival} + @{survivalHunt} + ?{Bonus Dice|0} ]] )d6dl( [[ @{survivalHunt} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Hunt</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Survival (Hunt)!** \n\n [[ ( [[ @{survival} + @{survivalHunt} + ?{Bonus Dice|0} ]] )d6dl[[ @{survivalHunt} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Hunt</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1245,7 +1245,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_survivalOrientation"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Survival (Orientation)!** \n\n [[ ( [[ @{survival} + @{survivalOrientation} + ?{Bonus Dice|0} ]] )d6dl( [[ @{survivalOrientation} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Orientation</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Survival (Orientation)!** \n\n [[ ( [[ @{survival} + @{survivalOrientation} + ?{Bonus Dice|0} ]] )d6dl[[ @{survivalOrientation} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Orientation</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1254,7 +1254,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_survivalTrack"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Survival (Track)!** \n\n [[ ( [[ @{survival} + @{survivalTrack} + ?{Bonus Dice|0} ]] )d6dl( [[ @{survivalTrack} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Track</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Survival (Track)!** \n\n [[ ( [[ @{survival} + @{survivalTrack} + ?{Bonus Dice|0} ]] )d6dl[[ @{survivalTrack} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Track</button>
                                 </div>
                             </div>
                         </div>
@@ -1277,7 +1277,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_thievery-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Thievery!** \n\n [[ ( [[ @{thievery} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Thievery!** \n\n [[ ( [[ @{thievery} + ?{Bonus Dice|0} ]] )d6dl[[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Thievery</label></button>
                             </div>
                         </div>
@@ -1296,7 +1296,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_thieveryPickLock"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Thievery (Pick Lock)!** \n\n [[ ( [[ @{thievery} + @{thieveryPickLock} + ?{Bonus Dice|0} ]] )d6dl( [[ @{thieveryPickLock} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Pick
+                                        value="&{template:sofai} {{input=**@{character_name} tests Thievery (Pick Lock)!** \n\n [[ ( [[ @{thievery} + @{thieveryPickLock} + ?{Bonus Dice|0} ]] )d6dl[[ @{thieveryPickLock} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Pick
                                         Lock</button>
                                 </div>
                             </div>
@@ -1306,7 +1306,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_thieverySleightOfHand"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Thievery (Sleight of Hand)!** \n\n [[ ( [[ @{thievery} + @{thieverySleightOfHand} + ?{Bonus Dice|0} ]] )d6dl( [[ @{thieverySleightOfHand} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Sleight
+                                        value="&{template:sofai} {{input=**@{character_name} tests Thievery (Sleight of Hand)!** \n\n [[ ( [[ @{thievery} + @{thieverySleightOfHand} + ?{Bonus Dice|0} ]] )d6dl[[ @{thieverySleightOfHand} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Sleight
                                         of Hand</button>
                                 </div>
                             </div>
@@ -1316,7 +1316,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_thieverySteal"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Thievery (Steal)!** \n\n [[ ( [[ @{thievery} + @{thieverySteal} + ?{Bonus Dice|0} ]] )d6dl( [[ @{thieverySteal} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Steal</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Thievery (Steal)!** \n\n [[ ( [[ @{thievery} + @{thieverySteal} + ?{Bonus Dice|0} ]] )d6dl[[ @{thieverySteal} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Steal</button>
                                 </div>
                             </div>
                         </div>
@@ -1339,7 +1339,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_warfare-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Warfare!** \n\n [[ ( [[ @{warfare} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Warfare!** \n\n [[ ( [[ @{warfare} + ?{Bonus Dice|0} ]] )d6dl[[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Warfare</label></button>
                             </div>
                         </div>
@@ -1358,7 +1358,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_warfareCommand"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Warfare (Command)!** \n\n [[ ( [[ @{warfare} + @{warfareCommand} + ?{Bonus Dice|0} ]] )d6dl( [[ @{warfareCommand} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Command</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Warfare (Command)!** \n\n [[ ( [[ @{warfare} + @{warfareCommand} + ?{Bonus Dice|0} ]] )d6dl[[ @{warfareCommand} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Command</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1367,7 +1367,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_warfareStrategy"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Warfare (Strategy)!** \n\n [[ ( [[ @{warfare} + @{warfareStrategy} + ?{Bonus Dice|0} ]] )d6dl( [[ @{warfareStrategy} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Strategy</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Warfare (Strategy)!** \n\n [[ ( [[ @{warfare} + @{warfareStrategy} + ?{Bonus Dice|0} ]] )d6dl[[ @{warfareStrategy} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Strategy</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1376,7 +1376,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_warfareTactics"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Warfare (Tactics)!** \n\n [[ ( [[ @{warfare} + @{warfareTactics} + ?{Bonus Dice|0} ]] )d6dl( [[ @{warfareTactics} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Tactics</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Warfare (Tactics)!** \n\n [[ ( [[ @{warfare} + @{warfareTactics} + ?{Bonus Dice|0} ]] )d6dl[[ @{warfareTactics} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Tactics</button>
                                 </div>
                             </div>
                         </div>
@@ -1399,7 +1399,7 @@
                             </div>
                             <div class="sheet-col">
                                 <button type='roll' class='sheet-characteristics' name='attr_will-roll'
-                                    value='&{template:sofai} {{input=**@{character_name} tests Will!** \n\n [[ ( [[ @{will} + ?{Bonus Dice|0} ]] )d6dl( [[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}'><label
+                                    value='&{template:sofai} {{input=**@{character_name} tests Will!** \n\n [[ ( [[ @{will} + ?{Bonus Dice|0} ]] )d6dl[[ ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}'><label
                                         style="vertical-align: middle;">Will</label></button>
                             </div>
                         </div>
@@ -1418,7 +1418,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_willCourage"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Will (Courage)!** \n\n [[ ( [[ @{will} + @{willCourage} + ?{Bonus Dice|0} ]] )d6dl( [[ @{willCourage} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Courage</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Will (Courage)!** \n\n [[ ( [[ @{will} + @{willCourage} + ?{Bonus Dice|0} ]] )d6dl[[ @{willCourage} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Courage</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1427,7 +1427,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_willCoordinate"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Will (Coordinate)!** \n\n [[ ( [[ @{will} + @{willCoordinate} + ?{Bonus Dice|0} ]] )d6dl( [[ @{willCoordinate} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Coordinate</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Will (Coordinate)!** \n\n [[ ( [[ @{will} + @{willCoordinate} + ?{Bonus Dice|0} ]] )d6dl[[ @{willCoordinate} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Coordinate</button>
                                 </div>
                             </div>
                             <div class="sheet-row">
@@ -1436,7 +1436,7 @@
                                         value='0' /></div>
                                 <div class="sheet-item" style="width: 85%;"><button type='roll'
                                         class="sheet-specialtyRoll" name="roll_willDedication"
-                                        value="&{template:sofai} {{input=**@{character_name} tests Will (Dedication)!** \n\n [[ ( [[ @{will} + @{willDedication} + ?{Bonus Dice|0} ]] )d6dl( [[ @{willDedication} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] ) - @{injuries} - @{fatigue} ]] }}">Dedication</button>
+                                        value="&{template:sofai} {{input=**@{character_name} tests Will (Dedication)!** \n\n [[ ( [[ @{will} + @{willDedication} + ?{Bonus Dice|0} ]] )d6[[ @{willDedication} + ?{Bonus Dice|0} + @{wounds} + ?{Penalty Dice|0} ]] - @{injuries} - @{fatigue} ]] }}">Dedication</button>
                                 </div>
                             </div>
                         </div>
@@ -2981,16 +2981,12 @@
             log: logLog
         };
     }());
-
     on('change:repeating_weapon', function(){
         TAS.repeatingSimpleSum('weapon','weaponBulk','totalWeaponBulk')
     });
-
-
     on('change:repeating_expSpend', function(){
         TAS.repeatingSimpleSum('expSpend', 'expSpendCost', 'expSpent')
     });
-
     on('change:repeating_glorySpend', function(){
         TAS.repeatingSimpleSum('glorySpend', 'glorySpendCost', 'glorySpent')
     });
@@ -2998,4 +2994,4 @@
 
 <rolltemplate class="sheet-rolltemplate-sofai">
         {{input}}
-    </rolltemplate>
+</rolltemplate>


### PR DESCRIPTION
Fixes regression of rolls not working after https://github.com/Roll20/roll20-character-sheets/commit/e7928985df2b5b635cee57780246bf265892ed03.

The issue comes from so wierd Roll20 behavour. E.g:
The roll `7d6dl2` works fine.
The roll `( 7 )d6dl2` works fine.
The roll `( 7 )d6dl( 2 )` does not work (always gives 7).
The roll `7d6dl( 2 )` does not work (always gives 7).

This should fix https://github.com/Roll20/roll20-character-sheets/issues/5243

## Changes / Comments

Removed parentheses `( )` around the drop lowest part of the rolls, as this stops them from working.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
