### PR TITLE
Tri-Stat: Fixed tristat roll for attack to actually display the weapon name.

### DIFF
--- a/Tri-Stat/Tri-Stat.html
+++ b/Tri-Stat/Tri-Stat.html
@@ -378,7 +378,7 @@
             <fieldset class="repeating_Weapon">
                 <table class="sheet-tableII">
                     <tr>
-                        <th style="width:65px;"><button type="roll" class="sheet-skillbtn" name="roll_Weapon" value="&{template:attack}{{attribute= @{Weapon-Name} }} {{character= @{character_name} }} {{roll= [[ 2d@{Die}sd ]] }} {{Check= [[ @{Weapon-Stat} + @{Weapon-Skill} + @{Weapon-Check_Mod} + @{Weapon-spec} ]] }} {{Abilities= @{Weapon-Abilities} }} {{Disabilities= @{Weapon-Disabilities} }} {{notes= @{Weapon-Notes} }} {{damage1= [[ [[floor(@{Weapon-Damage})]] + [[@{ACV}]] ]] }} {{damage2= [[ [[floor(@{Weapon-Damage}*3/4)]] + [[@{ACV}]] ]] }}{{damage3= [[ [[floor(@{Weapon-Damage}/2)]] + [[@{ACV}]] ]] }}{{damage4= [[ [[floor(@{Weapon-Damage}/4)]] + [[@{ACV}]] ]] }}{{crit= [[@{Weapon-Damage}*2]] }}">Roll</button></th>
+                        <th style="width:65px;"><button type="roll" class="sheet-skillbtn" name="roll_Weapon" value="&{template:attack}{{weapon= @{Weapon-Name} }} {{character= @{character_name} }} {{roll= [[ 2d@{Die}sd ]] }} {{Check= [[ @{Weapon-Stat} + @{Weapon-Skill} + @{Weapon-Check_Mod} + @{Weapon-spec} ]] }} {{Abilities= @{Weapon-Abilities} }} {{Disabilities= @{Weapon-Disabilities} }} {{notes= @{Weapon-Notes} }} {{damage1= [[ [[floor(@{Weapon-Damage})]] + [[@{ACV}]] ]] }} {{damage2= [[ [[floor(@{Weapon-Damage}*3/4)]] + [[@{ACV}]] ]] }}{{damage3= [[ [[floor(@{Weapon-Damage}/2)]] + [[@{ACV}]] ]] }}{{damage4= [[ [[floor(@{Weapon-Damage}/4)]] + [[@{ACV}]] ]] }}{{crit= [[@{Weapon-Damage}*2]] }}">Roll</button></th>
                         <th style="width:210px;"><input type="text" class="sheet-Specialty" name="attr_Weapon-Name" value="" /></th>
                         <th style="width:120px;"><input type="text" class="sheet-Specialty" name="attr_Weapon-Type" value="" /></th>
                         <th style="width:55px;"><input type="checkbox" class="sheet-othercheck" name="attr_Weapon-spec" value="1"/><span></span></th>
@@ -490,7 +490,6 @@
             </td>
         {{/rollTotal() roll 2}}
         <tr>
-            
         </tr>
 </rolltemplate>
 


### PR DESCRIPTION
## Changes / Comments
Fixed the Tri-Stat sheet to actually display the weapon name correctly for attacks. This is a bug fix. No new functionality, the only aesthetic change is to display the name as was originally intended. No changed or removed attributes.