### PR TITLE
Cypher Systems - DEV 2585 - replace the e in Numenera

### DIFF
--- a/Cypher Systems by Roll20/sheet.json
+++ b/Cypher Systems by Roll20/sheet.json
@@ -4,7 +4,7 @@
     "authors": "Natha",
     "roll20userid": "75857",
     "preview": "cypher_systems_by_roll20.jpg",
-    "instructions": "A Roll20 Official, all-in-one sheet for Cypher System, Numenéra, and The Strange.\n&copy;2019 Monte Cook Games, LLC. Cypher System, Numenera and The Strange are trademarks of Monte Cook Games, LLC, in the U.S.A. and other countries.",
+    "instructions": "A Roll20 Official, all-in-one sheet for Cypher System, Numenera, and The Strange.\n&copy;2019 Monte Cook Games, LLC. Cypher System, Numenera and The Strange are trademarks of Monte Cook Games, LLC, in the U.S.A. and other countries.",
     "useroptions": [
         {
             "attribute": "gnlsettings_sheet_style",


### PR DESCRIPTION
## Changes / Comments


* The accented e is throwing off the name in the sheet select settings. Replacing the accented e.



## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
