### PR TITLE
[Woin] Luck Pool, Attack fields and Dmg Mod auto-calc

### DIFF
--- a/WOIN/WOIN.html
+++ b/WOIN/WOIN.html
@@ -419,28 +419,32 @@
                 <div class="sheet-header">Defenses</div>
                 <table class="sheet-skill">
                     <tr>
-                        <th>Melee Defense</th>
-                        <th>Ranged Defense</th>
-                        <th>Mental Defense</th>
-                        <th>Vital Defense</th>
+                        <th>Melee</th>
+                        <th>Ranged</th>
+                        <th>Mental</th>
+                        <th>Vital</th>
+						<th>Points</th>
                     </tr>
                     <tr>
                         <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_melee_defense" value="0" /></td>
                         <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_ranged_defense" value="0" /></td>
                         <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_mental_defense" value="0" /></td>
                         <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_vital_defense" value="0" /></td>
+						<td><input type="number" class="sheet-number2" style="width:80px;" name="attr_Points" value="0" /></td>
                     </tr>
                     <tr>
                         <th>Soak</th>
                         <th>Health</th>
                         <th>Max Health</th>
-                        <th>Carry Increment</th>
+                        <th>Carry Incr.</th>
+						<th>Carried</th>
                     </tr>
                     <tr>
                         <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_soak" value="0" /></td>
                         <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_health" value="0" /></td>
                         <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_maxhealth" value="0" /></td>
                         <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_carry_rating" value="0" /></td>
+						<td><input type="number" class="sheet-number2" style="width:80px;" name="attr_carried_total" value="0" /></td>
                     </tr>
                 </table>
             </div>
@@ -467,7 +471,7 @@
                             <th>Soak</th>
                             <th>Type</th>
                             <th>Weight</th>
-                            <th>Inneffective</th>
+                            <th>Ineffective</th>
                             <th></th>
                         </tr>
                         <tr>
@@ -2930,4 +2934,34 @@ on('change:repeating_xpaward', function(){
 on('change:repeating_xp', function(){
     TAS.repeatingSimpleSum('xp','cost','xp_spent_total');
 });
+
+on("change:repeating_gear:equipment_weight change:repeating_gear2:equipment_weight change:repeating_armor:armor_weight remove:repeating_gear remove:repeating_gear2 remove:repeating_armor", function() {
+	var lcarried_total
+	lcarried_total = 0;
+	
+	TAS.repeating('armor')
+		.fields('armor_weight')
+		.each(function(row,attrSet,id,rowSet){
+			lcarried_total += Number(row.armor_weight);
+		})
+		.execute();
+		
+	TAS.repeating('gear')
+		.fields('equipment_weight')
+		.each(function(row,attrSet,id,rowSet){
+			lcarried_total += Number(row.equipment_weight);
+		})
+		.execute();	
+		
+		TAS.repeating('gear2')
+		.attrs('carried_total')
+		.fields('equipment_weight')
+		.each(function(row,attrSet,id,rowSet){
+			lcarried_total += Number(row.equipment_weight);
+		}, function(rowSet, attrSet){
+			attrSet.carried_total = lcarried_total;
+		})
+		.execute();	
+});
+
 </script>

--- a/WOIN/WOIN.html
+++ b/WOIN/WOIN.html
@@ -475,7 +475,7 @@
                             <th></th>
                         </tr>
                         <tr>
-                            <td><button type="roll" class="sheet-rollskill" name="roll_Armor" value="&{template:default} {{name= @{Armor_name} }} {{soak= @{Armor_soak} }} {{inneffective= @{Armor_Inneffective} }} {{notes= @{Armor_notes} }}"></button></td>
+                            <td><button type="roll" class="sheet-rollskill" name="roll_Armor" value="&{template:default} {{name= @{Armor_name} }} {{soak= @{Armor_soak} }} {{ineffective= @{Armor_ineffective} }} {{notes= @{Armor_notes} }}"></button></td>
                             <td><input type="text" class="sheet-text3" name="attr_Armor_name" value="" placeholder="Armor Name"/></td>
                             <td><input type="number" class="sheet-number2" name="attr_Armor_soak" value="0" /></td>
                                 <td>
@@ -487,7 +487,7 @@
                                     </select>
                                 </td>
                             <td><input type="number" class="sheet-number2" name="attr_Armor_weight" value="0" /></td>
-                            <td><input type="text" class="sheet-text3" name="attr_Armor_Inneffective" value="" placeholder="Blunt, Heat, Electricity"/></td>
+                            <td><input type="text" class="sheet-text3" name="attr_Armor_Ineffective" value="" placeholder="Blunt, Heat, Electricity"/></td>
                             <th><input type="checkbox" class="sheet-box" name="attr_Armor_open" value="1"/><span></span></th>
                         </tr>
                     </table>
@@ -509,11 +509,11 @@
                             <th>Soak</th>
                             <th>Type</th>
                             <th>Weight</th>
-                            <th>Inneffective</th>
+                            <th>Ineffective</th>
                             <th></th>
                         </tr>
                         <tr>
-                            <td><button type="roll" class="sheet-rollskillold" name="roll_Armor" value="&{template:default} {{name= @{Armor_name} }} {{soak= @{Armor_soak} }} {{inneffective= @{Armor_Inneffective} }} {{notes= @{Armor_notes} }}"></button></td>
+                            <td><button type="roll" class="sheet-rollskillold" name="roll_Armor" value="&{template:default} {{name= @{Armor_name} }} {{soak= @{Armor_soak} }} {{inneffective= @{Armor_Ineffective} }} {{notes= @{Armor_notes} }}"></button></td>
                             <td><input type="text" class="sheet-text3" name="attr_Armor_name" value="" placeholder="Armor Name"/></td>
                             <td><input type="number" class="sheet-number2" name="attr_Armor_soak" value="0" /></td>
                                 <td>
@@ -525,7 +525,7 @@
                                     </select>
                                 </td>
                             <td><input type="number" class="sheet-number2" name="attr_Armor_weight" value="0" /></td>
-                            <td><input type="text" class="sheet-text3" name="attr_Armor_Inneffective" value="" placeholder="Blunt, Heat, Electricity"/></td>
+                            <td><input type="text" class="sheet-text3" name="attr_Armor_Ineffective" value="" placeholder="Blunt, Heat, Electricity"/></td>
                             <th><input type="checkbox" class="sheet-box" name="attr_Armor_open" value="1"/><span></span></th>
                         </tr>
                     </table>
@@ -551,15 +551,15 @@
                             <th></th>
                             <th>Weapon</th>
                             <th>Attack Attribute</th>
-                            <th>Attack Mod.</th>
-                            <th>Damage</th>
-                            <th>Damage Mod.</th>
-<th>Damage Add.</th>
+                            <th>Skill</th>
+                            <th>Dmg</th>
+							<th>Dmg Add.</th>
+                            <th>Dmg Mod.</th>
                             <th>Range</th>
                             <th></th>
                         </tr>
                         <tr>
-                            <td><button type="roll" class="sheet-rollskill" name="roll_weapon1" value="&{template:default} {{name= @{weapon1_name} }} {{range= @{weapon1_range} }} {{attack= [[ (@{weaponattrib1_select} + @{weapon1_skill})d6]] }} {{damage= [[(@{weapon1_damage} + @{weapon1_damagemod})d6 + @{weapon1_damageadd} ]] }}"></button></td>
+                            <td><button type="roll" class="sheet-rollskill" name="roll_weapon1" value="&{template:default} {{name= @{weapon1_name} }} {{range= @{weapon1_range} }} {{attack= [[ (@{weaponattrib1_select} + @{weapon1_skill} - @{weapon1_damagemod}*2)d6]] }} {{damage= [[(@{weapon1_damage} + @{weapon1_damagemod})d6 + @{weapon1_damageadd} ]] }}"></button></td>
                             <td><input type="text" class="sheet-text3" name="attr_weapon1_name" value="" placeholder="Weapon Name"/></td>
                             <td>
                                 <select class="sheet-select1" name="attr_weaponattrib1_select">
@@ -578,8 +578,8 @@
                             </td>
                             <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_skill" value="0" /></td>
                             <td><input type="number" class="sheet-number2" name="attr_weapon1_damage" value="0" /></td>
+							<td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_damageadd" value="0" /></td>
                             <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_damagemod" value="0" /></td>
-<td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_damageadd" value="0" /></td>
                             <td><input type="number" class="sheet-number2" name="attr_weapon1_range" value="0" /></td>
                             <th><input type="checkbox" class="sheet-box" name="attr_weapon1_open" value="1"/><span></span></th>
                         </tr>
@@ -600,15 +600,15 @@
                             <th></th>
                             <th>Weapon</th>
                             <th>Attack Attribute</th>
-                            <th>Attack Mod.</th>
-                            <th>Damage</th>
-                            <th>Damage Mod.</th>
-		<th>Damage Add.</th>
+                            <th>Skill</th>
+                            <th>Dmg</th>
+							<th>Dmg Add.</th>
+                            <th>Dmg Mod.</th>
                             <th>Range</th>
                             <th></th>
                         </tr>
                         <tr>
-                            <td><button type="roll" class="sheet-rollskillold" name="roll_weapon1" value="&{template:default} {{name= @{weapon1_name} }} {{range= @{weapon1_range} }} {{attack= [[ (@{weaponattrib1_select} + @{weapon1_skill})d6]] }} {{damage= [[(@{weapon1_damage} + @{weapon1_damagemod})d6 + @{weapon1_damageadd}]] }}"></button></td>
+                            <td><button type="roll" class="sheet-rollskillold" name="roll_weapon1" value="&{template:default} {{name= @{weapon1_name} }} {{range= @{weapon1_range} }} {{attack= [[ (@{weaponattrib1_select} + @{weapon1_skill} - @{weapon1_damagemod}*2)d6]] }} {{damage= [[(@{weapon1_damage} + @{weapon1_damagemod})d6 + @{weapon1_damageadd}]] }}"></button></td>
                             <td><input type="text" class="sheet-text3" name="attr_weapon1_name" value="" placeholder="Weapon Name"/></td>
                             <td>
                                 <select class="sheet-select1" name="attr_weaponattrib1_select">
@@ -627,8 +627,8 @@
                             </td>
                             <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_skill" value="0" /></td>
                             <td><input type="number" class="sheet-number2" name="attr_weapon1_damage" value="0" /></td>
-                            <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_damagemod" value="0" /></td>
-<td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_damageadd" value="0" /></td>
+							<td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_damageadd" value="0" /></td>
+							<td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_damagemod" value="0" /></td>
                             <td><input type="number" class="sheet-number2" name="attr_weapon1_range" value="0" /></td>
                             <th><input type="checkbox" class="sheet-box" name="attr_weapon1_open" value="1"/><span></span></th>
                         </tr>

--- a/WOIN/WOIN.html
+++ b/WOIN/WOIN.html
@@ -1904,7 +1904,7 @@ on("change:charisma change:charisma_rank change:maximum_dice_pool sheet:opened",
     });
 });
 // Creating luck Dice Pool
-on("change:luck_rank sheet:opened", function() {
+on("change:luck_rank", function() {
     getAttrs(["luck_rank"], function(values) {
 
         if (values.luck_rank == 0) {


### PR DESCRIPTION
## Changes / Comments
Removed Luck Pool rebuild on sheet:open, to preserve Luck Pool use between sessions. Rebuild of Luck Pool happens only under specific circumstances and should be managed by player, not auto-calculated.





## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [Y] Does the pull request title have the sheet name(s)? Include each sheet name.
- [Y] Is this a bug fix?
- [N] Does this add functional enhancements (new features or extending existing features) ?
- [N] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [N/A ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [N/A] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
