### PR TITLE
[SOIAF] - Agility speciality fix

### DIFF
--- a/Song of Ice and Fire Roleplaying/SIFRP.html
+++ b/Song of Ice and Fire Roleplaying/SIFRP.html
@@ -136,7 +136,7 @@
                                         <table>
                                             <tr>
                                                 <td><input type='number' name='attr_agilitySpecialty' value='0'/></td>
-                                                <td><button type='roll' class="sheet-" name="roll_agilitySpecialty" value="&{template:sofai} {{input= @{name} rolls Agility:@{agilitySpecialtyname} [[ ( [[ @{agility} + @{agilitySpecialty} + @{wounds} ]] )d6dl@{agilitySpecialty4}sd + @{injuries} ]]}}"></button></td>
+                                                <td><button type='roll' class="sheet-" name="roll_agilitySpecialty" value="&{template:sofai} {{input= @{name} rolls Agility:@{agilitySpecialtyname} [[ ( [[ @{agility} + @{agilitySpecialty} + @{wounds} ]] )d6dl@{agilitySpecialty}sd + @{injuries} ]]}}"></button></td>
                                                 <td><input type='text' name='attr_agilitySpecialtyname' value=''/></td>
                                             </tr>
                                         </table>


### PR DESCRIPTION
## Changes
- Fix button roll for Agility Specialty for the repeating section. Was a typo in the attribute name called, leading to roll failing thanks to non-existing attribute
## Comments
- tested on firefox

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
