### PR TITLE
[Mekton Zeta] Additional roll templates

### DIFF
--- a/Mekton Z/Mekton Zeta.css
+++ b/Mekton Z/Mekton Zeta.css
@@ -913,7 +913,33 @@ input.sheet-radio1[type="radio"]:checked + span::before {
     content: "3";
 }
 input.sheet-radio1[type="radio"]:focus {outline:0;} 
-/*----  general ----*/
+
+/*----  roll templates  ----*/
+/*----  skill general  ----*/
+.sheet-rolltemplate-skill-general .inlinerollresult  {
+    display: inline-block;
+    min-width: 1.2em;
+    text-align: center;
+    border: 1px solid black; 
+    background:transparent;
+}
+
+.sheet-rolltemplate-skill-general .inlinerollresult.fullcrit { border: 1px solid black; }
+.sheet-rolltemplate-skill-general .inlinerollresult.fullfail { border: 1px solid black; }
+.sheet-rolltemplate-skill-general .inlinerollresult.importantroll { border: 1px solid black; }
+
+.sheet-rolltemplate-skill-general .sheet-no_border .inlinerollresult {
+    display: inline-block;
+    min-width: 1.5em;
+    border: 2px solid transparent; 
+    background:transparent;
+    font-weight:400;
+}
+.sheet-rolltemplate-skill-general .sheet-tcat {
+    color: black;
+    font-weight:bold;
+}
+
 .sheet-rolltemplate-skill-general table {
     width: 100%;
     background: white;
@@ -923,6 +949,11 @@ input.sheet-radio1[type="radio"]:focus {outline:0;}
     font-family: "Contrail One", sans-serif;
     box-shadow: -5px -5px 5px black;
     color: black;
+}
+
+.sheet-rolltemplate-skill-general td {
+    padding: 0px;
+    text-align:center;
 }
 
 .sheet-rolltemplate-skill-general th {
@@ -939,16 +970,9 @@ input.sheet-radio1[type="radio"]:focus {outline:0;}
     box-shadow: inset 5px 0px 20px 0px black, inset -5px 0px 20px 0px black;
 }
 
-.sheet-rolltemplate-skill-general .sheet-tcat {
-    font-weight: bold;
-}
-
-.sheet-rolltemplate-skill-general td {
-    padding: 0px;
-    text-align:center;
-}
-
-.sheet-rolltemplate-skill-general .inlinerollresult  {
+/*----  quick mecha weapon ----*/
+/*----  Happy to take input on how to avoid the duplication of these CSS rules! ----*/
+.sheet-rolltemplate-quick-mecha-weapon .inlinerollresult  {
     display: inline-block;
     min-width: 1.2em;
     text-align: center;
@@ -956,18 +980,194 @@ input.sheet-radio1[type="radio"]:focus {outline:0;}
     background:transparent;
 }
 
-.sheet-rolltemplate-skill-general .inlinerollresult.fullfail {
-    border: 1px solid black;
-}
+.sheet-rolltemplate-quick-mecha-weapon .inlinerollresult.fullcrit { border: 1px solid black; }
+.sheet-rolltemplate-quick-mecha-weapon .inlinerollresult.fullfail { border: 1px solid black; }
+.sheet-rolltemplate-quick-mecha-weapon .inlinerollresult.importantroll { border: 1px solid black; }
 
-.sheet-rolltemplate-skill-general .inlinerollresult.importantroll {
-	border: 1px solid black;
-}
-
-.sheet-rolltemplate-skill-general .sheet-no_border .inlinerollresult {
+.sheet-rolltemplate-quick-mecha-weapon .sheet-no_border .inlinerollresult {
     display: inline-block;
     min-width: 1.5em;
     border: 2px solid transparent; 
     background:transparent;
     font-weight:400;
+}
+.sheet-rolltemplate-quick-mecha-weapon .sheet-tcat {
+    color: black;
+    font-weight:bold;
+    text-align: right;
+    width: 50%;
+}
+
+.sheet-rolltemplate-quick-mecha-weapon table {
+    width: 100%;
+    background: white;
+    border: 3px ridge gray;
+    color: black;
+    font-size: 0.9em;
+    font-family: "Contrail One", sans-serif;
+    box-shadow: -5px -5px 5px black;
+    color: black;
+}
+
+.sheet-rolltemplate-quick-mecha-weapon td {
+    padding: 0px;
+    text-align:center;
+}
+
+.sheet-rolltemplate-quick-mecha-weapon th {
+    color: white;
+    padding: 4px;
+    line-height: 1.4em;
+    font-size: 1.2em;
+    width: 100%;
+    height: 100%;
+    border-spacing: 0;
+    text-shadow: 0px 0px 5px black, 0px 0px 5px black, 0px 0px 5px black;
+    
+    background: #B02F32; /* Old browsers */
+    box-shadow: inset 5px 0px 20px 0px black, inset -5px 0px 20px 0px black;
+}
+
+.sheet-rolltemplate-quick-mecha-weapon .sheet-description {
+    color:gray;
+    line-height:0.9em;
+    font-family:"Arial";
+    font-size:0.8em;
+    font-weight:normal;
+    padding: 4px;
+    text-align:left;
+}
+
+/*----  projectile mecha weapon  ----*/
+.sheet-rolltemplate-projectile-mecha-weapon .inlinerollresult  {
+    display: inline-block;
+    min-width: 1.2em;
+    text-align: center;
+    border: 1px solid black; 
+    background:transparent;
+}
+
+.sheet-rolltemplate-projectile-mecha-weapon .inlinerollresult.fullcrit { border: 1px solid black; }
+.sheet-rolltemplate-projectile-mecha-weapon .inlinerollresult.fullfail { border: 1px solid black; }
+.sheet-rolltemplate-projectile-mecha-weapon .inlinerollresult.importantroll { border: 1px solid black; }
+
+.sheet-rolltemplate-projectile-mecha-weapon .sheet-no_border .inlinerollresult {
+    display: inline-block;
+    min-width: 1.5em;
+    border: 2px solid transparent; 
+    background:transparent;
+    font-weight:400;
+}
+.sheet-rolltemplate-projectile-mecha-weapon .sheet-tcat {
+    color: black;
+    font-weight:bold;
+    text-align: right;
+    width: 50%;
+}
+
+.sheet-rolltemplate-projectile-mecha-weapon table {
+    width: 100%;
+    background: white;
+    border: 3px ridge gray;
+    color: black;
+    font-size: 0.9em;
+    font-family: "Contrail One", sans-serif;
+    box-shadow: -5px -5px 5px black;
+    color: black;
+}
+
+.sheet-rolltemplate-projectile-mecha-weapon td {
+    padding: 0px;
+    text-align:center;
+}
+
+.sheet-rolltemplate-projectile-mecha-weapon th {
+    color: white;
+    padding: 4px;
+    line-height: 1.4em;
+    font-size: 1.2em;
+    width: 100%;
+    height: 100%;
+    border-spacing: 0;
+    text-shadow: 0px 0px 5px black, 0px 0px 5px black, 0px 0px 5px black;
+    
+    background: #B02F32; /* Old browsers */
+    box-shadow: inset 5px 0px 20px 0px black, inset -5px 0px 20px 0px black;
+}
+
+.sheet-rolltemplate-projectile-mecha-weapon .sheet-description {
+    color:gray;
+    line-height:0.9em;
+    font-family:"Arial";
+    font-size:0.8em;
+    font-weight:normal;
+    padding: 4px;
+    text-align:left;
+}
+
+/*----  melee mecha weapon  ----*/
+.sheet-rolltemplate-melee-mecha-weapon .inlinerollresult  {
+    display: inline-block;
+    min-width: 1.2em;
+    text-align: center;
+    border: 1px solid black; 
+    background:transparent;
+}
+
+.sheet-rolltemplate-melee-mecha-weapon .inlinerollresult.fullcrit { border: 1px solid black; }
+.sheet-rolltemplate-melee-mecha-weapon .inlinerollresult.fullfail { border: 1px solid black; }
+.sheet-rolltemplate-melee-mecha-weapon .inlinerollresult.importantroll { border: 1px solid black; }
+
+.sheet-rolltemplate-melee-mecha-weapon .sheet-no_border .inlinerollresult {
+    display: inline-block;
+    min-width: 1.5em;
+    border: 2px solid transparent; 
+    background:transparent;
+    font-weight:400;
+}
+.sheet-rolltemplate-melee-mecha-weapon .sheet-tcat {
+    color: black;
+    font-weight:bold;
+    text-align: right;
+    width: 50%;
+}
+
+.sheet-rolltemplate-melee-mecha-weapon table {
+    width: 100%;
+    background: white;
+    border: 3px ridge gray;
+    color: black;
+    font-size: 0.9em;
+    font-family: "Contrail One", sans-serif;
+    box-shadow: -5px -5px 5px black;
+    color: black;
+}
+
+.sheet-rolltemplate-melee-mecha-weapon td {
+    padding: 0px;
+    text-align:center;
+}
+
+.sheet-rolltemplate-melee-mecha-weapon th {
+    color: white;
+    padding: 4px;
+    line-height: 1.4em;
+    font-size: 1.2em;
+    width: 100%;
+    height: 100%;
+    border-spacing: 0;
+    text-shadow: 0px 0px 5px black, 0px 0px 5px black, 0px 0px 5px black;
+    
+    background: #B02F32; /* Old browsers */
+    box-shadow: inset 5px 0px 20px 0px black, inset -5px 0px 20px 0px black;
+}
+
+.sheet-rolltemplate-melee-mecha-weapon .sheet-description {
+    color:gray;
+    line-height:0.9em;
+    font-family:"Arial";
+    font-size:0.8em;
+    font-weight:normal;
+    padding: 4px;
+    text-align:left;
 }

--- a/Mekton Z/Mekton Zeta.css
+++ b/Mekton Z/Mekton Zeta.css
@@ -570,8 +570,6 @@ input.sheet-arrow[type="checkbox"] + span::before
     
     font-family: "Pictos Three";
     content: "c";
-    width: 14px;
-    height: 14px;
     font-size: 1.5em;
     color:white;
     text-shadow: 0px 0px 3px blue, 0px 0px 3px blue, 0px 0px 3px blue;
@@ -620,8 +618,6 @@ input.sheet-shield[type="checkbox"] + span::before
     
     font-family: "Pictos Custom";
     content: "e";
-    width: 14px;
-    height: 14px;
     font-size: 1.5em;
     color:white;
     text-shadow: 0px 0px 3px blue, 0px 0px 3px blue, 0px 0px 3px blue;
@@ -673,8 +669,6 @@ input.sheet-shield_red[type="checkbox"] + span::before
     
     font-family: "Pictos Custom";
     content: "e";
-    width: 14px;
-    height: 14px;
     font-size: 1.5em;
     color:white;
     text-shadow: 0px 0px 3px black, 0px 0px 3px black, 0px 0px 3px black;
@@ -724,8 +718,6 @@ input.sheet-bolt[type="checkbox"] + span::before
     
     font-family: "Pictos";
     content: "Y";
-    width: 14px;
-    height: 14px;
     font-size: 1.5em;
     color:white;
     text-shadow: 0px 0px 3px blue, 0px 0px 3px blue, 0px 0px 3px blue;
@@ -835,9 +827,6 @@ input.sheet-bolt[type="checkbox"]:checked + span::before {
     color:black;
 }
 
-.charsheet .sheet-hider input[type=checkbox]:checked ~ .sheet-btn {
-}
-
 .charsheet button[type="roll"] label,
 .charsheet button[type="roll"] input {
     height:24px;
@@ -854,9 +843,6 @@ input.sheet-bolt[type="checkbox"]:checked + span::before {
     border:none;
     font-weight:700;
     border-radius:50%;
-}
-
-.charsheet button[type="roll"] input {
 }
 
 .charsheet button[type="roll"]:hover label,

--- a/Mekton Z/Mekton Zeta.html
+++ b/Mekton Z/Mekton Zeta.html
@@ -380,9 +380,9 @@
                             <th style="width:50px">Total</th>
                         </tr>
                         <tr>
-                            <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Endurance  [[d10!+ @{Attribute-Endurance } + @{Level-Endurance } + ?{Modifier|0}]]"></button></td>
-                            <td>Endurance </td>
-                            <td><select class="sheet-table_input" name="attr_Attribute-Endurance ">
+                            <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Endurance [[d10!+ @{Attribute-Endurance} + @{Level-Endurance} + ?{Modifier|0}]]"></button></td>
+                            <td>Endurance</td>
+                            <td><select class="sheet-table_input" name="attr_Attribute-Endurance">
                                 <option value="0"></option>
                                 <option value="@{Attractiveness}">Attractiveness</option>
                                 <option value="@{Body_Type}" selected>Body Type</option>
@@ -396,7 +396,7 @@
                             </td>
                             <td><input type="number" class="sheet-table_input" name="attr_Level-Endurance" value="0"/></td>
                             <td><input type="number" class="sheet-table_input" name="attr_IP-Endurance" value="0"/></td>
-                            <td><input type="number" class="sheet-table_input" name="attr_Total-Endurance " value="@{Attribute-Endurance }+@{Level-Endurance }" disabled="true"/></td>
+                            <td><input type="number" class="sheet-table_input" name="attr_Total-Endurance" value="@{Attribute-Endurance}+@{Level-Endurance}" disabled="true"/></td>
                         </tr>
                     </table>
                 </div>
@@ -684,9 +684,9 @@
                             <th style="width:50px">Total</th>
                         </tr>
                         <tr>
-                            <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Awreness/Notice [[d10!+ @{Attribute-Awreness_Notice} + @{Level-Awreness_Notice} + ?{Modifier|0}]]"></button></td>
-                            <td>Awreness/Notice</td>
-                            <td><select class="sheet-table_input" name="attr_Attribute-Awreness_Notice">
+                            <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Awareness/Notice [[d10!+ @{Attribute-Awareness_Notice} + @{Level-Awareness_Notice} + ?{Modifier|0}]]"></button></td>
+                            <td>Awareness/Notice</td>
+                            <td><select class="sheet-table_input" name="attr_Attribute-Awareness_Notice">
                                 <option value="0"></option>
                                 <option value="@{Attractiveness}">Attractiveness</option>
                                 <option value="@{Body_Type}">Body Type</option>
@@ -698,9 +698,9 @@
                                 <option value="@{Reflexes}">Reflexes</option>
                                 <option value="@{Tech_Ability}">Tech Ability</option></select>
                             </td>
-                            <td><input type="number" class="sheet-table_input" name="attr_Level-Awreness_Notice" value="0"/></td>
-                            <td><input type="number" class="sheet-table_input" name="attr_IP-Awreness_Notice" value="0"/></td>
-                            <td><input type="number" class="sheet-table_input" name="attr_Total-Awreness_Notice" value="@{Attribute-Awreness_Notice}+@{Level-Awreness_Notice}" disabled="true"/></td>
+                            <td><input type="number" class="sheet-table_input" name="attr_Level-Awareness_Notice" value="0"/></td>
+                            <td><input type="number" class="sheet-table_input" name="attr_IP-Awareness_Notice" value="0"/></td>
+                            <td><input type="number" class="sheet-table_input" name="attr_Total-Awareness_Notice" value="@{Attribute-Awareness_Notice}+@{Level-Awareness_Notice}" disabled="true"/></td>
                         </tr>
                         <tr>
                             <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Compose or Write [[d10!+ @{Attribute-Compose_Write} + @{Level-Compose_Write} + ?{Modifier|0}]]"></button></td>
@@ -836,7 +836,7 @@
                             <td><input type="number" class="sheet-table_input" name="attr_Total-Language" value="@{Attribute-Language}+@{Level-Language}" disabled="true"/></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Know Programming [[d10!+ @{Attribute-Programming} + @{Level-Programming} + ?{Modifier|0}]]"></button></td>
+                            <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Programming [[d10!+ @{Attribute-Programming} + @{Level-Programming} + ?{Modifier|0}]]"></button></td>
                             <td>Programming</td>
                             <td><select class="sheet-table_input" name="attr_Attribute-Programming">
                                 <option value="0"></option>
@@ -855,7 +855,7 @@
                             <td><input type="number" class="sheet-table_input" name="attr_Total-Programming" value="@{Attribute-Programming}+@{Level-Programming}" disabled="true"/></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Know Shadowing/Avoid Pursuit [[d10!+ @{Attribute-Shadowing} + @{Level-Shadowing} + ?{Modifier|0}]]"></button></td>
+                            <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Shadowing/Avoid Pursuit [[d10!+ @{Attribute-Shadowing} + @{Level-Shadowing} + ?{Modifier|0}]]"></button></td>
                             <td>Shadowing/Avoid Pursuit</td>
                             <td><select class="sheet-table_input" name="attr_Attribute-Shadowing">
                                 <option value="0"></option>
@@ -874,7 +874,7 @@
                             <td><input type="number" class="sheet-table_input" name="attr_Total-Shadowing" value="@{Attribute-Shadowing}+@{Level-Shadowing}" disabled="true"/></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Know Strategy [[d10!+ @{Attribute-Strategy} + @{Level-Strategy} + ?{Modifier|0}]]"></button></td>
+                            <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Strategy [[d10!+ @{Attribute-Strategy} + @{Level-Strategy} + ?{Modifier|0}]]"></button></td>
                             <td>Strategy</td>
                             <td><select class="sheet-table_input" name="attr_Attribute-Strategy">
                                 <option value="0"></option>
@@ -893,7 +893,7 @@
                             <td><input type="number" class="sheet-table_input" name="attr_Total-Strategy" value="@{Attribute-Strategy}+@{Level-Strategy}" disabled="true"/></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Know Survival [[d10!+ @{Attribute-Survival} + @{Level-Survival} + ?{Modifier|0}]]"></button></td>
+                            <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Survival [[d10!+ @{Attribute-Survival} + @{Level-Survival} + ?{Modifier|0}]]"></button></td>
                             <td>Survival</td>
                             <td><select class="sheet-table_input" name="attr_Attribute-Survival">
                                 <option value="0"></option>
@@ -912,7 +912,7 @@
                             <td><input type="number" class="sheet-table_input" name="attr_Total-Survival" value="@{Attribute-Survival}+@{Level-Survival}" disabled="true"/></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Know Tactics [[d10!+ @{Attribute-Tactics} + @{Level-Tactics} + ?{Modifier|0}]]"></button></td>
+                            <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Tactics [[d10!+ @{Attribute-Tactics} + @{Level-Tactics} + ?{Modifier|0}]]"></button></td>
                             <td>Tactics</td>
                             <td><select class="sheet-table_input" name="attr_Attribute-Tactics">
                                 <option value="0"></option>
@@ -931,7 +931,7 @@
                             <td><input type="number" class="sheet-table_input" name="attr_Total-Tactics" value="@{Attribute-Tactics}+@{Level-Tactics}" disabled="true"/></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Know Teaching [[d10!+ @{Attribute-Teaching} + @{Level-Teaching} + ?{Modifier|0}]]"></button></td>
+                            <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Teaching [[d10!+ @{Attribute-Teaching} + @{Level-Teaching} + ?{Modifier|0}]]"></button></td>
                             <td>Teaching</td>
                             <td><select class="sheet-table_input" name="attr_Attribute-Teaching">
                                 <option value="0"></option>
@@ -1256,7 +1256,7 @@
                         <tr>
                             <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Aircraft/Shuttle Pilot [[d10!+ @{Attribute-Aircraft_Shuttle_Pilot} + @{Level-Aircraft_Shuttle_Pilot} + ?{Modifier|0}]]"></button></td>
                             <td>Aircraft/Shuttle Pilot</td>
-                            <td><select class="sheet-table_input" name="attr_Attribute- Aircraft_Shuttle_Pilot">
+                            <td><select class="sheet-table_input" name="attr_Attribute-Aircraft_Shuttle_Pilot">
                                 <option value="0"></option>
                                 <option value="@{Attractiveness}">Attractiveness</option>
                                 <option value="@{Body_Type}">Body Type</option>
@@ -1482,7 +1482,7 @@
                             <td><input type="number" class="sheet-table_input" name="attr_Total-Forgery" value="@{Attribute-Forgery} + @{Level-Forgery}" disabled="true"/></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls First Aid [[d10!+ @{Attribute-Jury_Rig} + @{Level-Jury_Rig} + ?{Modifier|0}]]"></button></td>
+                            <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Jury Rig [[d10!+ @{Attribute-Jury_Rig} + @{Level-Jury_Rig} + ?{Modifier|0}]]"></button></td>
                             <td>Jury Rig</td>
                             <td><select class="sheet-table_input" name="attr_Attribute-Jury_Rig">
                                 <option value="0"></option>
@@ -1596,9 +1596,9 @@
                             <td><input type="number" class="sheet-table_input" name="attr_Total-Paint_or_Draw" value="@{Attribute-Paint_or_Draw} + @{Level-Paint_or_Draw}" disabled="true"/></td>
                         </tr>
                         <tr>
-                            <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Photgraphy & Film [[d10!+ @{Attribute-Photgraphy_Film} + @{Level-Photgraphy_Film} + ?{Modifier|0}]]"></button></td>
-                            <td>Photgraphy & Film</td>
-                            <td><select class="sheet-table_input" name="attr_Attribute-Photgraphy_Film">
+                            <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Photography & Film [[d10!+ @{Attribute-Photography_Film} + @{Level-Photography_Film} + ?{Modifier|0}]]"></button></td>
+                            <td>Photography & Film</td>
+                            <td><select class="sheet-table_input" name="attr_Attribute-Photography_Film">
                                 <option value="0"></option>
                                 <option value="@{Attractiveness}">Attractiveness</option>
                                 <option value="@{Body_Type}">Body Type</option>
@@ -1610,9 +1610,9 @@
                                 <option value="@{Reflexes}">Reflexes</option>
                                 <option value="@{Tech_Ability}" selected>Tech Ability</option></select>
                             </td>
-                            <td><input type="number" class="sheet-table_input" name="attr_Level-Photgraphy_Film" value="0"/></td>
-                            <td><input type="number" class="sheet-table_input" name="attr_IP-Photgraphy_Film" value="0"/></td>
-                            <td><input type="number" class="sheet-table_input" name="attr_Total-Photgraphy_Film" value="@{Attribute-Photgraphy_Film} + @{Level-Photgraphy_Film}" disabled="true"/></td>
+                            <td><input type="number" class="sheet-table_input" name="attr_Level-Photography_Film" value="0"/></td>
+                            <td><input type="number" class="sheet-table_input" name="attr_IP-Photography_Film" value="0"/></td>
+                            <td><input type="number" class="sheet-table_input" name="attr_Total-Photography_Film" value="@{Attribute-Photography_Film} + @{Level-Photography_Film}" disabled="true"/></td>
                         </tr>
                         <tr>
                             <td><button type='roll' class="sheet-roll" style="width:35px;" value="/e rolls Pick Lock [[d10!+ @{Attribute-Pick_Lock} + @{Level-Pick_Lock} + ?{Modifier|0}]]"></button></td>
@@ -3808,94 +3808,94 @@
                 <td class="sheet-thickright sheet-thickbottom">CP</td>
             </tr>
             <tr>
-                <td class="sheet-thickleft "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_1_SP"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_1_DC"/></td>
-                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_1_K"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_1_Servo"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_1_Servo_Spc"/></td>
-                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_1_Servo_CP"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_1_Armor"/></td>
-                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_1_Armor_CP"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_1_System"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_1_System_notes"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_1_System_Spc"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_1_System_K"/></td>
-                <td class="sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_1_System_CP"/></td>
+                <td class="sheet-thickleft "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_1_SP"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_1_DC"/></td>
+                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_1_K"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_1_Servo"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_1_Servo_Spc"/></td>
+                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_1_Servo_CP"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_1_Armor"/></td>
+                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_1_Armor_CP"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_1_System"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_1_System_notes"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_1_System_Spc"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_1_System_K"/></td>
+                <td class="sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_1_System_CP"/></td>
             </tr>
             <tr>
-                <td class="sheet-thickleft "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_2_SP"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_2_DC"/></td>
-                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_2_K"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_2_Servo"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_2_Servo_Spc"/></td>
-                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_2_Servo_CP"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_2_Armor"/></td>
-                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_2_Armor_CP"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_2_System"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_2_System_notes"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_2_System_Spc"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_2_System_K"/></td>
-                <td class="sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_2_System_CP"/></td>
+                <td class="sheet-thickleft "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_2_SP"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_2_DC"/></td>
+                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_2_K"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_2_Servo"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_2_Servo_Spc"/></td>
+                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_2_Servo_CP"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_2_Armor"/></td>
+                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_2_Armor_CP"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_2_System"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_2_System_notes"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_2_System_Spc"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_2_System_K"/></td>
+                <td class="sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_2_System_CP"/></td>
             </tr>
             <tr>
-                <td class="sheet-thickleft "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_3_SP"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_3_DC"/></td>
-                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_3_K"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_3_Servo"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_3_Servo_Spc"/></td>
-                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_3_Servo_CP"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_3_Armor"/></td>
-                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_3_Armor_CP"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_3_System"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_3_System_notes"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_3_System_Spc"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_3_System_K"/></td>
-                <td class="sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_3_System_CP"/></td>
+                <td class="sheet-thickleft "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_3_SP"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_3_DC"/></td>
+                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_3_K"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_3_Servo"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_3_Servo_Spc"/></td>
+                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_3_Servo_CP"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_3_Armor"/></td>
+                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_3_Armor_CP"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_3_System"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_3_System_notes"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_3_System_Spc"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_3_System_K"/></td>
+                <td class="sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_3_System_CP"/></td>
             </tr>
             <tr>
-                <td class="sheet-thickleft "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_4_SP"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_4_DC"/></td>
-                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_4_K"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_4_Servo"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_4_Servo_Spc"/></td>
-                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_4_Servo_CP"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_4_Armor"/></td>
-                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_4_Armor_CP"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_4_System"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_4_System_notes"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_4_System_Spc"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_4_System_K"/></td>
-                <td class="sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_4_System_CP"/></td>
+                <td class="sheet-thickleft "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_4_SP"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_4_DC"/></td>
+                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_4_K"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_4_Servo"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_4_Servo_Spc"/></td>
+                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_4_Servo_CP"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_4_Armor"/></td>
+                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_4_Armor_CP"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_4_System"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_4_System_notes"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_4_System_Spc"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_4_System_K"/></td>
+                <td class="sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_4_System_CP"/></td>
             </tr>
             <tr>
-                <td class="sheet-thickleft "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_5_SP"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_5_DC"/></td>
-                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_5_K"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_5_Servo"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_5_Servo_Spc"/></td>
-                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_5_Servo_CP"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_5_Armor"/></td>
-                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_5_Armor_CP"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_5_System"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_5_System_notes"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_5_System_Spc"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_5_System_K"/></td>
-                <td class="sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_5_System_CP"/></td>
+                <td class="sheet-thickleft "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_5_SP"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_5_DC"/></td>
+                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_5_K"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_5_Servo"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_5_Servo_Spc"/></td>
+                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_5_Servo_CP"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_5_Armor"/></td>
+                <td class=" sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_5_Armor_CP"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_5_System"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_5_System_notes"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_5_System_Spc"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_5_System_K"/></td>
+                <td class="sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_5_System_CP"/></td>
             </tr>
             <tr>
-                <td class="sheet-thickleft sheet-thickbottom"><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_6_SP"/></td>
-                <td class="sheet-thickbottom"><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_6_DC"/></td>
-                <td class="sheet-thickbottom sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_6_K"/></td>
-                <td class="sheet-thickbottom"><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_6_Servo"/></td>
-                <td class="sheet-thickbottom"><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_6_Servo_Spc"/></td>
-                <td class="sheet-thickbottom sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_6_Servo_CP"/></td>
-                <td class="sheet-thickbottom"><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_6_Armor"/></td>
-                <td class="sheet-thickbottom sheet-thickright "><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_6_Armor_CP"/></td>
-                <td class="sheet-thickbottom"><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_6_System"/></td>
-                <td class="sheet-thickbottom"><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_6_System_notes"/></td>
-                <td class="sheet-thickbottom"><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_6_System_Spc"/></td>
-                <td class="sheet-thickbottom"><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_6_System_K"/></td>
-                <td class="sheet-thickright sheet-thickbottom"><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_6_System_CP"/></td>
+                <td class="sheet-thickleft sheet-thickbottom"><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_6_SP"/></td>
+                <td class="sheet-thickbottom"><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_6_DC"/></td>
+                <td class="sheet-thickbottom sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_6_K"/></td>
+                <td class="sheet-thickbottom"><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_6_Servo"/></td>
+                <td class="sheet-thickbottom"><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_6_Servo_Spc"/></td>
+                <td class="sheet-thickbottom sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_6_Servo_CP"/></td>
+                <td class="sheet-thickbottom"><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_6_Armor"/></td>
+                <td class="sheet-thickbottom sheet-thickright "><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_6_Armor_CP"/></td>
+                <td class="sheet-thickbottom"><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_6_System"/></td>
+                <td class="sheet-thickbottom"><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_6_System_notes"/></td>
+                <td class="sheet-thickbottom"><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_6_System_Spc"/></td>
+                <td class="sheet-thickbottom"><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_6_System_K"/></td>
+                <td class="sheet-thickright sheet-thickbottom"><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_6_System_CP"/></td>
             </tr>
         </table>
     </div>
@@ -3918,72 +3918,72 @@
             </tr>
             <tr>
                 <td class="sheet-thickleft "><input type="text" class="sheet-table_input" style="width:80px" name="attr_mecha-Remotes_weapon_1_name"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_1_WA"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_1_Rng"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_1_Dmg"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_1_Shots"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_1_K"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_1_WA"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_1_Rng"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_1_Dmg"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_1_Shots"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_1_K"/></td>
                 <td><input type="text" class="sheet-table_input" style="width:80px" name="attr_mecha-Remotes_weapon_1_Loc"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_1_CP"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_1_Eff"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_1_Spc"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_1_Cost"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_1_CP"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_1_Eff"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_1_Spc"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_1_Cost"/></td>
                 <td class="sheet-thickright "><input type="text" class="sheet-table_input" style="width:80px" name="attr_mecha-Remotes_weapon_1_Notes"/></td>
             </tr>
             <tr>
                 <td class="sheet-thickleft "><input type="text" class="sheet-table_input" style="width:80px" name="attr_mecha-Remotes_weapon_2_name"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_2_WA"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_2_Rng"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_2_Dmg"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_2_Shots"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_2_K"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_2_WA"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_2_Rng"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_2_Dmg"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_2_Shots"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_2_K"/></td>
                 <td><input type="text" class="sheet-table_input" style="width:80px" name="attr_mecha-Remotes_weapon_2_Loc"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_2_CP"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_2_Eff"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_2_Spc"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_2_Cost"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_2_CP"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_2_Eff"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_2_Spc"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_2_Cost"/></td>
                 <td class="sheet-thickright "><input type="text" class="sheet-table_input" style="width:80px" name="attr_mecha-Remotes_weapon_2_Notes"/></td>
             </tr>
             <tr>
                 <td class="sheet-thickleft "><input type="text" class="sheet-table_input" style="width:80px" name="attr_mecha-Remotes_weapon_3_name"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_3_WA"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_3_Rng"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_3_Dmg"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_3_Shots"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_3_K"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_3_WA"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_3_Rng"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_3_Dmg"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_3_Shots"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_3_K"/></td>
                 <td><input type="text" class="sheet-table_input" style="width:80px" name="attr_mecha-Remotes_weapon_3_Loc"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_3_CP"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_3_Eff"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_3_Spc"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_3_Cost"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_3_CP"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_3_Eff"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_3_Spc"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_3_Cost"/></td>
                 <td class="sheet-thickright "><input type="text" class="sheet-table_input" style="width:80px" name="attr_mecha-Remotes_weapon_3_Notes"/></td>
             </tr>
             <tr>
                 <td class="sheet-thickleft "><input type="text" class="sheet-table_input" style="width:80px" name="attr_mecha-Remotes_weapon_4_name"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_4_WA"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_4_Rng"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_4_Dmg"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_4_Shots"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_4_K"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_4_WA"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_4_Rng"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_4_Dmg"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_4_Shots"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_4_K"/></td>
                 <td><input type="text" class="sheet-table_input" style="width:80px" name="attr_mecha-Remotes_weapon_4_Loc"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_4_CP"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_4_Eff"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_4_Spc"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_4_Cost"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_4_CP"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_4_Eff"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_4_Spc"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_4_Cost"/></td>
                 <td class="sheet-thickright "><input type="text" class="sheet-table_input" style="width:80px" name="attr_mecha-Remotes_weapon_4_Notes"/></td>
             </tr>
             <tr>
                 <td class="sheet-thickleft "><input type="text" class="sheet-table_input" style="width:80px" name="attr_mecha-Remotes_weapon_5_name"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_5_WA"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_5_Rng"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_5_Dmg"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_5_Shots"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_5_K"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_5_WA"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_5_Rng"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_5_Dmg"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_5_Shots"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_5_K"/></td>
                 <td><input type="text" class="sheet-table_input" style="width:80px" name="attr_mecha-Remotes_weapon_5_Loc"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_5_CP"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_5_Eff"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_5_Spc"/></td>
-                <td><input type="number" class="sheet-table_input" style="" name="attr_mecha-Remotes_weapon_5_Cost"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_5_CP"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_5_Eff"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_5_Spc"/></td>
+                <td><input type="number" class="sheet-table_input" name="attr_mecha-Remotes_weapon_5_Cost"/></td>
                 <td class="sheet-thickright "><input type="text" class="sheet-table_input" style="width:80px" name="attr_mecha-Remotes_weapon_5_Notes"/></td>
             </tr>
         </table>

--- a/Mekton Z/Mekton Zeta.html
+++ b/Mekton Z/Mekton Zeta.html
@@ -3718,7 +3718,6 @@
                 <td style="width:40px"><input type="number" class="sheet-table_input" style="width:40px" name="attr_mecha-Shields_1_Cost"/></td>
                 <td class="sheet-thickright"><input type="text" class="sheet-table_input" style="width:100%" name="attr_mecha-Shields_1_Notes"/></td>
             </tr>
-
             <tr>
                 <td class="sheet-thickleft" style="width:60px" ><input type="text" class="sheet-table_input" style="width:60px" name="attr_mecha-Shields_2_Location"/></td>
                 <td style="width:60px" ><input type="text" class="sheet-table_input" style="width:60px" name="attr_mecha-Shields_2_Class"/></td>
@@ -3988,8 +3987,6 @@
                 <td class="sheet-thickright "><input type="text" class="sheet-table_input" style="width:80px" name="attr_mecha-Remotes_weapon_5_Notes"/></td>
             </tr>
         </table>
-
-
     </div>
 </div>
 <!--Tab 10 Command Armor, Boosterpacks, and Droptanks-->
@@ -4168,7 +4165,7 @@
 
 <!--Roll Templates-->
 <div class="sheet-hidden">
-    <!-- Skill-general-->
+    <!-- skill-general-->
     <rolltemplate class="sheet-rolltemplate-skill-general">
         <table class="sheet-skill-general">
             <tr>
@@ -4179,7 +4176,7 @@
             </tr>
             <tr>
                 <td style="padding-left:10px" ><i>Range</i></td>
-                <td class="sheet-no_border">{{range}}meters</td>
+                <td class="sheet-no_border">{{range}} meters</td>
             </tr>
             <tr>
                 <td><span class="sheet-tcat"><b>Attack:</b> </span> </td>
@@ -4192,6 +4189,108 @@
             <tr>
                 <td><span class="sheet-tcat"><b>Hit Location:</b> </span>
                 <td>{{hit-location}}</td>
+            </tr>
+        </table>
+    </rolltemplate>
+    <!-- mecha-projectile-weapon -->
+    <rolltemplate class="sheet-rolltemplate-projectile-mecha-weapon">
+        <table class="sheet-projectile-mecha-weapon">
+            <tr>
+                <th colspan="2">{{weapon}}</th>
+            </tr>
+            <tr>
+                <td colspan="2"><i><b>{{character}}</b> fires the {{weapon}}</i></td>
+            </tr>
+            <tr>
+                <td class="sheet-tcat"><b>Attack:</b></td>
+                <td>{{attack}}</td>
+            </tr>
+            <tr>
+                <td class="sheet-tcat"><b>Hit Location:</b></td>
+                <td>{{hit-location}}</td>
+            </tr>
+            <tr>
+                <td class="sheet-tcat"><b>Range:</b></td>
+                <td class="sheet-no_border">{{range}} meters</td>
+            </tr>
+            <tr>
+                <td class="sheet-tcat"><b>Damage:</b></td>
+                <td>{{damage}} Kills</td>
+            </tr>
+            <tr>
+                <td class="sheet-tcat"><b>Burst Value:</b></td>
+                <td>{{bv}}</td>
+            </tr>
+            <tr>
+                <td class="sheet-tcat"><b>Ammo Type:</b></td>
+                <td>{{ammo}}</td>
+            </tr>
+            <tr>
+                <td class="sheet-tcat"><b>Firing Mode:</b></td>
+                <td>{{target}}</td>
+            </tr>    
+            <tr>
+                <td<span class="sheet-description" colspan="2"><i>{{desc}}</i></td>
+            </tr>
+        </table>
+    </rolltemplate>
+    <!-- melee-mecha-weapon -->
+    <rolltemplate class="sheet-rolltemplate-melee-mecha-weapon">
+        <table class="sheet-melee-mecha-weapon">
+            <tr>
+                <th colspan="2">{{weapon}}</th>
+            </tr>
+            <tr>
+                <td colspan="2"><i><b>{{character}}</b> attacks with the {{weapon}}</i></td>
+            </tr>
+            <tr>
+                <td class="sheet-tcat"><b>Attack:</b></td>
+                <td>{{attack}}</td>
+            </tr>
+            <tr>
+                <td class="sheet-tcat"><b>Hit Location:</b></td>
+                <td>{{hit-location}}</td>
+            </tr>
+            <tr>
+                <td class="sheet-tcat"><b>Damage:</b></td>
+                <td>{{damage}} Kills</td>
+            </tr>
+            <tr>
+                <td class="sheet-tcat"><b>Armour-Piercing:</b></td>
+                <td>{{ap}} SP</td>
+            </tr>
+            <tr>
+                <td<span class="sheet-description" colspan="2"><i>{{desc}}</i></td>
+            </tr>
+        </table>
+    </rolltemplate>
+    <!-- quick-mecha-weapon -->
+    <rolltemplate class="sheet-rolltemplate-quick-mecha-weapon">
+        <table class="sheet-quick-mecha-weapon">
+            <tr>
+                <th colspan="3">{{weapon}}</th>
+            </tr>
+            <tr>
+                <td colspan="3"><i><b>{{character}}</b> attacks with the {{weapon}}</i></td>
+            </tr>
+            <tr>
+                <td class="sheet-tcat"><b>Attacks:</b></td>
+                <td>{{attack-1}}</td><td>{{attack-2}}</td>
+            </tr>
+            <tr>
+                <td class="sheet-tcat"><b>Hit Locations:</b></td>
+                <td>{{hit-location-1}}</td><td>{{hit-location-2}}</td>
+            </tr>
+            <tr>
+                <td class="sheet-tcat"><b>Damage:</b></td>
+                <td colspan="2">{{damage}} Kills</td>
+            </tr>
+            <tr>
+                <td class="sheet-tcat"><b>Armour-Piercing:</b></td>
+                <td colspan="2">{{ap}} SP</td>
+            </tr>
+            <tr>
+                <td class="sheet-description" colspan="3"><i>{{desc}}</i></td>
             </tr>
         </table>
     </rolltemplate>


### PR DESCRIPTION
## Changes / Comments

Adds new Roll Templates for Mecha Weapons
* Allows creating macros for mecha weapon attacks identifying properties in a simple layout

Minor issue resolution
* Some skill rolls displayed the incorrect text
* Some attributes were mislabelled and the calculation was broken as a result
* Syntax warnings concerning empty rulesets that are superseded by other rules




## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
  - This has been added as requested.
- [x] Is this a bug fix?
  - Cleans up a few aesthetic issues with some rolls from the sheet.
- [ ] Does this add functional enhancements (new features or extending existing features)?
- [x] Does this add or change functional aesthetics (such as layout or color scheme)?
  - Adds new roll templates to allow for better macros.
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository)?

If you do not know English. Please leave a comment in your native language.
