### PR TITLE
[Woin] html & css - Added Condition Tracking for NEW version of sheet

### DIFF
--- a/WOIN/WOIN.css
+++ b/WOIN/WOIN.css
@@ -208,6 +208,11 @@ select.sheet-select1 {
     width:100px;
     margin-bottom:-2px;
 }
+select.sheet-select2 {
+    background:transparent;
+    width:250px;
+    margin-bottom:-2px;
+}
 hr {
     background:blue;
 }

--- a/WOIN/WOIN.html
+++ b/WOIN/WOIN.html
@@ -419,28 +419,32 @@
                 <div class="sheet-header">Defenses</div>
                 <table class="sheet-skill">
                     <tr>
-                        <th>Melee Defense</th>
-                        <th>Ranged Defense</th>
-                        <th>Mental Defense</th>
-                        <th>Vital Defense</th>
+                        <th>Melee</th>
+                        <th>Ranged</th>
+                        <th>Mental</th>
+                        <th>Vital</th>
+						<th>Points</th>
                     </tr>
                     <tr>
                         <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_melee_defense" value="0" /></td>
                         <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_ranged_defense" value="0" /></td>
                         <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_mental_defense" value="0" /></td>
                         <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_vital_defense" value="0" /></td>
+						<td><input type="number" class="sheet-number2" style="width:80px;" name="attr_Points" value="0" /></td>
                     </tr>
                     <tr>
                         <th>Soak</th>
                         <th>Health</th>
                         <th>Max Health</th>
-                        <th>Carry Increment</th>
+                        <th>Carry Incr.</th>
+						<th>Carried</th>
                     </tr>
                     <tr>
                         <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_soak" value="0" /></td>
                         <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_health" value="0" /></td>
                         <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_maxhealth" value="0" /></td>
                         <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_carry_rating" value="0" /></td>
+						<td><input type="number" class="sheet-number2" style="width:80px;" name="attr_carried_total" value="0" /></td>
                     </tr>
                 </table>
             </div>
@@ -467,7 +471,7 @@
                             <th>Soak</th>
                             <th>Type</th>
                             <th>Weight</th>
-                            <th>Inneffective</th>
+                            <th>Ineffective</th>
                             <th></th>
                         </tr>
                         <tr>
@@ -2930,4 +2934,34 @@ on('change:repeating_xpaward', function(){
 on('change:repeating_xp', function(){
     TAS.repeatingSimpleSum('xp','cost','xp_spent_total');
 });
+
+on("change:repeating_gear:equipment_weight change:repeating_gear2:equipment_weight change:repeating_armor:armor_weight remove:repeating_gear remove:repeating_gear2 remove:repeating_armor", function() {
+	var lcarried_total
+	lcarried_total = 0;
+	
+	TAS.repeating('armor')
+		.fields('armor_weight')
+		.each(function(row,attrSet,id,rowSet){
+			lcarried_total += Number(row.armor_weight);
+		})
+		.execute();
+		
+	TAS.repeating('gear')
+		.fields('equipment_weight')
+		.each(function(row,attrSet,id,rowSet){
+			lcarried_total += Number(row.equipment_weight);
+		})
+		.execute();	
+		
+		TAS.repeating('gear2')
+		.attrs('carried_total')
+		.fields('equipment_weight')
+		.each(function(row,attrSet,id,rowSet){
+			lcarried_total += Number(row.equipment_weight);
+		}, function(rowSet, attrSet){
+			attrSet.carried_total = lcarried_total;
+		})
+		.execute();	
+});
+
 </script>

--- a/WOIN/WOIN.html
+++ b/WOIN/WOIN.html
@@ -475,7 +475,7 @@
                             <th></th>
                         </tr>
                         <tr>
-                            <td><button type="roll" class="sheet-rollskill" name="roll_Armor" value="&{template:default} {{name= @{Armor_name} }} {{soak= @{Armor_soak} }} {{inneffective= @{Armor_Inneffective} }} {{notes= @{Armor_notes} }}"></button></td>
+                            <td><button type="roll" class="sheet-rollskill" name="roll_Armor" value="&{template:default} {{name= @{Armor_name} }} {{soak= @{Armor_soak} }} {{ineffective= @{Armor_ineffective} }} {{notes= @{Armor_notes} }}"></button></td>
                             <td><input type="text" class="sheet-text3" name="attr_Armor_name" value="" placeholder="Armor Name"/></td>
                             <td><input type="number" class="sheet-number2" name="attr_Armor_soak" value="0" /></td>
                                 <td>
@@ -487,7 +487,7 @@
                                     </select>
                                 </td>
                             <td><input type="number" class="sheet-number2" name="attr_Armor_weight" value="0" /></td>
-                            <td><input type="text" class="sheet-text3" name="attr_Armor_Inneffective" value="" placeholder="Blunt, Heat, Electricity"/></td>
+                            <td><input type="text" class="sheet-text3" name="attr_Armor_Ineffective" value="" placeholder="Blunt, Heat, Electricity"/></td>
                             <th><input type="checkbox" class="sheet-box" name="attr_Armor_open" value="1"/><span></span></th>
                         </tr>
                     </table>
@@ -509,11 +509,11 @@
                             <th>Soak</th>
                             <th>Type</th>
                             <th>Weight</th>
-                            <th>Inneffective</th>
+                            <th>Ineffective</th>
                             <th></th>
                         </tr>
                         <tr>
-                            <td><button type="roll" class="sheet-rollskillold" name="roll_Armor" value="&{template:default} {{name= @{Armor_name} }} {{soak= @{Armor_soak} }} {{inneffective= @{Armor_Inneffective} }} {{notes= @{Armor_notes} }}"></button></td>
+                            <td><button type="roll" class="sheet-rollskillold" name="roll_Armor" value="&{template:default} {{name= @{Armor_name} }} {{soak= @{Armor_soak} }} {{inneffective= @{Armor_Ineffective} }} {{notes= @{Armor_notes} }}"></button></td>
                             <td><input type="text" class="sheet-text3" name="attr_Armor_name" value="" placeholder="Armor Name"/></td>
                             <td><input type="number" class="sheet-number2" name="attr_Armor_soak" value="0" /></td>
                                 <td>
@@ -525,7 +525,7 @@
                                     </select>
                                 </td>
                             <td><input type="number" class="sheet-number2" name="attr_Armor_weight" value="0" /></td>
-                            <td><input type="text" class="sheet-text3" name="attr_Armor_Inneffective" value="" placeholder="Blunt, Heat, Electricity"/></td>
+                            <td><input type="text" class="sheet-text3" name="attr_Armor_Ineffective" value="" placeholder="Blunt, Heat, Electricity"/></td>
                             <th><input type="checkbox" class="sheet-box" name="attr_Armor_open" value="1"/><span></span></th>
                         </tr>
                     </table>
@@ -551,15 +551,15 @@
                             <th></th>
                             <th>Weapon</th>
                             <th>Attack Attribute</th>
-                            <th>Attack Mod.</th>
-                            <th>Damage</th>
-                            <th>Damage Mod.</th>
-<th>Damage Add.</th>
+                            <th>Skill</th>
+                            <th>Dmg</th>
+							<th>Dmg Add.</th>
+                            <th>Dmg Mod.</th>
                             <th>Range</th>
                             <th></th>
                         </tr>
                         <tr>
-                            <td><button type="roll" class="sheet-rollskill" name="roll_weapon1" value="&{template:default} {{name= @{weapon1_name} }} {{range= @{weapon1_range} }} {{attack= [[ (@{weaponattrib1_select} + @{weapon1_skill})d6]] }} {{damage= [[(@{weapon1_damage} + @{weapon1_damagemod})d6 + @{weapon1_damageadd} ]] }}"></button></td>
+                            <td><button type="roll" class="sheet-rollskill" name="roll_weapon1" value="&{template:default} {{name= @{weapon1_name} }} {{range= @{weapon1_range} }} {{attack= [[ (@{weaponattrib1_select} + @{weapon1_skill} - @{weapon1_damagemod}*2)d6]] }} {{damage= [[(@{weapon1_damage} + @{weapon1_damagemod})d6 + @{weapon1_damageadd} ]] }}"></button></td>
                             <td><input type="text" class="sheet-text3" name="attr_weapon1_name" value="" placeholder="Weapon Name"/></td>
                             <td>
                                 <select class="sheet-select1" name="attr_weaponattrib1_select">
@@ -578,8 +578,8 @@
                             </td>
                             <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_skill" value="0" /></td>
                             <td><input type="number" class="sheet-number2" name="attr_weapon1_damage" value="0" /></td>
+							<td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_damageadd" value="0" /></td>
                             <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_damagemod" value="0" /></td>
-<td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_damageadd" value="0" /></td>
                             <td><input type="number" class="sheet-number2" name="attr_weapon1_range" value="0" /></td>
                             <th><input type="checkbox" class="sheet-box" name="attr_weapon1_open" value="1"/><span></span></th>
                         </tr>
@@ -600,15 +600,15 @@
                             <th></th>
                             <th>Weapon</th>
                             <th>Attack Attribute</th>
-                            <th>Attack Mod.</th>
-                            <th>Damage</th>
-                            <th>Damage Mod.</th>
-		<th>Damage Add.</th>
+                            <th>Skill</th>
+                            <th>Dmg</th>
+							<th>Dmg Add.</th>
+                            <th>Dmg Mod.</th>
                             <th>Range</th>
                             <th></th>
                         </tr>
                         <tr>
-                            <td><button type="roll" class="sheet-rollskillold" name="roll_weapon1" value="&{template:default} {{name= @{weapon1_name} }} {{range= @{weapon1_range} }} {{attack= [[ (@{weaponattrib1_select} + @{weapon1_skill})d6]] }} {{damage= [[(@{weapon1_damage} + @{weapon1_damagemod})d6 + @{weapon1_damageadd}]] }}"></button></td>
+                            <td><button type="roll" class="sheet-rollskillold" name="roll_weapon1" value="&{template:default} {{name= @{weapon1_name} }} {{range= @{weapon1_range} }} {{attack= [[ (@{weaponattrib1_select} + @{weapon1_skill} - @{weapon1_damagemod}*2)d6]] }} {{damage= [[(@{weapon1_damage} + @{weapon1_damagemod})d6 + @{weapon1_damageadd}]] }}"></button></td>
                             <td><input type="text" class="sheet-text3" name="attr_weapon1_name" value="" placeholder="Weapon Name"/></td>
                             <td>
                                 <select class="sheet-select1" name="attr_weaponattrib1_select">
@@ -627,8 +627,8 @@
                             </td>
                             <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_skill" value="0" /></td>
                             <td><input type="number" class="sheet-number2" name="attr_weapon1_damage" value="0" /></td>
-                            <td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_damagemod" value="0" /></td>
-<td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_damageadd" value="0" /></td>
+							<td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_damageadd" value="0" /></td>
+							<td><input type="number" class="sheet-number2" style="width:80px;" name="attr_weapon1_damagemod" value="0" /></td>
                             <td><input type="number" class="sheet-number2" name="attr_weapon1_range" value="0" /></td>
                             <th><input type="checkbox" class="sheet-box" name="attr_weapon1_open" value="1"/><span></span></th>
                         </tr>

--- a/WOIN/WOIN.html
+++ b/WOIN/WOIN.html
@@ -1904,7 +1904,7 @@ on("change:charisma change:charisma_rank change:maximum_dice_pool sheet:opened",
     });
 });
 // Creating luck Dice Pool
-on("change:luck_rank sheet:opened", function() {
+on("change:luck_rank", function() {
     getAttrs(["luck_rank"], function(values) {
 
         if (values.luck_rank == 0) {

--- a/WOIN/WOIN.html
+++ b/WOIN/WOIN.html
@@ -755,11 +755,325 @@
             </div>
         </div>
         <br>
-    <!-- Status -->
-    
-        <input type="radio" class="sheet-new sheet-hidden" name="attr_sheet_type11" value="0" checked/>
-        <input type="radio" class="sheet-old sheet-hidden" name="attr_sheet_type11"  value="1" />
-        <div class="sheet-header">Status Track</div>
+    <!-- Conditions & Status Track -->
+    	<input type="radio" class="sheet-block1 sheet-hidden" name="attr_sheet_type11" value="0" checked/><span></span>
+        <input type="radio" class="sheet-block2 sheet-hidden" name="attr_sheet_type11" value="1"/><span></span>
+        <div class="sheet-block1">
+			<div class="sheet-header">Condition Track</div>
+				<table style="width:800px;">
+					<tr>
+						<td>Damage Type</td>
+						<td>Condition Track</td>
+						<td><div style="width:5px;"></div></td>
+						<td>None</td>
+						<td>Temp</td>
+						<td>Severe</td>
+						<td>Persist</td>
+					</tr>
+					<tr>
+						<td>Bleeding</td>
+						<td>
+							<select class="sheet-select2" name="attr_Bleeding_level">
+								<option value="0">None</option>
+								<option value="1">1d6 dmg start of your turn</option>
+								<option value="2">2d6 dmg start of your turn</option>
+							</select>
+						</td>
+						<td></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Bleeding" value="0" checked /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Bleeding" value="1" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Bleeding" value="2" /><span></span></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>Blind</td>
+						<td>
+							<select class="sheet-select2" name="attr_Blind_level">
+								<option value="0">None</option>
+								<option value="1">30' vision, SPEED/2</option>
+								<option value="2">Blind, SPEED/2, -2d6 sight Actions</option>
+							</select>
+						</td>
+						<td></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Blind" value="0" checked /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Blind" value="1" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Blind" value="2" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Blind" value="3" /><span></span></td>
+					</tr>
+					<tr>
+						<td>Burning</td>
+						<td>
+							<select class="sheet-select2" name="attr_Burning_level">
+								<option value="0">None</option>
+								<option value="1">1d6 dmg/round</option>
+								<option value="2">2d6 dmg/round</option>
+							</select>
+						</td>
+						<td></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Burning" value="0" checked /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Burning" value="1" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Burning" value="2" /><span></span></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>Charmed</td>
+						<td>
+							<select class="sheet-select2" name="attr_Charmed_level">
+								<option value="0">None</option>
+								<option value="1">Protect Charmer</option>
+								<option value="2">Obey Charmer</option>
+							</select>
+						</td>
+						<td></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Charmed" value="0" checked /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Charmed" value="1" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Charmed" value="2" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Charmed" value="3" /><span></span></td>
+					</tr>
+					<tr>
+						<td>Confused</td>
+						<td>
+							<select class="sheet-select2" name="attr_Confused_level">
+								<option value="0">None</option>
+								<option value="1">Drop carried, cannot tell friend from foe</option>
+								<option value="2">1d6 to determine Condition each turn</option>
+							</select>
+						</td>
+						<td></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Confused" checked value="0" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Confused" value="1" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Confused" value="2" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Confused" value="3" /><span></span></td>
+					</tr>
+					<tr>
+						<td>Dazed</td>
+						<td>
+							<select class="sheet-select2" name="attr_Dazed_level">
+								<option value="0">None</option>
+								<option value="1">You can take 1 Action/round</option>
+								<option value="2">You cannot take Actions</option>
+							</select>
+						</td>
+						<td></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Dazed" value="0" checked /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Dazed" value="1" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Dazed" value="2" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Dazed" value="3" /><span></span></td>
+					</tr>
+					<tr>
+						<td>Deaf</td>
+						<td>
+							<select class="sheet-select2" name="attr_Deaf_level">
+								<option value="0">None</option>
+								<option value="1">30' hearing, -1d6 PER/INIT, SOAK 5 sonic</option>
+								<option value="2">Deaf, -2d6 PER/INIT, SOAK 10 sonic</option>
+							</select>
+						</td>
+						<td></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Deaf" value="0" checked /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Deaf" value="1" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Deaf" value="2" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Deaf" value="3" /><span></span></td>
+					</tr>
+					<tr>
+						<td>Disarmed</td>
+						<td>
+							<select class="sheet-select2" name="attr_Disarmed_level">
+								<option value="0">None</option>
+								<option value="1">Current weapon cannot be used</option>
+								<option value="2">Severe, current weapon cannot be used</option>
+							</select>
+						</td>
+						<td></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Disarmed" value="0" checked /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Disarmed" value="1" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Disarmed" value="2" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Disarmed" value="3" /><span></span></td>
+					</tr>
+					<tr>
+						<td>Disarmored</td>
+						<td>
+							<select class="sheet-select2" name="attr_Disarmored_level">
+								<option value="0">None</option>
+								<option value="1">SOAK/2 round up</option>
+								<option value="2">SOAK=0</option>
+							</select>
+						</td>
+						<td></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Disarmored" value="0" checked /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Disarmored" value="1" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Disarmored" value="2" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Disarmored" value="3" /><span></span></td>
+					</tr>
+					<tr>
+						<td>Downed</td>
+						<td>
+							<select class="sheet-select2" name="attr_Downed_level">
+								<option value="0">None</option>
+								<option value="1">Prone, cannot stand</option>
+								<option value="2">Prone & helpless, DEF=10</option>
+							</select>
+						</td>
+						<td></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Downed" value="0" checked /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Downed" value="1" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Downed" value="2" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Downed" value="3" /><span></span></td>
+					</tr>
+					<tr>
+						<td>Drunk</td>
+						<td>
+							<select class="sheet-select2" name="attr_Drunk_level">
+								<option value="0">None</option>
+								<option value="1">Cannot move more than once/round</option>
+								<option value="2">Cannot move, wander 1d6 squares in random direction</option>
+							</select>
+						</td>
+						<td></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Drunk" value="0" checked /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Drunk" value="1" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Drunk" value="2" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Drunk" value="3" /><span></span></td>
+					</tr>
+					<tr>
+						<td>Fatigued</td>
+						<td>
+							<select class="sheet-select2" name="attr_Fatigued_level">
+								<option value="0">None</option>
+								<option value="1">Can take 1 Action/rnd, CARRY Increment/2</option>
+								<option value="2">As above & HEALTH/2</option>
+							</select>
+						</td>
+						<td></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Fatigued" value="0" checked /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Fatigued" value="1" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Fatigued" value="2" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Fatigued" value="3" /><span></span></td>
+					</tr>
+					<tr>
+						<td>Forgetful</td>
+						<td>
+							<select class="sheet-select2" name="attr_Forgetful_level">
+								<option value="0">None</option>
+								<option value="1">Cannot use Skills</option>
+								<option value="2">Complete loss of memory</option>
+							</select>
+						</td>
+						<td></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Forgetful" value="0" checked /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Forgetful" value="1" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Forgetful" value="2" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Forgetful" value="3" /><span></span></td>
+					</tr>
+					<tr>
+						<td>Manic</td>
+						<td>
+							<select class="sheet-select2" name="attr_Manic_level">
+								<option value="0">None</option>
+								<option value="1">Cannot take hostile/aggressive action</option>
+								<option value="2">Convulsed with laughter, no actions</option>
+							</select>
+						</td>
+						<td></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Manic" value="0" checked /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Manic" value="1" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Manic" value="2" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Manic" value="3" /><span></span></td>
+					</tr>
+					<tr>
+						<td>Pain</td>
+						<td>
+							<select class="sheet-select2" name="attr_Pain_level">
+								<option value="0">None</option>
+								<option value="1">1d6 dmg if you take 2nd Action in turn</option>
+								<option value="2">1d6 dmg if take any Action</option>
+							</select>
+						</td>
+						<td></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Pain" value="0" checked/><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Pain" value="1" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Pain" value="2" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Pain" value="3" /><span></span></td>
+					</tr>
+					<tr>
+						<td>Poisoned</td>
+						<td>
+							<select class="sheet-select2" name="attr_Poisoned_level">
+								<option value="0">None</option>
+								<option value="1">You cannot be healed</option>
+								<option value="2">You cannot be healed, 1d6 dmg/turn</option>
+							</select>
+						</td>
+						<td></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Poisoned" value="0" checked/><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Poisoned" value="1" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Poisoned" value="2" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Poisoned" value="3" /><span></span></td>
+					</tr>
+					<tr>
+						<td>Restrained</td>
+						<td>
+							<select class="sheet-select2" name="attr_Restrained_level">
+								<option value="0">None</option>
+								<option value="1">Cannot move from current square</option>
+								<option value="2">0 Actions, DEFENSE=10</option>
+							</select>
+						</td>
+						<td></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Restrained" value="0" checked/><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Restrained" value="1" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Restrained" value="2" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Restrained" value="3" /><span></span></td>
+					</tr>
+					<tr>
+						<td>Sick</td>
+						<td>
+							<select class="sheet-select2" name="attr_Sick_level">
+								<option value="0">None</option>
+								<option value="1">Cannot Jump, 1 Action/round</option>
+								<option value="2">as above, -2d6 Attribute checks</option>
+							</select>
+						</td>
+						<td></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Sick" value="0" checked/><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Sick" value="1" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Sick" value="2" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Sick" value="3" /><span></span></td>
+					</tr>
+					<tr>
+						<td>Sleeping</td>
+						<td>
+							<select class="sheet-select2" name="attr_Sleeping_level">
+								<option value="0">None</option>
+								<option value="1">Only 1 Action/turn</option>
+								<option value="2">Asleep, cannot be woken</option>
+							</select>
+						</td>
+						<td></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Sleeping" value="0" checked/><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Sleeping" value="1" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Sleeping" value="2" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Sleeping" value="3" /><span></span></td>
+					</tr>
+					<tr>
+						<td>Slowed</td>
+						<td>
+							<select class="sheet-select2" name="attr_Slowed_level">
+								<option value="0">None</option>
+								<option value="1">SPEED/2, -4 DEFENSEs</option>
+								<option value="2">SPEED/2, DEFENSEs=10, only 1 Action/turn</option>
+							</select>
+						</td>
+						<td></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Slowed" value="0" checked/><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Slowed" value="1" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Slowed" value="2" /><span></span></td>
+						<td><input type="radio" class="sheet-radio1" name="attr_Slowed" value="3" /><span></span></td>
+					</tr>
+				</table>
+		</div>
+		<div class="sheet-block2">
+			<div class="sheet-header">Status Track</div>
             <table style="width:800px;">
                 <tr>
                     <td>Damage Type</td>
@@ -1053,6 +1367,7 @@
                 </tr>
             </table>
     </div>
+	</div>
     <!-- Exploits -->
     <div class="sheet-tab-content sheet-tab4">
             <input type="radio" class="sheet-block1 sheet-hidden" name="attr_sheet_switch9" value="0" checked/><span></span>


### PR DESCRIPTION
## Changes / Comments
WOIN-NEW uses a Condition Tracking system different to WOIN-OLD Status Tracking. Changes are on the Combat/Equipment tab under Conditions & Status Track

- added Condition Tracking
- linked Condition Tracking to sheet type toggle (NEW)
- linked Status Tracking to sheet type toggle (OLD)
- updated CSS to support Condition Tracking pull down menus field

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [Y] Does the pull request title have the sheet name(s)? Include each sheet name.
- [N] Is this a bug fix?
- [Y] Does this add functional enhancements (new features or extending existing features) ?
- [N] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [N/A] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [N/A] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
