### PR TITLE
[Scum & Villainy] Allow system names to be editable

### DIFF
--- a/Scum - Villainy/scum.css
+++ b/Scum - Villainy/scum.css
@@ -1700,6 +1700,11 @@ input.sheet-friendup {
 	margin-bottom: 30px;
 	width: 100%;
 }
+
+.sheet-systems input.sheet-label {
+	padding-left:6px;
+}
+
 .sheet-systems textarea {
 	width: 100%;
 	resize: vertical;

--- a/Scum - Villainy/scum.html
+++ b/Scum - Villainy/scum.html
@@ -1107,7 +1107,8 @@
 	</div>
 	<div class="sheet-systems sheet-flex-layout">
 		<div class="sheet-col24b">
-			<input type="checkbox" name="attr_expand1" value="1" class="sheet-expand"/><span></span><div class="sheet-label" name="attr_system1">Rin</div>
+			<input type="checkbox" name="attr_expand1" value="1" class="sheet-expand"/><span></span>
+			<input type="text"  spellcheck="false" value="Rin" class="sheet-label" name="attr_system1" />
 			<div class="sheet-col100 sheet-heat sheet-flex-layout">
 				<div class="sheet-blackheader sheet-heat1">
 					<div class="sheet-label">Heat</div>
@@ -1126,7 +1127,8 @@
 			<textarea spellcheck="false" name="attr_notes1" placeholder="System notes"></textarea>
 			</div>
 		<div class="sheet-col24b">
-			<input type="checkbox" name="attr_expand2" value="1" class="sheet-expand"/><span></span><div class="sheet-label" name="attr_system2">Holt</div>
+			<input type="checkbox" name="attr_expand2" value="1" class="sheet-expand"/><span></span>
+			<input type="text" spellcheck="false" value="Holt" class="sheet-label" name="attr_system2" />
 			<div class="sheet-col100 sheet-heat sheet-flex-layout">
 				<div class="sheet-blackheader sheet-heat1">
 					<div class="sheet-label">Heat</div>
@@ -1145,7 +1147,8 @@
 			<textarea spellcheck="false" name="attr_notes2" placeholder="System notes"></textarea>
 		</div>
 		<div class="sheet-col24b">
-			<input type="checkbox" name="attr_expand3" value="1" class="sheet-expand"/><span></span><div class="sheet-label" name="attr_system3">Iota</div>
+			<input type="checkbox" name="attr_expand3" value="1" class="sheet-expand"/><span></span>
+			<input type="text" spellcheck="false" value="Iota" class="sheet-label" name="attr_system3" />
 			<div class="sheet-col100 sheet-heat sheet-flex-layout">
 				<div class="sheet-blackheader sheet-heat1">
 					<div class="sheet-label">Heat</div>
@@ -1164,7 +1167,8 @@
 			<textarea spellcheck="false" name="attr_notes3" placeholder="System notes"></textarea>
 		</div>
 		<div class="sheet-col24b">
-			<input type="checkbox" name="attr_expand4" value="1" class="sheet-expand"/><span></span><div class="sheet-label" name="attr_system2">Brekk</div>
+			<input type="checkbox" name="attr_expand4" value="1" class="sheet-expand"/><span></span>
+			<input type="text" spellcheck="false" value="Brekk" class="sheet-label" name="attr_system4" />
 			<div class="sheet-col100 sheet-heat sheet-flex-layout">
 				<div class="sheet-blackheader sheet-heat1">
 					<div class="sheet-label">Heat</div>


### PR DESCRIPTION
## Changes / Comments

- Updates the faction sheet to add a feature; system names can now be edited for games in custom settings.  System names default to the four provided in the default setting (Rin, Holt, Iota & Brekk) so existing players will see no change.
- Provides a small edit to CSS that adds padding between system names and the carat that expands the system's notes.  This helps to prevent the user from accidentally expanding the system notes when they wish to change the system name and vice-versa.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
