### PR TITLE
[Eclipse Phase V2] General bug fixes

### DIFF
--- a/Eclipse Phase V2/Eclipse Phase V2.html
+++ b/Eclipse Phase V2/Eclipse Phase V2.html
@@ -287,7 +287,7 @@
 						<div class="sheet-line">
 							<div style="width:94px;margin-right:10px;" class="sheet-column">
 								<button type="roll" name="roll_initiative" style="width:94px;" class="default-btn center" value="
-								@{gm} &{template:EPdefault} {{name=^{initiative}}} {{subname=^{score}}} {{roll=[[1D10+[[@{initiative}]] &{tracker} ]]}} {{title-roll=^{roll}}}">
+								@{gm} &{template:EPdefault} {{name=^{initiative}}} {{subname=^{score}}} {{roll=[[1D6+[[@{initiative}]] &{tracker} ]]}} {{title-roll=^{roll}}}">
 									<div class="apt-title center" data-i18n="initiative">Initiative</div>
 								</button>
 							</div>
@@ -3426,7 +3426,7 @@
 						<div class="sheet-line" style="margin-bottom:10px;">
 							<div style="width:100px;margin-right:10px;" class="sheet-column">
 								<button type="roll" name="roll_initiative" style="width:93px;" class="default-btn center" value="
-								@{gm} &{template:EPdefault} {{name=^{initiative}}} {{subname=^{score}}} {{roll=[[1D10+[[@{initiative}]] &{tracker} ]]}} {{title-roll=^{roll}}}">
+								@{gm} &{template:EPdefault} {{name=^{initiative}}} {{subname=^{score}}} {{roll=[[1D6+[[@{initiative}]] &{tracker} ]]}} {{title-roll=^{roll}}}">
 									<div class="apt-title center" data-i18n="initiative">Initiative</div>
 								</button>
 							</div>

--- a/Eclipse Phase V2/Eclipse Phase V2.html
+++ b/Eclipse Phase V2/Eclipse Phase V2.html
@@ -189,7 +189,7 @@
 					</div>
 					<div class="sheet-line">
 						<button type="roll" name="roll_apt-wil" style="width:100px;" class="apt-title apt-check" value="
-						@{gm} &{template:EPdefault} {{name=^{aptitudes}}} {{subname=^{willpower}}} {{roll=[[[[1D100-1]]]]}} {{target=[[[[@{willpower}*3]]-[[@{malus}]]+@{bCheckSOM}]]}} {{title-roll=^{roll}}} {{title-modifiers=^{modifiers}}} {{modifiers=[[[[(0-@{malus})]]]]}}">
+						@{gm} &{template:EPdefault} {{name=^{aptitudes}}} {{subname=^{willpower}}} {{roll=[[[[1D100-1]]]]}} {{target=[[[[@{willpower}*3]]-[[@{malus}]]+@{bCheckWIL}]]}} {{title-roll=^{roll}}} {{title-modifiers=^{modifiers}}} {{modifiers=[[[[(0-@{malus})]]]]}}">
 							<div class="center apt-title" data-i18n="willpower">Willpower</div>
 						</button>
 					</div>
@@ -287,7 +287,7 @@
 						<div class="sheet-line">
 							<div style="width:94px;margin-right:10px;" class="sheet-column">
 								<button type="roll" name="roll_initiative" style="width:94px;" class="default-btn center" value="
-								@{gm} &{template:EPdefault} {{name=^{initiative}}} {{subname=^{score}}} {{roll=[[1D6+[[@{initiative}]] ]]}} {{title-roll=^{roll}}}">
+								@{gm} &{template:EPdefault} {{name=^{initiative}}} {{subname=^{score}}} {{roll=[[1D10+[[@{initiative}]] &{tracker} ]]}} {{title-roll=^{roll}}}">
 									<div class="apt-title center" data-i18n="initiative">Initiative</div>
 								</button>
 							</div>
@@ -358,7 +358,7 @@
 						<div class="sheet-expand">
 							<textarea name="attr_mental-disorder-desc-1" style="height:80px;padding:0px;border:1px solid white;background-color:transparent;color:black"></textarea>
 						</div>
-						<button type="roll" name="attr_outputMentalDisorder1" class="output" value="@{gm} &{template:EPOutput} {{name=@{nameMentDis-1}}} {{output=@{disorder-desc-1}}}">w</button>
+						<button type="roll" name="attr_outputMentalDisorder1" class="output" value="@{gm} &{template:EPOutput} {{name=@{nameMentDis-1}}} {{output=@{mental-disorder-desc-1}}}">w</button>
 					</fieldset>
 				</div>
 			</div>
@@ -373,7 +373,7 @@
 						<div class="sheet-expand">
 							<textarea name="attr_mental-disorder-desc-2" style="height:80px;padding:0px;border:1px solid white;background-color:transparent;color:black"></textarea>
 						</div>
-						<button type="roll" name="attr_outputMentalDisorder2" class="output" value="@{gm} &{template:EPOutput} {{name=@{nameMentDis-2}}} {{output=@{disorder-desc-2}}}">w</button>
+						<button type="roll" name="attr_outputMentalDisorder2" class="output" value="@{gm} &{template:EPOutput} {{name=@{nameMentDis-2}}} {{output=@{mental-disorder-desc-2}}}">w</button>
 					</fieldset>
 				</div>
 			</div>
@@ -549,11 +549,11 @@
 					</button>
 					<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Eclipse%20Phase%20V2/images/Vigor.png" data-i18n-title="vigor" title="Vigor" class="iconPools-skills">
 					<input type="text" name="attr_spe-free-fall" class="sheet-spe-skills" data-i18n-placeholder="specializations" placeholder="Specializations" />
-					<input type="number" name="attr_total-free-fall" class="center" style="width:65px;border-color:#ccc" value="(@{reflexes}+@{rank-free-fall}+@{temp-free-fall})" disabled />
+					<input type="number" name="attr_total-free-fall" class="center" style="width:65px;border-color:#ccc" value="(@{somatics}+@{rank-free-fall}+@{temp-free-fall})" disabled />
 					<input type="number" name="attr_rank-free-fall" class="center" style="width:65px;" value="0" />
 					<input type="number" name="attr_temp-free-fall" class="center" style="width:65px;" value="0" />
 					<select name="attr_apt-free-fall" style="width:65px;margin:0px;vertical-align:middle;" disabled>
-						<option value="@{reflexes}" data-i18n="reflexes short" selected>REF</option>
+						<option value="@{somatics}" data-i18n="somatics short" selected>SOM</option>
 					</select>
 				</div>
 				<div class="sheet-line" data-i18n-list-item="guns">
@@ -1680,6 +1680,42 @@
 		</div>
 		<div class="sheet-line" style="margin-bottom:20px;">
 			<div class="sheet-column" style="width:398px;margin-right:20px;">
+				<input type="checkbox" name="attr_hardwareM1-hide" class="sheet-option sheet-optionHideMorph" checked><span class="sheet-option"></span><div class="block-title block-title-morph" data-i18n="hardware">Hardware</div>
+				<div class="blockSpe">
+					<div class="hidden">
+						<div class="sheet-line">
+							<fieldset class="repeating_hardwareM1">
+								<input type="checkbox" name="attr_hardware-expand" style="float:left;margin-right:0;margin-left:-15px;" class="sheet-option sheet-expand"><span style="float:left;margin-right:0;margin-left:-15px;" class="sheet-option sheet-expand"></span>
+								<input type="text" name="attr_nameHard" class="sheet-lower-inputWMargin center" style="width:330px;" data-i18n-title="Name" placeholder="Name" value="">
+								<div class="sheet-expand">
+									<textarea name="attr_hardware-desc" style="height:80px;padding:0px;border:1px solid white;background-color:transparent;color:black"></textarea>
+								</div>
+								<button type="roll" name="attr_outputHardware" class="output" value="@{gm} &{template:EPOutput} {{name=@{nameHard}}} {{output=@{hardware-desc}}}">w</button>
+							</fieldset>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="sheet-column" style="width:398px;">
+				<input type="checkbox" name="attr_meshwareM1-hide" class="sheet-option sheet-optionHideMorph" checked><span class="sheet-option"></span><div class="block-title block-title-morph" data-i18n="meshware">Meshware</div>
+				<div class="blockSpe">
+					<div class="hidden">
+						<div class="sheet-line">
+							<fieldset class="repeating_meshwareM1">
+								<input type="checkbox" name="attr_meshware-expand" style="float:left;margin-right:0;margin-left:-15px;" class="sheet-option sheet-expand"><span style="float:left;margin-right:0;margin-left:-15px;" class="sheet-option sheet-expand"></span>
+								<input type="text" name="attr_nameMesh" class="sheet-lower-inputWMargin center" style="width:330px;" data-i18n-title="Name" placeholder="Name" value="">
+								<div class="sheet-expand">
+									<textarea name="attr_meshware-desc" style="height:80px;padding:0px;border:1px solid white;background-color:transparent;color:black"></textarea>
+								</div>
+								<button type="roll" name="attr_outputMehsware" class="output" value="@{gm} &{template:EPOutput} {{name=@{nameMesh}}} {{output=@{meshware-desc}}}">w</button>
+							</fieldset>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div class="sheet-line" style="margin-bottom:20px;">
+			<div class="sheet-column" style="width:398px;margin-right:20px;">
 				<input type="checkbox" name="attr_nanowareM1-hide" class="sheet-option sheet-optionHideMorph" checked><span class="sheet-option"></span><div class="block-title block-title-morph" data-i18n="nanoware">Nanoware</div>
 				<div class="blockSpe">
 					<div class="hidden">
@@ -1756,7 +1792,7 @@
 				<div class="block-title block-title-morph" data-i18n="morph">Morph</div>
 				<div class="block" style="margin-bottom:20px;vertical-align:top;width: 140px;">
 					<div class="sheet-line">
-						<input type="text" name="attr_nameM2" class="sheet-lower-input apt-title" style="width:128px;" data-i18n-placeholder="name" placeholder="Name" value="Morph 1">
+						<input type="text" name="attr_nameM2" class="sheet-lower-input apt-title" style="width:128px;" data-i18n-placeholder="name" placeholder="Name" value="Morph 2">
 					</div>
 				</div>
 			</div>
@@ -1918,6 +1954,42 @@
 		</div>
 		<div class="sheet-line" style="margin-bottom:20px;">
 			<div class="sheet-column" style="width:398px;margin-right:20px;">
+				<input type="checkbox" name="attr_hardwareM2-hide" class="sheet-option sheet-optionHideMorph" checked><span class="sheet-option"></span><div class="block-title block-title-morph" data-i18n="hardware">Hardware</div>
+				<div class="blockSpe">
+					<div class="hidden">
+						<div class="sheet-line">
+							<fieldset class="repeating_hardwareM2">
+								<input type="checkbox" name="attr_hardware-expand" style="float:left;margin-right:0;margin-left:-15px;" class="sheet-option sheet-expand"><span style="float:left;margin-right:0;margin-left:-15px;" class="sheet-option sheet-expand"></span>
+								<input type="text" name="attr_nameHard" class="sheet-lower-inputWMargin center" style="width:330px;" data-i18n-title="Name" placeholder="Name" value="">
+								<div class="sheet-expand">
+									<textarea name="attr_hardware-desc" style="height:80px;padding:0px;border:1px solid white;background-color:transparent;color:black"></textarea>
+								</div>
+								<button type="roll" name="attr_outputHardware" class="output" value="@{gm} &{template:EPOutput} {{name=@{nameHard}}} {{output=@{hardware-desc}}}">w</button>
+							</fieldset>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="sheet-column" style="width:398px;">
+				<input type="checkbox" name="attr_meshwareM2-hide" class="sheet-option sheet-optionHideMorph" checked><span class="sheet-option"></span><div class="block-title block-title-morph" data-i18n="meshware">Meshware</div>
+				<div class="blockSpe">
+					<div class="hidden">
+						<div class="sheet-line">
+							<fieldset class="repeating_meshwareM2">
+								<input type="checkbox" name="attr_meshware-expand" style="float:left;margin-right:0;margin-left:-15px;" class="sheet-option sheet-expand"><span style="float:left;margin-right:0;margin-left:-15px;" class="sheet-option sheet-expand"></span>
+								<input type="text" name="attr_nameMesh" class="sheet-lower-inputWMargin center" style="width:330px;" data-i18n-title="Name" placeholder="Name" value="">
+								<div class="sheet-expand">
+									<textarea name="attr_meshware-desc" style="height:80px;padding:0px;border:1px solid white;background-color:transparent;color:black"></textarea>
+								</div>
+								<button type="roll" name="attr_outputMehsware" class="output" value="@{gm} &{template:EPOutput} {{name=@{nameMesh}}} {{output=@{meshware-desc}}}">w</button>
+							</fieldset>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div class="sheet-line" style="margin-bottom:20px;">
+			<div class="sheet-column" style="width:398px;margin-right:20px;">
 				<input type="checkbox" name="attr_nanowareM2-hide" class="sheet-option sheet-optionHideMorph" checked><span class="sheet-option"></span><div class="block-title block-title-morph" data-i18n="nanoware">Nanoware</div>
 				<div class="blockSpe">
 					<div class="hidden">
@@ -1994,7 +2066,7 @@
 				<div class="block-title block-title-morph" data-i18n="morph">Morph</div>
 				<div class="block" style="margin-bottom:20px;vertical-align:top;width: 140px;">
 					<div class="sheet-line">
-						<input type="text" name="attr_nameM3" class="sheet-lower-input apt-title" style="width:128px;" data-i18n-placeholder="name" placeholder="Name" value="Morph 1">
+						<input type="text" name="attr_nameM3" class="sheet-lower-input apt-title" style="width:128px;" data-i18n-placeholder="name" placeholder="Name" value="Morph 3">
 					</div>
 				</div>
 			</div>
@@ -2156,6 +2228,42 @@
 		</div>
 		<div class="sheet-line" style="margin-bottom:20px;">
 			<div class="sheet-column" style="width:398px;margin-right:20px;">
+				<input type="checkbox" name="attr_hardwareM3-hide" class="sheet-option sheet-optionHideMorph" checked><span class="sheet-option"></span><div class="block-title block-title-morph" data-i18n="hardware">Hardware</div>
+				<div class="blockSpe">
+					<div class="hidden">
+						<div class="sheet-line">
+							<fieldset class="repeating_hardwareM3">
+								<input type="checkbox" name="attr_hardware-expand" style="float:left;margin-right:0;margin-left:-15px;" class="sheet-option sheet-expand"><span style="float:left;margin-right:0;margin-left:-15px;" class="sheet-option sheet-expand"></span>
+								<input type="text" name="attr_nameHard" class="sheet-lower-inputWMargin center" style="width:330px;" data-i18n-title="Name" placeholder="Name" value="">
+								<div class="sheet-expand">
+									<textarea name="attr_hardware-desc" style="height:80px;padding:0px;border:1px solid white;background-color:transparent;color:black"></textarea>
+								</div>
+								<button type="roll" name="attr_outputHardware" class="output" value="@{gm} &{template:EPOutput} {{name=@{nameHard}}} {{output=@{hardware-desc}}}">w</button>
+							</fieldset>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="sheet-column" style="width:398px;">
+				<input type="checkbox" name="attr_meshwareM3-hide" class="sheet-option sheet-optionHideMorph" checked><span class="sheet-option"></span><div class="block-title block-title-morph" data-i18n="meshware">Meshware</div>
+				<div class="blockSpe">
+					<div class="hidden">
+						<div class="sheet-line">
+							<fieldset class="repeating_meshwareM3">
+								<input type="checkbox" name="attr_meshware-expand" style="float:left;margin-right:0;margin-left:-15px;" class="sheet-option sheet-expand"><span style="float:left;margin-right:0;margin-left:-15px;" class="sheet-option sheet-expand"></span>
+								<input type="text" name="attr_nameMesh" class="sheet-lower-inputWMargin center" style="width:330px;" data-i18n-title="Name" placeholder="Name" value="">
+								<div class="sheet-expand">
+									<textarea name="attr_meshware-desc" style="height:80px;padding:0px;border:1px solid white;background-color:transparent;color:black"></textarea>
+								</div>
+								<button type="roll" name="attr_outputMehsware" class="output" value="@{gm} &{template:EPOutput} {{name=@{nameMesh}}} {{output=@{meshware-desc}}}">w</button>
+							</fieldset>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div class="sheet-line" style="margin-bottom:20px;">
+			<div class="sheet-column" style="width:398px;margin-right:20px;">
 				<input type="checkbox" name="attr_nanowareM3-hide" class="sheet-option sheet-optionHideMorph" checked><span class="sheet-option"></span><div class="block-title block-title-morph" data-i18n="nanoware">Nanoware</div>
 				<div class="blockSpe">
 					<div class="hidden">
@@ -2232,7 +2340,7 @@
 				<div class="block-title block-title-morph" data-i18n="morph">Morph</div>
 				<div class="block" style="margin-bottom:20px;vertical-align:top;width: 140px;">
 					<div class="sheet-line">
-						<input type="text" name="attr_nameM4" class="sheet-lower-input apt-title" style="width:128px;" data-i18n-placeholder="name" placeholder="Name" value="Morph 1">
+						<input type="text" name="attr_nameM4" class="sheet-lower-input apt-title" style="width:128px;" data-i18n-placeholder="name" placeholder="Name" value="Morph 4">
 					</div>
 				</div>
 			</div>
@@ -2386,6 +2494,42 @@
 									<textarea name="attr_cyberware-desc" style="height:80px;padding:0px;border:1px solid white;background-color:transparent;color:black"></textarea>
 								</div>
 								<button type="roll" name="attr_outputCyberware" class="output" value="@{gm} &{template:EPOutput} {{name=@{nameCyb}}} {{output=@{cyberware-desc}}}">w</button>
+							</fieldset>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div class="sheet-line" style="margin-bottom:20px;">
+			<div class="sheet-column" style="width:398px;margin-right:20px;">
+				<input type="checkbox" name="attr_hardwareM4-hide" class="sheet-option sheet-optionHideMorph" checked><span class="sheet-option"></span><div class="block-title block-title-morph" data-i18n="hardware">Hardware</div>
+				<div class="blockSpe">
+					<div class="hidden">
+						<div class="sheet-line">
+							<fieldset class="repeating_hardwareM4">
+								<input type="checkbox" name="attr_hardware-expand" style="float:left;margin-right:0;margin-left:-15px;" class="sheet-option sheet-expand"><span style="float:left;margin-right:0;margin-left:-15px;" class="sheet-option sheet-expand"></span>
+								<input type="text" name="attr_nameHard" class="sheet-lower-inputWMargin center" style="width:330px;" data-i18n-title="Name" placeholder="Name" value="">
+								<div class="sheet-expand">
+									<textarea name="attr_hardware-desc" style="height:80px;padding:0px;border:1px solid white;background-color:transparent;color:black"></textarea>
+								</div>
+								<button type="roll" name="attr_outputHardware" class="output" value="@{gm} &{template:EPOutput} {{name=@{nameHard}}} {{output=@{hardware-desc}}}">w</button>
+							</fieldset>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="sheet-column" style="width:398px;">
+				<input type="checkbox" name="attr_meshwareM4-hide" class="sheet-option sheet-optionHideMorph" checked><span class="sheet-option"></span><div class="block-title block-title-morph" data-i18n="meshware">Meshware</div>
+				<div class="blockSpe">
+					<div class="hidden">
+						<div class="sheet-line">
+							<fieldset class="repeating_meshwareM4">
+								<input type="checkbox" name="attr_meshware-expand" style="float:left;margin-right:0;margin-left:-15px;" class="sheet-option sheet-expand"><span style="float:left;margin-right:0;margin-left:-15px;" class="sheet-option sheet-expand"></span>
+								<input type="text" name="attr_nameMesh" class="sheet-lower-inputWMargin center" style="width:330px;" data-i18n-title="Name" placeholder="Name" value="">
+								<div class="sheet-expand">
+									<textarea name="attr_meshware-desc" style="height:80px;padding:0px;border:1px solid white;background-color:transparent;color:black"></textarea>
+								</div>
+								<button type="roll" name="attr_outputMehsware" class="output" value="@{gm} &{template:EPOutput} {{name=@{nameMesh}}} {{output=@{meshware-desc}}}">w</button>
 							</fieldset>
 						</div>
 					</div>
@@ -3282,7 +3426,7 @@
 						<div class="sheet-line" style="margin-bottom:10px;">
 							<div style="width:100px;margin-right:10px;" class="sheet-column">
 								<button type="roll" name="roll_initiative" style="width:93px;" class="default-btn center" value="
-								@{gm} &{template:EPdefault} {{name=^{initiative}}} {{subname=^{score}}} {{roll=[[1D10+[[@{initiative}]] ]]}} {{title-roll=^{roll}}}">
+								@{gm} &{template:EPdefault} {{name=^{initiative}}} {{subname=^{score}}} {{roll=[[1D10+[[@{initiative}]] &{tracker} ]]}} {{title-roll=^{roll}}}">
 									<div class="apt-title center" data-i18n="initiative">Initiative</div>
 								</button>
 							</div>
@@ -3688,14 +3832,18 @@
 						<div class="sheet-line" style="border-bottom:1px solid white;margin-right:10px;min-height:22px;">
 							<input type="checkbox" name="attr_strain-effect-expand-1" class="sheet-option sheet-expand"><span class="sheet-option sheet-expand"></span>
 							<div style="width:15px;display:inline-block;padding-top:4px;" class="center"><b>1</b></div>
-							<div style="width:185px;display:inline-block;" data-i18n="breaking point">Breaking Point</div>
+							<div style="width:185px;display:inline-block;" data-i18n="physical damage">Physical Damage</div>
 							<div class="sheet-hidden sheet-expand">
 								<textarea name="attr_strain-effect-descript-1" style="height:80px;padding:0px;border:1px solid white;background-color:transparent;color:black"></textarea>
 							</div>
 						</div>
 						<div class="sheet-line" style="border-bottom:1px solid white;margin-right:10px;min-height:22px;">
+							<input type="checkbox" name="attr_strain-effect-expand-2" class="sheet-option sheet-expand"><span class="sheet-option sheet-expand"></span>
 							<div style="width:15px;display:inline-block;padding-top:4px;" class="center"><b>2</b></div>
-							<div style="width:185px;display:inline-block;" data-i18n="physical damage">Physical Damage</div>
+							<input type="text" name="attr_strain-effet-name-2" class="sheet-lower-input apt-title" style="width:175px;border:0px;padding:0px;text-align:left;vertical-align:bottom;" value="">
+							<div class="sheet-hidden sheet-expand">
+								<textarea name="attr_strain-effect-descript-2" style="height:80px;padding:0px;border:1px solid white;background-color:transparent;color:black"></textarea>
+							</div>
 						</div>
 						<div class="sheet-line" style="border-bottom:1px solid white;margin-right:10px;min-height:22px;">
 							<input type="checkbox" name="attr_strain-effect-expand-3" class="sheet-option sheet-expand"><span class="sheet-option sheet-expand"></span>

--- a/Eclipse Phase V2/translation.json
+++ b/Eclipse Phase V2/translation.json
@@ -134,6 +134,8 @@
 	"bioware": "Bioware",
 	"cyberware": "Cyberware",
 	"nanoware": "Nanoware",
+	"hardware": "Hardware",
+	"meshware": "Meshware",
 	"positive trait": "Positive Trait",
 	"negative trait": "Negative Trait",
 	"notes": "Notes",


### PR DESCRIPTION
## Changes / Comments
* Hardware & Meshware added to all four morph sections
* The 4 morph sections now are named Morph 1,2,3,4 by default instead of Morph 1,1,1,1
* Mental disorder roll buttons fixed
* Willpower check button fixed to use bcheckWIL instead of bcheckSom
* Free Fall changed to use somatics instead of previous reflexes
* Initiative rolls now add things to the turn tracker, and both uses 1d10 for rolls
* Psi table with "Break point" & "physical damage" mentioned now mentions only "physical damage" in the first slot, and the second slot is made editable plus missing description section of the second slot is added.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
