### PR TITLE
Fixed typo in computers M&M 2nd Ed skill name

### DIFF
--- a/mutants-and-masterminds-2e-master/mutants-and-masterminds-2e.html
+++ b/mutants-and-masterminds-2e-master/mutants-and-masterminds-2e.html
@@ -626,7 +626,7 @@
 					<td style="padding-top: 7px;">+</td>
 					<td><input type="text" style="width: 40px;" name="attr_computers-temp" value="0" title="computers-temp"/></td>
 					<td><textarea rows="1" cols="50" style="width: 200px; height: 18px;" name="attr_computers-notes" title="computers-notes"></textarea></td>
-					<td><textarea rows="1" cols="50" style="width: 150px; height: 18px;" name="attr_computers-macro" title="computers-macro">&{template:mnm2e-skill} {{name=@{character_name}}} {{skill-name=Compsuters}} {{skill-check=[[1d20+[[@{computers}]]]]}} {{skill-notes=@{computers-notes}}}</textarea></td>
+					<td><textarea rows="1" cols="50" style="width: 150px; height: 18px;" name="attr_computers-macro" title="computers-macro">&{template:mnm2e-skill} {{name=@{character_name}}} {{skill-name=Computers}} {{skill-check=[[1d20+[[@{computers}]]]]}} {{skill-notes=@{computers-notes}}}</textarea></td>
 				</tr>
 				<tr valign="top">
 					<td align="right"><button type="roll" name="attr_concentrate-check" title="concentrate-check" value="@{concentrate-macro}" ></button></td>


### PR DESCRIPTION
## Changes / Comments
Fixed a typo in the computers skill for Mutants and Masterminds 2e sheet (mutants-and-masterminds-2e.html).
