### PR TITLE
[Pathfinder Second Edition by Roll20] Bonus query for attacks

### DIFF
--- a/Pathfinder Second Edition by Roll20/worker.js
+++ b/Pathfinder Second Edition by Roll20/worker.js
@@ -524,7 +524,7 @@
                     update[`${id}_damage_dice_query`] = values[`query_roll_damage_dice`];
                 }
                 // Forced update to attack and damage rolls (in case of logic change)
-                update[`${id}_weapon_roll`] = "{{roll01_name=^{attack}}} {{roll01=[[1d20cs20cf1 + @{weapon_strike}[@{text_modifier}] + @{query_roll_bonus}[@{text_bonus}]]]}} {{roll01_type=attack}} {{roll01_info=@{weapon_traits}}} {{roll01_critical=1}}";
+                update[`${id}_weapon_roll`] = "{{roll01_name=^{attack}}} {{roll01=[[1d20cs20cf1 + ?{Modifier|0} + @{weapon_strike}[@{text_modifier}] + @{query_roll_bonus}[@{text_bonus}]]]}} {{roll01_type=attack}} {{roll01_info=@{weapon_traits}}} {{roll01_critical=1}}";
                 update[`${id}_damage_roll`] = "{{roll02_name=^{damage}}} {{roll02=[[@{damage_dice_query}@{damage_dice_size} + @{damage_ability}[@{text_ability_modifier}] + @{damage_weapon_specialization}[WEAPON SPECIALIZATION] + @{damage_temporary}[TEMP] + @{damage_other}[OTHER] + @{query_roll_damage_bonus}[@{text_roll_damage_bonus}]]]}} {{roll02_type=damage}} {{roll02_info=@{damage_info}}}";
                 update[`${id}_damage_critical_roll`] = "{{roll03_name=^{critical_damage}}} {{roll03=[[(@{damage_dice_query}@{damage_dice_size} + @{damage_ability}[@{text_ability_modifier}] + @{damage_weapon_specialization}[WEAPON SPECIALIZATION] + @{damage_temporary}[TEMP] + @{damage_other}[OTHER] + @{query_roll_damage_bonus}[@{text_roll_damage_bonus}])*2]]}} {{roll03_type=critical-damage}} {{roll03_info=@{damage_info}}}";
                 // End


### PR DESCRIPTION
# Changes / Comments
My players complained that they couldn't easily / responsively subtract the -5 and -10 for multiple attacks on each turn when making melee / ranged attacks.
We found a box on the sheet that you apparently fill in, but since they mostly close the sheet to see the map between their turns / until they need a button, this wasn't seen as very useful.

This change should fix that by asking the user to input a bonus to the roll with a default value of 0 so they can enter whatever situational modifiers happen during the game.


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
Yes the  sheet name is in the PR title.
- [x] Is this a bug fix?
No it's not a bug fix, more of a... feature addition?
- [x] Does this add functional enhancements (new features or extending existing features) ?
Ah! Yes it extends an existing feature. The attack macro basically.
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
No aesthetic changes.
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
No attributes removed or changed.
- [x] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?
It's not a new sheet.

If you do not know English. Please leave a comment in your native language.
