### PR TITLE
Log Horizon TRPG: Fix accuracy check for general skills

### DIFF
--- a/Log Horizon TRPG/LHsheet.html
+++ b/Log Horizon TRPG/LHsheet.html
@@ -883,9 +883,9 @@
       <select name=attr_gcheck style='width: 125px; height: 14px; font-size: 10px; padding: 0;'>
       <option value="">None</option>
       <option value="{{Accuracy=[[@{baseDie}+@{accuracyTotal}+@{accuracyBonus}+@{gAccBonus}]] vs. Evasion}}{{Damage=[[@{gDamage}@{gDamageBonus}+[[@{statDamage}]]+[[(@{gSRdamage}*@{SR})]]@{gSRdamageType} ]] @{gDamageType}}}">Acc vs Eva</option>
-      <option value="{{Accuracy=[[@{baseDie}+@{accuracyTotal}+@{accuracyBonus}+@{highMod}+@{gAccBonus}]] vs. Resistance}}{{Damage=[[@{gDamage}@{gDamageBonus}+[[@{statDamage}]]+[[(@{gSRdamage}*@{SR})]]@{gSRdamageType} ]] @{gDamageType}}}">Acc vs Res</option>
-      <option value="{{Accuracy=[[@{baseDie}+@{accuracyTotal}+@{accuracyBonus}+@{highMod}+@{gAccBonus}]] vs. Evasion}}">Acc vs Eva (no damage)</option>
-      <option value="{{Accuracy=[[@{baseDie}+@{accuracyTotal}+@{accuracyBonus}+@{highMod}+@{gAccBonus}]] vs. Resistance}}">Acc vs Res (no damage)</option>
+      <option value="{{Accuracy=[[@{baseDie}+@{accuracyTotal}+@{accuracyBonus}+@{gAccBonus}]] vs. Resistance}}{{Damage=[[@{gDamage}@{gDamageBonus}+[[@{statDamage}]]+[[(@{gSRdamage}*@{SR})]]@{gSRdamageType} ]] @{gDamageType}}}">Acc vs Res</option>
+      <option value="{{Accuracy=[[@{baseDie}+@{accuracyTotal}+@{accuracyBonus}+@{gAccBonus}]] vs. Evasion}}">Acc vs Eva (no damage)</option>
+      <option value="{{Accuracy=[[@{baseDie}+@{accuracyTotal}+@{accuracyBonus}+@{gAccBonus}]] vs. Resistance}}">Acc vs Res (no damage)</option>
       <option value="{{Check=Auto}} {{Damage=[[@{gDamage}@{gDamageBonus}+[[@{statDamage}]]+[[(@{gSRdamage}*@{SR})]]@{gSRdamageType} ]] @{gDamageType}}}">Auto</option>
       <option value="{{Check=Auto}}">Auto (No damage)</option>
       <option value="{{Healing=[[@{gDamage}@{gDamageBonus}+[[@{statDamage}]]+[[(@{gSRdamage}*@{SR})]]@{gSRdamageType} ]]}}">Healing</option>


### PR DESCRIPTION
## Changes / Comments

Fix accuracy check for general skills: accuracy mod was applied 2 times.
accuracyTotal already include highMod.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
