### PR TITLE
Bug fix for Feast of Legends (support stats <= 4)

### DIFF
--- a/Feast_of_Legends/feast_of_legends.html
+++ b/Feast_of_Legends/feast_of_legends.html
@@ -139,7 +139,7 @@ stats.forEach(stat => {
           const stat_base = parseInt(values[stat], 10)||0;
           console.log(stat_base);
 
-          if(stat_base == "2" || stat_base == "3" || stat_base == "4"){
+          if(stat_base <= "4"){
             const stat_bonus = "-2"
             setAttrs({
                 [`${stat}_bonus`]: stat_bonus 


### PR DESCRIPTION
A simple update to support all stats <=4 -- to account for the edge case of NPCs with stats that are super low (like hunger pang has charm of '1').

## Changes / Comments






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
