### PR TITLE
Update Lotfp.html

### DIFF
--- a/Lotfp/Lotfp.html
+++ b/Lotfp/Lotfp.html
@@ -7,7 +7,7 @@
          <!-- Header Content -->
          <div class="sheet-info-name sheet-info-margin">
              <span>Name: </span>
-             <input type="text" class="sheet-bottom-line" name="attr_name">
+             <input type="text" class="sheet-bottom-line" name="attr_character_name">
          </div>
          <div class="sheet-info-row">
              <input type="text" class="sheet-info3" name="attr_class">
@@ -45,7 +45,7 @@
                 <span class="sheet-subtext">Retainer Recruitment, Loyalty</span>
             </div>
             <div class="sheet-ability-column-roll sheet-flex">
-               <button class="sheet-ability-button" type="roll" value="&{template:lotfp_check} {{name=Charisma}} {{abilityroll=[[1d20+@{ChaMod}+(?{Bonus|0})]]}}" name="roll_ChaCheck"></button>
+               <button class="sheet-ability-button" type="roll" value="&{template:lotfp_check} {{name=Charisma}} {{abilityroll=[[1d20+(?{Bonus|0})]]}} {{target=[[@{Cha}]]}}" name="roll_ChaCheck"></button>
             </div>
         </div>
         <div class="sheet-flex">
@@ -58,7 +58,7 @@
                 <span class="sheet-subtext">Hit Points,<br>Daily Travel Distance</span>
             </div>
             <div class="sheet-ability-column-roll sheet-flex">
-               <button class="sheet-ability-button" type="roll" value="&{template:lotfp_check} {{name=Constitution}} {{abilityroll=[[1d20+@{ConMod}+(?{Bonus|0})]]}}" name="roll_ConCheck"></button>
+               <button class="sheet-ability-button" type="roll" value="&{template:lotfp_check} {{name=Constitution}} {{abilityroll=[[1d20+(?{Bonus|0})]]}} {{target=[[@{Con}]]}}" name="roll_ConCheck"></button>
             </div>
         </div>
         <div class="sheet-flex">
@@ -71,7 +71,7 @@
                 <span class="sheet-subtext">AC, Ranged AB, Initiative</span>
             </div>
             <div class="sheet-ability-column-roll sheet-flex">
-                <button class="sheet-ability-button" type="roll" value="&{template:lotfp_check} {{name=Dexterity}} {{abilityroll=[[1d20+@{DexMod}+(?{Bonus|0})]]}}" name="roll_DexCheck"></button>
+                <button class="sheet-ability-button" type="roll" value="&{template:lotfp_check} {{name=Dexterity}} {{abilityroll=[[1d20+(?{Bonus|0})]]}} {{target=[[@{Dex}]]}}" name="roll_DexCheck"></button>
             </div>
         </div>
         <div class="sheet-flex">
@@ -84,7 +84,7 @@
                 <span class="sheet-subtext">Saves vs Magic Effects, Languages</span>
             </div>
             <div class="sheet-ability-column-roll sheet-flex">
-                <button class="sheet-ability-button" type="roll" value="&{template:lotfp_check} {{name=Intelligence}} {{abilityroll=[[1d20+@{IntMod}+(?{Bonus|0})]]}}" name="roll_IntCheck"></button>
+                <button class="sheet-ability-button" type="roll" value="&{template:lotfp_check} {{name=Intelligence}} {{abilityroll=[[1d20+(?{Bonus|0})]]}} {{target=[[@{Int}]]}}" name="roll_IntCheck"></button>
             </div>
         </div>
         <div class="sheet-flex">
@@ -97,7 +97,7 @@
                 <span class="sheet-subtext">Mêlée AB,<br>Open Doors</span>
             </div>
             <div class="sheet-ability-column-roll sheet-flex">
-                <button class="sheet-ability-button" type="roll" value="&{template:lotfp_check} {{name=Strength}} {{abilityroll=[[1d20+@{StrMod}+(?{Bonus|0})]]}}" name="roll_StrCheck"></button>
+                <button class="sheet-ability-button" type="roll" value="&{template:lotfp_check} {{name=Strength}} {{abilityroll=[[1d20+(?{Bonus|0})]]}} {{target=[[@{Str}]]}}" name="roll_StrCheck"></button>
             </div>
         </div>
         <div class="sheet-flex">
@@ -110,7 +110,7 @@
                 <span class="sheet-subtext">Saves vs Non-Magic Effects</span>
             </div>
             <div class="sheet-ability-column-roll sheet-flex">
-                <button class="sheet-ability-button" type="roll" value="&{template:lotfp_check} {{name=Wisdom}} {{abilityroll=[[1d20+@{WisMod}+(?{Bonus|0})]]}}" name="roll_WisCheck"></button>
+                <button class="sheet-ability-button" type="roll" value="&{template:lotfp_check} {{name=Wisdom}} {{abilityroll=[[1d20+(?{Bonus|0})]]}} {{target=[[@{Wis}]]}}" name="roll_WisCheck"></button>
             </div>
         </div>
     </div>
@@ -225,7 +225,7 @@
         <input type="text" name="attr_shortrange" class="sheet-bottom-line sheet-damage">
         <input type="text" name="attr_mediumrange" class="sheet-bottom-line sheet-damage">
         <input type="text" name="attr_longrange" class="sheet-bottom-line sheet-damage">
-        <button class="sheet-attack-button" type="roll" value="&{template:lotfp_check} {{name=@{weaponname}}} {{charactername=@{name}}} {{attackroll=[[1d20+@{attackbonus}+(?{Bonus|0})]]}} {{damageroll=[[@{weapondamage}]]}}" name="roll_Attack"></button>
+        <button class="sheet-attack-button" type="roll" value="&{template:lotfp_check} {{name=@{weaponname}}} {{charactername=@{character_name}}} {{attackroll=[[1d20+@{attackbonus}+(?{Bonus|0})]]}} {{damageroll=[[@{weapondamage}]]}}" name="roll_Attack"></button>
     </fieldset>
 </div>
 
@@ -394,7 +394,7 @@
                 <span># prepared: </span>
                 <input type="number" name="attr_spellprepared" class="sheet-bottom-line sheet-spell-prepared" value="0" min="0">
             </div>
-            <button class="sheet-attack-button" type="roll" value="&{template:lotfp_check} {{name=@{spellname}}} {{spell=1}} {{charactername=@{name}}} {{type=@{spelltype}}} {{level=@{spelllevel}}} {{duration=@{spellduration}}} {{range=@{spellrange}}} {{description=@{spelldescription}}}" name="roll_Cast"></button>
+            <button class="sheet-attack-button" type="roll" value="&{template:lotfp_check} {{name=@{spellname}}} {{spell=1}} {{charactername=@{character_name}}} {{type=@{spelltype}}} {{level=@{spelllevel}}} {{duration=@{spellduration}}} {{range=@{spellrange}}} {{description=@{spelldescription}}}" name="roll_Cast"></button>
             <textarea spellcheck="false" name="attr_spelldescription" class="sheet-spell-description" placeholder="Description"></textarea>
         </div>
     </fieldset>
@@ -425,8 +425,17 @@
 <rolltemplate class="sheet-rolltemplate-lotfp_check">
     <table class="sheet-rt-table">
         {{#abilityroll}}
-            <tr><th>{{name}} check</th></tr>
-            <tr><td><span class="sheet-tcat">Roll: </span>{{abilityroll}}</td></tr>
+            <tr><th>{{name}} Ability Check</th></tr>
+            <tr><td><span class="sheet-tcat">Roll: </span>{{abilityroll}} &le; {{target}} </td></tr>
+            {{#rollLess() abilityroll target}}
+                    <tr><td class="sheet-subheader" style="color:green;"><b>Success!</b></td></tr>
+            {{/rollLess() abilityroll target}}
+            {{#rollTotal() abilityroll target}}
+                    <tr><td class="sheet-subheader" style="color:green;"><b>Success!</b></td></tr>
+            {{/rollTotal() abilityroll target}}
+            {{#rollGreater() abilityroll target}}
+                    <tr><td class="sheet-subheader" style="color:red;"><b>Failure.</b></td></tr>
+            {{/rollGreater() abilityroll target}}            
         {{/abilityroll}}
         {{#attackroll}}
             <tr><th>{{charactername}} attacks with {{name}}</th></tr>
@@ -434,8 +443,8 @@
             <tr><td><span class="sheet-tcat">Damage: </span>{{damageroll}}</td></tr>
         {{/attackroll}}
         {{#skillroll}}
-            <tr><th>{{name}} check</th></tr>
-            <tr><td><span class="sheet-tcat">Roll: </span>{{skillroll}} &lt;= {{target}} </td></tr>
+            <tr><th>{{name}} Skill Check</th></tr>
+            <tr><td><span class="sheet-tcat">Roll: </span>{{skillroll}} &le; {{target}} </td></tr>
             {{#rollLess() skillroll target}}
                     <tr><td class="sheet-subheader" style="color:green;"><b>Success!</b></td></tr>
             {{/rollLess() skillroll target}}
@@ -447,8 +456,8 @@
             {{/rollGreater() skillroll target}}
         {{/skillroll}}
         {{#saveroll}}
-            <tr><th>{{name}} save</th></tr>
-            <tr><td><span class="sheet-tcat">Roll: </span>{{saveroll}} &gt; {{target}}</td></tr>
+            <tr><th>{{name}} Saving Throw</th></tr>
+            <tr><td><span class="sheet-tcat">Roll: </span>{{saveroll}} &ge; {{target}}</td></tr>
             {{#rollLess() saveroll target}}
                     <tr><td class="sheet-subheader" style="color:red;"><b>Failure.</b></td></tr>
             {{/rollLess() saveroll target}}
@@ -539,21 +548,18 @@ on('change:repeating_equipment remove:repeating_equipment', () => {
   });
 });
 // Ability modifiers
+const classMods = {Dwarf: "Con", Halfling: "Dex"};
 ['Cha', 'Con', 'Dex', 'Int', 'Str', 'Wis'].forEach(ability => {
-  on(`sheet:opened change:${ability.toLowerCase()}`, () => {
-    getAttrs([ability.toLowerCase()], v => {
-      const value = parseInt(v[ability.toLowerCase()]) || 10,
-        setting = {};
-      if (value <= 3) setting[`${ability}Mod`] = -3;
-      else if (value <= 5) setting[`${ability}Mod`] = -2;
-      else if (value <= 8) setting[`${ability}Mod`] = -1;
-      else if (value <= 12) setting[`${ability}Mod`] = 0;
-      else if (value <= 15) setting[`${ability}Mod`] = 1;
-      else if (value <= 17) setting[`${ability}Mod`] = 2;
-      else setting[`${ability}Mod`] = 3;
-      setAttrs(setting);
+    on(`sheet:opened change:class change:${ability.toLowerCase()}`, () => {
+        getAttrs([ability.toLowerCase(), 'class'], v => {
+            const score = parseInt(v[ability.toLowerCase()]) || 10;
+            const race = v.class.trim();
+            const setting = {};
+            const statrank = [1,3,5,8,12,15,17,19].findIndex(rank => score <= rank);
+            setting[`${ability}Mod`] = (statrank === -1 ? 4 : statrank -4) + ((classMods[race] || '') === ability ? 1 : 0);
+            setAttrs(setting);
+        });
     });
-  });
 });
 // Conversion
 on('sheet:opened', () => {


### PR DESCRIPTION
- Changed attr_name to attr_character_name
- Added Ability Modifier support for Dwarf and Halfling classes with a new Ability Scores sheetworker provided by GiGi.
- Changed Ability Checks to be the more traditional roll under.
- Updated  the Ability Check rolltemplate to show success and failure.
- Added greater-than or equal to and less-than or equal to HTML symbols to the Ability Check, Skill Check, and Saving Throw rolltemplates.

## Changes / Comments






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
