### PR TITLE
[5th Edition OGL] Fix spell checkbox

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.css
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.css
@@ -1771,12 +1771,13 @@ span.sheet-spellconcentration
 }
 
 .sheet-spell .sheet-prep-box {
-    -webkit-appearance: checkbox;
-    -moz-appearance: checkbox;
+    -webkit-appearance: none;
+    -moz-appearance: none;
     opacity: 0;
     z-index: 2;
     position: relative;
-    width: 12px
+    width: 12px;
+    height: 12px;
 }
 
 .charsheet .sheet-spell .sheet-display button[type=roll].sheet-spellcard {


### PR DESCRIPTION
## Changes / Comments
In firefox checkboxes can't be resized. This leads to the spell name input poping to the next line.

![spells](https://user-images.githubusercontent.com/1530025/67804519-51e60b80-fa4c-11e9-944e-ddfaf7db0d19.png)

Th checkbox input doesn't actual need to display as a checkbox (you have you're own graphics for it). This pull request sets the input checkbox to `appearance: none` allowing it to resize.
![spells](https://user-images.githubusercontent.com/1530025/67804693-b7d29300-fa4c-11e9-842c-2c24663dde7b.png)






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
