### PR TITLE
[5th Edition OGL] Expand spells

### DIFF
--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.css
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.css
@@ -1778,6 +1778,21 @@ span.sheet-spellconcentration
     display: none;
 }
 
+.sheet-spell .sheet-details button.sheet-spell_link::before {
+    content: '|';
+}
+
+.sheet-spell .sheet-details button.sheet-spell_link {
+    float: right;
+    border: none;
+    background: none;
+    color: #A0A0A0;
+}
+
+.sheet-spell .sheet-details button.sheet-spell_link:hover {
+    color: #000000;
+}
+
 .sheet-spell .sheet-details-flag:checked + span {
     display: block;
     color: #000000;

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.css
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.css
@@ -1753,6 +1753,103 @@ span.sheet-spellconcentration
     color: black;
 }
 
+.sheet-spell .sheet-details-flag {
+    opacity: 0;
+    position: absolute;
+    top: 0px;
+    right: 23px;
+    width: 18px;
+    height: 18px;
+    z-index: 2;
+}
+
+.sheet-spell .sheet-details-flag + span {
+    position: absolute;
+    top: 0px;
+    right: 23px;
+    white-space: nowrap;
+    width: 18px;
+    height: 18px;
+    font-size: 20px;
+    font-family: pictos;
+    color: #A0A0A0;
+    cursor: pointer;
+    margin-top: 0px;
+    display: none;
+}
+
+.sheet-spell .sheet-details-flag:checked + span {
+    display: block;
+    color: #000000;
+}
+
+.sheet-spell:hover .sheet-details-flag + span {
+    display: block;
+}
+
+.sheet-spell .sheet-details-flag ~ .sheet-details {
+    display: none;
+}
+
+.sheet-spell .sheet-details-flag:checked ~ .sheet-details {
+    display: block;
+}
+
+.sheet-spell .sheet-details {
+    margin: 15px 0;
+}
+
+.sheet-spell .sheet-details span {
+    display: inline;
+    font-weight: normal;
+}
+
+.sheet-spell .sheet-details span.sheet-bold {
+    font-weight: bold;
+}
+
+.sheet-spell .sheet-details .sheet-italics {
+    font-style: italic;
+}
+
+.sheet-spell .sheet-details input[type="checkbox"] {
+    display: none;
+}
+
+.sheet-spell .sheet-details input[type="checkbox"] + span {
+    display: none;
+}
+
+.sheet-spell .sheet-details input[type="checkbox"]:checked + span {
+    display: inline;
+}
+
+.sheet-spell .sheet-details span[name="attr_spellname"] {
+    font-family: "Times New Roman", Times, serif;
+    font-size: 16px;
+    text-transform: capitalize;
+    font-variant: small-caps;
+    color: rgb(126, 45, 64);
+}
+
+.sheet-spell .sheet-details span[name="attr_innate"] {
+    font-family: "Times New Roman", Times, serif;
+    font-size: 16px;
+    color: #A0A0A0;
+}
+
+.sheet-spell .sheet-details input[name="attr_spellcomp_materials"] {
+    display: none;
+}
+
+.sheet-spell .sheet-details input[name="attr_spellcomp_materials"] + span {
+    display: none;
+}
+
+.sheet-spell .sheet-details input[name="attr_spellcomp_materials"]:valid + span {
+    display: inline;
+}
+
 .sheet-spell .sheet-display {
     position: relative;
 }

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.css
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.css
@@ -1814,7 +1814,7 @@ span.sheet-spellconcentration
     margin: 15px 0;
 }
 
-.sheet-spell .sheet-details span {
+.sheet-spell .sheet-details span:not(.sheet-innate){
     display: inline;
     font-weight: normal;
 }
@@ -1839,6 +1839,10 @@ span.sheet-spellconcentration
     display: inline;
 }
 
+.sheet-spell .sheet-details input[type="checkbox"]:checked ~ input[type="checkbox"]:checked + span::before {
+    content: ', ';
+}
+
 .sheet-spell .sheet-details span[name="attr_spellname"] {
     font-family: "Times New Roman", Times, serif;
     font-size: 16px;
@@ -1847,22 +1851,9 @@ span.sheet-spellconcentration
     color: rgb(126, 45, 64);
 }
 
-.sheet-spell .sheet-details span[name="attr_innate"] {
-    font-family: "Times New Roman", Times, serif;
-    font-size: 16px;
-    color: #A0A0A0;
-}
-
-.sheet-spell .sheet-details input[name="attr_spellcomp_materials"] {
+.sheet-spell .sheet-details input[name="attr_spellcomp_materials"][value=""] + span,
+.sheet-spell .sheet-details input[name="attr_spellathigherlevels"][value=""] + div {
     display: none;
-}
-
-.sheet-spell .sheet-details input[name="attr_spellcomp_materials"] + span {
-    display: none;
-}
-
-.sheet-spell .sheet-details input[name="attr_spellcomp_materials"]:valid + span {
-    display: inline;
 }
 
 .sheet-spell .sheet-display {

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.css
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.css
@@ -1037,6 +1037,7 @@ button[type=roll] * {
 
 }
 
+.sheet-spell .sheet-details-flag,
 .sheet-attacks .sheet-options-flag,
 .sheet-spell .sheet-options-flag,
 .sheet-tool .sheet-options-flag,
@@ -1059,6 +1060,7 @@ button[type=roll] * {
     z-index: 2;
 }
 
+.sheet-spell .sheet-details-flag + span,
 .sheet-attacks .sheet-options-flag + span,
 .sheet-spell .sheet-options-flag + span,
 .sheet-tool .sheet-options-flag + span,
@@ -1072,6 +1074,7 @@ button[type=roll] * {
 .sheet-equipment .sheet-inventorysubflag + span,
 .sheet-header .sheet-options-flag + span
 {
+    align-items: center;
     position: absolute;
     top: 0px;
     right: 0px;
@@ -1086,12 +1089,30 @@ button[type=roll] * {
     display: none;
 }
 
+.sheet-spell .sheet-details-flag:hover + span,
+.sheet-attacks .sheet-options-flag:hover + span,
+.sheet-spell .sheet-options-flag:hover + span,
+.sheet-tool .sheet-options-flag:hover + span,
+.sheet-npc .sheet-npc_options-flag:hover + span,
+.sheet-trait .sheet-options-flag:hover + span,
+.sheet-global-mod .sheet-options-flag:hover + span,
+.sheet-action .sheet-options-flag:hover + span,
+.sheet-textbox .sheet-options-flag:hover + span,
+.sheet-proficiencies .sheet-options-flag:hover + span,
+.sheet-traits .sheet-options-flag:hover + span,
+.sheet-equipment .sheet-inventorysubflag:hover + span,
+.sheet-header .sheet-options-flag:hover + span
+{
+    color: #000000;
+}
+
 .sheet-pc .sheet-global-mod .sheet-options-flag:not(:checked) ~ .sheet-display,
 .sheet-pc .sheet-global-mod .sheet-options-flag:checked ~ .sheet-options {
     width: 80%;
     display: inline-block;
 }
 
+.sheet-spell .sheet-details-flag:checked + span,
 .sheet-attacks .sheet-options-flag:checked + span,
 .sheet-spell .sheet-options-flag:checked + span,
 .sheet-tool .sheet-options-flag:checked + span,
@@ -1106,9 +1127,10 @@ button[type=roll] * {
 .sheet-header .sheet-options-flag:checked + span
 {
     color: black;
-    display: block;
+    display: flex;
 }
 
+.sheet-spell:hover .sheet-details-flag + span,
 .sheet-attacks .sheet-attack:hover .sheet-options-flag + span,
 .sheet-spell:hover .sheet-options-flag + span,
 .sheet-tool:hover .sheet-options-flag + span,
@@ -1122,7 +1144,7 @@ button[type=roll] * {
 .sheet-pc .sheet-trait:hover .sheet-output,
 .sheet-pc .sheet-header:hover .sheet-options-flag + span
 {
-    display: block;
+    display: flex;
 }
 
 .sheet-pc .sheet-header .sheet-options-flag {
@@ -1229,6 +1251,7 @@ button[type=roll] * {
     word-break: break-word;
 }
 
+.sheet-spell .sheet-details-flag:checked ~ .sheet-wrapper,
 .sheet-attacks .sheet-options-flag:checked ~ .sheet-options,
 .sheet-spell .sheet-options-flag:checked ~ .sheet-options,
 .sheet-tool .sheet-options-flag:checked ~ .sheet-options,
@@ -1753,65 +1776,54 @@ span.sheet-spellconcentration
     color: black;
 }
 
-.sheet-spell .sheet-details-flag {
-    opacity: 0;
-    position: absolute;
-    top: 0px;
-    right: 23px;
-    width: 18px;
-    height: 18px;
-    z-index: 2;
-}
-
+.sheet-spell .sheet-details-flag,
 .sheet-spell .sheet-details-flag + span {
-    position: absolute;
-    top: 0px;
-    right: 23px;
-    white-space: nowrap;
-    width: 18px;
-    height: 18px;
-    font-size: 20px;
-    font-family: pictos;
-    color: #A0A0A0;
-    cursor: pointer;
-    margin-top: 0px;
-    display: none;
+    right: 30px;
 }
 
-.sheet-spell .sheet-details button.sheet-spell_link::before {
+.sheet-spell .sheet-wrapper .sheet-options-flag + span {
+    display: flex;
+}
+
+.sheet-spell .sheet-wrapper button.sheet-spell_link::before {
     content: '|';
 }
 
-.sheet-spell .sheet-details button.sheet-spell_link {
-    float: right;
+.sheet-spell .sheet-wrapper button.sheet-spell_link {
+    position: absolute;
+    top: 0;
+    right: 5px;
     border: none;
     background: none;
     color: #A0A0A0;
+    margin: 0;
+    padding: 0;
 }
 
-.sheet-spell .sheet-details button.sheet-spell_link:hover {
+.sheet-spell .sheet-wrapper button.sheet-spell_link:hover {
     color: #000000;
 }
 
-.sheet-spell .sheet-details-flag:checked + span {
-    display: block;
-    color: #000000;
-}
-
-.sheet-spell:hover .sheet-details-flag + span {
-    display: block;
-}
-
-.sheet-spell .sheet-details-flag ~ .sheet-details {
+.sheet-spell .sheet-wrapper {
     display: none;
-}
-
-.sheet-spell .sheet-details-flag:checked ~ .sheet-details {
-    display: block;
-}
-
-.sheet-spell .sheet-details {
+    position: relative;
     margin: 15px 0;
+}
+
+.sheet-spell .sheet-wrapper .sheet-options-flag {
+    z-index: 10;
+}
+
+.sheet-spell .sheet-wrapper .sheet-options-flag,
+.sheet-spell .sheet-wrapper .sheet-options-flag + span {
+    right: 25px;
+    font-size: 1.3em;
+}
+
+.sheet-spell .sheet-wrapper .sheet-options-flag:checked + span,
+.sheet-spell .sheet-wrapper .sheet-options-flag:checked ~ button.sheet-spell_link,
+.sheet-spell .sheet-wrapper .sheet-options-flag:checked ~ .sheet-details {
+    display: none;
 }
 
 .sheet-spell .sheet-details span:not(.sheet-innate){
@@ -1853,6 +1865,38 @@ span.sheet-spellconcentration
 
 .sheet-spell .sheet-details input[name="attr_spellcomp_materials"][value=""] + span,
 .sheet-spell .sheet-details input[name="attr_spellathigherlevels"][value=""] + div {
+    display: none;
+}
+
+.sheet-spell .sheet-options {
+    border-top: none;
+    border-bottom: 2px dashed gold;
+    padding-bottom: 40px;
+}
+
+.sheet-spell .sheet-options-done {
+    display: inline-block;
+    margin-top: 5px;
+    padding: 3px 10px;
+    width: auto;
+    border-radius: 1em;
+    color: #ffffff;
+    background-color: #000000;
+    font-size: 1em;
+    float: right;
+    cursor: pointer;
+}
+
+.sheet-spell .sheet-options-done:hover {
+    opacity: 0.6;
+}
+
+.sheet-spell .sheet-options-done::before {
+    content: '3';
+    font-family: pictos;
+}
+
+.sheet-spell .sheet-options-done input[type="checkbox"] {
     display: none;
 }
 

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -2206,6 +2206,58 @@
                                 <span class="m" data-i18n="spell-component-material">M</span>
                             </span>
                         </div>
+                        <input class="details-flag" type="checkbox"><span>i</span>
+                        <div class="details">
+                            <a class="row">
+                                <span name="attr_spellname"></span>
+                                <span name="attr_innate"></span>
+                            </a>
+                            <div class="row italics">
+                                <span name="attr_spellschool"></span>
+                                <span name="attr_spelllevel"></span>
+                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="casting-time:">Casting Time:</span>
+                                <span name="attr_spellcastingtime"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="range:">Range:</span>
+                                <span name="attr_spellrange"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="target:">Target:</span>
+                                <span name="attr_spelltarget"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="components:">Components:</span>
+                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
+                                <span data-i18n="spell-component-verbal">V</span>
+                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
+                                <span data-i18n="spell-component-somatic">S</span>
+                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
+                                <span data-i18n="spell-component-material">M</span>
+                                <input type="text" name="attr_spellcomp_materials" required>
+                                <span>(<span name="attr_spellcomp_materials"></span>)</span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="duration:">Duration:</span>
+                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                <span data-i18n="concentration">Concentration</span>
+                                <span name="attr_spellduration"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="description:">Description:</span>
+                            </div>
+                            <div class="row">
+                                <span name="attr_spelldescription"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
+                                <span name="attr_spellathigherlevels"></span>
+                            </div>
+                        </div>
                     </div>
                 </fieldset>
             </div>
@@ -2416,6 +2468,58 @@
                                 <span class="m" data-i18n="spell-component-material">M</span>
                             </span>
                         </div>
+                        <input class="details-flag" type="checkbox"><span>i</span>
+                        <div class="details">
+                            <a class="row">
+                                <span name="attr_spellname"></span>
+                                <span name="attr_innate"></span>
+                            </a>
+                            <div class="row italics">
+                                <span name="attr_spellschool"></span>
+                                <span name="attr_spelllevel"></span>
+                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="casting-time:">Casting Time:</span>
+                                <span name="attr_spellcastingtime"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="range:">Range:</span>
+                                <span name="attr_spellrange"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="target:">Target:</span>
+                                <span name="attr_spelltarget"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="components:">Components:</span>
+                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
+                                <span data-i18n="spell-component-verbal">V</span>
+                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
+                                <span data-i18n="spell-component-somatic">S</span>
+                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
+                                <span data-i18n="spell-component-material">M</span>
+                                <input type="text" name="attr_spellcomp_materials" required>
+                                <span>(<span name="attr_spellcomp_materials"></span>)</span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="duration:">Duration:</span>
+                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                <span data-i18n="concentration">Concentration</span>
+                                <span name="attr_spellduration"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="description:">Description:</span>
+                            </div>
+                            <div class="row">
+                                <span name="attr_spelldescription"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
+                                <span name="attr_spellathigherlevels"></span>
+                            </div>
+                        </div>
                     </div>
                 </fieldset>
             </div>
@@ -2621,6 +2725,58 @@
                                 <span class="s" data-i18n="spell-component-somatic">S</span>
                                 <span class="m" data-i18n="spell-component-material">M</span>
                             </span>
+                        </div>
+                        <input class="details-flag" type="checkbox"><span>i</span>
+                        <div class="details">
+                            <a class="row">
+                                <span name="attr_spellname"></span>
+                                <span name="attr_innate"></span>
+                            </a>
+                            <div class="row italics">
+                                <span name="attr_spellschool"></span>
+                                <span name="attr_spelllevel"></span>
+                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="casting-time:">Casting Time:</span>
+                                <span name="attr_spellcastingtime"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="range:">Range:</span>
+                                <span name="attr_spellrange"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="target:">Target:</span>
+                                <span name="attr_spelltarget"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="components:">Components:</span>
+                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
+                                <span data-i18n="spell-component-verbal">V</span>
+                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
+                                <span data-i18n="spell-component-somatic">S</span>
+                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
+                                <span data-i18n="spell-component-material">M</span>
+                                <input type="text" name="attr_spellcomp_materials" required>
+                                <span>(<span name="attr_spellcomp_materials"></span>)</span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="duration:">Duration:</span>
+                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                <span data-i18n="concentration">Concentration</span>
+                                <span name="attr_spellduration"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="description:">Description:</span>
+                            </div>
+                            <div class="row">
+                                <span name="attr_spelldescription"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
+                                <span name="attr_spellathigherlevels"></span>
+                            </div>
                         </div>
                     </div>
                 </fieldset>
@@ -2831,6 +2987,58 @@
                                 <span class="m" data-i18n="spell-component-material">M</span>
                             </span>
                         </div>
+                        <input class="details-flag" type="checkbox"><span>i</span>
+                        <div class="details">
+                            <a class="row">
+                                <span name="attr_spellname"></span>
+                                <span name="attr_innate"></span>
+                            </a>
+                            <div class="row italics">
+                                <span name="attr_spellschool"></span>
+                                <span name="attr_spelllevel"></span>
+                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="casting-time:">Casting Time:</span>
+                                <span name="attr_spellcastingtime"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="range:">Range:</span>
+                                <span name="attr_spellrange"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="target:">Target:</span>
+                                <span name="attr_spelltarget"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="components:">Components:</span>
+                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
+                                <span data-i18n="spell-component-verbal">V</span>
+                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
+                                <span data-i18n="spell-component-somatic">S</span>
+                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
+                                <span data-i18n="spell-component-material">M</span>
+                                <input type="text" name="attr_spellcomp_materials" required>
+                                <span>(<span name="attr_spellcomp_materials"></span>)</span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="duration:">Duration:</span>
+                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                <span data-i18n="concentration">Concentration</span>
+                                <span name="attr_spellduration"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="description:">Description:</span>
+                            </div>
+                            <div class="row">
+                                <span name="attr_spelldescription"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
+                                <span name="attr_spellathigherlevels"></span>
+                            </div>
+                        </div>
                     </div>
                 </fieldset>
             </div>
@@ -3037,6 +3245,58 @@
                                 <span class="m" data-i18n="spell-component-material">M</span>
                             </span>
                         </div>
+                        <input class="details-flag" type="checkbox"><span>i</span>
+                        <div class="details">
+                            <a class="row">
+                                <span name="attr_spellname"></span>
+                                <span name="attr_innate"></span>
+                            </a>
+                            <div class="row italics">
+                                <span name="attr_spellschool"></span>
+                                <span name="attr_spelllevel"></span>
+                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="casting-time:">Casting Time:</span>
+                                <span name="attr_spellcastingtime"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="range:">Range:</span>
+                                <span name="attr_spellrange"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="target:">Target:</span>
+                                <span name="attr_spelltarget"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="components:">Components:</span>
+                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
+                                <span data-i18n="spell-component-verbal">V</span>
+                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
+                                <span data-i18n="spell-component-somatic">S</span>
+                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
+                                <span data-i18n="spell-component-material">M</span>
+                                <input type="text" name="attr_spellcomp_materials" required>
+                                <span>(<span name="attr_spellcomp_materials"></span>)</span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="duration:">Duration:</span>
+                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                <span data-i18n="concentration">Concentration</span>
+                                <span name="attr_spellduration"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="description:">Description:</span>
+                            </div>
+                            <div class="row">
+                                <span name="attr_spelldescription"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
+                                <span name="attr_spellathigherlevels"></span>
+                            </div>
+                        </div>
                     </div>
                 </fieldset>
             </div>
@@ -3242,6 +3502,58 @@
                                 <span class="s" data-i18n="spell-component-somatic">S</span>
                                 <span class="m" data-i18n="spell-component-material">M</span>
                             </span>
+                        </div>
+                        <input class="details-flag" type="checkbox"><span>i</span>
+                        <div class="details">
+                            <a class="row">
+                                <span name="attr_spellname"></span>
+                                <span name="attr_innate"></span>
+                            </a>
+                            <div class="row italics">
+                                <span name="attr_spellschool"></span>
+                                <span name="attr_spelllevel"></span>
+                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="casting-time:">Casting Time:</span>
+                                <span name="attr_spellcastingtime"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="range:">Range:</span>
+                                <span name="attr_spellrange"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="target:">Target:</span>
+                                <span name="attr_spelltarget"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="components:">Components:</span>
+                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
+                                <span data-i18n="spell-component-verbal">V</span>
+                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
+                                <span data-i18n="spell-component-somatic">S</span>
+                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
+                                <span data-i18n="spell-component-material">M</span>
+                                <input type="text" name="attr_spellcomp_materials" required>
+                                <span>(<span name="attr_spellcomp_materials"></span>)</span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="duration:">Duration:</span>
+                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                <span data-i18n="concentration">Concentration</span>
+                                <span name="attr_spellduration"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="description:">Description:</span>
+                            </div>
+                            <div class="row">
+                                <span name="attr_spelldescription"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
+                                <span name="attr_spellathigherlevels"></span>
+                            </div>
                         </div>
                     </div>
                 </fieldset>
@@ -3452,6 +3764,58 @@
                                 <span class="m" data-i18n="spell-component-material">M</span>
                             </span>
                         </div>
+                        <input class="details-flag" type="checkbox"><span>i</span>
+                        <div class="details">
+                            <a class="row">
+                                <span name="attr_spellname"></span>
+                                <span name="attr_innate"></span>
+                            </a>
+                            <div class="row italics">
+                                <span name="attr_spellschool"></span>
+                                <span name="attr_spelllevel"></span>
+                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="casting-time:">Casting Time:</span>
+                                <span name="attr_spellcastingtime"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="range:">Range:</span>
+                                <span name="attr_spellrange"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="target:">Target:</span>
+                                <span name="attr_spelltarget"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="components:">Components:</span>
+                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
+                                <span data-i18n="spell-component-verbal">V</span>
+                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
+                                <span data-i18n="spell-component-somatic">S</span>
+                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
+                                <span data-i18n="spell-component-material">M</span>
+                                <input type="text" name="attr_spellcomp_materials" required>
+                                <span>(<span name="attr_spellcomp_materials"></span>)</span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="duration:">Duration:</span>
+                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                <span data-i18n="concentration">Concentration</span>
+                                <span name="attr_spellduration"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="description:">Description:</span>
+                            </div>
+                            <div class="row">
+                                <span name="attr_spelldescription"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
+                                <span name="attr_spellathigherlevels"></span>
+                            </div>
+                        </div>
                     </div>
                 </fieldset>
             </div>
@@ -3657,6 +4021,58 @@
                                 <span class="s" data-i18n="spell-component-somatic">S</span>
                                 <span class="m" data-i18n="spell-component-material">M</span>
                             </span>
+                        </div>
+                        <input class="details-flag" type="checkbox"><span>i</span>
+                        <div class="details">
+                            <a class="row">
+                                <span name="attr_spellname"></span>
+                                <span name="attr_innate"></span>
+                            </a>
+                            <div class="row italics">
+                                <span name="attr_spellschool"></span>
+                                <span name="attr_spelllevel"></span>
+                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="casting-time:">Casting Time:</span>
+                                <span name="attr_spellcastingtime"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="range:">Range:</span>
+                                <span name="attr_spellrange"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="target:">Target:</span>
+                                <span name="attr_spelltarget"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="components:">Components:</span>
+                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
+                                <span data-i18n="spell-component-verbal">V</span>
+                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
+                                <span data-i18n="spell-component-somatic">S</span>
+                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
+                                <span data-i18n="spell-component-material">M</span>
+                                <input type="text" name="attr_spellcomp_materials" required>
+                                <span>(<span name="attr_spellcomp_materials"></span>)</span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="duration:">Duration:</span>
+                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                <span data-i18n="concentration">Concentration</span>
+                                <span name="attr_spellduration"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="description:">Description:</span>
+                            </div>
+                            <div class="row">
+                                <span name="attr_spelldescription"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
+                                <span name="attr_spellathigherlevels"></span>
+                            </div>
                         </div>
                     </div>
                 </fieldset>
@@ -3864,6 +4280,58 @@
                                 <span class="m" data-i18n="spell-component-material">M</span>
                             </span>
                         </div>
+                        <input class="details-flag" type="checkbox"><span>i</span>
+                        <div class="details">
+                            <a class="row">
+                                <span name="attr_spellname"></span>
+                                <span name="attr_innate"></span>
+                            </a>
+                            <div class="row italics">
+                                <span name="attr_spellschool"></span>
+                                <span name="attr_spelllevel"></span>
+                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="casting-time:">Casting Time:</span>
+                                <span name="attr_spellcastingtime"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="range:">Range:</span>
+                                <span name="attr_spellrange"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="target:">Target:</span>
+                                <span name="attr_spelltarget"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="components:">Components:</span>
+                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
+                                <span data-i18n="spell-component-verbal">V</span>
+                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
+                                <span data-i18n="spell-component-somatic">S</span>
+                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
+                                <span data-i18n="spell-component-material">M</span>
+                                <input type="text" name="attr_spellcomp_materials" required>
+                                <span>(<span name="attr_spellcomp_materials"></span>)</span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="duration:">Duration:</span>
+                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                <span data-i18n="concentration">Concentration</span>
+                                <span name="attr_spellduration"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="description:">Description:</span>
+                            </div>
+                            <div class="row">
+                                <span name="attr_spelldescription"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
+                                <span name="attr_spellathigherlevels"></span>
+                            </div>
+                        </div>
                     </div>
                 </fieldset>
             </div>
@@ -4069,6 +4537,58 @@
                                 <span class="s" data-i18n="spell-component-somatic">S</span>
                                 <span class="m" data-i18n="spell-component-material">M</span>
                             </span>
+                        </div>
+                        <input class="details-flag" type="checkbox"><span>i</span>
+                        <div class="details">
+                            <a class="row">
+                                <span name="attr_spellname"></span>
+                                <span name="attr_innate"></span>
+                            </a>
+                            <div class="row italics">
+                                <span name="attr_spellschool"></span>
+                                <span name="attr_spelllevel"></span>
+                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="casting-time:">Casting Time:</span>
+                                <span name="attr_spellcastingtime"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="range:">Range:</span>
+                                <span name="attr_spellrange"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="target:">Target:</span>
+                                <span name="attr_spelltarget"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="components:">Components:</span>
+                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
+                                <span data-i18n="spell-component-verbal">V</span>
+                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
+                                <span data-i18n="spell-component-somatic">S</span>
+                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
+                                <span data-i18n="spell-component-material">M</span>
+                                <input type="text" name="attr_spellcomp_materials" required>
+                                <span>(<span name="attr_spellcomp_materials"></span>)</span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="duration:">Duration:</span>
+                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                <span data-i18n="concentration">Concentration</span>
+                                <span name="attr_spellduration"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold" data-i18n="description:">Description:</span>
+                            </div>
+                            <div class="row">
+                                <span name="attr_spelldescription"></span>
+                            </div>
+                            <div class="row">
+                                <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
+                                <span name="attr_spellathigherlevels"></span>
+                            </div>
                         </div>
                     </div>
                 </fieldset>

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -2208,6 +2208,7 @@
                         </div>
                         <input class="details-flag" type="checkbox"><span>i</span>
                         <div class="details">
+                            <button class="spell_link" type="compendium" name="attr_spellname"></button>
                             <a class="row">
                                 <span name="attr_spellname"></span>
                                 <span name="attr_innate"></span>
@@ -2470,6 +2471,7 @@
                         </div>
                         <input class="details-flag" type="checkbox"><span>i</span>
                         <div class="details">
+                            <button class="spell_link" type="compendium" name="attr_spellname"></button>
                             <a class="row">
                                 <span name="attr_spellname"></span>
                                 <span name="attr_innate"></span>
@@ -2728,6 +2730,7 @@
                         </div>
                         <input class="details-flag" type="checkbox"><span>i</span>
                         <div class="details">
+                            <button class="spell_link" type="compendium" name="attr_spellname"></button>
                             <a class="row">
                                 <span name="attr_spellname"></span>
                                 <span name="attr_innate"></span>
@@ -2989,6 +2992,7 @@
                         </div>
                         <input class="details-flag" type="checkbox"><span>i</span>
                         <div class="details">
+                            <button class="spell_link" type="compendium" name="attr_spellname"></button>
                             <a class="row">
                                 <span name="attr_spellname"></span>
                                 <span name="attr_innate"></span>
@@ -3247,6 +3251,7 @@
                         </div>
                         <input class="details-flag" type="checkbox"><span>i</span>
                         <div class="details">
+                            <button class="spell_link" type="compendium" name="attr_spellname"></button>
                             <a class="row">
                                 <span name="attr_spellname"></span>
                                 <span name="attr_innate"></span>
@@ -3505,6 +3510,7 @@
                         </div>
                         <input class="details-flag" type="checkbox"><span>i</span>
                         <div class="details">
+                            <button class="spell_link" type="compendium" name="attr_spellname"></button>
                             <a class="row">
                                 <span name="attr_spellname"></span>
                                 <span name="attr_innate"></span>
@@ -3766,6 +3772,7 @@
                         </div>
                         <input class="details-flag" type="checkbox"><span>i</span>
                         <div class="details">
+                            <button class="spell_link" type="compendium" name="attr_spellname"></button>
                             <a class="row">
                                 <span name="attr_spellname"></span>
                                 <span name="attr_innate"></span>
@@ -4024,6 +4031,7 @@
                         </div>
                         <input class="details-flag" type="checkbox"><span>i</span>
                         <div class="details">
+                            <button class="spell_link" type="compendium" name="attr_spellname"></button>
                             <a class="row">
                                 <span name="attr_spellname"></span>
                                 <span name="attr_innate"></span>
@@ -4282,6 +4290,7 @@
                         </div>
                         <input class="details-flag" type="checkbox"><span>i</span>
                         <div class="details">
+                            <button class="spell_link" type="compendium" name="attr_spellname"></button>
                             <a class="row">
                                 <span name="attr_spellname"></span>
                                 <span name="attr_innate"></span>
@@ -4540,6 +4549,7 @@
                         </div>
                         <input class="details-flag" type="checkbox"><span>i</span>
                         <div class="details">
+                            <button class="spell_link" type="compendium" name="attr_spellname"></button>
                             <a class="row">
                                 <span name="attr_spellname"></span>
                                 <span name="attr_innate"></span>

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -2011,181 +2011,6 @@
             <div class="spell-container">
                 <fieldset class="repeating_spell-cantrip">
                     <div class="spell">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_spellname">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="school:-u">SCHOOL:</span>
-                                <select name="attr_spellschool">
-                                    <option value="abjuration" data-i18n="abjuration">Abjuration</option>
-                                    <option value="conjuration" data-i18n="conjuration">Conjuration</option>
-                                    <option value="divination" data-i18n="divination">Divination</option>
-                                    <option value="enchantment" data-i18n="enchantment">Enchantment</option>
-                                    <option value="evocation" data-i18n="evocation">Evocation</option>
-                                    <option value="illusion" data-i18n="illusion">Illusion</option>
-                                    <option value="necromancy" data-i18n="necromancy">Necromancy</option>
-                                    <option value="transmutation" data-i18n="transmutation">Transmutation</option>
-                                </select>
-                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-                                <span data-i18n="ritual-u">RITUAL</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="casting-time:-u">CASTING TIME:</span>
-                                <input type="text" name="attr_spellcastingtime">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_spellrange">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="target:-u">TARGET:</span>
-                                <input type="text" name="attr_spelltarget">
-                            </div>
-                            <input type="hidden" name="attr_spellcomp">
-                            <div class="row">
-                                <span data-i18n="components:-u">COMPONENTS:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-                                <span data-i18n="spell-component-verbal">V</span>
-                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-                                <span data-i18n="spell-component-somatic">S</span>
-                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-                                <span data-i18n="spell-component-material">M</span>
-                                <input type="text" name="attr_spellcomp_materials" placeholder="ruby dust worth 50gp" data-i18n-placeholder="ruby-dust-place">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration-u">CONCENTRATION</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="duration:-u">DURATION:</span>
-                                <input type="text" name="attr_spellduration">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="spell-ability-u">SPELLCASTING ABILITY</span>
-                                <select name="attr_spell_ability">
-                                    <option value="0*" data-i18n="none-u">NONE</option>
-                                    <option value="spell" data-i18n="spell-u">SPELL</option>
-                                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="innate:-u">INNATE:</span>
-                                <input type="text" name="attr_innate" placeholder="1/day" value="">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="output:-u">OUTPUT:</span>
-                                <select name="attr_spelloutput">
-                                    <option value="SPELLCARD" data-i18n="spellcard-u">SPELLCARD</option>
-                                    <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
-                                </select>
-                            </div>
-                            <input type="hidden" class="spellattackinfoflag" name="attr_spelloutput">
-                            <div class="spellattackinfo">
-                                <div class="row">
-                                    <span data-i18n="spell-atk:-u">SPELL ATTACK:</span>
-                                    <select name="attr_spellattack">
-                                        <option value="None" data-i18n="none">None</option>
-                                        <option value="Melee" data-i18n="melee">Melee</option>
-                                        <option value="Ranged" data-i18n="ranged">Ranged</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage:-u">DAMAGE:</span>
-                                    <input type="text" name="attr_spelldamage" style="width: 50px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_spelldamagetype" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                    <input type="text" name="attr_spelldamage2" style="width: 45px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_spelldamagetype2" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="healing:-u">HEALING:</span>
-                                    <input type="text" name="attr_spellhealing" style="width: 45px;">
-                                </div>
-                                <div class="row">
-                                    <input type="checkbox" name="attr_spelldmgmod" value="Yes">
-                                    <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="cantrip-progression:-u">CANTRIP PROGRESSION</span>
-                                    <select name="attr_spell_damage_progression">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Cantrip Dice" data-i18n="cantrip-dice-u">CANTRIP DICE</option>
-                                        <option value="Cantrip Beam" data-i18n="cantrip-beam-u">CANTRIP BEAM</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                    <select name="attr_spellsave">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Strength" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                        <option value="Constitution" data-i18n="con-u">CON</option>
-                                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                    </select>
-                                    <span data-i18n="effect:-u">EFFECT:</span>
-                                    <input type="text" name="attr_spellsavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
-                                    <input type="text" name="attr_spellhldie" placeholder="1" style="width: 15px; text-align: right;">
-                                    <select name="attr_spellhldietype">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="d4">d4</option>
-                                        <option value="d6">d6</option>
-                                        <option value="d8">d8</option>
-                                        <option value="d10">d10</option>
-                                        <option value="d12">d12</option>
-                                        <option value="d20">d20</option>
-                                    </select>
-                                    <span>+</span>
-                                    <input type="text" name="attr_spellhlbonus" placeholder="0" style="width: 15px; text-align: center;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="include_spell_desc:-u">INCLUDE SPELL DESCRIPTION IN ATTACK:</span>
-                                    <select name="attr_includedesc">
-                                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                                        <option value="partial" data-i18n="partial">Partial</option>
-                                        <option value="on" data-i18n="on">On</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_spelldescription"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_spellathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="class:-u">CLASS:</span>
-                                <input type="text" name="attr_spellclass" style="width: 45px;">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="type:-u">TYPE:</span>
-                                <input type="text" name="attr_spellsource" style="width: 45px;">
-                            </div>
-                            <input type="hidden" name="attr_spellattackid">
-                            <input type="hidden" name="attr_spelllevel" value="cantrip">
-                        </div>
                         <div class="display">
                             <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}}  {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
                             <button class="spellcard" type="roll" name="roll_spell" value="@{rollcontent}">
@@ -2207,51 +2032,224 @@
                             </span>
                         </div>
                         <input class="details-flag" type="checkbox"><span>i</span>
-                        <div class="details">
+                        <div class="wrapper">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>p</span>
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
-                            <span class="row">
-                                <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
-                            </span>
-                            <div class="row italics">
-                                <span name="attr_spellschool"></span>
-                                <span name="attr_spelllevel"></span>
-                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-                                <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_spellname">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="school:-u">SCHOOL:</span>
+                                    <select name="attr_spellschool">
+                                        <option value="abjuration" data-i18n="abjuration">Abjuration</option>
+                                        <option value="conjuration" data-i18n="conjuration">Conjuration</option>
+                                        <option value="divination" data-i18n="divination">Divination</option>
+                                        <option value="enchantment" data-i18n="enchantment">Enchantment</option>
+                                        <option value="evocation" data-i18n="evocation">Evocation</option>
+                                        <option value="illusion" data-i18n="illusion">Illusion</option>
+                                        <option value="necromancy" data-i18n="necromancy">Necromancy</option>
+                                        <option value="transmutation" data-i18n="transmutation">Transmutation</option>
+                                    </select>
+                                    <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                    <span data-i18n="ritual-u">RITUAL</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="casting-time:-u">CASTING TIME:</span>
+                                    <input type="text" name="attr_spellcastingtime">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_spellrange">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="target:-u">TARGET:</span>
+                                    <input type="text" name="attr_spelltarget">
+                                </div>
+                                <input type="hidden" name="attr_spellcomp">
+                                <div class="row">
+                                    <span data-i18n="components:-u">COMPONENTS:</span>
+                                    <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
+                                    <span data-i18n="spell-component-verbal">V</span>
+                                    <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
+                                    <span data-i18n="spell-component-somatic">S</span>
+                                    <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
+                                    <span data-i18n="spell-component-material">M</span>
+                                    <input type="text" name="attr_spellcomp_materials" placeholder="ruby dust worth 50gp" data-i18n-placeholder="ruby-dust-place">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration-u">CONCENTRATION</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="duration:-u">DURATION:</span>
+                                    <input type="text" name="attr_spellduration">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="spell-ability-u">SPELLCASTING ABILITY</span>
+                                    <select name="attr_spell_ability">
+                                        <option value="0*" data-i18n="none-u">NONE</option>
+                                        <option value="spell" data-i18n="spell-u">SPELL</option>
+                                        <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="innate:-u">INNATE:</span>
+                                    <input type="text" name="attr_innate" placeholder="1/day" value="">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="output:-u">OUTPUT:</span>
+                                    <select name="attr_spelloutput">
+                                        <option value="SPELLCARD" data-i18n="spellcard-u">SPELLCARD</option>
+                                        <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
+                                    </select>
+                                </div>
+                                <input type="hidden" class="spellattackinfoflag" name="attr_spelloutput">
+                                <div class="spellattackinfo">
+                                    <div class="row">
+                                        <span data-i18n="spell-atk:-u">SPELL ATTACK:</span>
+                                        <select name="attr_spellattack">
+                                            <option value="None" data-i18n="none">None</option>
+                                            <option value="Melee" data-i18n="melee">Melee</option>
+                                            <option value="Ranged" data-i18n="ranged">Ranged</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage:-u">DAMAGE:</span>
+                                        <input type="text" name="attr_spelldamage" style="width: 50px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_spelldamagetype" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                        <input type="text" name="attr_spelldamage2" style="width: 45px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_spelldamagetype2" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="healing:-u">HEALING:</span>
+                                        <input type="text" name="attr_spellhealing" style="width: 45px;">
+                                    </div>
+                                    <div class="row">
+                                        <input type="checkbox" name="attr_spelldmgmod" value="Yes">
+                                        <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                        <select name="attr_spellsave">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Strength" data-i18n="str-u">STR</option>
+                                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                            <option value="Constitution" data-i18n="con-u">CON</option>
+                                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                        </select>
+                                        <span data-i18n="effect:-u">EFFECT:</span>
+                                        <input type="text" name="attr_spellsavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
+                                        <input type="text" name="attr_spellhldie" placeholder="1" style="width: 15px; text-align: right;">
+                                        <select name="attr_spellhldietype">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="d4">d4</option>
+                                            <option value="d6">d6</option>
+                                            <option value="d8">d8</option>
+                                            <option value="d10">d10</option>
+                                            <option value="d12">d12</option>
+                                            <option value="d20">d20</option>
+                                        </select>
+                                        <span>+</span>
+                                        <input type="text" name="attr_spellhlbonus" placeholder="0" style="width: 15px; text-align: center;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="include_spell_desc:-u">INCLUDE SPELL DESCRIPTION IN ATTACK:</span>
+                                        <select name="attr_includedesc">
+                                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                                            <option value="partial" data-i18n="partial">Partial</option>
+                                            <option value="on" data-i18n="on">On</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_spelldescription"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_spellathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="class:-u">CLASS:</span>
+                                    <input type="text" name="attr_spellclass" style="width: 45px;">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="type:-u">TYPE:</span>
+                                    <input type="text" name="attr_spellsource" style="width: 45px;">
+                                </div>
+                                <input type="hidden" name="attr_spellattackid">
+                                <input type="hidden" name="attr_spelllevel" value="cantrip">
+                                <label class="options-done">
+                                    <input type="checkbox" name="attr_options-flag" checked="checked">
+                                    Done
+                                </label>
                             </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="casting-time:">Casting Time:</span>
-                                <span name="attr_spellcastingtime"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="range:">Range:</span>
-                                <span name="attr_spellrange"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="target:">Target:</span>
-                                <span name="attr_spelltarget"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="components:">Components:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
-                                <input type="hidden" name="attr_spellcomp_materials" value="">
-                                <span>(<span name="attr_spellcomp_materials"></span>)</span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="duration:">Duration:</span>
-                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration">Concentration</span>
-                                <span name="attr_spellduration"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="description:">Description:</span>
-                            </div>
-                            <div class="row">
-                                <span name="attr_spelldescription"></span>
-                            </div>
-                            <input type="hidden" name="attr_spellathigherlevels" value="">
-                            <div class="row">
-                                <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
-                                <span name="attr_spellathigherlevels"></span>
+                            <div class="details">
+                                <span class="row">
+                                    <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
+                                </span>
+                                <div class="row italics">
+                                    <span name="attr_spellschool"></span>
+                                    <span name="attr_spelllevel"></span>
+                                    <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                    <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="casting-time:">Casting Time:</span>
+                                    <span name="attr_spellcastingtime"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="range:">Range:</span>
+                                    <span name="attr_spellrange"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="target:">Target:</span>
+                                    <span name="attr_spelltarget"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="components:">Components:</span>
+                                    <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
+                                    <input type="hidden" name="attr_spellcomp_materials" value="">
+                                    <span>(<span name="attr_spellcomp_materials"></span>)</span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="duration:">Duration:</span>
+                                    <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration">Concentration</span>
+                                    <span name="attr_spellduration"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="description:">Description:</span>
+                                </div>
+                                <div class="row">
+                                    <span name="attr_spelldescription"></span>
+                                </div>
+                                <input type="hidden" name="attr_spellathigherlevels" value="">
+                                <div class="row">
+                                    <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
+                                    <span name="attr_spellathigherlevels"></span>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -2276,173 +2274,6 @@
             <div class="spell-container">
                 <fieldset class="repeating_spell-1">
                     <div class="spell">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_spellname">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="school:-u">SCHOOL:</span>
-                                <select name="attr_spellschool">
-                                    <option value="abjuration" data-i18n="abjuration">Abjuration</option>
-                                    <option value="conjuration" data-i18n="conjuration">Conjuration</option>
-                                    <option value="divination" data-i18n="divination">Divination</option>
-                                    <option value="enchantment" data-i18n="enchantment">Enchantment</option>
-                                    <option value="evocation" data-i18n="evocation">Evocation</option>
-                                    <option value="illusion" data-i18n="illusion">Illusion</option>
-                                    <option value="necromancy" data-i18n="necromancy">Necromancy</option>
-                                    <option value="transmutation" data-i18n="transmutation">Transmutation</option>
-                                </select>
-                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-                                <span data-i18n="ritual-u">RITUAL</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="casting-time:-u">CASTING TIME:</span>
-                                <input type="text" name="attr_spellcastingtime">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_spellrange">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="target:-u">TARGET:</span>
-                                <input type="text" name="attr_spelltarget">
-                            </div>
-                            <input type="hidden" name="attr_spellcomp">
-                            <div class="row">
-                                <span data-i18n="components:-u">COMPONENTS:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-                                <span data-i18n="spell-component-verbal">V</span>
-                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-                                <span data-i18n="spell-component-somatic">S</span>
-                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-                                <span data-i18n="spell-component-material">M</span>
-                                <input type="text" name="attr_spellcomp_materials" placeholder="ruby dust worth 50gp" data-i18n-placeholder="ruby-dust-place">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration-u">CONCENTRATION</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="duration:-u">DURATION:</span>
-                                <input type="text" name="attr_spellduration">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="spell-ability-u">SPELLCASTING ABILITY</span>
-                                <select name="attr_spell_ability">
-                                    <option value="0*" data-i18n="none-u">NONE</option>
-                                    <option value="spell" data-i18n="spell-u">SPELL</option>
-                                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="innate:-u">INNATE:</span>
-                                <input type="text" name="attr_innate" placeholder="1/day" value="">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="output:-u">OUTPUT:</span>
-                                <select name="attr_spelloutput">
-                                    <option value="SPELLCARD" data-i18n="spellcard-u">SPELLCARD</option>
-                                    <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
-                                </select>
-                            </div>
-                            <input type="hidden" class="spellattackinfoflag" name="attr_spelloutput">
-                            <div class="spellattackinfo">
-                                <div class="row">
-                                    <span data-i18n="spell-atk:-u">SPELL ATTACK:</span>
-                                    <select name="attr_spellattack">
-                                        <option value="None" data-i18n="none">None</option>
-                                        <option value="Melee" data-i18n="melee">Melee</option>
-                                        <option value="Ranged" data-i18n="ranged">Ranged</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage:-u">DAMAGE:</span>
-                                    <input type="text" name="attr_spelldamage" style="width: 50px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_spelldamagetype" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                    <input type="text" name="attr_spelldamage2" style="width: 45px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_spelldamagetype2" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="healing:-u">HEALING:</span>
-                                    <input type="text" name="attr_spellhealing" style="width: 45px;">
-                                </div>
-                                <div class="row">
-                                    <input type="checkbox" name="attr_spelldmgmod" value="Yes">
-                                    <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                    <select name="attr_spellsave">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Strength" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                        <option value="Constitution" data-i18n="con-u">CON</option>
-                                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                    </select>
-                                    <span data-i18n="effect:-u">EFFECT:</span>
-                                    <input type="text" name="attr_spellsavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
-                                    <input type="text" name="attr_spellhldie" placeholder="1" style="width: 15px; text-align: right;">
-                                    <select name="attr_spellhldietype">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="d4">d4</option>
-                                        <option value="d6">d6</option>
-                                        <option value="d8">d8</option>
-                                        <option value="d10">d10</option>
-                                        <option value="d12">d12</option>
-                                        <option value="d20">d20</option>
-                                    </select>
-                                    <span>+</span>
-                                    <input type="text" name="attr_spellhlbonus" placeholder="0" style="width: 15px; text-align: center;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="include_spell_desc:-u">INCLUDE SPELL DESCRIPTION IN ATTACK:</span>
-                                    <select name="attr_includedesc">
-                                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                                        <option value="partial" data-i18n="partial">Partial</option>
-                                        <option value="on" data-i18n="on">On</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_spelldescription"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_spellathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="class:-u">CLASS:</span>
-                                <input type="text" name="attr_spellclass" style="width: 45px;">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="type:-u">TYPE:</span>
-                                <input type="text" name="attr_spellsource" style="width: 45px;">
-                            </div>
-                            <input type="hidden" name="attr_spellattackid">
-                            <input type="hidden" name="attr_spelllevel" value="1">
-                        </div>
                         <div class="display">
                             <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}}  {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
                             <input type="checkbox" name="attr_spellprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
@@ -2465,51 +2296,224 @@
                             </span>
                         </div>
                         <input class="details-flag" type="checkbox"><span>i</span>
-                        <div class="details">
+                        <div class="wrapper">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>p</span>
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
-                            <span class="row">
-                                <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
-                            </span>
-                            <div class="row italics">
-                                <span name="attr_spellschool"></span>
-                                <span name="attr_spelllevel"></span>
-                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-                                <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_spellname">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="school:-u">SCHOOL:</span>
+                                    <select name="attr_spellschool">
+                                        <option value="abjuration" data-i18n="abjuration">Abjuration</option>
+                                        <option value="conjuration" data-i18n="conjuration">Conjuration</option>
+                                        <option value="divination" data-i18n="divination">Divination</option>
+                                        <option value="enchantment" data-i18n="enchantment">Enchantment</option>
+                                        <option value="evocation" data-i18n="evocation">Evocation</option>
+                                        <option value="illusion" data-i18n="illusion">Illusion</option>
+                                        <option value="necromancy" data-i18n="necromancy">Necromancy</option>
+                                        <option value="transmutation" data-i18n="transmutation">Transmutation</option>
+                                    </select>
+                                    <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                    <span data-i18n="ritual-u">RITUAL</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="casting-time:-u">CASTING TIME:</span>
+                                    <input type="text" name="attr_spellcastingtime">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_spellrange">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="target:-u">TARGET:</span>
+                                    <input type="text" name="attr_spelltarget">
+                                </div>
+                                <input type="hidden" name="attr_spellcomp">
+                                <div class="row">
+                                    <span data-i18n="components:-u">COMPONENTS:</span>
+                                    <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
+                                    <span data-i18n="spell-component-verbal">V</span>
+                                    <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
+                                    <span data-i18n="spell-component-somatic">S</span>
+                                    <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
+                                    <span data-i18n="spell-component-material">M</span>
+                                    <input type="text" name="attr_spellcomp_materials" placeholder="ruby dust worth 50gp" data-i18n-placeholder="ruby-dust-place">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration-u">CONCENTRATION</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="duration:-u">DURATION:</span>
+                                    <input type="text" name="attr_spellduration">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="spell-ability-u">SPELLCASTING ABILITY</span>
+                                    <select name="attr_spell_ability">
+                                        <option value="0*" data-i18n="none-u">NONE</option>
+                                        <option value="spell" data-i18n="spell-u">SPELL</option>
+                                        <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="innate:-u">INNATE:</span>
+                                    <input type="text" name="attr_innate" placeholder="1/day" value="">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="output:-u">OUTPUT:</span>
+                                    <select name="attr_spelloutput">
+                                        <option value="SPELLCARD" data-i18n="spellcard-u">SPELLCARD</option>
+                                        <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
+                                    </select>
+                                </div>
+                                <input type="hidden" class="spellattackinfoflag" name="attr_spelloutput">
+                                <div class="spellattackinfo">
+                                    <div class="row">
+                                        <span data-i18n="spell-atk:-u">SPELL ATTACK:</span>
+                                        <select name="attr_spellattack">
+                                            <option value="None" data-i18n="none">None</option>
+                                            <option value="Melee" data-i18n="melee">Melee</option>
+                                            <option value="Ranged" data-i18n="ranged">Ranged</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage:-u">DAMAGE:</span>
+                                        <input type="text" name="attr_spelldamage" style="width: 50px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_spelldamagetype" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                        <input type="text" name="attr_spelldamage2" style="width: 45px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_spelldamagetype2" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="healing:-u">HEALING:</span>
+                                        <input type="text" name="attr_spellhealing" style="width: 45px;">
+                                    </div>
+                                    <div class="row">
+                                        <input type="checkbox" name="attr_spelldmgmod" value="Yes">
+                                        <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                        <select name="attr_spellsave">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Strength" data-i18n="str-u">STR</option>
+                                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                            <option value="Constitution" data-i18n="con-u">CON</option>
+                                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                        </select>
+                                        <span data-i18n="effect:-u">EFFECT:</span>
+                                        <input type="text" name="attr_spellsavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
+                                        <input type="text" name="attr_spellhldie" placeholder="1" style="width: 15px; text-align: right;">
+                                        <select name="attr_spellhldietype">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="d4">d4</option>
+                                            <option value="d6">d6</option>
+                                            <option value="d8">d8</option>
+                                            <option value="d10">d10</option>
+                                            <option value="d12">d12</option>
+                                            <option value="d20">d20</option>
+                                        </select>
+                                        <span>+</span>
+                                        <input type="text" name="attr_spellhlbonus" placeholder="0" style="width: 15px; text-align: center;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="include_spell_desc:-u">INCLUDE SPELL DESCRIPTION IN ATTACK:</span>
+                                        <select name="attr_includedesc">
+                                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                                            <option value="partial" data-i18n="partial">Partial</option>
+                                            <option value="on" data-i18n="on">On</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_spelldescription"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_spellathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="class:-u">CLASS:</span>
+                                    <input type="text" name="attr_spellclass" style="width: 45px;">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="type:-u">TYPE:</span>
+                                    <input type="text" name="attr_spellsource" style="width: 45px;">
+                                </div>
+                                <input type="hidden" name="attr_spellattackid">
+                                <input type="hidden" name="attr_spelllevel" value="1">
+                                <label class="options-done">
+                                    <input type="checkbox" name="attr_options-flag" checked="checked">
+                                    Done
+                                </label>
                             </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="casting-time:">Casting Time:</span>
-                                <span name="attr_spellcastingtime"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="range:">Range:</span>
-                                <span name="attr_spellrange"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="target:">Target:</span>
-                                <span name="attr_spelltarget"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="components:">Components:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
-                                <input type="hidden" name="attr_spellcomp_materials" value="">
-                                <span>(<span name="attr_spellcomp_materials"></span>)</span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="duration:">Duration:</span>
-                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration">Concentration</span>
-                                <span name="attr_spellduration"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="description:">Description:</span>
-                            </div>
-                            <div class="row">
-                                <span name="attr_spelldescription"></span>
-                            </div>
-                            <input type="hidden" name="attr_spellathigherlevels" value="">
-                            <div class="row">
-                                <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
-                                <span name="attr_spellathigherlevels"></span>
+                            <div class="details">
+                                <span class="row">
+                                    <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
+                                </span>
+                                <div class="row italics">
+                                    <span name="attr_spellschool"></span>
+                                    <span name="attr_spelllevel"></span>
+                                    <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                    <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="casting-time:">Casting Time:</span>
+                                    <span name="attr_spellcastingtime"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="range:">Range:</span>
+                                    <span name="attr_spellrange"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="target:">Target:</span>
+                                    <span name="attr_spelltarget"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="components:">Components:</span>
+                                    <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
+                                    <input type="hidden" name="attr_spellcomp_materials" value="">
+                                    <span>(<span name="attr_spellcomp_materials"></span>)</span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="duration:">Duration:</span>
+                                    <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration">Concentration</span>
+                                    <span name="attr_spellduration"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="description:">Description:</span>
+                                </div>
+                                <div class="row">
+                                    <span name="attr_spelldescription"></span>
+                                </div>
+                                <input type="hidden" name="attr_spellathigherlevels" value="">
+                                <div class="row">
+                                    <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
+                                    <span name="attr_spellathigherlevels"></span>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -2530,173 +2534,6 @@
             <div class="spell-container">
                 <fieldset class="repeating_spell-2">
                     <div class="spell">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_spellname">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="school:-u">SCHOOL:</span>
-                                <select name="attr_spellschool">
-                                    <option value="abjuration" data-i18n="abjuration">Abjuration</option>
-                                    <option value="conjuration" data-i18n="conjuration">Conjuration</option>
-                                    <option value="divination" data-i18n="divination">Divination</option>
-                                    <option value="enchantment" data-i18n="enchantment">Enchantment</option>
-                                    <option value="evocation" data-i18n="evocation">Evocation</option>
-                                    <option value="illusion" data-i18n="illusion">Illusion</option>
-                                    <option value="necromancy" data-i18n="necromancy">Necromancy</option>
-                                    <option value="transmutation" data-i18n="transmutation">Transmutation</option>
-                                </select>
-                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-                                <span data-i18n="ritual-u">RITUAL</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="casting-time:-u">CASTING TIME:</span>
-                                <input type="text" name="attr_spellcastingtime">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_spellrange">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="target:-u">TARGET:</span>
-                                <input type="text" name="attr_spelltarget">
-                            </div>
-                            <input type="hidden" name="attr_spellcomp">
-                            <div class="row">
-                                <span data-i18n="components:-u">COMPONENTS:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-                                <span data-i18n="spell-component-verbal">V</span>
-                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-                                <span data-i18n="spell-component-somatic">S</span>
-                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-                                <span data-i18n="spell-component-material">M</span>
-                                <input type="text" name="attr_spellcomp_materials" placeholder="ruby dust worth 50gp" data-i18n-placeholder="ruby-dust-place">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration-u">CONCENTRATION</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="duration:-u">DURATION:</span>
-                                <input type="text" name="attr_spellduration">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="spell-ability-u">SPELLCASTING ABILITY</span>
-                                <select name="attr_spell_ability">
-                                    <option value="0*" data-i18n="none-u">NONE</option>
-                                    <option value="spell" data-i18n="spell-u">SPELL</option>
-                                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="innate:-u">INNATE:</span>
-                                <input type="text" name="attr_innate" placeholder="1/day" value="">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="output:-u">OUTPUT:</span>
-                                <select name="attr_spelloutput">
-                                    <option value="SPELLCARD" data-i18n="spellcard-u">SPELLCARD</option>
-                                    <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
-                                </select>
-                            </div>
-                            <input type="hidden" class="spellattackinfoflag" name="attr_spelloutput">
-                            <div class="spellattackinfo">
-                                <div class="row">
-                                    <span data-i18n="spell-atk:-u">SPELL ATTACK:</span>
-                                    <select name="attr_spellattack">
-                                        <option value="None" data-i18n="none">None</option>
-                                        <option value="Melee" data-i18n="melee">Melee</option>
-                                        <option value="Ranged" data-i18n="ranged">Ranged</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage:-u">DAMAGE:</span>
-                                    <input type="text" name="attr_spelldamage" style="width: 50px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_spelldamagetype" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                    <input type="text" name="attr_spelldamage2" style="width: 45px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_spelldamagetype2" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="healing:-u">HEALING:</span>
-                                    <input type="text" name="attr_spellhealing" style="width: 45px;">
-                                </div>
-                                <div class="row">
-                                    <input type="checkbox" name="attr_spelldmgmod" value="Yes">
-                                    <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                    <select name="attr_spellsave">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Strength" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                        <option value="Constitution" data-i18n="con-u">CON</option>
-                                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                    </select>
-                                    <span data-i18n="effect:-u">EFFECT:</span>
-                                    <input type="text" name="attr_spellsavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
-                                    <input type="text" name="attr_spellhldie" placeholder="1" style="width: 15px; text-align: right;">
-                                    <select name="attr_spellhldietype">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="d4">d4</option>
-                                        <option value="d6">d6</option>
-                                        <option value="d8">d8</option>
-                                        <option value="d10">d10</option>
-                                        <option value="d12">d12</option>
-                                        <option value="d20">d20</option>
-                                    </select>
-                                    <span>+</span>
-                                    <input type="text" name="attr_spellhlbonus" placeholder="0" style="width: 15px; text-align: center;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="include_spell_desc:-u">INCLUDE SPELL DESCRIPTION IN ATTACK:</span>
-                                    <select name="attr_includedesc">
-                                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                                        <option value="partial" data-i18n="partial">Partial</option>
-                                        <option value="on" data-i18n="on">On</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_spelldescription"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_spellathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="class:-u">CLASS:</span>
-                                <input type="text" name="attr_spellclass" style="width: 45px;">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="type:-u">TYPE:</span>
-                                <input type="text" name="attr_spellsource" style="width: 45px;">
-                            </div>
-                            <input type="hidden" name="attr_spellattackid">
-                            <input type="hidden" name="attr_spelllevel" value="2">
-                        </div>
                         <div class="display">
                             <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}}  {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
                             <input type="checkbox" name="attr_spellprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
@@ -2719,51 +2556,224 @@
                             </span>
                         </div>
                         <input class="details-flag" type="checkbox"><span>i</span>
-                        <div class="details">
+                        <div class="wrapper">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>p</span>
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
-                            <span class="row">
-                                <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
-                            </span>
-                            <div class="row italics">
-                                <span name="attr_spellschool"></span>
-                                <span name="attr_spelllevel"></span>
-                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-                                <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_spellname">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="school:-u">SCHOOL:</span>
+                                    <select name="attr_spellschool">
+                                        <option value="abjuration" data-i18n="abjuration">Abjuration</option>
+                                        <option value="conjuration" data-i18n="conjuration">Conjuration</option>
+                                        <option value="divination" data-i18n="divination">Divination</option>
+                                        <option value="enchantment" data-i18n="enchantment">Enchantment</option>
+                                        <option value="evocation" data-i18n="evocation">Evocation</option>
+                                        <option value="illusion" data-i18n="illusion">Illusion</option>
+                                        <option value="necromancy" data-i18n="necromancy">Necromancy</option>
+                                        <option value="transmutation" data-i18n="transmutation">Transmutation</option>
+                                    </select>
+                                    <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                    <span data-i18n="ritual-u">RITUAL</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="casting-time:-u">CASTING TIME:</span>
+                                    <input type="text" name="attr_spellcastingtime">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_spellrange">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="target:-u">TARGET:</span>
+                                    <input type="text" name="attr_spelltarget">
+                                </div>
+                                <input type="hidden" name="attr_spellcomp">
+                                <div class="row">
+                                    <span data-i18n="components:-u">COMPONENTS:</span>
+                                    <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
+                                    <span data-i18n="spell-component-verbal">V</span>
+                                    <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
+                                    <span data-i18n="spell-component-somatic">S</span>
+                                    <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
+                                    <span data-i18n="spell-component-material">M</span>
+                                    <input type="text" name="attr_spellcomp_materials" placeholder="ruby dust worth 50gp" data-i18n-placeholder="ruby-dust-place">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration-u">CONCENTRATION</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="duration:-u">DURATION:</span>
+                                    <input type="text" name="attr_spellduration">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="spell-ability-u">SPELLCASTING ABILITY</span>
+                                    <select name="attr_spell_ability">
+                                        <option value="0*" data-i18n="none-u">NONE</option>
+                                        <option value="spell" data-i18n="spell-u">SPELL</option>
+                                        <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="innate:-u">INNATE:</span>
+                                    <input type="text" name="attr_innate" placeholder="1/day" value="">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="output:-u">OUTPUT:</span>
+                                    <select name="attr_spelloutput">
+                                        <option value="SPELLCARD" data-i18n="spellcard-u">SPELLCARD</option>
+                                        <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
+                                    </select>
+                                </div>
+                                <input type="hidden" class="spellattackinfoflag" name="attr_spelloutput">
+                                <div class="spellattackinfo">
+                                    <div class="row">
+                                        <span data-i18n="spell-atk:-u">SPELL ATTACK:</span>
+                                        <select name="attr_spellattack">
+                                            <option value="None" data-i18n="none">None</option>
+                                            <option value="Melee" data-i18n="melee">Melee</option>
+                                            <option value="Ranged" data-i18n="ranged">Ranged</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage:-u">DAMAGE:</span>
+                                        <input type="text" name="attr_spelldamage" style="width: 50px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_spelldamagetype" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                        <input type="text" name="attr_spelldamage2" style="width: 45px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_spelldamagetype2" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="healing:-u">HEALING:</span>
+                                        <input type="text" name="attr_spellhealing" style="width: 45px;">
+                                    </div>
+                                    <div class="row">
+                                        <input type="checkbox" name="attr_spelldmgmod" value="Yes">
+                                        <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                        <select name="attr_spellsave">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Strength" data-i18n="str-u">STR</option>
+                                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                            <option value="Constitution" data-i18n="con-u">CON</option>
+                                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                        </select>
+                                        <span data-i18n="effect:-u">EFFECT:</span>
+                                        <input type="text" name="attr_spellsavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
+                                        <input type="text" name="attr_spellhldie" placeholder="1" style="width: 15px; text-align: right;">
+                                        <select name="attr_spellhldietype">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="d4">d4</option>
+                                            <option value="d6">d6</option>
+                                            <option value="d8">d8</option>
+                                            <option value="d10">d10</option>
+                                            <option value="d12">d12</option>
+                                            <option value="d20">d20</option>
+                                        </select>
+                                        <span>+</span>
+                                        <input type="text" name="attr_spellhlbonus" placeholder="0" style="width: 15px; text-align: center;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="include_spell_desc:-u">INCLUDE SPELL DESCRIPTION IN ATTACK:</span>
+                                        <select name="attr_includedesc">
+                                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                                            <option value="partial" data-i18n="partial">Partial</option>
+                                            <option value="on" data-i18n="on">On</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_spelldescription"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_spellathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="class:-u">CLASS:</span>
+                                    <input type="text" name="attr_spellclass" style="width: 45px;">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="type:-u">TYPE:</span>
+                                    <input type="text" name="attr_spellsource" style="width: 45px;">
+                                </div>
+                                <input type="hidden" name="attr_spellattackid">
+                                <input type="hidden" name="attr_spelllevel" value="2">
+                                <label class="options-done">
+                                    <input type="checkbox" name="attr_options-flag" checked="checked">
+                                    Done
+                                </label>
                             </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="casting-time:">Casting Time:</span>
-                                <span name="attr_spellcastingtime"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="range:">Range:</span>
-                                <span name="attr_spellrange"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="target:">Target:</span>
-                                <span name="attr_spelltarget"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="components:">Components:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
-                                <input type="hidden" name="attr_spellcomp_materials" value="">
-                                <span>(<span name="attr_spellcomp_materials"></span>)</span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="duration:">Duration:</span>
-                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration">Concentration</span>
-                                <span name="attr_spellduration"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="description:">Description:</span>
-                            </div>
-                            <div class="row">
-                                <span name="attr_spelldescription"></span>
-                            </div>
-                            <input type="hidden" name="attr_spellathigherlevels" value="">
-                            <div class="row">
-                                <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
-                                <span name="attr_spellathigherlevels"></span>
+                            <div class="details">
+                                <span class="row">
+                                    <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
+                                </span>
+                                <div class="row italics">
+                                    <span name="attr_spellschool"></span>
+                                    <span name="attr_spelllevel"></span>
+                                    <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                    <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="casting-time:">Casting Time:</span>
+                                    <span name="attr_spellcastingtime"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="range:">Range:</span>
+                                    <span name="attr_spellrange"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="target:">Target:</span>
+                                    <span name="attr_spelltarget"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="components:">Components:</span>
+                                    <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
+                                    <input type="hidden" name="attr_spellcomp_materials" value="">
+                                    <span>(<span name="attr_spellcomp_materials"></span>)</span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="duration:">Duration:</span>
+                                    <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration">Concentration</span>
+                                    <span name="attr_spellduration"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="description:">Description:</span>
+                                </div>
+                                <div class="row">
+                                    <span name="attr_spelldescription"></span>
+                                </div>
+                                <input type="hidden" name="attr_spellathigherlevels" value="">
+                                <div class="row">
+                                    <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
+                                    <span name="attr_spellathigherlevels"></span>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -2787,173 +2797,6 @@
             <div class="spell-container">
                 <fieldset class="repeating_spell-3">
                     <div class="spell">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_spellname">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="school:-u">SCHOOL:</span>
-                                <select name="attr_spellschool">
-                                    <option value="abjuration" data-i18n="abjuration">Abjuration</option>
-                                    <option value="conjuration" data-i18n="conjuration">Conjuration</option>
-                                    <option value="divination" data-i18n="divination">Divination</option>
-                                    <option value="enchantment" data-i18n="enchantment">Enchantment</option>
-                                    <option value="evocation" data-i18n="evocation">Evocation</option>
-                                    <option value="illusion" data-i18n="illusion">Illusion</option>
-                                    <option value="necromancy" data-i18n="necromancy">Necromancy</option>
-                                    <option value="transmutation" data-i18n="transmutation">Transmutation</option>
-                                </select>
-                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-                                <span data-i18n="ritual-u">RITUAL</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="casting-time:-u">CASTING TIME:</span>
-                                <input type="text" name="attr_spellcastingtime">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_spellrange">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="target:-u">TARGET:</span>
-                                <input type="text" name="attr_spelltarget">
-                            </div>
-                            <input type="hidden" name="attr_spellcomp">
-                            <div class="row">
-                                <span data-i18n="components:-u">COMPONENTS:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-                                <span data-i18n="spell-component-verbal">V</span>
-                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-                                <span data-i18n="spell-component-somatic">S</span>
-                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-                                <span data-i18n="spell-component-material">M</span>
-                                <input type="text" name="attr_spellcomp_materials" placeholder="ruby dust worth 50gp" data-i18n-placeholder="ruby-dust-place">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration-u">CONCENTRATION</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="duration:-u">DURATION:</span>
-                                <input type="text" name="attr_spellduration">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="spell-ability-u">SPELLCASTING ABILITY</span>
-                                <select name="attr_spell_ability">
-                                    <option value="0*" data-i18n="none-u">NONE</option>
-                                    <option value="spell" data-i18n="spell-u">SPELL</option>
-                                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="innate:-u">INNATE:</span>
-                                <input type="text" name="attr_innate" placeholder="1/day" value="">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="output:-u">OUTPUT:</span>
-                                <select name="attr_spelloutput">
-                                    <option value="SPELLCARD" data-i18n="spellcard-u">SPELLCARD</option>
-                                    <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
-                                </select>
-                            </div>
-                            <input type="hidden" class="spellattackinfoflag" name="attr_spelloutput">
-                            <div class="spellattackinfo">
-                                <div class="row">
-                                    <span data-i18n="spell-atk:-u">SPELL ATTACK:</span>
-                                    <select name="attr_spellattack">
-                                        <option value="None" data-i18n="none">None</option>
-                                        <option value="Melee" data-i18n="melee">Melee</option>
-                                        <option value="Ranged" data-i18n="ranged">Ranged</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage:-u">DAMAGE:</span>
-                                    <input type="text" name="attr_spelldamage" style="width: 50px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_spelldamagetype" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                    <input type="text" name="attr_spelldamage2" style="width: 45px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_spelldamagetype2" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="healing:-u">HEALING:</span>
-                                    <input type="text" name="attr_spellhealing" style="width: 45px;">
-                                </div>
-                                <div class="row">
-                                    <input type="checkbox" name="attr_spelldmgmod" value="Yes">
-                                    <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                    <select name="attr_spellsave">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Strength" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                        <option value="Constitution" data-i18n="con-u">CON</option>
-                                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                    </select>
-                                    <span data-i18n="effect:-u">EFFECT:</span>
-                                    <input type="text" name="attr_spellsavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
-                                    <input type="text" name="attr_spellhldie" placeholder="1" style="width: 15px; text-align: right;">
-                                    <select name="attr_spellhldietype">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="d4">d4</option>
-                                        <option value="d6">d6</option>
-                                        <option value="d8">d8</option>
-                                        <option value="d10">d10</option>
-                                        <option value="d12">d12</option>
-                                        <option value="d20">d20</option>
-                                    </select>
-                                    <span>+</span>
-                                    <input type="text" name="attr_spellhlbonus" placeholder="0" style="width: 15px; text-align: center;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="include_spell_desc:-u">INCLUDE SPELL DESCRIPTION IN ATTACK:</span>
-                                    <select name="attr_includedesc">
-                                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                                        <option value="partial" data-i18n="partial">Partial</option>
-                                        <option value="on" data-i18n="on">On</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_spelldescription"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_spellathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="class:-u">CLASS:</span>
-                                <input type="text" name="attr_spellclass" style="width: 45px;">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="type:-u">TYPE:</span>
-                                <input type="text" name="attr_spellsource" style="width: 45px;">
-                            </div>
-                            <input type="hidden" name="attr_spellattackid">
-                            <input type="hidden" name="attr_spelllevel" value="3">
-                        </div>
                         <div class="display">
                             <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}}  {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
                             <input type="checkbox" name="attr_spellprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
@@ -2976,51 +2819,224 @@
                             </span>
                         </div>
                         <input class="details-flag" type="checkbox"><span>i</span>
-                        <div class="details">
+                        <div class="wrapper">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>p</span>
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
-                            <span class="row">
-                                <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
-                            </span>
-                            <div class="row italics">
-                                <span name="attr_spellschool"></span>
-                                <span name="attr_spelllevel"></span>
-                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-                                <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_spellname">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="school:-u">SCHOOL:</span>
+                                    <select name="attr_spellschool">
+                                        <option value="abjuration" data-i18n="abjuration">Abjuration</option>
+                                        <option value="conjuration" data-i18n="conjuration">Conjuration</option>
+                                        <option value="divination" data-i18n="divination">Divination</option>
+                                        <option value="enchantment" data-i18n="enchantment">Enchantment</option>
+                                        <option value="evocation" data-i18n="evocation">Evocation</option>
+                                        <option value="illusion" data-i18n="illusion">Illusion</option>
+                                        <option value="necromancy" data-i18n="necromancy">Necromancy</option>
+                                        <option value="transmutation" data-i18n="transmutation">Transmutation</option>
+                                    </select>
+                                    <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                    <span data-i18n="ritual-u">RITUAL</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="casting-time:-u">CASTING TIME:</span>
+                                    <input type="text" name="attr_spellcastingtime">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_spellrange">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="target:-u">TARGET:</span>
+                                    <input type="text" name="attr_spelltarget">
+                                </div>
+                                <input type="hidden" name="attr_spellcomp">
+                                <div class="row">
+                                    <span data-i18n="components:-u">COMPONENTS:</span>
+                                    <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
+                                    <span data-i18n="spell-component-verbal">V</span>
+                                    <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
+                                    <span data-i18n="spell-component-somatic">S</span>
+                                    <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
+                                    <span data-i18n="spell-component-material">M</span>
+                                    <input type="text" name="attr_spellcomp_materials" placeholder="ruby dust worth 50gp" data-i18n-placeholder="ruby-dust-place">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration-u">CONCENTRATION</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="duration:-u">DURATION:</span>
+                                    <input type="text" name="attr_spellduration">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="spell-ability-u">SPELLCASTING ABILITY</span>
+                                    <select name="attr_spell_ability">
+                                        <option value="0*" data-i18n="none-u">NONE</option>
+                                        <option value="spell" data-i18n="spell-u">SPELL</option>
+                                        <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="innate:-u">INNATE:</span>
+                                    <input type="text" name="attr_innate" placeholder="1/day" value="">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="output:-u">OUTPUT:</span>
+                                    <select name="attr_spelloutput">
+                                        <option value="SPELLCARD" data-i18n="spellcard-u">SPELLCARD</option>
+                                        <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
+                                    </select>
+                                </div>
+                                <input type="hidden" class="spellattackinfoflag" name="attr_spelloutput">
+                                <div class="spellattackinfo">
+                                    <div class="row">
+                                        <span data-i18n="spell-atk:-u">SPELL ATTACK:</span>
+                                        <select name="attr_spellattack">
+                                            <option value="None" data-i18n="none">None</option>
+                                            <option value="Melee" data-i18n="melee">Melee</option>
+                                            <option value="Ranged" data-i18n="ranged">Ranged</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage:-u">DAMAGE:</span>
+                                        <input type="text" name="attr_spelldamage" style="width: 50px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_spelldamagetype" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                        <input type="text" name="attr_spelldamage2" style="width: 45px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_spelldamagetype2" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="healing:-u">HEALING:</span>
+                                        <input type="text" name="attr_spellhealing" style="width: 45px;">
+                                    </div>
+                                    <div class="row">
+                                        <input type="checkbox" name="attr_spelldmgmod" value="Yes">
+                                        <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                        <select name="attr_spellsave">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Strength" data-i18n="str-u">STR</option>
+                                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                            <option value="Constitution" data-i18n="con-u">CON</option>
+                                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                        </select>
+                                        <span data-i18n="effect:-u">EFFECT:</span>
+                                        <input type="text" name="attr_spellsavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
+                                        <input type="text" name="attr_spellhldie" placeholder="1" style="width: 15px; text-align: right;">
+                                        <select name="attr_spellhldietype">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="d4">d4</option>
+                                            <option value="d6">d6</option>
+                                            <option value="d8">d8</option>
+                                            <option value="d10">d10</option>
+                                            <option value="d12">d12</option>
+                                            <option value="d20">d20</option>
+                                        </select>
+                                        <span>+</span>
+                                        <input type="text" name="attr_spellhlbonus" placeholder="0" style="width: 15px; text-align: center;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="include_spell_desc:-u">INCLUDE SPELL DESCRIPTION IN ATTACK:</span>
+                                        <select name="attr_includedesc">
+                                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                                            <option value="partial" data-i18n="partial">Partial</option>
+                                            <option value="on" data-i18n="on">On</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_spelldescription"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_spellathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="class:-u">CLASS:</span>
+                                    <input type="text" name="attr_spellclass" style="width: 45px;">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="type:-u">TYPE:</span>
+                                    <input type="text" name="attr_spellsource" style="width: 45px;">
+                                </div>
+                                <input type="hidden" name="attr_spellattackid">
+                                <input type="hidden" name="attr_spelllevel" value="3">
+                                <label class="options-done">
+                                    <input type="checkbox" name="attr_options-flag" checked="checked">
+                                    Done
+                                </label>
                             </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="casting-time:">Casting Time:</span>
-                                <span name="attr_spellcastingtime"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="range:">Range:</span>
-                                <span name="attr_spellrange"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="target:">Target:</span>
-                                <span name="attr_spelltarget"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="components:">Components:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
-                                <input type="hidden" name="attr_spellcomp_materials" value="">
-                                <span>(<span name="attr_spellcomp_materials"></span>)</span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="duration:">Duration:</span>
-                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration">Concentration</span>
-                                <span name="attr_spellduration"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="description:">Description:</span>
-                            </div>
-                            <div class="row">
-                                <span name="attr_spelldescription"></span>
-                            </div>
-                            <input type="hidden" name="attr_spellathigherlevels" value="">
-                            <div class="row">
-                                <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
-                                <span name="attr_spellathigherlevels"></span>
+                            <div class="details">
+                                <span class="row">
+                                    <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
+                                </span>
+                                <div class="row italics">
+                                    <span name="attr_spellschool"></span>
+                                    <span name="attr_spelllevel"></span>
+                                    <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                    <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="casting-time:">Casting Time:</span>
+                                    <span name="attr_spellcastingtime"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="range:">Range:</span>
+                                    <span name="attr_spellrange"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="target:">Target:</span>
+                                    <span name="attr_spelltarget"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="components:">Components:</span>
+                                    <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
+                                    <input type="hidden" name="attr_spellcomp_materials" value="">
+                                    <span>(<span name="attr_spellcomp_materials"></span>)</span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="duration:">Duration:</span>
+                                    <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration">Concentration</span>
+                                    <span name="attr_spellduration"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="description:">Description:</span>
+                                </div>
+                                <div class="row">
+                                    <span name="attr_spelldescription"></span>
+                                </div>
+                                <input type="hidden" name="attr_spellathigherlevels" value="">
+                                <div class="row">
+                                    <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
+                                    <span name="attr_spellathigherlevels"></span>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -3041,173 +3057,6 @@
             <div class="spell-container">
                 <fieldset class="repeating_spell-4">
                     <div class="spell">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_spellname">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="school:-u">SCHOOL:</span>
-                                <select name="attr_spellschool">
-                                    <option value="abjuration" data-i18n="abjuration">Abjuration</option>
-                                    <option value="conjuration" data-i18n="conjuration">Conjuration</option>
-                                    <option value="divination" data-i18n="divination">Divination</option>
-                                    <option value="enchantment" data-i18n="enchantment">Enchantment</option>
-                                    <option value="evocation" data-i18n="evocation">Evocation</option>
-                                    <option value="illusion" data-i18n="illusion">Illusion</option>
-                                    <option value="necromancy" data-i18n="necromancy">Necromancy</option>
-                                    <option value="transmutation" data-i18n="transmutation">Transmutation</option>
-                                </select>
-                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-                                <span data-i18n="ritual-u">RITUAL</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="casting-time:-u">CASTING TIME:</span>
-                                <input type="text" name="attr_spellcastingtime">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_spellrange">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="target:-u">TARGET:</span>
-                                <input type="text" name="attr_spelltarget">
-                            </div>
-                            <input type="hidden" name="attr_spellcomp">
-                            <div class="row">
-                                <span data-i18n="components:-u">COMPONENTS:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-                                <span data-i18n="spell-component-verbal">V</span>
-                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-                                <span data-i18n="spell-component-somatic">S</span>
-                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-                                <span data-i18n="spell-component-material">M</span>
-                                <input type="text" name="attr_spellcomp_materials" placeholder="ruby dust worth 50gp" data-i18n-placeholder="ruby-dust-place">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration-u">CONCENTRATION</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="duration:-u">DURATION:</span>
-                                <input type="text" name="attr_spellduration">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="spell-ability-u">SPELLCASTING ABILITY</span>
-                                <select name="attr_spell_ability">
-                                    <option value="0*" data-i18n="none-u">NONE</option>
-                                    <option value="spell" data-i18n="spell-u">SPELL</option>
-                                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="innate:-u">INNATE:</span>
-                                <input type="text" name="attr_innate" placeholder="1/day" value="">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="output:-u">OUTPUT:</span>
-                                <select name="attr_spelloutput">
-                                    <option value="SPELLCARD" data-i18n="spellcard-u">SPELLCARD</option>
-                                    <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
-                                </select>
-                            </div>
-                            <input type="hidden" class="spellattackinfoflag" name="attr_spelloutput">
-                            <div class="spellattackinfo">
-                                <div class="row">
-                                    <span data-i18n="spell-atk:-u">SPELL ATTACK:</span>
-                                    <select name="attr_spellattack">
-                                        <option value="None" data-i18n="none">None</option>
-                                        <option value="Melee" data-i18n="melee">Melee</option>
-                                        <option value="Ranged" data-i18n="ranged">Ranged</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage:-u">DAMAGE:</span>
-                                    <input type="text" name="attr_spelldamage" style="width: 50px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_spelldamagetype" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                    <input type="text" name="attr_spelldamage2" style="width: 45px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_spelldamagetype2" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="healing:-u">HEALING:</span>
-                                    <input type="text" name="attr_spellhealing" style="width: 45px;">
-                                </div>
-                                <div class="row">
-                                    <input type="checkbox" name="attr_spelldmgmod" value="Yes">
-                                    <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                    <select name="attr_spellsave">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Strength" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                        <option value="Constitution" data-i18n="con-u">CON</option>
-                                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                    </select>
-                                    <span data-i18n="effect:-u">EFFECT:</span>
-                                    <input type="text" name="attr_spellsavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
-                                    <input type="text" name="attr_spellhldie" placeholder="1" style="width: 15px; text-align: right;">
-                                    <select name="attr_spellhldietype">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="d4">d4</option>
-                                        <option value="d6">d6</option>
-                                        <option value="d8">d8</option>
-                                        <option value="d10">d10</option>
-                                        <option value="d12">d12</option>
-                                        <option value="d20">d20</option>
-                                    </select>
-                                    <span>+</span>
-                                    <input type="text" name="attr_spellhlbonus" placeholder="0" style="width: 15px; text-align: center;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="include_spell_desc:-u">INCLUDE SPELL DESCRIPTION IN ATTACK:</span>
-                                    <select name="attr_includedesc">
-                                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                                        <option value="partial" data-i18n="partial">Partial</option>
-                                        <option value="on" data-i18n="on">On</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_spelldescription"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_spellathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="class:-u">CLASS:</span>
-                                <input type="text" name="attr_spellclass" style="width: 45px;">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="type:-u">TYPE:</span>
-                                <input type="text" name="attr_spellsource" style="width: 45px;">
-                            </div>
-                            <input type="hidden" name="attr_spellattackid">
-                            <input type="hidden" name="attr_spelllevel" value="4">
-                        </div>
                         <div class="display">
                             <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}}  {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
                             <input type="checkbox" name="attr_spellprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
@@ -3230,51 +3079,224 @@
                             </span>
                         </div>
                         <input class="details-flag" type="checkbox"><span>i</span>
-                        <div class="details">
+                        <div class="wrapper">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>p</span>
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
-                            <span class="row">
-                                <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
-                            </span>
-                            <div class="row italics">
-                                <span name="attr_spellschool"></span>
-                                <span name="attr_spelllevel"></span>
-                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-                                <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_spellname">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="school:-u">SCHOOL:</span>
+                                    <select name="attr_spellschool">
+                                        <option value="abjuration" data-i18n="abjuration">Abjuration</option>
+                                        <option value="conjuration" data-i18n="conjuration">Conjuration</option>
+                                        <option value="divination" data-i18n="divination">Divination</option>
+                                        <option value="enchantment" data-i18n="enchantment">Enchantment</option>
+                                        <option value="evocation" data-i18n="evocation">Evocation</option>
+                                        <option value="illusion" data-i18n="illusion">Illusion</option>
+                                        <option value="necromancy" data-i18n="necromancy">Necromancy</option>
+                                        <option value="transmutation" data-i18n="transmutation">Transmutation</option>
+                                    </select>
+                                    <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                    <span data-i18n="ritual-u">RITUAL</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="casting-time:-u">CASTING TIME:</span>
+                                    <input type="text" name="attr_spellcastingtime">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_spellrange">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="target:-u">TARGET:</span>
+                                    <input type="text" name="attr_spelltarget">
+                                </div>
+                                <input type="hidden" name="attr_spellcomp">
+                                <div class="row">
+                                    <span data-i18n="components:-u">COMPONENTS:</span>
+                                    <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
+                                    <span data-i18n="spell-component-verbal">V</span>
+                                    <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
+                                    <span data-i18n="spell-component-somatic">S</span>
+                                    <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
+                                    <span data-i18n="spell-component-material">M</span>
+                                    <input type="text" name="attr_spellcomp_materials" placeholder="ruby dust worth 50gp" data-i18n-placeholder="ruby-dust-place">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration-u">CONCENTRATION</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="duration:-u">DURATION:</span>
+                                    <input type="text" name="attr_spellduration">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="spell-ability-u">SPELLCASTING ABILITY</span>
+                                    <select name="attr_spell_ability">
+                                        <option value="0*" data-i18n="none-u">NONE</option>
+                                        <option value="spell" data-i18n="spell-u">SPELL</option>
+                                        <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="innate:-u">INNATE:</span>
+                                    <input type="text" name="attr_innate" placeholder="1/day" value="">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="output:-u">OUTPUT:</span>
+                                    <select name="attr_spelloutput">
+                                        <option value="SPELLCARD" data-i18n="spellcard-u">SPELLCARD</option>
+                                        <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
+                                    </select>
+                                </div>
+                                <input type="hidden" class="spellattackinfoflag" name="attr_spelloutput">
+                                <div class="spellattackinfo">
+                                    <div class="row">
+                                        <span data-i18n="spell-atk:-u">SPELL ATTACK:</span>
+                                        <select name="attr_spellattack">
+                                            <option value="None" data-i18n="none">None</option>
+                                            <option value="Melee" data-i18n="melee">Melee</option>
+                                            <option value="Ranged" data-i18n="ranged">Ranged</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage:-u">DAMAGE:</span>
+                                        <input type="text" name="attr_spelldamage" style="width: 50px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_spelldamagetype" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                        <input type="text" name="attr_spelldamage2" style="width: 45px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_spelldamagetype2" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="healing:-u">HEALING:</span>
+                                        <input type="text" name="attr_spellhealing" style="width: 45px;">
+                                    </div>
+                                    <div class="row">
+                                        <input type="checkbox" name="attr_spelldmgmod" value="Yes">
+                                        <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                        <select name="attr_spellsave">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Strength" data-i18n="str-u">STR</option>
+                                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                            <option value="Constitution" data-i18n="con-u">CON</option>
+                                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                        </select>
+                                        <span data-i18n="effect:-u">EFFECT:</span>
+                                        <input type="text" name="attr_spellsavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
+                                        <input type="text" name="attr_spellhldie" placeholder="1" style="width: 15px; text-align: right;">
+                                        <select name="attr_spellhldietype">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="d4">d4</option>
+                                            <option value="d6">d6</option>
+                                            <option value="d8">d8</option>
+                                            <option value="d10">d10</option>
+                                            <option value="d12">d12</option>
+                                            <option value="d20">d20</option>
+                                        </select>
+                                        <span>+</span>
+                                        <input type="text" name="attr_spellhlbonus" placeholder="0" style="width: 15px; text-align: center;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="include_spell_desc:-u">INCLUDE SPELL DESCRIPTION IN ATTACK:</span>
+                                        <select name="attr_includedesc">
+                                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                                            <option value="partial" data-i18n="partial">Partial</option>
+                                            <option value="on" data-i18n="on">On</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_spelldescription"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_spellathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="class:-u">CLASS:</span>
+                                    <input type="text" name="attr_spellclass" style="width: 45px;">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="type:-u">TYPE:</span>
+                                    <input type="text" name="attr_spellsource" style="width: 45px;">
+                                </div>
+                                <input type="hidden" name="attr_spellattackid">
+                                <input type="hidden" name="attr_spelllevel" value="4">
+                                <label class="options-done">
+                                    <input type="checkbox" name="attr_options-flag" checked="checked">
+                                    Done
+                                </label>
                             </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="casting-time:">Casting Time:</span>
-                                <span name="attr_spellcastingtime"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="range:">Range:</span>
-                                <span name="attr_spellrange"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="target:">Target:</span>
-                                <span name="attr_spelltarget"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="components:">Components:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
-                                <input type="hidden" name="attr_spellcomp_materials" value="">
-                                <span>(<span name="attr_spellcomp_materials"></span>)</span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="duration:">Duration:</span>
-                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration">Concentration</span>
-                                <span name="attr_spellduration"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="description:">Description:</span>
-                            </div>
-                            <div class="row">
-                                <span name="attr_spelldescription"></span>
-                            </div>
-                            <input type="hidden" name="attr_spellathigherlevels" value="">
-                            <div class="row">
-                                <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
-                                <span name="attr_spellathigherlevels"></span>
+                            <div class="details">
+                                <span class="row">
+                                    <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
+                                </span>
+                                <div class="row italics">
+                                    <span name="attr_spellschool"></span>
+                                    <span name="attr_spelllevel"></span>
+                                    <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                    <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="casting-time:">Casting Time:</span>
+                                    <span name="attr_spellcastingtime"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="range:">Range:</span>
+                                    <span name="attr_spellrange"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="target:">Target:</span>
+                                    <span name="attr_spelltarget"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="components:">Components:</span>
+                                    <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
+                                    <input type="hidden" name="attr_spellcomp_materials" value="">
+                                    <span>(<span name="attr_spellcomp_materials"></span>)</span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="duration:">Duration:</span>
+                                    <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration">Concentration</span>
+                                    <span name="attr_spellduration"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="description:">Description:</span>
+                                </div>
+                                <div class="row">
+                                    <span name="attr_spelldescription"></span>
+                                </div>
+                                <input type="hidden" name="attr_spellathigherlevels" value="">
+                                <div class="row">
+                                    <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
+                                    <span name="attr_spellathigherlevels"></span>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -3295,173 +3317,6 @@
             <div class="spell-container">
                 <fieldset class="repeating_spell-5">
                     <div class="spell">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_spellname">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="school:-u">SCHOOL:</span>
-                                <select name="attr_spellschool">
-                                    <option value="abjuration" data-i18n="abjuration">Abjuration</option>
-                                    <option value="conjuration" data-i18n="conjuration">Conjuration</option>
-                                    <option value="divination" data-i18n="divination">Divination</option>
-                                    <option value="enchantment" data-i18n="enchantment">Enchantment</option>
-                                    <option value="evocation" data-i18n="evocation">Evocation</option>
-                                    <option value="illusion" data-i18n="illusion">Illusion</option>
-                                    <option value="necromancy" data-i18n="necromancy">Necromancy</option>
-                                    <option value="transmutation" data-i18n="transmutation">Transmutation</option>
-                                </select>
-                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-                                <span data-i18n="ritual-u">RITUAL</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="casting-time:-u">CASTING TIME:</span>
-                                <input type="text" name="attr_spellcastingtime">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_spellrange">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="target:-u">TARGET:</span>
-                                <input type="text" name="attr_spelltarget">
-                            </div>
-                            <input type="hidden" name="attr_spellcomp">
-                            <div class="row">
-                                <span data-i18n="components:-u">COMPONENTS:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-                                <span data-i18n="spell-component-verbal">V</span>
-                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-                                <span data-i18n="spell-component-somatic">S</span>
-                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-                                <span data-i18n="spell-component-material">M</span>
-                                <input type="text" name="attr_spellcomp_materials" placeholder="ruby dust worth 50gp" data-i18n-placeholder="ruby-dust-place">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration-u">CONCENTRATION</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="duration:-u">DURATION:</span>
-                                <input type="text" name="attr_spellduration">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="spell-ability-u">SPELLCASTING ABILITY</span>
-                                <select name="attr_spell_ability">
-                                    <option value="0*" data-i18n="none-u">NONE</option>
-                                    <option value="spell" data-i18n="spell-u">SPELL</option>
-                                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="innate:-u">INNATE:</span>
-                                <input type="text" name="attr_innate" placeholder="1/day" value="">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="output:-u">OUTPUT:</span>
-                                <select name="attr_spelloutput">
-                                    <option value="SPELLCARD" data-i18n="spellcard-u">SPELLCARD</option>
-                                    <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
-                                </select>
-                            </div>
-                            <input type="hidden" class="spellattackinfoflag" name="attr_spelloutput">
-                            <div class="spellattackinfo">
-                                <div class="row">
-                                    <span data-i18n="spell-atk:-u">SPELL ATTACK:</span>
-                                    <select name="attr_spellattack">
-                                        <option value="None" data-i18n="none">None</option>
-                                        <option value="Melee" data-i18n="melee">Melee</option>
-                                        <option value="Ranged" data-i18n="ranged">Ranged</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage:-u">DAMAGE:</span>
-                                    <input type="text" name="attr_spelldamage" style="width: 50px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_spelldamagetype" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                    <input type="text" name="attr_spelldamage2" style="width: 45px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_spelldamagetype2" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="healing:-u">HEALING:</span>
-                                    <input type="text" name="attr_spellhealing" style="width: 45px;">
-                                </div>
-                                <div class="row">
-                                    <input type="checkbox" name="attr_spelldmgmod" value="Yes">
-                                    <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                    <select name="attr_spellsave">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Strength" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                        <option value="Constitution" data-i18n="con-u">CON</option>
-                                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                    </select>
-                                    <span data-i18n="effect:-u">EFFECT:</span>
-                                    <input type="text" name="attr_spellsavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
-                                    <input type="text" name="attr_spellhldie" placeholder="1" style="width: 15px; text-align: right;">
-                                    <select name="attr_spellhldietype">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="d4">d4</option>
-                                        <option value="d6">d6</option>
-                                        <option value="d8">d8</option>
-                                        <option value="d10">d10</option>
-                                        <option value="d12">d12</option>
-                                        <option value="d20">d20</option>
-                                    </select>
-                                    <span>+</span>
-                                    <input type="text" name="attr_spellhlbonus" placeholder="0" style="width: 15px; text-align: center;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="include_spell_desc:-u">INCLUDE SPELL DESCRIPTION IN ATTACK:</span>
-                                    <select name="attr_includedesc">
-                                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                                        <option value="partial" data-i18n="partial">Partial</option>
-                                        <option value="on" data-i18n="on">On</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_spelldescription"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_spellathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="class:-u">CLASS:</span>
-                                <input type="text" name="attr_spellclass" style="width: 45px;">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="type:-u">TYPE:</span>
-                                <input type="text" name="attr_spellsource" style="width: 45px;">
-                            </div>
-                            <input type="hidden" name="attr_spellattackid">
-                            <input type="hidden" name="attr_spelllevel" value="5">
-                        </div>
                         <div class="display">
                             <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}}  {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
                             <input type="checkbox" name="attr_spellprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
@@ -3484,51 +3339,224 @@
                             </span>
                         </div>
                         <input class="details-flag" type="checkbox"><span>i</span>
-                        <div class="details">
+                        <div class="wrapper">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>p</span>
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
-                            <span class="row">
-                                <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
-                            </span>
-                            <div class="row italics">
-                                <span name="attr_spellschool"></span>
-                                <span name="attr_spelllevel"></span>
-                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-                                <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_spellname">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="school:-u">SCHOOL:</span>
+                                    <select name="attr_spellschool">
+                                        <option value="abjuration" data-i18n="abjuration">Abjuration</option>
+                                        <option value="conjuration" data-i18n="conjuration">Conjuration</option>
+                                        <option value="divination" data-i18n="divination">Divination</option>
+                                        <option value="enchantment" data-i18n="enchantment">Enchantment</option>
+                                        <option value="evocation" data-i18n="evocation">Evocation</option>
+                                        <option value="illusion" data-i18n="illusion">Illusion</option>
+                                        <option value="necromancy" data-i18n="necromancy">Necromancy</option>
+                                        <option value="transmutation" data-i18n="transmutation">Transmutation</option>
+                                    </select>
+                                    <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                    <span data-i18n="ritual-u">RITUAL</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="casting-time:-u">CASTING TIME:</span>
+                                    <input type="text" name="attr_spellcastingtime">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_spellrange">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="target:-u">TARGET:</span>
+                                    <input type="text" name="attr_spelltarget">
+                                </div>
+                                <input type="hidden" name="attr_spellcomp">
+                                <div class="row">
+                                    <span data-i18n="components:-u">COMPONENTS:</span>
+                                    <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
+                                    <span data-i18n="spell-component-verbal">V</span>
+                                    <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
+                                    <span data-i18n="spell-component-somatic">S</span>
+                                    <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
+                                    <span data-i18n="spell-component-material">M</span>
+                                    <input type="text" name="attr_spellcomp_materials" placeholder="ruby dust worth 50gp" data-i18n-placeholder="ruby-dust-place">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration-u">CONCENTRATION</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="duration:-u">DURATION:</span>
+                                    <input type="text" name="attr_spellduration">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="spell-ability-u">SPELLCASTING ABILITY</span>
+                                    <select name="attr_spell_ability">
+                                        <option value="0*" data-i18n="none-u">NONE</option>
+                                        <option value="spell" data-i18n="spell-u">SPELL</option>
+                                        <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="innate:-u">INNATE:</span>
+                                    <input type="text" name="attr_innate" placeholder="1/day" value="">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="output:-u">OUTPUT:</span>
+                                    <select name="attr_spelloutput">
+                                        <option value="SPELLCARD" data-i18n="spellcard-u">SPELLCARD</option>
+                                        <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
+                                    </select>
+                                </div>
+                                <input type="hidden" class="spellattackinfoflag" name="attr_spelloutput">
+                                <div class="spellattackinfo">
+                                    <div class="row">
+                                        <span data-i18n="spell-atk:-u">SPELL ATTACK:</span>
+                                        <select name="attr_spellattack">
+                                            <option value="None" data-i18n="none">None</option>
+                                            <option value="Melee" data-i18n="melee">Melee</option>
+                                            <option value="Ranged" data-i18n="ranged">Ranged</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage:-u">DAMAGE:</span>
+                                        <input type="text" name="attr_spelldamage" style="width: 50px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_spelldamagetype" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                        <input type="text" name="attr_spelldamage2" style="width: 45px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_spelldamagetype2" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="healing:-u">HEALING:</span>
+                                        <input type="text" name="attr_spellhealing" style="width: 45px;">
+                                    </div>
+                                    <div class="row">
+                                        <input type="checkbox" name="attr_spelldmgmod" value="Yes">
+                                        <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                        <select name="attr_spellsave">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Strength" data-i18n="str-u">STR</option>
+                                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                            <option value="Constitution" data-i18n="con-u">CON</option>
+                                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                        </select>
+                                        <span data-i18n="effect:-u">EFFECT:</span>
+                                        <input type="text" name="attr_spellsavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
+                                        <input type="text" name="attr_spellhldie" placeholder="1" style="width: 15px; text-align: right;">
+                                        <select name="attr_spellhldietype">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="d4">d4</option>
+                                            <option value="d6">d6</option>
+                                            <option value="d8">d8</option>
+                                            <option value="d10">d10</option>
+                                            <option value="d12">d12</option>
+                                            <option value="d20">d20</option>
+                                        </select>
+                                        <span>+</span>
+                                        <input type="text" name="attr_spellhlbonus" placeholder="0" style="width: 15px; text-align: center;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="include_spell_desc:-u">INCLUDE SPELL DESCRIPTION IN ATTACK:</span>
+                                        <select name="attr_includedesc">
+                                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                                            <option value="partial" data-i18n="partial">Partial</option>
+                                            <option value="on" data-i18n="on">On</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_spelldescription"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_spellathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="class:-u">CLASS:</span>
+                                    <input type="text" name="attr_spellclass" style="width: 45px;">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="type:-u">TYPE:</span>
+                                    <input type="text" name="attr_spellsource" style="width: 45px;">
+                                </div>
+                                <input type="hidden" name="attr_spellattackid">
+                                <input type="hidden" name="attr_spelllevel" value="5">
+                                <label class="options-done">
+                                    <input type="checkbox" name="attr_options-flag" checked="checked">
+                                    Done
+                                </label>
                             </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="casting-time:">Casting Time:</span>
-                                <span name="attr_spellcastingtime"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="range:">Range:</span>
-                                <span name="attr_spellrange"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="target:">Target:</span>
-                                <span name="attr_spelltarget"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="components:">Components:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
-                                <input type="hidden" name="attr_spellcomp_materials" value="">
-                                <span>(<span name="attr_spellcomp_materials"></span>)</span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="duration:">Duration:</span>
-                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration">Concentration</span>
-                                <span name="attr_spellduration"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="description:">Description:</span>
-                            </div>
-                            <div class="row">
-                                <span name="attr_spelldescription"></span>
-                            </div>
-                            <input type="hidden" name="attr_spellathigherlevels" value="">
-                            <div class="row">
-                                <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
-                                <span name="attr_spellathigherlevels"></span>
+                            <div class="details">
+                                <span class="row">
+                                    <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
+                                </span>
+                                <div class="row italics">
+                                    <span name="attr_spellschool"></span>
+                                    <span name="attr_spelllevel"></span>
+                                    <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                    <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="casting-time:">Casting Time:</span>
+                                    <span name="attr_spellcastingtime"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="range:">Range:</span>
+                                    <span name="attr_spellrange"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="target:">Target:</span>
+                                    <span name="attr_spelltarget"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="components:">Components:</span>
+                                    <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
+                                    <input type="hidden" name="attr_spellcomp_materials" value="">
+                                    <span>(<span name="attr_spellcomp_materials"></span>)</span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="duration:">Duration:</span>
+                                    <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration">Concentration</span>
+                                    <span name="attr_spellduration"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="description:">Description:</span>
+                                </div>
+                                <div class="row">
+                                    <span name="attr_spelldescription"></span>
+                                </div>
+                                <input type="hidden" name="attr_spellathigherlevels" value="">
+                                <div class="row">
+                                    <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
+                                    <span name="attr_spellathigherlevels"></span>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -3552,173 +3580,6 @@
             <div class="spell-container">
                 <fieldset class="repeating_spell-6">
                     <div class="spell">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_spellname">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="school:-u">SCHOOL:</span>
-                                <select name="attr_spellschool">
-                                    <option value="abjuration" data-i18n="abjuration">Abjuration</option>
-                                    <option value="conjuration" data-i18n="conjuration">Conjuration</option>
-                                    <option value="divination" data-i18n="divination">Divination</option>
-                                    <option value="enchantment" data-i18n="enchantment">Enchantment</option>
-                                    <option value="evocation" data-i18n="evocation">Evocation</option>
-                                    <option value="illusion" data-i18n="illusion">Illusion</option>
-                                    <option value="necromancy" data-i18n="necromancy">Necromancy</option>
-                                    <option value="transmutation" data-i18n="transmutation">Transmutation</option>
-                                </select>
-                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-                                <span data-i18n="ritual-u">RITUAL</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="casting-time:-u">CASTING TIME:</span>
-                                <input type="text" name="attr_spellcastingtime">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_spellrange">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="target:-u">TARGET:</span>
-                                <input type="text" name="attr_spelltarget">
-                            </div>
-                            <input type="hidden" name="attr_spellcomp">
-                            <div class="row">
-                                <span data-i18n="components:-u">COMPONENTS:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-                                <span data-i18n="spell-component-verbal">V</span>
-                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-                                <span data-i18n="spell-component-somatic">S</span>
-                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-                                <span data-i18n="spell-component-material">M</span>
-                                <input type="text" name="attr_spellcomp_materials" placeholder="ruby dust worth 50gp" data-i18n-placeholder="ruby-dust-place">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration-u">CONCENTRATION</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="duration:-u">DURATION:</span>
-                                <input type="text" name="attr_spellduration">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="spell-ability-u">SPELLCASTING ABILITY</span>
-                                <select name="attr_spell_ability">
-                                    <option value="0*" data-i18n="none-u">NONE</option>
-                                    <option value="spell" data-i18n="spell-u">SPELL</option>
-                                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="innate:-u">INNATE:</span>
-                                <input type="text" name="attr_innate" placeholder="1/day" value="">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="output:-u">OUTPUT:</span>
-                                <select name="attr_spelloutput">
-                                    <option value="SPELLCARD" data-i18n="spellcard-u">SPELLCARD</option>
-                                    <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
-                                </select>
-                            </div>
-                            <input type="hidden" class="spellattackinfoflag" name="attr_spelloutput">
-                            <div class="spellattackinfo">
-                                <div class="row">
-                                    <span data-i18n="spell-atk:-u">SPELL ATTACK:</span>
-                                    <select name="attr_spellattack">
-                                        <option value="None" data-i18n="none">None</option>
-                                        <option value="Melee" data-i18n="melee">Melee</option>
-                                        <option value="Ranged" data-i18n="ranged">Ranged</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage:-u">DAMAGE:</span>
-                                    <input type="text" name="attr_spelldamage" style="width: 50px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_spelldamagetype" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                    <input type="text" name="attr_spelldamage2" style="width: 45px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_spelldamagetype2" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="healing:-u">HEALING:</span>
-                                    <input type="text" name="attr_spellhealing" style="width: 45px;">
-                                </div>
-                                <div class="row">
-                                    <input type="checkbox" name="attr_spelldmgmod" value="Yes">
-                                    <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                    <select name="attr_spellsave">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Strength" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                        <option value="Constitution" data-i18n="con-u">CON</option>
-                                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                    </select>
-                                    <span data-i18n="effect:-u">EFFECT:</span>
-                                    <input type="text" name="attr_spellsavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
-                                    <input type="text" name="attr_spellhldie" placeholder="1" style="width: 15px; text-align: right;">
-                                    <select name="attr_spellhldietype">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="d4">d4</option>
-                                        <option value="d6">d6</option>
-                                        <option value="d8">d8</option>
-                                        <option value="d10">d10</option>
-                                        <option value="d12">d12</option>
-                                        <option value="d20">d20</option>
-                                    </select>
-                                    <span>+</span>
-                                    <input type="text" name="attr_spellhlbonus" placeholder="0" style="width: 15px; text-align: center;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="include_spell_desc:-u">INCLUDE SPELL DESCRIPTION IN ATTACK:</span>
-                                    <select name="attr_includedesc">
-                                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                                        <option value="partial" data-i18n="partial">Partial</option>
-                                        <option value="on" data-i18n="on">On</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_spelldescription"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_spellathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="class:-u">CLASS:</span>
-                                <input type="text" name="attr_spellclass" style="width: 45px;">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="type:-u">TYPE:</span>
-                                <input type="text" name="attr_spellsource" style="width: 45px;">
-                            </div>
-                            <input type="hidden" name="attr_spellattackid">
-                            <input type="hidden" name="attr_spelllevel" value="6">
-                        </div>
                         <div class="display">
                             <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}}  {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
                             <input type="checkbox" name="attr_spellprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
@@ -3741,51 +3602,224 @@
                             </span>
                         </div>
                         <input class="details-flag" type="checkbox"><span>i</span>
-                        <div class="details">
+                        <div class="wrapper">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>p</span>
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
-                            <span class="row">
-                                <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
-                            </span>
-                            <div class="row italics">
-                                <span name="attr_spellschool"></span>
-                                <span name="attr_spelllevel"></span>
-                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-                                <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_spellname">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="school:-u">SCHOOL:</span>
+                                    <select name="attr_spellschool">
+                                        <option value="abjuration" data-i18n="abjuration">Abjuration</option>
+                                        <option value="conjuration" data-i18n="conjuration">Conjuration</option>
+                                        <option value="divination" data-i18n="divination">Divination</option>
+                                        <option value="enchantment" data-i18n="enchantment">Enchantment</option>
+                                        <option value="evocation" data-i18n="evocation">Evocation</option>
+                                        <option value="illusion" data-i18n="illusion">Illusion</option>
+                                        <option value="necromancy" data-i18n="necromancy">Necromancy</option>
+                                        <option value="transmutation" data-i18n="transmutation">Transmutation</option>
+                                    </select>
+                                    <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                    <span data-i18n="ritual-u">RITUAL</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="casting-time:-u">CASTING TIME:</span>
+                                    <input type="text" name="attr_spellcastingtime">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_spellrange">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="target:-u">TARGET:</span>
+                                    <input type="text" name="attr_spelltarget">
+                                </div>
+                                <input type="hidden" name="attr_spellcomp">
+                                <div class="row">
+                                    <span data-i18n="components:-u">COMPONENTS:</span>
+                                    <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
+                                    <span data-i18n="spell-component-verbal">V</span>
+                                    <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
+                                    <span data-i18n="spell-component-somatic">S</span>
+                                    <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
+                                    <span data-i18n="spell-component-material">M</span>
+                                    <input type="text" name="attr_spellcomp_materials" placeholder="ruby dust worth 50gp" data-i18n-placeholder="ruby-dust-place">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration-u">CONCENTRATION</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="duration:-u">DURATION:</span>
+                                    <input type="text" name="attr_spellduration">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="spell-ability-u">SPELLCASTING ABILITY</span>
+                                    <select name="attr_spell_ability">
+                                        <option value="0*" data-i18n="none-u">NONE</option>
+                                        <option value="spell" data-i18n="spell-u">SPELL</option>
+                                        <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="innate:-u">INNATE:</span>
+                                    <input type="text" name="attr_innate" placeholder="1/day" value="">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="output:-u">OUTPUT:</span>
+                                    <select name="attr_spelloutput">
+                                        <option value="SPELLCARD" data-i18n="spellcard-u">SPELLCARD</option>
+                                        <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
+                                    </select>
+                                </div>
+                                <input type="hidden" class="spellattackinfoflag" name="attr_spelloutput">
+                                <div class="spellattackinfo">
+                                    <div class="row">
+                                        <span data-i18n="spell-atk:-u">SPELL ATTACK:</span>
+                                        <select name="attr_spellattack">
+                                            <option value="None" data-i18n="none">None</option>
+                                            <option value="Melee" data-i18n="melee">Melee</option>
+                                            <option value="Ranged" data-i18n="ranged">Ranged</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage:-u">DAMAGE:</span>
+                                        <input type="text" name="attr_spelldamage" style="width: 50px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_spelldamagetype" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                        <input type="text" name="attr_spelldamage2" style="width: 45px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_spelldamagetype2" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="healing:-u">HEALING:</span>
+                                        <input type="text" name="attr_spellhealing" style="width: 45px;">
+                                    </div>
+                                    <div class="row">
+                                        <input type="checkbox" name="attr_spelldmgmod" value="Yes">
+                                        <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                        <select name="attr_spellsave">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Strength" data-i18n="str-u">STR</option>
+                                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                            <option value="Constitution" data-i18n="con-u">CON</option>
+                                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                        </select>
+                                        <span data-i18n="effect:-u">EFFECT:</span>
+                                        <input type="text" name="attr_spellsavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
+                                        <input type="text" name="attr_spellhldie" placeholder="1" style="width: 15px; text-align: right;">
+                                        <select name="attr_spellhldietype">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="d4">d4</option>
+                                            <option value="d6">d6</option>
+                                            <option value="d8">d8</option>
+                                            <option value="d10">d10</option>
+                                            <option value="d12">d12</option>
+                                            <option value="d20">d20</option>
+                                        </select>
+                                        <span>+</span>
+                                        <input type="text" name="attr_spellhlbonus" placeholder="0" style="width: 15px; text-align: center;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="include_spell_desc:-u">INCLUDE SPELL DESCRIPTION IN ATTACK:</span>
+                                        <select name="attr_includedesc">
+                                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                                            <option value="partial" data-i18n="partial">Partial</option>
+                                            <option value="on" data-i18n="on">On</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_spelldescription"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_spellathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="class:-u">CLASS:</span>
+                                    <input type="text" name="attr_spellclass" style="width: 45px;">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="type:-u">TYPE:</span>
+                                    <input type="text" name="attr_spellsource" style="width: 45px;">
+                                </div>
+                                <input type="hidden" name="attr_spellattackid">
+                                <input type="hidden" name="attr_spelllevel" value="6">
+                                <label class="options-done">
+                                    <input type="checkbox" name="attr_options-flag" checked="checked">
+                                    Done
+                                </label>
                             </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="casting-time:">Casting Time:</span>
-                                <span name="attr_spellcastingtime"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="range:">Range:</span>
-                                <span name="attr_spellrange"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="target:">Target:</span>
-                                <span name="attr_spelltarget"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="components:">Components:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
-                                <input type="hidden" name="attr_spellcomp_materials" value="">
-                                <span>(<span name="attr_spellcomp_materials"></span>)</span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="duration:">Duration:</span>
-                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration">Concentration</span>
-                                <span name="attr_spellduration"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="description:">Description:</span>
-                            </div>
-                            <div class="row">
-                                <span name="attr_spelldescription"></span>
-                            </div>
-                            <input type="hidden" name="attr_spellathigherlevels" value="">
-                            <div class="row">
-                                <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
-                                <span name="attr_spellathigherlevels"></span>
+                            <div class="details">
+                                <span class="row">
+                                    <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
+                                </span>
+                                <div class="row italics">
+                                    <span name="attr_spellschool"></span>
+                                    <span name="attr_spelllevel"></span>
+                                    <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                    <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="casting-time:">Casting Time:</span>
+                                    <span name="attr_spellcastingtime"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="range:">Range:</span>
+                                    <span name="attr_spellrange"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="target:">Target:</span>
+                                    <span name="attr_spelltarget"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="components:">Components:</span>
+                                    <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
+                                    <input type="hidden" name="attr_spellcomp_materials" value="">
+                                    <span>(<span name="attr_spellcomp_materials"></span>)</span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="duration:">Duration:</span>
+                                    <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration">Concentration</span>
+                                    <span name="attr_spellduration"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="description:">Description:</span>
+                                </div>
+                                <div class="row">
+                                    <span name="attr_spelldescription"></span>
+                                </div>
+                                <input type="hidden" name="attr_spellathigherlevels" value="">
+                                <div class="row">
+                                    <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
+                                    <span name="attr_spellathigherlevels"></span>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -3806,173 +3840,6 @@
             <div class="spell-container">
                 <fieldset class="repeating_spell-7">
                     <div class="spell">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_spellname">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="school:-u">SCHOOL:</span>
-                                <select name="attr_spellschool">
-                                    <option value="abjuration" data-i18n="abjuration">Abjuration</option>
-                                    <option value="conjuration" data-i18n="conjuration">Conjuration</option>
-                                    <option value="divination" data-i18n="divination">Divination</option>
-                                    <option value="enchantment" data-i18n="enchantment">Enchantment</option>
-                                    <option value="evocation" data-i18n="evocation">Evocation</option>
-                                    <option value="illusion" data-i18n="illusion">Illusion</option>
-                                    <option value="necromancy" data-i18n="necromancy">Necromancy</option>
-                                    <option value="transmutation" data-i18n="transmutation">Transmutation</option>
-                                </select>
-                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-                                <span data-i18n="ritual-u">RITUAL</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="casting-time:-u">CASTING TIME:</span>
-                                <input type="text" name="attr_spellcastingtime">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_spellrange">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="target:-u">TARGET:</span>
-                                <input type="text" name="attr_spelltarget">
-                            </div>
-                            <input type="hidden" name="attr_spellcomp">
-                            <div class="row">
-                                <span data-i18n="components:-u">COMPONENTS:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-                                <span data-i18n="spell-component-verbal">V</span>
-                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-                                <span data-i18n="spell-component-somatic">S</span>
-                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-                                <span data-i18n="spell-component-material">M</span>
-                                <input type="text" name="attr_spellcomp_materials" placeholder="ruby dust worth 50gp" data-i18n-placeholder="ruby-dust-place">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration-u">CONCENTRATION</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="duration:-u">DURATION:</span>
-                                <input type="text" name="attr_spellduration">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="spell-ability-u">SPELLCASTING ABILITY</span>
-                                <select name="attr_spell_ability">
-                                    <option value="0*" data-i18n="none-u">NONE</option>
-                                    <option value="spell" data-i18n="spell-u">SPELL</option>
-                                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="innate:-u">INNATE:</span>
-                                <input type="text" name="attr_innate" placeholder="1/day" value="">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="output:-u">OUTPUT:</span>
-                                <select name="attr_spelloutput">
-                                    <option value="SPELLCARD" data-i18n="spellcard-u">SPELLCARD</option>
-                                    <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
-                                </select>
-                            </div>
-                            <input type="hidden" class="spellattackinfoflag" name="attr_spelloutput">
-                            <div class="spellattackinfo">
-                                <div class="row">
-                                    <span data-i18n="spell-atk:-u">SPELL ATTACK:</span>
-                                    <select name="attr_spellattack">
-                                        <option value="None" data-i18n="none">None</option>
-                                        <option value="Melee" data-i18n="melee">Melee</option>
-                                        <option value="Ranged" data-i18n="ranged">Ranged</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage:-u">DAMAGE:</span>
-                                    <input type="text" name="attr_spelldamage" style="width: 50px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_spelldamagetype" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                    <input type="text" name="attr_spelldamage2" style="width: 45px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_spelldamagetype2" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="healing:-u">HEALING:</span>
-                                    <input type="text" name="attr_spellhealing" style="width: 45px;">
-                                </div>
-                                <div class="row">
-                                    <input type="checkbox" name="attr_spelldmgmod" value="Yes">
-                                    <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                    <select name="attr_spellsave">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Strength" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                        <option value="Constitution" data-i18n="con-u">CON</option>
-                                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                    </select>
-                                    <span data-i18n="effect:-u">EFFECT:</span>
-                                    <input type="text" name="attr_spellsavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
-                                    <input type="text" name="attr_spellhldie" placeholder="1" style="width: 15px; text-align: right;">
-                                    <select name="attr_spellhldietype">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="d4">d4</option>
-                                        <option value="d6">d6</option>
-                                        <option value="d8">d8</option>
-                                        <option value="d10">d10</option>
-                                        <option value="d12">d12</option>
-                                        <option value="d20">d20</option>
-                                    </select>
-                                    <span>+</span>
-                                    <input type="text" name="attr_spellhlbonus" placeholder="0" style="width: 15px; text-align: center;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="include_spell_desc:-u">INCLUDE SPELL DESCRIPTION IN ATTACK:</span>
-                                    <select name="attr_includedesc">
-                                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                                        <option value="partial" data-i18n="partial">Partial</option>
-                                        <option value="on" data-i18n="on">On</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_spelldescription"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_spellathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="class:-u">CLASS:</span>
-                                <input type="text" name="attr_spellclass" style="width: 45px;">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="type:-u">TYPE:</span>
-                                <input type="text" name="attr_spellsource" style="width: 45px;">
-                            </div>
-                            <input type="hidden" name="attr_spellattackid">
-                            <input type="hidden" name="attr_spelllevel" value="7">
-                        </div>
                         <div class="display">
                             <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}}  {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
                             <input type="checkbox" name="attr_spellprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
@@ -3995,51 +3862,224 @@
                             </span>
                         </div>
                         <input class="details-flag" type="checkbox"><span>i</span>
-                        <div class="details">
+                        <div class="wrapper">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>p</span>
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
-                            <span class="row">
-                                <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
-                            </span>
-                            <div class="row italics">
-                                <span name="attr_spellschool"></span>
-                                <span name="attr_spelllevel"></span>
-                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-                                <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_spellname">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="school:-u">SCHOOL:</span>
+                                    <select name="attr_spellschool">
+                                        <option value="abjuration" data-i18n="abjuration">Abjuration</option>
+                                        <option value="conjuration" data-i18n="conjuration">Conjuration</option>
+                                        <option value="divination" data-i18n="divination">Divination</option>
+                                        <option value="enchantment" data-i18n="enchantment">Enchantment</option>
+                                        <option value="evocation" data-i18n="evocation">Evocation</option>
+                                        <option value="illusion" data-i18n="illusion">Illusion</option>
+                                        <option value="necromancy" data-i18n="necromancy">Necromancy</option>
+                                        <option value="transmutation" data-i18n="transmutation">Transmutation</option>
+                                    </select>
+                                    <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                    <span data-i18n="ritual-u">RITUAL</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="casting-time:-u">CASTING TIME:</span>
+                                    <input type="text" name="attr_spellcastingtime">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_spellrange">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="target:-u">TARGET:</span>
+                                    <input type="text" name="attr_spelltarget">
+                                </div>
+                                <input type="hidden" name="attr_spellcomp">
+                                <div class="row">
+                                    <span data-i18n="components:-u">COMPONENTS:</span>
+                                    <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
+                                    <span data-i18n="spell-component-verbal">V</span>
+                                    <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
+                                    <span data-i18n="spell-component-somatic">S</span>
+                                    <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
+                                    <span data-i18n="spell-component-material">M</span>
+                                    <input type="text" name="attr_spellcomp_materials" placeholder="ruby dust worth 50gp" data-i18n-placeholder="ruby-dust-place">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration-u">CONCENTRATION</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="duration:-u">DURATION:</span>
+                                    <input type="text" name="attr_spellduration">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="spell-ability-u">SPELLCASTING ABILITY</span>
+                                    <select name="attr_spell_ability">
+                                        <option value="0*" data-i18n="none-u">NONE</option>
+                                        <option value="spell" data-i18n="spell-u">SPELL</option>
+                                        <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="innate:-u">INNATE:</span>
+                                    <input type="text" name="attr_innate" placeholder="1/day" value="">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="output:-u">OUTPUT:</span>
+                                    <select name="attr_spelloutput">
+                                        <option value="SPELLCARD" data-i18n="spellcard-u">SPELLCARD</option>
+                                        <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
+                                    </select>
+                                </div>
+                                <input type="hidden" class="spellattackinfoflag" name="attr_spelloutput">
+                                <div class="spellattackinfo">
+                                    <div class="row">
+                                        <span data-i18n="spell-atk:-u">SPELL ATTACK:</span>
+                                        <select name="attr_spellattack">
+                                            <option value="None" data-i18n="none">None</option>
+                                            <option value="Melee" data-i18n="melee">Melee</option>
+                                            <option value="Ranged" data-i18n="ranged">Ranged</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage:-u">DAMAGE:</span>
+                                        <input type="text" name="attr_spelldamage" style="width: 50px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_spelldamagetype" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                        <input type="text" name="attr_spelldamage2" style="width: 45px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_spelldamagetype2" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="healing:-u">HEALING:</span>
+                                        <input type="text" name="attr_spellhealing" style="width: 45px;">
+                                    </div>
+                                    <div class="row">
+                                        <input type="checkbox" name="attr_spelldmgmod" value="Yes">
+                                        <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                        <select name="attr_spellsave">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Strength" data-i18n="str-u">STR</option>
+                                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                            <option value="Constitution" data-i18n="con-u">CON</option>
+                                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                        </select>
+                                        <span data-i18n="effect:-u">EFFECT:</span>
+                                        <input type="text" name="attr_spellsavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
+                                        <input type="text" name="attr_spellhldie" placeholder="1" style="width: 15px; text-align: right;">
+                                        <select name="attr_spellhldietype">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="d4">d4</option>
+                                            <option value="d6">d6</option>
+                                            <option value="d8">d8</option>
+                                            <option value="d10">d10</option>
+                                            <option value="d12">d12</option>
+                                            <option value="d20">d20</option>
+                                        </select>
+                                        <span>+</span>
+                                        <input type="text" name="attr_spellhlbonus" placeholder="0" style="width: 15px; text-align: center;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="include_spell_desc:-u">INCLUDE SPELL DESCRIPTION IN ATTACK:</span>
+                                        <select name="attr_includedesc">
+                                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                                            <option value="partial" data-i18n="partial">Partial</option>
+                                            <option value="on" data-i18n="on">On</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_spelldescription"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_spellathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="class:-u">CLASS:</span>
+                                    <input type="text" name="attr_spellclass" style="width: 45px;">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="type:-u">TYPE:</span>
+                                    <input type="text" name="attr_spellsource" style="width: 45px;">
+                                </div>
+                                <input type="hidden" name="attr_spellattackid">
+                                <input type="hidden" name="attr_spelllevel" value="7">
+                                <label class="options-done">
+                                    <input type="checkbox" name="attr_options-flag" checked="checked">
+                                    Done
+                                </label>
                             </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="casting-time:">Casting Time:</span>
-                                <span name="attr_spellcastingtime"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="range:">Range:</span>
-                                <span name="attr_spellrange"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="target:">Target:</span>
-                                <span name="attr_spelltarget"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="components:">Components:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
-                                <input type="hidden" name="attr_spellcomp_materials" value="">
-                                <span>(<span name="attr_spellcomp_materials"></span>)</span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="duration:">Duration:</span>
-                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration">Concentration</span>
-                                <span name="attr_spellduration"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="description:">Description:</span>
-                            </div>
-                            <div class="row">
-                                <span name="attr_spelldescription"></span>
-                            </div>
-                            <input type="hidden" name="attr_spellathigherlevels" value="">
-                            <div class="row">
-                                <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
-                                <span name="attr_spellathigherlevels"></span>
+                            <div class="details">
+                                <span class="row">
+                                    <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
+                                </span>
+                                <div class="row italics">
+                                    <span name="attr_spellschool"></span>
+                                    <span name="attr_spelllevel"></span>
+                                    <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                    <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="casting-time:">Casting Time:</span>
+                                    <span name="attr_spellcastingtime"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="range:">Range:</span>
+                                    <span name="attr_spellrange"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="target:">Target:</span>
+                                    <span name="attr_spelltarget"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="components:">Components:</span>
+                                    <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
+                                    <input type="hidden" name="attr_spellcomp_materials" value="">
+                                    <span>(<span name="attr_spellcomp_materials"></span>)</span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="duration:">Duration:</span>
+                                    <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration">Concentration</span>
+                                    <span name="attr_spellduration"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="description:">Description:</span>
+                                </div>
+                                <div class="row">
+                                    <span name="attr_spelldescription"></span>
+                                </div>
+                                <input type="hidden" name="attr_spellathigherlevels" value="">
+                                <div class="row">
+                                    <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
+                                    <span name="attr_spellathigherlevels"></span>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -4060,173 +4100,6 @@
             <div class="spell-container">
                 <fieldset class="repeating_spell-8">
                     <div class="spell">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_spellname">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="school:-u">SCHOOL:</span>
-                                <select name="attr_spellschool">
-                                    <option value="abjuration" data-i18n="abjuration">Abjuration</option>
-                                    <option value="conjuration" data-i18n="conjuration">Conjuration</option>
-                                    <option value="divination" data-i18n="divination">Divination</option>
-                                    <option value="enchantment" data-i18n="enchantment">Enchantment</option>
-                                    <option value="evocation" data-i18n="evocation">Evocation</option>
-                                    <option value="illusion" data-i18n="illusion">Illusion</option>
-                                    <option value="necromancy" data-i18n="necromancy">Necromancy</option>
-                                    <option value="transmutation" data-i18n="transmutation">Transmutation</option>
-                                </select>
-                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-                                <span data-i18n="ritual-u">RITUAL</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="casting-time:-u">CASTING TIME:</span>
-                                <input type="text" name="attr_spellcastingtime">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_spellrange">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="target:-u">TARGET:</span>
-                                <input type="text" name="attr_spelltarget">
-                            </div>
-                            <input type="hidden" name="attr_spellcomp">
-                            <div class="row">
-                                <span data-i18n="components:-u">COMPONENTS:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-                                <span data-i18n="spell-component-verbal">V</span>
-                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-                                <span data-i18n="spell-component-somatic">S</span>
-                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-                                <span data-i18n="spell-component-material">M</span>
-                                <input type="text" name="attr_spellcomp_materials" placeholder="ruby dust worth 50gp" data-i18n-placeholder="ruby-dust-place">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration-u">CONCENTRATION</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="duration:-u">DURATION:</span>
-                                <input type="text" name="attr_spellduration">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="spell-ability-u">SPELLCASTING ABILITY</span>
-                                <select name="attr_spell_ability">
-                                    <option value="0*" data-i18n="none-u">NONE</option>
-                                    <option value="spell" data-i18n="spell-u">SPELL</option>
-                                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="innate:-u">INNATE:</span>
-                                <input type="text" name="attr_innate" placeholder="1/day" value="">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="output:-u">OUTPUT:</span>
-                                <select name="attr_spelloutput">
-                                    <option value="SPELLCARD" data-i18n="spellcard-u">SPELLCARD</option>
-                                    <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
-                                </select>
-                            </div>
-                            <input type="hidden" class="spellattackinfoflag" name="attr_spelloutput">
-                            <div class="spellattackinfo">
-                                <div class="row">
-                                    <span data-i18n="spell-atk:-u">SPELL ATTACK:</span>
-                                    <select name="attr_spellattack">
-                                        <option value="None" data-i18n="none">None</option>
-                                        <option value="Melee" data-i18n="melee">Melee</option>
-                                        <option value="Ranged" data-i18n="ranged">Ranged</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage:-u">DAMAGE:</span>
-                                    <input type="text" name="attr_spelldamage" style="width: 50px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_spelldamagetype" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                    <input type="text" name="attr_spelldamage2" style="width: 45px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_spelldamagetype2" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="healing:-u">HEALING:</span>
-                                    <input type="text" name="attr_spellhealing" style="width: 45px;">
-                                </div>
-                                <div class="row">
-                                    <input type="checkbox" name="attr_spelldmgmod" value="Yes">
-                                    <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                    <select name="attr_spellsave">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Strength" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                        <option value="Constitution" data-i18n="con-u">CON</option>
-                                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                    </select>
-                                    <span data-i18n="effect:-u">EFFECT:</span>
-                                    <input type="text" name="attr_spellsavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
-                                    <input type="text" name="attr_spellhldie" placeholder="1" style="width: 15px; text-align: right;">
-                                    <select name="attr_spellhldietype">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="d4">d4</option>
-                                        <option value="d6">d6</option>
-                                        <option value="d8">d8</option>
-                                        <option value="d10">d10</option>
-                                        <option value="d12">d12</option>
-                                        <option value="d20">d20</option>
-                                    </select>
-                                    <span>+</span>
-                                    <input type="text" name="attr_spellhlbonus" placeholder="0" style="width: 15px; text-align: center;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="include_spell_desc:-u">INCLUDE SPELL DESCRIPTION IN ATTACK:</span>
-                                    <select name="attr_includedesc">
-                                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                                        <option value="partial" data-i18n="partial">Partial</option>
-                                        <option value="on" data-i18n="on">On</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_spelldescription"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_spellathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="class:-u">CLASS:</span>
-                                <input type="text" name="attr_spellclass" style="width: 45px;">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="type:-u">TYPE:</span>
-                                <input type="text" name="attr_spellsource" style="width: 45px;">
-                            </div>
-                            <input type="hidden" name="attr_spellattackid">
-                            <input type="hidden" name="attr_spelllevel" value="8">
-                        </div>
                         <div class="display">
                             <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}}  {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
                             <input type="checkbox" name="attr_spellprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
@@ -4249,51 +4122,224 @@
                             </span>
                         </div>
                         <input class="details-flag" type="checkbox"><span>i</span>
-                        <div class="details">
+                        <div class="wrapper">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>p</span>
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
-                            <span class="row">
-                                <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
-                            </span>
-                            <div class="row italics">
-                                <span name="attr_spellschool"></span>
-                                <span name="attr_spelllevel"></span>
-                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-                                <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_spellname">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="school:-u">SCHOOL:</span>
+                                    <select name="attr_spellschool">
+                                        <option value="abjuration" data-i18n="abjuration">Abjuration</option>
+                                        <option value="conjuration" data-i18n="conjuration">Conjuration</option>
+                                        <option value="divination" data-i18n="divination">Divination</option>
+                                        <option value="enchantment" data-i18n="enchantment">Enchantment</option>
+                                        <option value="evocation" data-i18n="evocation">Evocation</option>
+                                        <option value="illusion" data-i18n="illusion">Illusion</option>
+                                        <option value="necromancy" data-i18n="necromancy">Necromancy</option>
+                                        <option value="transmutation" data-i18n="transmutation">Transmutation</option>
+                                    </select>
+                                    <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                    <span data-i18n="ritual-u">RITUAL</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="casting-time:-u">CASTING TIME:</span>
+                                    <input type="text" name="attr_spellcastingtime">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_spellrange">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="target:-u">TARGET:</span>
+                                    <input type="text" name="attr_spelltarget">
+                                </div>
+                                <input type="hidden" name="attr_spellcomp">
+                                <div class="row">
+                                    <span data-i18n="components:-u">COMPONENTS:</span>
+                                    <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
+                                    <span data-i18n="spell-component-verbal">V</span>
+                                    <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
+                                    <span data-i18n="spell-component-somatic">S</span>
+                                    <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
+                                    <span data-i18n="spell-component-material">M</span>
+                                    <input type="text" name="attr_spellcomp_materials" placeholder="ruby dust worth 50gp" data-i18n-placeholder="ruby-dust-place">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration-u">CONCENTRATION</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="duration:-u">DURATION:</span>
+                                    <input type="text" name="attr_spellduration">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="spell-ability-u">SPELLCASTING ABILITY</span>
+                                    <select name="attr_spell_ability">
+                                        <option value="0*" data-i18n="none-u">NONE</option>
+                                        <option value="spell" data-i18n="spell-u">SPELL</option>
+                                        <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="innate:-u">INNATE:</span>
+                                    <input type="text" name="attr_innate" placeholder="1/day" value="">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="output:-u">OUTPUT:</span>
+                                    <select name="attr_spelloutput">
+                                        <option value="SPELLCARD" data-i18n="spellcard-u">SPELLCARD</option>
+                                        <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
+                                    </select>
+                                </div>
+                                <input type="hidden" class="spellattackinfoflag" name="attr_spelloutput">
+                                <div class="spellattackinfo">
+                                    <div class="row">
+                                        <span data-i18n="spell-atk:-u">SPELL ATTACK:</span>
+                                        <select name="attr_spellattack">
+                                            <option value="None" data-i18n="none">None</option>
+                                            <option value="Melee" data-i18n="melee">Melee</option>
+                                            <option value="Ranged" data-i18n="ranged">Ranged</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage:-u">DAMAGE:</span>
+                                        <input type="text" name="attr_spelldamage" style="width: 50px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_spelldamagetype" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                        <input type="text" name="attr_spelldamage2" style="width: 45px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_spelldamagetype2" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="healing:-u">HEALING:</span>
+                                        <input type="text" name="attr_spellhealing" style="width: 45px;">
+                                    </div>
+                                    <div class="row">
+                                        <input type="checkbox" name="attr_spelldmgmod" value="Yes">
+                                        <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                        <select name="attr_spellsave">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Strength" data-i18n="str-u">STR</option>
+                                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                            <option value="Constitution" data-i18n="con-u">CON</option>
+                                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                        </select>
+                                        <span data-i18n="effect:-u">EFFECT:</span>
+                                        <input type="text" name="attr_spellsavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
+                                        <input type="text" name="attr_spellhldie" placeholder="1" style="width: 15px; text-align: right;">
+                                        <select name="attr_spellhldietype">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="d4">d4</option>
+                                            <option value="d6">d6</option>
+                                            <option value="d8">d8</option>
+                                            <option value="d10">d10</option>
+                                            <option value="d12">d12</option>
+                                            <option value="d20">d20</option>
+                                        </select>
+                                        <span>+</span>
+                                        <input type="text" name="attr_spellhlbonus" placeholder="0" style="width: 15px; text-align: center;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="include_spell_desc:-u">INCLUDE SPELL DESCRIPTION IN ATTACK:</span>
+                                        <select name="attr_includedesc">
+                                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                                            <option value="partial" data-i18n="partial">Partial</option>
+                                            <option value="on" data-i18n="on">On</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_spelldescription"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_spellathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="class:-u">CLASS:</span>
+                                    <input type="text" name="attr_spellclass" style="width: 45px;">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="type:-u">TYPE:</span>
+                                    <input type="text" name="attr_spellsource" style="width: 45px;">
+                                </div>
+                                <input type="hidden" name="attr_spellattackid">
+                                <input type="hidden" name="attr_spelllevel" value="8">
+                                <label class="options-done">
+                                    <input type="checkbox" name="attr_options-flag" checked="checked">
+                                    Done
+                                </label>
                             </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="casting-time:">Casting Time:</span>
-                                <span name="attr_spellcastingtime"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="range:">Range:</span>
-                                <span name="attr_spellrange"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="target:">Target:</span>
-                                <span name="attr_spelltarget"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="components:">Components:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
-                                <input type="hidden" name="attr_spellcomp_materials" value="">
-                                <span>(<span name="attr_spellcomp_materials"></span>)</span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="duration:">Duration:</span>
-                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration">Concentration</span>
-                                <span name="attr_spellduration"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="description:">Description:</span>
-                            </div>
-                            <div class="row">
-                                <span name="attr_spelldescription"></span>
-                            </div>
-                            <input type="hidden" name="attr_spellathigherlevels" value="">
-                            <div class="row">
-                                <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
-                                <span name="attr_spellathigherlevels"></span>
+                            <div class="details">
+                                <span class="row">
+                                    <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
+                                </span>
+                                <div class="row italics">
+                                    <span name="attr_spellschool"></span>
+                                    <span name="attr_spelllevel"></span>
+                                    <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                    <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="casting-time:">Casting Time:</span>
+                                    <span name="attr_spellcastingtime"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="range:">Range:</span>
+                                    <span name="attr_spellrange"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="target:">Target:</span>
+                                    <span name="attr_spelltarget"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="components:">Components:</span>
+                                    <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
+                                    <input type="hidden" name="attr_spellcomp_materials" value="">
+                                    <span>(<span name="attr_spellcomp_materials"></span>)</span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="duration:">Duration:</span>
+                                    <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration">Concentration</span>
+                                    <span name="attr_spellduration"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="description:">Description:</span>
+                                </div>
+                                <div class="row">
+                                    <span name="attr_spelldescription"></span>
+                                </div>
+                                <input type="hidden" name="attr_spellathigherlevels" value="">
+                                <div class="row">
+                                    <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
+                                    <span name="attr_spellathigherlevels"></span>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -4314,173 +4360,6 @@
             <div class="spell-container">
                 <fieldset class="repeating_spell-9">
                     <div class="spell">
-                        <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>y</span>
-                        <div class="options">
-                            <div class="row">
-                                <span data-i18n="name:-u">NAME:</span>
-                                <input type="text" name="attr_spellname">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="school:-u">SCHOOL:</span>
-                                <select name="attr_spellschool">
-                                    <option value="abjuration" data-i18n="abjuration">Abjuration</option>
-                                    <option value="conjuration" data-i18n="conjuration">Conjuration</option>
-                                    <option value="divination" data-i18n="divination">Divination</option>
-                                    <option value="enchantment" data-i18n="enchantment">Enchantment</option>
-                                    <option value="evocation" data-i18n="evocation">Evocation</option>
-                                    <option value="illusion" data-i18n="illusion">Illusion</option>
-                                    <option value="necromancy" data-i18n="necromancy">Necromancy</option>
-                                    <option value="transmutation" data-i18n="transmutation">Transmutation</option>
-                                </select>
-                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-                                <span data-i18n="ritual-u">RITUAL</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="casting-time:-u">CASTING TIME:</span>
-                                <input type="text" name="attr_spellcastingtime">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="range:-u">RANGE:</span>
-                                <input type="text" name="attr_spellrange">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="target:-u">TARGET:</span>
-                                <input type="text" name="attr_spelltarget">
-                            </div>
-                            <input type="hidden" name="attr_spellcomp">
-                            <div class="row">
-                                <span data-i18n="components:-u">COMPONENTS:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-                                <span data-i18n="spell-component-verbal">V</span>
-                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-                                <span data-i18n="spell-component-somatic">S</span>
-                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-                                <span data-i18n="spell-component-material">M</span>
-                                <input type="text" name="attr_spellcomp_materials" placeholder="ruby dust worth 50gp" data-i18n-placeholder="ruby-dust-place">
-                            </div>
-                            <div class="row">
-                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration-u">CONCENTRATION</span>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="duration:-u">DURATION:</span>
-                                <input type="text" name="attr_spellduration">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="spell-ability-u">SPELLCASTING ABILITY</span>
-                                <select name="attr_spell_ability">
-                                    <option value="0*" data-i18n="none-u">NONE</option>
-                                    <option value="spell" data-i18n="spell-u">SPELL</option>
-                                    <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
-                                    <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
-                                    <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
-                                    <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
-                                    <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
-                                    <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
-                                </select>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="innate:-u">INNATE:</span>
-                                <input type="text" name="attr_innate" placeholder="1/day" value="">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="output:-u">OUTPUT:</span>
-                                <select name="attr_spelloutput">
-                                    <option value="SPELLCARD" data-i18n="spellcard-u">SPELLCARD</option>
-                                    <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
-                                </select>
-                            </div>
-                            <input type="hidden" class="spellattackinfoflag" name="attr_spelloutput">
-                            <div class="spellattackinfo">
-                                <div class="row">
-                                    <span data-i18n="spell-atk:-u">SPELL ATTACK:</span>
-                                    <select name="attr_spellattack">
-                                        <option value="None" data-i18n="none">None</option>
-                                        <option value="Melee" data-i18n="melee">Melee</option>
-                                        <option value="Ranged" data-i18n="ranged">Ranged</option>
-                                    </select>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage:-u">DAMAGE:</span>
-                                    <input type="text" name="attr_spelldamage" style="width: 50px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_spelldamagetype" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="damage2:-u">DAMAGE2:</span>
-                                    <input type="text" name="attr_spelldamage2" style="width: 45px;">
-                                    <span data-i18n="type:-u">TYPE:</span>
-                                    <input type="text" name="attr_spelldamagetype2" style="width: 103px;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="healing:-u">HEALING:</span>
-                                    <input type="text" name="attr_spellhealing" style="width: 45px;">
-                                </div>
-                                <div class="row">
-                                    <input type="checkbox" name="attr_spelldmgmod" value="Yes">
-                                    <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="saving-throw:-u">SAVING THROW:</span>
-                                    <select name="attr_spellsave">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="Strength" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
-                                        <option value="Constitution" data-i18n="con-u">CON</option>
-                                        <option value="Intelligence" data-i18n="int-u">INT</option>
-                                        <option value="Wisdom" data-i18n="wis-u">WIS</option>
-                                        <option value="Charisma" data-i18n="cha-u">CHA</option>
-                                    </select>
-                                    <span data-i18n="effect:-u">EFFECT:</span>
-                                    <input type="text" name="attr_spellsavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
-                                    <input type="text" name="attr_spellhldie" placeholder="1" style="width: 15px; text-align: right;">
-                                    <select name="attr_spellhldietype">
-                                        <option value="" selected="selected" data-i18n="none-u">NONE</option>
-                                        <option value="d4">d4</option>
-                                        <option value="d6">d6</option>
-                                        <option value="d8">d8</option>
-                                        <option value="d10">d10</option>
-                                        <option value="d12">d12</option>
-                                        <option value="d20">d20</option>
-                                    </select>
-                                    <span>+</span>
-                                    <input type="text" name="attr_spellhlbonus" placeholder="0" style="width: 15px; text-align: center;">
-                                </div>
-                                <div class="row">
-                                    <span data-i18n="include_spell_desc:-u">INCLUDE SPELL DESCRIPTION IN ATTACK:</span>
-                                    <select name="attr_includedesc">
-                                        <option value="off" selected="selected" data-i18n="off">Off</option>
-                                        <option value="partial" data-i18n="partial">Partial</option>
-                                        <option value="on" data-i18n="on">On</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="description:-u">DESCRIPTION:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_spelldescription"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
-                            </div>
-                            <div class="row">
-                                <textarea name="attr_spellathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
-                            </div>
-                            <div class="row">
-                                <span data-i18n="class:-u">CLASS:</span>
-                                <input type="text" name="attr_spellclass" style="width: 45px;">
-                            </div>
-                            <div class="row">
-                                <span data-i18n="type:-u">TYPE:</span>
-                                <input type="text" name="attr_spellsource" style="width: 45px;">
-                            </div>
-                            <input type="hidden" name="attr_spellattackid">
-                            <input type="hidden" name="attr_spelllevel" value="9">
-                        </div>
                         <div class="display">
                             <input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}}  {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
                             <input type="checkbox" name="attr_spellprepared" value="1" class="sheet-prep-box"><span class="prep"></span>
@@ -4503,51 +4382,224 @@
                             </span>
                         </div>
                         <input class="details-flag" type="checkbox"><span>i</span>
-                        <div class="details">
+                        <div class="wrapper">
+                            <input class="options-flag" type="checkbox" name="attr_options-flag" checked="checked"><span>p</span>
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
-                            <span class="row">
-                                <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
-                            </span>
-                            <div class="row italics">
-                                <span name="attr_spellschool"></span>
-                                <span name="attr_spelllevel"></span>
-                                <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-                                <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                            <div class="options">
+                                <div class="row">
+                                    <span data-i18n="name:-u">NAME:</span>
+                                    <input type="text" name="attr_spellname">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="school:-u">SCHOOL:</span>
+                                    <select name="attr_spellschool">
+                                        <option value="abjuration" data-i18n="abjuration">Abjuration</option>
+                                        <option value="conjuration" data-i18n="conjuration">Conjuration</option>
+                                        <option value="divination" data-i18n="divination">Divination</option>
+                                        <option value="enchantment" data-i18n="enchantment">Enchantment</option>
+                                        <option value="evocation" data-i18n="evocation">Evocation</option>
+                                        <option value="illusion" data-i18n="illusion">Illusion</option>
+                                        <option value="necromancy" data-i18n="necromancy">Necromancy</option>
+                                        <option value="transmutation" data-i18n="transmutation">Transmutation</option>
+                                    </select>
+                                    <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                    <span data-i18n="ritual-u">RITUAL</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="casting-time:-u">CASTING TIME:</span>
+                                    <input type="text" name="attr_spellcastingtime">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="range:-u">RANGE:</span>
+                                    <input type="text" name="attr_spellrange">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="target:-u">TARGET:</span>
+                                    <input type="text" name="attr_spelltarget">
+                                </div>
+                                <input type="hidden" name="attr_spellcomp">
+                                <div class="row">
+                                    <span data-i18n="components:-u">COMPONENTS:</span>
+                                    <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
+                                    <span data-i18n="spell-component-verbal">V</span>
+                                    <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
+                                    <span data-i18n="spell-component-somatic">S</span>
+                                    <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
+                                    <span data-i18n="spell-component-material">M</span>
+                                    <input type="text" name="attr_spellcomp_materials" placeholder="ruby dust worth 50gp" data-i18n-placeholder="ruby-dust-place">
+                                </div>
+                                <div class="row">
+                                    <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration-u">CONCENTRATION</span>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="duration:-u">DURATION:</span>
+                                    <input type="text" name="attr_spellduration">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="spell-ability-u">SPELLCASTING ABILITY</span>
+                                    <select name="attr_spell_ability">
+                                        <option value="0*" data-i18n="none-u">NONE</option>
+                                        <option value="spell" data-i18n="spell-u">SPELL</option>
+                                        <option value="@{strength_mod}+" data-i18n="strength-u">STRENGTH</option>
+                                        <option value="@{dexterity_mod}+" data-i18n="dexterity-u">DEXTERITY</option>
+                                        <option value="@{constitution_mod}+" data-i18n="constitution-u">CONSTITUTION</option>
+                                        <option value="@{intelligence_mod}+" data-i18n="intelligence-u">INTELLIGENCE</option>
+                                        <option value="@{wisdom_mod}+" data-i18n="wisdom-u">WISDOM</option>
+                                        <option value="@{charisma_mod}+" data-i18n="charisma-u">CHARISMA</option>
+                                    </select>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="innate:-u">INNATE:</span>
+                                    <input type="text" name="attr_innate" placeholder="1/day" value="">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="output:-u">OUTPUT:</span>
+                                    <select name="attr_spelloutput">
+                                        <option value="SPELLCARD" data-i18n="spellcard-u">SPELLCARD</option>
+                                        <option value="ATTACK" data-i18n="attack-u">ATTACK</option>
+                                    </select>
+                                </div>
+                                <input type="hidden" class="spellattackinfoflag" name="attr_spelloutput">
+                                <div class="spellattackinfo">
+                                    <div class="row">
+                                        <span data-i18n="spell-atk:-u">SPELL ATTACK:</span>
+                                        <select name="attr_spellattack">
+                                            <option value="None" data-i18n="none">None</option>
+                                            <option value="Melee" data-i18n="melee">Melee</option>
+                                            <option value="Ranged" data-i18n="ranged">Ranged</option>
+                                        </select>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage:-u">DAMAGE:</span>
+                                        <input type="text" name="attr_spelldamage" style="width: 50px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_spelldamagetype" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="damage2:-u">DAMAGE2:</span>
+                                        <input type="text" name="attr_spelldamage2" style="width: 45px;">
+                                        <span data-i18n="type:-u">TYPE:</span>
+                                        <input type="text" name="attr_spelldamagetype2" style="width: 103px;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="healing:-u">HEALING:</span>
+                                        <input type="text" name="attr_spellhealing" style="width: 45px;">
+                                    </div>
+                                    <div class="row">
+                                        <input type="checkbox" name="attr_spelldmgmod" value="Yes">
+                                        <span data-i18n="add-ability-mod-u">ADD ABILITY MOD TO DAMAGE OR HEALING</span>
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="saving-throw:-u">SAVING THROW:</span>
+                                        <select name="attr_spellsave">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="Strength" data-i18n="str-u">STR</option>
+                                            <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                            <option value="Constitution" data-i18n="con-u">CON</option>
+                                            <option value="Intelligence" data-i18n="int-u">INT</option>
+                                            <option value="Wisdom" data-i18n="wis-u">WIS</option>
+                                            <option value="Charisma" data-i18n="cha-u">CHA</option>
+                                        </select>
+                                        <span data-i18n="effect:-u">EFFECT:</span>
+                                        <input type="text" name="attr_spellsavesuccess" style="width: 78px;" placeholder="Half damage" data-i18n-placeholder="half-dmg-place">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="at-higher-lvl-dmg:-u">HIGHER LVL CAST DMG:</span>
+                                        <input type="text" name="attr_spellhldie" placeholder="1" style="width: 15px; text-align: right;">
+                                        <select name="attr_spellhldietype">
+                                            <option value="" selected="selected" data-i18n="none-u">NONE</option>
+                                            <option value="d4">d4</option>
+                                            <option value="d6">d6</option>
+                                            <option value="d8">d8</option>
+                                            <option value="d10">d10</option>
+                                            <option value="d12">d12</option>
+                                            <option value="d20">d20</option>
+                                        </select>
+                                        <span>+</span>
+                                        <input type="text" name="attr_spellhlbonus" placeholder="0" style="width: 15px; text-align: center;">
+                                    </div>
+                                    <div class="row">
+                                        <span data-i18n="include_spell_desc:-u">INCLUDE SPELL DESCRIPTION IN ATTACK:</span>
+                                        <select name="attr_includedesc">
+                                            <option value="off" selected="selected" data-i18n="off">Off</option>
+                                            <option value="partial" data-i18n="partial">Partial</option>
+                                            <option value="on" data-i18n="on">On</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="description:-u">DESCRIPTION:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_spelldescription"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="at-higher-lvl:-u">AT HIGHER LEVELS:</span>
+                                </div>
+                                <div class="row">
+                                    <textarea name="attr_spellathigherlevels" style="height: 36px; min-height: 36px;"></textarea>
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="class:-u">CLASS:</span>
+                                    <input type="text" name="attr_spellclass" style="width: 45px;">
+                                </div>
+                                <div class="row">
+                                    <span data-i18n="type:-u">TYPE:</span>
+                                    <input type="text" name="attr_spellsource" style="width: 45px;">
+                                </div>
+                                <input type="hidden" name="attr_spellattackid">
+                                <input type="hidden" name="attr_spelllevel" value="9">
+                                <label class="options-done">
+                                    <input type="checkbox" name="attr_options-flag" checked="checked">
+                                    Done
+                                </label>
                             </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="casting-time:">Casting Time:</span>
-                                <span name="attr_spellcastingtime"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="range:">Range:</span>
-                                <span name="attr_spellrange"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="target:">Target:</span>
-                                <span name="attr_spelltarget"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="components:">Components:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
-                                <input type="hidden" name="attr_spellcomp_materials" value="">
-                                <span>(<span name="attr_spellcomp_materials"></span>)</span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="duration:">Duration:</span>
-                                <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-                                <span data-i18n="concentration">Concentration</span>
-                                <span name="attr_spellduration"></span>
-                            </div>
-                            <div class="row">
-                                <span class="bold" data-i18n="description:">Description:</span>
-                            </div>
-                            <div class="row">
-                                <span name="attr_spelldescription"></span>
-                            </div>
-                            <input type="hidden" name="attr_spellathigherlevels" value="">
-                            <div class="row">
-                                <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
-                                <span name="attr_spellathigherlevels"></span>
+                            <div class="details">
+                                <span class="row">
+                                    <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
+                                </span>
+                                <div class="row italics">
+                                    <span name="attr_spellschool"></span>
+                                    <span name="attr_spelllevel"></span>
+                                    <input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+                                    <span>(<span data-i18n="ritual-l">ritual</span>)</span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="casting-time:">Casting Time:</span>
+                                    <span name="attr_spellcastingtime"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="range:">Range:</span>
+                                    <span name="attr_spellrange"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="target:">Target:</span>
+                                    <span name="attr_spelltarget"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="components:">Components:</span>
+                                    <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
+                                    <input type="hidden" name="attr_spellcomp_materials" value="">
+                                    <span>(<span name="attr_spellcomp_materials"></span>)</span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="duration:">Duration:</span>
+                                    <input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+                                    <span data-i18n="concentration">Concentration</span>
+                                    <span name="attr_spellduration"></span>
+                                </div>
+                                <div class="row">
+                                    <span class="bold" data-i18n="description:">Description:</span>
+                                </div>
+                                <div class="row">
+                                    <span name="attr_spelldescription"></span>
+                                </div>
+                                <input type="hidden" name="attr_spellathigherlevels" value="">
+                                <div class="row">
+                                    <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
+                                    <span name="attr_spellathigherlevels"></span>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -2209,10 +2209,10 @@
                         <input class="details-flag" type="checkbox"><span>i</span>
                         <div class="details">
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
-                            <a class="row">
+                            <span class="row">
                                 <span name="attr_spellname"></span>
                                 <span name="attr_innate"></span>
-                            </a>
+                            </span>
                             <div class="row italics">
                                 <span name="attr_spellschool"></span>
                                 <span name="attr_spelllevel"></span>
@@ -2472,10 +2472,10 @@
                         <input class="details-flag" type="checkbox"><span>i</span>
                         <div class="details">
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
-                            <a class="row">
+                            <span class="row">
                                 <span name="attr_spellname"></span>
                                 <span name="attr_innate"></span>
-                            </a>
+                            </span>
                             <div class="row italics">
                                 <span name="attr_spellschool"></span>
                                 <span name="attr_spelllevel"></span>
@@ -2731,10 +2731,10 @@
                         <input class="details-flag" type="checkbox"><span>i</span>
                         <div class="details">
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
-                            <a class="row">
+                            <span class="row">
                                 <span name="attr_spellname"></span>
                                 <span name="attr_innate"></span>
-                            </a>
+                            </span>
                             <div class="row italics">
                                 <span name="attr_spellschool"></span>
                                 <span name="attr_spelllevel"></span>
@@ -2993,10 +2993,10 @@
                         <input class="details-flag" type="checkbox"><span>i</span>
                         <div class="details">
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
-                            <a class="row">
+                            <span class="row">
                                 <span name="attr_spellname"></span>
                                 <span name="attr_innate"></span>
-                            </a>
+                            </span>
                             <div class="row italics">
                                 <span name="attr_spellschool"></span>
                                 <span name="attr_spelllevel"></span>
@@ -3252,10 +3252,10 @@
                         <input class="details-flag" type="checkbox"><span>i</span>
                         <div class="details">
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
-                            <a class="row">
+                            <span class="row">
                                 <span name="attr_spellname"></span>
                                 <span name="attr_innate"></span>
-                            </a>
+                            </span>
                             <div class="row italics">
                                 <span name="attr_spellschool"></span>
                                 <span name="attr_spelllevel"></span>
@@ -3511,10 +3511,10 @@
                         <input class="details-flag" type="checkbox"><span>i</span>
                         <div class="details">
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
-                            <a class="row">
+                            <span class="row">
                                 <span name="attr_spellname"></span>
                                 <span name="attr_innate"></span>
-                            </a>
+                            </span>
                             <div class="row italics">
                                 <span name="attr_spellschool"></span>
                                 <span name="attr_spelllevel"></span>
@@ -3773,10 +3773,10 @@
                         <input class="details-flag" type="checkbox"><span>i</span>
                         <div class="details">
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
-                            <a class="row">
+                            <span class="row">
                                 <span name="attr_spellname"></span>
                                 <span name="attr_innate"></span>
-                            </a>
+                            </span>
                             <div class="row italics">
                                 <span name="attr_spellschool"></span>
                                 <span name="attr_spelllevel"></span>
@@ -4032,10 +4032,10 @@
                         <input class="details-flag" type="checkbox"><span>i</span>
                         <div class="details">
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
-                            <a class="row">
+                            <span class="row">
                                 <span name="attr_spellname"></span>
                                 <span name="attr_innate"></span>
-                            </a>
+                            </span>
                             <div class="row italics">
                                 <span name="attr_spellschool"></span>
                                 <span name="attr_spelllevel"></span>
@@ -4291,10 +4291,10 @@
                         <input class="details-flag" type="checkbox"><span>i</span>
                         <div class="details">
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
-                            <a class="row">
+                            <span class="row">
                                 <span name="attr_spellname"></span>
                                 <span name="attr_innate"></span>
-                            </a>
+                            </span>
                             <div class="row italics">
                                 <span name="attr_spellschool"></span>
                                 <span name="attr_spelllevel"></span>
@@ -4550,10 +4550,10 @@
                         <input class="details-flag" type="checkbox"><span>i</span>
                         <div class="details">
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
-                            <a class="row">
+                            <span class="row">
                                 <span name="attr_spellname"></span>
                                 <span name="attr_innate"></span>
-                            </a>
+                            </span>
                             <div class="row italics">
                                 <span name="attr_spellschool"></span>
                                 <span name="attr_spelllevel"></span>

--- a/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
+++ b/5th Edition OGL by Roll20/5th Edition OGL by Roll20.html
@@ -2210,8 +2210,7 @@
                         <div class="details">
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
                             <span class="row">
-                                <span name="attr_spellname"></span>
-                                <span name="attr_innate"></span>
+                                <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
                             </span>
                             <div class="row italics">
                                 <span name="attr_spellschool"></span>
@@ -2233,13 +2232,8 @@
                             </div>
                             <div class="row">
                                 <span class="bold" data-i18n="components:">Components:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-                                <span data-i18n="spell-component-verbal">V</span>
-                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-                                <span data-i18n="spell-component-somatic">S</span>
-                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-                                <span data-i18n="spell-component-material">M</span>
-                                <input type="text" name="attr_spellcomp_materials" required>
+                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
+                                <input type="hidden" name="attr_spellcomp_materials" value="">
                                 <span>(<span name="attr_spellcomp_materials"></span>)</span>
                             </div>
                             <div class="row">
@@ -2254,6 +2248,7 @@
                             <div class="row">
                                 <span name="attr_spelldescription"></span>
                             </div>
+                            <input type="hidden" name="attr_spellathigherlevels" value="">
                             <div class="row">
                                 <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
                                 <span name="attr_spellathigherlevels"></span>
@@ -2473,8 +2468,7 @@
                         <div class="details">
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
                             <span class="row">
-                                <span name="attr_spellname"></span>
-                                <span name="attr_innate"></span>
+                                <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
                             </span>
                             <div class="row italics">
                                 <span name="attr_spellschool"></span>
@@ -2496,13 +2490,8 @@
                             </div>
                             <div class="row">
                                 <span class="bold" data-i18n="components:">Components:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-                                <span data-i18n="spell-component-verbal">V</span>
-                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-                                <span data-i18n="spell-component-somatic">S</span>
-                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-                                <span data-i18n="spell-component-material">M</span>
-                                <input type="text" name="attr_spellcomp_materials" required>
+                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
+                                <input type="hidden" name="attr_spellcomp_materials" value="">
                                 <span>(<span name="attr_spellcomp_materials"></span>)</span>
                             </div>
                             <div class="row">
@@ -2517,6 +2506,7 @@
                             <div class="row">
                                 <span name="attr_spelldescription"></span>
                             </div>
+                            <input type="hidden" name="attr_spellathigherlevels" value="">
                             <div class="row">
                                 <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
                                 <span name="attr_spellathigherlevels"></span>
@@ -2732,8 +2722,7 @@
                         <div class="details">
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
                             <span class="row">
-                                <span name="attr_spellname"></span>
-                                <span name="attr_innate"></span>
+                                <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
                             </span>
                             <div class="row italics">
                                 <span name="attr_spellschool"></span>
@@ -2755,13 +2744,8 @@
                             </div>
                             <div class="row">
                                 <span class="bold" data-i18n="components:">Components:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-                                <span data-i18n="spell-component-verbal">V</span>
-                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-                                <span data-i18n="spell-component-somatic">S</span>
-                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-                                <span data-i18n="spell-component-material">M</span>
-                                <input type="text" name="attr_spellcomp_materials" required>
+                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
+                                <input type="hidden" name="attr_spellcomp_materials" value="">
                                 <span>(<span name="attr_spellcomp_materials"></span>)</span>
                             </div>
                             <div class="row">
@@ -2776,6 +2760,7 @@
                             <div class="row">
                                 <span name="attr_spelldescription"></span>
                             </div>
+                            <input type="hidden" name="attr_spellathigherlevels" value="">
                             <div class="row">
                                 <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
                                 <span name="attr_spellathigherlevels"></span>
@@ -2994,8 +2979,7 @@
                         <div class="details">
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
                             <span class="row">
-                                <span name="attr_spellname"></span>
-                                <span name="attr_innate"></span>
+                                <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
                             </span>
                             <div class="row italics">
                                 <span name="attr_spellschool"></span>
@@ -3017,13 +3001,8 @@
                             </div>
                             <div class="row">
                                 <span class="bold" data-i18n="components:">Components:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-                                <span data-i18n="spell-component-verbal">V</span>
-                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-                                <span data-i18n="spell-component-somatic">S</span>
-                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-                                <span data-i18n="spell-component-material">M</span>
-                                <input type="text" name="attr_spellcomp_materials" required>
+                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
+                                <input type="hidden" name="attr_spellcomp_materials" value="">
                                 <span>(<span name="attr_spellcomp_materials"></span>)</span>
                             </div>
                             <div class="row">
@@ -3038,6 +3017,7 @@
                             <div class="row">
                                 <span name="attr_spelldescription"></span>
                             </div>
+                            <input type="hidden" name="attr_spellathigherlevels" value="">
                             <div class="row">
                                 <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
                                 <span name="attr_spellathigherlevels"></span>
@@ -3253,8 +3233,7 @@
                         <div class="details">
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
                             <span class="row">
-                                <span name="attr_spellname"></span>
-                                <span name="attr_innate"></span>
+                                <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
                             </span>
                             <div class="row italics">
                                 <span name="attr_spellschool"></span>
@@ -3276,13 +3255,8 @@
                             </div>
                             <div class="row">
                                 <span class="bold" data-i18n="components:">Components:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-                                <span data-i18n="spell-component-verbal">V</span>
-                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-                                <span data-i18n="spell-component-somatic">S</span>
-                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-                                <span data-i18n="spell-component-material">M</span>
-                                <input type="text" name="attr_spellcomp_materials" required>
+                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
+                                <input type="hidden" name="attr_spellcomp_materials" value="">
                                 <span>(<span name="attr_spellcomp_materials"></span>)</span>
                             </div>
                             <div class="row">
@@ -3297,6 +3271,7 @@
                             <div class="row">
                                 <span name="attr_spelldescription"></span>
                             </div>
+                            <input type="hidden" name="attr_spellathigherlevels" value="">
                             <div class="row">
                                 <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
                                 <span name="attr_spellathigherlevels"></span>
@@ -3512,8 +3487,7 @@
                         <div class="details">
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
                             <span class="row">
-                                <span name="attr_spellname"></span>
-                                <span name="attr_innate"></span>
+                                <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
                             </span>
                             <div class="row italics">
                                 <span name="attr_spellschool"></span>
@@ -3535,13 +3509,8 @@
                             </div>
                             <div class="row">
                                 <span class="bold" data-i18n="components:">Components:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-                                <span data-i18n="spell-component-verbal">V</span>
-                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-                                <span data-i18n="spell-component-somatic">S</span>
-                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-                                <span data-i18n="spell-component-material">M</span>
-                                <input type="text" name="attr_spellcomp_materials" required>
+                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
+                                <input type="hidden" name="attr_spellcomp_materials" value="">
                                 <span>(<span name="attr_spellcomp_materials"></span>)</span>
                             </div>
                             <div class="row">
@@ -3556,6 +3525,7 @@
                             <div class="row">
                                 <span name="attr_spelldescription"></span>
                             </div>
+                            <input type="hidden" name="attr_spellathigherlevels" value="">
                             <div class="row">
                                 <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
                                 <span name="attr_spellathigherlevels"></span>
@@ -3774,8 +3744,7 @@
                         <div class="details">
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
                             <span class="row">
-                                <span name="attr_spellname"></span>
-                                <span name="attr_innate"></span>
+                                <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
                             </span>
                             <div class="row italics">
                                 <span name="attr_spellschool"></span>
@@ -3797,13 +3766,8 @@
                             </div>
                             <div class="row">
                                 <span class="bold" data-i18n="components:">Components:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-                                <span data-i18n="spell-component-verbal">V</span>
-                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-                                <span data-i18n="spell-component-somatic">S</span>
-                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-                                <span data-i18n="spell-component-material">M</span>
-                                <input type="text" name="attr_spellcomp_materials" required>
+                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
+                                <input type="hidden" name="attr_spellcomp_materials" value="">
                                 <span>(<span name="attr_spellcomp_materials"></span>)</span>
                             </div>
                             <div class="row">
@@ -3818,6 +3782,7 @@
                             <div class="row">
                                 <span name="attr_spelldescription"></span>
                             </div>
+                            <input type="hidden" name="attr_spellathigherlevels" value="">
                             <div class="row">
                                 <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
                                 <span name="attr_spellathigherlevels"></span>
@@ -4033,8 +3998,7 @@
                         <div class="details">
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
                             <span class="row">
-                                <span name="attr_spellname"></span>
-                                <span name="attr_innate"></span>
+                                <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
                             </span>
                             <div class="row italics">
                                 <span name="attr_spellschool"></span>
@@ -4056,13 +4020,8 @@
                             </div>
                             <div class="row">
                                 <span class="bold" data-i18n="components:">Components:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-                                <span data-i18n="spell-component-verbal">V</span>
-                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-                                <span data-i18n="spell-component-somatic">S</span>
-                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-                                <span data-i18n="spell-component-material">M</span>
-                                <input type="text" name="attr_spellcomp_materials" required>
+                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
+                                <input type="hidden" name="attr_spellcomp_materials" value="">
                                 <span>(<span name="attr_spellcomp_materials"></span>)</span>
                             </div>
                             <div class="row">
@@ -4077,6 +4036,7 @@
                             <div class="row">
                                 <span name="attr_spelldescription"></span>
                             </div>
+                            <input type="hidden" name="attr_spellathigherlevels" value="">
                             <div class="row">
                                 <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
                                 <span name="attr_spellathigherlevels"></span>
@@ -4292,8 +4252,7 @@
                         <div class="details">
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
                             <span class="row">
-                                <span name="attr_spellname"></span>
-                                <span name="attr_innate"></span>
+                                <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
                             </span>
                             <div class="row italics">
                                 <span name="attr_spellschool"></span>
@@ -4315,13 +4274,8 @@
                             </div>
                             <div class="row">
                                 <span class="bold" data-i18n="components:">Components:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-                                <span data-i18n="spell-component-verbal">V</span>
-                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-                                <span data-i18n="spell-component-somatic">S</span>
-                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-                                <span data-i18n="spell-component-material">M</span>
-                                <input type="text" name="attr_spellcomp_materials" required>
+                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
+                                <input type="hidden" name="attr_spellcomp_materials" value="">
                                 <span>(<span name="attr_spellcomp_materials"></span>)</span>
                             </div>
                             <div class="row">
@@ -4336,6 +4290,7 @@
                             <div class="row">
                                 <span name="attr_spelldescription"></span>
                             </div>
+                            <input type="hidden" name="attr_spellathigherlevels" value="">
                             <div class="row">
                                 <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
                                 <span name="attr_spellathigherlevels"></span>
@@ -4551,8 +4506,7 @@
                         <div class="details">
                             <button class="spell_link" type="compendium" name="attr_spellname"></button>
                             <span class="row">
-                                <span name="attr_spellname"></span>
-                                <span name="attr_innate"></span>
+                                <span name="attr_spellname"></span><input class="innate_flag" type="hidden" name="attr_innate" value=""><span class="innate" name="attr_innate"></span>
                             </span>
                             <div class="row italics">
                                 <span name="attr_spellschool"></span>
@@ -4574,13 +4528,8 @@
                             </div>
                             <div class="row">
                                 <span class="bold" data-i18n="components:">Components:</span>
-                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-                                <span data-i18n="spell-component-verbal">V</span>
-                                <input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-                                <span data-i18n="spell-component-somatic">S</span>
-                                <input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-                                <span data-i18n="spell-component-material">M</span>
-                                <input type="text" name="attr_spellcomp_materials" required>
+                                <input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked"><span data-i18n="spell-component-verbal">V</span><input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked"><span data-i18n="spell-component-somatic">S</span><input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked"><span class="spellcomp_m" data-i18n="spell-component-material">M</span>
+                                <input type="hidden" name="attr_spellcomp_materials" value="">
                                 <span>(<span name="attr_spellcomp_materials"></span>)</span>
                             </div>
                             <div class="row">
@@ -4595,6 +4544,7 @@
                             <div class="row">
                                 <span name="attr_spelldescription"></span>
                             </div>
+                            <input type="hidden" name="attr_spellathigherlevels" value="">
                             <div class="row">
                                 <span class="bold italics" data-i18n="at-higher-lvl">At Higher Levels</span>
                                 <span name="attr_spellathigherlevels"></span>

--- a/5th Edition OGL by Roll20/_translation.json
+++ b/5th Edition OGL by Roll20/_translation.json
@@ -318,6 +318,7 @@
 	"ammunition:-u": "AMMUNITION:",
 	"ammunition-place": "Arrows",
 	"description:-u": "DESCRIPTION:",
+	"description:": "Description:",
 	"description-place": "Up to 2 creatures within 5 feet",
 	"atk-spellcasting-u": "ATTACKS &amp; SPELLCASTING",
 	"copper-piece-u": "CP",


### PR DESCRIPTION
## Changes / Comments
Adds a button next to the settings button in the spells section that opens a detailed view of the spell.
![expand](https://user-images.githubusercontent.com/1530025/67816281-b746f600-fa66-11e9-98e4-e75f51e0a491.png)

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
