### PR TITLE
[Exalted 2E] Add Dragon-Blooded stat-blocks

### DIFF
--- a/Exalted2e/README.md
+++ b/Exalted2e/README.md
@@ -6,9 +6,17 @@ Character sheet for _Exalted, Second Edition_ by White Wolf Publishing.
 
 `exalted2e.css` and `exalted2e.html` **must** be saved with Unicode encoding. Using Unicode character codes does not currently work with the character sheet system, so the characters themselves must be used. Saving the file as ANSI, etc. will break the appearance of the character sheet.
 
+### To Do
+* Add Ability sections for Lunars, Abyssals, Infernals and Sidereals
+* Fix the stat-tracking radio-inputs so that stats are truly zeroed with the first radio-button, in the way every other Wolrd of Darkness sheet works
+* Fix roll buttons in Combat section
+* Add roll buttons for stats in general
+* Refactor code: move roll template to the end, place html sections in order they appear on sheet, borrow more code from later WoD sheets 
+
 ### Contributors
 
 If you feel you've contributed to the development of this character sheet, don't forget to add your name here!
 
 * Brian Shields
 * Benjamin Bandelow
+* Andreas J.

--- a/Exalted2e/exalted2e.css
+++ b/Exalted2e/exalted2e.css
@@ -538,63 +538,6 @@ input[type=checkbox] + span::before
 
 .sheet-familiar-health-row select.sheet-health-value { float: none; }
 
-/* makes radio button for zeroing stat partially transparent by default, and solid on hover */
-/* Styles unique to fake checkbox (unchecked) */
-/*
-.sheet-dots input[type="checkbox"].sheet-normal + span::before
-{
-    position:relative;
-    content: "";
-    opacity: 1.0;
-    width: 10px;
-    height: 10px;
-    font-size: 12px;
-
-    -moz-border-radius: 1px;
-    -webkit-border-radius: 1px;
-    border-radius: 1px;
-}
-
-.sheet-dots input[type="checkbox"].sheet-normal:checked + span::before
-{
-    background:
-        linear-gradient(to top left,
-           rgba(0,0,0,0) 0%,
-           rgba(0,0,0,0) calc(50% - 0.8px),
-           rgba(0,0,0,1) 50%,
-           rgba(0,0,0,0) calc(50% + 0.8px),
-           rgba(0,0,0,0) 100%),
-       linear-gradient(to top right,
-           rgba(0,0,0,0) 0%,
-           rgba(0,0,0,0) calc(50% - 0.8px),
-           rgba(0,0,0,1) 50%,
-           rgba(0,0,0,0) calc(50% + 0.8px),
-           rgba(0,0,0,0) 100%);
-
-    -moz-box-shadow: 0 0 2px transparent;
-    -webkit-box-shadow: 0 0 2px transparent;
-    box-shadow: 0 0 2px transparent;
-}
-
-
-.sheet-dots input[type="radio"].sheet-normal:checked ~ input[type="radio"] + span::before
-{
-    content: "";
-}
-
-
-.sheet-dots input[type=radio].sheet-zero:checked + span::before{ opacity: 0; }
-
-.sheet-dots input[type=radio].sheet-zero:hover + span::before
-{
-    opacity: 0.75;
-    font-size: 12px;
-    content: "✖";
-    text-indent: 0.5px;
-}
-
-.sheet-dots input[type=radio].sheet-zero + span::before { opacity: 0.4; }
-*/
 
 /* *************** */
 /*      TABS       */

--- a/Exalted2e/exalted2e.css
+++ b/Exalted2e/exalted2e.css
@@ -1,3 +1,18 @@
+/*    TOC
+....
+1. Roll Templates..
+2. General Styling.
+3. Checkboxes......
+4. Tabs............
+5. Misc............
+6. Caste Abilities.
+....
+ */
+
+/* *************** */
+/*  Roll Templates */
+/* *************** */
+
 .sheet-rolltemplate-joinbattle > div > img,
 .sheet-rolltemplate-joindebate > div > img,
 .sheet-rolltemplate-joinwar > div > img {
@@ -61,6 +76,11 @@
     padding: 0 3px 0 3px;
 }
 .sheet-rolltemplate-damage span.sheet-damage-type::first-letter { text-transform: uppercase; }
+
+
+/* *************** */
+/* General Styling */
+/* *************** */
 
 .charsheet
 {
@@ -401,12 +421,16 @@ label.sheet-soak input:focus,
     padding-right: 0;
 }
 
+
+/* *************** */
+/*   Checkboxes    */
+/* *************** */
+
 input[type=radio],
 input[type=checkbox]
 {
     cursor: pointer;
-
-    top:    5px;
+    top:    2px;
     left:   6px;
     width:  16px;
     height: 16px;
@@ -514,6 +538,68 @@ input[type=checkbox] + span::before
 
 .sheet-familiar-health-row select.sheet-health-value { float: none; }
 
+/* makes radio button for zeroing stat partially transparent by default, and solid on hover */
+/* Styles unique to fake checkbox (unchecked) */
+/*
+.sheet-dots input[type="checkbox"].sheet-normal + span::before
+{
+    position:relative;
+    content: "";
+    opacity: 1.0;
+    width: 10px;
+    height: 10px;
+    font-size: 12px;
+
+    -moz-border-radius: 1px;
+    -webkit-border-radius: 1px;
+    border-radius: 1px;
+}
+
+.sheet-dots input[type="checkbox"].sheet-normal:checked + span::before
+{
+    background:
+        linear-gradient(to top left,
+           rgba(0,0,0,0) 0%,
+           rgba(0,0,0,0) calc(50% - 0.8px),
+           rgba(0,0,0,1) 50%,
+           rgba(0,0,0,0) calc(50% + 0.8px),
+           rgba(0,0,0,0) 100%),
+       linear-gradient(to top right,
+           rgba(0,0,0,0) 0%,
+           rgba(0,0,0,0) calc(50% - 0.8px),
+           rgba(0,0,0,1) 50%,
+           rgba(0,0,0,0) calc(50% + 0.8px),
+           rgba(0,0,0,0) 100%);
+
+    -moz-box-shadow: 0 0 2px transparent;
+    -webkit-box-shadow: 0 0 2px transparent;
+    box-shadow: 0 0 2px transparent;
+}
+
+
+.sheet-dots input[type="radio"].sheet-normal:checked ~ input[type="radio"] + span::before
+{
+    content: "";
+}
+
+
+.sheet-dots input[type=radio].sheet-zero:checked + span::before{ opacity: 0; }
+
+.sheet-dots input[type=radio].sheet-zero:hover + span::before
+{
+    opacity: 0.75;
+    font-size: 12px;
+    content: "✖";
+    text-indent: 0.5px;
+}
+
+.sheet-dots input[type=radio].sheet-zero + span::before { opacity: 0.4; }
+*/
+
+/* *************** */
+/*      TABS       */
+/* *************** */
+
 input.sheet-tab
 {
     width:  100px;
@@ -574,6 +660,11 @@ input.sheet-tab:checked + span::before
 
 .sheet-tab-content { display: none; }
 
+
+/* *************** */
+/*      MISC       */
+/* *************** */
+
 .sheet-center,
 h3.sheet-ability,
 h4,
@@ -588,8 +679,9 @@ input[type=number] { text-align: center; }
 .sheet-intimacy .sheet-dots { text-align: right; }
 
 button[type=roll].sheet-blank-roll-button::before,
-input[type=radio]:not(.sheet-tab):checked ~ input[type=radio] + span::before,
-.sheet-dots input[type=checkbox]:checked ~ input[type=radio] + span::before { content: ""; }
+input[type=radio]:not(.sheet-tab):checked ~ input[type=radio] + span::before{ content: ""; }
+
+.sheet-dots input[type=radio]:not(.sheet-tab):checked ~ input[type=radio] + span::before{ content: ""; }
 
 span.sheet-attribute + div,
 span.sheet-ability + div,
@@ -624,38 +716,42 @@ div.sheet-attribute > input[type=checkbox]:first-child + span::before,
 .sheet-dots input[type=checkbox]:first-child:checked + span::before { opacity: 1; }
 
 
-/*Configure the tab buttons*/
+/* ********************* */
+/*     Caste Ability     */
+/* ********************* */
+
+/* Hides all Castes in 'Abilities'-section by default*/
 .sheet-solar-ab,
+.sheet-lunar-ab,
+.sheet-abyssal-ab,
+.sheet-sidereal-ab,
 .sheet-dragon-ab{
     display: none;
 }
 
-/* show the selected tab */
+/* selectively shows Caste Abilities based on selected caste/subcaste */
 .sheet-caste-toggle[value="Dawn"] ~ div.sheet-solar-ab,
 .sheet-caste-toggle[value="Zenith"] ~ div.sheet-solar-ab,
 .sheet-caste-toggle[value="Twilight"] ~ div.sheet-solar-ab,
 .sheet-caste-toggle[value="Night"] ~ div.sheet-solar-ab,
 .sheet-caste-toggle[value="Eclipse"] ~ div.sheet-solar-ab,
-.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
-.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
-.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
-
-.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
-.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
-.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
-.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
-.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
-
-.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
-.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
-.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
-.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
-.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
-
+.sheet-caste-toggle[value="FullMoon"] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value="ChangingMoon"] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value="NoMoon"] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value="Dusk"] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value="Day"] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value="Midnight"] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value="Moonshadow"] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value="Daybreak"] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value="Journey"] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value="Serenity"] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value="Battle"] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value="Secret"] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value="Ending"] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value="Air"] ~ div.sheet-dragon-ab,
 .sheet-caste-toggle[value="Earth"] ~ div.sheet-dragon-ab,
 .sheet-caste-toggle[value="Fire"] ~ div.sheet-dragon-ab,
 .sheet-caste-toggle[value="Water"] ~ div.sheet-dragon-ab,
-.sheet-caste-toggle[value="Air"] ~ div.sheet-dragon-ab,
 .sheet-caste-toggle[value="Wood"] ~ div.sheet-dragon-ab,{
     display: block;
 }

--- a/Exalted2e/exalted2e.css
+++ b/Exalted2e/exalted2e.css
@@ -622,3 +622,40 @@ div.sheet-ability > input[type=checkbox]:first-child + span::before,
 div.sheet-attribute > input[type=checkbox]:first-child + span::before,
 .sheet-dots input[type=checkbox]:first-child:hover + span::before,
 .sheet-dots input[type=checkbox]:first-child:checked + span::before { opacity: 1; }
+
+
+/*Configure the tab buttons*/
+.sheet-solar-ab,
+.sheet-dragon-ab{
+    display: none;
+}
+
+/* show the selected tab */
+.sheet-caste-toggle[value="Dawn"] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value="Zenith"] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value="Twilight"] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value="Night"] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value="Eclipse"] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
+
+.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
+
+.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
+.sheet-caste-toggle[value=""] ~ div.sheet-solar-ab,
+
+.sheet-caste-toggle[value="Earth"] ~ div.sheet-dragon-ab,
+.sheet-caste-toggle[value="Fire"] ~ div.sheet-dragon-ab,
+.sheet-caste-toggle[value="Water"] ~ div.sheet-dragon-ab,
+.sheet-caste-toggle[value="Air"] ~ div.sheet-dragon-ab,
+.sheet-caste-toggle[value="Wood"] ~ div.sheet-dragon-ab,{
+    display: block;
+}

--- a/Exalted2e/exalted2e.css
+++ b/Exalted2e/exalted2e.css
@@ -626,7 +626,6 @@ input.sheet-tab:checked ~ input.sheet-tab + span::before
     background-image: -ms-linear-gradient(top, #cbd600, #d9b84e);
     background-image: -o-linear-gradient(top, #cbd600, #d9b84e);
     background-image: linear-gradient(to bottom, #cbd600, #d9b84e);
-    filter:           progid: DXImageTransform.Microsoft.gradient(GradientType=0, startColorstr=#cbd600, endColorstr=#d9b84e);
 
     color: #f8f8f8;
     content: attr(title);
@@ -653,7 +652,6 @@ input.sheet-tab:checked + span::before
     background-image: -ms-linear-gradient(top, #9ba300, #c9a32b);
     background-image: -o-linear-gradient(top, #9ba300, #c9a32b);
     background-image: linear-gradient(to bottom, #9ba300, #c9a32b);
-    filter:           progid: DXImageTransform.Microsoft.gradient(GradientType=0, startColorstr=#9ba300, endColorstr=#c9a32b);
 
     border: 1px solid #6a7000;
 }
@@ -679,9 +677,10 @@ input[type=number] { text-align: center; }
 .sheet-intimacy .sheet-dots { text-align: right; }
 
 button[type=roll].sheet-blank-roll-button::before,
-input[type=radio]:not(.sheet-tab):checked ~ input[type=radio] + span::before{ content: ""; }
+input[type=radio]:not(.sheet-tab):checked ~ input[type=radio] + span::before,
+.sheet-dots input[type=checkbox]:checked ~ input[type=radio] + span::before { content: ""; }
 
-.sheet-dots input[type=radio]:not(.sheet-tab):checked ~ input[type=radio] + span::before{ content: ""; }
+
 
 span.sheet-attribute + div,
 span.sheet-ability + div,
@@ -752,6 +751,6 @@ div.sheet-attribute > input[type=checkbox]:first-child + span::before,
 .sheet-caste-toggle[value="Earth"] ~ div.sheet-dragon-ab,
 .sheet-caste-toggle[value="Fire"] ~ div.sheet-dragon-ab,
 .sheet-caste-toggle[value="Water"] ~ div.sheet-dragon-ab,
-.sheet-caste-toggle[value="Wood"] ~ div.sheet-dragon-ab,{
+.sheet-caste-toggle[value="Wood"] ~ div.sheet-dragon-ab{
     display: block;
 }

--- a/Exalted2e/exalted2e.html
+++ b/Exalted2e/exalted2e.html
@@ -1069,7 +1069,7 @@
                     <input type="checkbox" name="attr_ArcheryFavored" value="1" /><span></span>
                     <span class="ability">Archery</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Archery_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Archery_max" value="1" checked="checked" /><span></span>
                         <input type="radio" name="attr_Archery" value="0" checked="checked" />
                         <input type="radio" name="attr_Archery" value="1" /><span></span>
                         <input type="radio" name="attr_Archery" value="2" /><span></span>
@@ -1082,7 +1082,7 @@
                     <input type="checkbox" name="attr_MartialArtsFavored" value="1" /><span></span>
                     <span class="ability">Martial Arts</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_MartialArts_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_MartialArts_max" value="1" checked="checked" /><span></span>
                         <input type="radio" name="attr_MartialArts" value="0" checked="checked"/>
                         <input type="radio" name="attr_MartialArts" value="1" /><span></span>
                         <input type="radio" name="attr_MartialArts" value="2" /><span></span>
@@ -1095,7 +1095,7 @@
                     <input type="checkbox" name="attr_MeleeFavored" value="1" /><span></span>
                     <span class="ability">Melee</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Melee_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Melee_max" value="1" checked="checked" /><span></span>
                         <input type="radio" name="attr_Melee" value="0" checked="checked" />
                         <input type="radio" name="attr_Melee" value="1" /><span></span>
                         <input type="radio" name="attr_Melee" value="2" /><span></span>
@@ -1108,7 +1108,7 @@
                     <input type="checkbox" name="attr_ThrownFavored" value="1" /><span></span>
                     <span class="ability">Thrown</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Thrown_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Thrown_max" value="1" checked="checked" /><span></span>
                         <input type="radio" name="attr_Thrown" value="0" checked="checked" />
                         <input type="radio" name="attr_Thrown" value="1" /><span></span>
                         <input type="radio" name="attr_Thrown" value="2" /><span></span>
@@ -1121,7 +1121,7 @@
                     <input type="checkbox" name="attr_WarFavored" value="1" /><span></span>
                     <span class="ability">War</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_War_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_War_max" value="1" checked="checked" /><span></span>
                         <input type="radio" name="attr_War" value="0" checked="checked" />
                         <input type="radio" name="attr_War" value="1" /><span></span>
                         <input type="radio" name="attr_War" value="2" /><span></span>
@@ -1139,7 +1139,7 @@
                     <input type="checkbox" name="attr_IntegrityFavored" value="1" /><span></span>
                     <span class="ability">Integrity</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Integrity_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Integrity_max" value="1" checked="checked" /><span></span>
                         <input type="radio" name="attr_Integrity" value="0" checked="checked" />
                         <input type="radio" name="attr_Integrity" value="1" /><span></span>
                         <input type="radio" name="attr_Integrity" value="2" /><span></span>
@@ -1152,7 +1152,7 @@
                     <input type="checkbox" name="attr_PerformanceFavored" value="1" /><span></span>
                     <span class="ability">Performance</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Performance_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Performance_max" value="1" checked="checked" /><span></span>
                         <input type="radio" name="attr_Performance" value="0" checked="checked" />
                         <input type="radio" name="attr_Performance" value="1" /><span></span>
                         <input type="radio" name="attr_Performance" value="2" /><span></span>
@@ -1165,7 +1165,7 @@
                     <input type="checkbox" name="attr_PresenceFavored" value="1" /><span></span>
                     <span class="ability">Presence</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Presence_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Presence_max" value="1" checked="checked" /><span></span>
                         <input type="radio" name="attr_Presence" value="0" checked="checked" />
                         <input type="radio" name="attr_Presence" value="1" /><span></span>
                         <input type="radio" name="attr_Presence" value="2" /><span></span>
@@ -1178,7 +1178,7 @@
                     <input type="checkbox" name="attr_ResistanceFavored" value="1" /><span></span>
                     <span class="ability">Resistance</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Resistance_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Resistance_max" value="1" checked="checked" /><span></span>
                         <input type="radio" name="attr_Resistance" value="0" checked="checked" />
                         <input type="radio" name="attr_Resistance" value="1" /><span></span>
                         <input type="radio" name="attr_Resistance" value="2" /><span></span>
@@ -1191,7 +1191,7 @@
                     <input type="checkbox" name="attr_SurvivalFavored" value="1" /><span></span>
                     <span class="ability">Survival</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Survival_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Survival_max" value="1" checked="checked" /><span></span>
                         <input type="radio" name="attr_Survival" value="0" checked="checked" />
                         <input type="radio" name="attr_Survival" value="1" /><span></span>
                         <input type="radio" name="attr_Survival" value="2" /><span></span>
@@ -1212,7 +1212,7 @@
                         <li title="[Mundane] Making small, decorative, or high-precision items">
                             Air
                             <div class="dots">
-                                <input type="checkbox" name="attr_CraftAir_max" value="1" /><span></span>
+                                <input type="checkbox" name="attr_CraftAir_max" value="1" checked="checked" /><span></span>
                                 <input type="radio" name="attr_CraftAir" value="0" checked="checked" />
                                 <input type="radio" name="attr_CraftAir" value="1" /><span></span>
                                 <input type="radio" name="attr_CraftAir" value="2" /><span></span>
@@ -1224,7 +1224,7 @@
                         <li title="[Mundane] Creating buildings and large objects with stone or earth">
                             Earth
                             <div class="dots">
-                                <input type="checkbox" name="attr_CraftEarth_max" value="1" /><span></span>
+                                <input type="checkbox" name="attr_CraftEarth_max" value="1" checked="checked" /><span></span>
                                 <input type="radio" name="attr_CraftEarth" value="0" checked="checked" />
                                 <input type="radio" name="attr_CraftEarth" value="1" /><span></span>
                                 <input type="radio" name="attr_CraftEarth" value="2" /><span></span>
@@ -1236,7 +1236,7 @@
                         <li title="[Mundane] Forging and casting large metal objects and creating objects using fire">
                             Fire
                             <div class="dots">
-                                <input type="checkbox" name="attr_CraftFire_max" value="1" /><span></span>
+                                <input type="checkbox" name="attr_CraftFire_max" value="1" checked="checked" /><span></span>
                                 <input type="radio" name="attr_CraftFire" value="0" checked="checked" />
                                 <input type="radio" name="attr_CraftFire" value="1" /><span></span>
                                 <input type="radio" name="attr_CraftFire" value="2" /><span></span>
@@ -1248,7 +1248,7 @@
                         <li title="[Mundane] Boiling and cooking plants, chemicals, and animal materials">
                             Water
                             <div class="dots">
-                                <input type="checkbox" name="attr_CraftWater_max" value="1" /><span></span>
+                                <input type="checkbox" name="attr_CraftWater_max" value="1" checked="checked" /><span></span>
                                 <input type="radio" name="attr_CraftWater" value="0" checked="checked" />
                                 <input type="radio" name="attr_CraftWater" value="1" /><span></span>
                                 <input type="radio" name="attr_CraftWater" value="2" /><span></span>
@@ -1260,7 +1260,7 @@
                         <li title="[Mundane] Carving, weaving, and manipulating natural elements">
                             Wood
                             <div class="dots">
-                                <input type="checkbox" name="attr_CraftWood_max" value="1" /><span></span>
+                                <input type="checkbox" name="attr_CraftWood_max" value="1" checked="checked" /><span></span>
                                 <input type="radio" name="attr_CraftWood" value="0" checked="checked" />
                                 <input type="radio" name="attr_CraftWood" value="1" /><span></span>
                                 <input type="radio" name="attr_CraftWood" value="2" /><span></span>
@@ -1272,7 +1272,7 @@
                         <li title="[Esoteric, Sidereal] Manipulate fate for certain Astrologies and Charms">
                             Fate
                             <div class="dots">
-                                <input type="checkbox" name="attr_CraftFate_max" value="1" /><span></span>
+                                <input type="checkbox" name="attr_CraftFate_max" value="1" checked="checked" /><span></span>
                                 <input type="radio" name="attr_CraftFate" value="0" checked="checked" />
                                 <input type="radio" name="attr_CraftFate" value="1" /><span></span>
                                 <input type="radio" name="attr_CraftFate" value="2" /><span></span>
@@ -1284,7 +1284,7 @@
                         <li title="[Esoteric, First Age] Create or modify life">
                             Genesis
                             <div class="dots">
-                                <input type="checkbox" name="attr_CraftGenesis_max" value="1" /><span></span>
+                                <input type="checkbox" name="attr_CraftGenesis_max" value="1" checked="checked" /><span></span>
                                 <input type="radio" name="attr_CraftGenesis" value="0" checked="checked" />
                                 <input type="radio" name="attr_CraftGenesis" value="1" /><span></span>
                                 <input type="radio" name="attr_CraftGenesis" value="2" /><span></span>
@@ -1296,7 +1296,7 @@
                         <li title="[Esoteric, Raksha] Manipulate the physical manifestation of shaping effects, from Essence to dreams">
                             Glamour
                             <div class="dots">
-                                <input type="checkbox" name="attr_CraftGlamour_max" value="1" /><span></span>
+                                <input type="checkbox" name="attr_CraftGlamour_max" value="1" checked="checked" /><span></span>
                                 <input type="radio" name="attr_CraftGlamour" value="0" checked="checked" />
                                 <input type="radio" name="attr_CraftGlamour" value="1" /><span></span>
                                 <input type="radio" name="attr_CraftGlamour" value="2" /><span></span>
@@ -1308,7 +1308,7 @@
                         <li title="[Esoteric, First Age] Creation, enchantment, and maintenance of First Age devices">
                             Magitech
                             <div class="dots">
-                                <input type="checkbox" name="attr_CraftMagitech_max" value="1" /><span></span>
+                                <input type="checkbox" name="attr_CraftMagitech_max" value="1" checked="checked" /><span></span>
                                 <input type="radio" name="attr_CraftMagitech" value="0" checked="checked" />
                                 <input type="radio" name="attr_CraftMagitech" value="1" /><span></span>
                                 <input type="radio" name="attr_CraftMagitech" value="2" /><span></span>
@@ -1320,7 +1320,7 @@
                         <li title="[Esoteric, Infernal] Use Malfean Vitriol to catalyze a mundane Craft">
                             Vitriol
                             <div class="dots">
-                                <input type="checkbox" name="attr_CraftVitriol_max" value="1" /><span></span>
+                                <input type="checkbox" name="attr_CraftVitriol_max" value="1" checked="checked" /><span></span>
                                 <input type="radio" name="attr_CraftVitriol" value="0" checked="checked" />
                                 <input type="radio" name="attr_CraftVitriol" value="1" /><span></span>
                                 <input type="radio" name="attr_CraftVitriol" value="2" /><span></span>
@@ -1336,7 +1336,7 @@
                     <input type="checkbox" name="attr_InvestigationFavored" value="1" /><span></span>
                     <span class="ability">Investigation</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Investigation_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Investigation_max" value="1" checked="checked" /><span></span>
                         <input type="radio" name="attr_Investigation" value="0" checked="checked" />
                         <input type="radio" name="attr_Investigation" value="1" /><span></span>
                         <input type="radio" name="attr_Investigation" value="2" /><span></span>
@@ -1349,7 +1349,7 @@
                     <input type="checkbox" name="attr_LoreFavored" value="1" /><span></span>
                     <span class="ability">Lore</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Lore_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Lore_max" value="1" checked="checked" /><span></span>
                         <input type="radio" name="attr_Lore" value="0" checked="checked" />
                         <input type="radio" name="attr_Lore" value="1" /><span></span>
                         <input type="radio" name="attr_Lore" value="2" /><span></span>
@@ -1362,7 +1362,7 @@
                     <input type="checkbox" name="attr_MedicineFavored" value="1" /><span></span>
                     <span class="ability">Medicine</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Medicine_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Medicine_max" value="1" checked="checked" /><span></span>
                         <input type="radio" name="attr_Medicine" value="0" checked="checked" />
                         <input type="radio" name="attr_Medicine" value="1" /><span></span>
                         <input type="radio" name="attr_Medicine" value="2" /><span></span>
@@ -1375,7 +1375,7 @@
                     <input type="checkbox" name="attr_OccultFavored" value="1" /><span></span>
                     <span class="ability">Occult</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Occult_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Occult_max" value="1" checked="checked" /><span></span>
                         <input type="radio" name="attr_Occult" value="0" checked="checked" />
                         <input type="radio" name="attr_Occult" value="1" /><span></span>
                         <input type="radio" name="attr_Occult" value="2" /><span></span>
@@ -1395,7 +1395,7 @@
                     <input type="checkbox" name="attr_AthleticsFavored" value="1" /><span></span>
                     <span class="ability">Athletics</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Athletics_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Athletics_max" value="1" checked="checked" checked="checked"/><span></span>
                         <input type="radio" name="attr_Athletics" value="0" checked="checked" />
                         <input type="radio" name="attr_Athletics" value="1" /><span></span>
                         <input type="radio" name="attr_Athletics" value="2" /><span></span>
@@ -1408,7 +1408,7 @@
                     <input type="checkbox" name="attr_AwarenessFavored" value="1" /><span></span>
                     <span class="ability">Awareness</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Awareness_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Awareness_max" value="1" checked="checked" checked="checked"/><span></span>
                         <input type="radio" name="attr_Awareness" value="0" checked="checked" />
                         <input type="radio" name="attr_Awareness" value="1" /><span></span>
                         <input type="radio" name="attr_Awareness" value="2" /><span></span>
@@ -1421,7 +1421,7 @@
                     <input type="checkbox" name="attr_DodgeFavored" value="1" /><span></span>
                     <span class="ability">Dodge</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Dodge_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Dodge_max" value="1" checked="checked" checked="checked"/><span></span>
                         <input type="radio" name="attr_Dodge" value="0" checked="checked" />
                         <input type="radio" name="attr_Dodge" value="1" /><span></span>
                         <input type="radio" name="attr_Dodge" value="2" /><span></span>
@@ -1434,7 +1434,7 @@
                     <input type="checkbox" name="attr_LarcenyFavored" value="1" /><span></span>
                     <span class="ability">Larceny</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Larceny_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Larceny_max" value="1" checked="checked" checked="checked"/><span></span>
                         <input type="radio" name="attr_Larceny" value="0" checked="checked" />
                         <input type="radio" name="attr_Larceny" value="1" /><span></span>
                         <input type="radio" name="attr_Larceny" value="2" /><span></span>
@@ -1447,7 +1447,7 @@
                     <input type="checkbox" name="attr_StealthFavored" value="1" /><span></span>
                     <span class="ability">Stealth</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Stealth_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Stealth_max" value="1" checked="checked" checked="checked"/><span></span>
                         <input type="radio" name="attr_Stealth" value="0" checked="checked" />
                         <input type="radio" name="attr_Stealth" value="1" /><span></span>
                         <input type="radio" name="attr_Stealth" value="2" /><span></span>
@@ -1465,7 +1465,7 @@
                     <input type="checkbox" name="attr_BureaucracyFavored" value="1" /><span></span>
                     <span class="ability">Bureaucracy</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Bureaucracy_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Bureaucracy_max" value="1" checked="checked" /><span></span>
                         <input type="radio" name="attr_Bureaucracy" value="0" checked="checked" />
                         <input type="radio" name="attr_Bureaucracy" value="1" /><span></span>
                         <input type="radio" name="attr_Bureaucracy" value="2" /><span></span>
@@ -1478,7 +1478,7 @@
                     <input type="checkbox" name="attr_LinguisticsFavored" value="1" /><span></span>
                     <span class="ability">Linguistics</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Linguistics_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Linguistics_max" value="1" checked="checked" /><span></span>
                         <input type="radio" name="attr_Linguistics" value="0" checked="checked" />
                         <input type="radio" name="attr_Linguistics" value="1" /><span></span>
                         <input type="radio" name="attr_Linguistics" value="2" /><span></span>
@@ -1491,7 +1491,7 @@
                     <input type="checkbox" name="attr_RideFavored" value="1" /><span></span>
                     <span class="ability">Ride</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Ride_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Ride_max" value="1" checked="checked" /><span></span>
                         <input type="radio" name="attr_Ride" value="0" checked="checked" />
                         <input type="radio" name="attr_Ride" value="1" /><span></span>
                         <input type="radio" name="attr_Ride" value="2" /><span></span>
@@ -1504,7 +1504,7 @@
                     <input type="checkbox" name="attr_SailFavored" value="1" /><span></span>
                     <span class="ability">Sail</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Sail_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Sail_max" value="1" checked="checked" /><span></span>
                         <input type="radio" name="attr_Sail" value="0" checked="checked" />
                         <input type="radio" name="attr_Sail" value="1" /><span></span>
                         <input type="radio" name="attr_Sail" value="2" /><span></span>
@@ -1517,7 +1517,7 @@
                     <input type="checkbox" name="attr_SocializeFavored" value="1" /><span></span>
                     <span class="ability">Socialize</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Socialize_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Socialize_max" value="1" checked="checked" /><span></span>
                         <input type="radio" name="attr_Socialize" value="0" checked="checked" />
                         <input type="radio" name="attr_Socialize" value="1" /><span></span>
                         <input type="radio" name="attr_Socialize" value="2" /><span></span>
@@ -1559,7 +1559,7 @@
                     <input type="checkbox" name="attr_LinguisticsFavored" value="1" /><span></span>
                     <span class="ability">Linguistics</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Linguistics_max" value="1" /><span></span>
+                        <input type="checkbox" name="attr_Linguistics_max" value="1"  /><span></span>
                         <input type="radio" name="attr_Linguistics" value="0" checked="checked" />
                         <input type="radio" name="attr_Linguistics" value="1" /><span></span>
                         <input type="radio" name="attr_Linguistics" value="2" /><span></span>

--- a/Exalted2e/exalted2e.html
+++ b/Exalted2e/exalted2e.html
@@ -1,3 +1,4 @@
+
 <rolltemplate class="sheet-rolltemplate-joinbattle">
     <div>
         <img src="http://i.imgur.com/SncEMzz.png" />
@@ -132,6 +133,12 @@
                 <option value="ChangingMoon">Lunar: Changing Moon</option>
                 <option value="NoMoon">Lunar: No Moon</option>
 
+                <option value="Dusk">Abyssal: Dusk</option>
+                <option value="Day">Abyssal: Day</option>
+                <option value="Midnight">Abyssal: Midnight</option>
+                <option value="Moonshadow">Abyssal: Moonshadow</option>
+                <option value="Daybreak">Abyssal: Daybreak</option>
+
                 <option value="Journey">Sidereal: Journey</option>
                 <option value="Serenity">Sidereal: Serenity</option>
                 <option value="Battle">Sidereal: Battle</option>
@@ -142,6 +149,7 @@
                 <option value="Fire">Dragon-Blooded: Fire</option>
                 <option value="Water">Dragon-Blooded: Water</option>
                 <option value="Air">Dragon-Blooded: Air</option>
+                <option value="Wood">Dragon-Blooded: Wood</option>
             </select>
         </label>
     </div>
@@ -1041,470 +1049,544 @@
     </div>
     
     <h1 class="separator"><span>Abilities</span></h1>
-    
-    <div class="sheet-3colrow">
-        <div class="sheet-col">
-            <h3 class="ability">Dawn</h3>
-            <div class="ability">
-                <input type="checkbox" name="attr_ArcheryFavored" value="1" /><span></span>
-                <span class="ability">Archery</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Archery_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Archery" value="0" checked="checked" />
-                    <input type="radio" name="attr_Archery" value="1" /><span></span>
-                    <input type="radio" name="attr_Archery" value="2" /><span></span>
-                    <input type="radio" name="attr_Archery" value="3" /><span></span>
-                    <input type="radio" name="attr_Archery" value="4" /><span></span>
-                    <input type="radio" name="attr_Archery" value="5" /><span></span>
+    <input name="attr_Caste" type="hidden" class="caste-toggle">
+    <div class="solar-ab">
+        <div class="sheet-3colrow">
+            <div class="sheet-col"> <!-- Dawn -->
+                <h3 class="ability">Dawn</h3>
+                <div class="ability">
+                    <input type="checkbox" name="attr_ArcheryFavored" value="1" /><span></span>
+                    <span class="ability">Archery</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Archery_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Archery" value="0" checked="checked" />
+                        <input type="radio" name="attr_Archery" value="1" /><span></span>
+                        <input type="radio" name="attr_Archery" value="2" /><span></span>
+                        <input type="radio" name="attr_Archery" value="3" /><span></span>
+                        <input type="radio" name="attr_Archery" value="4" /><span></span>
+                        <input type="radio" name="attr_Archery" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_MartialArtsFavored" value="1" /><span></span>
+                    <span class="ability">Martial Arts</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_MartialArts_max" value="1" /><span></span>
+                        <input type="radio" name="attr_MartialArts" value="0" checked="checked" />
+                        <input type="radio" name="attr_MartialArts" value="1" /><span></span>
+                        <input type="radio" name="attr_MartialArts" value="2" /><span></span>
+                        <input type="radio" name="attr_MartialArts" value="3" /><span></span>
+                        <input type="radio" name="attr_MartialArts" value="4" /><span></span>
+                        <input type="radio" name="attr_MartialArts" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_MeleeFavored" value="1" /><span></span>
+                    <span class="ability">Melee</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Melee_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Melee" value="0" checked="checked" />
+                        <input type="radio" name="attr_Melee" value="1" /><span></span>
+                        <input type="radio" name="attr_Melee" value="2" /><span></span>
+                        <input type="radio" name="attr_Melee" value="3" /><span></span>
+                        <input type="radio" name="attr_Melee" value="4" /><span></span>
+                        <input type="radio" name="attr_Melee" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_ThrownFavored" value="1" /><span></span>
+                    <span class="ability">Thrown</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Thrown_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Thrown" value="0" checked="checked" />
+                        <input type="radio" name="attr_Thrown" value="1" /><span></span>
+                        <input type="radio" name="attr_Thrown" value="2" /><span></span>
+                        <input type="radio" name="attr_Thrown" value="3" /><span></span>
+                        <input type="radio" name="attr_Thrown" value="4" /><span></span>
+                        <input type="radio" name="attr_Thrown" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_WarFavored" value="1" /><span></span>
+                    <span class="ability">War</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_War_max" value="1" /><span></span>
+                        <input type="radio" name="attr_War" value="0" checked="checked" />
+                        <input type="radio" name="attr_War" value="1" /><span></span>
+                        <input type="radio" name="attr_War" value="2" /><span></span>
+                        <input type="radio" name="attr_War" value="3" /><span></span>
+                        <input type="radio" name="attr_War" value="4" /><span></span>
+                        <input type="radio" name="attr_War" value="5" /><span></span>
+                    </div>
                 </div>
             </div>
-            <div class="ability">
-                <input type="checkbox" name="attr_MartialArtsFavored" value="1" /><span></span>
-                <span class="ability">Martial Arts</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_MartialArts_max" value="1" /><span></span>
-                    <input type="radio" name="attr_MartialArts" value="0" checked="checked" />
-                    <input type="radio" name="attr_MartialArts" value="1" /><span></span>
-                    <input type="radio" name="attr_MartialArts" value="2" /><span></span>
-                    <input type="radio" name="attr_MartialArts" value="3" /><span></span>
-                    <input type="radio" name="attr_MartialArts" value="4" /><span></span>
-                    <input type="radio" name="attr_MartialArts" value="5" /><span></span>
+
+            <div class="sheet-col"> <!-- Zenith -->
+                <h3 class="ability">Zenith</h3>
+                <div class="ability">
+                    <input type="checkbox" name="attr_IntegrityFavored" value="1" /><span></span>
+                    <span class="ability">Integrity</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Integrity_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Integrity" value="0" checked="checked" />
+                        <input type="radio" name="attr_Integrity" value="1" /><span></span>
+                        <input type="radio" name="attr_Integrity" value="2" /><span></span>
+                        <input type="radio" name="attr_Integrity" value="3" /><span></span>
+                        <input type="radio" name="attr_Integrity" value="4" /><span></span>
+                        <input type="radio" name="attr_Integrity" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_PerformanceFavored" value="1" /><span></span>
+                    <span class="ability">Performance</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Performance_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Performance" value="0" checked="checked" />
+                        <input type="radio" name="attr_Performance" value="1" /><span></span>
+                        <input type="radio" name="attr_Performance" value="2" /><span></span>
+                        <input type="radio" name="attr_Performance" value="3" /><span></span>
+                        <input type="radio" name="attr_Performance" value="4" /><span></span>
+                        <input type="radio" name="attr_Performance" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_PresenceFavored" value="1" /><span></span>
+                    <span class="ability">Presence</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Presence_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Presence" value="0" checked="checked" />
+                        <input type="radio" name="attr_Presence" value="1" /><span></span>
+                        <input type="radio" name="attr_Presence" value="2" /><span></span>
+                        <input type="radio" name="attr_Presence" value="3" /><span></span>
+                        <input type="radio" name="attr_Presence" value="4" /><span></span>
+                        <input type="radio" name="attr_Presence" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_ResistanceFavored" value="1" /><span></span>
+                    <span class="ability">Resistance</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Resistance_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Resistance" value="0" checked="checked" />
+                        <input type="radio" name="attr_Resistance" value="1" /><span></span>
+                        <input type="radio" name="attr_Resistance" value="2" /><span></span>
+                        <input type="radio" name="attr_Resistance" value="3" /><span></span>
+                        <input type="radio" name="attr_Resistance" value="4" /><span></span>
+                        <input type="radio" name="attr_Resistance" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_SurvivalFavored" value="1" /><span></span>
+                    <span class="ability">Survival</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Survival_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Survival" value="0" checked="checked" />
+                        <input type="radio" name="attr_Survival" value="1" /><span></span>
+                        <input type="radio" name="attr_Survival" value="2" /><span></span>
+                        <input type="radio" name="attr_Survival" value="3" /><span></span>
+                        <input type="radio" name="attr_Survival" value="4" /><span></span>
+                        <input type="radio" name="attr_Survival" value="5" /><span></span>
+                    </div>
                 </div>
             </div>
-            <div class="ability">
-                <input type="checkbox" name="attr_MeleeFavored" value="1" /><span></span>
-                <span class="ability">Melee</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Melee_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Melee" value="0" checked="checked" />
-                    <input type="radio" name="attr_Melee" value="1" /><span></span>
-                    <input type="radio" name="attr_Melee" value="2" /><span></span>
-                    <input type="radio" name="attr_Melee" value="3" /><span></span>
-                    <input type="radio" name="attr_Melee" value="4" /><span></span>
-                    <input type="radio" name="attr_Melee" value="5" /><span></span>
+
+            <div class="sheet-col"> <!-- Twilight -->
+                <h3 class="ability">Twilight</h3>
+                <div class="ability craft-types">
+                    <input type="checkbox" name="attr_CraftFavored" value="1" /><span></span>
+                    <span class="ability">Craft</span>
+                    <ul class="craft-types">
+                        <li title="[Mundane] Making small, decorative, or high-precision items">
+                            Air
+                            <div class="dots">
+                                <input type="checkbox" name="attr_CraftAir_max" value="1" /><span></span>
+                                <input type="radio" name="attr_CraftAir" value="0" checked="checked" />
+                                <input type="radio" name="attr_CraftAir" value="1" /><span></span>
+                                <input type="radio" name="attr_CraftAir" value="2" /><span></span>
+                                <input type="radio" name="attr_CraftAir" value="3" /><span></span>
+                                <input type="radio" name="attr_CraftAir" value="4" /><span></span>
+                                <input type="radio" name="attr_CraftAir" value="5" /><span></span>
+                            </div>
+                        </li>
+                        <li title="[Mundane] Creating buildings and large objects with stone or earth">
+                            Earth
+                            <div class="dots">
+                                <input type="checkbox" name="attr_CraftEarth_max" value="1" /><span></span>
+                                <input type="radio" name="attr_CraftEarth" value="0" checked="checked" />
+                                <input type="radio" name="attr_CraftEarth" value="1" /><span></span>
+                                <input type="radio" name="attr_CraftEarth" value="2" /><span></span>
+                                <input type="radio" name="attr_CraftEarth" value="3" /><span></span>
+                                <input type="radio" name="attr_CraftEarth" value="4" /><span></span>
+                                <input type="radio" name="attr_CraftEarth" value="5" /><span></span>
+                            </div>
+                        </li>
+                        <li title="[Mundane] Forging and casting large metal objects and creating objects using fire">
+                            Fire
+                            <div class="dots">
+                                <input type="checkbox" name="attr_CraftFire_max" value="1" /><span></span>
+                                <input type="radio" name="attr_CraftFire" value="0" checked="checked" />
+                                <input type="radio" name="attr_CraftFire" value="1" /><span></span>
+                                <input type="radio" name="attr_CraftFire" value="2" /><span></span>
+                                <input type="radio" name="attr_CraftFire" value="3" /><span></span>
+                                <input type="radio" name="attr_CraftFire" value="4" /><span></span>
+                                <input type="radio" name="attr_CraftFire" value="5" /><span></span>
+                            </div>
+                        </li>
+                        <li title="[Mundane] Boiling and cooking plants, chemicals, and animal materials">
+                            Water
+                            <div class="dots">
+                                <input type="checkbox" name="attr_CraftWater_max" value="1" /><span></span>
+                                <input type="radio" name="attr_CraftWater" value="0" checked="checked" />
+                                <input type="radio" name="attr_CraftWater" value="1" /><span></span>
+                                <input type="radio" name="attr_CraftWater" value="2" /><span></span>
+                                <input type="radio" name="attr_CraftWater" value="3" /><span></span>
+                                <input type="radio" name="attr_CraftWater" value="4" /><span></span>
+                                <input type="radio" name="attr_CraftWater" value="5" /><span></span>
+                            </div>
+                        </li>
+                        <li title="[Mundane] Carving, weaving, and manipulating natural elements">
+                            Wood
+                            <div class="dots">
+                                <input type="checkbox" name="attr_CraftWood_max" value="1" /><span></span>
+                                <input type="radio" name="attr_CraftWood" value="0" checked="checked" />
+                                <input type="radio" name="attr_CraftWood" value="1" /><span></span>
+                                <input type="radio" name="attr_CraftWood" value="2" /><span></span>
+                                <input type="radio" name="attr_CraftWood" value="3" /><span></span>
+                                <input type="radio" name="attr_CraftWood" value="4" /><span></span>
+                                <input type="radio" name="attr_CraftWood" value="5" /><span></span>
+                            </div>
+                        </li>
+                        <li title="[Esoteric, Sidereal] Manipulate fate for certain Astrologies and Charms">
+                            Fate
+                            <div class="dots">
+                                <input type="checkbox" name="attr_CraftFate_max" value="1" /><span></span>
+                                <input type="radio" name="attr_CraftFate" value="0" checked="checked" />
+                                <input type="radio" name="attr_CraftFate" value="1" /><span></span>
+                                <input type="radio" name="attr_CraftFate" value="2" /><span></span>
+                                <input type="radio" name="attr_CraftFate" value="3" /><span></span>
+                                <input type="radio" name="attr_CraftFate" value="4" /><span></span>
+                                <input type="radio" name="attr_CraftFate" value="5" /><span></span>
+                            </div>
+                        </li>
+                        <li title="[Esoteric, First Age] Create or modify life">
+                            Genesis
+                            <div class="dots">
+                                <input type="checkbox" name="attr_CraftGenesis_max" value="1" /><span></span>
+                                <input type="radio" name="attr_CraftGenesis" value="0" checked="checked" />
+                                <input type="radio" name="attr_CraftGenesis" value="1" /><span></span>
+                                <input type="radio" name="attr_CraftGenesis" value="2" /><span></span>
+                                <input type="radio" name="attr_CraftGenesis" value="3" /><span></span>
+                                <input type="radio" name="attr_CraftGenesis" value="4" /><span></span>
+                                <input type="radio" name="attr_CraftGenesis" value="5" /><span></span>
+                            </div>
+                        </li>
+                        <li title="[Esoteric, Raksha] Manipulate the physical manifestation of shaping effects, from Essence to dreams">
+                            Glamour
+                            <div class="dots">
+                                <input type="checkbox" name="attr_CraftGlamour_max" value="1" /><span></span>
+                                <input type="radio" name="attr_CraftGlamour" value="0" checked="checked" />
+                                <input type="radio" name="attr_CraftGlamour" value="1" /><span></span>
+                                <input type="radio" name="attr_CraftGlamour" value="2" /><span></span>
+                                <input type="radio" name="attr_CraftGlamour" value="3" /><span></span>
+                                <input type="radio" name="attr_CraftGlamour" value="4" /><span></span>
+                                <input type="radio" name="attr_CraftGlamour" value="5" /><span></span>
+                            </div>
+                        </li>
+                        <li title="[Esoteric, First Age] Creation, enchantment, and maintenance of First Age devices">
+                            Magitech
+                            <div class="dots">
+                                <input type="checkbox" name="attr_CraftMagitech_max" value="1" /><span></span>
+                                <input type="radio" name="attr_CraftMagitech" value="0" checked="checked" />
+                                <input type="radio" name="attr_CraftMagitech" value="1" /><span></span>
+                                <input type="radio" name="attr_CraftMagitech" value="2" /><span></span>
+                                <input type="radio" name="attr_CraftMagitech" value="3" /><span></span>
+                                <input type="radio" name="attr_CraftMagitech" value="4" /><span></span>
+                                <input type="radio" name="attr_CraftMagitech" value="5" /><span></span>
+                            </div>
+                        </li>
+                        <li title="[Esoteric, Infernal] Use Malfean Vitriol to catalyze a mundane Craft">
+                            Vitriol
+                            <div class="dots">
+                                <input type="checkbox" name="attr_CraftVitriol_max" value="1" /><span></span>
+                                <input type="radio" name="attr_CraftVitriol" value="0" checked="checked" />
+                                <input type="radio" name="attr_CraftVitriol" value="1" /><span></span>
+                                <input type="radio" name="attr_CraftVitriol" value="2" /><span></span>
+                                <input type="radio" name="attr_CraftVitriol" value="3" /><span></span>
+                                <input type="radio" name="attr_CraftVitriol" value="4" /><span></span>
+                                <input type="radio" name="attr_CraftVitriol" value="5" /><span></span>
+                            </div>
+                        </li>
+                    </ul>
+                    <div class="right" style="padding-right: 20px; font-style: italic">Hover to select crafts</div>
                 </div>
-            </div>
-            <div class="ability">
-                <input type="checkbox" name="attr_ThrownFavored" value="1" /><span></span>
-                <span class="ability">Thrown</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Thrown_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Thrown" value="0" checked="checked" />
-                    <input type="radio" name="attr_Thrown" value="1" /><span></span>
-                    <input type="radio" name="attr_Thrown" value="2" /><span></span>
-                    <input type="radio" name="attr_Thrown" value="3" /><span></span>
-                    <input type="radio" name="attr_Thrown" value="4" /><span></span>
-                    <input type="radio" name="attr_Thrown" value="5" /><span></span>
+                <div class="ability">
+                    <input type="checkbox" name="attr_InvestigationFavored" value="1" /><span></span>
+                    <span class="ability">Investigation</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Investigation_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Investigation" value="0" checked="checked" />
+                        <input type="radio" name="attr_Investigation" value="1" /><span></span>
+                        <input type="radio" name="attr_Investigation" value="2" /><span></span>
+                        <input type="radio" name="attr_Investigation" value="3" /><span></span>
+                        <input type="radio" name="attr_Investigation" value="4" /><span></span>
+                        <input type="radio" name="attr_Investigation" value="5" /><span></span>
+                    </div>
                 </div>
-            </div>
-            <div class="ability">
-                <input type="checkbox" name="attr_WarFavored" value="1" /><span></span>
-                <span class="ability">War</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_War_max" value="1" /><span></span>
-                    <input type="radio" name="attr_War" value="0" checked="checked" />
-                    <input type="radio" name="attr_War" value="1" /><span></span>
-                    <input type="radio" name="attr_War" value="2" /><span></span>
-                    <input type="radio" name="attr_War" value="3" /><span></span>
-                    <input type="radio" name="attr_War" value="4" /><span></span>
-                    <input type="radio" name="attr_War" value="5" /><span></span>
+                <div class="ability">
+                    <input type="checkbox" name="attr_LoreFavored" value="1" /><span></span>
+                    <span class="ability">Lore</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Lore_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Lore" value="0" checked="checked" />
+                        <input type="radio" name="attr_Lore" value="1" /><span></span>
+                        <input type="radio" name="attr_Lore" value="2" /><span></span>
+                        <input type="radio" name="attr_Lore" value="3" /><span></span>
+                        <input type="radio" name="attr_Lore" value="4" /><span></span>
+                        <input type="radio" name="attr_Lore" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_MedicineFavored" value="1" /><span></span>
+                    <span class="ability">Medicine</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Medicine_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Medicine" value="0" checked="checked" />
+                        <input type="radio" name="attr_Medicine" value="1" /><span></span>
+                        <input type="radio" name="attr_Medicine" value="2" /><span></span>
+                        <input type="radio" name="attr_Medicine" value="3" /><span></span>
+                        <input type="radio" name="attr_Medicine" value="4" /><span></span>
+                        <input type="radio" name="attr_Medicine" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_OccultFavored" value="1" /><span></span>
+                    <span class="ability">Occult</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Occult_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Occult" value="0" checked="checked" />
+                        <input type="radio" name="attr_Occult" value="1" /><span></span>
+                        <input type="radio" name="attr_Occult" value="2" /><span></span>
+                        <input type="radio" name="attr_Occult" value="3" /><span></span>
+                        <input type="radio" name="attr_Occult" value="4" /><span></span>
+                        <input type="radio" name="attr_Occult" value="5" /><span></span>
+                    </div>
                 </div>
             </div>
         </div>
-        
-        <div class="sheet-col">
-            <h3 class="ability">Zenith</h3>
-            <div class="ability">
-                <input type="checkbox" name="attr_IntegrityFavored" value="1" /><span></span>
-                <span class="ability">Integrity</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Integrity_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Integrity" value="0" checked="checked" />
-                    <input type="radio" name="attr_Integrity" value="1" /><span></span>
-                    <input type="radio" name="attr_Integrity" value="2" /><span></span>
-                    <input type="radio" name="attr_Integrity" value="3" /><span></span>
-                    <input type="radio" name="attr_Integrity" value="4" /><span></span>
-                    <input type="radio" name="attr_Integrity" value="5" /><span></span>
+        <div class="sheet-3colrow">
+            <div class="sheet-col"> <!-- Night -->
+                <h3 class="ability">Night</h3>
+                <div class="ability">
+                    <input type="checkbox" name="attr_AthleticsFavored" value="1" /><span></span>
+                    <span class="ability">Athletics</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Athletics_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Athletics" value="0" checked="checked" />
+                        <input type="radio" name="attr_Athletics" value="1" /><span></span>
+                        <input type="radio" name="attr_Athletics" value="2" /><span></span>
+                        <input type="radio" name="attr_Athletics" value="3" /><span></span>
+                        <input type="radio" name="attr_Athletics" value="4" /><span></span>
+                        <input type="radio" name="attr_Athletics" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_AwarenessFavored" value="1" /><span></span>
+                    <span class="ability">Awareness</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Awareness_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Awareness" value="0" checked="checked" />
+                        <input type="radio" name="attr_Awareness" value="1" /><span></span>
+                        <input type="radio" name="attr_Awareness" value="2" /><span></span>
+                        <input type="radio" name="attr_Awareness" value="3" /><span></span>
+                        <input type="radio" name="attr_Awareness" value="4" /><span></span>
+                        <input type="radio" name="attr_Awareness" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_DodgeFavored" value="1" /><span></span>
+                    <span class="ability">Dodge</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Dodge_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Dodge" value="0" checked="checked" />
+                        <input type="radio" name="attr_Dodge" value="1" /><span></span>
+                        <input type="radio" name="attr_Dodge" value="2" /><span></span>
+                        <input type="radio" name="attr_Dodge" value="3" /><span></span>
+                        <input type="radio" name="attr_Dodge" value="4" /><span></span>
+                        <input type="radio" name="attr_Dodge" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_LarcenyFavored" value="1" /><span></span>
+                    <span class="ability">Larceny</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Larceny_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Larceny" value="0" checked="checked" />
+                        <input type="radio" name="attr_Larceny" value="1" /><span></span>
+                        <input type="radio" name="attr_Larceny" value="2" /><span></span>
+                        <input type="radio" name="attr_Larceny" value="3" /><span></span>
+                        <input type="radio" name="attr_Larceny" value="4" /><span></span>
+                        <input type="radio" name="attr_Larceny" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_StealthFavored" value="1" /><span></span>
+                    <span class="ability">Stealth</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Stealth_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Stealth" value="0" checked="checked" />
+                        <input type="radio" name="attr_Stealth" value="1" /><span></span>
+                        <input type="radio" name="attr_Stealth" value="2" /><span></span>
+                        <input type="radio" name="attr_Stealth" value="3" /><span></span>
+                        <input type="radio" name="attr_Stealth" value="4" /><span></span>
+                        <input type="radio" name="attr_Stealth" value="5" /><span></span>
+                    </div>
                 </div>
             </div>
-            <div class="ability">
-                <input type="checkbox" name="attr_PerformanceFavored" value="1" /><span></span>
-                <span class="ability">Performance</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Performance_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Performance" value="0" checked="checked" />
-                    <input type="radio" name="attr_Performance" value="1" /><span></span>
-                    <input type="radio" name="attr_Performance" value="2" /><span></span>
-                    <input type="radio" name="attr_Performance" value="3" /><span></span>
-                    <input type="radio" name="attr_Performance" value="4" /><span></span>
-                    <input type="radio" name="attr_Performance" value="5" /><span></span>
+
+            <div class="sheet-col"> <!-- Eclipse -->
+                <h3 class="ability">Eclipse</h3>
+                <div class="ability">
+                    <input type="checkbox" name="attr_BureaucracyFavored" value="1" /><span></span>
+                    <span class="ability">Bureaucracy</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Bureaucracy_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Bureaucracy" value="0" checked="checked" />
+                        <input type="radio" name="attr_Bureaucracy" value="1" /><span></span>
+                        <input type="radio" name="attr_Bureaucracy" value="2" /><span></span>
+                        <input type="radio" name="attr_Bureaucracy" value="3" /><span></span>
+                        <input type="radio" name="attr_Bureaucracy" value="4" /><span></span>
+                        <input type="radio" name="attr_Bureaucracy" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_LinguisticsFavored" value="1" /><span></span>
+                    <span class="ability">Linguistics</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Linguistics_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Linguistics" value="0" checked="checked" />
+                        <input type="radio" name="attr_Linguistics" value="1" /><span></span>
+                        <input type="radio" name="attr_Linguistics" value="2" /><span></span>
+                        <input type="radio" name="attr_Linguistics" value="3" /><span></span>
+                        <input type="radio" name="attr_Linguistics" value="4" /><span></span>
+                        <input type="radio" name="attr_Linguistics" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_RideFavored" value="1" /><span></span>
+                    <span class="ability">Ride</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Ride_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Ride" value="0" checked="checked" />
+                        <input type="radio" name="attr_Ride" value="1" /><span></span>
+                        <input type="radio" name="attr_Ride" value="2" /><span></span>
+                        <input type="radio" name="attr_Ride" value="3" /><span></span>
+                        <input type="radio" name="attr_Ride" value="4" /><span></span>
+                        <input type="radio" name="attr_Ride" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_SailFavored" value="1" /><span></span>
+                    <span class="ability">Sail</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Sail_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Sail" value="0" checked="checked" />
+                        <input type="radio" name="attr_Sail" value="1" /><span></span>
+                        <input type="radio" name="attr_Sail" value="2" /><span></span>
+                        <input type="radio" name="attr_Sail" value="3" /><span></span>
+                        <input type="radio" name="attr_Sail" value="4" /><span></span>
+                        <input type="radio" name="attr_Sail" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_SocializeFavored" value="1" /><span></span>
+                    <span class="ability">Socialize</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Socialize_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Socialize" value="0" checked="checked" />
+                        <input type="radio" name="attr_Socialize" value="1" /><span></span>
+                        <input type="radio" name="attr_Socialize" value="2" /><span></span>
+                        <input type="radio" name="attr_Socialize" value="3" /><span></span>
+                        <input type="radio" name="attr_Socialize" value="4" /><span></span>
+                        <input type="radio" name="attr_Socialize" value="5" /><span></span>
+                    </div>
                 </div>
             </div>
-            <div class="ability">
-                <input type="checkbox" name="attr_PresenceFavored" value="1" /><span></span>
-                <span class="ability">Presence</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Presence_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Presence" value="0" checked="checked" />
-                    <input type="radio" name="attr_Presence" value="1" /><span></span>
-                    <input type="radio" name="attr_Presence" value="2" /><span></span>
-                    <input type="radio" name="attr_Presence" value="3" /><span></span>
-                    <input type="radio" name="attr_Presence" value="4" /><span></span>
-                    <input type="radio" name="attr_Presence" value="5" /><span></span>
-                </div>
-            </div>
-            <div class="ability">
-                <input type="checkbox" name="attr_ResistanceFavored" value="1" /><span></span>
-                <span class="ability">Resistance</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Resistance_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Resistance" value="0" checked="checked" />
-                    <input type="radio" name="attr_Resistance" value="1" /><span></span>
-                    <input type="radio" name="attr_Resistance" value="2" /><span></span>
-                    <input type="radio" name="attr_Resistance" value="3" /><span></span>
-                    <input type="radio" name="attr_Resistance" value="4" /><span></span>
-                    <input type="radio" name="attr_Resistance" value="5" /><span></span>
-                </div>
-            </div>
-            <div class="ability">
-                <input type="checkbox" name="attr_SurvivalFavored" value="1" /><span></span>
-                <span class="ability">Survival</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Survival_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Survival" value="0" checked="checked" />
-                    <input type="radio" name="attr_Survival" value="1" /><span></span>
-                    <input type="radio" name="attr_Survival" value="2" /><span></span>
-                    <input type="radio" name="attr_Survival" value="3" /><span></span>
-                    <input type="radio" name="attr_Survival" value="4" /><span></span>
-                    <input type="radio" name="attr_Survival" value="5" /><span></span>
-                </div>
-            </div>
-        </div>
-        
-        <div class="sheet-col">
-            <h3 class="ability">Twilight</h3>
-            <div class="ability craft-types">
-                <input type="checkbox" name="attr_CraftFavored" value="1" /><span></span>
-                <span class="ability">Craft</span>
-                <ul class="craft-types">
-                    <li title="[Mundane] Making small, decorative, or high-precision items">
-                        Air
-                        <div class="dots">
-                            <input type="checkbox" name="attr_CraftAir_max" value="1" /><span></span>
-                            <input type="radio" name="attr_CraftAir" value="0" checked="checked" />
-                            <input type="radio" name="attr_CraftAir" value="1" /><span></span>
-                            <input type="radio" name="attr_CraftAir" value="2" /><span></span>
-                            <input type="radio" name="attr_CraftAir" value="3" /><span></span>
-                            <input type="radio" name="attr_CraftAir" value="4" /><span></span>
-                            <input type="radio" name="attr_CraftAir" value="5" /><span></span>
-                        </div>
-                    </li>
-                    <li title="[Mundane] Creating buildings and large objects with stone or earth">
-                        Earth
-                        <div class="dots">
-                            <input type="checkbox" name="attr_CraftEarth_max" value="1" /><span></span>
-                            <input type="radio" name="attr_CraftEarth" value="0" checked="checked" />
-                            <input type="radio" name="attr_CraftEarth" value="1" /><span></span>
-                            <input type="radio" name="attr_CraftEarth" value="2" /><span></span>
-                            <input type="radio" name="attr_CraftEarth" value="3" /><span></span>
-                            <input type="radio" name="attr_CraftEarth" value="4" /><span></span>
-                            <input type="radio" name="attr_CraftEarth" value="5" /><span></span>
-                        </div>
-                    </li>
-                    <li title="[Mundane] Forging and casting large metal objects and creating objects using fire">
-                        Fire
-                        <div class="dots">
-                            <input type="checkbox" name="attr_CraftFire_max" value="1" /><span></span>
-                            <input type="radio" name="attr_CraftFire" value="0" checked="checked" />
-                            <input type="radio" name="attr_CraftFire" value="1" /><span></span>
-                            <input type="radio" name="attr_CraftFire" value="2" /><span></span>
-                            <input type="radio" name="attr_CraftFire" value="3" /><span></span>
-                            <input type="radio" name="attr_CraftFire" value="4" /><span></span>
-                            <input type="radio" name="attr_CraftFire" value="5" /><span></span>
-                        </div>
-                    </li>
-                    <li title="[Mundane] Boiling and cooking plants, chemicals, and animal materials">
-                        Water
-                        <div class="dots">
-                            <input type="checkbox" name="attr_CraftWater_max" value="1" /><span></span>
-                            <input type="radio" name="attr_CraftWater" value="0" checked="checked" />
-                            <input type="radio" name="attr_CraftWater" value="1" /><span></span>
-                            <input type="radio" name="attr_CraftWater" value="2" /><span></span>
-                            <input type="radio" name="attr_CraftWater" value="3" /><span></span>
-                            <input type="radio" name="attr_CraftWater" value="4" /><span></span>
-                            <input type="radio" name="attr_CraftWater" value="5" /><span></span>
-                        </div>
-                    </li>
-                    <li title="[Mundane] Carving, weaving, and manipulating natural elements">
-                        Wood
-                        <div class="dots">
-                            <input type="checkbox" name="attr_CraftWood_max" value="1" /><span></span>
-                            <input type="radio" name="attr_CraftWood" value="0" checked="checked" />
-                            <input type="radio" name="attr_CraftWood" value="1" /><span></span>
-                            <input type="radio" name="attr_CraftWood" value="2" /><span></span>
-                            <input type="radio" name="attr_CraftWood" value="3" /><span></span>
-                            <input type="radio" name="attr_CraftWood" value="4" /><span></span>
-                            <input type="radio" name="attr_CraftWood" value="5" /><span></span>
-                        </div>
-                    </li>
-                    <li title="[Esoteric, Sidereal] Manipulate fate for certain Astrologies and Charms">
-                        Fate
-                        <div class="dots">
-                            <input type="checkbox" name="attr_CraftFate_max" value="1" /><span></span>
-                            <input type="radio" name="attr_CraftFate" value="0" checked="checked" />
-                            <input type="radio" name="attr_CraftFate" value="1" /><span></span>
-                            <input type="radio" name="attr_CraftFate" value="2" /><span></span>
-                            <input type="radio" name="attr_CraftFate" value="3" /><span></span>
-                            <input type="radio" name="attr_CraftFate" value="4" /><span></span>
-                            <input type="radio" name="attr_CraftFate" value="5" /><span></span>
-                        </div>
-                    </li>
-                    <li title="[Esoteric, First Age] Create or modify life">
-                        Genesis
-                        <div class="dots">
-                            <input type="checkbox" name="attr_CraftGenesis_max" value="1" /><span></span>
-                            <input type="radio" name="attr_CraftGenesis" value="0" checked="checked" />
-                            <input type="radio" name="attr_CraftGenesis" value="1" /><span></span>
-                            <input type="radio" name="attr_CraftGenesis" value="2" /><span></span>
-                            <input type="radio" name="attr_CraftGenesis" value="3" /><span></span>
-                            <input type="radio" name="attr_CraftGenesis" value="4" /><span></span>
-                            <input type="radio" name="attr_CraftGenesis" value="5" /><span></span>
-                        </div>
-                    </li>
-                    <li title="[Esoteric, Raksha] Manipulate the physical manifestation of shaping effects, from Essence to dreams">
-                        Glamour
-                        <div class="dots">
-                            <input type="checkbox" name="attr_CraftGlamour_max" value="1" /><span></span>
-                            <input type="radio" name="attr_CraftGlamour" value="0" checked="checked" />
-                            <input type="radio" name="attr_CraftGlamour" value="1" /><span></span>
-                            <input type="radio" name="attr_CraftGlamour" value="2" /><span></span>
-                            <input type="radio" name="attr_CraftGlamour" value="3" /><span></span>
-                            <input type="radio" name="attr_CraftGlamour" value="4" /><span></span>
-                            <input type="radio" name="attr_CraftGlamour" value="5" /><span></span>
-                        </div>
-                    </li>
-                    <li title="[Esoteric, First Age] Creation, enchantment, and maintenance of First Age devices">
-                        Magitech
-                        <div class="dots">
-                            <input type="checkbox" name="attr_CraftMagitech_max" value="1" /><span></span>
-                            <input type="radio" name="attr_CraftMagitech" value="0" checked="checked" />
-                            <input type="radio" name="attr_CraftMagitech" value="1" /><span></span>
-                            <input type="radio" name="attr_CraftMagitech" value="2" /><span></span>
-                            <input type="radio" name="attr_CraftMagitech" value="3" /><span></span>
-                            <input type="radio" name="attr_CraftMagitech" value="4" /><span></span>
-                            <input type="radio" name="attr_CraftMagitech" value="5" /><span></span>
-                        </div>
-                    </li>
-                    <li title="[Esoteric, Infernal] Use Malfean Vitriol to catalyze a mundane Craft">
-                        Vitriol
-                        <div class="dots">
-                            <input type="checkbox" name="attr_CraftVitriol_max" value="1" /><span></span>
-                            <input type="radio" name="attr_CraftVitriol" value="0" checked="checked" />
-                            <input type="radio" name="attr_CraftVitriol" value="1" /><span></span>
-                            <input type="radio" name="attr_CraftVitriol" value="2" /><span></span>
-                            <input type="radio" name="attr_CraftVitriol" value="3" /><span></span>
-                            <input type="radio" name="attr_CraftVitriol" value="4" /><span></span>
-                            <input type="radio" name="attr_CraftVitriol" value="5" /><span></span>
-                        </div>
-                    </li>
-                </ul>
-                <div class="right" style="padding-right: 20px; font-style: italic">Hover to select crafts</div>
-            </div>
-            <div class="ability">
-                <input type="checkbox" name="attr_InvestigationFavored" value="1" /><span></span>
-                <span class="ability">Investigation</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Investigation_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Investigation" value="0" checked="checked" />
-                    <input type="radio" name="attr_Investigation" value="1" /><span></span>
-                    <input type="radio" name="attr_Investigation" value="2" /><span></span>
-                    <input type="radio" name="attr_Investigation" value="3" /><span></span>
-                    <input type="radio" name="attr_Investigation" value="4" /><span></span>
-                    <input type="radio" name="attr_Investigation" value="5" /><span></span>
-                </div>
-            </div>
-            <div class="ability">
-                <input type="checkbox" name="attr_LoreFavored" value="1" /><span></span>
-                <span class="ability">Lore</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Lore_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Lore" value="0" checked="checked" />
-                    <input type="radio" name="attr_Lore" value="1" /><span></span>
-                    <input type="radio" name="attr_Lore" value="2" /><span></span>
-                    <input type="radio" name="attr_Lore" value="3" /><span></span>
-                    <input type="radio" name="attr_Lore" value="4" /><span></span>
-                    <input type="radio" name="attr_Lore" value="5" /><span></span>
-                </div>
-            </div>
-            <div class="ability">
-                <input type="checkbox" name="attr_MedicineFavored" value="1" /><span></span>
-                <span class="ability">Medicine</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Medicine_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Medicine" value="0" checked="checked" />
-                    <input type="radio" name="attr_Medicine" value="1" /><span></span>
-                    <input type="radio" name="attr_Medicine" value="2" /><span></span>
-                    <input type="radio" name="attr_Medicine" value="3" /><span></span>
-                    <input type="radio" name="attr_Medicine" value="4" /><span></span>
-                    <input type="radio" name="attr_Medicine" value="5" /><span></span>
-                </div>
-            </div>
-            <div class="ability">
-                <input type="checkbox" name="attr_OccultFavored" value="1" /><span></span>
-                <span class="ability">Occult</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Occult_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Occult" value="0" checked="checked" />
-                    <input type="radio" name="attr_Occult" value="1" /><span></span>
-                    <input type="radio" name="attr_Occult" value="2" /><span></span>
-                    <input type="radio" name="attr_Occult" value="3" /><span></span>
-                    <input type="radio" name="attr_Occult" value="4" /><span></span>
-                    <input type="radio" name="attr_Occult" value="5" /><span></span>
-                </div>
-            </div>
-        </div>
+
+            <div class="sheet-col"><!-- Specialties are on a different page --></div>
+        </div>       
     </div>
-    <div class="sheet-3colrow">
-        <div class="sheet-col">
-            <h3 class="ability">Night</h3>
-            <div class="ability">
-                <input type="checkbox" name="attr_AthleticsFavored" value="1" /><span></span>
-                <span class="ability">Athletics</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Athletics_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Athletics" value="0" checked="checked" />
-                    <input type="radio" name="attr_Athletics" value="1" /><span></span>
-                    <input type="radio" name="attr_Athletics" value="2" /><span></span>
-                    <input type="radio" name="attr_Athletics" value="3" /><span></span>
-                    <input type="radio" name="attr_Athletics" value="4" /><span></span>
-                    <input type="radio" name="attr_Athletics" value="5" /><span></span>
+
+    <div class="dragon-ab">
+            <div class="sheet-col"> <!-- Earth -->
+                <h3 class="ability">Earth</h3>
+                <div class="ability">
+                    <input type="checkbox" name="attr_AwarnessFavored" value="1" /><span></span>
+                    <span class="ability">Awarness</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Awarness_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Awarness" value="0" checked="checked" />
+                        <input type="radio" name="attr_Awarness" value="1" /><span></span>
+                        <input type="radio" name="attr_Awarness" value="2" /><span></span>
+                        <input type="radio" name="attr_Awarness" value="3" /><span></span>
+                        <input type="radio" name="attr_Awarness" value="4" /><span></span>
+                        <input type="radio" name="attr_Awarness" value="5" /><span></span>
+                    </div>
                 </div>
-            </div>
-            <div class="ability">
-                <input type="checkbox" name="attr_AwarenessFavored" value="1" /><span></span>
-                <span class="ability">Awareness</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Awareness_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Awareness" value="0" checked="checked" />
-                    <input type="radio" name="attr_Awareness" value="1" /><span></span>
-                    <input type="radio" name="attr_Awareness" value="2" /><span></span>
-                    <input type="radio" name="attr_Awareness" value="3" /><span></span>
-                    <input type="radio" name="attr_Awareness" value="4" /><span></span>
-                    <input type="radio" name="attr_Awareness" value="5" /><span></span>
+                <div class="ability">
+                    <input type="checkbox" name="attr_CraftsFavored" value="1" /><span></span>
+                    <span class="ability">Crafts</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Crafts_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Crafts" value="0" checked="checked" />
+                        <input type="radio" name="attr_Crafts" value="1" /><span></span>
+                        <input type="radio" name="attr_Crafts" value="2" /><span></span>
+                        <input type="radio" name="attr_Crafts" value="3" /><span></span>
+                        <input type="radio" name="attr_Crafts" value="4" /><span></span>
+                        <input type="radio" name="attr_Crafts" value="5" /><span></span>
+                    </div>
                 </div>
-            </div>
-            <div class="ability">
-                <input type="checkbox" name="attr_DodgeFavored" value="1" /><span></span>
-                <span class="ability">Dodge</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Dodge_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Dodge" value="0" checked="checked" />
-                    <input type="radio" name="attr_Dodge" value="1" /><span></span>
-                    <input type="radio" name="attr_Dodge" value="2" /><span></span>
-                    <input type="radio" name="attr_Dodge" value="3" /><span></span>
-                    <input type="radio" name="attr_Dodge" value="4" /><span></span>
-                    <input type="radio" name="attr_Dodge" value="5" /><span></span>
+                <div class="ability">
+                    <input type="checkbox" name="attr_IntegrityFavored" value="1" /><span></span>
+                    <span class="ability">Integrity</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Integrity_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Integrity" value="0" checked="checked" />
+                        <input type="radio" name="attr_Integrity" value="1" /><span></span>
+                        <input type="radio" name="attr_Integrity" value="2" /><span></span>
+                        <input type="radio" name="attr_Integrity" value="3" /><span></span>
+                        <input type="radio" name="attr_Integrity" value="4" /><span></span>
+                        <input type="radio" name="attr_Integrity" value="5" /><span></span>
+                    </div>
                 </div>
-            </div>
-            <div class="ability">
-                <input type="checkbox" name="attr_LarcenyFavored" value="1" /><span></span>
-                <span class="ability">Larceny</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Larceny_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Larceny" value="0" checked="checked" />
-                    <input type="radio" name="attr_Larceny" value="1" /><span></span>
-                    <input type="radio" name="attr_Larceny" value="2" /><span></span>
-                    <input type="radio" name="attr_Larceny" value="3" /><span></span>
-                    <input type="radio" name="attr_Larceny" value="4" /><span></span>
-                    <input type="radio" name="attr_Larceny" value="5" /><span></span>
+                <div class="ability">
+                    <input type="checkbox" name="attr_ResistanceFavored" value="1" /><span></span>
+                    <span class="ability">Resistance</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Resistance_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Resistance" value="0" checked="checked" />
+                        <input type="radio" name="attr_Resistance" value="1" /><span></span>
+                        <input type="radio" name="attr_Resistance" value="2" /><span></span>
+                        <input type="radio" name="attr_Resistance" value="3" /><span></span>
+                        <input type="radio" name="attr_Resistance" value="4" /><span></span>
+                        <input type="radio" name="attr_Resistance" value="5" /><span></span>
+                    </div>
                 </div>
-            </div>
-            <div class="ability">
-                <input type="checkbox" name="attr_StealthFavored" value="1" /><span></span>
-                <span class="ability">Stealth</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Stealth_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Stealth" value="0" checked="checked" />
-                    <input type="radio" name="attr_Stealth" value="1" /><span></span>
-                    <input type="radio" name="attr_Stealth" value="2" /><span></span>
-                    <input type="radio" name="attr_Stealth" value="3" /><span></span>
-                    <input type="radio" name="attr_Stealth" value="4" /><span></span>
-                    <input type="radio" name="attr_Stealth" value="5" /><span></span>
+                <div class="ability">
+                    <input type="checkbox" name="attr_WarFavored" value="1" /><span></span>
+                    <span class="ability">War</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_War_max" value="1" /><span></span>
+                        <input type="radio" name="attr_War" value="0" checked="checked" />
+                        <input type="radio" name="attr_War" value="1" /><span></span>
+                        <input type="radio" name="attr_War" value="2" /><span></span>
+                        <input type="radio" name="attr_War" value="3" /><span></span>
+                        <input type="radio" name="attr_War" value="4" /><span></span>
+                        <input type="radio" name="attr_War" value="5" /><span></span>
+                    </div>
                 </div>
-            </div>
-        </div>
-        
-        <div class="sheet-col">
-            <h3 class="ability">Eclipse</h3>
-            <div class="ability">
-                <input type="checkbox" name="attr_BureaucracyFavored" value="1" /><span></span>
-                <span class="ability">Bureaucracy</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Bureaucracy_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Bureaucracy" value="0" checked="checked" />
-                    <input type="radio" name="attr_Bureaucracy" value="1" /><span></span>
-                    <input type="radio" name="attr_Bureaucracy" value="2" /><span></span>
-                    <input type="radio" name="attr_Bureaucracy" value="3" /><span></span>
-                    <input type="radio" name="attr_Bureaucracy" value="4" /><span></span>
-                    <input type="radio" name="attr_Bureaucracy" value="5" /><span></span>
-                </div>
-            </div>
-            <div class="ability">
-                <input type="checkbox" name="attr_LinguisticsFavored" value="1" /><span></span>
-                <span class="ability">Linguistics</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Linguistics_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Linguistics" value="0" checked="checked" />
-                    <input type="radio" name="attr_Linguistics" value="1" /><span></span>
-                    <input type="radio" name="attr_Linguistics" value="2" /><span></span>
-                    <input type="radio" name="attr_Linguistics" value="3" /><span></span>
-                    <input type="radio" name="attr_Linguistics" value="4" /><span></span>
-                    <input type="radio" name="attr_Linguistics" value="5" /><span></span>
-                </div>
-            </div>
-            <div class="ability">
-                <input type="checkbox" name="attr_RideFavored" value="1" /><span></span>
-                <span class="ability">Ride</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Ride_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Ride" value="0" checked="checked" />
-                    <input type="radio" name="attr_Ride" value="1" /><span></span>
-                    <input type="radio" name="attr_Ride" value="2" /><span></span>
-                    <input type="radio" name="attr_Ride" value="3" /><span></span>
-                    <input type="radio" name="attr_Ride" value="4" /><span></span>
-                    <input type="radio" name="attr_Ride" value="5" /><span></span>
-                </div>
-            </div>
-            <div class="ability">
-                <input type="checkbox" name="attr_SailFavored" value="1" /><span></span>
-                <span class="ability">Sail</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Sail_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Sail" value="0" checked="checked" />
-                    <input type="radio" name="attr_Sail" value="1" /><span></span>
-                    <input type="radio" name="attr_Sail" value="2" /><span></span>
-                    <input type="radio" name="attr_Sail" value="3" /><span></span>
-                    <input type="radio" name="attr_Sail" value="4" /><span></span>
-                    <input type="radio" name="attr_Sail" value="5" /><span></span>
-                </div>
-            </div>
-            <div class="ability">
-                <input type="checkbox" name="attr_SocializeFavored" value="1" /><span></span>
-                <span class="ability">Socialize</span>
-                <div class="dots">
-                    <input type="checkbox" name="attr_Socialize_max" value="1" /><span></span>
-                    <input type="radio" name="attr_Socialize" value="0" checked="checked" />
-                    <input type="radio" name="attr_Socialize" value="1" /><span></span>
-                    <input type="radio" name="attr_Socialize" value="2" /><span></span>
-                    <input type="radio" name="attr_Socialize" value="3" /><span></span>
-                    <input type="radio" name="attr_Socialize" value="4" /><span></span>
-                    <input type="radio" name="attr_Socialize" value="5" /><span></span>
-                </div>
-            </div>
-        </div>
-        
-        <div class="sheet-col"><!-- Specialties are on a different page --></div>
+            </div>        
     </div>
+
     
     <h1 class="separator"><span>Advantages</span></h1>
     
@@ -1709,3 +1791,31 @@
         </div>
     </div>
 </div>
+
+<!-- 
+            <span>Caste:</span>
+            <select name="attr_Caste">
+                <option value="Dawn">Solar: Dawn</option>
+                <option value="Zenith">Solar: Zenith</option>
+                <option value="Twilight">Solar: Twilight</option>
+                <option value="Night">Solar: Night</option>
+                <option value="Eclipse">Solar: Eclipse</option>
+
+                <option value="FullMoon">Lunar: Full Moon</option>
+                <option value="ChangingMoon">Lunar: Changing Moon</option>
+                <option value="NoMoon">Lunar: No Moon</option>
+
+                <option value="Journey">Sidereal: Journey</option>
+                <option value="Serenity">Sidereal: Serenity</option>
+                <option value="Battle">Sidereal: Battle</option>
+                <option value="Secret">Sidereal: Secret</option>
+                <option value="Ending">Sidereal: Ending</option>
+
+                <option value="Earth">Dragon-Blooded: Earth</option>
+                <option value="Fire">Dragon-Blooded: Fire</option>
+                <option value="Water">Dragon-Blooded: Water</option>
+                <option value="Air">Dragon-Blooded: Air</option>
+            </select>
+ -->
+
+

--- a/Exalted2e/exalted2e.html
+++ b/Exalted2e/exalted2e.html
@@ -123,33 +123,33 @@
         <label>
             <span>Caste:</span>
             <select name="attr_Caste">
-                <option value="Dawn">Solar: Dawn</option>
+                <option value="Dawn" selected="selected">Solar: Dawn</option>
                 <option value="Zenith">Solar: Zenith</option>
                 <option value="Twilight">Solar: Twilight</option>
                 <option value="Night">Solar: Night</option>
                 <option value="Eclipse">Solar: Eclipse</option>
 
+                <option value="Dusk">Abyssal: Dusk</option>
+                <option value="Midnight">Abyssal: Midnight</option>
+                <option value="Daybreak">Abyssal: Daybreak</option>
+                <option value="Day">Abyssal: Day</option>
+                <option value="Moonshadow">Abyssal: Moonshadow</option>
+
+                <option value="Air">Dragon-Blooded: Air</option>
+                <option value="Earth">Dragon-Blooded: Earth</option>
+                <option value="Fire">Dragon-Blooded: Fire</option>
+                <option value="Water">Dragon-Blooded: Water</option>
+                <option value="Wood">Dragon-Blooded: Wood</option>
+
                 <option value="FullMoon">Lunar: Full Moon</option>
                 <option value="ChangingMoon">Lunar: Changing Moon</option>
                 <option value="NoMoon">Lunar: No Moon</option>
-
-                <option value="Dusk">Abyssal: Dusk</option>
-                <option value="Day">Abyssal: Day</option>
-                <option value="Midnight">Abyssal: Midnight</option>
-                <option value="Moonshadow">Abyssal: Moonshadow</option>
-                <option value="Daybreak">Abyssal: Daybreak</option>
 
                 <option value="Journey">Sidereal: Journey</option>
                 <option value="Serenity">Sidereal: Serenity</option>
                 <option value="Battle">Sidereal: Battle</option>
                 <option value="Secret">Sidereal: Secret</option>
                 <option value="Ending">Sidereal: Ending</option>
-
-                <option value="Earth">Dragon-Blooded: Earth</option>
-                <option value="Fire">Dragon-Blooded: Fire</option>
-                <option value="Water">Dragon-Blooded: Water</option>
-                <option value="Air">Dragon-Blooded: Air</option>
-                <option value="Wood">Dragon-Blooded: Wood</option>
             </select>
         </label>
     </div>
@@ -267,11 +267,13 @@
             <fieldset class="repeating_specialties">
                 <div class="ability specialty">
                     <input type="checkbox" name="attr_SpecialtyFavored" value="1" /><span></span>
-                    <input type="text" name="attr_SpecialtyName" />
+                    <input type="text" name="attr_SpecialtyName" style="width:100px;"/>
                     <div class="dots">
                         <input type="radio" name="attr_Specialty" value="1" checked="checked" /><span></span>
                         <input type="radio" name="attr_Specialty" value="2" /><span></span>
                         <input type="radio" name="attr_Specialty" value="3" /><span></span>
+                        <input type="radio" name="attr_Specialty" value="4" /><span></span>
+                        <input type="radio" name="attr_Specialty" value="5" /><span></span>
                     </div>
                 </div>
             </fieldset>
@@ -1049,10 +1051,19 @@
     </div>
     
     <h1 class="separator"><span>Abilities</span></h1>
-    <input name="attr_Caste" type="hidden" class="caste-toggle">
+    <input name="attr_Caste" type="hidden" class="caste-toggle" value="Dawn">
+    
+    <!-- Abyssals TODO -->
+    <div class="abyssal-ab">
+    </div>
+
+    <!-- Solars -->
     <div class="solar-ab">
+        <h3 class="ability">Solars</h3>
+
         <div class="sheet-3colrow">
-            <div class="sheet-col"> <!-- Dawn -->
+            <!-- Dawn -->
+            <div class="sheet-col"> 
                 <h3 class="ability">Dawn</h3>
                 <div class="ability">
                     <input type="checkbox" name="attr_ArcheryFavored" value="1" /><span></span>
@@ -1072,7 +1083,7 @@
                     <span class="ability">Martial Arts</span>
                     <div class="dots">
                         <input type="checkbox" name="attr_MartialArts_max" value="1" /><span></span>
-                        <input type="radio" name="attr_MartialArts" value="0" checked="checked" />
+                        <input type="radio" name="attr_MartialArts" value="0" checked="checked"/>
                         <input type="radio" name="attr_MartialArts" value="1" /><span></span>
                         <input type="radio" name="attr_MartialArts" value="2" /><span></span>
                         <input type="radio" name="attr_MartialArts" value="3" /><span></span>
@@ -1121,7 +1132,8 @@
                 </div>
             </div>
 
-            <div class="sheet-col"> <!-- Zenith -->
+            <!-- Zenith -->
+            <div class="sheet-col"> 
                 <h3 class="ability">Zenith</h3>
                 <div class="ability">
                     <input type="checkbox" name="attr_IntegrityFavored" value="1" /><span></span>
@@ -1190,7 +1202,8 @@
                 </div>
             </div>
 
-            <div class="sheet-col"> <!-- Twilight -->
+            <!-- Twilight -->
+            <div class="sheet-col"> 
                 <h3 class="ability">Twilight</h3>
                 <div class="ability craft-types">
                     <input type="checkbox" name="attr_CraftFavored" value="1" /><span></span>
@@ -1373,8 +1386,10 @@
                 </div>
             </div>
         </div>
+
         <div class="sheet-3colrow">
-            <div class="sheet-col"> <!-- Night -->
+             <!-- Night -->
+            <div class="sheet-col">
                 <h3 class="ability">Night</h3>
                 <div class="ability">
                     <input type="checkbox" name="attr_AthleticsFavored" value="1" /><span></span>
@@ -1443,7 +1458,8 @@
                 </div>
             </div>
 
-            <div class="sheet-col"> <!-- Eclipse -->
+            <!-- Eclipse -->
+            <div class="sheet-col"> 
                 <h3 class="ability">Eclipse</h3>
                 <div class="ability">
                     <input type="checkbox" name="attr_BureaucracyFavored" value="1" /><span></span>
@@ -1512,12 +1528,102 @@
                 </div>
             </div>
 
-            <div class="sheet-col"><!-- Specialties are on a different page --></div>
+            <!-- Specialities -->
+            <div class="sheet-col">
+                <h3 class="ability">Specialties</h3>
+                <fieldset class="repeating_specialties">
+                    <div class="ability specialty">
+                        <input type="checkbox" name="attr_SpecialtyFavored" value="1" style="margin-top: 1px" /><span></span>
+                        <input type="text" name="attr_SpecialtyName" style="width:100px;height:24px;padding-top: 0px;padding-bottom: 1px;"/>
+                        <div class="dots">
+                            <input type="radio" name="attr_Specialty" value="1" checked="checked" /><span></span>
+                            <input type="radio" name="attr_Specialty" value="2" /><span></span>
+                            <input type="radio" name="attr_Specialty" value="3" /><span></span>
+                            <input type="radio" name="attr_Specialty" value="4" /><span></span>
+                            <input type="radio" name="attr_Specialty" value="5" /><span></span>
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
         </div>       
     </div>
-
+    
+    <!-- Dragon Blooded -->
     <div class="dragon-ab">
-            <div class="sheet-col"> <!-- Earth -->
+        <h3 class="ability">Dragon-Blooded</h3>
+        <div class="sheet-3colrow">
+            <!-- Air -->
+            <div class="sheet-col"> 
+                <h3 class="ability">Air</h3>
+                <div class="ability">
+                    <input type="checkbox" name="attr_LinguisticsFavored" value="1" /><span></span>
+                    <span class="ability">Linguistics</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Linguistics_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Linguistics" value="0" checked="checked" />
+                        <input type="radio" name="attr_Linguistics" value="1" /><span></span>
+                        <input type="radio" name="attr_Linguistics" value="2" /><span></span>
+                        <input type="radio" name="attr_Linguistics" value="3" /><span></span>
+                        <input type="radio" name="attr_Linguistics" value="4" /><span></span>
+                        <input type="radio" name="attr_Linguistics" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_LoreFavored" value="1" /><span></span>
+                    <span class="ability">Lore</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Lore_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Lore" value="0" checked="checked" />
+                        <input type="radio" name="attr_Lore" value="1" /><span></span>
+                        <input type="radio" name="attr_Lore" value="2" /><span></span>
+                        <input type="radio" name="attr_Lore" value="3" /><span></span>
+                        <input type="radio" name="attr_Lore" value="4" /><span></span>
+                        <input type="radio" name="attr_Lore" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_OccultFavored" value="1" /><span></span>
+                    <span class="ability">Occult</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Occult_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Occult" value="0" checked="checked" />
+                        <input type="radio" name="attr_Occult" value="1" /><span></span>
+                        <input type="radio" name="attr_Occult" value="2" /><span></span>
+                        <input type="radio" name="attr_Occult" value="3" /><span></span>
+                        <input type="radio" name="attr_Occult" value="4" /><span></span>
+                        <input type="radio" name="attr_Occult" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_StealthFavored" value="1" /><span></span>
+                    <span class="ability">Stealth</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Stealth_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Stealth" value="0" checked="checked" />
+                        <input type="radio" name="attr_Stealth" value="1" /><span></span>
+                        <input type="radio" name="attr_Stealth" value="2" /><span></span>
+                        <input type="radio" name="attr_Stealth" value="3" /><span></span>
+                        <input type="radio" name="attr_Stealth" value="4" /><span></span>
+                        <input type="radio" name="attr_Stealth" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_ThrownFavored" value="1" /><span></span>
+                    <span class="ability">Thrown</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Thrown_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Thrown" value="0" checked="checked" />
+                        <input type="radio" name="attr_Thrown" value="1" /><span></span>
+                        <input type="radio" name="attr_Thrown" value="2" /><span></span>
+                        <input type="radio" name="attr_Thrown" value="3" /><span></span>
+                        <input type="radio" name="attr_Thrown" value="4" /><span></span>
+                        <input type="radio" name="attr_Thrown" value="5" /><span></span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Earth -->
+            <div class="sheet-col"> 
                 <h3 class="ability">Earth</h3>
                 <div class="ability">
                     <input type="checkbox" name="attr_AwarnessFavored" value="1" /><span></span>
@@ -1584,7 +1690,241 @@
                         <input type="radio" name="attr_War" value="5" /><span></span>
                     </div>
                 </div>
-            </div>        
+            </div>
+
+            <!-- Fire -->
+            <div class="sheet-col"> 
+                <h3 class="ability">Fire</h3>
+                <div class="ability">
+                    <input type="checkbox" name="attr_AthleticsFavored" value="1" /><span></span>
+                    <span class="ability">Athletics</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Athletics_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Athletics" value="0" checked="checked" />
+                        <input type="radio" name="attr_Athletics" value="1" /><span></span>
+                        <input type="radio" name="attr_Athletics" value="2" /><span></span>
+                        <input type="radio" name="attr_Athletics" value="3" /><span></span>
+                        <input type="radio" name="attr_Athletics" value="4" /><span></span>
+                        <input type="radio" name="attr_Athletics" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_DodgeFavored" value="1" /><span></span>
+                    <span class="ability">Dodge</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Dodge_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Dodge" value="0" checked="checked" />
+                        <input type="radio" name="attr_Dodge" value="1" /><span></span>
+                        <input type="radio" name="attr_Dodge" value="2" /><span></span>
+                        <input type="radio" name="attr_Dodge" value="3" /><span></span>
+                        <input type="radio" name="attr_Dodge" value="4" /><span></span>
+                        <input type="radio" name="attr_Dodge" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_MeleeFavored" value="1" /><span></span>
+                    <span class="ability">Melee</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Melee_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Melee" value="0" checked="checked" />
+                        <input type="radio" name="attr_Melee" value="1" /><span></span>
+                        <input type="radio" name="attr_Melee" value="2" /><span></span>
+                        <input type="radio" name="attr_Melee" value="3" /><span></span>
+                        <input type="radio" name="attr_Melee" value="4" /><span></span>
+                        <input type="radio" name="attr_Melee" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_SocializeFavored" value="1" /><span></span>
+                    <span class="ability">Socialize</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Socialize_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Socialize" value="0" checked="checked" />
+                        <input type="radio" name="attr_Socialize" value="1" /><span></span>
+                        <input type="radio" name="attr_Socialize" value="2" /><span></span>
+                        <input type="radio" name="attr_Socialize" value="3" /><span></span>
+                        <input type="radio" name="attr_Socialize" value="4" /><span></span>
+                        <input type="radio" name="attr_Socialize" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_PresenceFavored" value="1" /><span></span>
+                    <span class="ability">Presence</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Presence_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Presence" value="0" checked="checked" />
+                        <input type="radio" name="attr_Presence" value="1" /><span></span>
+                        <input type="radio" name="attr_Presence" value="2" /><span></span>
+                        <input type="radio" name="attr_Presence" value="3" /><span></span>
+                        <input type="radio" name="attr_Presence" value="4" /><span></span>
+                        <input type="radio" name="attr_Presence" value="5" /><span></span>
+                    </div>
+                </div>
+            </div>            
+        </div>
+
+        <div class="sheet-3colrow">
+
+
+            <!-- Water -->
+            <div class="sheet-col"> 
+                <h3 class="ability">Water</h3>
+                <div class="ability">
+                    <input type="checkbox" name="attr_BureaucracyFavored" value="1" /><span></span>
+                    <span class="ability">Bureaucracy</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Bureaucracy_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Bureaucracy" value="0" checked="checked" />
+                        <input type="radio" name="attr_Bureaucracy" value="1" /><span></span>
+                        <input type="radio" name="attr_Bureaucracy" value="2" /><span></span>
+                        <input type="radio" name="attr_Bureaucracy" value="3" /><span></span>
+                        <input type="radio" name="attr_Bureaucracy" value="4" /><span></span>
+                        <input type="radio" name="attr_Bureaucracy" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_InvestigationFavored" value="1" /><span></span>
+                    <span class="ability">Investigation</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Investigation_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Investigation" value="0" checked="checked" />
+                        <input type="radio" name="attr_Investigation" value="1" /><span></span>
+                        <input type="radio" name="attr_Investigation" value="2" /><span></span>
+                        <input type="radio" name="attr_Investigation" value="3" /><span></span>
+                        <input type="radio" name="attr_Investigation" value="4" /><span></span>
+                        <input type="radio" name="attr_Investigation" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_LarcenyFavored" value="1" /><span></span>
+                    <span class="ability">Larceny</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Larceny_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Larceny" value="0" checked="checked" />
+                        <input type="radio" name="attr_Larceny" value="1" /><span></span>
+                        <input type="radio" name="attr_Larceny" value="2" /><span></span>
+                        <input type="radio" name="attr_Larceny" value="3" /><span></span>
+                        <input type="radio" name="attr_Larceny" value="4" /><span></span>
+                        <input type="radio" name="attr_Larceny" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_MartialArtsFavored" value="1" /><span></span>
+                    <span class="ability">Martial Arts</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_MartialArts_max" value="1" /><span></span>
+                        <input type="radio" name="attr_MartialArts" value="0" checked="checked" />
+                        <input type="radio" name="attr_MartialArts" value="1" /><span></span>
+                        <input type="radio" name="attr_MartialArts" value="2" /><span></span>
+                        <input type="radio" name="attr_MartialArts" value="3" /><span></span>
+                        <input type="radio" name="attr_MartialArts" value="4" /><span></span>
+                        <input type="radio" name="attr_MartialArts" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_SailFavored" value="1" /><span></span>
+                    <span class="ability">Sail</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Sail_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Sail" value="0" checked="checked" />
+                        <input type="radio" name="attr_Sail" value="1" /><span></span>
+                        <input type="radio" name="attr_Sail" value="2" /><span></span>
+                        <input type="radio" name="attr_Sail" value="3" /><span></span>
+                        <input type="radio" name="attr_Sail" value="4" /><span></span>
+                        <input type="radio" name="attr_Sail" value="5" /><span></span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Wood -->
+            <div class="sheet-col"> 
+                <h3 class="ability">Wood</h3>
+                <div class="ability">
+                    <input type="checkbox" name="attr_ArcheryFavored" value="1" /><span></span>
+                    <span class="ability">Archery</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Archery_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Archery" value="0" checked="checked" />
+                        <input type="radio" name="attr_Archery" value="1" /><span></span>
+                        <input type="radio" name="attr_Archery" value="2" /><span></span>
+                        <input type="radio" name="attr_Archery" value="3" /><span></span>
+                        <input type="radio" name="attr_Archery" value="4" /><span></span>
+                        <input type="radio" name="attr_Archery" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_MedicineFavored" value="1" /><span></span>
+                    <span class="ability">Medicine</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Medicine_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Medicine" value="0" checked="checked" />
+                        <input type="radio" name="attr_Medicine" value="1" /><span></span>
+                        <input type="radio" name="attr_Medicine" value="2" /><span></span>
+                        <input type="radio" name="attr_Medicine" value="3" /><span></span>
+                        <input type="radio" name="attr_Medicine" value="4" /><span></span>
+                        <input type="radio" name="attr_Medicine" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_PerformanceFavored" value="1" /><span></span>
+                    <span class="ability">Performance</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Performance_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Performance" value="0" checked="checked" />
+                        <input type="radio" name="attr_Performance" value="1" /><span></span>
+                        <input type="radio" name="attr_Performance" value="2" /><span></span>
+                        <input type="radio" name="attr_Performance" value="3" /><span></span>
+                        <input type="radio" name="attr_Performance" value="4" /><span></span>
+                        <input type="radio" name="attr_Performance" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_RideFavored" value="1" /><span></span>
+                    <span class="ability">Ride</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Ride_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Ride" value="0" checked="checked" />
+                        <input type="radio" name="attr_Ride" value="1" /><span></span>
+                        <input type="radio" name="attr_Ride" value="2" /><span></span>
+                        <input type="radio" name="attr_Ride" value="3" /><span></span>
+                        <input type="radio" name="attr_Ride" value="4" /><span></span>
+                        <input type="radio" name="attr_Ride" value="5" /><span></span>
+                    </div>
+                </div>
+                <div class="ability">
+                    <input type="checkbox" name="attr_SurvivalFavored" value="1" /><span></span>
+                    <span class="ability">Survival</span>
+                    <div class="dots">
+                        <input type="checkbox" name="attr_Survival_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Survival" value="0" checked="checked" />
+                        <input type="radio" name="attr_Survival" value="1" /><span></span>
+                        <input type="radio" name="attr_Survival" value="2" /><span></span>
+                        <input type="radio" name="attr_Survival" value="3" /><span></span>
+                        <input type="radio" name="attr_Survival" value="4" /><span></span>
+                        <input type="radio" name="attr_Survival" value="5" /><span></span>
+                    </div>
+                </div>
+            </div> 
+
+            <!-- Specialities -->
+            <div class="sheet-col">
+                <h3 class="ability">Specialties</h3>
+                <fieldset class="repeating_specialties">
+                    <div class="ability specialty">
+                        <input type="checkbox" name="attr_SpecialtyFavored" value="1" style="margin-top: 1px" /><span></span>
+                        <input type="text" name="attr_SpecialtyName" style="width:100px;height:24px;padding-top: 0px;padding-bottom: 1px;"/>
+                        <div class="dots">
+                            <input type="radio" name="attr_Specialty" value="1" checked="checked" /><span></span>
+                            <input type="radio" name="attr_Specialty" value="2" /><span></span>
+                            <input type="radio" name="attr_Specialty" value="3" /><span></span>
+                            <input type="radio" name="attr_Specialty" value="4" /><span></span>
+                            <input type="radio" name="attr_Specialty" value="5" /><span></span>
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+        </div>
+
     </div>
 
     
@@ -1791,31 +2131,3 @@
         </div>
     </div>
 </div>
-
-<!-- 
-            <span>Caste:</span>
-            <select name="attr_Caste">
-                <option value="Dawn">Solar: Dawn</option>
-                <option value="Zenith">Solar: Zenith</option>
-                <option value="Twilight">Solar: Twilight</option>
-                <option value="Night">Solar: Night</option>
-                <option value="Eclipse">Solar: Eclipse</option>
-
-                <option value="FullMoon">Lunar: Full Moon</option>
-                <option value="ChangingMoon">Lunar: Changing Moon</option>
-                <option value="NoMoon">Lunar: No Moon</option>
-
-                <option value="Journey">Sidereal: Journey</option>
-                <option value="Serenity">Sidereal: Serenity</option>
-                <option value="Battle">Sidereal: Battle</option>
-                <option value="Secret">Sidereal: Secret</option>
-                <option value="Ending">Sidereal: Ending</option>
-
-                <option value="Earth">Dragon-Blooded: Earth</option>
-                <option value="Fire">Dragon-Blooded: Fire</option>
-                <option value="Water">Dragon-Blooded: Water</option>
-                <option value="Air">Dragon-Blooded: Air</option>
-            </select>
- -->
-
-


### PR DESCRIPTION
## Changes / Comments
- When selecting one of the Dragon-Blooded Castes, the sheet will show Dragon-Blooded statblocks, otherwise it still defaults to Solar
- Added some comments/space to code
- Minor formatting
- expanded Readme comments

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
