### PR TITLE
[Exalted2E] Fix Solar abilities bug from last week

### DIFF
--- a/Exalted2e/README.md
+++ b/Exalted2e/README.md
@@ -6,6 +6,7 @@ Character sheet for _Exalted, Second Edition_ by White Wolf Publishing.
 
 `exalted2e.css` and `exalted2e.html` **must** be saved with Unicode encoding. Using Unicode character codes does not currently work with the character sheet system, so the characters themselves must be used. Saving the file as ANSI, etc. will break the appearance of the character sheet.
 
+
 ### To Do
 * Add Ability sections for Lunars, Abyssals, Infernals and Sidereals
 * Fix the stat-tracking radio-inputs so that stats are truly zeroed with the first radio-button, in the way every other Wolrd of Darkness sheet works
@@ -20,3 +21,12 @@ If you feel you've contributed to the development of this character sheet, don't
 * Brian Shields
 * Benjamin Bandelow
 * Andreas J.
+
+### Changelog
+
+#### 2019-12-03
+* Dragonblooded abilities are now tracked by separate Roll20 attributes, as not to interfere with the default Solar abililtes. The Solars abilities are no longer hidden with the red checkbox by default.
+
+
+#### 2019-11-24
+* added dragonblooded ability tracking

--- a/Exalted2e/exalted2e.html
+++ b/Exalted2e/exalted2e.html
@@ -1069,7 +1069,7 @@
                     <input type="checkbox" name="attr_ArcheryFavored" value="1" /><span></span>
                     <span class="ability">Archery</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Archery_max" value="1" checked="checked" /><span></span>
+                        <input type="checkbox" name="attr_Archery_max" value="1"  /><span></span>
                         <input type="radio" name="attr_Archery" value="0" checked="checked" />
                         <input type="radio" name="attr_Archery" value="1" /><span></span>
                         <input type="radio" name="attr_Archery" value="2" /><span></span>
@@ -1082,7 +1082,7 @@
                     <input type="checkbox" name="attr_MartialArtsFavored" value="1" /><span></span>
                     <span class="ability">Martial Arts</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_MartialArts_max" value="1" checked="checked" /><span></span>
+                        <input type="checkbox" name="attr_MartialArts_max" value="1"  /><span></span>
                         <input type="radio" name="attr_MartialArts" value="0" checked="checked"/>
                         <input type="radio" name="attr_MartialArts" value="1" /><span></span>
                         <input type="radio" name="attr_MartialArts" value="2" /><span></span>
@@ -1095,7 +1095,7 @@
                     <input type="checkbox" name="attr_MeleeFavored" value="1" /><span></span>
                     <span class="ability">Melee</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Melee_max" value="1" checked="checked" /><span></span>
+                        <input type="checkbox" name="attr_Melee_max" value="1"  /><span></span>
                         <input type="radio" name="attr_Melee" value="0" checked="checked" />
                         <input type="radio" name="attr_Melee" value="1" /><span></span>
                         <input type="radio" name="attr_Melee" value="2" /><span></span>
@@ -1108,7 +1108,7 @@
                     <input type="checkbox" name="attr_ThrownFavored" value="1" /><span></span>
                     <span class="ability">Thrown</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Thrown_max" value="1" checked="checked" /><span></span>
+                        <input type="checkbox" name="attr_Thrown_max" value="1"  /><span></span>
                         <input type="radio" name="attr_Thrown" value="0" checked="checked" />
                         <input type="radio" name="attr_Thrown" value="1" /><span></span>
                         <input type="radio" name="attr_Thrown" value="2" /><span></span>
@@ -1121,7 +1121,7 @@
                     <input type="checkbox" name="attr_WarFavored" value="1" /><span></span>
                     <span class="ability">War</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_War_max" value="1" checked="checked" /><span></span>
+                        <input type="checkbox" name="attr_War_max" value="1" /><span></span>
                         <input type="radio" name="attr_War" value="0" checked="checked" />
                         <input type="radio" name="attr_War" value="1" /><span></span>
                         <input type="radio" name="attr_War" value="2" /><span></span>
@@ -1139,7 +1139,7 @@
                     <input type="checkbox" name="attr_IntegrityFavored" value="1" /><span></span>
                     <span class="ability">Integrity</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Integrity_max" value="1" checked="checked" /><span></span>
+                        <input type="checkbox" name="attr_Integrity_max" value="1"  /><span></span>
                         <input type="radio" name="attr_Integrity" value="0" checked="checked" />
                         <input type="radio" name="attr_Integrity" value="1" /><span></span>
                         <input type="radio" name="attr_Integrity" value="2" /><span></span>
@@ -1152,7 +1152,7 @@
                     <input type="checkbox" name="attr_PerformanceFavored" value="1" /><span></span>
                     <span class="ability">Performance</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Performance_max" value="1" checked="checked" /><span></span>
+                        <input type="checkbox" name="attr_Performance_max" value="1"  /><span></span>
                         <input type="radio" name="attr_Performance" value="0" checked="checked" />
                         <input type="radio" name="attr_Performance" value="1" /><span></span>
                         <input type="radio" name="attr_Performance" value="2" /><span></span>
@@ -1165,7 +1165,7 @@
                     <input type="checkbox" name="attr_PresenceFavored" value="1" /><span></span>
                     <span class="ability">Presence</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Presence_max" value="1" checked="checked" /><span></span>
+                        <input type="checkbox" name="attr_Presence_max" value="1"  /><span></span>
                         <input type="radio" name="attr_Presence" value="0" checked="checked" />
                         <input type="radio" name="attr_Presence" value="1" /><span></span>
                         <input type="radio" name="attr_Presence" value="2" /><span></span>
@@ -1178,7 +1178,7 @@
                     <input type="checkbox" name="attr_ResistanceFavored" value="1" /><span></span>
                     <span class="ability">Resistance</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Resistance_max" value="1" checked="checked" /><span></span>
+                        <input type="checkbox" name="attr_Resistance_max" value="1"  /><span></span>
                         <input type="radio" name="attr_Resistance" value="0" checked="checked" />
                         <input type="radio" name="attr_Resistance" value="1" /><span></span>
                         <input type="radio" name="attr_Resistance" value="2" /><span></span>
@@ -1191,7 +1191,7 @@
                     <input type="checkbox" name="attr_SurvivalFavored" value="1" /><span></span>
                     <span class="ability">Survival</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Survival_max" value="1" checked="checked" /><span></span>
+                        <input type="checkbox" name="attr_Survival_max" value="1"  /><span></span>
                         <input type="radio" name="attr_Survival" value="0" checked="checked" />
                         <input type="radio" name="attr_Survival" value="1" /><span></span>
                         <input type="radio" name="attr_Survival" value="2" /><span></span>
@@ -1212,7 +1212,7 @@
                         <li title="[Mundane] Making small, decorative, or high-precision items">
                             Air
                             <div class="dots">
-                                <input type="checkbox" name="attr_CraftAir_max" value="1" checked="checked" /><span></span>
+                                <input type="checkbox" name="attr_CraftAir_max" value="1"  /><span></span>
                                 <input type="radio" name="attr_CraftAir" value="0" checked="checked" />
                                 <input type="radio" name="attr_CraftAir" value="1" /><span></span>
                                 <input type="radio" name="attr_CraftAir" value="2" /><span></span>
@@ -1224,7 +1224,7 @@
                         <li title="[Mundane] Creating buildings and large objects with stone or earth">
                             Earth
                             <div class="dots">
-                                <input type="checkbox" name="attr_CraftEarth_max" value="1" checked="checked" /><span></span>
+                                <input type="checkbox" name="attr_CraftEarth_max" value="1"  /><span></span>
                                 <input type="radio" name="attr_CraftEarth" value="0" checked="checked" />
                                 <input type="radio" name="attr_CraftEarth" value="1" /><span></span>
                                 <input type="radio" name="attr_CraftEarth" value="2" /><span></span>
@@ -1236,7 +1236,7 @@
                         <li title="[Mundane] Forging and casting large metal objects and creating objects using fire">
                             Fire
                             <div class="dots">
-                                <input type="checkbox" name="attr_CraftFire_max" value="1" checked="checked" /><span></span>
+                                <input type="checkbox" name="attr_CraftFire_max" value="1"  /><span></span>
                                 <input type="radio" name="attr_CraftFire" value="0" checked="checked" />
                                 <input type="radio" name="attr_CraftFire" value="1" /><span></span>
                                 <input type="radio" name="attr_CraftFire" value="2" /><span></span>
@@ -1248,7 +1248,7 @@
                         <li title="[Mundane] Boiling and cooking plants, chemicals, and animal materials">
                             Water
                             <div class="dots">
-                                <input type="checkbox" name="attr_CraftWater_max" value="1" checked="checked" /><span></span>
+                                <input type="checkbox" name="attr_CraftWater_max" value="1"  /><span></span>
                                 <input type="radio" name="attr_CraftWater" value="0" checked="checked" />
                                 <input type="radio" name="attr_CraftWater" value="1" /><span></span>
                                 <input type="radio" name="attr_CraftWater" value="2" /><span></span>
@@ -1260,7 +1260,7 @@
                         <li title="[Mundane] Carving, weaving, and manipulating natural elements">
                             Wood
                             <div class="dots">
-                                <input type="checkbox" name="attr_CraftWood_max" value="1" checked="checked" /><span></span>
+                                <input type="checkbox" name="attr_CraftWood_max" value="1"  /><span></span>
                                 <input type="radio" name="attr_CraftWood" value="0" checked="checked" />
                                 <input type="radio" name="attr_CraftWood" value="1" /><span></span>
                                 <input type="radio" name="attr_CraftWood" value="2" /><span></span>
@@ -1272,7 +1272,7 @@
                         <li title="[Esoteric, Sidereal] Manipulate fate for certain Astrologies and Charms">
                             Fate
                             <div class="dots">
-                                <input type="checkbox" name="attr_CraftFate_max" value="1" checked="checked" /><span></span>
+                                <input type="checkbox" name="attr_CraftFate_max" value="1"  /><span></span>
                                 <input type="radio" name="attr_CraftFate" value="0" checked="checked" />
                                 <input type="radio" name="attr_CraftFate" value="1" /><span></span>
                                 <input type="radio" name="attr_CraftFate" value="2" /><span></span>
@@ -1284,7 +1284,7 @@
                         <li title="[Esoteric, First Age] Create or modify life">
                             Genesis
                             <div class="dots">
-                                <input type="checkbox" name="attr_CraftGenesis_max" value="1" checked="checked" /><span></span>
+                                <input type="checkbox" name="attr_CraftGenesis_max" value="1"  /><span></span>
                                 <input type="radio" name="attr_CraftGenesis" value="0" checked="checked" />
                                 <input type="radio" name="attr_CraftGenesis" value="1" /><span></span>
                                 <input type="radio" name="attr_CraftGenesis" value="2" /><span></span>
@@ -1296,7 +1296,7 @@
                         <li title="[Esoteric, Raksha] Manipulate the physical manifestation of shaping effects, from Essence to dreams">
                             Glamour
                             <div class="dots">
-                                <input type="checkbox" name="attr_CraftGlamour_max" value="1" checked="checked" /><span></span>
+                                <input type="checkbox" name="attr_CraftGlamour_max" value="1"  /><span></span>
                                 <input type="radio" name="attr_CraftGlamour" value="0" checked="checked" />
                                 <input type="radio" name="attr_CraftGlamour" value="1" /><span></span>
                                 <input type="radio" name="attr_CraftGlamour" value="2" /><span></span>
@@ -1308,7 +1308,7 @@
                         <li title="[Esoteric, First Age] Creation, enchantment, and maintenance of First Age devices">
                             Magitech
                             <div class="dots">
-                                <input type="checkbox" name="attr_CraftMagitech_max" value="1" checked="checked" /><span></span>
+                                <input type="checkbox" name="attr_CraftMagitech_max" value="1"  /><span></span>
                                 <input type="radio" name="attr_CraftMagitech" value="0" checked="checked" />
                                 <input type="radio" name="attr_CraftMagitech" value="1" /><span></span>
                                 <input type="radio" name="attr_CraftMagitech" value="2" /><span></span>
@@ -1320,7 +1320,7 @@
                         <li title="[Esoteric, Infernal] Use Malfean Vitriol to catalyze a mundane Craft">
                             Vitriol
                             <div class="dots">
-                                <input type="checkbox" name="attr_CraftVitriol_max" value="1" checked="checked" /><span></span>
+                                <input type="checkbox" name="attr_CraftVitriol_max" value="1"  /><span></span>
                                 <input type="radio" name="attr_CraftVitriol" value="0" checked="checked" />
                                 <input type="radio" name="attr_CraftVitriol" value="1" /><span></span>
                                 <input type="radio" name="attr_CraftVitriol" value="2" /><span></span>
@@ -1336,7 +1336,7 @@
                     <input type="checkbox" name="attr_InvestigationFavored" value="1" /><span></span>
                     <span class="ability">Investigation</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Investigation_max" value="1" checked="checked" /><span></span>
+                        <input type="checkbox" name="attr_Investigation_max" value="1"  /><span></span>
                         <input type="radio" name="attr_Investigation" value="0" checked="checked" />
                         <input type="radio" name="attr_Investigation" value="1" /><span></span>
                         <input type="radio" name="attr_Investigation" value="2" /><span></span>
@@ -1349,7 +1349,7 @@
                     <input type="checkbox" name="attr_LoreFavored" value="1" /><span></span>
                     <span class="ability">Lore</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Lore_max" value="1" checked="checked" /><span></span>
+                        <input type="checkbox" name="attr_Lore_max" value="1"  /><span></span>
                         <input type="radio" name="attr_Lore" value="0" checked="checked" />
                         <input type="radio" name="attr_Lore" value="1" /><span></span>
                         <input type="radio" name="attr_Lore" value="2" /><span></span>
@@ -1362,7 +1362,7 @@
                     <input type="checkbox" name="attr_MedicineFavored" value="1" /><span></span>
                     <span class="ability">Medicine</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Medicine_max" value="1" checked="checked" /><span></span>
+                        <input type="checkbox" name="attr_Medicine_max" value="1" /><span></span>
                         <input type="radio" name="attr_Medicine" value="0" checked="checked" />
                         <input type="radio" name="attr_Medicine" value="1" /><span></span>
                         <input type="radio" name="attr_Medicine" value="2" /><span></span>
@@ -1375,7 +1375,7 @@
                     <input type="checkbox" name="attr_OccultFavored" value="1" /><span></span>
                     <span class="ability">Occult</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Occult_max" value="1" checked="checked" /><span></span>
+                        <input type="checkbox" name="attr_Occult_max" value="1"  /><span></span>
                         <input type="radio" name="attr_Occult" value="0" checked="checked" />
                         <input type="radio" name="attr_Occult" value="1" /><span></span>
                         <input type="radio" name="attr_Occult" value="2" /><span></span>
@@ -1395,7 +1395,7 @@
                     <input type="checkbox" name="attr_AthleticsFavored" value="1" /><span></span>
                     <span class="ability">Athletics</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Athletics_max" value="1" checked="checked" checked="checked"/><span></span>
+                        <input type="checkbox" name="attr_Athletics_max" value="1"  /><span></span>
                         <input type="radio" name="attr_Athletics" value="0" checked="checked" />
                         <input type="radio" name="attr_Athletics" value="1" /><span></span>
                         <input type="radio" name="attr_Athletics" value="2" /><span></span>
@@ -1408,7 +1408,7 @@
                     <input type="checkbox" name="attr_AwarenessFavored" value="1" /><span></span>
                     <span class="ability">Awareness</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Awareness_max" value="1" checked="checked" checked="checked"/><span></span>
+                        <input type="checkbox" name="attr_Awareness_max" value="1"  /><span></span>
                         <input type="radio" name="attr_Awareness" value="0" checked="checked" />
                         <input type="radio" name="attr_Awareness" value="1" /><span></span>
                         <input type="radio" name="attr_Awareness" value="2" /><span></span>
@@ -1421,7 +1421,7 @@
                     <input type="checkbox" name="attr_DodgeFavored" value="1" /><span></span>
                     <span class="ability">Dodge</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Dodge_max" value="1" checked="checked" checked="checked"/><span></span>
+                        <input type="checkbox" name="attr_Dodge_max" value="1" /><span></span>
                         <input type="radio" name="attr_Dodge" value="0" checked="checked" />
                         <input type="radio" name="attr_Dodge" value="1" /><span></span>
                         <input type="radio" name="attr_Dodge" value="2" /><span></span>
@@ -1434,7 +1434,7 @@
                     <input type="checkbox" name="attr_LarcenyFavored" value="1" /><span></span>
                     <span class="ability">Larceny</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Larceny_max" value="1" checked="checked" checked="checked"/><span></span>
+                        <input type="checkbox" name="attr_Larceny_max" value="1" /><span></span>
                         <input type="radio" name="attr_Larceny" value="0" checked="checked" />
                         <input type="radio" name="attr_Larceny" value="1" /><span></span>
                         <input type="radio" name="attr_Larceny" value="2" /><span></span>
@@ -1447,7 +1447,7 @@
                     <input type="checkbox" name="attr_StealthFavored" value="1" /><span></span>
                     <span class="ability">Stealth</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Stealth_max" value="1" checked="checked" checked="checked"/><span></span>
+                        <input type="checkbox" name="attr_Stealth_max" value="1"/><span></span>
                         <input type="radio" name="attr_Stealth" value="0" checked="checked" />
                         <input type="radio" name="attr_Stealth" value="1" /><span></span>
                         <input type="radio" name="attr_Stealth" value="2" /><span></span>
@@ -1465,7 +1465,7 @@
                     <input type="checkbox" name="attr_BureaucracyFavored" value="1" /><span></span>
                     <span class="ability">Bureaucracy</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Bureaucracy_max" value="1" checked="checked" /><span></span>
+                        <input type="checkbox" name="attr_Bureaucracy_max" value="1"  /><span></span>
                         <input type="radio" name="attr_Bureaucracy" value="0" checked="checked" />
                         <input type="radio" name="attr_Bureaucracy" value="1" /><span></span>
                         <input type="radio" name="attr_Bureaucracy" value="2" /><span></span>
@@ -1478,7 +1478,7 @@
                     <input type="checkbox" name="attr_LinguisticsFavored" value="1" /><span></span>
                     <span class="ability">Linguistics</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Linguistics_max" value="1" checked="checked" /><span></span>
+                        <input type="checkbox" name="attr_Linguistics_max" value="1"  /><span></span>
                         <input type="radio" name="attr_Linguistics" value="0" checked="checked" />
                         <input type="radio" name="attr_Linguistics" value="1" /><span></span>
                         <input type="radio" name="attr_Linguistics" value="2" /><span></span>
@@ -1491,7 +1491,7 @@
                     <input type="checkbox" name="attr_RideFavored" value="1" /><span></span>
                     <span class="ability">Ride</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Ride_max" value="1" checked="checked" /><span></span>
+                        <input type="checkbox" name="attr_Ride_max" value="1" /><span></span>
                         <input type="radio" name="attr_Ride" value="0" checked="checked" />
                         <input type="radio" name="attr_Ride" value="1" /><span></span>
                         <input type="radio" name="attr_Ride" value="2" /><span></span>
@@ -1504,7 +1504,7 @@
                     <input type="checkbox" name="attr_SailFavored" value="1" /><span></span>
                     <span class="ability">Sail</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Sail_max" value="1" checked="checked" /><span></span>
+                        <input type="checkbox" name="attr_Sail_max" value="1" /><span></span>
                         <input type="radio" name="attr_Sail" value="0" checked="checked" />
                         <input type="radio" name="attr_Sail" value="1" /><span></span>
                         <input type="radio" name="attr_Sail" value="2" /><span></span>
@@ -1517,7 +1517,7 @@
                     <input type="checkbox" name="attr_SocializeFavored" value="1" /><span></span>
                     <span class="ability">Socialize</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Socialize_max" value="1" checked="checked" /><span></span>
+                        <input type="checkbox" name="attr_Socialize_max" value="1" /><span></span>
                         <input type="radio" name="attr_Socialize" value="0" checked="checked" />
                         <input type="radio" name="attr_Socialize" value="1" /><span></span>
                         <input type="radio" name="attr_Socialize" value="2" /><span></span>
@@ -1556,68 +1556,68 @@
             <div class="sheet-col"> 
                 <h3 class="ability">Air</h3>
                 <div class="ability">
-                    <input type="checkbox" name="attr_LinguisticsFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Linguistics2Favored" value="1" /><span></span>
                     <span class="ability">Linguistics</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Linguistics_max" value="1"  /><span></span>
-                        <input type="radio" name="attr_Linguistics" value="0" checked="checked" />
-                        <input type="radio" name="attr_Linguistics" value="1" /><span></span>
-                        <input type="radio" name="attr_Linguistics" value="2" /><span></span>
-                        <input type="radio" name="attr_Linguistics" value="3" /><span></span>
-                        <input type="radio" name="attr_Linguistics" value="4" /><span></span>
-                        <input type="radio" name="attr_Linguistics" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Linguistics2_max" value="1"  /><span></span>
+                        <input type="radio" name="attr_Linguistics2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Linguistics2" value="1" /><span></span>
+                        <input type="radio" name="attr_Linguistics2" value="2" /><span></span>
+                        <input type="radio" name="attr_Linguistics2" value="3" /><span></span>
+                        <input type="radio" name="attr_Linguistics2" value="4" /><span></span>
+                        <input type="radio" name="attr_Linguistics2" value="5" /><span></span>
                     </div>
                 </div>
                 <div class="ability">
-                    <input type="checkbox" name="attr_LoreFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Lore2Favored" value="1" /><span></span>
                     <span class="ability">Lore</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Lore_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Lore" value="0" checked="checked" />
-                        <input type="radio" name="attr_Lore" value="1" /><span></span>
-                        <input type="radio" name="attr_Lore" value="2" /><span></span>
-                        <input type="radio" name="attr_Lore" value="3" /><span></span>
-                        <input type="radio" name="attr_Lore" value="4" /><span></span>
-                        <input type="radio" name="attr_Lore" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Lore2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Lore2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Lore2" value="1" /><span></span>
+                        <input type="radio" name="attr_Lore2" value="2" /><span></span>
+                        <input type="radio" name="attr_Lore2" value="3" /><span></span>
+                        <input type="radio" name="attr_Lore2" value="4" /><span></span>
+                        <input type="radio" name="attr_Lore2" value="5" /><span></span>
                     </div>
                 </div>
                 <div class="ability">
-                    <input type="checkbox" name="attr_OccultFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Occult2Favored" value="1" /><span></span>
                     <span class="ability">Occult</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Occult_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Occult" value="0" checked="checked" />
-                        <input type="radio" name="attr_Occult" value="1" /><span></span>
-                        <input type="radio" name="attr_Occult" value="2" /><span></span>
-                        <input type="radio" name="attr_Occult" value="3" /><span></span>
-                        <input type="radio" name="attr_Occult" value="4" /><span></span>
-                        <input type="radio" name="attr_Occult" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Occult2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Occult2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Occult2" value="1" /><span></span>
+                        <input type="radio" name="attr_Occult2" value="2" /><span></span>
+                        <input type="radio" name="attr_Occult2" value="3" /><span></span>
+                        <input type="radio" name="attr_Occult2" value="4" /><span></span>
+                        <input type="radio" name="attr_Occult2" value="5" /><span></span>
                     </div>
                 </div>
                 <div class="ability">
-                    <input type="checkbox" name="attr_StealthFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Stealth2Favored" value="1" /><span></span>
                     <span class="ability">Stealth</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Stealth_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Stealth" value="0" checked="checked" />
-                        <input type="radio" name="attr_Stealth" value="1" /><span></span>
-                        <input type="radio" name="attr_Stealth" value="2" /><span></span>
-                        <input type="radio" name="attr_Stealth" value="3" /><span></span>
-                        <input type="radio" name="attr_Stealth" value="4" /><span></span>
-                        <input type="radio" name="attr_Stealth" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Stealth2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Stealth2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Stealth2" value="1" /><span></span>
+                        <input type="radio" name="attr_Stealth2" value="2" /><span></span>
+                        <input type="radio" name="attr_Stealth2" value="3" /><span></span>
+                        <input type="radio" name="attr_Stealth2" value="4" /><span></span>
+                        <input type="radio" name="attr_Stealth2" value="5" /><span></span>
                     </div>
                 </div>
                 <div class="ability">
-                    <input type="checkbox" name="attr_ThrownFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Thrown2Favored" value="1" /><span></span>
                     <span class="ability">Thrown</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Thrown_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Thrown" value="0" checked="checked" />
-                        <input type="radio" name="attr_Thrown" value="1" /><span></span>
-                        <input type="radio" name="attr_Thrown" value="2" /><span></span>
-                        <input type="radio" name="attr_Thrown" value="3" /><span></span>
-                        <input type="radio" name="attr_Thrown" value="4" /><span></span>
-                        <input type="radio" name="attr_Thrown" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Thrown2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Thrown2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Thrown2" value="1" /><span></span>
+                        <input type="radio" name="attr_Thrown2" value="2" /><span></span>
+                        <input type="radio" name="attr_Thrown2" value="3" /><span></span>
+                        <input type="radio" name="attr_Thrown2" value="4" /><span></span>
+                        <input type="radio" name="attr_Thrown2" value="5" /><span></span>
                     </div>
                 </div>
             </div>
@@ -1626,68 +1626,68 @@
             <div class="sheet-col"> 
                 <h3 class="ability">Earth</h3>
                 <div class="ability">
-                    <input type="checkbox" name="attr_AwarnessFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Awarness2Favored" value="1" /><span></span>
                     <span class="ability">Awarness</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Awarness_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Awarness" value="0" checked="checked" />
-                        <input type="radio" name="attr_Awarness" value="1" /><span></span>
-                        <input type="radio" name="attr_Awarness" value="2" /><span></span>
-                        <input type="radio" name="attr_Awarness" value="3" /><span></span>
-                        <input type="radio" name="attr_Awarness" value="4" /><span></span>
-                        <input type="radio" name="attr_Awarness" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Awarness2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Awarness2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Awarness2" value="1" /><span></span>
+                        <input type="radio" name="attr_Awarness2" value="2" /><span></span>
+                        <input type="radio" name="attr_Awarness2" value="3" /><span></span>
+                        <input type="radio" name="attr_Awarness2" value="4" /><span></span>
+                        <input type="radio" name="attr_Awarness2" value="5" /><span></span>
                     </div>
                 </div>
                 <div class="ability">
-                    <input type="checkbox" name="attr_CraftsFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Crafts2Favored" value="1" /><span></span>
                     <span class="ability">Crafts</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Crafts_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Crafts" value="0" checked="checked" />
-                        <input type="radio" name="attr_Crafts" value="1" /><span></span>
-                        <input type="radio" name="attr_Crafts" value="2" /><span></span>
-                        <input type="radio" name="attr_Crafts" value="3" /><span></span>
-                        <input type="radio" name="attr_Crafts" value="4" /><span></span>
-                        <input type="radio" name="attr_Crafts" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Crafts2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Crafts2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Crafts2" value="1" /><span></span>
+                        <input type="radio" name="attr_Crafts2" value="2" /><span></span>
+                        <input type="radio" name="attr_Crafts2" value="3" /><span></span>
+                        <input type="radio" name="attr_Crafts2" value="4" /><span></span>
+                        <input type="radio" name="attr_Crafts2" value="5" /><span></span>
                     </div>
                 </div>
                 <div class="ability">
-                    <input type="checkbox" name="attr_IntegrityFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Integrity2Favored" value="1" /><span></span>
                     <span class="ability">Integrity</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Integrity_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Integrity" value="0" checked="checked" />
-                        <input type="radio" name="attr_Integrity" value="1" /><span></span>
-                        <input type="radio" name="attr_Integrity" value="2" /><span></span>
-                        <input type="radio" name="attr_Integrity" value="3" /><span></span>
-                        <input type="radio" name="attr_Integrity" value="4" /><span></span>
-                        <input type="radio" name="attr_Integrity" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Integrity2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Integrity2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Integrity2" value="1" /><span></span>
+                        <input type="radio" name="attr_Integrity2" value="2" /><span></span>
+                        <input type="radio" name="attr_Integrity2" value="3" /><span></span>
+                        <input type="radio" name="attr_Integrity2" value="4" /><span></span>
+                        <input type="radio" name="attr_Integrity2" value="5" /><span></span>
                     </div>
                 </div>
                 <div class="ability">
-                    <input type="checkbox" name="attr_ResistanceFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Resistance2Favored" value="1" /><span></span>
                     <span class="ability">Resistance</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Resistance_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Resistance" value="0" checked="checked" />
-                        <input type="radio" name="attr_Resistance" value="1" /><span></span>
-                        <input type="radio" name="attr_Resistance" value="2" /><span></span>
-                        <input type="radio" name="attr_Resistance" value="3" /><span></span>
-                        <input type="radio" name="attr_Resistance" value="4" /><span></span>
-                        <input type="radio" name="attr_Resistance" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Resistance2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Resistance2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Resistance2" value="1" /><span></span>
+                        <input type="radio" name="attr_Resistance2" value="2" /><span></span>
+                        <input type="radio" name="attr_Resistance2" value="3" /><span></span>
+                        <input type="radio" name="attr_Resistance2" value="4" /><span></span>
+                        <input type="radio" name="attr_Resistance2" value="5" /><span></span>
                     </div>
                 </div>
                 <div class="ability">
-                    <input type="checkbox" name="attr_WarFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_War2Favored" value="1" /><span></span>
                     <span class="ability">War</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_War_max" value="1" /><span></span>
-                        <input type="radio" name="attr_War" value="0" checked="checked" />
-                        <input type="radio" name="attr_War" value="1" /><span></span>
-                        <input type="radio" name="attr_War" value="2" /><span></span>
-                        <input type="radio" name="attr_War" value="3" /><span></span>
-                        <input type="radio" name="attr_War" value="4" /><span></span>
-                        <input type="radio" name="attr_War" value="5" /><span></span>
+                        <input type="checkbox" name="attr_War2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_War2" value="0" checked="checked" />
+                        <input type="radio" name="attr_War2" value="1" /><span></span>
+                        <input type="radio" name="attr_War2" value="2" /><span></span>
+                        <input type="radio" name="attr_War2" value="3" /><span></span>
+                        <input type="radio" name="attr_War2" value="4" /><span></span>
+                        <input type="radio" name="attr_War2" value="5" /><span></span>
                     </div>
                 </div>
             </div>
@@ -1696,68 +1696,68 @@
             <div class="sheet-col"> 
                 <h3 class="ability">Fire</h3>
                 <div class="ability">
-                    <input type="checkbox" name="attr_AthleticsFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Athletics2Favored" value="1" /><span></span>
                     <span class="ability">Athletics</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Athletics_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Athletics" value="0" checked="checked" />
-                        <input type="radio" name="attr_Athletics" value="1" /><span></span>
-                        <input type="radio" name="attr_Athletics" value="2" /><span></span>
-                        <input type="radio" name="attr_Athletics" value="3" /><span></span>
-                        <input type="radio" name="attr_Athletics" value="4" /><span></span>
-                        <input type="radio" name="attr_Athletics" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Athletics2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Athletics2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Athletics2" value="1" /><span></span>
+                        <input type="radio" name="attr_Athletics2" value="2" /><span></span>
+                        <input type="radio" name="attr_Athletics2" value="3" /><span></span>
+                        <input type="radio" name="attr_Athletics2" value="4" /><span></span>
+                        <input type="radio" name="attr_Athletics2" value="5" /><span></span>
                     </div>
                 </div>
                 <div class="ability">
-                    <input type="checkbox" name="attr_DodgeFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Dodge2Favored" value="1" /><span></span>
                     <span class="ability">Dodge</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Dodge_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Dodge" value="0" checked="checked" />
-                        <input type="radio" name="attr_Dodge" value="1" /><span></span>
-                        <input type="radio" name="attr_Dodge" value="2" /><span></span>
-                        <input type="radio" name="attr_Dodge" value="3" /><span></span>
-                        <input type="radio" name="attr_Dodge" value="4" /><span></span>
-                        <input type="radio" name="attr_Dodge" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Dodge2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Dodge2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Dodge2" value="1" /><span></span>
+                        <input type="radio" name="attr_Dodge2" value="2" /><span></span>
+                        <input type="radio" name="attr_Dodge2" value="3" /><span></span>
+                        <input type="radio" name="attr_Dodge2" value="4" /><span></span>
+                        <input type="radio" name="attr_Dodge2" value="5" /><span></span>
                     </div>
                 </div>
                 <div class="ability">
-                    <input type="checkbox" name="attr_MeleeFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Melee2Favored" value="1" /><span></span>
                     <span class="ability">Melee</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Melee_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Melee" value="0" checked="checked" />
-                        <input type="radio" name="attr_Melee" value="1" /><span></span>
-                        <input type="radio" name="attr_Melee" value="2" /><span></span>
-                        <input type="radio" name="attr_Melee" value="3" /><span></span>
-                        <input type="radio" name="attr_Melee" value="4" /><span></span>
-                        <input type="radio" name="attr_Melee" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Melee2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Melee2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Melee2" value="1" /><span></span>
+                        <input type="radio" name="attr_Melee2" value="2" /><span></span>
+                        <input type="radio" name="attr_Melee2" value="3" /><span></span>
+                        <input type="radio" name="attr_Melee2" value="4" /><span></span>
+                        <input type="radio" name="attr_Melee2" value="5" /><span></span>
                     </div>
                 </div>
                 <div class="ability">
-                    <input type="checkbox" name="attr_SocializeFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Socialize2Favored" value="1" /><span></span>
                     <span class="ability">Socialize</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Socialize_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Socialize" value="0" checked="checked" />
-                        <input type="radio" name="attr_Socialize" value="1" /><span></span>
-                        <input type="radio" name="attr_Socialize" value="2" /><span></span>
-                        <input type="radio" name="attr_Socialize" value="3" /><span></span>
-                        <input type="radio" name="attr_Socialize" value="4" /><span></span>
-                        <input type="radio" name="attr_Socialize" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Socialize2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Socialize2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Socialize2" value="1" /><span></span>
+                        <input type="radio" name="attr_Socialize2" value="2" /><span></span>
+                        <input type="radio" name="attr_Socialize2" value="3" /><span></span>
+                        <input type="radio" name="attr_Socialize2" value="4" /><span></span>
+                        <input type="radio" name="attr_Socialize2" value="5" /><span></span>
                     </div>
                 </div>
                 <div class="ability">
-                    <input type="checkbox" name="attr_PresenceFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Presence2Favored" value="1" /><span></span>
                     <span class="ability">Presence</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Presence_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Presence" value="0" checked="checked" />
-                        <input type="radio" name="attr_Presence" value="1" /><span></span>
-                        <input type="radio" name="attr_Presence" value="2" /><span></span>
-                        <input type="radio" name="attr_Presence" value="3" /><span></span>
-                        <input type="radio" name="attr_Presence" value="4" /><span></span>
-                        <input type="radio" name="attr_Presence" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Presence2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Presence2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Presence2" value="1" /><span></span>
+                        <input type="radio" name="attr_Presence2" value="2" /><span></span>
+                        <input type="radio" name="attr_Presence2" value="3" /><span></span>
+                        <input type="radio" name="attr_Presence2" value="4" /><span></span>
+                        <input type="radio" name="attr_Presence2" value="5" /><span></span>
                     </div>
                 </div>
             </div>            
@@ -1770,68 +1770,68 @@
             <div class="sheet-col"> 
                 <h3 class="ability">Water</h3>
                 <div class="ability">
-                    <input type="checkbox" name="attr_BureaucracyFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Bureaucracy2Favored" value="1" /><span></span>
                     <span class="ability">Bureaucracy</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Bureaucracy_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Bureaucracy" value="0" checked="checked" />
-                        <input type="radio" name="attr_Bureaucracy" value="1" /><span></span>
-                        <input type="radio" name="attr_Bureaucracy" value="2" /><span></span>
-                        <input type="radio" name="attr_Bureaucracy" value="3" /><span></span>
-                        <input type="radio" name="attr_Bureaucracy" value="4" /><span></span>
-                        <input type="radio" name="attr_Bureaucracy" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Bureaucracy2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Bureaucracy2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Bureaucracy2" value="1" /><span></span>
+                        <input type="radio" name="attr_Bureaucracy2" value="2" /><span></span>
+                        <input type="radio" name="attr_Bureaucracy2" value="3" /><span></span>
+                        <input type="radio" name="attr_Bureaucracy2" value="4" /><span></span>
+                        <input type="radio" name="attr_Bureaucracy2" value="5" /><span></span>
                     </div>
                 </div>
                 <div class="ability">
-                    <input type="checkbox" name="attr_InvestigationFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Investigation2Favored" value="1" /><span></span>
                     <span class="ability">Investigation</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Investigation_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Investigation" value="0" checked="checked" />
-                        <input type="radio" name="attr_Investigation" value="1" /><span></span>
-                        <input type="radio" name="attr_Investigation" value="2" /><span></span>
-                        <input type="radio" name="attr_Investigation" value="3" /><span></span>
-                        <input type="radio" name="attr_Investigation" value="4" /><span></span>
-                        <input type="radio" name="attr_Investigation" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Investigation2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Investigation2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Investigation2" value="1" /><span></span>
+                        <input type="radio" name="attr_Investigation2" value="2" /><span></span>
+                        <input type="radio" name="attr_Investigation2" value="3" /><span></span>
+                        <input type="radio" name="attr_Investigation2" value="4" /><span></span>
+                        <input type="radio" name="attr_Investigation2" value="5" /><span></span>
                     </div>
                 </div>
                 <div class="ability">
-                    <input type="checkbox" name="attr_LarcenyFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Larceny2Favored" value="1" /><span></span>
                     <span class="ability">Larceny</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Larceny_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Larceny" value="0" checked="checked" />
-                        <input type="radio" name="attr_Larceny" value="1" /><span></span>
-                        <input type="radio" name="attr_Larceny" value="2" /><span></span>
-                        <input type="radio" name="attr_Larceny" value="3" /><span></span>
-                        <input type="radio" name="attr_Larceny" value="4" /><span></span>
-                        <input type="radio" name="attr_Larceny" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Larceny2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Larceny2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Larceny2" value="1" /><span></span>
+                        <input type="radio" name="attr_Larceny2" value="2" /><span></span>
+                        <input type="radio" name="attr_Larceny2" value="3" /><span></span>
+                        <input type="radio" name="attr_Larceny2" value="4" /><span></span>
+                        <input type="radio" name="attr_Larceny2" value="5" /><span></span>
                     </div>
                 </div>
                 <div class="ability">
-                    <input type="checkbox" name="attr_MartialArtsFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_MartialArts2Favored" value="1" /><span></span>
                     <span class="ability">Martial Arts</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_MartialArts_max" value="1" /><span></span>
-                        <input type="radio" name="attr_MartialArts" value="0" checked="checked" />
-                        <input type="radio" name="attr_MartialArts" value="1" /><span></span>
-                        <input type="radio" name="attr_MartialArts" value="2" /><span></span>
-                        <input type="radio" name="attr_MartialArts" value="3" /><span></span>
-                        <input type="radio" name="attr_MartialArts" value="4" /><span></span>
-                        <input type="radio" name="attr_MartialArts" value="5" /><span></span>
+                        <input type="checkbox" name="attr_MartialArts2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_MartialArts2" value="0" checked="checked" />
+                        <input type="radio" name="attr_MartialArts2" value="1" /><span></span>
+                        <input type="radio" name="attr_MartialArts2" value="2" /><span></span>
+                        <input type="radio" name="attr_MartialArts2" value="3" /><span></span>
+                        <input type="radio" name="attr_MartialArts2" value="4" /><span></span>
+                        <input type="radio" name="attr_MartialArts2" value="5" /><span></span>
                     </div>
                 </div>
                 <div class="ability">
-                    <input type="checkbox" name="attr_SailFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Sail2Favored" value="1" /><span></span>
                     <span class="ability">Sail</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Sail_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Sail" value="0" checked="checked" />
-                        <input type="radio" name="attr_Sail" value="1" /><span></span>
-                        <input type="radio" name="attr_Sail" value="2" /><span></span>
-                        <input type="radio" name="attr_Sail" value="3" /><span></span>
-                        <input type="radio" name="attr_Sail" value="4" /><span></span>
-                        <input type="radio" name="attr_Sail" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Sail2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Sail2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Sail2" value="1" /><span></span>
+                        <input type="radio" name="attr_Sail2" value="2" /><span></span>
+                        <input type="radio" name="attr_Sail2" value="3" /><span></span>
+                        <input type="radio" name="attr_Sail2" value="4" /><span></span>
+                        <input type="radio" name="attr_Sail2" value="5" /><span></span>
                     </div>
                 </div>
             </div>
@@ -1840,68 +1840,68 @@
             <div class="sheet-col"> 
                 <h3 class="ability">Wood</h3>
                 <div class="ability">
-                    <input type="checkbox" name="attr_ArcheryFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Archery2Favored" value="1" /><span></span>
                     <span class="ability">Archery</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Archery_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Archery" value="0" checked="checked" />
-                        <input type="radio" name="attr_Archery" value="1" /><span></span>
-                        <input type="radio" name="attr_Archery" value="2" /><span></span>
-                        <input type="radio" name="attr_Archery" value="3" /><span></span>
-                        <input type="radio" name="attr_Archery" value="4" /><span></span>
-                        <input type="radio" name="attr_Archery" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Archery2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Archery2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Archery2" value="1" /><span></span>
+                        <input type="radio" name="attr_Archery2" value="2" /><span></span>
+                        <input type="radio" name="attr_Archery2" value="3" /><span></span>
+                        <input type="radio" name="attr_Archery2" value="4" /><span></span>
+                        <input type="radio" name="attr_Archery2" value="5" /><span></span>
                     </div>
                 </div>
                 <div class="ability">
-                    <input type="checkbox" name="attr_MedicineFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Medicine2Favored" value="1" /><span></span>
                     <span class="ability">Medicine</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Medicine_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Medicine" value="0" checked="checked" />
-                        <input type="radio" name="attr_Medicine" value="1" /><span></span>
-                        <input type="radio" name="attr_Medicine" value="2" /><span></span>
-                        <input type="radio" name="attr_Medicine" value="3" /><span></span>
-                        <input type="radio" name="attr_Medicine" value="4" /><span></span>
-                        <input type="radio" name="attr_Medicine" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Medicine2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Medicine2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Medicine2" value="1" /><span></span>
+                        <input type="radio" name="attr_Medicine2" value="2" /><span></span>
+                        <input type="radio" name="attr_Medicine2" value="3" /><span></span>
+                        <input type="radio" name="attr_Medicine2" value="4" /><span></span>
+                        <input type="radio" name="attr_Medicine2" value="5" /><span></span>
                     </div>
                 </div>
                 <div class="ability">
-                    <input type="checkbox" name="attr_PerformanceFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Performance2Favored" value="1" /><span></span>
                     <span class="ability">Performance</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Performance_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Performance" value="0" checked="checked" />
-                        <input type="radio" name="attr_Performance" value="1" /><span></span>
-                        <input type="radio" name="attr_Performance" value="2" /><span></span>
-                        <input type="radio" name="attr_Performance" value="3" /><span></span>
-                        <input type="radio" name="attr_Performance" value="4" /><span></span>
-                        <input type="radio" name="attr_Performance" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Performance2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Performance2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Performance2" value="1" /><span></span>
+                        <input type="radio" name="attr_Performance2" value="2" /><span></span>
+                        <input type="radio" name="attr_Performance2" value="3" /><span></span>
+                        <input type="radio" name="attr_Performance2" value="4" /><span></span>
+                        <input type="radio" name="attr_Performance2" value="5" /><span></span>
                     </div>
                 </div>
                 <div class="ability">
-                    <input type="checkbox" name="attr_RideFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Ride2Favored" value="1" /><span></span>
                     <span class="ability">Ride</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Ride_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Ride" value="0" checked="checked" />
-                        <input type="radio" name="attr_Ride" value="1" /><span></span>
-                        <input type="radio" name="attr_Ride" value="2" /><span></span>
-                        <input type="radio" name="attr_Ride" value="3" /><span></span>
-                        <input type="radio" name="attr_Ride" value="4" /><span></span>
-                        <input type="radio" name="attr_Ride" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Ride2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Ride2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Ride2" value="1" /><span></span>
+                        <input type="radio" name="attr_Ride2" value="2" /><span></span>
+                        <input type="radio" name="attr_Ride2" value="3" /><span></span>
+                        <input type="radio" name="attr_Ride2" value="4" /><span></span>
+                        <input type="radio" name="attr_Ride2" value="5" /><span></span>
                     </div>
                 </div>
                 <div class="ability">
-                    <input type="checkbox" name="attr_SurvivalFavored" value="1" /><span></span>
+                    <input type="checkbox" name="attr_Survival2Favored" value="1" /><span></span>
                     <span class="ability">Survival</span>
                     <div class="dots">
-                        <input type="checkbox" name="attr_Survival_max" value="1" /><span></span>
-                        <input type="radio" name="attr_Survival" value="0" checked="checked" />
-                        <input type="radio" name="attr_Survival" value="1" /><span></span>
-                        <input type="radio" name="attr_Survival" value="2" /><span></span>
-                        <input type="radio" name="attr_Survival" value="3" /><span></span>
-                        <input type="radio" name="attr_Survival" value="4" /><span></span>
-                        <input type="radio" name="attr_Survival" value="5" /><span></span>
+                        <input type="checkbox" name="attr_Survival2_max" value="1" /><span></span>
+                        <input type="radio" name="attr_Survival2" value="0" checked="checked" />
+                        <input type="radio" name="attr_Survival2" value="1" /><span></span>
+                        <input type="radio" name="attr_Survival2" value="2" /><span></span>
+                        <input type="radio" name="attr_Survival2" value="3" /><span></span>
+                        <input type="radio" name="attr_Survival2" value="4" /><span></span>
+                        <input type="radio" name="attr_Survival2" value="5" /><span></span>
                     </div>
                 </div>
             </div> 


### PR DESCRIPTION
## Changes
*  split Dragonblooded to use separate attributes from Solars, to track abilities. 

##  Comments
Due to this WoD sheet being older & more outdated than the others, making sensible additions harder to implement.
My addition of  statblocks for Dragon-blooded caused problems to existing sheets last week(specifically, the radio buttons did not display the  right number of dots for attributes shared with DragonBlooded, leading to the user to only see the stats valuee from the A&A tab).
This quick fix makes the Dragonblooded use separate set of attributes to track the same thing as the original Solars. It should be possible to implement the DragonBlooded  and other Castes without needing to give their "Abilities"-section separate attributes. If more Castes would be added by my current method, the sheet would start to have an large number of duplicate attributes, which could bloat the sheet somewhat, so a way to avoid duplicates would be better.

## Roll20 Requests
Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
