### PR TITLE
Pavillon Noir 2 - Custom roll (enhancement)

### DIFF
--- a/Pavillon Noir 2/Pavillon Noir 2.css
+++ b/Pavillon Noir 2/Pavillon Noir 2.css
@@ -197,3 +197,58 @@ textarea {
 .charsheet input[type="number"] {
     text-align:center;
 }
+
+.sheet-rolltemplate-simpletest table {
+    width: 189px;
+    height: 189px;
+    padding: 2px;
+    background: url(https://svgsilh.com/png/1296177-9e9e9e.png) top left;
+    background-size: 189px 189px;
+    background-repeat: no-repeat;
+    font-family: "Courier New", Courier, monospace;
+    font-weight: bold;
+    border-spacing: 0;
+}
+
+.sheet-rolltemplate-simpletest th {
+	color: rgb(112, 0, 0);
+    padding: 15px 2px 2px 20px;
+	line-height: 1.2em;
+	font-size: 1.2em;
+    text-align: c;
+}
+
+
+.sheet-rolltemplate-simpletest td {
+    padding-left: 20px;
+    font-size: 1.0em;
+    vertical-align: top;
+}
+
+.sheet-rolltemplate-simpletest .sheet-result {
+    font-size: 1.2em;
+    text-align: center;
+    color: rgb(112, 0, 0);
+    padding-bottom: 20px;
+}
+
+.sheet-rolltemplate-simpletest .inlinerollresult  {
+    background-color: transparent;
+    color: #000000;
+    border: none;
+}
+
+.sheet-rolltemplate-simpletest .inlinerollresult.fullcrit {
+   color: #3FB315;
+    border: none;
+}
+
+.sheet-rolltemplate-simpletest .inlinerollresult.fullfail {
+    color: #000000;
+    border: none;
+}
+
+.sheet-rolltemplate-simpletest .inlinerollresult.importantroll {
+	color: #3FB315;
+    border: none;
+}

--- a/Pavillon Noir 2/Pavillon Noir 2.html
+++ b/Pavillon Noir 2/Pavillon Noir 2.html
@@ -48,23 +48,24 @@
 
     <div class="attrib roue" style="width:49%;padding-top:10px;">
         <div>
-            <p style="margin-top:0;"><button type="roll" class="roll" value="/em - Jet d'Adresse \n\n/roll 2d10<@{adresse}">Adresse</button><br><input type="number" name="attr_adresse" value="0"></p> <br>
+            <p style="margin-top:0;"><button type="roll" class="roll"
+value="&{template:simpletest} {{NomDuJet=Jet d'Adresse}} {{Perso=@{character_name}}} {{Résultat=[[2d10<@{adresse}]]}}">Adresse</button><br><input type="number" name="attr_adresse" value="0"></p> <br>
         </div> <br>
         <div>
-            <p style="width:49%;"><button type="roll" class="roll" value="/em - Jet d'Expression \n\n/roll 2d10<@{expression}">Expression</button><br><input type="number" name="attr_expression" value="0"></p>
-            <p style="width:49%;"><button type="roll" class="roll" value="/em - Jet de Force \n\n/roll 2d10<@{force}">Force</button><br><input type="number" name="attr_force" value="0"></p>
+            <p style="width:49%;"><button type="roll" class="roll" value="&{template:simpletest} {{NomDuJet=Jet d'Expression}} {{Perso=@{character_name}}} {{Résultat=[[2d10<@{expression}]]}}">Expression</button><br><input type="number" name="attr_expression" value="0"></p>
+            <p style="width:49%;"><button type="roll" class="roll" value="&{template:simpletest} {{NomDuJet=Jet de Force}} {{Perso=@{character_name}}} {{Résultat=[[2d10<@{force}]]}}">Force</button><br><input type="number" name="attr_force" value="0"></p>
         </div> <br>
         <div>
-            <p><button type="roll" class="roll" value="&{template:simpletest} {{NomDuJet=Perception}} {{Perso=@{character_name}}} {{Résultat=[[2d10<@{perception}]]}}">Perception</button><input type="number" name="attr_perception" value="0"><br></p>
-            <p><button type="roll" class="roll" value="/em - Jet de Pouvoir \n\n/roll 2d10<@{pouvoir}">Pouvoir</button><br><input type="number" name="attr_pouvoir" value="0"></p>
-            <p><button type="roll" class="roll" value="/em - Jet de Résistance \n\n/roll 2d10<@{résistance}">Résistance</button><br><input type="number" name="attr_résistance" value="0"></p>
+            <p><button type="roll" class="roll" value="&{template:simpletest} {{NomDuJet=Jet de Perception}} {{Perso=@{character_name}}} {{Résultat=[[2d10<@{perception}]]}}">Perception</button><input type="number" name="attr_perception" value="0"><br></p>
+            <p><button type="roll" class="roll" value="&{template:simpletest} {{NomDuJet=Jet de Pouvoir}} {{Perso=@{character_name}}} {{Résultat=[[2d10<@{pouvoir}]]}}">Pouvoir</button><br><input type="number" name="attr_pouvoir" value="0"></p>
+            <p><button type="roll" class="roll" value="&{template:simpletest} {{NomDuJet=Jet de Résistance}} {{Perso=@{character_name}}} {{Résultat=[[2d10<@{résistance}]]}}">Résistance</button><br><input type="number" name="attr_résistance" value="0"></p>
         </div> <br>
         <div>
-            <p style="width:49%;"><button type="roll" class="roll" value="/em - Jet de Charisme \n\n/roll 2d10<@{charisme}">Charisme</button><br><input type="number" name="attr_charisme" value="0"></p>
-            <p style="width:49%;"><button type="roll" class="roll" value="/em - Jet d'Adaptabilité \n\n/roll 2d10<@{adaptabilité}">Adaptabilité</button><br><input type="number" name="attr_adaptabilité" value="0"></p>
+            <p style="width:49%;"><button type="roll" class="roll" value="&{template:simpletest} {{NomDuJet=Jet de Charisme}} {{Perso=@{character_name}}} {{Résultat=[[2d10<@charisme}]]}}">Charisme</button><br><input type="number" name="attr_charisme" value="0"></p>
+            <p style="width:49%;"><button type="roll" class="roll" value="&{template:simpletest} {{NomDuJet=Jet d'Adaptabilité}} {{Perso=@{character_name}}} {{Résultat=[[2d10<@{adaptabilité}]]}}">Adaptabilité</button><br><input type="number" name="attr_adaptabilité" value="0"></p>
         </div> <br>
         <div>
-            <p style="margin-bottom:0;"><button type="roll" class="roll" value="/em - Jet d'Érudition \n\n/roll 2d10<@{érudition}">Érudition</button><br><input type="number" name="attr_érudition" value="0"></p>
+            <p style="margin-bottom:0;"><button type="roll" class="roll" value="&{template:simpletest} {{NomDuJet=Jet d'Érudition}} {{Perso=@{character_name}}} {{Résultat=[[2d10<@{érudition}]]}}">Érudition</button><br><input type="number" name="attr_érudition" value="0"></p>
         </div>
         <div style="visibility:hidden;height:5px;"></div>
     </div>
@@ -77,55 +78,54 @@
         <div class="base" style="margin-bottom:20px;">
             <p class="titre">Compétences de connaissances</p>
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Balistique \n\n/roll @{balistique}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
-            Balistique • (CC)</button></p> <input type="number" name="attr_balistique" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_balistiqueexp"> <input type="number" name="attr_balistiquepoints" value="0">
+            value="&{template:simpletest} {{NomDuJet=Jet de Balistique}} {{Perso=@{character_name}}} {{Résultat=[[@{balistique}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">Balistique • (CC)</button></p> <input type="number" name="attr_balistique" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_balistiqueexp"> <input type="number" name="attr_balistiquepoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Cartographie \n\n/roll @{cartographie}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Cartographie}} {{Perso=@{character_name}}} {{Résultat=[[@{cartographie}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Cartographie •</button></p> <input type="number" name="attr_cartographie" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_cartographieexp"> <input type="number" name="attr_cartographiepoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Commerce \n\n/roll @{commerce}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Commerce}} {{Perso=@{character_name}}} {{Résultat=[[@{commerce}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Commerce</button></p> <input type="number" name="attr_commerce" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_commerceexp"> <input type="number" name="attr_commercepoints" value="0">
             <p style="width:100%;">Connaissance spécialisée :</p>
             <p>&emsp;&emsp;<button type="roll" class="roll2"
-            value="/em - Jet de Droit \n\n/roll @{droit}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Droit}} {{Perso=@{character_name}}} {{Résultat=[[@{droit}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             - Droit •</button></p> <input type="number" name="attr_droit" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_droitexp"> <input type="number" name="attr_droitpoints" value="0">
             <p>&emsp;&emsp;<button type="roll" class="roll2"
-            value="/em - Jet de Géographie \n\n/roll @{géographie}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Géographie}} {{Perso=@{character_name}}} {{Résultat=[[@{géographie}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             - Géographie</button></p> <input type="number" name="attr_géographie" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_géographieexp"> <input type="number" name="attr_géographiepoints" value="0">
             <p>&emsp;&emsp;<button type="roll" class="roll2"
-            value="/em - Jet de Histoire \n\n/roll @{histoire}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Histoire}} {{Perso=@{character_name}}} {{Résultat=[[@{histoire}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             - Histoire</button></p> <input type="number" name="attr_histoire" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_histoireexp"> <input type="number" name="attr_histoirepoints" value="0">
             <fieldset class="repeating_connaissance">
                 <button type="roll" class="roll3"
-                value="/em - Jet de @{connaissancespénom} \n\n/roll @{connaissancespé}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+                value="&{template:simpletest} {{NomDuJet=Jet de @{connaissancespénom}}} {{Perso=@{character_name}}} {{Résultat=[[@{connaissancespé}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
                 </button><input type="text" name="attr_connaissancespénom" style="width:41.5%;"> <input type="number" name="attr_connaissancespé" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_connaissancespéexp"> <input type="number" name="attr_connaissancespépoints" value="0">
             </fieldset><br>
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Herboristerie \n\n/roll @{herboristerie}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Herboristerie}} {{Perso=@{character_name}}} {{Résultat=[[@{herboristerie}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Herboristerie •</button></p> <input type="number" name="attr_herboristerie" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_herboristerieexp"> <input type="number" name="attr_herboristeriepoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet d'Ingénierie \n\n/roll @{ingénierie}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet d'Ingénierie}} {{Perso=@{character_name}}} {{Résultat=[[@{ingénierie}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Ingénierie •</button></p> <input type="number" name="attr_ingénierie" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_ingénierieexp"> <input type="number" name="attr_ingénieriepoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet d'Intendance \n\n/roll @{intendance}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet d'Intendance}} {{Perso=@{character_name}}} {{Résultat=[[@{intendance}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Intendance •</button></p> <input type="number" name="attr_intendance" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_intendanceexp"> <input type="number" name="attr_intendancepoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Lire/Écrire \n\n/roll @{lire}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Lire/Écrire}} {{Perso=@{character_name}}} {{Résultat=[[@{lire}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Lire/Écrire •</button></p> <input type="number" name="attr_lire" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_lireexp"> <input type="number" name="attr_lirepoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Médecine \n\n/roll @{médecine}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Médecine}} {{Perso=@{character_name}}} {{Résultat=[[@{médecine}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Médecine •</button></p> <input type="number" name="attr_médecine" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_médecineexp"> <input type="number" name="attr_médecinepoints" value="0">
             <p style="width:100%;">Religion</p>
             <fieldset class="repeating_religion">
                 <button type="roll" class="roll3"
-                value="/em - Jet de @{religionnom} \n\n/roll @{religion}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+                value="&{template:simpletest} {{NomDuJet=Jet de @{religionnom}}} {{Perso=@{character_name}}} {{Résultat=[[@{religion}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
                 </button><input type="text" name="attr_religionnom" style="width:41.5%;"> <input type="number" name="attr_religion" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_religionexp"> <input type="number" name="attr_religionpoints" value="0">
             </fieldset><br>
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Sciences \n\n/roll @{sciences}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Sciences}} {{Perso=@{character_name}}} {{Résultat=[[@{sciences}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Sciences •</button></p> <input type="number" name="attr_sciences" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_sciencesexp"> <input type="number" name="attr_sciencespoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Tactique \n\n/roll @{tactique}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Tactique}} {{Perso=@{character_name}}} {{Résultat=[[@{tactique}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Tactique (CC)</button></p> <input type="number" name="attr_tactique" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_tactiqueexp"> <input type="number" name="attr_tactiquepoints" value="0">
         </div>
 
@@ -134,45 +134,45 @@
             <p style="width:100%;">Art •</p>
             <fieldset class="repeating_art">
                 <button type="roll" class="roll3"
-                value="/em - Jet de @{artnom} \n\n/roll @{art}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+                value="&{template:simpletest} {{NomDuJet=Jet de @{artnom}}} {{Perso=@{character_name}}} {{Résultat=[[@{art}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
                 </button><input type="text" name="attr_artnom" style="width:41.5%;"> <input type="number" name="attr_art" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_artexp"> <input type="number" name="attr_artpoints" value="0">
             </fieldset><br>
             <p style="width:100%;">Artillerie :</p>
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Pointage de pièces \n\n/roll @{pointage}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Pointage de pièces}} {{Perso=@{character_name}}} {{Résultat=[[@{pointage}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             - Pointage pièces (CC)</button></p> <input type="number" name="attr_pointage" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_pointageexp"> <input type="number" name="attr_pointagepoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Recharge de pièce \n\n/roll @{recharge}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Recharge de pièce}} {{Perso=@{character_name}}} {{Résultat=[[@{recharge}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             - Recharge pièces (CC)</button></p> <input type="number" name="attr_recharge" style="margin-right:10px;vertical-align:50%;" value="0"> <input type="checkbox" name="attr_rechargeexp" style="vertical-align:50%;"> <input type="number" name="attr_rechargepoints" style="vertical-align:50%;" value="0">
             <p style="width:100%;">Artisanat :</p>
             <p>&emsp;&emsp;<button type="roll" class="roll2"
-            value="/em - Jet de Calfatage \n\n/roll @{calfatage}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Calfatage}} {{Perso=@{character_name}}} {{Résultat=[[@{calfatage}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             - Calfatage •</button></p> <input type="number" name="attr_calfatage" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_calfatageexp"> <input type="number" name="attr_calfatagepoints" value="0">
             <p>&emsp;&emsp;<button type="roll" class="roll2"
-            value="/em - Jet de Charpentrie \n\n/roll @{charpentrie}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Charpentrie}} {{Perso=@{character_name}}} {{Résultat=[[@{charpenterie}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             - Charpentrie •</button></p> <input type="number" name="attr_charpenterie" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_charpenterieexp"> <input type="number" name="attr_charpenteriepoints" value="0">
             <p>&emsp;&emsp;<button type="roll" class="roll2"
-            value="/em - Jet de Voilerie \n\n/roll @{voilerie}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Voilerie}} {{Perso=@{character_name}}} {{Résultat=[[@{voilerie}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             - Voilerie •</button></p> <input type="number" name="attr_voilerie" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_voilerieexp"> <input type="number" name="attr_voileriepoints" value="0">
             <p>&emsp;&emsp;<button type="roll" class="roll2"
-            value="/em - Jet de Cuisine \n\n/roll @{cuisine}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Cuisine}} {{Perso=@{character_name}}} {{Résultat=[[@{cuisine}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             - Cuisine</button></p> <input type="number" name="attr_cuisine" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_cuisineexp"> <input type="number" name="attr_cuisinepoints" value="0">
             <fieldset class="repeating_artisanat">
                 <button type="roll" class="roll3"
-                value="/em - Jet de @{artisanatnom} \n\n/roll @{artisanat}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de @{artisanatnom}}} {{Perso=@{character_name}}} {{Résultat=[[@{artisanat}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
                 </button><input type="text" name="attr_artisanatnom" style="width:41.5%;"> <input type="number" name="attr_artisanat" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_artisanatexp"> <input type="number" name="attr_artisanatpoints" value="0">
             </fieldset><br>
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Chasse \n\n/roll @{chasse}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Chasse}} {{Perso=@{character_name}}} {{Résultat=[[@{chasse}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Chasse</button></p> <input type="number" name="attr_chasse" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_chasseexp"> <input type="number" name="attr_chassepoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Chirurgie \n\n/roll @{chirurgie}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Chirurgie}} {{Perso=@{character_name}}} {{Résultat=[[@{chirurgie}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Chirurgie •</button></p> <input type="number" name="attr_chirurgie" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_chirurgieexp"> <input type="number" name="attr_chirurgiepoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Dressage \n\n/roll @{dressage}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Dressage}} {{Perso=@{character_name}}} {{Résultat=[[@{dressage}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Dressage</button></p> <input type="number" name="attr_dressage" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_dressageexp"> <input type="number" name="attr_dressagepoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Premiers soins \n\n/roll @{premiersoins}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Premiers soins}} {{Perso=@{character_name}}} {{Résultat=[[@{premierssoins}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Premiers soins</button></p> <input type="number" name="attr_premierssoins" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_premierssoinsexp"> <input type="number" name="attr_premierssoinspoints" value="0">
         </div>
     </div>
@@ -201,56 +201,56 @@
         <div class="comp base" style="margin-bottom:22px;">
             <p class="titre">Compétences maritimes</p>
             <div><p><button type="roll" class="roll2"
-            value="/em - Jet de Connaissances nautique \n\n/roll @{nautique}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Connaissances nautique}} {{Perso=@{character_name}}} {{Résultat=[[@{nautique}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Connaissances nautique • (CC)</button></p> <input type="number" name="attr_nautique" style="margin-right:10px;vertical-align:50%;" value="0"> <input type="checkbox" name="attr_nautiqueexp" style="vertical-align:50%;"> <input type="number" name="attr_nautiquepoints" style="vertical-align:50%;" value="0"></div>
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Connaissances des navires \n\n/roll @{navire}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Connaissances des navires}} {{Perso=@{character_name}}} {{Résultat=[[@{navire}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Connaissance navires</button></p> <input type="number" name="attr_navire" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_navireexp"> <input type="number" name="attr_navirepoints" value="0">
             <div><p><button type="roll" class="roll2"
-            value="/em - Jet de Connaissance de la signalisation • \n\n/roll @{signalisation}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Connaissance de la signalisation}} {{Perso=@{character_name}}} {{Résultat=[[@{signalisation}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Connaissance de la signalisation •</button></p> <input type="number" name="attr_signalisation" style="margin-right:10px;vertical-align:50%;" value="0"> <input type="checkbox" name="attr_signalisationexp" style="vertical-align:50%;"> <input type="number" name="attr_signalisationpoints" style="vertical-align:50%;" value="0"></div>
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Hydrographie \n\n/roll @{hydrographie}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Hydrographie}} {{Perso=@{character_name}}} {{Résultat=[[@{hydrographie}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Hydrographie • (CC)</button></p> <input type="number" name="attr_hydrographie" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_hydrographieexp"> <input type="number" name="attr_hydrographiepoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Navigation \n\n/roll @{navigation}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Navigation}} {{Perso=@{character_name}}} {{Résultat=[[@{navigation}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Navigation •</button></p> <input type="number" name="attr_navigation" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_navigationexp"> <input type="number" name="attr_navigationpoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Pêche \n\n/roll @{peche}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Pêche}} {{Perso=@{character_name}}} {{Résultat=[[@{peche}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Pêche</button></p> <input type="number" name="attr_peche" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_pecheexp"> <input type="number" name="attr_pechepoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Pratique nautique \n\n/roll @{pratique}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Pratique nautique}} {{Perso=@{character_name}}} {{Résultat=[[@{pratique}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Pratique nautique (CC)</button></p> <input type="number" name="attr_pratique" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_pratiqueexp"> <input type="number" name="attr_pratiquepoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Timonerie \n\n/roll @{timonerie}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Timonerie}} {{Perso=@{character_name}}} {{Résultat=[[@{timonerie}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Timonerie (CC)</button></p> <input type="number" name="attr_timonerie" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_timonerieexp"> <input type="number" name="attr_timoneriepoints" value="0">
         </div>
 
         <div class="comp base">
             <p class="titre">Compétences physiques</p>
             <p><button type="roll" class="roll2"
-            value="/em - Jet d'Acrobaties/Escalade \n\n/roll @{acrobaties}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet d'Acrobaties}} {{Perso=@{character_name}}} {{Résultat=[[@{acrobaties}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Acrobaties/Escalade</button></p> <input type="number" name="attr_acrobaties" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_acrobatiesexp"> <input type="number" name="attr_acrobatiespoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet d'Athlétisme \n\n/roll @{athlétisme}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet d'Athlétisme}} {{Perso=@{character_name}}} {{Résultat=[[@{athlétisme}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Athlétisme</button></p> <input type="number" name="attr_athlétisme" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_athlétismeexp"> <input type="number" name="attr_athlétismepoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Discrétion \n\n/roll @{discrétion}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Discrétion}} {{Perso=@{character_name}}} {{Résultat=[[@{discrétion}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Discrétion (CC)</button></p> <input type="number" name="attr_discrétion" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_discrétionexp"> <input type="number" name="attr_discrétionpoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet d'Équitation \n\n/roll @{équitation}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet d'Équitation}} {{Perso=@{character_name}}} {{Résultat=[[@{équitation}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Équitation</button></p> <input type="number" name="attr_équitation" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_équitationexp"> <input type="number" name="attr_équitationpoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Larcins \n\n/roll @{larcins}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Larcins}} {{Perso=@{character_name}}} {{Résultat=[[@{larcins}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Larcins •</button></p> <input type="number" name="attr_larcins" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_larcinsexp"> <input type="number" name="attr_larcinspoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Natation \n\n/roll @{natation}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Natation}} {{Perso=@{character_name}}} {{Résultat=[[@{natation}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Natation</button></p> <input type="number" name="attr_natation" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_natationexp"> <input type="number" name="attr_natationpoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Survie \n\n/roll @{survie}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Survie}} {{Perso=@{character_name}}} {{Résultat=[[@{survie}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Survie •</button></p> <input type="number" name="attr_survie" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_survieexp"> <input type="number" name="attr_surviepoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Vigilance \n\n/roll @{vigilance}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Vigilance}} {{Perso=@{character_name}}} {{Résultat=[[@{vigilance}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Vigilance (CC)</button></p> <input type="number" name="attr_vigilance" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_vigilanceexp"> <input type="number" name="attr_vigilancepoints" value="0">
         </div>
     </div>
@@ -259,52 +259,52 @@
         <div class="base" style="margin-bottom:22px;">
             <p class="titre">Compétences sociales</p>
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Comédie \n\n/roll @{comédie}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Comédie}} {{Perso=@{character_name}}} {{Résultat=[[@{comédie}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Comédie</button></p> <input type="number" name="attr_comédie" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_comédieexp"> <input type="number" name="attr_comédiepoints" value="0">
             <p style="width:100%;">Connaissance des colons/indigènes :</p>
             <fieldset class="repeating_colons">
                 <button type="roll" class="roll3"
-                value="/em - Jet de @{colonsnom} \n\n/roll @{colons}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+                value="&{template:simpletest} {{NomDuJet=Jet de @{colonsnom}}} {{Perso=@{character_name}}} {{Résultat=[[@{colons}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
                 </button><input type="text" name="attr_colonsnom" style="width:41.5%;"> <input type="number" name="attr_colons" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_colonsexp"> <input type="number" name="attr_colonspoints" value="0">
             </fieldset><br>
             <p style="width:100%;">Connaissance des marins :</p>
             <fieldset class="repeating_marins">
                 <button type="roll" class="roll3"
-                value="/em - Jet de @{marinsnom} \n\n/roll @{marins}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de @{marinsnom}}} {{Perso=@{character_name}}} {{Résultat=[[@{marins}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
                 </button><input type="text" name="attr_marinsnom" style="width:41.5%;"> <input type="number" name="attr_marins" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_marinsexp"> <input type="number" name="attr_marinspoints" value="0">
             </fieldset><br>
             <p><button type="roll" class="roll2"
-            value="/em - Jet d'Empathie \n\n/roll @{empathie}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet d'Empathie}} {{Perso=@{character_name}}} {{Résultat=[[@{empathie}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Empathie (CC)</button></p> <input type="number" name="attr_empathie" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_empathieexp"> <input type="number" name="attr_empathiepoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet d'Enseignement \n\n/roll @{enseignement}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet d'Enseignement}} {{Perso=@{character_name}}} {{Résultat=[[@{enseignement}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Enseignement (CC)</button></p> <input type="number" name="attr_enseignement" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_enseignementexp"> <input type="number" name="attr_enseignementpoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet d'Étiquette \n\n/roll @{étiquette}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet d'Étiquette}} {{Perso=@{character_name}}} {{Résultat=[[@{étiquette}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Étiquette •</button></p> <input type="number" name="attr_étiquette" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_étiquetteexp"> <input type="number" name="attr_étiquettepoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet d'Intimidation \n\n/roll @{intimidation}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet d'Intimidation}} {{Perso=@{character_name}}} {{Résultat=[[@{intimidation}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Intimidation (CC)</button></p> <input type="number" name="attr_intimidation" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_intimidationexp"> <input type="number" name="attr_intimidationpoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Jeu \n\n/roll @{jeu}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Jeu}} {{Perso=@{character_name}}} {{Résultat=[[@{jeu}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Jeu</button></p> <input type="number" name="attr_jeu" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_jeuexp"> <input type="number" name="attr_jeupoints" value="0">
             <p style="width:100%;">Langues étrangères :</p>
             <fieldset class="repeating_langues">
                 <button type="roll" class="roll3"
-                value="/em - Jet de @{languesnom} \n\n/roll @{langues}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+                value="&{template:simpletest} {{NomDuJet=Jet de @{languesnom}}} {{Perso=@{character_name}}} {{Résultat=[[@{langues}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
                 </button><input type="text" name="attr_languesnom" style="width:41.5%;"> <input type="number" name="attr_langues" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_languesexp"> <input type="number" name="attr_languespoints" value="0">
             </fieldset><br>
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Meneur d'hommes \n\n/roll @{meneur}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Meneur d'hommes}} {{Perso=@{character_name}}} {{Résultat=[[@{meneur}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Meneur d'hommes (CC)</button></p> <input type="number" name="attr_meneur" style="margin-right:10px;vertical-align:50%;" value="0"> <input type="checkbox" name="attr_meneurexp" style="vertical-align:50%;"> <input type="number" name="attr_meneurpoints" style="vertical-align:50%;" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Persuasion \n\n/roll @{persuasion}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Persuasion}} {{Perso=@{character_name}}} {{Résultat=[[@{persuasion}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Persuasion (CC)</button></p> <input type="number" name="attr_persuasion" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_persuasionexp"> <input type="number" name="attr_persuasionpoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Politique \n\n/roll @{politique}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Politique}} {{Perso=@{character_name}}} {{Résultat=[[@{politique}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Politique •</button></p> <input type="number" name="attr_politique" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_politiqueexp"> <input type="number" name="attr_politiquepoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Séduction \n\n/roll @{séduction}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Séduction}} {{Perso=@{character_name}}} {{Résultat=[[@{séduction}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Séduction</button></p> <input type="number" name="attr_séduction" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_séductionexp"> <input type="number" name="attr_séductionpoints" value="0">
         </div>
 
@@ -313,34 +313,34 @@
             <p style="width:100%;">Armes blanches :</p>
             <fieldset class="repeating_armesblanches">
                 <button type="roll" class="roll3"
-                value="/em - Jet de @{armesblanchesnom} \n\n/roll @{armesblanches}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+                value="&{template:simpletest} {{NomDuJet=Jet de @{armesblanchesnom}}} {{Perso=@{character_name}}} {{Résultat=[[@{armesblanches}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
                 </button><input type="text" name="attr_armesblanchesnom" style="width:41.5%;"> <input type="number" name="attr_armesblanches" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_armesblanchesexp"> <input type="number" name="attr_armesblanchespoints" value="0">
             </fieldset><br>
             <p style="width:100%;">Armes à feu (• Ind./Afr.) :</p>
             <p>&emsp;&emsp;<button type="roll" class="roll2"
-            value="/em - Jet de Mousquet \n\n/roll @{mousquet}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Mousquet}} {{Perso=@{character_name}}} {{Résultat=[[@{mousquet}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             - Mousquet</button></p> <input type="number" name="attr_mousquet" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_mousquetexp"> <input type="number" name="attr_mousquetpoints" value="0">
             <p>&emsp;&emsp;<button type="roll" class="roll2"
-            value="/em - Jet de Pistolet \n\n/roll @{pistolet}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Pistolet}} {{Perso=@{character_name}}} {{Résultat=[[@{pistolet}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             - Pistolet</button></p> <input type="number" name="attr_pistolet" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_pistoletexp"> <input type="number" name="attr_pistoletpoints" value="0">
             <p>&emsp;&emsp;<button type="roll" class="roll2"
-            value="/em - Jet de Grenade \n\n/roll @{grenade}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Grenade}} {{Perso=@{character_name}}} {{Résultat=[[@{grenade}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             - Grenade</button></p> <input type="number" name="attr_grenade" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_grenadeexp"> <input type="number" name="attr_grenadepoints" value="0">
             <p style="width:100%;">Armes de jet/trait :</p>
             <fieldset class="repeating_armesjet">
                 <button type="roll" class="roll3"
-                value="/em - Jet de @{armesjetnom} \n\n/roll @{armesjet}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+                 value="&{template:simpletest} {{NomDuJet=Jet de @{armesjetnom}}} {{Perso=@{character_name}}} {{Résultat=[[@{armesjet}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
                 </button><input type="text" name="attr_armesjetnom" style="width:41.5%;"> <input type="number" name="attr_armesjet" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_armesjetexp"> <input type="number" name="attr_armesjetpoints" value="0">
             </fieldset><br>
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Combat à mains nues \n\n/roll @{combatmains}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet de Combat à mains nues}} {{Perso=@{character_name}}} {{Résultat=[[@{combatmains}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Combat à mains nues</button></p> <input type="number" name="attr_combatmains" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_combatmainsexp"> <input type="number" name="attr_combatmainspoints" value="0">
             <p style="width:22%;"><button type="roll" class="roll2"
-            value="/em - Jet d'Escrime \n\n/roll @{escrime}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet d'Escrimes}} {{Perso=@{character_name}}} {{Résultat=[[@{escrime}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Escrime •</button></p> <input type="checkbox" name="attr_escrime1"><input type="checkbox" name="attr_escrime2"><input type="checkbox" name="attr_escrime3"><input type="checkbox" name="attr_escrime4"><input type="checkbox" name="attr_escrime5" style="margin-right:8px;">
             <input type="number" name="attr_escrime" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_escrimeexp"> <input type="number" name="attr_escrimepoints" value="0">
             <p><button type="roll" class="roll2"
-            value="/em - Jet de Esquive \n\n/roll @{esquive}d10<?{Caractéristique |Adresse,@{adresse}|Expression,@{expression}|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition} }">
+            value="&{template:simpletest} {{NomDuJet=Jet d'Esquive}} {{Perso=@{character_name}}} {{Résultat=[[@{esquive}d10<?{Caractéristique|Adresse,@{adresse}|Expression,|Force,@{force}|Perception,@{perception}|Pouvoir,@{pouvoir}|Résistance,@{résistance}|Charisme,@{charisme}|Adaptabilité,@{adaptabilité}|Érudition,@{érudition}}]]}}">
             Esquive</button></p> <input type="number" name="attr_esquive" style="margin-right:10px;" value="0"> <input type="checkbox" name="attr_esquiveexp"> <input type="number" name="attr_esquivepoints" value="0">
     </div>
 </div>

--- a/Pavillon Noir 2/Pavillon Noir 2.html
+++ b/Pavillon Noir 2/Pavillon Noir 2.html
@@ -16,6 +16,36 @@
         <textarea name="attr_description"></textarea>
     </div>
 
+    <rolltemplate class="sheet-rolltemplate-simpletest">
+      <span style="color:black">{{Perso}}</span>
+      <table>
+        <tr>
+            <th><span style="color:black">{{NomDuJet}}</span></th>
+        </tr>
+	<tr/>
+	<tr/>
+        <tr>
+            <td><span style="color:black">Résultat: {{Résultat}}</span></td>
+        </tr>
+        {{#rollWasCrit() Résultat}}
+        <tr>
+           <td>Au moins un 10!</td>
+        </tr>
+        {{/rollWasCrit() Résultat}}
+        {{#rollWasFumble() Résultat}}
+        <tr>
+           <td>Au moins un 1!</td>
+        </tr>
+        {{/rollWasFumble() Résultat}}
+        {{#notes}}
+        <tr>
+            <td><span>Notes: </span>{{notes}}</td>
+        </tr>
+        {{/notes}}
+      </table>
+   </rolltemplate>
+
+
     <div class="attrib roue" style="width:49%;padding-top:10px;">
         <div>
             <p style="margin-top:0;"><button type="roll" class="roll" value="/em - Jet d'Adresse \n\n/roll 2d10<@{adresse}">Adresse</button><br><input type="number" name="attr_adresse" value="0"></p> <br>
@@ -25,7 +55,7 @@
             <p style="width:49%;"><button type="roll" class="roll" value="/em - Jet de Force \n\n/roll 2d10<@{force}">Force</button><br><input type="number" name="attr_force" value="0"></p>
         </div> <br>
         <div>
-            <p><button type="roll" class="roll" value="/em - Jet de Perception \n\n/roll 2d10<@{perception}">Perception</button><br><input type="number" name="attr_perception" value="0"></p>
+            <p><button type="roll" class="roll" value="&{template:simpletest} {{NomDuJet=Perception}} {{Perso=@{character_name}}} {{Résultat=[[2d10<@{perception}]]}}">Perception</button><input type="number" name="attr_perception" value="0"><br></p>
             <p><button type="roll" class="roll" value="/em - Jet de Pouvoir \n\n/roll 2d10<@{pouvoir}">Pouvoir</button><br><input type="number" name="attr_pouvoir" value="0"></p>
             <p><button type="roll" class="roll" value="/em - Jet de Résistance \n\n/roll 2d10<@{résistance}">Résistance</button><br><input type="number" name="attr_résistance" value="0"></p>
         </div> <br>


### PR DESCRIPTION
Those changes simply add a nice "jolly roger" flag behind the roll result. It's mostly esthetic, but it does also outline when the roll contains a critical success (1 on 1d10 in Pavillon Noir) or a potential critical fail (10 on 1d10).

I've split the change in two commit for clarity purpose, so that one can look at the commit adding the custom roll without the "change everywhere" of the second commit...





