### PR TITLE
[Knight] Bugfix Druid

### DIFF
--- a/Knight/knight.html
+++ b/Knight/knight.html
@@ -7893,7 +7893,7 @@ Effet : L’arme reçoit un bonus de 3 permanent aux dégâts qu’elle inflige.
 										<span title="Jumelé (Ambidextrie)"></span>
 									</label>
 									<label class="simple">
-										<input type="checkbox" name="attr_leste" value="{{leste=[[@{force}]]}}" />
+										<input type="checkbox" name="attr_leste" value="{{leste=[[@{druidLionChairTot}]]}}" />
 										<span title="Lesté"></span>
 									</label>
 									<label class="simple">

--- a/Knight/knight.html
+++ b/Knight/knight.html
@@ -2980,6 +2980,34 @@
 			}
 		});
 	});
+	
+	on("sheet:opened",function()
+	{		
+		getAttrs(["DruidLionBF"], function(value)
+		{
+			if(value.DruidLionBF != 1)
+			{
+				getSectionIDs("repeating_armeDruidLion", function (ids) 
+				{
+					_.each(ids,function(id) 
+					{
+						getAttrs([
+						"repeating_armeDruidLion_"+id+"_leste", function (v) 
+						{
+							var LL = v["repeating_armeDruidLion_"+id+"_leste"];
+							
+							if(LL == "{{leste=[[@{force}]]}}")
+							{
+								setAttrs({["repeating_armeDruidLion_"+id+"_leste"]: "{{leste=[[@{druidLionChairTot}]]}}"});
+							}
+						});
+						
+					});
+				});
+				setAttrs({DruidLionBF: 1});
+			}
+		});
+	});
 </script>
 <div class="container">
 	<input type="hidden" name="attr_MAJ" value="0" />
@@ -2994,6 +3022,7 @@
 	<input type="hidden" name="attr_MAJV15LDB_1" value="0" />
 	<input type="hidden" name="attr_MAJV15LDB_2" value="0" />
 	<input type="hidden" name="attr_MAJV15LDB_3" value="0" />
+	<input type="hidden" name="attr_DruidLionBF" value="0" />
 	<div class="logo">
 	</div>
 	<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Knight/knightLogo.png" class="logo" width="350" height="49">

--- a/Knight/knight.html
+++ b/Knight/knight.html
@@ -6374,7 +6374,7 @@ Attention : l’effet ne peut pas se cumuler alors que la cible est déjà sous 
 							<div class="limiteArmure psion150">
 								<h4 class="titre bouton">
 									Mode Puppet Master
-									<button name="attr_jetBasePsion" type="roll" class="boutonBase" value="@{jetGM} &{template:simple} {{Nom=@{name}}}  @{caracteristique1Psion} @{jetModifDes}+ @{caracteristique2} {{@{armure}=@{armure}}} {{situationnel=[[@{jetModifDes}]]}} {{taille=[[@{barbarianGoliath}]]}}" />
+									<button name="attr_jetBasePsion" type="roll" class="boutonBase" value="@{jetGM} &{template:simple} {{Nom=@{name}}}  {{carac1=Aura}} {{bonusWarrOD1=[[@{warriorHeraldA}]]}} {{bonusBarb1=[[0]]}} {{OD1=[[@{auraOD}]]}} {{jet=[[ {[[{@{aura}+ @{jetModifDes}+ @{caracteristique2} {{@{armure}=@{armure}}} {{situationnel=[[@{jetModifDes}]]}} {{taille=[[@{barbarianGoliath}]]}}" />
 								</h4>
 							</div>
 							<div class="limiteArmure psion150">
@@ -13689,7 +13689,7 @@ Effet : L’arme reçoit un bonus de 3 permanent aux dégâts qu’elle inflige.
 							<!-- La violence-->
 							<input type="hidden" name="attr_poingMACviolence" value="{{Violence=[[ [[ {[[@{poingMACaCViolence}]], 0}kh1]]d6+@{poingMACaCBViolence}]]}}" />
 							<!-- Bonus de Force -->
-							<input type="hidden" name="attr_poingMACbForce" value="{{force=[[@{force}]]}} {{BonusForce=[[@{forOD}*3]]}}" />
+							<input type="hidden" name="attr_poingMACbForce" value="{{force=[[@{force}]]}} {{BonusForce=[[ [[@{forOD}+@{warriorSoldierA}]]*3]]}}" />
 							<!-- Les styles -->
 							<input type="hidden" name="attr_poingMACstyles" value="{{@{styleCombat}=@{styleCombat}}} {{style=@{styleCombat}}}" />
 							<input type="hidden" name="attr_poingMACstyleBM" value="[[{ [[{@{atkAkimbo}, 0}kl1]], 0}kl1]]+[[{ [[{@{atkAmbidextre}, 0}kl1]],[[{@{atkAmbidextre}, 0}kl1]]}kh1 ]]+[[{@{atkCouvert}, 0}kl1]]+[[{@{atkDefensif}, 0}kl1]]+[[@{atkAgressif}]]" />
@@ -14590,7 +14590,7 @@ Effet : L’arme reçoit un bonus de 3 permanent aux dégâts qu’elle inflige.
 							<!-- La violence de l'arme -->
 							<input type="hidden" name="attr_violence" value="{{Violence=[[ [[ {[[@{armeCaCViolence}]], 0}kh1]]d6+@{armeCaCBViolence}]]}}" />
 							<!-- Bonus de Force -->
-							<input type="hidden" name="attr_bForce" value="{{force=[[@{force}]]}} {{BonusForce=[[@{forOD}*3]]}}" />
+							<input type="hidden" name="attr_bForce" value="{{force=[[@{force}]]}} {{BonusForce=[[ [[@{forOD}+@{warriorSoldierA}]]*3]]}}" />
 							<!-- Les styles -->
 							<input type="hidden" name="attr_styles" value="{{@{styleCombat}=@{styleCombat}}} {{style=@{styleCombat}}}" />
 							<input type="hidden" name="attr_styleBM" value="[[{ [[{@{atkAkimbo}+@{akimbo}, 0}kl1]],[[{@{atkAkimbo}+@{jumelle}, 0}kl1]]}kh1 ]]+[[{ [[{@{atkAmbidextre}+@{ambidextrie}, 0}kl1]],[[{@{atkAmbidextre}+@{soeur}, 0}kl1]]}kh1 ]]+[[{@{atkCouvert}+@{tirSecurite}, 0}kl1]]+[[{@{atkDefensif}+@{protectrice}, 0}kl1]]+[[@{atkAgressif}]]" />
@@ -20474,7 +20474,7 @@ Effet : L’arme reçoit un bonus de 3 permanent aux dégâts qu’elle inflige.
 					<div class="limiteArmure ODAur2">
 						<h4 class="h4W30">2</h4>
 						<p class="pWAdjusted">
-							Le personnage, lorsqu’il Aurbat des humains, est toujours attaqué en dernier par les hostiles ou les salopards.
+							Le personnage, lorsqu’il Combat des humains, est toujours attaqué en dernier par les hostiles ou les salopards.
 						</p>
 					</div>
 					<div class="limiteArmure ODAur3">


### PR DESCRIPTION
## Changes / Comments
Pour le changement fait à l'attribut :
Première ouverture de la fiche, je vérifie une checkbox qui, si elle est à 0 (valeur par défaut), déclenche la suite : 
- On vérifie les valeurs dans le repeating concerné (repeating_armeDruidLion) du bouton concerné (attr_leste). Si la valeur est celle cherchée (l'ancienne), je met la nouvelle. Sinon je ne fais rien.
- Je met ensuite à 1 la checkbox de vérification, histoire que la fiche ne revérifie pas.





## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [X] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
