### PR TITLE
[Ironsworn][Fix] Clear Vow and Page Switching did not support multiple sheets open at once.

### DIFF
--- a/Ironsworn/Ironsworn.css
+++ b/Ironsworn/Ironsworn.css
@@ -122,7 +122,8 @@ hr {
 input[type=radio].sheet-page1:checked ~ div.sheet-page1tab,
 input[type=radio].sheet-page2:checked ~ div.sheet-page2tab,
 input[type=radio].sheet-page3:checked ~ div.sheet-page3tab,
-input[type=radio].sheet-page4:checked ~ div.sheet-page4tab {
+input[type=radio].sheet-page4:checked ~ div.sheet-page4tab
+{
     display: block;
 }
 
@@ -132,23 +133,70 @@ input.sheet-clear-vow + .sheet-vow-clear-label {
     padding: 2px 4px;
 }
 
-.sheet-vow-clear-label {
-    border: 1px solid #ccc;
-    margin-right: 11px;
+input.sheet-pages {
+    opacity: 0;
+    cursor: pointer;  
 }
 
-.sheet-pages:checked + .sheet-page-label {
+input.sheet-clear-vow {
+    opacity: 0;
+    width: 54px;
+    margin-right: 22px;
+    cursor: pointer;  
+}
+
+.sheet-vow-clear-label {
+    border: 1px solid #ccc;
+    margin-left: -80px;
+    width: 80px;
+}
+
+.sheet-pages:checked + span.sheet-page-label {
     background-color: black;
     color: white;
 }
 
-.sheet-page-label:hover,
-.sheet-vow-clear-label:hover {
-    cursor: pointer;
+.sheet-pages:hover + .sheet-page-label,
+.sheet-clear-vow:hover + .sheet-vow-clear-label {
     border-radius: 4px;
     padding: 2px 4px;
     background-color: #ccc;
     color: black;
+}
+
+.sheet-page-label:hover,
+.sheet-vow-clear-label:hover {
+    border-radius: 4px;
+    padding: 2px 4px;
+    background-color: #ccc;
+    color: black;
+}
+
+input.sheet-page1 {
+    width: 140px;
+}
+
+span.sheet-page-label-1 {
+    margin-left: -144px;
+    width: 140px;
+}
+
+input.sheet-page2 {
+    width: 75px;
+}
+
+span.sheet-page-label-2 {
+    width: 75px;
+    margin-left: -82px;
+}
+
+input.sheet-page3 {
+    width: 60px;
+}
+
+span.sheet-page-label-3 {
+    margin-left: -64px;
+    width: 60px;
 }
 
 .sheet-vertleft {

--- a/Ironsworn/Ironsworn.html
+++ b/Ironsworn/Ironsworn.html
@@ -52,17 +52,19 @@
     </tr>
 </table>
 
-<input type="radio" class="sheet-pages sheet-page1 sheet-hidden" id="page1" name="attr_pagenumber" title="Page 1"
+<!-- <div class="sheet-page-container"> -->
+<input type="radio" class="sheet-pages sheet-page1" name="attr_pagenumber" title="Page 1"
     value="1" />
-<label class="sheet-page-label" for="page1">Character Sheet</label>
+<span class="sheet-page-label sheet-page-label-1">Character Sheet</span>
 
-<input type="radio" class="sheet-pages sheet-page2 sheet-hidden" id="page2" name="attr_pagenumber" title="Page 2"
+<input type="radio" class="sheet-pages sheet-page2" name="attr_pagenumber" title="Page 2"
     value="2" />
-<label class="sheet-page-label" for="page2">Progress</label>
+<span class="sheet-page-label sheet-page-label-2">Progress</span>
 
-<input type="radio" class="sheet-pages sheet-page3 sheet-hidden" id="page3" name="attr_pagenumber" title="Page 3"
+<input type="radio" class="sheet-pages sheet-page3" name="attr_pagenumber" title="Page 3"
     value="3" />
-<label class="sheet-page-label" for="page3">Assets</label>
+<span class="sheet-page-label sheet-page-label-3">Assets</span>
+<!-- </div> -->
 
 <div class="page1tab">
     <hr>
@@ -285,9 +287,11 @@
                     </div>
                     <div class="sheet-vow">
                         <div>
-                            <input class="sheet-clear-vow sheet-hidden" id="clear-vow-1" type="checkbox"
-                                name="attr_clear_vow_1">
-                            <label class="sheet-vow-clear-label" for="clear-vow-1">Clear</label>
+                            <input class="sheet-clear-vow sheet-hidden" type="radio"
+                                name="attr_clear_vow" value="0">
+                            <input class="sheet-clear-vow" type="radio"
+                                name="attr_clear_vow" value="1">
+                            <span class="sheet-vow-clear-label">Clear</span>
                             <select name="attr_vow1-0" class="sheet-progress-input">
                                 <option value="0" selected></option>
                                 <option value="1">-</option>
@@ -383,9 +387,9 @@
                     </div>
                     <div class="sheet-vow">
                         <div>
-                            <input class="sheet-clear-vow sheet-hidden" id="clear-vow-2" type="checkbox"
-                                name="attr_clear_vow_2">
-                            <label class="sheet-vow-clear-label" for="clear-vow-2">Clear</label>
+                            <input class="sheet-clear-vow" type="radio"
+                                name="attr_clear_vow" value="2">
+                            <span class="sheet-vow-clear-label">Clear</span>
                             <select name="attr_vow2-0" class="sheet-progress-input">
                                 <option value="0" selected></option>
                                 <option value="1">-</option>
@@ -481,9 +485,9 @@
                     </div>
                     <div class="sheet-vow">
                         <div>
-                            <input class="sheet-clear-vow sheet-hidden" id="clear-vow-3" type="checkbox"
-                                name="attr_clear_vow_3">
-                            <label class="sheet-vow-clear-label" for="clear-vow-3">Clear</label>
+                            <input class="sheet-clear-vow" type="radio"
+                                name="attr_clear_vow" value="3">
+                            <span class="sheet-vow-clear-label">Clear</span>
                             <select name="attr_vow3-0" class="sheet-progress-input">
                                 <option value="0" selected></option>
                                 <option value="1">-</option>
@@ -579,9 +583,9 @@
                     </div>
                     <div class="sheet-vow">
                         <div>
-                            <input class="sheet-clear-vow sheet-hidden" id="clear-vow-4" type="checkbox"
-                                name="attr_clear_vow_4">
-                            <label class="sheet-vow-clear-label" for="clear-vow-4">Clear</label>
+                            <input class="sheet-clear-vow" type="radio"
+                                name="attr_clear_vow" value="4">
+                            <span class="sheet-vow-clear-label">Clear</span>
                             <select name="attr_vow4-0" class="sheet-progress-input">
                                 <option value="0" selected></option>
                                 <option value="1">-</option>
@@ -677,9 +681,9 @@
                     </div>
                     <div class="sheet-vow">
                         <div>
-                            <input class="sheet-clear-vow sheet-hidden" id="clear-vow-5" type="checkbox"
-                                name="attr_clear_vow_5">
-                            <label class="sheet-vow-clear-label" for="clear-vow-5">Clear</label>
+                            <input class="sheet-clear-vow" type="radio"
+                                name="attr_clear_vow" value="5">
+                            <span class="sheet-vow-clear-label">Clear</span>
                             <select name="attr_vow5-0" class="sheet-progress-input">
                                 <option value="0" selected></option>
                                 <option value="1">-</option>
@@ -4062,22 +4066,24 @@ on('change:momentum change:momentum_max', function() {
         if(parseInt(values.momentum) > parseInt(values.momentum_max)) setAttrs({ momentum: parseInt(values.momentum_max)});
     });
 });
-on('change:clear_vow_1', function() {
-    setAttrs({ 'vow1-0': '0', 'vow1-1': '0', 'vow1-2': '0', 'vow1-3': '0', 'vow1-4': '0', 'vow1-5': '0', 'vow1-6': '0', 'vow1-7': '0', 'vow1-8': '0', 'vow1-9': '0', clear_vow_1: 'off' });
+on('change:clear_vow', function(values) {
+    console.log(values)
+    if(values.newValue === '1'){
+        setAttrs({ 'vow1-0': '0', 'vow1-1': '0', 'vow1-2': '0', 'vow1-3': '0', 'vow1-4': '0', 'vow1-5': '0', 'vow1-6': '0', 'vow1-7': '0', 'vow1-8': '0', 'vow1-9': '0', clear_vow: '0' });
+    }
+    if(values.newValue === '2'){
+        setAttrs({ 'vow2-0': '0', 'vow2-1': '0', 'vow2-2': '0', 'vow2-3': '0', 'vow2-4': '0', 'vow2-5': '0', 'vow2-6': '0', 'vow2-7': '0', 'vow2-8': '0', 'vow2-9': '0', clear_vow: '0' });
+    }
+    if(values.newValue === '3'){
+        setAttrs({ 'vow3-0': '0', 'vow3-1': '0', 'vow3-2': '0', 'vow3-3': '0', 'vow3-4': '0', 'vow3-5': '0', 'vow3-6': '0', 'vow3-7': '0', 'vow3-8': '0', 'vow3-9': '0', clear_vow: '0' });
+    }
+    if(values.newValue === '4'){
+        setAttrs({ 'vow4-0': '0', 'vow4-1': '0', 'vow4-2': '0', 'vow4-3': '0', 'vow4-4': '0', 'vow4-5': '0', 'vow4-6': '0', 'vow4-7': '0', 'vow4-8': '0', 'vow4-9': '0', clear_vow: '0' });
+    }
+    if(values.newValue === '5'){
+        setAttrs({ 'vow5-0': '0', 'vow5-1': '0', 'vow5-2': '0', 'vow5-3': '0', 'vow5-4': '0', 'vow5-5': '0', 'vow5-6': '0', 'vow5-7': '0', 'vow5-8': '0', 'vow5-9': '0', clear_vow: '0' });
+    }
 });
-on('change:clear_vow_2', function() {
-    setAttrs({ 'vow2-0': '0', 'vow2-1': '0', 'vow2-2': '0', 'vow2-3': '0', 'vow2-4': '0', 'vow2-5': '0', 'vow2-6': '0', 'vow2-7': '0', 'vow2-8': '0', 'vow2-9': '0', clear_vow_2: 'off' });
-});
-on('change:clear_vow_3', function() {
-    setAttrs({ 'vow3-0': '0', 'vow3-1': '0', 'vow3-2': '0', 'vow3-3': '0', 'vow3-4': '0', 'vow3-5': '0', 'vow3-6': '0', 'vow3-7': '0', 'vow3-8': '0', 'vow3-9': '0', clear_vow_3: 'off' });
-});
-on('change:clear_vow_4', function() {
-    setAttrs({ 'vow4-0': '0', 'vow4-1': '0', 'vow4-2': '0', 'vow4-3': '0', 'vow4-4': '0', 'vow4-5': '0', 'vow4-6': '0', 'vow4-7': '0', 'vow4-8': '0', 'vow4-9': '0', clear_vow_4: 'off' });
-});
-on('change:clear_vow_5', function() {
-    setAttrs({ 'vow5-0': '0', 'vow5-1': '0', 'vow5-2': '0', 'vow5-3': '0', 'vow5-4': '0', 'vow5-5': '0', 'vow5-6': '0', 'vow5-7': '0', 'vow5-8': '0', 'vow5-9': '0', clear_vow_5: 'off' });
-});
-
 on('change:repeating_assets:assettype', function(values) {
     setAttrs({
         ['repeating_assets_Asset' + values.previousValue]: 'off',

--- a/Ironsworn/Ironsworn.html
+++ b/Ironsworn/Ironsworn.html
@@ -4067,7 +4067,6 @@ on('change:momentum change:momentum_max', function() {
     });
 });
 on('change:clear_vow', function(values) {
-    console.log(values)
     if(values.newValue === '1'){
         setAttrs({ 'vow1-0': '0', 'vow1-1': '0', 'vow1-2': '0', 'vow1-3': '0', 'vow1-4': '0', 'vow1-5': '0', 'vow1-6': '0', 'vow1-7': '0', 'vow1-8': '0', 'vow1-9': '0', clear_vow: '0' });
     }


### PR DESCRIPTION
## Changes / Comments
There was a issue using labels where `for='id'` would break when having multiple character sheet open. Replaced them with spans.

This affected changing pages with multiple sheets open and clearing vows. 

The clearing vow progress also needed to be updated to use radio buttons. Since it also relied on labels. This meant updating the attributes to be a single `attr_clear_vow` but this will not effect player data at it was only set temporarily for the `on(change)` function.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
