### PR TITLE
Update [Palladium Fantasy 1E]

### DIFF
--- a/Palladium Fantasy 1E/palladium_fantasy_1e.css
+++ b/Palladium Fantasy 1E/palladium_fantasy_1e.css
@@ -227,7 +227,8 @@ button[type=roll].sheet-rolldice::before {
 .sheet-wealth-field, .sheet-bonus-field, .sheet-occ-field, .sheet-skill-notes, .sheet-elective-field, 
 .sheet-secondary-field, .sheet-mystic-field, .sheet-melee-field, .sheet-ranged-field, 
 .sheet-combat-field, .sheet-combat-textarea, .sheet-save-field, .sheet-notes-field, .sheet-notes-textarea, 
-.sheet-weight-box, .sheet-weightsub-box, .sheet-whisper-select, .sheet-mattack-text, .sheet-rattack-text{
+.sheet-weight-box, .sheet-weightsub-box, .sheet-whisper-select, .sheet-mattack-text, .sheet-rattack-text, 
+.sheet-save-misc{
     background-color:#ebebeb;
 }
 .sheet-fraction-grid-container{
@@ -494,6 +495,14 @@ button[type=roll].sheet-savedice::before {
 .sheet-savedice{
     color: #ebebeb;
     background: #6b8a76;
+}
+.sheet-save-notes-container{
+    display:grid;
+    grid-template-columns: 500px 30px
+}
+.sheet-save-misc{
+    max-width:500px;
+    max-height:60px;
 }
 .sheet-underline{
     text-decoration: underline;

--- a/Palladium Fantasy 1E/palladium_fantasy_1e.html
+++ b/Palladium Fantasy 1E/palladium_fantasy_1e.html
@@ -104,7 +104,7 @@
             <div class='gold-grid-container'>
                 <h4 class='calc-title'>Autocalc</h4>
                 <h4 class='calc-title'>Stats</h4>
-                <h4 class='calc-label' title='Maximum Lift' >Lift lbs.</h4>
+                <h4 class='calc-label' title='Maximum Lift Weight' >Lift lbs.</h4>
                 <input class='calc-field' type="text" value="" name="attr_lift" readonly>
                 <h4 class='calc-label' title='Maximum Carrying Weight' >Carry lbs.</h4>
                 <input class='calc-field' type="text" value="" name="attr_carry" readonly>
@@ -327,8 +327,21 @@
                     </div>
                 </fieldset>
             </div>
-        </div> 
+        </div>
+        <h4>Warning</h4>
+        <h5>Upcoming changes to the melee and ranged repeating attacks section:</h5>
+        <ul>
+            <li>I will be removing the temporary bonus field from the repeating section to declutter the line.</li>
+            <li>Since I originally intended for these to be used for short term magic effects, they should have been set up as <br>
+            global bonuses to begin with. There will be global bonuse fields for Strike, Parry, and Damage that only affect the <br>
+            Melee section.  There will be a Strike and Damage bonus that will only affect the Ranged section.  That should make <br>
+            short term bonuses easier to add and remove.</li>
+            <li>With this change, the attributes that the roll buttons look for will change.  Any bonuses in the current repeating <br>
+		temp bonus fields will be lost.</li>
+            <li>I intend to make this change in a couple weeks, so prepare accordingly!</li>
+        </ul>
     </div>
+    <!--Character Sheet Tab-->
     <div class='sheet-social'>
         <h1>Social Information</h1>
         <div class='physical-grid-container'>
@@ -362,8 +375,11 @@
             <textarea class='mental-field' value="" name="attr_character_hostility" placeholder='Hostilities, pet peeves, likes and dislikes' /></textarea>
             <h4 class='mental-label'>Insanity</h4>
             <textarea class='mental-field' value="" name="attr_character_insanity" placeholder='Hope this placeholder never gets replaced...' /></textarea>
+            <h4 class='mental-label'>O.C.C. Notes</h4>
+            <textarea class='mental-field' value="" name="attr_character_occnotes" placeholder='Anything about your character's occupation(s) that needs kept in mind' /></textarea>
         </div> 
     </div>
+    <!--Character Sheet Tab-->
     <div class='sheet-skill'>
         <h1>Skills</h1>
         <div class='universalrow-grid-container'>
@@ -469,6 +485,7 @@
             </div>
         </div> 
     </div>
+    <!--Character Sheet Tab-->
     <div class='sheet-combat'>
         <h1>Combat</h1>
         <div class="melee-proficiency-panel">
@@ -641,10 +658,15 @@
                     <h5>ME Insanity Bonus</h5>
                     <input class='bonus-field' type="text" value="" title="@{me_insanity}" name="attr_me_insanity" readonly>
                     <div class='space-holder'></div>
+                    
+                    <div class="save-notes-container" >
+                        <textarea class='save-misc' value='' name='attr_save_notes' title='@{save_notes}' placeholder='Notes displayed with all saves except coma/death.' ></textarea>
+                    </div>
                 </div>
             </div>
         </div> 
     </div>
+    <!--Character Sheet Tab-->
     <div class="sheet-equipment">
         <h1>Equipment</h1>
         <div class='encumbrance-panel'>
@@ -785,6 +807,7 @@
             </div>
         </div>
     </div>
+    <!--Character Sheet Tab-->
     <div class="sheet-journal">
         <h1>Notes</h1>
         <div class="note-one-panel">
@@ -830,15 +853,21 @@
             </div>
         </div> 
     </div>
+    <!--Character Sheet Tab-->
     <div class="sheet-release">
         <h1>Sheet Version: 1.0</h1>
-        <h5>Recent Changes:</h5>
+        <h5>January 12, 2020</h5>
         <ul>
-	    <li>Toggles have been added for the mounted parry/dodge, damage, and charge damage to be included in the melee attack macros.</li>
-	    <li>The parry/dodge toggle will add the mounted dodge bonus to the dodge roll button macro, so no more query when dodging.</li>
+            <li>Added a notes field to the saving throw section for situational bonuses that aren't specific to a certain type of effect (like protective wards).</li>
+            <li>Added a field on the social tab for class related notes.</li>
+        </ul>
+        <h5>Older Changes:</h5>
+        <ul>
+    	    <li>Toggles have been added for the mounted parry/dodge, damage, and charge damage to be included in the melee attack macros.</li>
+    	    <li>The parry/dodge toggle will add the mounted dodge bonus to the dodge roll button macro, so no more query when dodging.</li>
             <li>The sheet tabs have been altered to run on sheetworkers.</li>
             <li>The repeating attack entries on the statistics tab are now all text instead of number to allow entry of attributes instead of only numbers.  
-            This allows the use of repeating section attributes to pull numbers from the weapon proficiencies on the combat tab.</li>
+                This allows the use of repeating section attributes to pull numbers from the weapon proficiencies on the combat tab.</li>
             <li>If there are any issues with the sheetworker tabs, I will revert back to a regular tab system.</li>
             <li>Hopefully this will be the final stabile version of this sheet.</li>
         </ul>

--- a/Palladium Fantasy 1E/palladium_fantasy_1e.html
+++ b/Palladium Fantasy 1E/palladium_fantasy_1e.html
@@ -376,7 +376,7 @@
             <h4 class='mental-label'>Insanity</h4>
             <textarea class='mental-field' value="" name="attr_character_insanity" placeholder='Hope this placeholder never gets replaced...' /></textarea>
             <h4 class='mental-label'>O.C.C. Notes</h4>
-            <textarea class='mental-field' value="" name="attr_character_occnotes" placeholder='Anything about your character's occupation(s) that needs kept in mind' /></textarea>
+            <textarea class='mental-field' value="" name="attr_character_occnotes" placeholder='Anything about your character occupation(s) that needs kept in mind' /></textarea>
         </div> 
     </div>
     <!--Character Sheet Tab-->

--- a/Palladium Fantasy 1E/palladium_fantasy_1e.html
+++ b/Palladium Fantasy 1E/palladium_fantasy_1e.html
@@ -600,38 +600,38 @@
                     <h5 class='underline'>Save Type</h5>
                     <h5 class='underline'>Target</h5>
                     <h5 class='underline'>Bonus</h5>
-                    <button class='savedice' type="roll" name='roll_circlesave' value="@{whispertoggle}&{template:custom} {{color=brown}} {{title=**@{character_name}**}} {{subtitle=Save vs. Circles}} {{Save=[[d20+@{save_circle}+@{pe_magpois}]]}} {{Target= @{save_circle-target}}}" >Circles</button>
+                    <button class='savedice' type="roll" name='roll_circlesave' value="@{whispertoggle}&{template:custom} {{color=brown}} {{title=**@{character_name}**}} {{subtitle=Save vs. Circles}} {{Save=[[d20+@{save_circle}+@{pe_magpois}]]}} {{Target= @{save_circle-target}}} {{desc=@{save_notes}}}" >Circles</button>
                     <input class='save-field' type="number" value="13" name="attr_save_circle-target" />
                     <input class='save-field' type="number" value="0" name="attr_save_circle" />
                     <div class='space-holder'></div>
-                    <button class='savedice' type="roll" name='roll_insanitysave' value="@{whispertoggle}&{template:custom} {{color=brown}} {{title=**@{character_name}**}} {{subtitle=Save vs. Insanity}} {{Save=[[d20+@{save_insane}+@{me_insanity}]]}} {{Target= @{save_insanity-target}}}" >Insanity</button>
+                    <button class='savedice' type="roll" name='roll_insanitysave' value="@{whispertoggle}&{template:custom} {{color=brown}} {{title=**@{character_name}**}} {{subtitle=Save vs. Insanity}} {{Save=[[d20+@{save_insane}+@{me_insanity}]]}} {{Target= @{save_insanity-target}}} {{desc=@{save_notes}}}" >Insanity</button>
                     <input class='save-field' type="number" value="12" name="attr_save_insanity-target" />
                     <input class='save-field' type="number" value="0" name="attr_save_insane" />
                                        
                     
-                    <button class='savedice' type="roll" name='roll_fumesave' value="@{whispertoggle}&{template:custom} {{color=brown}} {{title=**@{character_name}**}} {{subtitle=Save vs. Fumes}} {{Save=[[d20+@{save_fumes}+@{pe_magpois}]]}} {{Target= @{save_fumes-target}}}" >Fumes</button>
+                    <button class='savedice' type="roll" name='roll_fumesave' value="@{whispertoggle}&{template:custom} {{color=brown}} {{title=**@{character_name}**}} {{subtitle=Save vs. Fumes}} {{Save=[[d20+@{save_fumes}+@{pe_magpois}]]}} {{Target= @{save_fumes-target}}} {{desc=@{save_notes}}}" >Fumes</button>
                     <input class='save-field' type="number" value="14" name="attr_save_fumes-target" />
                     <input class='save-field' type="number" value="0" name="attr_save_fumes" />
                     <div class='space-holder'></div>
-                    <button class='savedice' type="roll" name='roll_psionicsave' value="@{whispertoggle}&{template:custom} {{color=brown}} {{title=**@{character_name}**}} {{subtitle=Save vs. Psionics}} {{Save=[[d20+@{save_psi}+@{me_psionic}]]}} {{Target= @{save_psi-target}}}" >Psionics</button>
+                    <button class='savedice' type="roll" name='roll_psionicsave' value="@{whispertoggle}&{template:custom} {{color=brown}} {{title=**@{character_name}**}} {{subtitle=Save vs. Psionics}} {{Save=[[d20+@{save_psi}+@{me_psionic}]]}} {{Target= @{save_psi-target}}} {{desc=@{save_notes}}}" >Psionics</button>
                     <input class='save-field' type="number" value="15" name="attr_save_psi-target" />
                     <input class='save-field' type="number" value="0" name="attr_save_psi" />
                     
                     
-                    <button class='savedice' type="roll" name='roll_spellsave' value="@{whispertoggle}&{template:custom} {{color=brown}} {{title=**@{character_name}**}} {{subtitle=Save vs. Spells}} {{Save=[[d20+@{save_spells}+@{pe_magpois}]]}} {{Target= @{save_spells-target}}}" >Spells</button>
+                    <button class='savedice' type="roll" name='roll_spellsave' value="@{whispertoggle}&{template:custom} {{color=brown}} {{title=**@{character_name}**}} {{subtitle=Save vs. Spells}} {{Save=[[d20+@{save_spells}+@{pe_magpois}]]}} {{Target= @{save_spells-target}}} {{desc=@{save_notes}}}" >Spells</button>
                     <input class='save-field' type="number" value="12" name="attr_save_spells-target" />
                     <input class='save-field' type="number" value="0" name="attr_save_spells" />
                     <div class='space-holder'></div>
-                    <button class='savedice' type="roll" name='roll_soulsave' value="@{whispertoggle}&{template:custom} {{color=brown}} {{title=**@{character_name}**}} {{subtitle=Save vs. Souldrinking}} {{Save=[[d20+@{save_souldrinking}+@{pe_magpois}]]}} {{Target= @{save_souldrink-target}}}" >Soul Drink</button>
+                    <button class='savedice' type="roll" name='roll_soulsave' value="@{whispertoggle}&{template:custom} {{color=brown}} {{title=**@{character_name}**}} {{subtitle=Save vs. Souldrinking}} {{Save=[[d20+@{save_souldrinking}+@{pe_magpois}]]}} {{Target= @{save_souldrink-target}}} {{desc=@{save_notes}}}" >Soul Drink</button>
                     <input class='save-field' type="number" value="14" name="attr_save_souldrink-target" />
                     <input class='save-field' type="number" value="0" name="attr_save_souldrinking" />
                     
                     
-                    <button class='savedice' type="roll" name='roll_wardsave' value="@{whispertoggle}&{template:custom} {{color=brown}} {{title=**@{character_name}**}} {{subtitle=Save vs. Wards}} {{Save=[[d20+@{save_wards}+@{pe_magpois}]]}} {{Target= @{save_wards-target}}}" >Wards</button>
+                    <button class='savedice' type="roll" name='roll_wardsave' value="@{whispertoggle}&{template:custom} {{color=brown}} {{title=**@{character_name}**}} {{subtitle=Save vs. Wards}} {{Save=[[d20+@{save_wards}+@{pe_magpois}]]}} {{Target= @{save_wards-target}}} {{desc=@{save_notes}}}" >Wards</button>
                     <input class='save-field' type="number" value="13" name="attr_save_wards-target" />
                     <input class='save-field' type="number" value="0" name="attr_save_wards" />
                     <div class='space-holder'></div>
-                    <button class='savedice' type="roll" name='roll_poisonsave' value="@{whispertoggle}&{template:custom} {{color=brown}} {{title=**@{character_name}**}} {{subtitle=Save vs. Poison}} {{Save=[[d20+@{save_poison}+@{pe_magpois}]]}} {{Target= @{save_poison-target}}}" >Poison</button>
+                    <button class='savedice' type="roll" name='roll_poisonsave' value="@{whispertoggle}&{template:custom} {{color=brown}} {{title=**@{character_name}**}} {{subtitle=Save vs. Poison}} {{Save=[[d20+@{save_poison}+@{pe_magpois}]]}} {{Target= @{save_poison-target}}} {{desc=@{save_notes}}}" >Poison</button>
                     <input class='save-field' type="number" value="14" name="attr_save_poison-target" />
                     <input class='save-field' type="number" value="0" name="attr_save_poison" />
                     


### PR DESCRIPTION
## Changes / Comments

I created a notes field to input situational saving throw bonuses to be displayed when saves are rolled, added a new field for character occupation specific notes, and posted a warning at the bottom of the first tab of the character sheet.  
There will be upcoming changes to the repeating attacks section that will remove a couple entry fields to make them "global" to that repeating section, so that this serves as prior warning of that change to the temporary bonus fields.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
