### PR TITLE
[Pathfinder_Cazra] fix Chaotic Neutral alignment value

### DIFF
--- a/Pathfinder_Cazra/sheet.html
+++ b/Pathfinder_Cazra/sheet.html
@@ -312,7 +312,7 @@
                     <option value="CG" data-i18n="chaotic-good">Chaotic Good</option>
                     <option value="LN" data-i18n="lawful-neutral">Lawful Neutral</option>
                     <option value="N" data-i18n="neutral">Neutral</option>
-                    <option value="CG" data-i18n="chaotic-neutral">Chaotic Neutral</option>
+                    <option value="CN" data-i18n="chaotic-neutral">Chaotic Neutral</option>
                     <option value="LE" data-i18n="lawful-evil">Lawful Evil</option>
                     <option value="NE" data-i18n="neutral-evil">Neutral Evil</option>
                     <option value="CE" data-i18n="chaotic-evil">Chaotic Evil</option>


### PR DESCRIPTION
## Changes / Comments

There was a bug in the HTML of the sheet "Pathfinder_Cazra" (also known as "Pathfinder (Simple)" in the sheet picker during game creation) that showed the alignment value of "Chaotic Neutral as "CG" - resulting in everyone who chose "Chaotic Good" as an alignment in the character sheet to be displayed as "Chaotic Neutral" once the sheet was closed and re-opened.

I tested this with a custom sheet in an own game of mine and there were no issues. No player data needs to be changed or is affected otherwise, the alignment will simply be displayed correctly in the sheet from now on.




## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
