### PR TITLE
[Nephilim V5 FR] FIX - incorrect repeating ID

### DIFF
--- a/nephilimV5-vf/nephilim-legende-vf.html
+++ b/nephilimV5-vf/nephilim-legende-vf.html
@@ -211,7 +211,7 @@
         </div>
         <div class="sheet-box sheet-col">
             <h3> vécus passé</h3>
-            <fieldset class="repeating_vecus_passe">
+            <fieldset class="repeating_vecus-passe">
                 <input type="text" name="attr_vecus-passe" type="text" /><input class="sheet-rond" name="attr_degres_vecu_passe" type="number" />
             </fieldset>
         </div>


### PR DESCRIPTION
The repeating_vecus_passe line 214 is forbidden as state here https://wiki.roll20.net/Building_Character_Sheets#Repeating_Sections and should be modified into repeating_vecus-passe

## Changes / Comments






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
