### PR TITLE
[AS&SH] Fix repeating section

### DIFF
--- a/AS&SH/assh.html
+++ b/AS&SH/assh.html
@@ -274,7 +274,7 @@
                 <div class="sheet-ligne">
                     <span class="sheet-lib2 sheet-wid50" style="width:250;">Weapon Masteries / New Weapon Skills</span>
                     <span class="sheet-lib2 sheet-wid50" style="width:50px;">Level</span>
-                    <fieldset class="repeating_weapon_skills">
+                    <fieldset class="repeating_weaponskills">
                         <div class="sheet-ligne">
                             <input type="text" name="attr_wpnskill" value="" class="sheet-longinput sheet-bold" style="width:250px;" placeholder="" />
                             <input type="text" name="attr_wpnlevel" value="" class="sheet-shortinput sheet-bold" style="width:50px;" placeholder="" />


### PR DESCRIPTION
## Changes / Comments
* "Astonishing Swordsmen & Sorcerers of Hyperborea" had a incorrectly named repeating section that resulted in stats in the section to not save
* [reported in this thread](https://app.roll20.net/forum/post/8069819/new-field-disappears-after-added)





## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
