### PR TITLE
[AD&D 2e Character Sheet] Fixed currency calculations for all settings and all currencies

### DIFF
--- a/AD&D 2E Revised/2ESheet.html
+++ b/AD&D 2E Revised/2ESheet.html
@@ -6185,15 +6185,15 @@
             <td><input type="text" name="attr_copper1" title="@{copper1}" class="sheet-short" value="@{electrum}*10*5" disabled="true"/></td>
             <td><input type="text" name="attr_copsilver" title="@{copsilver}" class="sheet-short" value="@{electrum}*5" disabled="true"/></td>
             <td><input type="text" name="attr_copelectrum" title="@{copelectrum}" class="sheet-short" value="@{electrum}*1" disabled="true"/></td>
-            <td><input type="text" name="attr_copgold" title="@{copgold}" class="sheet-short" value="@{electrum}/5" disabled="true"/></td>
-            <td><input type="text" name="attr_copplatinum" title="@{copplatinum}" class="sheet-short" value="@{electrum}/5/10" disabled="true"/></td>
+            <td><input type="text" name="attr_copgold" title="@{copgold}" class="sheet-short" value="@{electrum}/2" disabled="true"/></td>
+            <td><input type="text" name="attr_copplatinum" title="@{copplatinum}" class="sheet-short" value="@{electrum}/2/10" disabled="true"/></td>
     </tr>
     <tr>
             <td style="background-color: #7C0303; color: #FFF; font-family: Arial; font-weight: bold;">Gold</td>
             <td><input type="text" name="attr_goldquantity" title="@{goldquantity}" value="@{gold}" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_copper1" title="@{copper1}" class="sheet-short" value="@{gold}*10*10" disabled="true"/></td>
             <td><input type="text" name="attr_copsilver" title="@{copsilver}" class="sheet-short" value="@{gold}*10" disabled="true"/></td>
-            <td><input type="text" name="attr_copelectrum" title="@{copelectrum}" class="sheet-short" value="@{gold}*5" disabled="true"/></td>
+            <td><input type="text" name="attr_copelectrum" title="@{copelectrum}" class="sheet-short" value="@{gold}*2" disabled="true"/></td>
             <td><input type="text" name="attr_copgold" title="@{copgold}" class="sheet-short" value="@{gold}*1" disabled="true"/></td>
             <td><input type="text" name="attr_copplatinum" title="@{copplatinum}" class="sheet-short" value="@{gold}/10" disabled="true"/></td>
     </tr>
@@ -6202,7 +6202,7 @@
             <td><input type="text" name="attr_platinumquantity" title="@{platinumquantity}" value="@{platinum}" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_copper1" title="@{copper1}" class="sheet-short" value="@{platinum}*10*10*10" disabled="true"/></td>
             <td><input type="text" name="attr_copsilver" title="@{copsilver}" class="sheet-short" value="@{platinum}*10*10" disabled="true"/></td>
-            <td><input type="text" name="attr_copelectrum" title="@{copelectrum}" class="sheet-short" value="@{platinum}*5*10" disabled="true"/></td>
+            <td><input type="text" name="attr_copelectrum" title="@{copelectrum}" class="sheet-short" value="@{platinum}*2*10" disabled="true"/></td>
             <td><input type="text" name="attr_copgold" title="@{copgold}" class="sheet-short" value="@{platinum}*10" disabled="true"/></td>
             <td><input type="text" name="attr_copplatinum" title="@{copplatinum}" class="sheet-short" value="@{platinum}*1" disabled="true"/></td>
     </tr>
@@ -6284,7 +6284,7 @@
             <td><input type="text" name="attr_gold3" title="@{gold3}" class="sheet-short" value="@{gold2}*1" disabled="true"/></td>
             <td><input type="text" name="attr_silver3" title="@{silver3}" class="sheet-short" value="@{gold2}/2" disabled="true"/></td>
             <td><input type="text" name="attr_iron3" title="@{iron3}" class="sheet-short" value="@{gold2}/20" disabled="true"/></td>
-            <td><input type="text" name="attr_bronze3" title="@{bronze3}" class="sheet-short" value="@{gold2}/40" disabled="true"/></td>
+            <td><input type="text" name="attr_bronze3" title="@{bronze3}" class="sheet-short" value="@{gold2}/20" disabled="true"/></td>
             <td><input type="text" name="attr_steel3" title="@{steel3}" class="sheet-short" value="@{gold2}/40" disabled="true"/></td>
             <td><input type="text" name="attr_platinum3" title="@{platinum3}" class="sheet-short" value="@{gold2}/200" disabled="true"/></td>
     </tr>
@@ -6439,8 +6439,8 @@
     <tr>
             <td style="background-color: #7C0303; color: #FFF; font-family: Arial; font-weight: bold;">Silver</td>
             <td><input type="text" name="attr_silverquantity9" title="@{silverquantity9}" value="@{silver5}" class="sheet-short" disabled="true"/></td>
-            <td><input type="text" name="attr_bit1" title="@{bit1}" class="sheet-short" value="@{silver5}*10*10*10" disabled="true"/></td>
-            <td><input type="text" name="attr_ceramic1" title="@{ceramic1}" class="sheet-short" value="@{silver5}*10*10" disabled="true"/></td>
+            <td><input type="text" name="attr_bit1" title="@{bit1}" class="sheet-short" value="@{silver5}*10*10" disabled="true"/></td>
+            <td><input type="text" name="attr_ceramic1" title="@{ceramic1}" class="sheet-short" value="@{silver5}*10" disabled="true"/></td>
             <td><input type="text" name="attr_copper9" title="@{copper9}" class="sheet-short" value="@{silver5}*10" disabled="true"/></td>
             <td><input type="text" name="attr_copsilver9" title="@{copsilver9}" class="sheet-short" value="@{silver5}*1" disabled="true"/></td>
             <td><input type="text" name="attr_copelectrum9" title="@{copelectrum9}" class="sheet-short" value="@{silver5}/5" disabled="true"/></td>
@@ -6450,33 +6450,33 @@
     <tr>
             <td style="background-color: #7C0303; color: #FFF; font-family: Arial; font-weight: bold;">Electrum</td>
             <td><input type="text" name="attr_electrumquantity9" title="@{electrumquantity9}" value="@{electrum5}" class="sheet-short" disabled="true"/></td>
-            <td><input type="text" name="attr_bit1" title="@{bit1}" class="sheet-short" value="@{electrum5}*10*10*10*5" disabled="true"/></td>
-            <td><input type="text" name="attr_ceramic1" title="@{ceramic1}" class="sheet-short" value="@{electrum5}*10*10*5" disabled="true"/></td>
+            <td><input type="text" name="attr_bit1" title="@{bit1}" class="sheet-short" value="@{electrum5}*10*10*5" disabled="true"/></td>
+            <td><input type="text" name="attr_ceramic1" title="@{ceramic1}" class="sheet-short" value="@{electrum5}*10*5" disabled="true"/></td>
             <td><input type="text" name="attr_copper9" title="@{copper9}" class="sheet-short" value="@{electrum5}*10*5" disabled="true"/></td>
             <td><input type="text" name="attr_copsilver9" title="@{copsilver9}" class="sheet-short" value="@{electrum5}*5" disabled="true"/></td>
             <td><input type="text" name="attr_copelectrum9" title="@{copelectrum9}" class="sheet-short" value="@{electrum5}*1" disabled="true"/></td>
-            <td><input type="text" name="attr_copgold9" title="@{copgold9}" class="sheet-short" value="@{electrum5}/5" disabled="true"/></td>
-            <td><input type="text" name="attr_copplatinum9" title="@{copplatinum9}" class="sheet-short" value="@{electrum5}/5/5" disabled="true"/></td>
+            <td><input type="text" name="attr_copgold9" title="@{copgold9}" class="sheet-short" value="@{electrum5}/2" disabled="true"/></td>
+            <td><input type="text" name="attr_copplatinum9" title="@{copplatinum9}" class="sheet-short" value="@{electrum5}/2/5" disabled="true"/></td>
     </tr>
     <tr>
             <td style="background-color: #7C0303; color: #FFF; font-family: Arial; font-weight: bold;">Gold</td>
             <td><input type="text" name="attr_goldquantity9" title="@{goldquantity9}" value="@{gold5}" class="sheet-short" disabled="true"/></td>
-            <td><input type="text" name="attr_bit1" title="@{bit1}" class="sheet-short" value="@{gold5}*10*10*10*10" disabled="true"/></td>
-            <td><input type="text" name="attr_ceramic1" title="@{ceramic1}" class="sheet-short" value="@{gold5}*10*10*10" disabled="true"/></td>
+            <td><input type="text" name="attr_bit1" title="@{bit1}" class="sheet-short" value="@{gold5}*10*10*10" disabled="true"/></td>
+            <td><input type="text" name="attr_ceramic1" title="@{ceramic1}" class="sheet-short" value="@{gold5}*10*10" disabled="true"/></td>
             <td><input type="text" name="attr_copper9" title="@{copper9}" class="sheet-short" value="@{gold5}*10*10" disabled="true"/></td>
             <td><input type="text" name="attr_copsilver9" title="@{copsilver9}" class="sheet-short" value="@{gold5}*10" disabled="true"/></td>
-            <td><input type="text" name="attr_copelectrum9" title="@{copelectrum9}" class="sheet-short" value="@{gold5}*5" disabled="true"/></td>
+            <td><input type="text" name="attr_copelectrum9" title="@{copelectrum9}" class="sheet-short" value="@{gold5}*2" disabled="true"/></td>
             <td><input type="text" name="attr_copgold9" title="@{copgold9}" class="sheet-short" value="@{gold5}*1" disabled="true"/></td>
             <td><input type="text" name="attr_copplatinum9" title="@{copplatinum9}" class="sheet-short" value="@{gold5}/5" disabled="true"/></td>
     </tr>
     <tr>
             <td style="background-color: #7C0303; color: #FFF; font-family: Arial; font-weight: bold;">Platinum</td>
             <td><input type="text" name="attr_platinumquantity9" title="@{platinumquantity9}" value="@{platinum5}" class="sheet-short" disabled="true"/></td>
-            <td><input type="text" name="attr_bit1" title="@{bit1}" class="sheet-short" value="@{platinum5}*10*10*10*10*5" disabled="true"/></td>
-            <td><input type="text" name="attr_ceramic1" title="@{ceramic1}" class="sheet-short" value="@{platinum5}*10*10*10*5" disabled="true"/></td>
+            <td><input type="text" name="attr_bit1" title="@{bit1}" class="sheet-short" value="@{platinum5}*10*10*10*5" disabled="true"/></td>
+            <td><input type="text" name="attr_ceramic1" title="@{ceramic1}" class="sheet-short" value="@{platinum5}*10*10*5" disabled="true"/></td>
             <td><input type="text" name="attr_copper9" title="@{copper9}" class="sheet-short" value="@{platinum5}*10*10*5" disabled="true"/></td>
             <td><input type="text" name="attr_copsilver9" title="@{copsilver9}" class="sheet-short" value="@{platinum5}*10*5" disabled="true"/></td>
-            <td><input type="text" name="attr_copelectrum9" title="@{copelectrum9}" class="sheet-short" value="@{platinum5}*5*5" disabled="true"/></td>
+            <td><input type="text" name="attr_copelectrum9" title="@{copelectrum9}" class="sheet-short" value="@{platinum5}*5*2" disabled="true"/></td>
             <td><input type="text" name="attr_copgold9" title="@{copgold9}" class="sheet-short" value="@{platinum5}*5" disabled="true"/></td>
             <td><input type="text" name="attr_copplatinum9" title="@{copplatinum9}" class="sheet-short" value="@{platinum5}*1" disabled="true"/></td>
     </tr>
@@ -6564,16 +6564,16 @@
             <td><input type="text" name="attr_copper8" title="@{copper8}" class="sheet-short" value="@{electrum4}*10*5" disabled="true"/></td>
             <td><input type="text" name="attr_copsilver8" title="@{copsilver8}" class="sheet-short" value="@{electrum4}*5" disabled="true"/></td>
             <td><input type="text" name="attr_copelectrum8" title="@{copelectrum8}" class="sheet-short" value="@{electrum4}*1" disabled="true"/></td>
-            <td><input type="text" name="attr_copkroner" title="@{copkroner}" class="sheet-short" value="@{electrum4}/5" disabled="true"/></td>
-            <td><input type="text" name="attr_copgold8" title="@{copgold8}" class="sheet-short" value="@{electrum4}/5" disabled="true"/></td>
-            <td><input type="text" name="attr_copplatinum8" title="@{copplatinum8}" class="sheet-short" value="@{electrum4}/5/5" disabled="true"/></td>
+            <td><input type="text" name="attr_copkroner" title="@{copkroner}" class="sheet-short" value="@{electrum4}/2" disabled="true"/></td>
+            <td><input type="text" name="attr_copgold8" title="@{copgold8}" class="sheet-short" value="@{electrum4}/2" disabled="true"/></td>
+            <td><input type="text" name="attr_copplatinum8" title="@{copplatinum8}" class="sheet-short" value="@{electrum4}/2/5" disabled="true"/></td>
     </tr>
     <tr>
             <td style="background-color: #7C0303; color: #FFF; font-family: Arial; font-weight: bold;">Kroner</td>
             <td><input type="text" name="attr_kronerquantity" title="@{kronerquantity}" value="@{kroner}" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_copper8" title="@{copper8}" class="sheet-short" value="@{kroner}*10*10" disabled="true"/></td>
             <td><input type="text" name="attr_copsilver8" title="@{copsilver8}" class="sheet-short" value="@{kroner}*10" disabled="true"/></td>
-            <td><input type="text" name="attr_copelectrum8" title="@{copelectrum8}" class="sheet-short" value="@{kroner}*5" disabled="true"/></td>
+            <td><input type="text" name="attr_copelectrum8" title="@{copelectrum8}" class="sheet-short" value="@{kroner}*2" disabled="true"/></td>
             <td><input type="text" name="attr_copkroner" title="@{copkroner}" class="sheet-short" value="@{kroner}*1" disabled="true"/></td>
             <td><input type="text" name="attr_copgold8" title="@{copgold8}" class="sheet-short" value="@{kroner}*1" disabled="true"/></td>
             <td><input type="text" name="attr_copplatinum8" title="@{copplatinum8}" class="sheet-short" value="@{kroner}/5" disabled="true"/></td>
@@ -6583,7 +6583,7 @@
             <td><input type="text" name="attr_goldquantity8" title="@{goldquantity8}" value="@{gold4}" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_copper8" title="@{copper8}" class="sheet-short" value="@{gold4}*10*10" disabled="true"/></td>
             <td><input type="text" name="attr_copsilver8" title="@{copsilver8}" class="sheet-short" value="@{gold4}*10" disabled="true"/></td>
-            <td><input type="text" name="attr_copelectrum8" title="@{copelectrum8}" class="sheet-short" value="@{gold4}*5" disabled="true"/></td>
+            <td><input type="text" name="attr_copelectrum8" title="@{copelectrum8}" class="sheet-short" value="@{gold4}*2" disabled="true"/></td>
             <td><input type="text" name="attr_copkroner" title="@{copkroner}" class="sheet-short" value="@{gold4}*1" disabled="true"/></td>
             <td><input type="text" name="attr_copgold8" title="@{copgold8}" class="sheet-short" value="@{gold4}*1" disabled="true"/></td>
             <td><input type="text" name="attr_copplatinum8" title="@{copplatinum8}" class="sheet-short" value="@{gold4}/5" disabled="true"/></td>
@@ -6593,7 +6593,7 @@
             <td><input type="text" name="attr_platinumquantity8" title="@{platinumquantity8}" value="@{platinum4}" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_copper8" title="@{copper8}" class="sheet-short" value="@{platinum4}*10*10*5" disabled="true"/></td>
             <td><input type="text" name="attr_copsilver8" title="@{copsilver8}" class="sheet-short" value="@{platinum4}*10*5" disabled="true"/></td>
-            <td><input type="text" name="attr_copelectrum8" title="@{copelectrum8}" class="sheet-short" value="@{platinum4}*5*5" disabled="true"/></td>
+            <td><input type="text" name="attr_copelectrum8" title="@{copelectrum8}" class="sheet-short" value="@{platinum4}*5*2" disabled="true"/></td>
             <td><input type="text" name="attr_copkroner" title="@{copkroner}" class="sheet-short" value="@{platinum4}*5" disabled="true"/></td>
             <td><input type="text" name="attr_copgold8" title="@{copgold8}" class="sheet-short" value="@{platinum4}*5" disabled="true"/></td>
             <td><input type="text" name="attr_copplatinum8" title="@{copplatinum8}" class="sheet-short" value="@{platinum4}*1" disabled="true"/></td>
@@ -6664,7 +6664,7 @@
             <td><input type="text" name="attr_cocoaquantity" title="@{cocoaquantity}" value="@{cocoabean}" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_maizequantity" title="@{maizequantity}" value="@{cocoabean}" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_bladequantity" title="@{bladequantity}" value="@{cocoabean}/10" class="sheet-short" disabled="true"/></td>
-            <td><input type="text" name="attr_coralquantity" title="@{coralquantity}" value="@{cocoabean}/10/5" class="sheet-short" disabled="true"/></td>
+            <td><input type="text" name="attr_coralquantity" title="@{coralquantity}" value="@{cocoabean}/10/2" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_jadequantity" title="@{jadequantity}" value="@{cocoabean}/10/10" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_quillquantity" title="@{quillquantity}" value="@{cocoabean}/10/10/5" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_turquoisequantity" title="@{turquoisequantity}" value="@{cocoabean}/10/10/10" class="sheet-short" disabled="true"/></td>
@@ -6675,7 +6675,7 @@
             <td><input type="text" name="attr_cocoaquantity" title="@{cocoaquantity}" value="@{earmaize}" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_maizequantity" title="@{maizequantity}" value="@{earmaize}" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_bladequantity" title="@{bladequantity}" value="@{earmaize}/10" class="sheet-short" disabled="true"/></td>
-            <td><input type="text" name="attr_coralquantity" title="@{coralquantity}" value="@{earmaize}/10/5" class="sheet-short" disabled="true"/></td>
+            <td><input type="text" name="attr_coralquantity" title="@{coralquantity}" value="@{earmaize}/10/2" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_jadequantity" title="@{jadequantity}" value="@{earmaize}/10/10" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_quillquantity" title="@{quillquantity}" value="@{earmaize}/10/10/5" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_turquoisequantity" title="@{turquoisequantity}" value="@{earmaize}/10/10/10" class="sheet-short" disabled="true"/></td>
@@ -6686,7 +6686,7 @@
             <td><input type="text" name="attr_cocoaquantity" title="@{cocoaquantity}" value="@{copperblade}*10" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_maizequantity" title="@{maizequantity}" value="@{copperblade}*10" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_bladequantity" title="@{bladequantity}" value="@{copperblade}" class="sheet-short" disabled="true"/></td>
-            <td><input type="text" name="attr_coralquantity" title="@{coralquantity}" value="@{copperblade}/5" class="sheet-short" disabled="true"/></td>
+            <td><input type="text" name="attr_coralquantity" title="@{coralquantity}" value="@{copperblade}/2" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_jadequantity" title="@{jadequantity}" value="@{copperblade}/10" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_quillquantity" title="@{quillquantity}" value="@{copperblade}/10/5" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_turquoisequantity" title="@{turquoisequantity}" value="@{copperblade}/10/10" class="sheet-short" disabled="true"/></td>
@@ -6694,13 +6694,13 @@
     <tr>
             <td style="background-color: #7C0303; color: #FFF; font-family: Arial; font-weight: bold;">Coral Bud</td>
             <td><input type="text" name="attr_coralbudquantity" title="@{coralbudquantity}" value="@{coralbud}" class="sheet-short" disabled="true"/></td>
-            <td><input type="text" name="attr_cocoaquantity" title="@{cocoaquantity}" value="@{coralbud}*10*5" class="sheet-short" disabled="true"/></td>
-            <td><input type="text" name="attr_maizequantity" title="@{maizequantity}" value="@{coralbud}*10*5" class="sheet-short" disabled="true"/></td>
-            <td><input type="text" name="attr_bladequantity" title="@{bladequantity}" value="@{coralbud}*5" class="sheet-short" disabled="true"/></td>
+            <td><input type="text" name="attr_cocoaquantity" title="@{cocoaquantity}" value="@{coralbud}*10*2" class="sheet-short" disabled="true"/></td>
+            <td><input type="text" name="attr_maizequantity" title="@{maizequantity}" value="@{coralbud}*10*2" class="sheet-short" disabled="true"/></td>
+            <td><input type="text" name="attr_bladequantity" title="@{bladequantity}" value="@{coralbud}*2" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_coralquantity" title="@{coralquantity}" value="@{coralbud}" class="sheet-short" disabled="true"/></td>
-            <td><input type="text" name="attr_jadequantity" title="@{jadequantity}" value="@{coralbud}/2" class="sheet-short" disabled="true"/></td>
-            <td><input type="text" name="attr_quillquantity" title="@{quillquantity}" value="@{coralbud}/10/5" class="sheet-short" disabled="true"/></td>
-            <td><input type="text" name="attr_turquoisequantity" title="@{turquoisequantity}" value="@{coralbud}/10/2" class="sheet-short" disabled="true"/></td>
+            <td><input type="text" name="attr_jadequantity" title="@{jadequantity}" value="@{coralbud}/5" class="sheet-short" disabled="true"/></td>
+            <td><input type="text" name="attr_quillquantity" title="@{quillquantity}" value="@{coralbud}/5/5" class="sheet-short" disabled="true"/></td>
+            <td><input type="text" name="attr_turquoisequantity" title="@{turquoisequantity}" value="@{coralbud}/5/5/2" class="sheet-short" disabled="true"/></td>
     </tr>
     <tr>
             <td style="background-color: #7C0303; color: #FFF; font-family: Arial; font-weight: bold;">Jade</td>
@@ -6708,10 +6708,10 @@
             <td><input type="text" name="attr_cocoaquantity" title="@{cocoaquantity}" value="@{jade}*10*10" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_maizequantity" title="@{maizequantity}" value="@{jade}*10*10" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_bladequantity" title="@{bladequantity}" value="@{jade}*10" class="sheet-short" disabled="true"/></td>
-            <td><input type="text" name="attr_coralquantity" title="@{coralquantity}" value="@{jade}*2" class="sheet-short" disabled="true"/></td>
+            <td><input type="text" name="attr_coralquantity" title="@{coralquantity}" value="@{jade}*5" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_jadequantity" title="@{jadequantity}" value="@{jade}" class="sheet-short" disabled="true"/></td>
-            <td><input type="text" name="attr_quillquantity" title="@{quillquantity}" value="@{jade}/10" class="sheet-short" disabled="true"/></td>
-            <td><input type="text" name="attr_turquoisequantity" title="@{turquoisequantity}" value="@{jade}/10/2" class="sheet-short" disabled="true"/></td>
+            <td><input type="text" name="attr_quillquantity" title="@{quillquantity}" value="@{jade}/5" class="sheet-short" disabled="true"/></td>
+            <td><input type="text" name="attr_turquoisequantity" title="@{turquoisequantity}" value="@{jade}/5/2" class="sheet-short" disabled="true"/></td>
     </tr>
     <tr>
             <td style="background-color: #7C0303; color: #FFF; font-family: Arial; font-weight: bold;">Quill</td>
@@ -6719,7 +6719,7 @@
             <td><input type="text" name="attr_cocoaquantity" title="@{cocoaquantity}" value="@{goldquill}*10*10*5" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_maizequantity" title="@{maizequantity}" value="@{goldquill}*10*10*5" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_bladequantity" title="@{bladequantity}" value="@{goldquill}*10*5" class="sheet-short" disabled="true"/></td>
-            <td><input type="text" name="attr_coralquantity" title="@{coralquantity}" value="@{goldquill}*10" class="sheet-short" disabled="true"/></td>
+            <td><input type="text" name="attr_coralquantity" title="@{coralquantity}" value="@{goldquill}*5*5" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_jadequantity" title="@{jadequantity}" value="@{goldquill}*5" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_quillquantity" title="@{quillquantity}" value="@{goldquill}" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_turquoisequantity" title="@{turquoisequantity}" value="@{goldquill}/2" class="sheet-short" disabled="true"/></td>
@@ -6730,7 +6730,7 @@
             <td><input type="text" name="attr_cocoaquantity" title="@{cocoaquantity}" value="@{turquoise}*10*10*10" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_maizequantity" title="@{maizequantity}" value="@{turquoise}*10*10*10" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_bladequantity" title="@{bladequantity}" value="@{turquoise}*10*10" class="sheet-short" disabled="true"/></td>
-            <td><input type="text" name="attr_coralquantity" title="@{coralquantity}" value="@{turquoise}*10*2" class="sheet-short" disabled="true"/></td>
+            <td><input type="text" name="attr_coralquantity" title="@{coralquantity}" value="@{turquoise}*10*5" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_jadequantity" title="@{jadequantity}" value="@{turquoise}*10" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_quillquantity" title="@{quillquantity}" value="@{turquoise}*2" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_turquoisequantity" title="@{turquoisequantity}" value="@{turquoise}" class="sheet-short" disabled="true"/></td>
@@ -6798,7 +6798,7 @@
             <td><input type="text" name="attr_copsilver" title="@{copsilver}" class="sheet-short" value="@{copper6}/10" disabled="true"/></td>
             <td><input type="text" name="attr_copgb" title="@{copgb}" class="sheet-short" value="@{copper6}/10/10/2000" disabled="true"/></td>
             <td><input type="text" name="attr_copgold" title="@{copgold}" class="sheet-short" value="@{copper6}/10/10" disabled="true"/></td>
-            <td><input type="text" name="attr_copplatinum" title="@{copplatinum}" class="sheet-short" value="@{copper6}/10/10/5" disabled="true"/></td>
+            <td><input type="text" name="attr_copplatinum" title="@{copplatinum}" class="sheet-short" value="@{copper6}/10/10/10" disabled="true"/></td>
     </tr>
     <tr>
             <td style="background-color: #7C0303; color: #FFF; font-family: Arial; font-weight: bold;">Silver</td>
@@ -6807,7 +6807,7 @@
             <td><input type="text" name="attr_copsilver" title="@{copsilver}" class="sheet-short" value="@{silver6}*1" disabled="true"/></td>
             <td><input type="text" name="attr_copgb" title="@{copgb}" class="sheet-short" value="@{silver6}/10/2000" disabled="true"/></td>
             <td><input type="text" name="attr_copgold" title="@{copgold}" class="sheet-short" value="@{silver6}/10" disabled="true"/></td>
-            <td><input type="text" name="attr_copplatinum" title="@{copplatinum}" class="sheet-short" value="@{silver6}/10/5" disabled="true"/></td>
+            <td><input type="text" name="attr_copplatinum" title="@{copplatinum}" class="sheet-short" value="@{silver6}/10/10" disabled="true"/></td>
     </tr>
     <tr>
             <td style="background-color: #7C0303; color: #FFF; font-family: Arial; font-weight: bold;">Gold Bar</td>
@@ -6816,7 +6816,7 @@
             <td><input type="text" name="attr_copsilver" title="@{copsilver}" class="sheet-short" value="@{goldbar}*10*2000" disabled="true"/></td>
             <td><input type="text" name="attr_copgb" title="@{copgb}" class="sheet-short" value="@{goldbar}*1" disabled="true"/></td>
             <td><input type="text" name="attr_copgold" title="@{copgold}" class="sheet-short" value="@{goldbar}*2000" disabled="true"/></td>
-            <td><input type="text" name="attr_copplatinum" title="@{copplatinum}" class="sheet-short" value="@{goldbar}/5*2000" disabled="true"/></td>
+            <td><input type="text" name="attr_copplatinum" title="@{copplatinum}" class="sheet-short" value="@{goldbar}/10*2000" disabled="true"/></td>
     </tr>
     <tr>
             <td style="background-color: #7C0303; color: #FFF; font-family: Arial; font-weight: bold;">Gold</td>
@@ -6825,15 +6825,15 @@
             <td><input type="text" name="attr_copsilver" title="@{copsilver}" class="sheet-short" value="@{gold6}*10" disabled="true"/></td>
             <td><input type="text" name="attr_copgb" title="@{copgb}" class="sheet-short" value="@{gold6}/2000" disabled="true"/></td>
             <td><input type="text" name="attr_copgold" title="@{copgold}" class="sheet-short" value="@{gold6}*1" disabled="true"/></td>
-            <td><input type="text" name="attr_copplatinum" title="@{copplatinum}" class="sheet-short" value="@{gold6}/5" disabled="true"/></td>
+            <td><input type="text" name="attr_copplatinum" title="@{copplatinum}" class="sheet-short" value="@{gold6}/10" disabled="true"/></td>
     </tr>
     <tr>
             <td style="background-color: #7C0303; color: #FFF; font-family: Arial; font-weight: bold;">Platinum</td>
             <td><input type="text" name="attr_platinumquantity" title="@{platinumquantity}" value="@{platinum6}" class="sheet-short" disabled="true"/></td>
             <td><input type="text" name="attr_copper1" title="@{copper1}" class="sheet-short" value="@{platinum6}*10*10*10" disabled="true"/></td>
             <td><input type="text" name="attr_copsilver" title="@{copsilver}" class="sheet-short" value="@{platinum6}*10*10" disabled="true"/></td>
-            <td><input type="text" name="attr_copgb" title="@{copgb}" class="sheet-short" value="@{platinum6}*5/2000" disabled="true"/></td>
-            <td><input type="text" name="attr_copgold" title="@{copgold}" class="sheet-short" value="@{platinum6}*5" disabled="true"/></td>
+            <td><input type="text" name="attr_copgb" title="@{copgb}" class="sheet-short" value="@{platinum6}*10/2000" disabled="true"/></td>
+            <td><input type="text" name="attr_copgold" title="@{copgold}" class="sheet-short" value="@{platinum6}*10" disabled="true"/></td>
             <td><input type="text" name="attr_copplatinum" title="@{copplatinum}" class="sheet-short" value="@{platinum6}*1" disabled="true"/></td>
     </tr>
 </table>


### PR DESCRIPTION
## Changes / Comments
Fixed currency calculations for all settings, this includes
- Standard
- Dragonlance
- Dark Sun
- Ravenloft
- Maztica
- BirthRight

My tests and results can be seen here:
https://app.roll20.net/forum/post/8070888/ad-and-d-2e-currency-calculation-is-wrong-for-ep-gp-and-pp/?pageforid=8072523#post-8072523

I have not changed any whitespacing or HTML element closures, even though the document seems to have multiple unclosed elements. I stricktly only fixed the calculations for curencies.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
