### PR TITLE
Update Palladium_Fantasy_1E sheet

### DIFF
--- a/Palladium Fantasy 1E/palladium_fantasy_1e.css
+++ b/Palladium Fantasy 1E/palladium_fantasy_1e.css
@@ -228,7 +228,7 @@ button[type=roll].sheet-rolldice::before {
 .sheet-secondary-field, .sheet-mystic-field, .sheet-melee-field, .sheet-ranged-field, 
 .sheet-combat-field, .sheet-combat-textarea, .sheet-save-field, .sheet-notes-field, .sheet-notes-textarea, 
 .sheet-weight-box, .sheet-weightsub-box, .sheet-whisper-select, .sheet-mattack-text, .sheet-rattack-text, 
-.sheet-save-misc{
+.sheet-save-misc, .sheet-mattack-label, .sheet-rattack-label, .sheet-mattack-bonus, .sheet-rattack-bonus{
     background-color:#ebebeb;
 }
 .sheet-fraction-grid-container{
@@ -311,9 +311,16 @@ button[type=roll].sheet-rolldice::before {
     background: #9cb09b;
     border-bottom-color: black;
 }
+.sheet-meleetemp-container{
+    display:grid;
+    align-items:center;
+    padding-bottom:5px;
+    grid-template-columns: 160px 50px 50px 50px 50px 60px 40px
+}
 .sheet-mattack-grid-container{
     display:grid;
-    grid-template-columns: 160px 35px 50px 48px 35px 50px 50px 35px 62px 50px 170px
+    align-items:center;
+    grid-template-columns: 160px 80px 80px 80px 62px 75px
 }
 button[type=roll].sheet-meleedice::before {
     content: ''; 
@@ -331,21 +338,57 @@ button[type=roll].sheet-rangeddice::before {
 .sheet-damage-dice{
     width: 60px;
 }
+div.sheet-mbonus-hide {
+    display: none;
+}
+input.sheet-mbonus-toggle[value='1']~div.sheet-mbonus-hide {
+    display: block;
+}
+.sheet-mbonus-container{
+    display:grid;
+    grid-template-columns: 213px 213px 301px
+}
 .sheet-mattack-text, .sheet-rattack-text{
-    width: 48px;
+    width: 38px;
 }
 .sheet-mattack-notes{
-    width:170px;
+    height:18px;
+    width:300px;
+    margin:0px;
+    overflow:auto;
+    resize:vertical;
+}
+.sheet-rattack-notes{
+    height:18px;
+    width:512px;
+    margin:0px;
+    overflow:auto;
+    resize:vertical;
 }
 .sheet-ranged-attack-panel{
     max-width:745px;
+    border-bottom:5px solid #889987;
+}
+.sheet-rangedtemp-container{
+    display:grid;
+    align-items:center;
+    padding-bottom:5px;
+    grid-template-columns: 160px 50px 50px 60px 40px
 }
 .sheet-rattack-grid-container{
     display:grid;
-    grid-template-columns: 160px 35px 50px 48px 35px 62px 50px 50px 50px 50px 155px
+    align-items:center;
+    grid-template-columns: 160px 80px 80px 62px 40px 40px 40px 75px
 }
-.sheet-rattack-notes{
-    width: 153px;
+div.sheet-rbonus-hide {
+    display: none;
+}
+input.sheet-rbonus-toggle[value='1']~div.sheet-rbonus-hide {
+    display: block;
+}
+.sheet-rbonus-container{
+    display:grid;
+    grid-template-columns: 213px 563px
 }
 .sheet-physical-grid-container{
     display:grid;

--- a/Palladium Fantasy 1E/palladium_fantasy_1e.html
+++ b/Palladium Fantasy 1E/palladium_fantasy_1e.html
@@ -104,7 +104,7 @@
             <div class='gold-grid-container'>
                 <h4 class='calc-title'>Autocalc</h4>
                 <h4 class='calc-title'>Stats</h4>
-                <h4 class='calc-label' title='Maximum Lift Weight' >Lift lbs.</h4>
+                <h4 class='calc-label' title='Maximum Lift' >Lift lbs.</h4>
                 <input class='calc-field' type="text" value="" name="attr_lift" readonly>
                 <h4 class='calc-label' title='Maximum Carrying Weight' >Carry lbs.</h4>
                 <input class='calc-field' type="text" value="" name="attr_carry" readonly>
@@ -263,33 +263,40 @@
                         <input type="radio" class="ctoggle-middle" name="attr_mounteddam" title="Adds mounted damage to melee damage rolls" value="+@{hth_mounteddamage}"><span title="Mounted"></span>
                         <input type="radio" class="ctoggle-right" name="attr_mounteddam" title="Adds mounted charge damage to melee damage rolls" value="+@{hth_chargedamage}"><span title="Charge"></span>
                     </div>                    
-                </div> 
-                <div class='mattack-grid-container' >
-                    <h5>Weapon</h5>
+                </div>
+                <div class='meleetemp-container'>
+                    <h4>Temporary Bonuses:</h4>
+                    <h5>Strike:</h5>
+                    <input class='mattack-text' type="text" title='Temporary Melee Strike Bonuses' value="0" name="attr_mtemp_strike" />
+                    <h5>Parry:</h5>
+                    <input class='mattack-text' type="text" title='Temporary Melee Parry Bonuses' value="0" name="attr_mtemp_parry" />
+                    <h5>Damage:</h5>
+                    <input class='mattack-text' type="text" title='Temporary Melee Damage Bonuses' value="0" name="attr_mtemp_damage" />
+                </div>
+                <div class='mattack-grid-container'>
+                    <h5>Weapon Name</h5>
                     <div class='space-holder'></div>
-                    <h5>Strike</h5>
-                    <h5>Temp</h5>
                     <div class='space-holder'></div>
-                    <h5>Parry</h5>
-                    <h5>Temp</h5>
                     <div class='space-holder'></div>
                     <h5>Damage</h5>
-                    <h5>Temp</h5>
-                    <h5>Notes</h5>
+                    <div class='space-holder'></div>
                 </div>
                 <fieldset class="repeating_meleeattacks">
                     <div class='mattack-grid-container' > 
-                        <input class='mattack-label' type="text" value="" name="attr_weapon_attack" placeholder="Weapon Name" />
-                        <button class='meleedice' type='roll' title='Strike (Attack) Roll with Damage' name='roll_meleeattack' value="@{whispertoggle}&{template:custom} {{color=blue}} {{title=**@{character_name}**}} {{subtitle=attacks with @{weapon_attack}}} {{Attack= [[d20cs>@{hth_critical}+@{weapon_strike}+@{hth_strike}+@{pp_bonus}+@{temp_strike}]]}} {{Damage= [[@{weapon_damage}+@{hth_damage}+@{ps_bonus}+@{temp_damage}@{mounteddam}]]}} {{desc=@{mattack_reference}}}">S</button>
-                        <input class='mattack-text' type="text" title='Strike Bonuses other than HtH or PP' value="0" name="attr_weapon_strike" />
-                        <input class='mattack-text' type="text" title='Temporary Strike Bonuses' value="0" name="attr_temp_strike" />
-                        <button class='meleedice' type='roll' title='Parry Roll' name='roll_meleeparry' value="@{whispertoggle}&{template:custom} {{color=grey}} {{title=**@{character_name}**}} {{subtitle=parries with @{weapon_attack}}} {{Parry= [[d20+@{weapon_parry}+@{hth_parry}+@{pp_bonus}+@{temp_parry}@{mountedpd}]]}}">P</button>
-                        <input class='mattack-text' type="text" title='Parry Bonuses other than HtH or PP' value="0" name="attr_weapon_parry" />
-                        <input class='mattack-text' type="text" title='Temporary Parry Bonuses' value="0" name="attr_temp_parry" />
-                        <button class='meleedice' type='roll' title='Damage Roll' name='roll_meleedamage' value="@{whispertoggle}&{template:custom} {{color=red}} {{title=**@{character_name}**}} {{subtitle=lashes out}} {{@{character_name}'s @{weapon_attack} deals= [[@{weapon_damage}+@{hth_damage}+@{ps_bonus}+@{temp_damage}@{mounteddam}]]}} {{desc=@{mattack_reference}}}">D</button>
+                        <input class='mattack-label' type="text" value="" title='Weapon name that will display in template header' name="attr_weapon_attack" placeholder="Weapon Name" />
+                        <button class='meleedice' type='roll' title='Strike (Attack) Roll with Damage' name='roll_meleeattack' value="@{whispertoggle}&{template:custom} {{color=blue}} {{title=**@{character_name}**}} {{subtitle=attacks with @{weapon_attack}}} {{Attack= [[d20cs>@{hth_critical}+@{weapon_strike}+@{hth_strike}+@{pp_bonus}+@{mtemp_strike}]]}} {{Damage= [[@{weapon_damage}+@{hth_damage}+@{ps_bonus}+@{mtemp_damage}@{mounteddam}]]}} {{desc=@{mattack_reference}}}">Strike</button>
+                        <button class='meleedice' type='roll' title='Parry Roll' name='roll_meleeparry' value="@{whispertoggle}&{template:custom} {{color=grey}} {{title=**@{character_name}**}} {{subtitle=parries with @{weapon_attack}}} {{Parry= [[d20+@{weapon_parry}+@{hth_parry}+@{pp_bonus}+@{mtemp_parry}@{mountedpd}]]}}">Parry</button>
+                        <button class='meleedice' type='roll' title='Damage Roll' name='roll_meleedamage' value="@{whispertoggle}&{template:custom} {{color=red}} {{title=**@{character_name}**}} {{subtitle=lashes out}} {{@{character_name}'s @{weapon_attack} deals= [[@{weapon_damage}+@{hth_damage}+@{ps_bonus}+@{mtemp_damage}@{mounteddam}]]}} {{desc=@{mattack_reference}}}">Damage</button>
                         <input class='damage-dice' type="text" title='Damage Dice Calculation other than HtH and PS' value="" name="attr_weapon_damage" placeholder="xdy+z" />
-                        <input class='mattack-text' type="text" title='Temporary Damage Bonuses' value="0" name="attr_temp_damage" />
-                        <input class='mattack-notes' type="text" title='Special Note About This Attack' value="" name="attr_mattack_reference" />
+                        <input type='checkbox' title='Show Bonus and Notes Fields' name='attr_toggle_mbonus' value="1">
+                        <input class='mbonus-toggle' type='hidden' name='attr_toggle_mbonus'>
+                        <div class='mbonus-hide'>
+                            <div class='mbonus-container'>
+                                <input class='mattack-bonus' type='text' value='' title='Strike Bonuses other than HtH or PP' value="0" name="attr_weapon_strike" />
+                                <input class='mattack-bonus' type="text" title='Parry Bonuses other than HtH or PP' value="0" name="attr_weapon_parry" />
+                                <textarea class='mattack-notes' type="text" title='Special Note About This Attack' value="" name="attr_mattack_reference" ></textarea>
+                            </div>
+                        </div>
                     </div>
                 </fieldset>
             </div>
@@ -298,48 +305,44 @@
             <input type="checkbox" name="attr_ranged_attacks-toggle" class="sheet-arrow" />
             <h4>Ranged or Magical Attacks</h4>
             <div class="body">
+                <div class='rangedtemp-container'>
+                    <h4>Temporary Bonuses:</h4>
+                    <h5>Strike:</h5>
+                    <input class='rattack-text' type="text" title='Temporary Ranged Strike Bonuses' value="0" name="attr_rtemp_strike" />
+                    <h5>Damage:</h5>
+                    <input class='rattack-text' type="text" title='Temporary Ranged Damage Bonuses' value="0" name="attr_rtemp_damage" />
+                </div>
                 <div class='rattack-grid-container' >
-                    <h5>Weapon</h5>
+                    <h5>Weapon Name</h5>
                     <div class='space-holder'></div>
-                    <h5>Strike</h5>
-                    <h5>Temp</h5>
                     <div class='space-holder'></div>
                     <h5>Damage</h5>
-                    <h5>Temp</h5>
                     <h5>Range</h5>
                     <h5>RoF</h5>
                     <h5>Ammo</h5>
-                    <h5>Notes</h5>
+                    <div class='space-holder'></div>
                 </div>
                 <fieldset class="repeating_rangedattacks"> 
                     <div class='rattack-grid-container' >
-                        <input class='rattack-label' type="text" value="" name="attr_weapon_attack" placeholder="Weapon Name" />
-                        <button class='rangeddice' type='roll' title='Strike (Attack) Roll with Damage' name='roll_rangedattack' value="@{whispertoggle}&{template:custom} {{color=blue}} {{title=**@{character_name}**}} {{subtitle=attacks with @{weapon_attack}}} {{Attack= [[d20cs>@{hth_ranged_critical}+@{weapon_strike}+@{temp_strike}]]}} {{Damage= [[@{weapon_damage}+@{temp_damage}]]}} {{desc=@{attack_reference}}}">S</button>
-                        <input class='rattack-text' type="text" title='Bonuses to Strike' value="0" name="attr_weapon_strike" />
-                        <input class='rattack-text' type="text" title='Temporary Strike Bonuses' value="0" name="attr_temp_strike" />
-                        <button class='rangeddice' type='roll' title='Damage Roll Alone' name='roll_rangeddamage' value="@{whispertoggle}&{template:custom} {{color=red}} {{title=**@{character_name}**}} {{subtitle=hits with @{weapon_attack}}} {{@{character_name}'s @{weapon_attack} deals= [[@{weapon_damage}+@{temp_damage}]]}} {{desc=@{attack_reference}}}">D</button>
+                        <input class='rattack-label' type="text" title='Weapon name that will display in template header' value="" name="attr_weapon_attack" placeholder="Weapon Name" />
+                        <button class='rangeddice' type='roll' title='Strike (Attack) Roll with Damage' name='roll_rangedattack' value="@{whispertoggle}&{template:custom} {{color=blue}} {{title=**@{character_name}**}} {{subtitle=attacks with @{weapon_attack}}} {{Attack= [[d20cs>@{hth_ranged_critical}+@{weapon_strike}+@{rtemp_strike}]]}} {{Damage= [[@{weapon_damage}+@{rtemp_damage}]]}} {{desc=@{attack_reference}}}">Strike</button>
+                        <button class='rangeddice' type='roll' title='Damage Roll Alone' name='roll_rangeddamage' value="@{whispertoggle}&{template:custom} {{color=red}} {{title=**@{character_name}**}} {{subtitle=hits with @{weapon_attack}}} {{@{character_name}'s @{weapon_attack} deals= [[@{weapon_damage}+@{rtemp_damage}]]}} {{desc=@{attack_reference}}}">Damage</button>
                         <input class='damage-dice' type="text" title='Damage Dice Calculation' value="" name="attr_weapon_damage" placeholder="xdy+z" />
-                        <input class='rattack-text' type="text" title='Temporary Damage Bonuses' value="0" name="attr_temp_damage" />
                         <input class='rattack-text' type="text" title='Maximum Range of This Attack' value="" name="attr_weapon_range" />
                         <input class='rattack-text' type="text" title='Rate of Fire per Melee' value="1" name="attr_weapon_rate_of_fire" />
                         <input class='rattack-text' type='text' title='Ammunition' value='0' name='attr_ammunition' />
-                        <input class='rattack-notes' type="text" title='Special Note About This Attack' value="" name="attr_attack_reference" />
+                        <input type='checkbox' title='Show Bonus and Notes Fields' name='attr_toggle_rbonus' value="1">
+                        <input class='rbonus-toggle' type='hidden' name='attr_toggle_rbonus'>
+                        <div class='rbonus-hide'>
+                            <div class='rbonus-container'>
+                                <input class='rattack-bonus' type="text" title='Bonuses to Strike' value="0" name="attr_weapon_strike" />
+                                <textarea class='rattack-notes' title='Special Note About This Attack' value="" name="attr_attack_reference" ></textarea>
+                            </div>
+                        </div>    
                     </div>
                 </fieldset>
             </div>
-        </div>
-        <h4>Warning</h4>
-        <h5>Upcoming changes to the melee and ranged repeating attacks section:</h5>
-        <ul>
-            <li>I will be removing the temporary bonus field from the repeating section to declutter the line.</li>
-            <li>Since I originally intended for these to be used for short term magic effects, they should have been set up as <br>
-            global bonuses to begin with. There will be global bonuse fields for Strike, Parry, and Damage that only affect the <br>
-            Melee section.  There will be a Strike and Damage bonus that will only affect the Ranged section.  That should make <br>
-            short term bonuses easier to add and remove.</li>
-            <li>With this change, the attributes that the roll buttons look for will change.  Any bonuses in the current repeating <br>
-		temp bonus fields will be lost.</li>
-            <li>I intend to make this change in a couple weeks, so prepare accordingly!</li>
-        </ul>
+        </div> 
     </div>
     <!--Character Sheet Tab-->
     <div class='sheet-social'>
@@ -376,7 +379,7 @@
             <h4 class='mental-label'>Insanity</h4>
             <textarea class='mental-field' value="" name="attr_character_insanity" placeholder='Hope this placeholder never gets replaced...' /></textarea>
             <h4 class='mental-label'>O.C.C. Notes</h4>
-            <textarea class='mental-field' value="" name="attr_character_occnotes" placeholder='Anything about your character occupation(s) that needs kept in mind' /></textarea>
+            <textarea class='mental-field' value="" name="attr_character_classnotes" placeholder='Anything about your class that needs kept in mind' /></textarea>
         </div> 
     </div>
     <!--Character Sheet Tab-->
@@ -661,7 +664,7 @@
                     
                     <div class="save-notes-container" >
                         <textarea class='save-misc' value='' name='attr_save_notes' title='@{save_notes}' placeholder='Notes displayed with all saves except coma/death.' ></textarea>
-                    </div>
+                    </div> 
                 </div>
             </div>
         </div> 
@@ -853,21 +856,13 @@
             </div>
         </div> 
     </div>
-    <!--Character Sheet Tab-->
     <div class="sheet-release">
         <h1>Sheet Version: 1.0</h1>
-        <h5>January 12, 2020</h5>
+        <h5>Recent Changes:</h5>
         <ul>
-            <li>Added a notes field to the saving throw section for situational bonuses that aren't specific to a certain type of effect (like protective wards).</li>
-            <li>Added a field on the social tab for class related notes.</li>
-        </ul>
-        <h5>Older Changes:</h5>
-        <ul>
-    	    <li>Toggles have been added for the mounted parry/dodge, damage, and charge damage to be included in the melee attack macros.</li>
-    	    <li>The parry/dodge toggle will add the mounted dodge bonus to the dodge roll button macro, so no more query when dodging.</li>
             <li>The sheet tabs have been altered to run on sheetworkers.</li>
             <li>The repeating attack entries on the statistics tab are now all text instead of number to allow entry of attributes instead of only numbers.  
-                This allows the use of repeating section attributes to pull numbers from the weapon proficiencies on the combat tab.</li>
+            This allows the use of repeating section attributes to pull numbers from the weapon proficiencies on the combat tab.</li>
             <li>If there are any issues with the sheetworker tabs, I will revert back to a regular tab system.</li>
             <li>Hopefully this will be the final stabile version of this sheet.</li>
         </ul>


### PR DESCRIPTION
## Changes / Comments
I have restructured the melee and ranged repeating attacks sections on the main tab of the sheet.  First I pulled the temporary bonus fields out of the repeating sections and gave them a place at the top of each section to make it easier to add and remove temporary bonuses.  I enlarged the bonus and notes fields and put them on a second line which can be hidden or revealed with a checkbox for each repeating entry.  I changed the "notes" entry from text to a textarea to enable line breaks, since the roll template can handle that formatting.

The temporary bonus fields within the repeating section are gone, and the button macros no longer check for those attributes, so any values left there will be gone.  I put a warning at the bottom of those sections 3 weeks ago and posted in the forum thread for this sheet.  Only the temporary bonus attribute has changed, and the other bonus fields remain untouched other than display size.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
