### PR TITLE
Update StarWarsSagaEdition.html

### DIFF
--- a/Star Wars Saga Edition/StarWarsSagaEdition.html
+++ b/Star Wars Saga Edition/StarWarsSagaEdition.html
@@ -1620,7 +1620,7 @@
 					<div class="table-row">	
 						<span class="table-data">	<input type="text" name="attr_TotalEquipmentWt" value="0" readonly="readonly" style="width:95%" title="Total Equipment Weight @{TotalEquipmentWt}" />	</span>
 						<span class="table-data" style="width:20px">	&nbsp;/&nbsp;	</span>
-						<span class="table-data">	<input type="number" name="attr_EquipmentCapacity" value="(@{Str}/2)*(@{Str}/2)" disabled="true" style="width:95%" title="Equipment Weight Capacity @{EquipmentCapacity}" />	</span>
+						<span class="table-data">	<input type="number" name="attr_EquipmentCapacity" value="(@{Str}/2)*(@{Str}/2)*@{CarryingCapacitySize}" disabled="true" style="width:95%" title="Equipment Weight Capacity @{EquipmentCapacity}" />	</span>
 					</div>					
 					<div class="table-row">				
 						<span class="table-header">Heavy Load </span>
@@ -3595,9 +3595,9 @@ on("change:repeating_equipment remove:repeating_equipment",function(){
         .execute(); 
 });
 
-on("change:equipmentwtrunningtotal change:armorwt change:armorcarry change:str",function(){	
-	getAttrs(["ArmorWt","EquipmentWtRunningTotal", "STR", "ArmorCarry"], function(v) {
-		EquipmentCapacity = parseFloat(v["STR"]/2)*(v["STR"]/2).toFixed(1);
+on("change:equipmentwtrunningtotal change:armorwt change:armorcarry change:size change:str",function(){	
+	getAttrs(["ArmorWt","EquipmentWtRunningTotal", "STR", "ArmorCarry", "CarryingCapacitySize"], function(v) {
+		EquipmentCapacity = parseFloat(v["STR"]/2)*(v["STR"]/2).toFixed(1) * v["CarryingCapacitySize"];
 		if(v["ArmorCarry"] == 1) {TotalWeight = parseFloat(v["ArmorWt"]) + parseFloat(v["EquipmentWtRunningTotal"]); console.log("=== Armor is Carried ===");}
 		else {TotalWeight = parseFloat(v["EquipmentWtRunningTotal"]); console.log("=== Armor is NOT Carried ===");}
 		TotalWeight = parseFloat(TotalWeight).toFixed(1)


### PR DESCRIPTION
Include CarryingCapacitySize on equipment capacity field.

## Changes / Comments

Larger-and-smaller-than-medium creatures are beholden to their equipment carrying capacity size being appropriately larger or smaller according to the ratio for overall lifting capacity.

This is mostly a sanity fix since armour with any tweaks for large creatures ends up being **a lot** of weight, and you are over-encumbered easily.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
