### PR TITLE
[Les Chants de Loss] bug correction

### DIFF
--- a/Les Chants de Loss/LCDL.html
+++ b/Les Chants de Loss/LCDL.html
@@ -618,7 +618,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetArcherie" value="@{typeJet}&{template:talent} {{name=Archerie}} {{spe=@{speArcherie}}} {{resultat=[[{1d10!}kh2+@{scoreArcherie}+@{Honneur}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Archerie" class="bTalent"></button>
+						<button type="roll" name="roll_jetArcherie" value="@{typeJet}&{template:talent} {{name=Archerie}} {{spe=@{speArcherie}}} {{resultat=[[{1d10!}kh2+@{scoreArcherie}+@{Courage}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Archerie" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speArcherie" class="talentInputSpe width114" />
@@ -629,7 +629,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetArmesDeJet" value="@{typeJet}&{template:talent} {{name=Armes de jet}} {{spe=@{speArmesDeJet}}} {{resultat=[[{1d10!}kh2+@{scoreArmesDeJet}+@{Honneur}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Armes de jet" class="bTalent"></button>
+						<button type="roll" name="roll_jetArmesDeJet" value="@{typeJet}&{template:talent} {{name=Armes de jet}} {{spe=@{speArmesDeJet}}} {{resultat=[[{1d10!}kh2+@{scoreArmesDeJet}+@{Courage}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Armes de jet" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speArmesDeJet" class="talentInputSpe width114" />
@@ -640,7 +640,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetArmesLourdes" value="@{typeJet}&{template:talent} {{name=Armes lourdes}} {{spe=@{speArmesLourdes}}} {{resultat=[[{1d10!}kh2+@{scoreArmesLourdes}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Armes lourdes*" class="bTalent"></button>
+						<button type="roll" name="roll_jetArmesLourdes" value="@{typeJet}&{template:talent} {{name=Armes lourdes}} {{spe=@{speArmesLourdes}}} {{resultat=[[{1d10!}kh2+@{scoreArmesLourdes}+@{Courage}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Armes lourdes*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speArmesLourdes" class="talentInputSpe width114" />
@@ -651,7 +651,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetArmesDeMelee" value="@{typeJet}&{template:talent} {{name=Armes de m&#234;l&#233;e}} {{spe=@{speArmesDeMelee}}} {{resultat=[[{1d10!}kh2+@{scoreArmesDeMelee}+@{Honneur}+?{Trait|Puissance,@{valuepuissance}|Agilit&#233;,@{valueagilite}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Esprit,@{valueesprit}|Instinct,@{valueinstinct}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Armes de m&#234;l&#233;e" class="bTalent"></button>
+						<button type="roll" name="roll_jetArmesDeMelee" value="@{typeJet}&{template:talent} {{name=Armes de m&#234;l&#233;e}} {{spe=@{speArmesDeMelee}}} {{resultat=[[{1d10!}kh2+@{scoreArmesDeMelee}+@{Courage}+?{Trait|Puissance,@{valuepuissance}|Agilit&#233;,@{valueagilite}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Esprit,@{valueesprit}|Instinct,@{valueinstinct}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Armes de m&#234;l&#233;e" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speArmesDeMelee" class="talentInputSpe width114" />
@@ -662,7 +662,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetImpulseurs" value="@{typeJet}&{template:talent} {{name=Impulseurs}} {{spe=@{speImpulseurs}}} {{resultat=[[{1d10!}kh2+@{scoreImpulseurs}+@{Honneur}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Impulseurs" class="bTalent"></button>
+						<button type="roll" name="roll_jetImpulseurs" value="@{typeJet}&{template:talent} {{name=Impulseurs}} {{spe=@{speImpulseurs}}} {{resultat=[[{1d10!}kh2+@{scoreImpulseurs}+@{Courage}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Impulseurs" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speImpulseurs" class="talentInputSpe width114" />
@@ -673,7 +673,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetCorpsACorps" value="@{typeJet}&{template:talent} {{name=Corps &#225; corps}} {{spe=@{speCorpsACorps}}} {{resultat=[[{1d10!}kh2+@{scoreCorpsACorps}+@{Honneur}+?{Trait|Puissance,@{valuepuissance}|Agilit&#233;,@{valueagilite}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Esprit,@{valueesprit}|Instinct,@{valueinstinct}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Corps &#225; corps" class="bTalent"></button>
+						<button type="roll" name="roll_jetCorpsACorps" value="@{typeJet}&{template:talent} {{name=Corps &#225; corps}} {{spe=@{speCorpsACorps}}} {{resultat=[[{1d10!}kh2+@{scoreCorpsACorps}+@{Courage}+?{Trait|Puissance,@{valuepuissance}|Agilit&#233;,@{valueagilite}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Esprit,@{valueesprit}|Instinct,@{valueinstinct}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Corps &#225; corps" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speCorpsACorps" class="talentInputSpe width114" />
@@ -684,7 +684,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetEsquive" value="@{typeJet}&{template:talent} {{name=Esquive}} {{spe=@{speEsquive}}} {{resultat=[[{1d10!}kh2+@{scoreEsquive}+@{Honneur}+?{Trait|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Esprit,@{valueesprit}|Instinct,@{valueinstinct}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Esquive" class="bTalent"></button>
+						<button type="roll" name="roll_jetEsquive" value="@{typeJet}&{template:talent} {{name=Esquive}} {{spe=@{speEsquive}}} {{resultat=[[{1d10!}kh2+@{scoreEsquive}+@{Courage}+?{Trait|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Esprit,@{valueesprit}|Instinct,@{valueinstinct}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Esquive" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speEsquive" class="talentInputSpe width114" />
@@ -695,7 +695,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetTactique" value="@{typeJet}&{template:talent} {{name=Tactique}} {{spe=@{speTactique}}} {{resultat=[[{1d10!}kh2+@{scoreTactique}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Tactique" class="bTalent"></button>
+						<button type="roll" name="roll_jetTactique" value="@{typeJet}&{template:talent} {{name=Tactique}} {{spe=@{speTactique}}} {{resultat=[[{1d10!}kh2+@{scoreTactique}+@{Courage}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Tactique" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speTactique" class="talentInputSpe width114" />
@@ -718,7 +718,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetAthletisme" value="@{typeJet}&{template:talent} {{name=Athl&#233;tisme}} {{spe=@{speAthletisme}}} {{resultat=[[{1d10!}kh2+@{scoreAthletisme}+@{Honneur}+?{Trait|Puissance,@{valuepuissance}|Agilit&#233;,@{valueagilite}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Athl&#233;tisme" class="bTalent"></button>
+						<button type="roll" name="roll_jetAthletisme" value="@{typeJet}&{template:talent} {{name=Athl&#233;tisme}} {{spe=@{speAthletisme}}} {{resultat=[[{1d10!}kh2+@{scoreAthletisme}+@{Courage}+?{Trait|Puissance,@{valuepuissance}|Agilit&#233;,@{valueagilite}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Athl&#233;tisme" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speAthletisme" class="talentInputSpe width114" />
@@ -729,7 +729,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetEscalade" value="@{typeJet}&{template:talent} {{name=Escalade}} {{spe=@{speEscalade}}} {{resultat=[[{1d10!}kh2+@{scoreEscalade}+@{Honneur}+?{Trait|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Escalade" class="bTalent"></button>
+						<button type="roll" name="roll_jetEscalade" value="@{typeJet}&{template:talent} {{name=Escalade}} {{spe=@{speEscalade}}} {{resultat=[[{1d10!}kh2+@{scoreEscalade}+@{Courage}+?{Trait|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Escalade" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speEscalade" class="talentInputSpe width114" />
@@ -740,7 +740,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetEvasion" value="@{typeJet}&{template:talent} {{name=&#201;vasion}} {{spe=@{speEvasion}}} {{resultat=[[{1d10!}kh2+@{scoreEvasion}+@{Honneur}+?{Trait|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="&#201;vasion*" class="bTalent"></button>
+						<button type="roll" name="roll_jetEvasion" value="@{typeJet}&{template:talent} {{name=&#201;vasion}} {{spe=@{speEvasion}}} {{resultat=[[{1d10!}kh2+@{scoreEvasion}+@{Courage}+?{Trait|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="&#201;vasion*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speEvasion" class="talentInputSpe width114" />
@@ -751,7 +751,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetFurtivite" value="@{typeJet}&{template:talent} {{name=Furtivit&#233;}} {{spe=@{speFurtivite}}} {{resultat=[[{1d10!}kh2+@{scoreFurtivite}+@{Honneur}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Furtivit&#233;" class="bTalent"></button>
+						<button type="roll" name="roll_jetFurtivite" value="@{typeJet}&{template:talent} {{name=Furtivit&#233;}} {{spe=@{speFurtivite}}} {{resultat=[[{1d10!}kh2+@{scoreFurtivite}+@{Courage}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Furtivit&#233;" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speFurtivite" class="talentInputSpe width114" />
@@ -762,7 +762,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetManipulation" value="@{typeJet}&{template:talent} {{name=Manipulation}} {{spe=@{speManipulation}}} {{resultat=[[{1d10!}kh2+@{scoreManipulation}+@{Honneur}+?{Trait|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Manipulation" class="bTalent"></button>
+						<button type="roll" name="roll_jetManipulation" value="@{typeJet}&{template:talent} {{name=Manipulation}} {{spe=@{speManipulation}}} {{resultat=[[{1d10!}kh2+@{scoreManipulation}+@{Courage}+?{Trait|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Manipulation" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speManipulation" class="talentInputSpe width114" />
@@ -785,7 +785,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetAttelage" value="@{typeJet}&{template:talent} {{name=Attelage}} {{spe=@{speAttelage}}} {{resultat=[[{1d10!}kh2+@{scoreAttelage}+@{Honneur}+?{Trait|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Attelage*" class="bTalent"></button>
+						<button type="roll" name="roll_jetAttelage" value="@{typeJet}&{template:talent} {{name=Attelage}} {{spe=@{speAttelage}}} {{resultat=[[{1d10!}kh2+@{scoreAttelage}+@{Courage}+?{Trait|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Attelage*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speAttelage" class="talentInputSpe width114" />
@@ -796,7 +796,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetEquitation" value="@{typeJet}&{template:talent} {{name=&#201;quitation}} {{spe=@{speEquitation}}} {{resultat=[[{1d10!}kh2+@{scoreEquitation}+@{Honneur}+?{Trait|Empathie,@{valueempathie}|Pouvoir,@{valuepouvoir}|Puissance,@{valuepuissance}|Agilit&#233;,@{valueagilite}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="&#201;quitation" class="bTalent"></button>
+						<button type="roll" name="roll_jetEquitation" value="@{typeJet}&{template:talent} {{name=&#201;quitation}} {{spe=@{speEquitation}}} {{resultat=[[{1d10!}kh2+@{scoreEquitation}+@{Courage}+?{Trait|Empathie,@{valueempathie}|Pouvoir,@{valuepouvoir}|Puissance,@{valuepuissance}|Agilit&#233;,@{valueagilite}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="&#201;quitation" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speEquitation" class="talentInputSpe width114" />
@@ -807,7 +807,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetNavigation" value="@{typeJet}&{template:talent} {{name=Navigation}} {{spe=@{speNavigation}}} {{resultat=[[{1d10!}kh2+@{scoreNavigation}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Puissance,@{valuepuissance}|Agilit&#233;,@{valueagilite}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Navigation*" class="bTalent"></button>
+						<button type="roll" name="roll_jetNavigation" value="@{typeJet}&{template:talent} {{name=Navigation}} {{spe=@{speNavigation}}} {{resultat=[[{1d10!}kh2+@{scoreNavigation}+@{Courage}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Puissance,@{valuepuissance}|Agilit&#233;,@{valueagilite}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Navigation*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speNavigation" class="talentInputSpe width114" />
@@ -818,7 +818,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetVol" value="@{typeJet}&{template:talent} {{name=Vol}} {{spe=@{speVol}}} {{resultat=[[{1d10!}kh2+@{scoreVol}+@{Honneur}+?{Trait|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Vol" class="bTalent"></button>
+						<button type="roll" name="roll_jetVol" value="@{typeJet}&{template:talent} {{name=Vol}} {{spe=@{speVol}}} {{resultat=[[{1d10!}kh2+@{scoreVol}+@{Courage}+?{Trait|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Vol" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speVol" class="talentInputSpe width114" />
@@ -852,7 +852,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetChimie" value="@{typeJet}&{template:talent} {{name=Chimie}} {{spe=@{speChimie}}} {{resultat=[[{1d10!}kh2+@{scoreChimie}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Chimie*" class="bTalent"></button>
+						<button type="roll" name="roll_jetChimie" value="@{typeJet}&{template:talent} {{name=Chimie}} {{spe=@{speChimie}}} {{resultat=[[{1d10!}kh2+@{scoreChimie}+@{Sagesse}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Chimie*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speChimie" class="talentInputSpe width114" />
@@ -863,7 +863,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetElectricite" value="@{typeJet}&{template:talent} {{name=&#201;lectricit&#233;}} {{spe=@{speElectricite}}} {{resultat=[[{1d10!}kh2+@{scoreElectricite}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="&#201;lectricit&#233;*" class="bTalent"></button>
+						<button type="roll" name="roll_jetElectricite" value="@{typeJet}&{template:talent} {{name=&#201;lectricit&#233;}} {{spe=@{speElectricite}}} {{resultat=[[{1d10!}kh2+@{scoreElectricite}+@{Sagesse}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="&#201;lectricit&#233;*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speElectricite" class="talentInputSpe width114" />
@@ -874,7 +874,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetGeologie" value="@{typeJet}&{template:talent} {{name=G&#233;ologie}} {{spe=@{speGeologie}}} {{resultat=[[{1d10!}kh2+@{scoreGeologie}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="G&#233;ologie*" class="bTalent"></button>
+						<button type="roll" name="roll_jetGeologie" value="@{typeJet}&{template:talent} {{name=G&#233;ologie}} {{spe=@{speGeologie}}} {{resultat=[[{1d10!}kh2+@{scoreGeologie}+@{Sagesse}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="G&#233;ologie*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speGeologie" class="talentInputSpe width114" />
@@ -885,7 +885,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetIngenierie" value="@{typeJet}&{template:talent} {{name=Ing&#233;nierie}} {{spe=@{speIngenierie}}} {{resultat=[[{1d10!}kh2+@{scoreIngenierie}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Ing&#233;nierie*" class="bTalent"></button>
+						<button type="roll" name="roll_jetIngenierie" value="@{typeJet}&{template:talent} {{name=Ing&#233;nierie}} {{spe=@{speIngenierie}}} {{resultat=[[{1d10!}kh2+@{scoreIngenierie}+@{Sagesse}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Ing&#233;nierie*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speIngenierie" class="talentInputSpe width114" />
@@ -896,7 +896,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetMedecine" value="@{typeJet}&{template:talent} {{name=M&#233;decine}} {{spe=@{speMedecine}}} {{resultat=[[{1d10!}kh2+@{scoreMedecine}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="M&#233;decine" class="bTalent"></button>
+						<button type="roll" name="roll_jetMedecine" value="@{typeJet}&{template:talent} {{name=M&#233;decine}} {{spe=@{speMedecine}}} {{resultat=[[{1d10!}kh2+@{scoreMedecine}+@{Sagesse}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="M&#233;decine" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speMedecine" class="talentInputSpe width114" />
@@ -907,7 +907,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetPhysique" value="@{typeJet}&{template:talent} {{name=Physique}} {{spe=@{spePhysique}}} {{resultat=[[{1d10!}kh2+@{scorePhysique}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Physique*" class="bTalent"></button>
+						<button type="roll" name="roll_jetPhysique" value="@{typeJet}&{template:talent} {{name=Physique}} {{spe=@{spePhysique}}} {{resultat=[[{1d10!}kh2+@{scorePhysique}+@{Sagesse}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Physique*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_spePhysique" class="talentInputSpe width114" />
@@ -918,7 +918,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetZoologie" value="@{typeJet}&{template:talent} {{name=Zoologie}} {{spe=@{speZoologie}}} {{resultat=[[{1d10!}kh2+@{scoreZoologie}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Zoologie" class="bTalent"></button>
+						<button type="roll" name="roll_jetZoologie" value="@{typeJet}&{template:talent} {{name=Zoologie}} {{spe=@{speZoologie}}} {{resultat=[[{1d10!}kh2+@{scoreZoologie}+@{Sagesse}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Zoologie" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speZoologie" class="talentInputSpe width114" />
@@ -941,7 +941,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetBureaucratie" value="@{typeJet}&{template:talent} {{name=Bureaucratie}} {{spe=@{speBureaucratie}}} {{resultat=[[{1d10!}kh2+@{scoreBureaucratie}+@{Honneur}+?{Trait|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Bureaucratie*" class="bTalent"></button>
+						<button type="roll" name="roll_jetBureaucratie" value="@{typeJet}&{template:talent} {{name=Bureaucratie}} {{spe=@{speBureaucratie}}} {{resultat=[[{1d10!}kh2+@{scoreBureaucratie}+@{Sagesse}+?{Trait|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Bureaucratie*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speBureaucratie" class="talentInputSpe width114" />
@@ -952,7 +952,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetFolklore" value="@{typeJet}&{template:talent} {{name=Folklore}} {{spe=@{speFolklore}}} {{resultat=[[{1d10!}kh2+@{scoreFolklore}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Folklore" class="bTalent"></button>
+						<button type="roll" name="roll_jetFolklore" value="@{typeJet}&{template:talent} {{name=Folklore}} {{spe=@{speFolklore}}} {{resultat=[[{1d10!}kh2+@{scoreFolklore}+@{Sagesse}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Folklore" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speFolklore" class="talentInputSpe width114" />
@@ -963,7 +963,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetGeographie" value="@{typeJet}&{template:talent} {{name=G&#233;ographie}} {{spe=@{speGeographie}}} {{resultat=[[{1d10!}kh2+@{scoreGeographie}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="G&#233;ographie*" class="bTalent"></button>
+						<button type="roll" name="roll_jetGeographie" value="@{typeJet}&{template:talent} {{name=G&#233;ographie}} {{spe=@{speGeographie}}} {{resultat=[[{1d10!}kh2+@{scoreGeographie}+@{Sagesse}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="G&#233;ographie*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speGeographie" class="talentInputSpe width114" />
@@ -974,7 +974,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetHistoire" value="@{typeJet}&{template:talent} {{name=Histoire}} {{spe=@{speHistoire}}} {{resultat=[[{1d10!}kh2+@{scoreHistoire}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Histoire*" class="bTalent"></button>
+						<button type="roll" name="roll_jetHistoire" value="@{typeJet}&{template:talent} {{name=Histoire}} {{spe=@{speHistoire}}} {{resultat=[[{1d10!}kh2+@{scoreHistoire}+@{Sagesse}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Histoire*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speHistoire" class="talentInputSpe width114" />
@@ -985,7 +985,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetLinguistique" value="@{typeJet}&{template:talent} {{name=Linguistique}} {{spe=@{speLinguistique}}} {{resultat=[[{1d10!}kh2+@{scoreLinguistique}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Linguistique*" class="bTalent"></button>
+						<button type="roll" name="roll_jetLinguistique" value="@{typeJet}&{template:talent} {{name=Linguistique}} {{spe=@{speLinguistique}}} {{resultat=[[{1d10!}kh2+@{scoreLinguistique}+@{Sagesse}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Linguistique*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speLinguistique" class="talentInputSpe width114" />
@@ -996,7 +996,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetSoinsDesAnimaux" value="@{typeJet}&{template:talent} {{name=Soins des animaux}} {{spe=@{speSoinsDesAnimaux}}} {{resultat=[[{1d10!}kh2+@{scoreSoinsDesAnimaux}+@{Honneur}+?{Trait|Empathie,@{valueempathie}|Pouvoir,@{valuepouvoir}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Soins des animaux" class="bTalent"></button>
+						<button type="roll" name="roll_jetSoinsDesAnimaux" value="@{typeJet}&{template:talent} {{name=Soins des animaux}} {{spe=@{speSoinsDesAnimaux}}} {{resultat=[[{1d10!}kh2+@{scoreSoinsDesAnimaux}+@{Sagesse}+?{Trait|Empathie,@{valueempathie}|Pouvoir,@{valuepouvoir}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Soins des animaux" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speSoinsDesAnimaux" class="talentInputSpe width114" />
@@ -1007,7 +1007,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetSurvie" value="@{typeJet}&{template:talent} {{name=Survie}} {{spe=@{speSurvie}}} {{resultat=[[{1d10!}kh2+@{scoreSurvie}+@{Honneur}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Survie" class="bTalent"></button>
+						<button type="roll" name="roll_jetSurvie" value="@{typeJet}&{template:talent} {{name=Survie}} {{spe=@{speSurvie}}} {{resultat=[[{1d10!}kh2+@{scoreSurvie}+@{Sagesse}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Survie" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speSurvie" class="talentInputSpe width114" />
@@ -1030,7 +1030,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetCrochetage" value="@{typeJet}&{template:talent} {{name=Crochetage}} {{spe=@{speCrochetage}}} {{resultat=[[{1d10!}kh2+@{scoreCrochetage}+@{Honneur}+?{Trait|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Crochetage*" class="bTalent"></button>
+						<button type="roll" name="roll_jetCrochetage" value="@{typeJet}&{template:talent} {{name=Crochetage}} {{spe=@{speCrochetage}}} {{resultat=[[{1d10!}kh2+@{scoreCrochetage}+@{Sagesse}+?{Trait|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Crochetage*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speCrochetage" class="talentInputSpe width114" />
@@ -1041,7 +1041,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetFouille" value="@{typeJet}&{template:talent} {{name=Fouille}} {{spe=@{speFouille}}} {{resultat=[[{1d10!}kh2+@{scoreFouille}+@{Honneur}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Fouille" class="bTalent"></button>
+						<button type="roll" name="roll_jetFouille" value="@{typeJet}&{template:talent} {{name=Fouille}} {{spe=@{speFouille}}} {{resultat=[[{1d10!}kh2+@{scoreFouille}+@{Sagesse}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Fouille" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speFouille" class="talentInputSpe width114" />
@@ -1052,7 +1052,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetLectureSurLesLevres" value="@{typeJet}&{template:talent} {{name=Lecture sur les l&#232;vres}} {{spe=@{speLectureSurLesLevres}}} {{resultat=[[{1d10!}kh2+@{scoreLectureSurLesLevres}+@{Honneur}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Lecture sur les l&#232;vres*" class="bTalent"></button>
+						<button type="roll" name="roll_jetLectureSurLesLevres" value="@{typeJet}&{template:talent} {{name=Lecture sur les l&#232;vres}} {{spe=@{speLectureSurLesLevres}}} {{resultat=[[{1d10!}kh2+@{scoreLectureSurLesLevres}+@{Sagesse}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Lecture sur les l&#232;vres*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speLectureSurLesLevres" class="talentInputSpe width114" />
@@ -1063,7 +1063,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetOrientation" value="@{typeJet}&{template:talent} {{name=Orientation}} {{spe=@{speOrientation}}} {{resultat=[[{1d10!}kh2+@{scoreOrientation}+@{Honneur}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Orientation" class="bTalent"></button>
+						<button type="roll" name="roll_jetOrientation" value="@{typeJet}&{template:talent} {{name=Orientation}} {{spe=@{speOrientation}}} {{resultat=[[{1d10!}kh2+@{scoreOrientation}+@{Sagesse}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Orientation" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speOrientation" class="talentInputSpe width114" />
@@ -1074,7 +1074,7 @@
 				</div>			
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetPister" value="@{typeJet}&{template:talent} {{name=Pister}} {{spe=@{spePister}}} {{resultat=[[{1d10!}kh2+@{scorePister}+@{Honneur}+?{Trait|Empathie,@{valueempathie}|Pouvoir,@{valuepouvoir}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Pister" class="bTalent"></button>
+						<button type="roll" name="roll_jetPister" value="@{typeJet}&{template:talent} {{name=Pister}} {{spe=@{spePister}}} {{resultat=[[{1d10!}kh2+@{scorePister}+@{Sagesse}+?{Trait|Empathie,@{valueempathie}|Pouvoir,@{valuepouvoir}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Pister" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_spePister" class="talentInputSpe width114" />
@@ -1085,7 +1085,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetPsychologie" value="@{typeJet}&{template:talent} {{name=Psychologie}} {{spe=@{spePsychologie}}} {{resultat=[[{1d10!}kh2+@{scorePsychologie}+@{Honneur}+?{TraitInstinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}||Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Psychologie" class="bTalent"></button>
+						<button type="roll" name="roll_jetPsychologie" value="@{typeJet}&{template:talent} {{name=Psychologie}} {{spe=@{spePsychologie}}} {{resultat=[[{1d10!}kh2+@{scorePsychologie}+@{Sagesse}+?{TraitInstinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}||Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Psychologie" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_spePsychologie" class="talentInputSpe width114" />
@@ -1096,7 +1096,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetVigilance" value="@{typeJet}&{template:talent} {{name=Vigilance}} {{spe=@{speVigilance}}} {{resultat=[[{1d10!}kh2+@{scoreVigilance}+@{Honneur}+?{Trait|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Vigilance" class="bTalent"></button>
+						<button type="roll" name="roll_jetVigilance" value="@{typeJet}&{template:talent} {{name=Vigilance}} {{spe=@{speVigilance}}} {{resultat=[[{1d10!}kh2+@{scoreVigilance}+@{Sagesse}+?{Trait|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Vigilance" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speVigilance" class="talentInputSpe width114" />
@@ -1131,7 +1131,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetArcheologie" value="@{typeJet}&{template:talent} {{name=Arch&#233;ologie}} {{spe=@{speArcheologie}}} {{resultat=[[{1d10!}kh2+@{scoreArcheologie}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Arch&#233;ologie*" class="bTalent"></button>
+						<button type="roll" name="roll_jetArcheologie" value="@{typeJet}&{template:talent} {{name=Arch&#233;ologie}} {{spe=@{speArcheologie}}} {{resultat=[[{1d10!}kh2+@{scoreArcheologie}+@{Foi}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Arch&#233;ologie*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speArcheologie" class="talentInputSpe width114" />
@@ -1142,7 +1142,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetArtefacts" value="@{typeJet}&{template:talent} {{name=Artefacts}} {{spe=@{speArtefacts}}} {{resultat=[[{1d10!}kh2+@{scoreArtefacts}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Artefacts*" class="bTalent"></button>
+						<button type="roll" name="roll_jetArtefacts" value="@{typeJet}&{template:talent} {{name=Artefacts}} {{spe=@{speArtefacts}}} {{resultat=[[{1d10!}kh2+@{scoreArtefacts}+@{Foi}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Artefacts*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speArtefacts" class="talentInputSpe width114" />
@@ -1153,7 +1153,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetPhysiqueDuLoss" value="@{typeJet}&{template:talent} {{name=Physique du loss}} {{spe=@{spePhysiqueDuLoss}}} {{resultat=[[{1d10!}kh2+@{scorePhysiqueDuLoss}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Physique du loss*" class="bTalent"></button>
+						<button type="roll" name="roll_jetPhysiqueDuLoss" value="@{typeJet}&{template:talent} {{name=Physique du loss}} {{spe=@{spePhysiqueDuLoss}}} {{resultat=[[{1d10!}kh2+@{scorePhysiqueDuLoss}+@{Foi}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Physique du loss*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_spePhysiqueDuLoss" class="talentInputSpe width114" />
@@ -1176,7 +1176,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetConnDuChant" value="@{typeJet}&{template:talent} {{name=Conn. du Chant}} {{spe=@{speConnDuChant}}} {{resultat=[[{1d10!}kh2+@{scoreConnDuChant}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Conn. du Chant*" class="bTalent"></button>
+						<button type="roll" name="roll_jetConnDuChant" value="@{typeJet}&{template:talent} {{name=Conn. du Chant}} {{spe=@{speConnDuChant}}} {{resultat=[[{1d10!}kh2+@{scoreConnDuChant}+@{Foi}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Conn. du Chant*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speConnDuChant" class="talentInputSpe width114" />
@@ -1187,7 +1187,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetCultesProscrits" value="@{typeJet}&{template:talent} {{name=Cultes proscrits}} {{spe=@{speCultesProscrits}}} {{resultat=[[{1d10!}kh2+@{scoreCultesProscrits}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Cultes proscrits*" class="bTalent"></button>
+						<button type="roll" name="roll_jetCultesProscrits" value="@{typeJet}&{template:talent} {{name=Cultes proscrits}} {{spe=@{speCultesProscrits}}} {{resultat=[[{1d10!}kh2+@{scoreCultesProscrits}+@{Foi}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Cultes proscrits*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speCultesProscrits" class="talentInputSpe width114" />
@@ -1198,7 +1198,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetSavoirsAnciens" value="@{typeJet}&{template:talent} {{name=Savoirs Anciens}} {{spe=@{speSavoirsAnciens}}} {{resultat=[[{1d10!}kh2+@{scoreSavoirsAnciens}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Savoirs Anciens*" class="bTalent"></button>
+						<button type="roll" name="roll_jetSavoirsAnciens" value="@{typeJet}&{template:talent} {{name=Savoirs Anciens}} {{spe=@{speSavoirsAnciens}}} {{resultat=[[{1d10!}kh2+@{scoreSavoirsAnciens}+@{Foi}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Savoirs Anciens*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speSavoirsAnciens" class="talentInputSpe width114" />
@@ -1221,7 +1221,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetChamanisme" value="@{typeJet}&{template:talent} {{name=Chamanisme}} {{spe=@{speChamanisme}}} {{resultat=[[{1d10!}kh2+@{scoreChamanisme}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Chamanisme*" class="bTalent"></button>
+						<button type="roll" name="roll_jetChamanisme" value="@{typeJet}&{template:talent} {{name=Chamanisme}} {{spe=@{speChamanisme}}} {{resultat=[[{1d10!}kh2+@{scoreChamanisme}+@{Foi}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Chamanisme*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speChamanisme" class="talentInputSpe width114" />
@@ -1232,7 +1232,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetMeditation" value="@{typeJet}&{template:talent} {{name=M&#233;ditation}} {{spe=@{speMeditation}}} {{resultat=[[{1d10!}kh2+@{scoreMeditation}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="M&#233;ditation*" class="bTalent"></button>
+						<button type="roll" name="roll_jetMeditation" value="@{typeJet}&{template:talent} {{name=M&#233;ditation}} {{spe=@{speMeditation}}} {{resultat=[[{1d10!}kh2+@{scoreMeditation}+@{Foi}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="M&#233;ditation*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speMeditation" class="talentInputSpe width114" />
@@ -1243,7 +1243,7 @@
 				</div>
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetRituel" value="@{typeJet}&{template:talent} {{name=Rituel}} {{spe=@{speRituel}}} {{resultat=[[{1d10!}kh2+@{scoreRituel}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Rituel*" class="bTalent"></button>
+						<button type="roll" name="roll_jetRituel" value="@{typeJet}&{template:talent} {{name=Rituel}} {{spe=@{speRituel}}} {{resultat=[[{1d10!}kh2+@{scoreRituel}+@{Foi}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Rituel*" class="bTalent"></button>
 					</div>
 					<div class="talentSubColumn width114">
 						<input type="text" value="" name="attr_speRituel" class="talentInputSpe width114" />
@@ -2191,7 +2191,7 @@
 			</div>
 			<div class="hideBlock">
 				<div class="talentSubColumn width110">
-					<button type="roll" name="roll_jetArcherie" value="@{typeJet}&{template:talent} {{name=Archerie}} {{spe=@{speArcherie}}} {{resultat=[[{1d10!}kh2+@{scoreArcherie}+@{Honneur}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]] ]]}} {{malus=[[@{malus}]]}}" title="Archerie" class="bTalent"></button>
+					<button type="roll" name="roll_jetArcherie" value="@{typeJet}&{template:talent} {{name=Archerie}} {{spe=@{speArcherie}}} {{resultat=[[{1d10!}kh2+@{scoreArcherie}+@{Courage}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]] ]]}} {{malus=[[@{malus}]]}}" title="Archerie" class="bTalent"></button>
 				</div>
 				<div class="talentSubColumn width114">
 					<input type="text" value="" name="attr_speArcherie" class="talentInputSpe width114" />
@@ -2202,7 +2202,7 @@
 			</div>
 			<div class="hideBlock">
 				<div class="talentSubColumn width110">
-					<button type="roll" name="roll_jetArmesDeJet" value="@{typeJet}&{template:talent} {{name=Armes de jet}} {{spe=@{speArmesDeJet}}} {{resultat=[[{1d10!}kh2+@{scoreArmesDeJet}+@{Honneur}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]] ]]}} {{malus=[[@{malus}]]}}" title="Armes de jet" class="bTalent"></button>
+					<button type="roll" name="roll_jetArmesDeJet" value="@{typeJet}&{template:talent} {{name=Armes de jet}} {{spe=@{speArmesDeJet}}} {{resultat=[[{1d10!}kh2+@{scoreArmesDeJet}+@{Courage}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]] ]]}} {{malus=[[@{malus}]]}}" title="Armes de jet" class="bTalent"></button>
 				</div>
 				<div class="talentSubColumn width114">
 					<input type="text" value="" name="attr_speArmesDeJet" class="talentInputSpe width114" />
@@ -2213,7 +2213,7 @@
 			</div>
 			<div class="hideBlock">
 				<div class="talentSubColumn width110">
-					<button type="roll" name="roll_jetArmesLourdes" value="@{typeJet}&{template:talent} {{name=Armes lourdes}} {{spe=@{speArmesLourdes}}} {{resultat=[[{1d10!}kh2+@{scoreArmesLourdes}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]] ]]}} {{malus=[[@{malus}]]}}" title="Armes lourdes*" class="bTalent"></button>
+					<button type="roll" name="roll_jetArmesLourdes" value="@{typeJet}&{template:talent} {{name=Armes lourdes}} {{spe=@{speArmesLourdes}}} {{resultat=[[{1d10!}kh2+@{scoreArmesLourdes}+@{Courage}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]] ]]}} {{malus=[[@{malus}]]}}" title="Armes lourdes*" class="bTalent"></button>
 				</div>
 				<div class="talentSubColumn width114">
 					<input type="text" value="" name="attr_speArmesLourdes" class="talentInputSpe width114" />
@@ -2224,7 +2224,7 @@
 			</div>
 			<div class="hideBlock">
 				<div class="talentSubColumn width110">
-					<button type="roll" name="roll_jetArmesDeMelee" value="@{typeJet}&{template:talent} {{name=Armes de m&#234;l&#233;e}} {{spe=@{speArmesDeMelee}}} {{resultat=[[{1d10!}kh2+@{scoreArmesDeMelee}+@{Honneur}+?{Trait|Puissance,@{valuepuissance}|Agilit&#233;,@{valueagilite}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Esprit,@{valueesprit}|Instinct,@{valueinstinct}}-[[@{malus}]] ]]}} {{malus=[[@{malus}]]}}" title="Armes de m&#234;l&#233;e" class="bTalent"></button>
+					<button type="roll" name="roll_jetArmesDeMelee" value="@{typeJet}&{template:talent} {{name=Armes de m&#234;l&#233;e}} {{spe=@{speArmesDeMelee}}} {{resultat=[[{1d10!}kh2+@{scoreArmesDeMelee}+@{Courage}+?{Trait|Puissance,@{valuepuissance}|Agilit&#233;,@{valueagilite}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Esprit,@{valueesprit}|Instinct,@{valueinstinct}}-[[@{malus}]] ]]}} {{malus=[[@{malus}]]}}" title="Armes de m&#234;l&#233;e" class="bTalent"></button>
 				</div>
 				<div class="talentSubColumn width114">
 					<input type="text" value="" name="attr_speArmesDeMelee" class="talentInputSpe width114" />
@@ -2235,7 +2235,7 @@
 			</div>
 			<div class="hideBlock">
 				<div class="talentSubColumn width110">
-					<button type="roll" name="roll_jetImpulseurs" value="@{typeJet}&{template:talent} {{name=Impulseurs}} {{spe=@{speImpulseurs}}} {{resultat=[[{1d10!}kh2+@{scoreImpulseurs}+@{Honneur}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]] ]]}} {{malus=[[@{malus}]]}}" title="Impulseurs" class="bTalent"></button>
+					<button type="roll" name="roll_jetImpulseurs" value="@{typeJet}&{template:talent} {{name=Impulseurs}} {{spe=@{speImpulseurs}}} {{resultat=[[{1d10!}kh2+@{scoreImpulseurs}+@{Courage}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]] ]]}} {{malus=[[@{malus}]]}}" title="Impulseurs" class="bTalent"></button>
 				</div>
 				<div class="talentSubColumn width114">
 					<input type="text" value="" name="attr_speImpulseurs" class="talentInputSpe width114" />
@@ -2246,7 +2246,7 @@
 			</div>
 			<div class="hideBlock">
 				<div class="talentSubColumn width110">
-					<button type="roll" name="roll_jetCorpsACorps" value="@{typeJet}&{template:talent} {{name=Corps &#225; corps}} {{spe=@{speCorpsACorps}}} {{resultat=[[{1d10!}kh2+@{scoreCorpsACorps}+@{Honneur}+?{Trait|Puissance,@{valuepuissance}|Agilit&#233;,@{valueagilite}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Esprit,@{valueesprit}|Instinct,@{valueinstinct}}-[[@{malus}]] ]]}} {{malus=[[@{malus}]]}}" title="Corps &#225; corps" class="bTalent"></button>
+					<button type="roll" name="roll_jetCorpsACorps" value="@{typeJet}&{template:talent} {{name=Corps &#225; corps}} {{spe=@{speCorpsACorps}}} {{resultat=[[{1d10!}kh2+@{scoreCorpsACorps}+@{Courage}+?{Trait|Puissance,@{valuepuissance}|Agilit&#233;,@{valueagilite}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Esprit,@{valueesprit}|Instinct,@{valueinstinct}}-[[@{malus}]] ]]}} {{malus=[[@{malus}]]}}" title="Corps &#225; corps" class="bTalent"></button>
 				</div>
 				<div class="talentSubColumn width114">
 					<input type="text" value="" name="attr_speCorpsACorps" class="talentInputSpe width114" />
@@ -2257,7 +2257,7 @@
 			</div>
 			<div class="hideBlock">
 				<div class="talentSubColumn width110">
-					<button type="roll" name="roll_jetEsquive" value="@{typeJet}&{template:talent} {{name=Esquive}} {{spe=@{speEsquive}}} {{resultat=[[{1d10!}kh2+@{scoreEsquive}+@{Honneur}+?{Trait|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Esprit,@{valueesprit}|Instinct,@{valueinstinct}}-[[@{malus}]] ]]}} {{malus=[[@{malus}]]}}" title="Esquive" class="bTalent"></button>
+					<button type="roll" name="roll_jetEsquive" value="@{typeJet}&{template:talent} {{name=Esquive}} {{spe=@{speEsquive}}} {{resultat=[[{1d10!}kh2+@{scoreEsquive}+@{Courage}+?{Trait|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Esprit,@{valueesprit}|Instinct,@{valueinstinct}}-[[@{malus}]] ]]}} {{malus=[[@{malus}]]}}" title="Esquive" class="bTalent"></button>
 				</div>
 				<div class="talentSubColumn width114">
 					<input type="text" value="" name="attr_speEsquive" class="talentInputSpe width114" />
@@ -2268,7 +2268,7 @@
 			</div>
 			<div class="hideBlock">
 				<div class="talentSubColumn width110">
-					<button type="roll" name="roll_jetTactique" value="@{typeJet}&{template:talent} {{name=Tactique}} {{spe=@{speTactique}}} {{resultat=[[{1d10!}kh2+@{scoreTactique}+@{Honneur}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]] ]]}} {{malus=[[@{malus}]]}}" title="Tactique" class="bTalent"></button>
+					<button type="roll" name="roll_jetTactique" value="@{typeJet}&{template:talent} {{name=Tactique}} {{spe=@{speTactique}}} {{resultat=[[{1d10!}kh2+@{scoreTactique}+@{Courage}+?{Trait|Esprit,@{valueesprit}|Instinct,@{valueinstinct}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]] ]]}} {{malus=[[@{malus}]]}}" title="Tactique" class="bTalent"></button>
 				</div>
 				<div class="talentSubColumn width114">
 					<input type="text" value="" name="attr_speTactique" class="talentInputSpe width114" />

--- a/Les Chants de Loss/LCDL.html
+++ b/Les Chants de Loss/LCDL.html
@@ -112,7 +112,7 @@
 				<td class="subtitle"><h4>Total</h4></td>
 				<td style="width:33px;"><input type="number" name="attr_Experience" value="0" min="0"/></td>
 				<td class="subtitle"><h4>R&#233;serve</h4></td>
-				<td style="width:33px;"><input type="number" name="attr_Experience" value="0" min="0"/></td>
+				<td style="width:33px;"><input type="number" name="attr_Experience_Reserve" value="0" min="0"/></td>
 			</tr>
 		</table>
 		<div class="marginTopBlock">
@@ -147,7 +147,7 @@
 		<div class="blockInspirationL">
 			<div class="blockInspiration">
 				Honneur
-				<input type="number" name="attr_hon" value="0" min="0"/>
+				<input type="number" name="attr_inspi_hon" value="0" min="0"/>
 				<div class="blockPts">
 					<input type="checkbox" value="1" name="attr_PointsHonneur1" class="marginPtsR"/>
 					<input type="checkbox" value="1" name="attr_PointsHonneur2" class="marginPtsR"/>
@@ -158,7 +158,7 @@
 			</div>
 			<div class="blockInspiration">
 				Sagesse
-				<input type="number" name="attr_hon" value="0" min="0"/>
+				<input type="number" name="attr_inspi_sag" value="0" min="0"/>
 				<div class="blockPts">
 					<input type="checkbox" value="1" name="attr_PointsSagesse1" class="marginPtsR"/>
 					<input type="checkbox" value="1" name="attr_PointsSagesse2" class="marginPtsR" />
@@ -171,7 +171,7 @@
 		<div class="blockInspirationR">
 			<div class="blockInspiration">
 				Courage
-				<input type="number" name="attr_hon" value="0" min="0"/>
+				<input type="number" name="attr_inspi_cour" value="0" min="0"/>
 				<div class="blockPts">
 					<input type="checkbox" value="1" name="attr_PointsCourage1" class="marginPtsR"/>
 					<input type="checkbox" value="1" name="attr_PointsCourage2" class="marginPtsR"/>
@@ -182,7 +182,7 @@
 			</div>
 			<div class="blockInspiration">
 				Foi
-				<input type="number" name="attr_hon" value="0" min="0"/>
+				<input type="number" name="attr_inspi_foi" value="0" min="0"/>
 				<div class="blockPts">
 					<input type="checkbox" value="1" name="attr_PointsFoi1" class="marginPtsR"/>
 					<input type="checkbox" value="1" name="attr_PointsFoi2" class="marginPtsR" />
@@ -603,7 +603,7 @@
 					<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Les%20Chants%20de%20Loss/images/courage.png" alt="Courage" class="talent"/>
 					LE CORPS
 				</h4></div>
-				<input type="number" name="attr_Corps" value="0" min="0" style="margin-top:-3px;" class="talentInputNum"/>
+				<input type="number" name="attr_Courage" value="0" min="0" style="margin-top:-3px;" class="talentInputNum"/>
 			</div>
 			<div class="talentSubBlock">
 				<input type="checkbox" name="attr_hideCombat" class="hideBlock" value="1" /><span></span>
@@ -837,7 +837,7 @@
 					<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Les%20Chants%20de%20Loss/images/sagesse.png" alt="Sagesse" class="talent"/>
 					L'ESPRIT
 				</h4></div>
-				<input type="number" name="attr_Corps" value="0" min="0" style="margin-top:-3px;" class="talentInputNum"/>
+				<input type="number" name="attr_Sagesse" value="0" min="0" style="margin-top:-3px;" class="talentInputNum"/>
 			</div>
 			<div class="talentSubBlock">
 				<input type="checkbox" name="attr_hideSciences" class="hideBlock" value="1" /><span></span>
@@ -1071,18 +1071,7 @@
 					<div class="talentSubColumn width45">
 						<input type="number" value="0" name="attr_scoreOrientation" class="talentInputNum"/>
 					</div>
-				</div>
-				<div class="hideBlock">
-					<div class="talentSubColumn width110">
-						<button type="roll" name="roll_jetOrientation" value="@{typeJet}&{template:talent} {{name=Orientation}} {{spe=@{speOrientation}}} {{resultat=[[{1d10!}kh2+@{scoreOrientation}+@{Honneur}+?{Trait|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Pouvoir,@{valuepouvoir}|Empathie,@{valueempathie}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Orientation" class="bTalent"></button>
-					</div>
-					<div class="talentSubColumn width114">
-						<input type="text" value="" name="attr_speOrientation" class="talentInputSpe width114" />
-					</div>
-					<div class="talentSubColumn width45">
-						<input type="number" value="0" name="attr_scoreOrientation" class="talentInputNum"/>
-					</div>
-				</div>
+				</div>			
 				<div class="hideBlock">
 					<div class="talentSubColumn width110">
 						<button type="roll" name="roll_jetPister" value="@{typeJet}&{template:talent} {{name=Pister}} {{spe=@{spePister}}} {{resultat=[[{1d10!}kh2+@{scorePister}+@{Honneur}+?{Trait|Empathie,@{valueempathie}|Pouvoir,@{valuepouvoir}|Instinct,@{valueinstinct}|Esprit,@{valueesprit}|Agilit&#233;,@{valueagilite}|Puissance,@{valuepuissance}}-[[@{malus}]]+@{modDivers} ]]}} {{mod=[[@{modDivers}]]}} {{malus=[[@{malus}]]}}" title="Pister" class="bTalent"></button>
@@ -1125,7 +1114,7 @@
 					LA FOI
 					<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Les%20Chants%20de%20Loss/images/foi.png" alt="Foi" class="talent"/>
 					LE DIVIN
-					<input type="number" name="attr_Corps" value="0" min="0" style="margin-top:-3px;"/>
+					<input type="number" name="attr_Foi" value="0" min="0" style="margin-top:-3px;"/>
 				</h4></div>
 				
 			</div>

--- a/Les Chants de Loss/LCDL.html
+++ b/Les Chants de Loss/LCDL.html
@@ -118,7 +118,7 @@
 		<div class="marginTopBlock">
 			<div>
 				<div class="titre borderRightNoRadius titreNoRight"><h4 class="titreNoRight">LEGENDE</h4></div>
-				<input type="number" name="attr_Experience" value="0" min="0" style="margin-top:-3px;"/>
+				<input type="number" name="attr_Legende" value="0" min="0" style="margin-top:-3px;"/>
 			</div>
 			<div style="font-size:11px;">
 				Points de L&#233;gende


### PR DESCRIPTION
bug correction for the following problems : 
- duplicate skill orientation
- duplicate attribute names for "experience total" and "experience reserve"
- duplicate attribute names for the diverse inspirations (Courage, Sagesse, Foi and Honneur used attr_hon)
- duplicate attribute names for the diverse affinités (Courage, Sagesse, Foi used the Attr_Corps)
- correct affinity score use in the skill rolls (all were using the attr_Honneur instead of the correct Courage, Sagesse and Foi affinity attributes)

## Changes / Comments

@Zakarik if you can check the changes...

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
