### PR TITLE
Update 5e Darker Dungeons to 2.2

### DIFF
--- a/5e Darker Dungeons/5e Darker Dungeons.css
+++ b/5e Darker Dungeons/5e Darker Dungeons.css
@@ -27,7 +27,6 @@
     padding: 0;
     font-size: inherit;
     font-weight: inherit; }
-
 .charsheet .sheet-darkerdungeons button[type=roll] {
   color: inherit;
   font-size: inherit;
@@ -41,7 +40,6 @@
     outline: none; }
   .charsheet .sheet-darkerdungeons button[type=roll]::before {
     display: none; }
-
 .charsheet .sheet-darkerdungeons .sheet-checkbox-image {
   height: 14px;
   overflow: hidden;
@@ -55,7 +53,8 @@
     top: 0;
     width: 100%;
     z-index: 1; }
-    .charsheet .sheet-darkerdungeons .sheet-checkbox-image [type=checkbox]:hover ~ span, .charsheet .sheet-darkerdungeons .sheet-checkbox-image [type=checkbox]:focus ~ span {
+    .charsheet .sheet-darkerdungeons .sheet-checkbox-image [type=checkbox]:hover ~ span,
+    .charsheet .sheet-darkerdungeons .sheet-checkbox-image [type=checkbox]:focus ~ span {
       background: #e5fffb; }
     .charsheet .sheet-darkerdungeons .sheet-checkbox-image [type=checkbox]:checked ~ span {
       background: gainsboro; }
@@ -78,7 +77,6 @@
     position: absolute;
     top: 0;
     width: 100% !important; }
-
 .charsheet .sheet-darkerdungeons .sheet-compendium-drop-target.dropping {
   background: none;
   position: relative; }
@@ -96,7 +94,6 @@
     width: 385px; }
   .charsheet .sheet-darkerdungeons .sheet-compendium-drop-target.dropping .sheet-section-pc::before {
     width: 800px; }
-
 .charsheet .sheet-darkerdungeons .sheet-container-attribute {
   background: url("https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/5e%20Darker%20Dungeons/img/sheet-attribute-bg.png");
   background-size: 100% 100%;
@@ -144,7 +141,6 @@
       font-weight: bold; }
       .charsheet .sheet-darkerdungeons .sheet-container-attribute .sheet-container-footer span:hover {
         display: none; }
-
 .charsheet .sheet-darkerdungeons .sheet-container-bar {
   display: flex;
   height: 30px;
@@ -199,7 +195,6 @@
       border: 0;
       text-align: center;
       width: 100%; }
-
 .charsheet .sheet-darkerdungeons .sheet-container-box {
   display: flex;
   flex-direction: column-reverse;
@@ -312,7 +307,6 @@
       line-height: 14px; }
     .charsheet .sheet-darkerdungeons .sheet-container-box .sheet-form-inline > .sheet-form-body {
       padding-bottom: 0; }
-
 .charsheet .sheet-darkerdungeons .sheet-container-counter {
   display: flex;
   flex-direction: row-reverse;
@@ -347,7 +341,6 @@
     justify-content: center;
     text-align: center;
     width: 39px; }
-
 .charsheet .sheet-darkerdungeons .sheet-container-panel {
   display: flex;
   flex-direction: column;
@@ -412,7 +405,6 @@
       line-height: 14px; }
     .charsheet .sheet-darkerdungeons .sheet-container-panel .sheet-form-inline > .sheet-form-body {
       padding-bottom: 0; }
-
 .charsheet .sheet-darkerdungeons .sheet-container-spell {
   display: flex;
   flex-direction: column;
@@ -515,7 +507,6 @@
       display: none; }
       .charsheet .sheet-darkerdungeons .sheet-container-spell .sheet-container-body .sheet-container-body-header span {
         width: 100%; }
-
 .charsheet .sheet-darkerdungeons .sheet-container-well {
   min-height: 65px;
   padding: 10px;
@@ -534,7 +525,6 @@
     top: 0;
     width: 100%;
     z-index: -1; }
-
 .charsheet .sheet-darkerdungeons fieldset {
   position: relative; }
 .charsheet .sheet-darkerdungeons .repcontainer {
@@ -594,7 +584,6 @@
   min-height: 18px; }
   .charsheet .sheet-darkerdungeons .sheet-fieldset-item > :last-child {
     margin-bottom: 0; }
-
 .charsheet .sheet-darkerdungeons .sheet-form {
   border-radius: 6px;
   border: 2px solid #7e2d40;
@@ -686,7 +675,6 @@
       width: auto; }
       .charsheet .sheet-darkerdungeons .sheet-form .sheet-form-checkbox input + span {
         margin-left: 5px; }
-
 .charsheet .sheet-darkerdungeons .sheet-hidden {
   display: none !important; }
 .charsheet .sheet-darkerdungeons .sheet-display-brackets::after {
@@ -697,7 +685,6 @@
   content: " XP)"; }
 .charsheet .sheet-darkerdungeons .sheet-display-brackets-xp::before {
   content: "("; }
-
 .sheet-compendium-warning,
 .sheet-monster-confirm {
   display: none;
@@ -715,10 +702,8 @@
   text-transform: uppercase;
   font-weight: bold;
   box-shadow: 0px 3px 5px 0px rgba(0, 0, 0, 0.75); }
-
 .sheet-compendium-warning {
   margin-top: -41px; }
-
 .sheet-monster-confirm {
   margin-top: -75px; }
   .sheet-monster-confirm .sheet-monster-confirm-buttons {
@@ -741,32 +726,26 @@
         left: 0;
         top: 0;
         opacity: 0; }
-
 .sheet-licensecontainer.active-drop-target.dropping .sheet-compendium-warning,
 .sheet-monster_confirm_flag[value="1"] .sheet-licensecontainer .sheet-monster-confirm {
   display: block; }
-
 .sheet-rolltemplate-spell .sheet-grey {
   color: #A0A0A0;
   font-weight: normal; }
-
 .sheet-rolltemplates {
   display: none; }
-
 .sheet-rolltemplate-simple .sheet-containerold {
   width: 189px;
   background: url(http://i.imgur.com/53WSdhx.png) top left;
   background-size: 189px 100%;
   background-repeat: no-repeat;
   color: black; }
-
 .sheet-rolltemplate-simple .sheet-container {
   width: 189px;
   color: black;
   border: 1px solid black;
   border-radius: 10px;
   background-color: white; }
-
 .sheet-rolltemplate-atk .sheet-containerold,
 .sheet-rolltemplate-atkdmg .sheet-container.sheet-atkold,
 .sheet-rolltemplate-dmg .sheet-atkold {
@@ -775,7 +754,6 @@
   background-size: 189px 100%;
   background-repeat: no-repeat;
   color: black; }
-
 .sheet-rolltemplate-atk .sheet-container,
 .sheet-rolltemplate-atkdmg .sheet-container.sheet-atk,
 .sheet-rolltemplate-dmg .sheet-atk {
@@ -785,7 +763,6 @@
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
   background-color: white; }
-
 .sheet-rolltemplate-dmg .sheet-containerold,
 .sheet-rolltemplate-atkdmg .sheet-container.sheet-damagetemplateold {
   width: 189px;
@@ -793,7 +770,6 @@
   background-size: 189px 100%;
   background-repeat: no-repeat;
   color: black; }
-
 .sheet-rolltemplate-dmg .sheet-container,
 .sheet-rolltemplate-atkdmg .sheet-container.sheet-damagetemplate {
   width: 189px;
@@ -802,18 +778,15 @@
   border-bottom-left-radius: 10px;
   border-bottom-right-radius: 10px;
   background-color: white; }
-
 .sheet-rolltemplate-simple .sheet-result,
 .sheet-rolltemplate-atk .sheet-result,
 .sheet-rolltemplate-atkdmg .sheet-result,
 .sheet-rolltemplate-dmg .sheet-result,
 .sheet-npc .sheet-subtitle .sheet-italics {
   width: 100%; }
-
 .sheet-rolltemplate-atkdmg .sheet-damagetemplate .sheet-result,
 .sheet-rolltemplate-dmg .sheet-damagetemplate .sheet-result {
   min-height: 45px; }
-
 .sheet-rolltemplate-simple .sheet-adv,
 .sheet-rolltemplate-atk .sheet-adv,
 .sheet-rolltemplate-atkdmg .sheet-adv,
@@ -823,21 +796,18 @@
   text-align: center;
   vertical-align: top;
   margin-top: 15px; }
-
 .sheet-rolltemplate-simple .sheet-adv:first-child,
 .sheet-rolltemplate-atk .sheet-adv:first-child,
 .sheet-rolltemplate-atkdmg .sheet-adv:first-child,
 .sheet-rolltemplate-dmg .sheet-adv:first-child {
   margin-left: 8px;
   margin-right: -3px; }
-
 .sheet-rolltemplate-simple .sheet-adv:nth-child(3),
 .sheet-rolltemplate-atk .sheet-adv:nth-child(3),
 .sheet-rolltemplate-atkdmg .sheet-adv:nth-child(3),
 .sheet-rolltemplate-dmg .sheet-adv:nth-child(3) {
   margin-right: 8px;
   margin-left: -3px; }
-
 .sheet-rolltemplate-simple .sheet-adv span,
 .sheet-rolltemplate-simple .sheet-solo span,
 .sheet-rolltemplate-atk .sheet-adv span,
@@ -851,7 +821,6 @@
   background-color: transparent;
   border: 0px;
   padding: 0px; }
-
 .sheet-rolltemplate-simple .sheet-advspacer,
 .sheet-rolltemplate-atk .sheet-advspacer,
 .sheet-rolltemplate-atkdmg .sheet-advspacer,
@@ -860,7 +829,6 @@
   border: 1px solid black;
   display: inline-block;
   height: 35px; }
-
 .sheet-rolltemplate-simple .sheet-solo,
 .sheet-rolltemplate-atk .sheet-solo,
 .sheet-rolltemplate-atkdmg .sheet-solo,
@@ -869,7 +837,6 @@
   text-align: center;
   height: 23px;
   padding-top: 15px; }
-
 .sheet-rolltemplate-simple span,
 .sheet-rolltemplate-atk span,
 .sheet-rolltemplate-atkdmg span,
@@ -879,13 +846,11 @@
   line-height: 12px;
   text-align: center;
   font-weight: bold; }
-
 .sheet-rolltemplate-dmg .sheet-desc span.sheet-plus,
 .sheet-rolltemplate-atkdmg .sheet-desc span.sheet-plus {
   font-weight: bold;
   font-size: 20px;
   display: inline; }
-
 .sheet-rolltemplate-simple .sheet-grey,
 .sheet-rolltemplate-simple .sheet-grey .inlinerollresult.fullcrit,
 .sheet-rolltemplate-simple .sheet-grey .inlinerollresult.fullfail,
@@ -921,7 +886,6 @@
   color: #A0A0A0;
   border: 0px;
   font-weight: normal; }
-
 .sheet-rolltemplate-simple .sheet-label,
 .sheet-rolltemplate-atk .sheet-label,
 .sheet-rolltemplate-atkdmg .sheet-label,
@@ -929,7 +893,6 @@
   text-align: center;
   margin-top: -3px;
   padding-bottom: 5px; }
-
 .sheet-rolltemplate-simple .sheet-label span span,
 .sheet-rolltemplate-atk .sheet-label span span,
 .sheet-rolltemplate-atkdmg .sheet-label span span,
@@ -938,34 +901,29 @@
   border: 0px;
   background-color: transparent;
   font-size: 12px; }
-
 .sheet-rolltemplate-simple .inlinerollresult.fullcrit,
 .sheet-rolltemplate-atk .inlinerollresult.fullcrit,
 .sheet-rolltemplate-atkdmg .inlinerollresult.fullcrit,
 .sheet-rolltemplate-dmg .inlinerollresult.fullcrit {
   color: #3FB315;
   border: 0px; }
-
 .sheet-rolltemplate-simple .inlinerollresult.fullfail,
 .sheet-rolltemplate-atk .inlinerollresult.fullfail,
 .sheet-rolltemplate-atkdmg .inlinerollresult.fullfail,
 .sheet-rolltemplate-dmg .inlinerollresult.fullfail {
   color: #B31515;
   border: 0px; }
-
 .sheet-rolltemplate-simple .inlinerollresult.importantroll,
 .sheet-rolltemplate-atk .inlinerollresult.importantroll,
 .sheet-rolltemplate-atkdmg .inlinerollresult.importantroll,
 .sheet-rolltemplate-dmg .inlinerollresult.importantroll {
   color: #4A57ED;
   border: 0px; }
-
 .sheet-rolltemplate-atk .sheet-damage,
 .sheet-rolltemplate-atkdmg .sheet-damage,
 .sheet-rolltemplate-dmg .sheet-damage {
   text-align: center;
   margin-top: -5px; }
-
 .sheet-rolltemplate-atkdmg .sheet-damagetemplate .inlinerollresult.fullcrit,
 .sheet-rolltemplate-atkdmg .sheet-damagetemplate .inlinerollresult.fullfail,
 .sheet-rolltemplate-atkdmg .sheet-damagetemplate .inlinerollresult.importantroll,
@@ -989,25 +947,21 @@
 .sheet-rolltemplate-atk .sheet-desc .inlinerollresult.fullfail {
   color: black;
   border: 0px; }
-
 .sheet-rolltemplate-atk .sheet-save .sheet-savedc,
 .sheet-rolltemplate-dmg .sheet-save .sheet-savedc,
 .sheet-rolltemplate-atkdmg .sheet-save .sheet-savedc {
   padding-bottom: 5px;
   padding-top: 15px;
   text-align: center; }
-
 .sheet-rolltemplate-atk .sheet-save .sheet-savedc span,
 .sheet-rolltemplate-dmg .sheet-save .sheet-savedc span,
 .sheet-rolltemplate-atkdmg .sheet-save .sheet-savedc span {
   font-size: 15px;
   font-weight: bold; }
-
 .sheet-rolltemplate-atk .sheet-save .sheet-label span,
 .sheet-rolltemplate-dmg .sheet-save .sheet-label span,
 .sheet-rolltemplate-atkdmg .sheet-save .sheet-label span {
   font-weight: bold; }
-
 .sheet-rolltemplate-atk .sheet-save .inlinerollresult,
 .sheet-rolltemplate-dmg .sheet-save .inlinerollresult,
 .sheet-rolltemplate-atkdmg .sheet-save .inlinerollresult {
@@ -1016,7 +970,6 @@
   padding: 0px;
   display: inline-block;
   font-weight: bold; }
-
 .sheet-rolltemplate-dmg .sheet-desc .inlinerollresult,
 .sheet-rolltemplate-atkdmg .sheet-desc .inlinerollresult,
 .sheet-rolltemplate-atk .sheet-desc .inlinerollresult {
@@ -1027,24 +980,20 @@
   font-size: 20px;
   padding-top: 10px;
   padding-bottom: 6px; }
-
 .sheet-rolltemplate-dmg .sheet-desc .sheet-label span,
 .sheet-rolltemplate-atkdmg .sheet-desc .sheet-label span {
   font-weight: bold; }
-
 .sheet-rolltemplate-atk .sheet-save span,
 .sheet-rolltemplate-dmg .sheet-save span,
 .sheet-rolltemplate-atkdmg .sheet-save span {
   font-weight: normal;
   line-height: 12px;
   display: block; }
-
 .sheet-rolltemplate-atk .sheet-save span.sheet-bold,
 .sheet-rolltemplate-dmg .sheet-save span.sheet-bold,
 .sheet-rolltemplate-atkdmg .sheet-save span.sheet-bold {
   font-weight: bold;
   display: inline-block; }
-
 .sheet-rolltemplate-atk .sheet-sublabel,
 .sheet-rolltemplate-atkdmg .sheet-sublabel,
 .sheet-rolltemplate-dmg .sheet-sublabel {
@@ -1052,7 +1001,6 @@
   font-style: italic;
   margin-top: -2px;
   min-height: 17px; }
-
 .sheet-rolltemplate-atk .sheet-descold,
 .sheet-rolltemplate-atkdmg .sheet-descold,
 .sheet-rolltemplate-dmg .sheet-descold {
@@ -1064,7 +1012,6 @@
   text-align: center;
   padding-top: 5px;
   padding-bottom: 5px; }
-
 .sheet-rolltemplate-atk .sheet-desc,
 .sheet-rolltemplate-atkdmg .sheet-desc,
 .sheet-rolltemplate-dmg .sheet-desc,
@@ -1076,7 +1023,6 @@
   padding-top: 5px;
   padding-bottom: 5px;
   background-color: white; }
-
 .sheet-rolltemplate-atk .sheet-desc span,
 .sheet-rolltemplate-atkdmg .sheet-desc span,
 .sheet-rolltemplate-dmg .sheet-desc span,
@@ -1084,19 +1030,16 @@
   font-weight: normal;
   line-height: 12px;
   display: block; }
-
 .sheet-rolltemplate-atk .sheet-info span,
 .sheet-rolltemplate-atkdmg .sheet-info span,
 .sheet-rolltemplate-dmg .sheet-info span {
   text-align: left;
   padding: 0px 5px 0px 5px; }
-
 .sheet-rolltemplate-atk .sheet-info .inlinerollresult,
 .sheet-rolltemplate-atkdmg .sheet-info .inlinerollresult,
 .sheet-rolltemplate-dmg .sheet-info .inlinerollresult {
   font-size: inherit;
   padding: 0px; }
-
 .sheet-rolltemplate-atkdmg .sheet-damagetemplate .sheet-sublabel,
 .sheet-rolltemplate-dmg .sheet-damagetemplate .sheet-sublabel,
 .sheet-rolltemplate-atkdmg .sheet-desc .sheet-sublabel,
@@ -1107,34 +1050,27 @@
   font-weight: normal;
   margin-top: -5px;
   color: #A0A0A0; }
-
 .sheet-rolltemplate-atk .sheet-sublabel span,
 .sheet-rolltemplate-atkdmg .sheet-sublabel span,
 .sheet-rolltemplate-dmg .sheet-sublabel span {
   font-weight: normal;
   color: black; }
-
 .sheet-rolltemplate-atk .sheet-spacer,
 .sheet-rolltemplate-atkdmg .sheet-spacer,
 .sheet-rolltemplate-dmg .sheet-spacer {
   height: 10px; }
-
 .sheet-rolltemplate-dmg {
   margin-top: -7px;
   position: relative; }
-
 .sheet-rolltemplate-atk a[href^="~"] {
   background-color: transparent;
   padding: 0px;
   color: black;
   border: 0px; }
-
 .sheet-rolltemplate-atk a:hover {
   color: #EC2127; }
-
 .sheet-rolltemplate-atk a[href^="~"]:visited {
   pointer-events: none; }
-
 .sheet-rolltemplate-spell .sheet-container {
   width: 263px;
   background: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/5th%20Edition%20OGL%20by%20Roll20/images/spellbg.jpg) center center;
@@ -1145,28 +1081,21 @@
   padding: 10px;
   margin-left: -45px;
   border: 1px solid black; }
-
 .withoutavatars .sheet-rolltemplate-spell .sheet-container {
   margin-left: -15px; }
-
 .sheet-rolltemplate-spell .sheet-row {
   display: block; }
-
 .sheet-rolltemplate-spell .sheet-title {
   color: #7e2d40;
   font-size: 1.2em; }
-
 .sheet-rolltemplate-spell .sheet-italics,
 .sheet-npc .sheet-italics {
   font-style: italic; }
-
 .sheet-rolltemplate-spell .sheet-bold,
 .sheet-actions .sheet-bold {
   font-weight: bold; }
-
 .sheet-rolltemplate-spell .sheet-spacer {
   height: 5px; }
-
 .sheet-rolltemplate-npc,
 .sheet-rolltemplate-npcaction .sheet-container,
 .sheet-rolltemplate-npcatk,
@@ -1176,13 +1105,10 @@
   border: 1px solid;
   background-color: #ffffff;
   padding: 5px; }
-
 .sheet-rolltemplate-npcaction .sheet-container.sheet-dmgcontainer {
   margin-top: 5px; }
-
 .sheet-rolltemplate-npcdmg {
   margin-top: -8px; }
-
 .sheet-rolltemplate-npc .sheet-header,
 .sheet-rolltemplate-npcaction .sheet-header,
 .sheet-rolltemplate-npcatk .sheet-header,
@@ -1192,7 +1118,6 @@
   text-align: left;
   font-family: "Times New Roman", Times, serif;
   font-variant: small-caps; }
-
 .sheet-rolltemplate-traits .sheet-header {
   font-family: "Times New Roman", Times, serif;
   font-size: 16px;
@@ -1200,45 +1125,38 @@
   font-variant: small-caps;
   font-weight: bold;
   color: #7e2d40; }
-
 .sheet-rolltemplate-npc .sheet-italics,
 .sheet-rolltemplate-npcaction .sheet-italics,
 .sheet-rolltemplate-npcatk .sheet-italics,
 .sheet-rolltemplate-npcdmg .sheet-italics,
 .sheet-rolltemplate-traits .sheet-italics {
   font-style: italic; }
-
 .sheet-rolltemplate-npc .sheet-subheader,
 .sheet-rolltemplate-npcaction .sheet-subheader,
 .sheet-rolltemplate-npcatk .sheet-subheader,
 .sheet-rolltemplate-npcdmg .sheet-subheader {
   line-height: 13px;
   margin-top: -3px; }
-
 .sheet-rolltemplate-traits .sheet-subheader {
   font-style: italic;
   color: #A0A0A0;
   margin-top: -5px; }
-
 .sheet-rolltemplate-npc .sheet-subheader span,
 .sheet-rolltemplate-npcaction .sheet-subheader span,
 .sheet-rolltemplate-npcatk .sheet-subheader span,
 .sheet-rolltemplate-npcdmg .sheet-subheader span {
   font-size: 11px;
   line-height: 11px; }
-
 .sheet-rolltemplate-traits .sheet-subheader span {
   font-weight: normal;
   font-size: 10px;
   text-align: left;
   line-height: 16px; }
-
 .sheet-rolltemplate-traits .sheet-desc {
   font-weight: normal;
   font-size: 12px;
   text-align: left;
   line-height: 16px; }
-
 .sheet-rolltemplate-npc .sheet-arrow-rightold,
 .sheet-rolltemplate-npcaction .sheet-arrow-rightold,
 .sheet-rolltemplate-npcatk .sheet-arrow-rightold,
@@ -1246,7 +1164,6 @@
   border-top: 3px solid transparent;
   border-bottom: 3px solid transparent;
   border-left: 195px solid #7e2d40; }
-
 .sheet-rolltemplate-npc .sheet-arrow-right,
 .sheet-rolltemplate-npcaction .sheet-arrow-right,
 .sheet-rolltemplate-npcatk .sheet-arrow-right,
@@ -1254,7 +1171,6 @@
   border: 1px solid #7e2d40;
   margin-bottom: 2px;
   margin-top: 2px; }
-
 .sheet-rolltemplate-npc .inlinerollresult,
 .sheet-rolltemplate-npcaction .inlinerollresult,
 .sheet-rolltemplate-npcatk .inlinerollresult,
@@ -1262,47 +1178,39 @@
 .sheet-rolltemplate-traits .inlinerollresult {
   background-color: #ffffff;
   border: none; }
-
 .sheet-rolltemplate-npc .inlinerollresult.fullcrit,
 .sheet-rolltemplate-npcaction .inlinerollresult.fullcrit,
 .sheet-rolltemplate-npcatk .inlinerollresult.fullcrit,
 .sheet-rolltemplate-npcdmg .inlinerollresult.fullcrit {
   color: #3FB315;
   border: none; }
-
 .sheet-rolltemplate-npc .inlinerollresult.fullfail,
 .sheet-rolltemplate-npcaction .inlinerollresult.fullfail,
 .sheet-rolltemplate-npcatk .inlinerollresult.fullfail,
 .sheet-rolltemplate-npcdmg .inlinerollresult.fullfail {
   color: #B31515;
   border: none; }
-
 .sheet-rolltemplate-npc .inlinerollresult.importantroll,
 .sheet-rolltemplate-npcaction .inlinerollresult.importantroll,
 .sheet-rolltemplate-npcatk .inlinerollresult.importantroll,
 .sheet-rolltemplate-npcdmg .inlinerollresult.importantroll {
   color: #4A57ED;
   border: none; }
-
 .sheet-rolltemplate-npcatk a[href^="~"] {
   background-color: transparent;
   padding: 0px;
   color: black;
   border: 0px; }
-
 .sheet-rolltemplate-npcatk .sheet-header a[href^="~"] {
   color: #7e2d40; }
-
 .sheet-rolltemplate-npcatk a[href^="~"]:hover {
   color: #EC2127; }
-
 .sheet-rolltemplate-simple .sheet-charname,
 .sheet-rolltemplate-atk .sheet-charname,
 .sheet-rolltemplate-dmg .sheet-charname,
 .sheet-rolltemplate-atkdmg .sheet-charname {
   text-align: center;
   margin-top: -10px; }
-
 .sheet-rolltemplate-simple .sheet-charname span,
 .sheet-rolltemplate-atk .sheet-charname span,
 .sheet-rolltemplate-dmg .sheet-charname span,
@@ -1310,13 +1218,11 @@
   font-size: 11px;
   font-weight: normal;
   color: #A0A0A0; }
-
 .sheet-rolltemplate-dmg .sheet-label .sheet-rolltemplate-inline,
 .sheet-rolltemplate-dmg .sheet-savedc .sheet-rolltemplate-inline,
 .sheet-rolltemplate-atkdmg .sheet-savedc .sheet-rolltemplate-inline,
 .sheet-rolltemplate-atkdmg .sheet-label .sheet-rolltemplate-inline {
   display: inline-block; }
-
 .charsheet .sheet-darkerdungeons .sheet-section-npc-display .sheet-npc-header .sheet-npc-header-name {
   padding-right: 20px; }
 .charsheet .sheet-darkerdungeons .sheet-section-npc-display .sheet-npc-header > span {
@@ -1472,16 +1378,17 @@
   .charsheet .sheet-darkerdungeons .sheet-section-npc-display .sheet-npc-trait .sheet-npc-trait-desc {
     display: inline; }
 .charsheet .sheet-darkerdungeons .sheet-section-npc-display .sheet-npc-reaction {
-  font-size: 11px;
-  padding-right: 20px; }
+  font-size: 11px; }
   .charsheet .sheet-darkerdungeons .sheet-section-npc-display .sheet-npc-reaction .sheet-npc-reaction-name {
     font-weight: bold;
     padding: 0 5px;
     background: #dddddd;
     border-radius: 3px;
-    display: inline-block; }
+    display: block;
+    text-align: center; }
   .charsheet .sheet-darkerdungeons .sheet-section-npc-display .sheet-npc-reaction .sheet-npc-reaction-description {
-    display: inline-block; }
+    display: block;
+    white-space: normal; }
 .charsheet .sheet-darkerdungeons .sheet-section-npc-display .sheet-npc-action {
   font-size: 11px; }
   .charsheet .sheet-darkerdungeons .sheet-section-npc-display .sheet-npc-action button:hover {
@@ -1526,6 +1433,14 @@
   font-style: italic; }
 .charsheet .sheet-darkerdungeons .sheet-section-npc-display .sheet-fieldset-item-npcaction .sheet-fieldset-item-npcaction-checked-onhit > :first-child {
   font-style: italic; }
+.charsheet .sheet-darkerdungeons .sheet-section-npc-display .sheet-fieldset-item-npcreaction .sheet-fieldset-item-npcaction-checked-roll {
+  background: none;
+  border: 0;
+  box-shadow: none;
+  text-align: left;
+  width: 100%; }
+.charsheet .sheet-darkerdungeons .sheet-section-npc-display .sheet-fieldset-item-npcreaction .sheet-fieldset-item-npcreaction-name {
+  font-weight: bold; }
 .charsheet .sheet-darkerdungeons .sheet-toggle-npc:not([value="0"]) + .sheet-toggle-npc-spells:checked ~ .sheet-section-npc .sheet-section-npc-footer {
   display: none; }
 .charsheet .sheet-darkerdungeons .sheet-toggle-npc:not([value="0"]) + .sheet-toggle-npc-spells:checked ~ .sheet-section-pc {
@@ -1567,7 +1482,6 @@
             min-height: 112px; }
 .charsheet .sheet-darkerdungeons .sheet-toggle-npc:not([value="0"]) ~ .sheet-toggle-npc-edit:checked ~ .sheet-section-pc .sheet-tab-content {
   display: none !important; }
-
 .charsheet .sheet-darkerdungeons .sheet-form-fieldset-npc-attributes .sheet-form-fieldset-body,
 .charsheet .sheet-darkerdungeons .sheet-form-fieldset-npc-saves .sheet-form-fieldset-body {
   display: grid;
@@ -1590,7 +1504,6 @@
   grid-template-rows: 1fr 1fr 1fr 1fr 1fr 1fr; }
   .charsheet .sheet-darkerdungeons .sheet-form-fieldset-npc-skills .sheet-form-fieldset-body .sheet-form-group {
     margin: 0; }
-
 .charsheet .sheet-darkerdungeons .sheet-section-npc {
   margin: 0 auto;
   max-width: 385px;
@@ -1605,11 +1518,9 @@
       .charsheet .sheet-darkerdungeons .sheet-section-npc .sheet-section-npc-footer p a:hover {
         text-decoration: none;
         background: #e5fffb; }
-
 .charsheet .sheet-darkerdungeons .sheet-section-pc {
   margin: 0 auto;
   width: 800px; }
-
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-section-pc-footer p {
   color: #cccccc;
   font-size: 9px;
@@ -1620,12 +1531,11 @@
     .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-section-pc-footer p a:hover {
       text-decoration: none;
       background: #e5fffb; }
-
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-section-pc-header {
   background: url("https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/5e%20Darker%20Dungeons/img/sheet-header-bg.png");
   background-size: 100% 100%;
   display: grid;
-  grid-template-areas: ". logo . . ." ". logo . details ." ". name . details ." ". . . . .";
+  grid-template-areas: ". logo . . ." ". logo . details ." ". name . details ." ". . . . .";
   grid-template-columns: 18px 289px 38px auto 18px;
   grid-template-rows: 40px 33px 46px auto;
   height: 141px;
@@ -1695,7 +1605,6 @@
       display: block;
       background-size: 100%;
       margin: 0 auto; }
-
 .sheet-tabs {
   position: relative;
   width: 800px; }
@@ -1705,15 +1614,20 @@
     display: block; }
   .sheet-tabs .sheet-tab {
     width: 800px; }
-    .sheet-tabs .sheet-tab:nth-of-type(2) > input[type="radio"], .sheet-tabs .sheet-tab:nth-of-type(2) > .sheet-tab-label {
+    .sheet-tabs .sheet-tab:nth-of-type(2) > input[type="radio"],
+    .sheet-tabs .sheet-tab:nth-of-type(2) > .sheet-tab-label {
       margin-left: 16.66667%; }
-    .sheet-tabs .sheet-tab:nth-of-type(3) > input[type="radio"], .sheet-tabs .sheet-tab:nth-of-type(3) > .sheet-tab-label {
+    .sheet-tabs .sheet-tab:nth-of-type(3) > input[type="radio"],
+    .sheet-tabs .sheet-tab:nth-of-type(3) > .sheet-tab-label {
       margin-left: 33.33333%; }
-    .sheet-tabs .sheet-tab:nth-of-type(4) > input[type="radio"], .sheet-tabs .sheet-tab:nth-of-type(4) > .sheet-tab-label {
+    .sheet-tabs .sheet-tab:nth-of-type(4) > input[type="radio"],
+    .sheet-tabs .sheet-tab:nth-of-type(4) > .sheet-tab-label {
       margin-left: 50%; }
-    .sheet-tabs .sheet-tab:nth-of-type(5) > input[type="radio"], .sheet-tabs .sheet-tab:nth-of-type(5) > .sheet-tab-label {
+    .sheet-tabs .sheet-tab:nth-of-type(5) > input[type="radio"],
+    .sheet-tabs .sheet-tab:nth-of-type(5) > .sheet-tab-label {
       margin-left: 66.66667%; }
-    .sheet-tabs .sheet-tab:nth-of-type(6) > input[type="radio"], .sheet-tabs .sheet-tab:nth-of-type(6) > .sheet-tab-label {
+    .sheet-tabs .sheet-tab:nth-of-type(6) > input[type="radio"],
+    .sheet-tabs .sheet-tab:nth-of-type(6) > .sheet-tab-label {
       margin-left: 83.33333%; }
     .sheet-tabs .sheet-tab > input[type="radio"] {
       height: 30px;
@@ -1761,12 +1675,11 @@
       min-height: 847px;
       padding-top: 35px;
       width: 100%; }
-
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-core > input[type="radio"]:checked ~ .sheet-tab-content {
   display: grid;
   grid-column-gap: 5px;
   grid-row-gap: 5px;
-  grid-template-areas: "attributes trackers trackers" "attributes health health" "attributes attacks effects";
+  grid-template-areas: "attributes trackers trackers" "attributes health health" "attributes attacks effects";
   grid-template-columns: 265px 1fr 1fr;
   grid-template-rows: 85px auto 1fr; }
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-core .sheet-container-well-attributes {
@@ -1774,7 +1687,7 @@
   display: grid;
   grid-template-columns: 75px auto;
   grid-template-rows: 30px auto auto auto 1fr;
-  grid-template-areas: "attributes proficiency-bonus" "attributes saves" "attributes skills" "tools tools" "proficiencies proficiencies";
+  grid-template-areas: "attributes proficiency-bonus" "attributes saves" "attributes skills" "tools tools" "proficiencies proficiencies";
   grid-column-gap: 5px;
   grid-row-gap: 5px; }
   .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-core .sheet-container-well-attributes .sheet-pc-attributes {
@@ -1841,6 +1754,25 @@
         color: #b61037; }
   .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-core .sheet-container-well-attributes .sheet-pc-skills {
     grid-area: skills; }
+  .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-core .sheet-container-well-attributes .sheet-pc-skill .sheet-checkbox-image,
+  .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-core .sheet-container-well-attributes .sheet-pc-skill span {
+    flex-grow: 0;
+    flex-shrink: 0; }
+  .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-core .sheet-container-well-attributes .sheet-pc-skill button {
+    flex-grow: 0; }
+  .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-core .sheet-container-well-attributes .sheet-pc-skill select {
+    margin: 0;
+    padding: 0;
+    height: 18px;
+    font-size: 11px;
+    width: 5rem;
+    border: none;
+    flex-grow: 1;
+    color: #b3b3b3; }
+  .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-core .sheet-container-well-attributes .sheet-pc-skill.sheet-pc-skill-animal-handling button {
+    letter-spacing: -0.6px; }
+  .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-core .sheet-container-well-attributes .sheet-pc-skill.sheet-pc-skill-sleight-of-hand button {
+    letter-spacing: -0.25px; }
   .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-core .sheet-container-well-attributes .sheet-pc-tools {
     grid-area: tools; }
     .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-core .sheet-container-well-attributes .sheet-pc-tools .sheet-container-body-header span:nth-of-type(1) {
@@ -2044,7 +1976,7 @@
   grid-template-rows: 30px 30px;
   grid-column-gap: 5px;
   grid-row-gap: 5px;
-  grid-template-areas: "armor initiative perception speed fate fate" "armor initiative perception speed inspiration inspiration"; }
+  grid-template-areas: "armor initiative perception speed fate fate" "armor initiative perception speed inspiration inspiration"; }
   .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-core .sheet-container-well-trackers .sheet-pc-armor {
     grid-area: armor; }
   .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-core .sheet-container-well-trackers .sheet-pc-initiative {
@@ -2070,7 +2002,7 @@
   grid-area: health;
   grid-column-gap: 5px;
   grid-row-gap: 5px;
-  grid-template-areas: "hp-max hp hp health wounds wounds" "hit-dice hit-dice death health wounds wounds";
+  grid-template-areas: "hp-max hp hp health wounds wounds" "hit-dice hit-dice death health wounds wounds";
   grid-template-columns: repeat(6, 1fr);
   grid-template-rows: 65px auto; }
   .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-core .sheet-container-well-health .sheet-pc-hp-max {
@@ -2163,7 +2095,7 @@
   grid-area: conditions;
   grid-column-gap: 5px;
   grid-row-gap: 5px;
-  grid-template-areas: "conditions conditions conditions conditions rations rations" "conditions conditions conditions conditions water water" "conditions conditions conditions conditions exhaustion exhaustion";
+  grid-template-areas: "conditions conditions conditions conditions rations rations" "conditions conditions conditions conditions water water" "conditions conditions conditions conditions exhaustion exhaustion";
   grid-template-columns: repeat(6, 1fr);
   grid-template-rows: 30px 30px 65px;
   margin-top: 5px; }
@@ -2222,7 +2154,7 @@
   grid-template-rows: 65px 1fr;
   grid-column-gap: 5px;
   grid-row-gap: 5px;
-  grid-template-areas: "pc-stress levels levels" "afflictions afflictions afflictions";
+  grid-template-areas: "pc-stress levels levels" "afflictions afflictions afflictions";
   min-height: 85px;
   margin-bottom: 5px; }
   .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-core .sheet-container-well-stress .sheet-pc-stress {
@@ -2286,7 +2218,7 @@
   grid-area: attacks;
   grid-column-gap: 5px;
   grid-row-gap: 5px;
-  grid-template-areas: "spell-ability spell-dc spell-attack" "resource-class resource-other spell-burnout" "resources resources resources" "attacks attacks attacks";
+  grid-template-areas: "spell-ability spell-dc spell-attack" "resource-class resource-other spell-burnout" "resources resources resources" "attacks attacks attacks";
   grid-template-columns: repeat(3, 1fr);
   grid-template-rows: 65px 65px auto 1fr; }
   .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-core .sheet-container-well-attacks .sheet-pc-spell-ability {
@@ -2474,7 +2406,6 @@
     background: #cf7d01; }
   .charsheet .sheet-darkerdungeons .sheet-list-conditions li:nth-of-type(6) input[type=radio]:checked + span {
     background: #cf4601; }
-
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-alert-warning {
   background: #7e2d40;
   font-size: 9px;
@@ -2482,6 +2413,34 @@
   margin-bottom: 4px;
   color: white;
   border-radius: 3px; }
+.charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-cp .sheet-container-header,
+.charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-sp .sheet-container-header,
+.charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-ep .sheet-container-header,
+.charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-gp .sheet-container-header,
+.charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-pp .sheet-container-header,
+.charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-other .sheet-container-header {
+  padding: 0; }
+.charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-cp .sheet-container-header input,
+.charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-sp .sheet-container-header input,
+.charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-ep .sheet-container-header input,
+.charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-gp .sheet-container-header input,
+.charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-pp .sheet-container-header input,
+.charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-other .sheet-container-header input {
+  text-align: center;
+  width: 100%;
+  border: 0;
+  padding-left: 0;
+  padding-right: 0;
+  font-size: 8px;
+  font-weight: bold;
+  background: none; }
+  .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-cp .sheet-container-header input:hover,
+  .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-sp .sheet-container-header input:hover,
+  .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-ep .sheet-container-header input:hover,
+  .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-gp .sheet-container-header input:hover,
+  .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-pp .sheet-container-header input:hover,
+  .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-other .sheet-container-header input:hover {
+    background: #e5fffb; }
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-cp .sheet-container-body input,
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-sp .sheet-container-body input,
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-ep .sheet-container-body input,
@@ -2503,23 +2462,13 @@
   grid-area: pp; }
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-other {
   grid-area: other; }
-  .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-other .sheet-container-header {
-    padding: 0 10px 0 12px; }
-  .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-purse-other .sheet-container-header input {
-    text-align: center;
-    width: 100%;
-    border: 0;
-    padding-left: 0;
-    padding-right: 0;
-    font-size: 8px;
-    font-weight: bold; }
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment > input[type="radio"]:checked ~ .sheet-tab-content {
   display: grid;
   grid-template-columns: auto 262.5px;
   grid-template-rows: 85px 120px 110px auto;
   grid-column-gap: 5px;
   grid-row-gap: 5px;
-  grid-template-areas: "equipment supplies" "equipment purse" "equipment encumberance" "equipment general"; }
+  grid-template-areas: "equipment supplies" "equipment purse" "equipment encumberance" "equipment general"; }
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-container-well-equipment {
   grid-area: equipment;
   display: grid; }
@@ -2528,7 +2477,7 @@
   display: grid;
   grid-template-rows: repeat(2, 30px);
   grid-row-gap: 5px;
-  grid-template-areas: "rations" "water"; }
+  grid-template-areas: "rations" "water"; }
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-container-well-equipment-purse {
   grid-area: purse;
   display: grid;
@@ -2536,7 +2485,7 @@
   grid-template-columns: 1fr 1fr;
   grid-row-gap: 5px;
   grid-column-gap: 5px;
-  grid-template-areas: "cp gp" "sp pp" "ep other" ". ."; }
+  grid-template-areas: "cp gp" "sp pp" "ep other" ". ."; }
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-container-well-equipment-encumberance {
   grid-area: encumberance;
   display: grid;
@@ -2586,6 +2535,23 @@
   justify-content: center;
   align-items: center;
   border-radius: 100%; }
+.charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-item-carried {
+  background: #dddddd;
+  color: black;
+  display: inline-block;
+  height: 14px;
+  width: 14px;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 100%; }
+.charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment [name="attr_equipped"][value="1"] ~ .sheet-pc-item-carried {
+  display: none; }
+.charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment [name="attr_equipped"][value="0"] ~ [name="attr_carried"][value="0"] + .sheet-pc-item-carried {
+  display: inline-flex !important;
+  background: none;
+  border: 1px solid #dddddd;
+  color: white; }
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-item {
   font-size: 11px;
   padding-right: 20px; }
@@ -2607,6 +2573,12 @@
   .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-item .sheet-pc-item-content {
     display: flex;
     border-radius: 3px; }
+    .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-item .sheet-pc-item-content input {
+      text-align: center;
+      width: 100%;
+      height: 100%;
+      border: none;
+      padding: 0; }
   .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-item:hover {
     background: #f2f2f2; }
   .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-item .sheet-pc-item-name {
@@ -2622,7 +2594,8 @@
     flex-grow: 0;
     width: 50px;
     text-align: center;
-    margin-left: 1px; }
+    margin-left: 1px;
+    display: flex; }
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-equipment-container {
   background: #7e2d40;
   color: white;
@@ -2631,6 +2604,21 @@
   padding: 0 5px; }
   .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-equipment-container .sheet-pc-equipment-container-slots {
     opacity: .75; }
+  .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-equipment-container .sheet-pc-item-equipped {
+    background: none;
+    border: 1px solid #dddddd;
+    color: white; }
+  .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-equipment-container .sheet-pc-item-carried {
+    background: none;
+    border: 1px solid #dddddd;
+    color: white; }
+  .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-equipment-container [name="attr_equipped"][value="1"] ~ .sheet-pc-item-carried {
+    display: none; }
+  .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-pc-equipment-container [name="attr_equipped"][value="0"] ~ [name="attr_carried"][value="0"] + .sheet-pc-item-carried {
+    display: inline-flex !important;
+    background: none;
+    border: 1px solid #dddddd;
+    color: #7e2d40; }
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-equipment .sheet-form-item .sheet-item-columns-2 {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -2717,14 +2705,13 @@
 .charsheet .sheet-darkerdungeons .sheet-pc-equipment .sheet-toggle-slots[value="1"] ~ .repcontainer .sheet-pc-item-header span:nth-of-type(3),
 .charsheet .sheet-darkerdungeons .sheet-pc-equipment .sheet-toggle-slots[value="1"] ~ .repcontainer .sheet-pc-item .sheet-pc-item-weight {
   display: none; }
-
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-features > input[type="radio"]:checked ~ .sheet-tab-content {
   display: grid;
   grid-template-columns: auto 262.5px;
   grid-template-rows: 355px auto;
   grid-column-gap: 5px;
   grid-row-gap: 5px;
-  grid-template-areas: "details features" "memories features"; }
+  grid-template-areas: "details features" "memories features"; }
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-features .sheet-container-well-details {
   grid-area: details;
   display: grid;
@@ -2732,7 +2719,7 @@
   grid-template-rows: repeat(4, 1fr);
   grid-column-gap: 5px;
   grid-row-gap: 5px;
-  grid-template-areas: "details personality" "details ideals" "details bonds" "details flaws"; }
+  grid-template-areas: "details personality" "details ideals" "details bonds" "details flaws"; }
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-features .sheet-container-well-memories {
   grid-area: memories;
   display: grid;
@@ -2740,7 +2727,7 @@
   grid-template-rows: repeat(2, 30px) auto;
   grid-column-gap: 5px;
   grid-row-gap: 5px;
-  grid-template-areas: "memories xp" "memories training" "memories notes"; }
+  grid-template-areas: "memories xp" "memories training" "memories notes"; }
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-features .sheet-container-well-features {
   grid-area: features;
   display: grid;
@@ -2911,7 +2898,6 @@
       background: #dddddd;
       padding: 3px 5px;
       border-radius: 3px; }
-
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-notes > input[type="radio"]:checked ~ .sheet-tab-content {
   display: grid; }
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-notes .sheet-pc-notes {
@@ -2920,7 +2906,7 @@
   grid-template-rows: 1fr 1fr;
   grid-column-gap: 10px;
   grid-row-gap: 10px;
-  grid-template-areas: "backstory features features" "allies allies treasure"; }
+  grid-template-areas: "backstory features features" "allies allies treasure"; }
   .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-notes .sheet-pc-notes textarea {
     width: 100%;
     height: 100%;
@@ -2937,7 +2923,6 @@
     grid-area: allies; }
   .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-notes .sheet-pc-notes .sheet-pc-notes-treasure {
     grid-area: treasure; }
-
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-spells .sheet-pc-spell-ability .sheet-container-header,
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-spells .sheet-pc-burnout .sheet-container-header {
   padding-left: 10px;
@@ -3054,7 +3039,6 @@
       min-height: 112px; }
   .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-spells .sheet-container-well-spells .sheet-container-spell {
     min-height: 218px; }
-
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-options > input[type="radio"]:checked ~ .sheet-tab-content {
   display: grid;
   grid-row-gap: 5px;
@@ -3063,7 +3047,7 @@
   display: grid;
   grid-column-gap: 5px;
   grid-row-gap: 5px;
-  grid-template-areas: "class multiclass custom" "class spell custom" "general attribute skill" "general save skill" "darker save skill";
+  grid-template-areas: "class multiclass custom" "class spell custom" "general attribute skill" "general save skill" "darker save skill";
   grid-template-columns: repeat(3, 1fr);
   grid-template-rows: auto auto auto auto 1fr; }
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-options .sheet-pc-option-class {
@@ -3119,7 +3103,6 @@
   margin-top: 5px; }
 .charsheet .sheet-darkerdungeons .sheet-section-pc .sheet-tab-options .sheet-form-fieldset-hp-modifiers .repitem + .repitem {
   margin-top: 5px; }
-
 .charsheet .sheet-darkerdungeons .sheet-section-roll {
   margin: 0 auto;
   width: 800px;
@@ -3177,10 +3160,8 @@
   .charsheet .sheet-darkerdungeons .sheet-toggle-npc:not([value="0"]) ~ .sheet-section-roll .sheet-section-roll-advantage,
   .charsheet .sheet-darkerdungeons .sheet-toggle-npc:not([value="0"]) ~ .sheet-section-roll .sheet-section-roll-whisper {
     margin-bottom: 10px; }
-
 .charsheet .sheet-darkerdungeons .sheet-section-templates {
   display: none; }
-
 .charsheet .sheet-darkerdungeons .sheet-checkbox-cog {
   display: inline-block;
   height: 18px;

--- a/5e Darker Dungeons/5e Darker Dungeons.html
+++ b/5e Darker Dungeons/5e Darker Dungeons.html
@@ -588,7 +588,7 @@
 								</button>
 							</span>
 							<span>
-							<input type="hidden" name="attr_npc_survival_flag" value="0" class="sheet-field-toggle">
+								<input type="hidden" name="attr_npc_survival_flag" value="0" class="sheet-field-toggle">
 								<button type="roll" name="roll_npc_survival" value="@{wtype}&{template:npc} @{npc_name_flag} {{rname=Survival}} {{mod=@{npc_survival}}} {{r1=[[@{d20}+@{npc_survival}]]}} @{rtype}+@{npc_survival}]]}} {{type=Skill}}">
 									<span>Survival</span>
 									<span name="attr_npc_survival"></span>
@@ -754,7 +754,7 @@
 													<input type="checkbox" name="attr_attack_flag" value="on" class="sheet-toggle" hidden>
 													<div class="sheet-toggle-checked">
 														<div class="sheet-fieldset-item-npcaction-checked-attack">
-															<span name="attr_attack_type"></span><span> Weapon Attack: </span><span name="attr_attack_tohitrange">
+															<span name="attr_attack_type"></span><span> Weapon Attack: </span><span name="attr_attack_tohitrange"></span>
 														</div>
 														<div class="sheet-fieldset-item-npcaction-checked-onhit">
 															<span>Hit: </span><span name="attr_attack_onhit"></span>
@@ -773,46 +773,46 @@
 								</fieldset>
 							</div>
 						</div>
-						<input type="checkbox" name="attr_npcreactionsflag" class="sheet-toggle" hidden>
-						<div class="sheet-toggle-checked">
-							<div class="sheet-container-panel sheet-npc-reactions">
-								<div class="sheet-container-header">Reactions</div>
-								<div class="sheet-container-body">
-									<fieldset class="repeating_npcreaction">
-										<div class="sheet-fieldset-item sheet-fieldset-item-npcreaction">
-											<div class="sheet-checkbox-cog">
-												<input type="checkbox" name="attr_npc_options-flag" checked="checked" value="on">
-												<span class="sheet-toggle-icon"></span>
-											</div>
-											<input type="checkbox" name="attr_npc_options-flag" checked="checked" class="sheet-toggle" hidden>
-											<div class="sheet-toggle-checked">
-												<div class="sheet-form">
-													<div class="sheet-form-header">Edit Reaction</div>
-													<div class="sheet-form-body">
-														<div class="sheet-form-group">
-															<label>Name:</label>
-															<input type="text" name="attr_name">
-														</div>
-														<div class="sheet-form-group">
-															<label>Description:</label>
-															<textarea name="attr_desc"></textarea>
-														</div>
+						<input type="hidden" name="attr_npcreactionsflag" value="0" class="sheet-field-toggle">
+						<div class="sheet-container-panel sheet-npc-reactions">
+							<div class="sheet-container-header">Reactions</div>
+							<div class="sheet-container-body">
+								<fieldset class="repeating_npcreaction">
+									<div class="sheet-fieldset-item sheet-fieldset-item-npcreaction">
+										<div class="sheet-checkbox-cog">
+											<input type="checkbox" name="attr_npc_options-flag" checked="checked" value="on">
+											<span class="sheet-toggle-icon"></span>
+										</div>
+										<input type="checkbox" name="attr_npc_options-flag" checked="checked" class="sheet-toggle" hidden>
+										<div class="sheet-toggle-checked">
+											<div class="sheet-form">
+												<div class="sheet-form-header">Edit Reaction</div>
+												<div class="sheet-form-body">
+													<div class="sheet-form-group">
+														<label>Name:</label>
+														<input type="text" name="attr_name">
+													</div>
+													<div class="sheet-form-group">
+														<label>Description:</label>
+														<textarea name="attr_desc"></textarea>
 													</div>
 												</div>
 											</div>
-											<div class="sheet-toggle-unchecked">
-												<div class="sheet-npc-reaction">
+										</div>
+										<div class="sheet-toggle-unchecked">
+											<div class="sheet-npc-reaction">
+												<button type="roll" name="roll_npc_action" value="@{wtype}&{template:npcaction} @{npc_name_flag} {{rname=@{name}}} {{description=@{desc}}} @{charname_output}" class="sheet-fieldset-item-npcaction-checked-roll sheet-btn-text">
 													<div class="sheet-npc-reaction-name">
 														<span name="attr_name"></span>
 													</div>
 													<div class="sheet-npc-reaction-description">
 														<span name="attr_desc"></span>
 													</div>
-												</div>
+												</button>
 											</div>
 										</div>
-									</fieldset>
-								</div>
+									</div>
+								</fieldset>
 							</div>
 						</div>
 						<input type="hidden" name="attr_npc_legendary_actions" value="0" class="sheet-field-toggle">
@@ -904,7 +904,7 @@
 													<input type="checkbox" name="attr_attack_flag" value="on" class="sheet-toggle" hidden>
 													<div class="sheet-toggle-checked">
 														<div class="sheet-fieldset-item-npcaction-checked-attack">
-															<span name="attr_attack_type"></span><span> Weapon Attack: </span><span name="attr_attack_tohitrange">
+															<span name="attr_attack_type"></span><span> Weapon Attack: </span><span name="attr_attack_tohitrange"></span>
 														</div>
 														<div class="sheet-fieldset-item-npcaction-checked-onhit">
 															<span>Hit: </span><span name="attr_attack_onhit"></span>
@@ -1036,7 +1036,7 @@
 											<input type="text" name="attr_dexterity_base" title="@{dexterity}" value="10">
 											<input type="hidden" name="attr_dexterity" value="10">
 											<input type="hidden" name="attr_dexterity_flag" value="0" class="sheet-field-toggle">
-											<span name="attr_dexterity">
+											<span name="attr_dexterity"></span>
 										</div>
 									</div>
 									<div class="sheet-container-attribute">
@@ -1050,7 +1050,7 @@
 											<input type="text" name="attr_constitution_base" title="@{constitution}" value="10">
 											<input type="hidden" name="attr_constitution" value="10">
 											<input type="hidden" name="attr_constitution_flag" value="0" class="sheet-field-toggle">
-											<span name="attr_constitution">
+											<span name="attr_constitution"></span>
 										</div>
 									</div>
 									<div class="sheet-container-attribute">
@@ -1064,7 +1064,7 @@
 											<input type="text" name="attr_intelligence_base" title="@{intelligence}" value="10">
 											<input type="hidden" name="attr_intelligence" value="10">
 											<input type="hidden" name="attr_intelligence_flag" value="0" class="sheet-field-toggle">
-											<span name="attr_intelligence">
+											<span name="attr_intelligence"></span>
 										</div>
 									</div>
 									<div class="sheet-container-attribute">
@@ -1078,7 +1078,7 @@
 											<input type="text" name="attr_wisdom_base" title="@{wisdom}" value="10">
 											<input type="hidden" name="attr_wisdom" value="10">
 											<input type="hidden" name="attr_wisdom_flag" value="0" class="sheet-field-toggle">
-											<span name="attr_wisdom">
+											<span name="attr_wisdom"></span>
 										</div>
 									</div>
 									<div class="sheet-container-attribute">
@@ -1092,7 +1092,7 @@
 											<input type="text" name="attr_charisma_base" title="@{charisma}" value="10">
 											<input type="hidden" name="attr_charisma" value="10">
 											<input type="hidden" name="attr_charisma_flag" value="0" class="sheet-field-toggle">
-											<span name="attr_charisma">
+											<span name="attr_charisma"></span>
 										</div>
 									</div>
 								</div>
@@ -1207,15 +1207,31 @@
 												<span></span>
 											</div>
 											<span name="attr_acrobatics_bonus" title="@{acrobatics_bonus}">0</span>
-											<button type="roll" name="roll_acrobatics" value="@{wtype}&{template:simple} {{rname=Acrobatics}} {{mod=@{acrobatics_bonus}}} {{r1=[[@{d20}+@{acrobatics_bonus}@{pbd_safe}]]}} @{rtype}+@{acrobatics_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}">Acrobatics <span>(Dex)</span></button>
+											<button type="roll" name="roll_acrobatics" value="@{wtype}&{template:simple} {{rname=@{acrobatics_attribute} (Acrobatics)}} {{mod=@{acrobatics_bonus}}} {{r1=[[@{d20}+@{acrobatics_bonus}@{pbd_safe}]]}} @{rtype}+@{acrobatics_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}">Acrobatics</button>
+											<select name="attr_acrobatics_attribute" title="@{acrobatics_attribute}">
+												<option value="Strength">Str</option>
+												<option value="Dexterity" selected="selected">Dex</option>
+												<option value="Constitution">Con</option>
+												<option value="Intelligence">Int</option>
+												<option value="Wisdom">Wis</option>
+												<option value="Charisma">Cha</option>
+											</select>
 										</div>
-										<div class="sheet-pc-skill">
+										<div class="sheet-pc-skill sheet-pc-skill-animal-handling">
 											<div class="sheet-checkbox-image">
 												<input type="checkbox" name="attr_animal_handling_prof" title="@{animal_handling_prof}" value="(@{pb}*@{animal_handling_type})">
 												<span></span>
 											</div>
 											<span name='attr_animal_handling_bonus' title='@{animal_handling_bonus}'>0</span>
-											<button type='roll' name='roll_animal_handling' value='@{wtype}&{template:simple} {{rname=Animal Handling}} {{mod=@{animal_handling_bonus}}} {{r1=[[@{d20}+@{animal_handling_bonus}@{pbd_safe}]]}} @{rtype}+@{animal_handling_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Animal Handling <span>(Wis)</span></button>
+											<button type='roll' name='roll_animal_handling' value='@{wtype}&{template:simple} {{rname=@{animal_handling_attribute} (Animal Handling)}} {{mod=@{animal_handling_bonus}}} {{r1=[[@{d20}+@{animal_handling_bonus}@{pbd_safe}]]}} @{rtype}+@{animal_handling_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Animal Handling</button>
+											<select name="attr_animal_handling_attribute" title="@{animal_handling_attribute}">
+												<option value="Strength">Str</option>
+												<option value="Dexterity">Dex</option>
+												<option value="Constitution">Con</option>
+												<option value="Intelligence">Int</option>
+												<option value="Wisdom" selected="selected">Wis</option>
+												<option value="Charisma">Cha</option>
+											</select>
 										</div>
 										<div class="sheet-pc-skill">
 											<div class="sheet-checkbox-image">
@@ -1223,7 +1239,15 @@
 												<span></span>
 											</div>
 											<span name='attr_arcana_bonus' title='@{arcana_bonus}'>0</span>
-											<button type='roll' name='roll_arcana' value='@{wtype}&{template:simple} {{rname=Arcana}} {{mod=@{arcana_bonus}}} {{r1=[[@{d20}+@{arcana_bonus}@{pbd_safe}]]}} @{rtype}+@{arcana_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Arcana <span>(Int)</span></button>
+											<button type='roll' name='roll_arcana' value='@{wtype}&{template:simple} {{rname=@{arcana_attribute} (Arcana)}} {{mod=@{arcana_bonus}}} {{r1=[[@{d20}+@{arcana_bonus}@{pbd_safe}]]}} @{rtype}+@{arcana_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Arcana</button>
+											<select name="attr_arcana_attribute" title="@{arcana_attribute}">
+												<option value="Strength">Str</option>
+												<option value="Dexterity">Dex</option>
+												<option value="Constitution">Con</option>
+												<option value="Intelligence" selected="selected">Int</option>
+												<option value="Wisdom">Wis</option>
+												<option value="Charisma">Cha</option>
+											</select>
 										</div>
 										<div class="sheet-pc-skill">
 											<div class="sheet-checkbox-image">
@@ -1231,7 +1255,15 @@
 												<span></span>
 											</div>
 											<span name='attr_athletics_bonus' title='@{athletics_bonus}'>0</span>
-											<button type='roll' name='roll_athletics' value='@{wtype}&{template:simple} {{rname=Athletics}} {{mod=@{athletics_bonus}}} {{r1=[[@{d20}+@{athletics_bonus}@{pbd_safe}]]}} @{rtype}+@{athletics_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Athletics <span>(Str)</span></button>
+											<button type='roll' name='roll_athletics' value='@{wtype}&{template:simple} {{rname=@{athletics_attribute} (Athletics)}} {{mod=@{athletics_bonus}}} {{r1=[[@{d20}+@{athletics_bonus}@{pbd_safe}]]}} @{rtype}+@{athletics_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Athletics</button>
+											<select name="attr_athletics_attribute" title="@{athletics_attribute}">
+												<option value="Strength" selected="selected">Str</option>
+												<option value="Dexterity">Dex</option>
+												<option value="Constitution">Con</option>
+												<option value="Intelligence">Int</option>
+												<option value="Wisdom">Wis</option>
+												<option value="Charisma">Cha</option>
+											</select>
 										</div>
 										<div class="sheet-pc-skill">
 											<div class="sheet-checkbox-image">
@@ -1239,7 +1271,15 @@
 												<span></span>
 											</div>
 											<span name='attr_deception_bonus' title='@{deception_bonus}'>0</span>
-											<button type='roll' name='roll_deception' value='@{wtype}&{template:simple} {{rname=Deception}} {{mod=@{deception_bonus}}} {{r1=[[@{d20}+@{deception_bonus}@{pbd_safe}]]}} @{rtype}+@{deception_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Deception <span>(Cha)</span></button>
+											<button type='roll' name='roll_deception' value='@{wtype}&{template:simple} {{rname=@{deception_attribute} (Deception)}} {{mod=@{deception_bonus}}} {{r1=[[@{d20}+@{deception_bonus}@{pbd_safe}]]}} @{rtype}+@{deception_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Deception</button>
+											<select name="attr_deception_attribute" title="@{deception_attribute}">
+												<option value="Strength">Str</option>
+												<option value="Dexterity">Dex</option>
+												<option value="Constitution">Con</option>
+												<option value="Intelligence">Int</option>
+												<option value="Wisdom">Wis</option>
+												<option value="Charisma" selected="selected">Cha</option>
+											</select>
 										</div>
 										<div class="sheet-pc-skill">
 											<div class="sheet-checkbox-image">
@@ -1247,7 +1287,15 @@
 												<span></span>
 											</div>
 											<span name='attr_history_bonus' title='@{history_bonus}'>0</span>
-											<button type='roll' name='roll_history' value='@{wtype}&{template:simple} {{rname=History}} {{mod=@{history_bonus}}} {{r1=[[@{d20}+@{history_bonus}@{pbd_safe}]]}} @{rtype}+@{history_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>History <span>(Int)</span></button>
+											<button type='roll' name='roll_history' value='@{wtype}&{template:simple} {{rname=@{history_attribute} (History)}} {{mod=@{history_bonus}}} {{r1=[[@{d20}+@{history_bonus}@{pbd_safe}]]}} @{rtype}+@{history_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>History</button>
+											<select name="attr_history_attribute" title="@{history_attribute}">
+												<option value="Strength">Str</option>
+												<option value="Dexterity">Dex</option>
+												<option value="Constitution">Con</option>
+												<option value="Intelligence" selected="selected">Int</option>
+												<option value="Wisdom">Wis</option>
+												<option value="Charisma">Cha</option>
+											</select>
 										</div>
 										<div class="sheet-pc-skill">
 											<div class="sheet-checkbox-image">
@@ -1255,7 +1303,15 @@
 												<span></span>
 											</div>
 											<span name='attr_insight_bonus' title='@{insight_bonus}'>0</span>
-											<button type='roll' name='roll_insight' value='@{wtype}&{template:simple} {{rname=Insight}} {{mod=@{insight_bonus}}} {{r1=[[@{d20}+@{insight_bonus}@{pbd_safe}]]}} @{rtype}+@{insight_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Insight <span>(Wis)</span></button>
+											<button type='roll' name='roll_insight' value='@{wtype}&{template:simple} {{rname=@{insight_attribute} (Insight)}} {{mod=@{insight_bonus}}} {{r1=[[@{d20}+@{insight_bonus}@{pbd_safe}]]}} @{rtype}+@{insight_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Insight</button>
+											<select name="attr_insight_attribute" title="@{insight_attribute}">
+												<option value="Strength">Str</option>
+												<option value="Dexterity">Dex</option>
+												<option value="Constitution">Con</option>
+												<option value="Intelligence">Int</option>
+												<option value="Wisdom" selected="selected">Wis</option>
+												<option value="Charisma">Cha</option>
+											</select>
 										</div>
 										<div class="sheet-pc-skill">
 											<div class="sheet-checkbox-image">
@@ -1263,7 +1319,15 @@
 												<span></span>
 											</div>
 											<span name='attr_intimidation_bonus' title='@{intimidation_bonus}'>0</span>
-											<button type='roll' name='roll_intimidation' value='@{wtype}&{template:simple} {{rname=Intimidation}} {{mod=@{intimidation_bonus}}} {{r1=[[@{d20}+@{intimidation_bonus}@{pbd_safe}]]}} @{rtype}+@{intimidation_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Intimidation <span>(Cha)</span></button>
+											<button type='roll' name='roll_intimidation' value='@{wtype}&{template:simple} {{rname=@{intimidation_attribute} (Intimidation)}} {{mod=@{intimidation_bonus}}} {{r1=[[@{d20}+@{intimidation_bonus}@{pbd_safe}]]}} @{rtype}+@{intimidation_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Intimidation</button>
+											<select name="attr_intimidation_attribute" title="@{intimidation_attribute}">
+												<option value="Strength">Str</option>
+												<option value="Dexterity">Dex</option>
+												<option value="Constitution">Con</option>
+												<option value="Intelligence">Int</option>
+												<option value="Wisdom">Wis</option>
+												<option value="Charisma" selected="selected">Cha</option>
+											</select>
 										</div>
 										<div class="sheet-pc-skill">
 											<div class="sheet-checkbox-image">
@@ -1271,7 +1335,15 @@
 												<span></span>
 											</div>
 											<span name='attr_investigation_bonus' title='@{investigation_bonus}'>0</span>
-											<button type='roll' name='roll_investigation' value='@{wtype}&{template:simple} {{rname=Investigation}} {{mod=@{investigation_bonus}}} {{r1=[[@{d20}+@{investigation_bonus}@{pbd_safe}]]}} @{rtype}+@{investigation_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Investigation <span>(Int)</span></button>
+											<button type='roll' name='roll_investigation' value='@{wtype}&{template:simple} {{rname=@{investigation_attribute} (Investigation)}} {{mod=@{investigation_bonus}}} {{r1=[[@{d20}+@{investigation_bonus}@{pbd_safe}]]}} @{rtype}+@{investigation_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Investigation</button>
+											<select name="attr_investigation_attribute" title="@{investigation_attribute}">
+												<option value="Strength">Str</option>
+												<option value="Dexterity">Dex</option>
+												<option value="Constitution">Con</option>
+												<option value="Intelligence" selected="selected">Int</option>
+												<option value="Wisdom">Wis</option>
+												<option value="Charisma">Cha</option>
+											</select>
 										</div>
 										<div class="sheet-pc-skill">
 											<div class="sheet-checkbox-image">
@@ -1279,7 +1351,15 @@
 												<span></span>
 											</div>
 											<span name='attr_medicine_bonus' title='@{medicine_bonus}'>0</span>
-											<button type='roll' name='roll_medicine' value='@{wtype}&{template:simple} {{rname=Medicine}} {{mod=@{medicine_bonus}}} {{r1=[[@{d20}+@{medicine_bonus}@{pbd_safe}]]}} @{rtype}+@{medicine_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Medicine <span>(Wis)</span></button>
+											<button type='roll' name='roll_medicine' value='@{wtype}&{template:simple} {{rname=@{medicine_attribute} (Medicine)}} {{mod=@{medicine_bonus}}} {{r1=[[@{d20}+@{medicine_bonus}@{pbd_safe}]]}} @{rtype}+@{medicine_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Medicine</button>
+											<select name="attr_medicine_attribute" title="@{medicine_attribute}">
+												<option value="Strength">Str</option>
+												<option value="Dexterity">Dex</option>
+												<option value="Constitution">Con</option>
+												<option value="Intelligence">Int</option>
+												<option value="Wisdom" selected="selected">Wis</option>
+												<option value="Charisma">Cha</option>
+											</select>
 										</div>
 										<div class="sheet-pc-skill">
 											<div class="sheet-checkbox-image">
@@ -1287,7 +1367,15 @@
 												<span></span>
 											</div>
 											<span name='attr_nature_bonus' title='@{nature_bonus}'>0</span>
-											<button type='roll' name='roll_nature' value='@{wtype}&{template:simple} {{rname=Nature}} {{mod=@{nature_bonus}}} {{r1=[[@{d20}+@{nature_bonus}@{pbd_safe}]]}} @{rtype}+@{nature_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Nature <span>(Int)</span></button>
+											<button type='roll' name='roll_nature' value='@{wtype}&{template:simple} {{rname=@{nature_attribute} (Nature)}} {{mod=@{nature_bonus}}} {{r1=[[@{d20}+@{nature_bonus}@{pbd_safe}]]}} @{rtype}+@{nature_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Nature</button>
+											<select name="attr_nature_attribute" title="@{nature_attribute}">
+												<option value="Strength">Str</option>
+												<option value="Dexterity">Dex</option>
+												<option value="Constitution">Con</option>
+												<option value="Intelligence" selected="selected">Int</option>
+												<option value="Wisdom">Wis</option>
+												<option value="Charisma">Cha</option>
+											</select>
 										</div>
 										<div class="sheet-pc-skill">
 											<div class="sheet-checkbox-image">
@@ -1295,7 +1383,15 @@
 												<span></span>
 											</div>
 											<span name='attr_perception_bonus' title='@{perception_bonus}'>0</span>
-											<button type='roll' name='roll_perception' value='@{wtype}&{template:simple} {{rname=Perception}} {{mod=@{perception_bonus}}} {{r1=[[@{d20}+@{perception_bonus}@{pbd_safe}]]}} @{rtype}+@{perception_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Perception <span>(Wis)</span></button>
+											<button type='roll' name='roll_perception' value='@{wtype}&{template:simple} {{rname=@{perception_attribute} (Perception)}} {{mod=@{perception_bonus}}} {{r1=[[@{d20}+@{perception_bonus}@{pbd_safe}]]}} @{rtype}+@{perception_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Perception</button>
+											<select name="attr_perception_attribute" title="@{perception_attribute}">
+												<option value="Strength">Str</option>
+												<option value="Dexterity">Dex</option>
+												<option value="Constitution">Con</option>
+												<option value="Intelligence">Int</option>
+												<option value="Wisdom" selected="selected">Wis</option>
+												<option value="Charisma">Cha</option>
+											</select>
 										</div>
 										<div class="sheet-pc-skill">
 											<div class="sheet-checkbox-image">
@@ -1303,7 +1399,15 @@
 												<span></span>
 											</div>
 											<span name='attr_performance_bonus' title='@{performance_bonus}'>0</span>
-											<button type='roll' name='roll_performance' value='@{wtype}&{template:simple} {{rname=Performance}} {{mod=@{performance_bonus}}} {{r1=[[@{d20}+@{performance_bonus}@{pbd_safe}]]}} @{rtype}+@{performance_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Performance <span>(Cha)</span></button>
+											<button type='roll' name='roll_performance' value='@{wtype}&{template:simple} {{rname=@{performance_attribute} (Performance)}} {{mod=@{performance_bonus}}} {{r1=[[@{d20}+@{performance_bonus}@{pbd_safe}]]}} @{rtype}+@{performance_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Performance</button>
+											<select name="attr_performance_attribute" title="@{performance_attribute}">
+												<option value="Strength">Str</option>
+												<option value="Dexterity">Dex</option>
+												<option value="Constitution">Con</option>
+												<option value="Intelligence">Int</option>
+												<option value="Wisdom">Wis</option>
+												<option value="Charisma" selected="selected">Cha</option>
+											</select>
 										</div>
 										<div class="sheet-pc-skill">
 											<div class="sheet-checkbox-image">
@@ -1311,7 +1415,15 @@
 												<span></span>
 											</div>
 											<span name='attr_persuasion_bonus' title='@{persuasion_bonus}'>0</span>
-											<button type='roll' name='roll_persuasion' value='@{wtype}&{template:simple} {{rname=Persuasion}} {{mod=@{persuasion_bonus}}} {{r1=[[@{d20}+@{persuasion_bonus}@{pbd_safe}]]}} @{rtype}+@{persuasion_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Persuasion <span>(Cha)</span></button>
+											<button type='roll' name='roll_persuasion' value='@{wtype}&{template:simple} {{rname=@{persuasion_attribute} (Persuasion)}} {{mod=@{persuasion_bonus}}} {{r1=[[@{d20}+@{persuasion_bonus}@{pbd_safe}]]}} @{rtype}+@{persuasion_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Persuasion</button>
+											<select name="attr_persuasion_attribute" title="@{persuasion_attribute}">
+												<option value="Strength">Str</option>
+												<option value="Dexterity">Dex</option>
+												<option value="Constitution">Con</option>
+												<option value="Intelligence">Int</option>
+												<option value="Wisdom">Wis</option>
+												<option value="Charisma" selected="selected">Cha</option>
+											</select>
 										</div>
 										<div class="sheet-pc-skill">
 											<div class="sheet-checkbox-image">
@@ -1319,15 +1431,31 @@
 												<span></span>
 											</div>
 											<span name='attr_religion_bonus' title='@{religion_bonus}'>0</span>
-											<button type='roll' name='roll_religion' value='@{wtype}&{template:simple} {{rname=Religion}} {{mod=@{religion_bonus}}} {{r1=[[@{d20}+@{religion_bonus}@{pbd_safe}]]}} @{rtype}+@{religion_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Religion <span>(Int)</span></button>
+											<button type='roll' name='roll_religion' value='@{wtype}&{template:simple} {{rname=@{religion_attribute} (Religion)}} {{mod=@{religion_bonus}}} {{r1=[[@{d20}+@{religion_bonus}@{pbd_safe}]]}} @{rtype}+@{religion_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Religion</button>
+											<select name="attr_religion_attribute" title="@{religion_attribute}">
+												<option value="Strength">Str</option>
+												<option value="Dexterity">Dex</option>
+												<option value="Constitution">Con</option>
+												<option value="Intelligence" selected="selected">Int</option>
+												<option value="Wisdom">Wis</option>
+												<option value="Charisma">Cha</option>
+											</select>
 										</div>
-										<div class="sheet-pc-skill">
+										<div class="sheet-pc-skill sheet-pc-skill-sleight-of-hand">
 											<div class="sheet-checkbox-image">
 												<input type="checkbox" name="attr_sleight_of_hand_prof" title="@{sleight_of_hand_prof}" value="(@{pb}*@{sleight_of_hand_type})">
 												<span></span>
 											</div>
 											<span name='attr_sleight_of_hand_bonus' title='@{sleight_of_hand_bonus}'>0</span>
-											<button type='roll' name='roll_sleight_of_hand' value='@{wtype}&{template:simple} {{rname=Sleight of Hand}} {{mod=@{sleight_of_hand_bonus}}} {{r1=[[@{d20}+@{sleight_of_hand_bonus}@{pbd_safe}]]}} @{rtype}+@{sleight_of_hand_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Sleight of Hand <span>(Dex)</span></button>
+											<button type='roll' name='roll_sleight_of_hand' value='@{wtype}&{template:simple} {{rname=@{sleight_of_hand_attribute} (Sleight of Hand)}} {{mod=@{sleight_of_hand_bonus}}} {{r1=[[@{d20}+@{sleight_of_hand_bonus}@{pbd_safe}]]}} @{rtype}+@{sleight_of_hand_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Sleight of Hand</button>
+											<select name="attr_sleight_of_hand_attribute" title="@{sleight_of_hand_attribute}">
+												<option value="Strength">Str</option>
+												<option value="Dexterity" selected="selected">Dex</option>
+												<option value="Constitution">Con</option>
+												<option value="Intelligence">Int</option>
+												<option value="Wisdom">Wis</option>
+												<option value="Charisma">Cha</option>
+											</select>
 										</div>
 										<div class="sheet-pc-skill">
 											<div class="sheet-checkbox-image">
@@ -1335,7 +1463,15 @@
 												<span></span>
 											</div>
 											<span name='attr_stealth_bonus' title='@{stealth_bonus}'>0</span>
-											<button type='roll' name='roll_stealth' value='@{wtype}&{template:simple} {{rname=Stealth}} {{mod=@{stealth_bonus}}} {{r1=[[@{d20}+@{stealth_bonus}@{pbd_safe}]]}} @{rtype}+@{stealth_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Stealth <span>(Dex)</span></button>
+											<button type='roll' name='roll_stealth' value='@{wtype}&{template:simple} {{rname=@{stealth_attribute} (Stealth)}} {{mod=@{stealth_bonus}}} {{r1=[[@{d20}+@{stealth_bonus}@{pbd_safe}]]}} @{rtype}+@{stealth_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Stealth</button>
+											<select name="attr_stealth_attribute" title="@{stealth_attribute}">
+												<option value="Strength">Str</option>
+												<option value="Dexterity" selected="selected">Dex</option>
+												<option value="Constitution">Con</option>
+												<option value="Intelligence">Int</option>
+												<option value="Wisdom">Wis</option>
+												<option value="Charisma">Cha</option>
+											</select>
 										</div>
 										<div class="sheet-pc-skill">
 											<div class="sheet-checkbox-image">
@@ -1343,7 +1479,15 @@
 												<span></span>
 											</div>
 											<span name='attr_survival_bonus' title='@{survival_bonus}'>0</span>
-											<button type='roll' name='roll_survival' value='@{wtype}&{template:simple} {{rname=Survival}} {{mod=@{survival_bonus}}} {{r1=[[@{d20}+@{survival_bonus}@{pbd_safe}]]}} @{rtype}+@{survival_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Survival <span>(Wis)</span></button>
+											<button type='roll' name='roll_survival' value='@{wtype}&{template:simple} {{rname=@{survival_attribute} (Survival)}} {{mod=@{survival_bonus}}} {{r1=[[@{d20}+@{survival_bonus}@{pbd_safe}]]}} @{rtype}+@{survival_bonus}@{pbd_safe}]]}} {{global=@{global_skill_mod}}} @{charname_output}'>Survival</button>
+											<select name="attr_survival_attribute" title="@{survival_attribute}">
+												<option value="Strength">Str</option>
+												<option value="Dexterity">Dex</option>
+												<option value="Constitution">Con</option>
+												<option value="Intelligence">Int</option>
+												<option value="Wisdom" selected="selected">Wis</option>
+												<option value="Charisma">Cha</option>
+											</select>
 										</div>
 									</div>
 								</div>
@@ -1492,8 +1636,8 @@
 													</div>
 												</div>
 											</div>
-										</div>
-									</fieldset>
+										</fieldset>
+									</div>
 								</div>
 							</div>
 							<div class="sheet-container-well sheet-container-well-trackers">
@@ -2859,7 +3003,7 @@
 																<input type="text" name="attr_memory_name">
 															</div>
 															<div class="sheet-form-group">
-																<textarea name="attr_memory_description"/></textarea>
+																<textarea name="attr_memory_description"></textarea>
 															</div>
 														</div>
 													</div>
@@ -2893,7 +3037,7 @@
 																<input type="text" name="attr_note_name">
 															</div>
 															<div class="sheet-form-group">
-																<textarea name="attr_note_description"/></textarea>
+																<textarea name="attr_note_description"></textarea>
 															</div>
 														</div>
 													</div>
@@ -2943,7 +3087,13 @@
 																<input type="text" name="attr_source_type">
 															</div>
 															<div class="sheet-form-group">
-																<textarea name="attr_description"/></textarea>
+																<textarea name="attr_description"></textarea>
+															</div>
+															<div class="sheet-form-group">
+																<label class="sheet-form-checkbox">
+																	<input type="checkbox" name="attr_hide_details" value="1">
+																	<span>Hide Details</span>
+																</label>
 															</div>
 														</div>
 													</div>
@@ -2954,6 +3104,7 @@
 															<div class="sheet-pc-feature-name">
 																<span name="attr_name"></span>
 															</div>
+															<input type="hidden" name="attr_hide_details" class="sheet-field-untoggle">
 															<div class="sheet-pc-feature-details">
 																<span class="sheet-pc-feature-source">
 																	<span name="attr_source"></span>
@@ -2961,7 +3112,6 @@
 																</span>
 																<span name="attr_description"></span>
 															</div>
-															<div>
 														</button>
 													</div>
 												</div>
@@ -3062,31 +3212,41 @@
 							</div>
 							<div class="sheet-container-well sheet-container-well-equipment-purse">
 								<div class="sheet-container-bar sheet-pc-purse-cp">
-									<div class="sheet-container-header">Copper</div>
+									<div class="sheet-container-header">
+										<input type="text" name="attr_cp_title" title="@{cp_title}" value="COPPER">
+									</div>
 									<div class="sheet-container-body">
 										<input type="text" name="attr_cp" title="@{cp}">
 									</div>
 								</div>
 								<div class="sheet-container-bar sheet-pc-purse-sp">
-									<div class="sheet-container-header">Silver</div>
+									<div class="sheet-container-header">
+										<input type="text" name="attr_sp_title" title="@{sp_title}" value="SILVER">
+									</div>
 									<div class="sheet-container-body">
 										<input type="text" name="attr_sp" title="@{sp}">
 									</div>
 								</div>
 								<div class="sheet-container-bar sheet-pc-purse-gp">
-									<div class="sheet-container-header">Gold</div>
+									<div class="sheet-container-header">
+										<input type="text" name="attr_gp_title" title="@{gp_title}" value="GOLD">
+									</div>
 									<div class="sheet-container-body">
 										<input type="text" name="attr_gp" title="@{gp}">
 									</div>
 								</div>
 								<div class="sheet-container-bar sheet-pc-purse-ep">
-									<div class="sheet-container-header">Electrum</div>
+									<div class="sheet-container-header">
+										<input type="text" name="attr_ep_title" title="@{ep_title}" value="ELECTRUM">
+									</div>
 									<div class="sheet-container-body">
 										<input type="text" name="attr_ep" title="@{ep}">
 									</div>
 								</div>
 								<div class="sheet-container-bar sheet-pc-purse-pp">
-									<div class="sheet-container-header">Platinum</div>
+									<div class="sheet-container-header">
+										<input type="text" name="attr_pp_title" title="@{pp_title}" value="PLATINUM">
+									</div>
 									<div class="sheet-container-body">
 										<input type="text" name="attr_pp" title="@{pp}">
 									</div>
@@ -3192,6 +3352,7 @@
 														<div class="sheet-form-header">Edit Item</div>
 														<div class="sheet-form-body">
 															<input type="hidden" name="attr_equipped">
+															<input type="hidden" name="attr_carried">
 															<input type="hidden" name="attr_inventorysubflag">
 															<input type="hidden" name="attr_itemattackid">
 															<input type="hidden" name="attr_itemresourceid">
@@ -3279,9 +3440,13 @@
 																			</select>
 																		</div>
 																		<div class="sheet-form-group">
-																			<label>Slots:</label>
+																			<label>Max. Capacity (Slots):</label>
 																			<input type="text" name="attr_itemcontainer_slots" value="3">
 																		</div>
+																	</div>
+																	<div class="sheet-form-group">
+																		<label>Inventory Slots Modifier:</label>
+																		<input type="text" name="attr_itemcontainer_slots_modifier">
 																	</div>
 																</div>
 															</div>
@@ -3290,6 +3455,12 @@
 																	<label class="sheet-form-checkbox">
 																		<input type="checkbox" name="attr_equipped" value="1" checked="checked">
 																		<span>Equipped</span>
+																	</label>
+																</div>
+																<div class="sheet-form-group">
+																	<label class="sheet-form-checkbox">
+																		<input type="checkbox" name="attr_carried" value="1" checked="checked">
+																		<span>Carried</span>
 																	</label>
 																</div>
 																<div class="sheet-form-group">
@@ -3332,28 +3503,41 @@
 																<span class="sheet-pc-item-name">
 																	<input type="hidden" name="attr_equipped" value="1" class="sheet-field-toggle">
 																	<span class="sheet-pc-item-equipped"><strong>E</strong></span>
+																	<input type="hidden" name="attr_carried" value="1" class="sheet-field-toggle">
+																	<span class="sheet-pc-item-carried"><strong>C</strong></span>
 																	<span name="attr_itemname"></span>
 																</span>
 																<span class="sheet-pc-item-quantity">
-																	<span name="attr_itemcount"></span>
+																	<input type="text" name="attr_itemcount">
 																</span>
 																<span class="sheet-pc-item-weight">
+																	<input type="text" name="attr_itemweight">
 																	<span name="attr_itemweight"></span>
 																</span>
 																<span class="sheet-pc-item-slots">
-																	<span name="attr_itemsize"></span>
+																	<input type="text" name="attr_itemsize">
 																</span>
 																<span class="sheet-pc-item-notches">
-																	<span name="attr_itemnotches"></span>
+																	<input type="text" name="attr_itemnotches">
 																</span>
 															</div>
 														</div>
 													</div>
 													<div class="sheet-toggle-checked">
 														<div class="sheet-pc-equipment-container">
+															<input type="hidden" name="attr_equipped" value="1" class="sheet-field-toggle">
+															<span class="sheet-pc-item-equipped"><strong>E</strong></span>
+															<input type="hidden" name="attr_carried" value="1" class="sheet-field-toggle">
+															<span class="sheet-pc-item-carried"><strong>C</strong></span>
 															<span name="attr_itemname"></span>
 															<span class="sheet-pc-equipment-container-slots">
-																(<span name="attr_itemcontainer_slots"></span>-slot <span name="attr_itemcontainer_type"></span>)
+																(
+																<span name="attr_itemcontainer_type"></span>
+																<input type="hidden" name="attr_itemcontainer_slots" class="sheet-field-toggle">
+																<span>· capacity <span name="attr_itemcontainer_slots"></span></span>
+																<input type="hidden" name="attr_itemcontainer_slots_modifier" class="sheet-field-toggle">
+																<span>· extra slots <span name="attr_itemcontainer_slots_modifier"></span></span>
+																)
 															</span>
 														</div>
 														<div class="sheet-pc-equipment-container-footer">
@@ -3650,7 +3834,7 @@
 															<input type="checkbox" name="attr_spellprepared" value="1">
 															<span></span>
 														</div>
-														<input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}}	{{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
+														<input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}} {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
 														<button type="roll" name="roll_spell" value="@{rollcontent}" class="sheet-pc-spell-button">
 															<span class="sheet-pc-spell-name">
 																<span name="attr_spellname"></span>
@@ -3875,7 +4059,7 @@
 															<input type="checkbox" name="attr_spellprepared" value="1">
 															<span></span>
 														</div>
-														<input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}}	{{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
+														<input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}} {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
 														<button type="roll" name="roll_spell" value="@{rollcontent}" class="sheet-pc-spell-button">
 															<span class="sheet-pc-spell-name">
 																<span name="attr_spellname"></span>
@@ -4100,7 +4284,7 @@
 															<input type="checkbox" name="attr_spellprepared" value="1">
 															<span></span>
 														</div>
-														<input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}}	{{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
+														<input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}} {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
 														<button type="roll" name="roll_spell" value="@{rollcontent}" class="sheet-pc-spell-button">
 															<span class="sheet-pc-spell-name">
 																<span name="attr_spellname"></span>
@@ -4325,7 +4509,7 @@
 															<input type="checkbox" name="attr_spellprepared" value="1">
 															<span></span>
 														</div>
-														<input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}}	{{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
+														<input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}} {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
 														<button type="roll" name="roll_spell" value="@{rollcontent}" class="sheet-pc-spell-button">
 															<span class="sheet-pc-spell-name">
 																<span name="attr_spellname"></span>
@@ -4361,219 +4545,219 @@
 									</div>
 									<div class="sheet-container-body">
 										<fieldset class="repeating_spell-4">
-												<div class="sheet-fieldset-item">
-													<div class="sheet-checkbox-cog">
-														<input type="checkbox" name="attr_options-flag" checked="checked">
-														<span class="sheet-toggle-icon"></span>
-													</div>
-													<input type="checkbox" name="attr_options-flag" checked="checked" class="sheet-toggle" hidden>
-													<div class="sheet-toggle-checked">
-														<div class="sheet-form">
-															<div class="sheet-form-header">Edit Spell</div>
-															<div class="sheet-form-body">
-																<input type="hidden" name="attr_spellattackid">
-																<input type="hidden" name="attr_spelllevel" value="4">
-																<input type="hidden" name="attr_spelloutput">
-																<input type="hidden" name="attr_spellcomp">
-																<div class="sheet-form-group">
-																	<label>Name:</label>
-																	<input type="text" name="attr_spellname">
-																</div>
-																<div class="sheet-form-group">
-																	<label>School:</label>
-																	<select name="attr_spellschool">
-																		<option value="abjuration">Abjuration</option>
-																		<option value="conjuration">Conjuration</option>
-																		<option value="divination">Divination</option>
-																		<option value="enchantment">Enchantment</option>
-																		<option value="evocation">Evocation</option>
-																		<option value="illusion">Illusion</option>
-																		<option value="necromancy">Necromancy</option>
-																		<option value="transmutation">Transmutation</option>
-																	</select>
-																	<label class="sheet-form-checkbox">
-																		<input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-																		<span>Ritual</span>
-																	</label>
-																</div>
-																<div class="sheet-form-group">
-																	<label>Casting Time:</label>
-																	<input type="text" name="attr_spellcastingtime">
-																</div>
-																<div class="sheet-form-group">
-																	<label>Range:</label>
-																	<input type="text" name="attr_spellrange">
-																</div>
-																<div class="sheet-form-group">
-																	<label>Target:</label>
-																	<input type="text" name="attr_spelltarget">
-																</div>
-																<div class="sheet-form-group">
-																	<label>Components:</label>
-																	<label class="sheet-form-checkbox">
-																		<input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-																		<span>V</span>
-																	</label>
-																	<label class="sheet-form-checkbox">
-																		<input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-																		<span>S</span>
-																	</label>
-																	<label class="sheet-form-checkbox">
-																		<input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-																		<span>M</span>
-																	</label>
-																	<input type="text" name="attr_spellcomp_materials">
-																</div>
-																<div class="sheet-form-group">
-																	<label class="sheet-form-checkbox">
-																		<input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-																		<span>Concentration</span>
-																	</label>
-																</div>
-																<div class="sheet-form-group">
-																	<label>Duration:</label>
-																	<input type="text" name="attr_spellduration">
-																</div>
-																<div class="sheet-form-group">
-																	<label>Spellcasting Ability</label>
-																	<select name="attr_spell_ability">
-																		<option value="0*">&mdash;</option>
-																		<option value="spell">SPELL</option>
-																		<option value="@{strength_mod}+">STR</option>
-																		<option value="@{dexterity_mod}+">DEX</option>
-																		<option value="@{constitution_mod}+">CON</option>
-																		<option value="@{intelligence_mod}+">INT</option>
-																		<option value="@{wisdom_mod}+">WIS</option>
-																		<option value="@{charisma_mod}+">CHA</option>
-																	</select>
-																</div>
-																<div class="sheet-form-group">
-																	<label>Innate:</label>
-																	<input type="text" name="attr_innate" value="">
-																</div>
-																<div class="sheet-form-group">
-																	<label>Output:</label>
-																	<select name="attr_spelloutput">
-																		<option value="SPELLCARD">SPELLCARD</option>
-																		<option value="ATTACK">ATTACK</option>
-																	</select>
-																</div>
-																<div class="sheet-form-group">
-																	<label>Spell Attack:</label>
-																	<select name="attr_spellattack">
-																		<option value="None">None</option>
-																		<option value="Melee">Melee</option>
-																		<option value="Ranged">Ranged</option>
-																	</select>
-																</div>
-																<div class="sheet-form-group">
-																	<label>Damage 1:</label>
-																	<input type="text" name="attr_spelldamage">
-																	<label>Type:</label>
-																	<input type="text" name="attr_spelldamagetype">
-																</div>
-																<div class="sheet-form-group">
-																	<label>Damage 2:</label>
-																	<input type="text" name="attr_spelldamage2">
-																	<label>Type:</label>
-																	<input type="text" name="attr_spelldamagetype2">
-																</div>
-																<div class="sheet-form-group">
-																	<label>Healing:</label>
-																	<input type="text" name="attr_spellhealing">
-																</div>
-																<div class="sheet-form-group">
-																	<label class="sheet-form-checkbox">
-																		<input type="checkbox" name="attr_spelldmgmod" value="Yes">
-																		<span>Add Ability Mod to Damage or Healing</span>
-																	</label>
-																</div>
-																<div class="sheet-form-group">
-																	<label>Cantrip Progression:</label>
-																	<select name="attr_spell_damage_progression">
-																		<option value="" selected="selected">&mdash;</option>
-																		<option value="Cantrip Dice">CANTRIP DICE</option>
-																		<option value="Cantrip Beam">CANTRIP BEAM</option>
-																	</select>
-																</div>
-																<div class="sheet-form-group">
-																	<label>Saving Throw:</label>
-																	<select name="attr_spellsave">
-																		<option value="" selected="selected">&mdash;</option>
-																		<option value="Strength">STR</option>
-																		<option value="Dexterity">DEX</option>
-																		<option value="Constitution">CON</option>
-																		<option value="Intelligence">INT</option>
-																		<option value="Wisdom">WIS</option>
-																		<option value="Charisma">CHA</option>
-																	</select>
-																	<label>Effect:</label>
-																	<input type="text" name="attr_spellsavesuccess">
-																</div>
-																<div class="sheet-form-group">
-																	<label>Higher Lvl Cast Dmg:</label>
-																	<input type="text" name="attr_spellhldie" placeholder="1">
-																	<select name="attr_spellhldietype">
-																		<option value="" selected="selected">&mdash;</option>
-																		<option value="d4">d4</option>
-																		<option value="d6">d6</option>
-																		<option value="d8">d8</option>
-																		<option value="d10">d10</option>
-																		<option value="d12">d12</option>
-																		<option value="d20">d20</option>
-																	</select>
-																	<span>+</span>
-																	<input type="text" name="attr_spellhlbonus" placeholder="0">
-																</div>
-																<div class="sheet-form-group">
-																	<label>Include Spell Description in Attack:</label>
-																	<select name="attr_includedesc">
-																		<option value="off" selected="selected">Off</option>
-																		<option value="partial">Partial</option>
-																		<option value="on">On</option>
-																	</select>
-																</div>
-																<div class="sheet-form-group">
-																	<label>Description:</label>
-																	<textarea name="attr_spelldescription"></textarea>
-																</div>
-																<div class="sheet-form-group">
-																	<label>At Higher Levels:</label>
-																	<textarea name="attr_spellathigherlevels"></textarea>
-																</div>
+											<div class="sheet-fieldset-item">
+												<div class="sheet-checkbox-cog">
+													<input type="checkbox" name="attr_options-flag" checked="checked">
+													<span class="sheet-toggle-icon"></span>
+												</div>
+												<input type="checkbox" name="attr_options-flag" checked="checked" class="sheet-toggle" hidden>
+												<div class="sheet-toggle-checked">
+													<div class="sheet-form">
+														<div class="sheet-form-header">Edit Spell</div>
+														<div class="sheet-form-body">
+															<input type="hidden" name="attr_spellattackid">
+															<input type="hidden" name="attr_spelllevel" value="4">
+															<input type="hidden" name="attr_spelloutput">
+															<input type="hidden" name="attr_spellcomp">
+															<div class="sheet-form-group">
+																<label>Name:</label>
+																<input type="text" name="attr_spellname">
 															</div>
-														</div>
-													</div>
-													<div class="sheet-toggle-unchecked">
-														<div class="sheet-pc-spell">
-															<div class="sheet-checkbox-image">
-																<input type="checkbox" name="attr_spellprepared" value="1">
-																<span></span>
+															<div class="sheet-form-group">
+																<label>School:</label>
+																<select name="attr_spellschool">
+																	<option value="abjuration">Abjuration</option>
+																	<option value="conjuration">Conjuration</option>
+																	<option value="divination">Divination</option>
+																	<option value="enchantment">Enchantment</option>
+																	<option value="evocation">Evocation</option>
+																	<option value="illusion">Illusion</option>
+																	<option value="necromancy">Necromancy</option>
+																	<option value="transmutation">Transmutation</option>
+																</select>
+																<label class="sheet-form-checkbox">
+																	<input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+																	<span>Ritual</span>
+																</label>
 															</div>
-															<input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}}	{{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
-															<button type="roll" name="roll_spell" value="@{rollcontent}" class="sheet-pc-spell-button">
-																<span class="sheet-pc-spell-name">
-																	<span name="attr_spellname"></span>
-																	<input type="hidden" name="attr_innate" value="" class="sheet-field-toggle">
-																	<span name="attr_innate" class="sheet-display-brackets"></span>
-																</span>
-																<span class="sheet-pc-spell-components">
-																	<input type="hidden" name="attr_spellritual" value="0" class="sheet-field-toggle">
-																	<span>R</span>
-																	<input type="hidden" name="attr_spellconcentration" value="0" class="sheet-field-toggle">
-																	<span>C</span>
-																	<input type="hidden" name="attr_spellcomp_v" value="{{v=1}}" class="sheet-field-toggle">
+															<div class="sheet-form-group">
+																<label>Casting Time:</label>
+																<input type="text" name="attr_spellcastingtime">
+															</div>
+															<div class="sheet-form-group">
+																<label>Range:</label>
+																<input type="text" name="attr_spellrange">
+															</div>
+															<div class="sheet-form-group">
+																<label>Target:</label>
+																<input type="text" name="attr_spelltarget">
+															</div>
+															<div class="sheet-form-group">
+																<label>Components:</label>
+																<label class="sheet-form-checkbox">
+																	<input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
 																	<span>V</span>
-																	<input type="hidden" name="attr_spellcomp_s" value="{{s=1}}" class="sheet-field-toggle">
+																</label>
+																<label class="sheet-form-checkbox">
+																	<input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
 																	<span>S</span>
-																	<input type="hidden" name="attr_spellcomp_m" value="{{m=1}}" class="sheet-field-toggle">
+																</label>
+																<label class="sheet-form-checkbox">
+																	<input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
 																	<span>M</span>
-																</span>
-															</button>
+																</label>
+																<input type="text" name="attr_spellcomp_materials">
+															</div>
+															<div class="sheet-form-group">
+																<label class="sheet-form-checkbox">
+																	<input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+																	<span>Concentration</span>
+																</label>
+															</div>
+															<div class="sheet-form-group">
+																<label>Duration:</label>
+																<input type="text" name="attr_spellduration">
+															</div>
+															<div class="sheet-form-group">
+																<label>Spellcasting Ability</label>
+																<select name="attr_spell_ability">
+																	<option value="0*">&mdash;</option>
+																	<option value="spell">SPELL</option>
+																	<option value="@{strength_mod}+">STR</option>
+																	<option value="@{dexterity_mod}+">DEX</option>
+																	<option value="@{constitution_mod}+">CON</option>
+																	<option value="@{intelligence_mod}+">INT</option>
+																	<option value="@{wisdom_mod}+">WIS</option>
+																	<option value="@{charisma_mod}+">CHA</option>
+																</select>
+															</div>
+															<div class="sheet-form-group">
+																<label>Innate:</label>
+																<input type="text" name="attr_innate" value="">
+															</div>
+															<div class="sheet-form-group">
+																<label>Output:</label>
+																<select name="attr_spelloutput">
+																	<option value="SPELLCARD">SPELLCARD</option>
+																	<option value="ATTACK">ATTACK</option>
+																</select>
+															</div>
+															<div class="sheet-form-group">
+																<label>Spell Attack:</label>
+																<select name="attr_spellattack">
+																	<option value="None">None</option>
+																	<option value="Melee">Melee</option>
+																	<option value="Ranged">Ranged</option>
+																</select>
+															</div>
+															<div class="sheet-form-group">
+																<label>Damage 1:</label>
+																<input type="text" name="attr_spelldamage">
+																<label>Type:</label>
+																<input type="text" name="attr_spelldamagetype">
+															</div>
+															<div class="sheet-form-group">
+																<label>Damage 2:</label>
+																<input type="text" name="attr_spelldamage2">
+																<label>Type:</label>
+																<input type="text" name="attr_spelldamagetype2">
+															</div>
+															<div class="sheet-form-group">
+																<label>Healing:</label>
+																<input type="text" name="attr_spellhealing">
+															</div>
+															<div class="sheet-form-group">
+																<label class="sheet-form-checkbox">
+																	<input type="checkbox" name="attr_spelldmgmod" value="Yes">
+																	<span>Add Ability Mod to Damage or Healing</span>
+																</label>
+															</div>
+															<div class="sheet-form-group">
+																<label>Cantrip Progression:</label>
+																<select name="attr_spell_damage_progression">
+																	<option value="" selected="selected">&mdash;</option>
+																	<option value="Cantrip Dice">CANTRIP DICE</option>
+																	<option value="Cantrip Beam">CANTRIP BEAM</option>
+																</select>
+															</div>
+															<div class="sheet-form-group">
+																<label>Saving Throw:</label>
+																<select name="attr_spellsave">
+																	<option value="" selected="selected">&mdash;</option>
+																	<option value="Strength">STR</option>
+																	<option value="Dexterity">DEX</option>
+																	<option value="Constitution">CON</option>
+																	<option value="Intelligence">INT</option>
+																	<option value="Wisdom">WIS</option>
+																	<option value="Charisma">CHA</option>
+																</select>
+																<label>Effect:</label>
+																<input type="text" name="attr_spellsavesuccess">
+															</div>
+															<div class="sheet-form-group">
+																<label>Higher Lvl Cast Dmg:</label>
+																<input type="text" name="attr_spellhldie" placeholder="1">
+																<select name="attr_spellhldietype">
+																	<option value="" selected="selected">&mdash;</option>
+																	<option value="d4">d4</option>
+																	<option value="d6">d6</option>
+																	<option value="d8">d8</option>
+																	<option value="d10">d10</option>
+																	<option value="d12">d12</option>
+																	<option value="d20">d20</option>
+																</select>
+																<span>+</span>
+																<input type="text" name="attr_spellhlbonus" placeholder="0">
+															</div>
+															<div class="sheet-form-group">
+																<label>Include Spell Description in Attack:</label>
+																<select name="attr_includedesc">
+																	<option value="off" selected="selected">Off</option>
+																	<option value="partial">Partial</option>
+																	<option value="on">On</option>
+																</select>
+															</div>
+															<div class="sheet-form-group">
+																<label>Description:</label>
+																<textarea name="attr_spelldescription"></textarea>
+															</div>
+															<div class="sheet-form-group">
+																<label>At Higher Levels:</label>
+																<textarea name="attr_spellathigherlevels"></textarea>
+															</div>
 														</div>
 													</div>
 												</div>
-											</fieldset>
+												<div class="sheet-toggle-unchecked">
+													<div class="sheet-pc-spell">
+														<div class="sheet-checkbox-image">
+															<input type="checkbox" name="attr_spellprepared" value="1">
+															<span></span>
+														</div>
+														<input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}} {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
+														<button type="roll" name="roll_spell" value="@{rollcontent}" class="sheet-pc-spell-button">
+															<span class="sheet-pc-spell-name">
+																<span name="attr_spellname"></span>
+																<input type="hidden" name="attr_innate" value="" class="sheet-field-toggle">
+																<span name="attr_innate" class="sheet-display-brackets"></span>
+															</span>
+															<span class="sheet-pc-spell-components">
+																<input type="hidden" name="attr_spellritual" value="0" class="sheet-field-toggle">
+																<span>R</span>
+																<input type="hidden" name="attr_spellconcentration" value="0" class="sheet-field-toggle">
+																<span>C</span>
+																<input type="hidden" name="attr_spellcomp_v" value="{{v=1}}" class="sheet-field-toggle">
+																<span>V</span>
+																<input type="hidden" name="attr_spellcomp_s" value="{{s=1}}" class="sheet-field-toggle">
+																<span>S</span>
+																<input type="hidden" name="attr_spellcomp_m" value="{{m=1}}" class="sheet-field-toggle">
+																<span>M</span>
+															</span>
+														</button>
+													</div>
+												</div>
+											</div>
+										</fieldset>
 									</div>
 								</div>
 								<div class="sheet-container-spell">
@@ -4775,7 +4959,7 @@
 															<input type="checkbox" name="attr_spellprepared" value="1">
 															<span></span>
 														</div>
-														<input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}}	{{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
+														<input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}} {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
 														<button type="roll" name="roll_spell" value="@{rollcontent}" class="sheet-pc-spell-button">
 															<span class="sheet-pc-spell-name">
 																<span name="attr_spellname"></span>
@@ -5000,7 +5184,7 @@
 															<input type="checkbox" name="attr_spellprepared" value="1">
 															<span></span>
 														</div>
-														<input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}}	{{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
+														<input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}} {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
 														<button type="roll" name="roll_spell" value="@{rollcontent}" class="sheet-pc-spell-button">
 															<span class="sheet-pc-spell-name">
 																<span name="attr_spellname"></span>
@@ -5225,7 +5409,7 @@
 															<input type="checkbox" name="attr_spellprepared" value="1">
 															<span></span>
 														</div>
-														<input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}}	{{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
+														<input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}} {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
 														<button type="roll" name="roll_spell" value="@{rollcontent}" class="sheet-pc-spell-button">
 															<span class="sheet-pc-spell-name">
 																<span name="attr_spellname"></span>
@@ -5451,7 +5635,7 @@
 																<input type="checkbox" name="attr_spellprepared" value="1">
 																<span></span>
 															</div>
-															<input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}}	{{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
+															<input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}} {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
 															<button type="roll" name="roll_spell" value="@{rollcontent}" class="sheet-pc-spell-button">
 																<span class="sheet-pc-spell-name">
 																	<span name="attr_spellname"></span>
@@ -5487,219 +5671,219 @@
 										</div>
 										<div class="sheet-container-body">
 											<fieldset class="repeating_spell-9">
-													<div class="sheet-fieldset-item">
-														<div class="sheet-checkbox-cog">
-															<input type="checkbox" name="attr_options-flag" checked="checked">
-															<span class="sheet-toggle-icon"></span>
-														</div>
-														<input type="checkbox" name="attr_options-flag" checked="checked" class="sheet-toggle" hidden>
-														<div class="sheet-toggle-checked">
-															<div class="sheet-form">
-																<div class="sheet-form-header">Edit Spell</div>
-																<div class="sheet-form-body">
-																	<input type="hidden" name="attr_spellattackid">
-																	<input type="hidden" name="attr_spelllevel" value="9">
-																	<input type="hidden" name="attr_spelloutput">
-																	<input type="hidden" name="attr_spellcomp">
-																	<div class="sheet-form-group">
-																		<label>Name:</label>
-																		<input type="text" name="attr_spellname">
-																	</div>
-																	<div class="sheet-form-group">
-																		<label>School:</label>
-																		<select name="attr_spellschool">
-																			<option value="abjuration">Abjuration</option>
-																			<option value="conjuration">Conjuration</option>
-																			<option value="divination">Divination</option>
-																			<option value="enchantment">Enchantment</option>
-																			<option value="evocation">Evocation</option>
-																			<option value="illusion">Illusion</option>
-																			<option value="necromancy">Necromancy</option>
-																			<option value="transmutation">Transmutation</option>
-																		</select>
-																		<label class="sheet-form-checkbox">
-																			<input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
-																			<span>Ritual</span>
-																		</label>
-																	</div>
-																	<div class="sheet-form-group">
-																		<label>Casting Time:</label>
-																		<input type="text" name="attr_spellcastingtime">
-																	</div>
-																	<div class="sheet-form-group">
-																		<label>Range:</label>
-																		<input type="text" name="attr_spellrange">
-																	</div>
-																	<div class="sheet-form-group">
-																		<label>Target:</label>
-																		<input type="text" name="attr_spelltarget">
-																	</div>
-																	<div class="sheet-form-group">
-																		<label>Components:</label>
-																		<label class="sheet-form-checkbox">
-																			<input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
-																			<span>V</span>
-																		</label>
-																		<label class="sheet-form-checkbox">
-																			<input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
-																			<span>S</span>
-																		</label>
-																		<label class="sheet-form-checkbox">
-																			<input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
-																			<span>M</span>
-																		</label>
-																		<input type="text" name="attr_spellcomp_materials">
-																	</div>
-																	<div class="sheet-form-group">
-																		<label class="sheet-form-checkbox">
-																			<input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
-																			<span>Concentration</span>
-																		</label>
-																	</div>
-																	<div class="sheet-form-group">
-																		<label>Duration:</label>
-																		<input type="text" name="attr_spellduration">
-																	</div>
-																	<div class="sheet-form-group">
-																		<label>Spellcasting Ability</label>
-																		<select name="attr_spell_ability">
-																			<option value="0*">&mdash;</option>
-																			<option value="spell">SPELL</option>
-																			<option value="@{strength_mod}+">STR</option>
-																			<option value="@{dexterity_mod}+">DEX</option>
-																			<option value="@{constitution_mod}+">CON</option>
-																			<option value="@{intelligence_mod}+">INT</option>
-																			<option value="@{wisdom_mod}+">WIS</option>
-																			<option value="@{charisma_mod}+">CHA</option>
-																		</select>
-																	</div>
-																	<div class="sheet-form-group">
-																		<label>Innate:</label>
-																		<input type="text" name="attr_innate" value="">
-																	</div>
-																	<div class="sheet-form-group">
-																		<label>Output:</label>
-																		<select name="attr_spelloutput">
-																			<option value="SPELLCARD">SPELLCARD</option>
-																			<option value="ATTACK">ATTACK</option>
-																		</select>
-																	</div>
-																	<div class="sheet-form-group">
-																		<label>Spell Attack:</label>
-																		<select name="attr_spellattack">
-																			<option value="None">None</option>
-																			<option value="Melee">Melee</option>
-																			<option value="Ranged">Ranged</option>
-																		</select>
-																	</div>
-																	<div class="sheet-form-group">
-																		<label>Damage 1:</label>
-																		<input type="text" name="attr_spelldamage">
-																		<label>Type:</label>
-																		<input type="text" name="attr_spelldamagetype">
-																	</div>
-																	<div class="sheet-form-group">
-																		<label>Damage 2:</label>
-																		<input type="text" name="attr_spelldamage2">
-																		<label>Type:</label>
-																		<input type="text" name="attr_spelldamagetype2">
-																	</div>
-																	<div class="sheet-form-group">
-																		<label>Healing:</label>
-																		<input type="text" name="attr_spellhealing">
-																	</div>
-																	<div class="sheet-form-group">
-																		<label class="sheet-form-checkbox">
-																			<input type="checkbox" name="attr_spelldmgmod" value="Yes">
-																			<span>Add Ability Mod to Damage or Healing</span>
-																		</label>
-																	</div>
-																	<div class="sheet-form-group">
-																		<label>Cantrip Progression:</label>
-																		<select name="attr_spell_damage_progression">
-																			<option value="" selected="selected">&mdash;</option>
-																			<option value="Cantrip Dice">CANTRIP DICE</option>
-																			<option value="Cantrip Beam">CANTRIP BEAM</option>
-																		</select>
-																	</div>
-																	<div class="sheet-form-group">
-																		<label>Saving Throw:</label>
-																		<select name="attr_spellsave">
-																			<option value="" selected="selected">&mdash;</option>
-																			<option value="Strength">STR</option>
-																			<option value="Dexterity">DEX</option>
-																			<option value="Constitution">CON</option>
-																			<option value="Intelligence">INT</option>
-																			<option value="Wisdom">WIS</option>
-																			<option value="Charisma">CHA</option>
-																		</select>
-																		<label>Effect:</label>
-																		<input type="text" name="attr_spellsavesuccess">
-																	</div>
-																	<div class="sheet-form-group">
-																		<label>Higher Lvl Cast Dmg:</label>
-																		<input type="text" name="attr_spellhldie" placeholder="1">
-																		<select name="attr_spellhldietype">
-																			<option value="" selected="selected">&mdash;</option>
-																			<option value="d4">d4</option>
-																			<option value="d6">d6</option>
-																			<option value="d8">d8</option>
-																			<option value="d10">d10</option>
-																			<option value="d12">d12</option>
-																			<option value="d20">d20</option>
-																		</select>
-																		<span>+</span>
-																		<input type="text" name="attr_spellhlbonus" placeholder="0">
-																	</div>
-																	<div class="sheet-form-group">
-																		<label>Include Spell Description in Attack:</label>
-																		<select name="attr_includedesc">
-																			<option value="off" selected="selected">Off</option>
-																			<option value="partial">Partial</option>
-																			<option value="on">On</option>
-																		</select>
-																	</div>
-																	<div class="sheet-form-group">
-																		<label>Description:</label>
-																		<textarea name="attr_spelldescription"></textarea>
-																	</div>
-																	<div class="sheet-form-group">
-																		<label>At Higher Levels:</label>
-																		<textarea name="attr_spellathigherlevels"></textarea>
-																	</div>
+												<div class="sheet-fieldset-item">
+													<div class="sheet-checkbox-cog">
+														<input type="checkbox" name="attr_options-flag" checked="checked">
+														<span class="sheet-toggle-icon"></span>
+													</div>
+													<input type="checkbox" name="attr_options-flag" checked="checked" class="sheet-toggle" hidden>
+													<div class="sheet-toggle-checked">
+														<div class="sheet-form">
+															<div class="sheet-form-header">Edit Spell</div>
+															<div class="sheet-form-body">
+																<input type="hidden" name="attr_spellattackid">
+																<input type="hidden" name="attr_spelllevel" value="9">
+																<input type="hidden" name="attr_spelloutput">
+																<input type="hidden" name="attr_spellcomp">
+																<div class="sheet-form-group">
+																	<label>Name:</label>
+																	<input type="text" name="attr_spellname">
 																</div>
-															</div>
-														</div>
-														<div class="sheet-toggle-unchecked">
-															<div class="sheet-pc-spell">
-																<div class="sheet-checkbox-image">
-																	<input type="checkbox" name="attr_spellprepared" value="1">
-																	<span></span>
+																<div class="sheet-form-group">
+																	<label>School:</label>
+																	<select name="attr_spellschool">
+																		<option value="abjuration">Abjuration</option>
+																		<option value="conjuration">Conjuration</option>
+																		<option value="divination">Divination</option>
+																		<option value="enchantment">Enchantment</option>
+																		<option value="evocation">Evocation</option>
+																		<option value="illusion">Illusion</option>
+																		<option value="necromancy">Necromancy</option>
+																		<option value="transmutation">Transmutation</option>
+																	</select>
+																	<label class="sheet-form-checkbox">
+																		<input type="checkbox" name="attr_spellritual" value="{{ritual=1}}">
+																		<span>Ritual</span>
+																	</label>
 																</div>
-																<input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}}	{{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
-																<button type="roll" name="roll_spell" value="@{rollcontent}" class="sheet-pc-spell-button">
-																	<span class="sheet-pc-spell-name">
-																		<span name="attr_spellname"></span>
-																		<input type="hidden" name="attr_innate" value="" class="sheet-field-toggle">
-																		<span name="attr_innate" class="sheet-display-brackets"></span>
-																	</span>
-																	<span class="sheet-pc-spell-components">
-																		<input type="hidden" name="attr_spellritual" value="0" class="sheet-field-toggle">
-																		<span>R</span>
-																		<input type="hidden" name="attr_spellconcentration" value="0" class="sheet-field-toggle">
-																		<span>C</span>
-																		<input type="hidden" name="attr_spellcomp_v" value="{{v=1}}" class="sheet-field-toggle">
+																<div class="sheet-form-group">
+																	<label>Casting Time:</label>
+																	<input type="text" name="attr_spellcastingtime">
+																</div>
+																<div class="sheet-form-group">
+																	<label>Range:</label>
+																	<input type="text" name="attr_spellrange">
+																</div>
+																<div class="sheet-form-group">
+																	<label>Target:</label>
+																	<input type="text" name="attr_spelltarget">
+																</div>
+																<div class="sheet-form-group">
+																	<label>Components:</label>
+																	<label class="sheet-form-checkbox">
+																		<input type="checkbox" name="attr_spellcomp_v" value="{{v=1}}" checked="checked">
 																		<span>V</span>
-																		<input type="hidden" name="attr_spellcomp_s" value="{{s=1}}" class="sheet-field-toggle">
+																	</label>
+																	<label class="sheet-form-checkbox">
+																		<input type="checkbox" name="attr_spellcomp_s" value="{{s=1}}" checked="checked">
 																		<span>S</span>
-																		<input type="hidden" name="attr_spellcomp_m" value="{{m=1}}" class="sheet-field-toggle">
+																	</label>
+																	<label class="sheet-form-checkbox">
+																		<input type="checkbox" name="attr_spellcomp_m" value="{{m=1}}" checked="checked">
 																		<span>M</span>
-																	</span>
-																</button>
+																	</label>
+																	<input type="text" name="attr_spellcomp_materials">
+																</div>
+																<div class="sheet-form-group">
+																	<label class="sheet-form-checkbox">
+																		<input type="checkbox" name="attr_spellconcentration" value="{{concentration=1}}">
+																		<span>Concentration</span>
+																	</label>
+																</div>
+																<div class="sheet-form-group">
+																	<label>Duration:</label>
+																	<input type="text" name="attr_spellduration">
+																</div>
+																<div class="sheet-form-group">
+																	<label>Spellcasting Ability</label>
+																	<select name="attr_spell_ability">
+																		<option value="0*">&mdash;</option>
+																		<option value="spell">SPELL</option>
+																		<option value="@{strength_mod}+">STR</option>
+																		<option value="@{dexterity_mod}+">DEX</option>
+																		<option value="@{constitution_mod}+">CON</option>
+																		<option value="@{intelligence_mod}+">INT</option>
+																		<option value="@{wisdom_mod}+">WIS</option>
+																		<option value="@{charisma_mod}+">CHA</option>
+																	</select>
+																</div>
+																<div class="sheet-form-group">
+																	<label>Innate:</label>
+																	<input type="text" name="attr_innate" value="">
+																</div>
+																<div class="sheet-form-group">
+																	<label>Output:</label>
+																	<select name="attr_spelloutput">
+																		<option value="SPELLCARD">SPELLCARD</option>
+																		<option value="ATTACK">ATTACK</option>
+																	</select>
+																</div>
+																<div class="sheet-form-group">
+																	<label>Spell Attack:</label>
+																	<select name="attr_spellattack">
+																		<option value="None">None</option>
+																		<option value="Melee">Melee</option>
+																		<option value="Ranged">Ranged</option>
+																	</select>
+																</div>
+																<div class="sheet-form-group">
+																	<label>Damage 1:</label>
+																	<input type="text" name="attr_spelldamage">
+																	<label>Type:</label>
+																	<input type="text" name="attr_spelldamagetype">
+																</div>
+																<div class="sheet-form-group">
+																	<label>Damage 2:</label>
+																	<input type="text" name="attr_spelldamage2">
+																	<label>Type:</label>
+																	<input type="text" name="attr_spelldamagetype2">
+																</div>
+																<div class="sheet-form-group">
+																	<label>Healing:</label>
+																	<input type="text" name="attr_spellhealing">
+																</div>
+																<div class="sheet-form-group">
+																	<label class="sheet-form-checkbox">
+																		<input type="checkbox" name="attr_spelldmgmod" value="Yes">
+																		<span>Add Ability Mod to Damage or Healing</span>
+																	</label>
+																</div>
+																<div class="sheet-form-group">
+																	<label>Cantrip Progression:</label>
+																	<select name="attr_spell_damage_progression">
+																		<option value="" selected="selected">&mdash;</option>
+																		<option value="Cantrip Dice">CANTRIP DICE</option>
+																		<option value="Cantrip Beam">CANTRIP BEAM</option>
+																	</select>
+																</div>
+																<div class="sheet-form-group">
+																	<label>Saving Throw:</label>
+																	<select name="attr_spellsave">
+																		<option value="" selected="selected">&mdash;</option>
+																		<option value="Strength">STR</option>
+																		<option value="Dexterity">DEX</option>
+																		<option value="Constitution">CON</option>
+																		<option value="Intelligence">INT</option>
+																		<option value="Wisdom">WIS</option>
+																		<option value="Charisma">CHA</option>
+																	</select>
+																	<label>Effect:</label>
+																	<input type="text" name="attr_spellsavesuccess">
+																</div>
+																<div class="sheet-form-group">
+																	<label>Higher Lvl Cast Dmg:</label>
+																	<input type="text" name="attr_spellhldie" placeholder="1">
+																	<select name="attr_spellhldietype">
+																		<option value="" selected="selected">&mdash;</option>
+																		<option value="d4">d4</option>
+																		<option value="d6">d6</option>
+																		<option value="d8">d8</option>
+																		<option value="d10">d10</option>
+																		<option value="d12">d12</option>
+																		<option value="d20">d20</option>
+																	</select>
+																	<span>+</span>
+																	<input type="text" name="attr_spellhlbonus" placeholder="0">
+																</div>
+																<div class="sheet-form-group">
+																	<label>Include Spell Description in Attack:</label>
+																	<select name="attr_includedesc">
+																		<option value="off" selected="selected">Off</option>
+																		<option value="partial">Partial</option>
+																		<option value="on">On</option>
+																	</select>
+																</div>
+																<div class="sheet-form-group">
+																	<label>Description:</label>
+																	<textarea name="attr_spelldescription"></textarea>
+																</div>
+																<div class="sheet-form-group">
+																	<label>At Higher Levels:</label>
+																	<textarea name="attr_spellathigherlevels"></textarea>
+																</div>
 															</div>
 														</div>
 													</div>
-												</fieldset>
+													<div class="sheet-toggle-unchecked">
+														<div class="sheet-pc-spell">
+															<div class="sheet-checkbox-image">
+																<input type="checkbox" name="attr_spellprepared" value="1">
+																<span></span>
+															</div>
+															<input type="hidden" name="attr_rollcontent" value="@{wtype}&{template:spell} {{level=@{spellschool} @{spelllevel}}} {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}">
+															<button type="roll" name="roll_spell" value="@{rollcontent}" class="sheet-pc-spell-button">
+																<span class="sheet-pc-spell-name">
+																	<span name="attr_spellname"></span>
+																	<input type="hidden" name="attr_innate" value="" class="sheet-field-toggle">
+																	<span name="attr_innate" class="sheet-display-brackets"></span>
+																</span>
+																<span class="sheet-pc-spell-components">
+																	<input type="hidden" name="attr_spellritual" value="0" class="sheet-field-toggle">
+																	<span>R</span>
+																	<input type="hidden" name="attr_spellconcentration" value="0" class="sheet-field-toggle">
+																	<span>C</span>
+																	<input type="hidden" name="attr_spellcomp_v" value="{{v=1}}" class="sheet-field-toggle">
+																	<span>V</span>
+																	<input type="hidden" name="attr_spellcomp_s" value="{{s=1}}" class="sheet-field-toggle">
+																	<span>S</span>
+																	<input type="hidden" name="attr_spellcomp_m" value="{{m=1}}" class="sheet-field-toggle">
+																	<span>M</span>
+																</span>
+															</button>
+														</div>
+													</div>
+												</div>
+											</fieldset>
 										</div>
 									</div>
 								</div>
@@ -5995,8 +6179,8 @@
 											<div class="sheet-form-body">
 												<div class="sheet-form-group">
 													<label>Version:</label>
-													<input type="text" name="attr_version" value="2.1" hidden disabled>
-													<span name="attr_version"</span>
+													<input type="text" name="attr_version" value="2.2" hidden disabled>
+													<span name="attr_version"></span>
 												</div>
 												<div class="sheet-form-group">
 													<label class="sheet-form-checkbox" title="@{npc}">
@@ -6596,93 +6780,6 @@
 		</div>
 		<div class="sheet-section-templates">
 			<div class="sheet-rolltemplates">
-				<rolltemplate class="sheet-rolltemplate-simple">
-					<div class="container">
-						<div class="result">
-							{{#always}}
-								<div class="adv">
-									<span>{{r1}}{{#global}} + {{global}}{{/global}}</span>
-								</div>
-								<div class="advspacer"></div>
-								<div class="adv">
-									<span>{{r2}}{{#global}} + {{global}}{{/global}}</span>
-								</div>
-							{{/always}}
-							{{#normal}}
-								<div class="solo">
-									<span>{{r1}}{{#global}} + {{global}}{{/global}}</span>
-								</div>
-							{{/normal}}
-							{{#advantage}}
-								{{#rollLess() r1 r2}}
-									<div class="adv">
-										<span class="grey">{{r1}}{{#global}} + {{global}}{{/global}}</span>
-									</div>
-									<div class="advspacer"></div>
-									<div class="adv">
-										<span>{{r2}}{{#global}} + {{global}}{{/global}}</span>
-									</div>
-								{{/rollLess() r1 r2}}
-								{{#rollTotal() r1 r2}}
-									<div class="adv">
-										<span>{{r1}}{{#global}} + {{global}}{{/global}}</span>
-									</div>
-									<div class="advspacer"></div>
-									<div class="adv">
-										<span>{{r2}}{{#global}} + {{global}}{{/global}}</span>
-									</div>
-								{{/rollTotal() r1 r2}}
-								{{#rollGreater() r1 r2}}
-									<div class="adv">
-										<span>{{r1}}{{#global}} + {{global}}{{/global}}</span>
-									</div>
-									<div class="advspacer"></div>
-									<div class="adv">
-										<span class="grey">{{r2}}{{#global}} + {{global}}{{/global}}</span>
-									</div>
-								{{/rollGreater() r1 r2}}
-							{{/advantage}}
-							{{#disadvantage}}
-								{{#rollLess() r1 r2}}
-									<div class="adv">
-										<span>{{r1}}{{#global}} + {{global}}{{/global}}</span>
-									</div>
-									<div class="advspacer"></div>
-									<div class="adv">
-										<span class="grey">{{r2}}{{#global}} + {{global}}{{/global}}</span>
-									</div>
-								{{/rollLess() r1 r2}}
-								{{#rollTotal() r1 r2}}
-									<div class="adv">
-										<span>{{r1}}{{#global}} + {{global}}{{/global}}</span>
-									</div>
-									<div class="advspacer"></div>
-									<div class="adv">
-										<span>{{r2}}{{#global}} + {{global}}{{/global}}</span>
-									</div>
-								{{/rollTotal() r1 r2}}
-								{{#rollGreater() r1 r2}}
-									<div class="adv">
-										<span class="grey">{{r1}}{{#global}} + {{global}}{{/global}}</span>
-									</div>
-									<div class="advspacer"></div>
-									<div class="adv">
-										<span>{{r2}}{{#global}} + {{global}}{{/global}}</span>
-									</div>
-								{{/rollGreater() r1 r2}}
-							{{/disadvantage}}
-						</div>
-						<div class="label">
-							<span>{{rname}}{{#mod}} <span>({{mod}})</span>{{/mod}}</span>
-						</div>
-						{{#charname}}
-							<div class="charname">
-								<span>{{charname}}</span>
-							</div>
-						{{/charname}}
-					</div>
-				</rolltemplate>
-
 				<rolltemplate class="sheet-rolltemplate-atk">
 					<div class="container">
 						<div class="result">
@@ -6803,107 +6900,6 @@
 					{{/desc}}
 				</rolltemplate>
 
-				<rolltemplate class="sheet-rolltemplate-dmg">
-					{{#save}}
-						{{#attack}}
-							<div class="desc save">
-						{{/attack}}
-						{{^attack}}
-							<div class="atk save">
-						{{/attack}}
-							<div class="savedc">
-								<span class="rolltemplate-inline">DC</span><span class="rolltemplate-inline">{{savedc}}</span>
-							</div>
-							{{#savedesc}}
-								<div class="sublabel">
-									<span>{{savedesc}}</span>
-								</div>
-							{{/savedesc}}
-							<div class="label">
-								<span class="rolltemplate-inline">{{saveattr}}</span> <span class="rolltemplate-inline">Save</span>
-							</div>
-						</div>
-					{{/save}}
-					{{^attack}}
-						{{#desc}}
-							<div class="desc info">
-								<span>
-									<span class="top"></span><span class="middle">{{desc}}</span><span class="bottom"></span>
-								</span>
-							</div>
-						{{/desc}}
-					{{/attack}}
-					{{#globaldamage}}
-						{{#^rollTotal() globaldamage 0}}
-							<div class="desc">
-								<span>{{globaldamage}}{{#globaldamagecrit}}<span class="plus"> + </span>{{globaldamagecrit}}{{/globaldamagecrit}}</span>
-								<span class="sublabel">{{globaldamagetype}}</span>
-							</div>
-						{{/^rollTotal() globaldamage 0}}
-					{{/globaldamage}}
-					{{#hldmg}}
-						{{#^rollTotal() hldmg 0}}
-							<div class="desc">
-								<span>{{hldmg}}{{#hldmgcrit}}<span class="plus"> + </span>{{hldmgcrit}}{{/hldmgcrit}}</span>
-								<span class="sublabel">{{dmg1type}}</span>
-								<div class="label">
-									<span>Higher Level Cast</span>
-								</div>
-							</div>
-						{{/^rollTotal() hldmg 0}}
-					{{/hldmg}}
-					<div class="container damagetemplate">
-						<div class="result">
-							{{#dmg1flag}}
-								{{^dmg2flag}}
-									<div class="solo">
-										<span class="damage">{{dmg1}}{{#crit}} + {{crit1}}{{/crit}}</span>
-										<span class="sublabel">{{dmg1type}}</span>
-									</div>
-								{{/dmg2flag}}
-							{{/dmg1flag}}
-							{{#dmg2flag}}
-								{{^dmg1flag}}
-									<div class="solo">
-										<span class="damage">{{dmg2}}{{#crit}} + {{crit2}}{{/crit}}</span>
-										<span class="sublabel">{{dmg2type}}</span>
-									</div>
-								{{/dmg1flag}}
-							{{/dmg2flag}}
-							{{#dmg1flag}}
-								{{#dmg2flag}}
-									<div class="adv">
-										<span class="damage">{{dmg1}}{{#crit}} + {{crit1}}{{/crit}}</span>
-										<span class="sublabel">{{dmg1type}}</span>
-									</div>
-									<div class="advspacer"></div>
-									<div class="adv">
-										<span class="damage">{{dmg2}}{{#crit}} + {{crit2}}{{/crit}}</span>
-										<span class="sublabel">{{dmg2type}}</span>
-									</div>
-								{{/dmg2flag}}
-							{{/dmg1flag}}
-						</div>
-						{{^attack}}
-							{{#range}}
-								<div class="sublabel" style="color: black;">
-									<span>{{range}}</span>
-								</div>
-							{{/range}}
-							<div class="label">
-								<span>{{rname}}</span>{{#innate}}<span class="grey">, {{innate}}</span>{{/innate}}
-							</div>
-							{{#charname}}
-								<div class="charname">
-									<span>{{charname}}</span>
-								</div>
-							{{/charname}}
-						{{/attack}}
-					</div>
-				</rolltemplate>
-
-
-
 				<rolltemplate class="sheet-rolltemplate-atkdmg">
 					{{#attack}}
 						<div class="container atk">
@@ -6997,12 +6993,7 @@
 						</div>
 					{{/attack}}
 					{{#save}}
-						{{#attack}}
-							<div class="container desc save">
-						{{/attack}}
-						{{^attack}}
-							<div class="container atk save">
-						{{/attack}}
+						<div class="container {{#attack}}desc{{/attack}}{{^attack}}atk{{/attack}} save">
 							<div class="savedc">
 								<span class="rolltemplate-inline">DC</span><span class="rolltemplate-inline">{{savedc}}</span>
 							</div>
@@ -7223,71 +7214,98 @@
 					</div>
 				</rolltemplate>
 
-				<rolltemplate class="sheet-rolltemplate-spell">
-					<div class="container">
-						<div class="title row">
-							<span>{{name}}</span>{{#innate}}<span class="grey">, {{innate}}</span>{{/innate}}
+				<rolltemplate class="sheet-rolltemplate-dmg">
+					{{#save}}
+						<div class="{{#attack}}desc{{/attack}}{{^attack}}atk{{/attack}} save">
+							<div class="savedc">
+								<span class="rolltemplate-inline">DC</span><span class="rolltemplate-inline">{{savedc}}</span>
+							</div>
+							{{#savedesc}}
+								<div class="sublabel">
+									<span>{{savedesc}}</span>
+								</div>
+							{{/savedesc}}
+							<div class="label">
+								<span class="rolltemplate-inline">{{saveattr}}</span> <span class="rolltemplate-inline">Save</span>
+							</div>
 						</div>
-						<div class="italics row">
-							<span>{{level}}{{#ritual}} (<span></span>){{/ritual}}</span>
+					{{/save}}
+					{{^attack}}
+						{{#desc}}
+							<div class="desc info">
+								<span>
+									<span class="top"></span><span class="middle">{{desc}}</span><span class="bottom"></span>
+								</span>
+							</div>
+						{{/desc}}
+					{{/attack}}
+					{{#globaldamage}}
+						{{#^rollTotal() globaldamage 0}}
+							<div class="desc">
+								<span>{{globaldamage}}{{#globaldamagecrit}}<span class="plus"> + </span>{{globaldamagecrit}}{{/globaldamagecrit}}</span>
+								<span class="sublabel">{{globaldamagetype}}</span>
+							</div>
+						{{/^rollTotal() globaldamage 0}}
+					{{/globaldamage}}
+					{{#hldmg}}
+						{{#^rollTotal() hldmg 0}}
+							<div class="desc">
+								<span>{{hldmg}}{{#hldmgcrit}}<span class="plus"> + </span>{{hldmgcrit}}{{/hldmgcrit}}</span>
+								<span class="sublabel">{{dmg1type}}</span>
+								<div class="label">
+									<span>Higher Level Cast</span>
+								</div>
+							</div>
+						{{/^rollTotal() hldmg 0}}
+					{{/hldmg}}
+					<div class="container damagetemplate">
+						<div class="result">
+							{{#dmg1flag}}
+								{{^dmg2flag}}
+									<div class="solo">
+										<span class="damage">{{dmg1}}{{#crit}} + {{crit1}}{{/crit}}</span>
+										<span class="sublabel">{{dmg1type}}</span>
+									</div>
+								{{/dmg2flag}}
+							{{/dmg1flag}}
+							{{#dmg2flag}}
+								{{^dmg1flag}}
+									<div class="solo">
+										<span class="damage">{{dmg2}}{{#crit}} + {{crit2}}{{/crit}}</span>
+										<span class="sublabel">{{dmg2type}}</span>
+									</div>
+								{{/dmg1flag}}
+							{{/dmg2flag}}
+							{{#dmg1flag}}
+								{{#dmg2flag}}
+									<div class="adv">
+										<span class="damage">{{dmg1}}{{#crit}} + {{crit1}}{{/crit}}</span>
+										<span class="sublabel">{{dmg1type}}</span>
+									</div>
+									<div class="advspacer"></div>
+									<div class="adv">
+										<span class="damage">{{dmg2}}{{#crit}} + {{crit2}}{{/crit}}</span>
+										<span class="sublabel">{{dmg2type}}</span>
+									</div>
+								{{/dmg2flag}}
+							{{/dmg1flag}}
 						</div>
-						<div class="spacer"></div>
-						{{#castingtime}}
-						<div class="row">
-							<span class="bold">Casting Time:</span> <span>{{castingtime}}</span>
-						</div>
-						{{/castingtime}}
-						{{#range}}
-						<div class="row">
-							<span class="bold">Range:</span> <span>{{range}}</span>
-						</div>
-						{{/range}}
-						{{#target}}
-						<div class="row">
-							<span class="bold">Target:</span> <span>{{target}}</span>
-						</div>
-						{{/target}}
-						<div class="row">
-							<span class="bold">Components:</span>
-							<span>
-								{{#v}}V{{#s}}, {{/s}}{{^s}}{{#m}}, {{/m}}{{/s}}{{/v}}
-								{{#s}}S{{#m}}, {{/m}}{{/s}}
-								{{#m}}M {{#material}}({{material}}){{/material}}{{/m}}
-							</span>
-						</div>
-						{{#duration}}
-						<div class="row">
-							<span class="bold">Duration:</span> <span>{{#concentration}}<span>Concentration</span> {{/concentration}}{{duration}}</span>
-						</div>
-						{{/duration}}
-						<div class="spacer"></div>
-						{{#description}}
-						<div class="row">
-							<span class="description">{{description}}</span>
-						</div>
-						{{/description}}
-						{{#athigherlevels}}
-						<div class="row">
-							<span class="bold italics">At Higher Levels</span>. <span class="description">{{athigherlevels}}</span>
-						</div>
-						{{/athigherlevels}}
+						{{^attack}}
+							{{#range}}
+								<div class="sublabel" style="color: black;">
+									<span>{{range}}</span>
+								</div>
+							{{/range}}
+							<div class="label">
+								<span>{{rname}}</span>{{#innate}}<span class="grey">, {{innate}}</span>{{/innate}}
+							</div>
+							{{#charname}}
+								<div class="charname">
+									<span>{{charname}}</span>
+								</div>
+							{{/charname}}
+						{{/attack}}
 					</div>
-				</rolltemplate>
-
-				<rolltemplate class="sheet-rolltemplate-traits">
-					<div class="row header">
-						<span>{{name}}</span>
-					</div>
-					{{#source}}
-						<div class="row subheader">
-							<span class="italics">{{#charname}}{{charname}} {{/charname}}{{source}}</span>
-						</div>
-					{{/source}}
-					{{#description}}
-						<div class="row">
-							<span class="desc">{{description}}</span>
-						</div>
-					{{/description}}
 				</rolltemplate>
 
 				<rolltemplate class="sheet-rolltemplate-npc">
@@ -7330,6 +7348,103 @@
 							{{/rollGreater() r1 r2}}
 						{{/disadvantage}}
 					</div>
+				</rolltemplate>
+
+				<rolltemplate class="sheet-rolltemplate-npcaction">
+					<div class="container">
+						<div class="row header">
+							<span>{{rname}}</span>
+						</div>
+						{{#name}}
+							<div class="row subheader">
+								<span class="italics">{{name}}</span>
+							</div>
+						{{/name}}
+						<div class="arrow-right"></div>
+						{{#attack}}
+							<div class="row">
+								{{#normal}}
+									<span class="italics">Attack: </span><span>{{r1}}</span>
+								{{/normal}}
+								{{#always}}
+									<span class="italics">Attack: </span><span>{{r1}}</span><span> | </span><span>{{r2}}</span>
+								{{/always}}
+								{{#advantage}}
+									{{#rollLess() r1 r2}}
+										<span class="italics">Attack: </span><span class="grey">{{r1}}</span><span> | </span><span>{{r2}}</span>
+									{{/rollLess() r1 r2}}
+									{{#rollTotal() r1 r2}}
+										<span class="italics">Attack: </span><span>{{r1}}</span><span> | </span><span>{{r2}}</span>
+									{{/rollTotal() r1 r2}}
+									{{#rollGreater() r1 r2}}
+										<span class="italics">Attack: </span><span>{{r1}}</span><span> | </span><span class="grey">{{r2}}</span>
+									{{/rollGreater() r1 r2}}
+								{{/advantage}}
+								{{#disadvantage}}
+									{{#rollLess() r1 r2}}
+										<span class="italics">Attack: </span><span>{{r1}}</span><span> | </span><span class="grey">{{r2}}</span>
+									{{/rollLess() r1 r2}}
+									{{#rollTotal() r1 r2}}
+										<span class="italics">Attack: </span><span>{{r1}}</span><span> | </span><span>{{r2}}</span>
+									{{/rollTotal() r1 r2}}
+									{{#rollGreater() r1 r2}}
+										<span class="italics">Attack: </span><span class="grey">{{r1}}</span><span> | </span><span>{{r2}}</span>
+									{{/rollGreater() r1 r2}}
+								{{/disadvantage}}
+							</div>
+						{{/attack}}
+						{{#description}}
+							<span class="desc">{{description}}</span>
+						{{/description}}
+					</div>
+					{{#damage}}
+						<div class="container dmgcontainer damagetemplate">
+							<span class="italics">Damage: </span>
+							<span>
+								{{#dmg1flag}}
+									{{dmg1}}
+									{{#normal}}
+										{{#rollWasCrit() r1}} + {{crit1}}{{/rollWasCrit() r1}}
+									{{/normal}}
+									{{#always}}
+										{{#rollLess() r1 r2}}{{#rollWasCrit() r2}} + {{crit1}}{{/rollWasCrit() r2}}{{/rollLess() r1 r2}}
+										{{#rollTotal() r1 r2}}{{#rollWasCrit() r1}} + {{crit1}}{{/rollWasCrit() r1}}{{/rollTotal() r1 r2}}
+										{{#rollGreater() r1 r2}}{{#rollWasCrit() r1}} + {{crit1}}{{/rollWasCrit() r1}}{{/rollGreater() r1 r2}}
+									{{/always}}
+									{{#advantage}}
+										{{#rollLess() r1 r2}}{{#rollWasCrit() r2}} + {{crit1}}{{/rollWasCrit() r2}}{{/rollLess() r1 r2}}
+										{{#rollTotal() r1 r2}}{{#rollWasCrit() r1}} + {{crit1}}{{/rollWasCrit() r1}}{{/rollTotal() r1 r2}}
+										{{#rollGreater() r1 r2}}{{#rollWasCrit() r1}} + {{crit1}}{{/rollWasCrit() r1}}{{/rollGreater() r1 r2}}
+									{{/advantage}}
+									{{#disadvantage}}
+										{{#rollTotal() r1 r2}}{{#rollWasCrit() r1}} + {{crit1}}{{/rollWasCrit() r1}}{{/rollTotal() r1 r2}}
+									{{/disadvantage}}
+									{{dmg1type}}
+								{{/dmg1flag}}
+								{{#dmg1flag}}{{#dmg2flag}}+{{/dmg2flag}}{{/dmg1flag}}
+								{{#dmg2flag}}
+									{{dmg2}}
+									{{#normal}}
+										{{#rollWasCrit() r1}} + {{crit2}}{{/rollWasCrit() r1}}
+									{{/normal}}
+									{{#always}}
+										{{#rollLess() r1 r2}}{{#rollWasCrit() r2}} + {{crit2}}{{/rollWasCrit() r2}}{{/rollLess() r1 r2}}
+										{{#rollTotal() r1 r2}}{{#rollWasCrit() r1}} + {{crit2}}{{/rollWasCrit() r1}}{{/rollTotal() r1 r2}}
+										{{#rollGreater() r1 r2}}{{#rollWasCrit() r1}} + {{crit2}}{{/rollWasCrit() r1}}{{/rollGreater() r1 r2}}
+									{{/always}}
+									{{#advantage}}
+										{{#rollLess() r1 r2}}{{#rollWasCrit() r2}} + {{crit2}}{{/rollWasCrit() r2}}{{/rollLess() r1 r2}}
+										{{#rollTotal() r1 r2}}{{#rollWasCrit() r1}} + {{crit2}}{{/rollWasCrit() r1}}{{/rollTotal() r1 r2}}
+										{{#rollGreater() r1 r2}}{{#rollWasCrit() r1}} + {{crit2}}{{/rollWasCrit() r1}}{{/rollGreater() r1 r2}}
+									{{/advantage}}
+									{{#disadvantage}}
+										{{#rollTotal() r1 r2}}{{#rollWasCrit() r1}} + {{crit2}}{{/rollWasCrit() r1}}{{/rollTotal() r1 r2}}
+									{{/disadvantage}}
+									{{dmg2type}}
+								{{/dmg2flag}}
+							</span>
+						</div>
+					{{/damage}}
 				</rolltemplate>
 
 				<rolltemplate class="sheet-rolltemplate-npcatk">
@@ -7437,133 +7552,190 @@
 					</div>
 				</rolltemplate>
 
-				<rolltemplate class="sheet-rolltemplate-npcaction">
+				<rolltemplate class="sheet-rolltemplate-simple">
 					<div class="container">
-						<div class="row header">
-							<span>{{rname}}</span>
+						<div class="result">
+							{{#always}}
+								<div class="adv">
+									<span>{{r1}}{{#global}} + {{global}}{{/global}}</span>
+								</div>
+								<div class="advspacer"></div>
+								<div class="adv">
+									<span>{{r2}}{{#global}} + {{global}}{{/global}}</span>
+								</div>
+							{{/always}}
+							{{#normal}}
+								<div class="solo">
+									<span>{{r1}}{{#global}} + {{global}}{{/global}}</span>
+								</div>
+							{{/normal}}
+							{{#advantage}}
+								{{#rollLess() r1 r2}}
+									<div class="adv">
+										<span class="grey">{{r1}}{{#global}} + {{global}}{{/global}}</span>
+									</div>
+									<div class="advspacer"></div>
+									<div class="adv">
+										<span>{{r2}}{{#global}} + {{global}}{{/global}}</span>
+									</div>
+								{{/rollLess() r1 r2}}
+								{{#rollTotal() r1 r2}}
+									<div class="adv">
+										<span>{{r1}}{{#global}} + {{global}}{{/global}}</span>
+									</div>
+									<div class="advspacer"></div>
+									<div class="adv">
+										<span>{{r2}}{{#global}} + {{global}}{{/global}}</span>
+									</div>
+								{{/rollTotal() r1 r2}}
+								{{#rollGreater() r1 r2}}
+									<div class="adv">
+										<span>{{r1}}{{#global}} + {{global}}{{/global}}</span>
+									</div>
+									<div class="advspacer"></div>
+									<div class="adv">
+										<span class="grey">{{r2}}{{#global}} + {{global}}{{/global}}</span>
+									</div>
+								{{/rollGreater() r1 r2}}
+							{{/advantage}}
+							{{#disadvantage}}
+								{{#rollLess() r1 r2}}
+									<div class="adv">
+										<span>{{r1}}{{#global}} + {{global}}{{/global}}</span>
+									</div>
+									<div class="advspacer"></div>
+									<div class="adv">
+										<span class="grey">{{r2}}{{#global}} + {{global}}{{/global}}</span>
+									</div>
+								{{/rollLess() r1 r2}}
+								{{#rollTotal() r1 r2}}
+									<div class="adv">
+										<span>{{r1}}{{#global}} + {{global}}{{/global}}</span>
+									</div>
+									<div class="advspacer"></div>
+									<div class="adv">
+										<span>{{r2}}{{#global}} + {{global}}{{/global}}</span>
+									</div>
+								{{/rollTotal() r1 r2}}
+								{{#rollGreater() r1 r2}}
+									<div class="adv">
+										<span class="grey">{{r1}}{{#global}} + {{global}}{{/global}}</span>
+									</div>
+									<div class="advspacer"></div>
+									<div class="adv">
+										<span>{{r2}}{{#global}} + {{global}}{{/global}}</span>
+									</div>
+								{{/rollGreater() r1 r2}}
+							{{/disadvantage}}
 						</div>
-						{{#name}}
-							<div class="row subheader">
-								<span class="italics">{{name}}</span>
+						<div class="label">
+							<span>{{rname}}{{#mod}} <span>({{mod}})</span>{{/mod}}</span>
+						</div>
+						{{#charname}}
+							<div class="charname">
+								<span>{{charname}}</span>
 							</div>
-						{{/name}}
-						<div class="arrow-right"></div>
-						{{#attack}}
+						{{/charname}}
+					</div>
+				</rolltemplate>
+
+				<rolltemplate class="sheet-rolltemplate-spell">
+					<div class="container">
+						<div class="title row">
+							<span>{{name}}</span>{{#innate}}<span class="grey">, {{innate}}</span>{{/innate}}
+						</div>
+						<div class="italics row">
+							<span>{{level}}{{#ritual}} (<span></span>){{/ritual}}</span>
+						</div>
+						<div class="spacer"></div>
+						{{#castingtime}}
 							<div class="row">
-								{{#normal}}
-									<span class="italics">Attack: </span><span>{{r1}}</span>
-								{{/normal}}
-								{{#always}}
-									<span class="italics">Attack: </span><span>{{r1}}</span><span> | </span><span>{{r2}}</span>
-								{{/always}}
-								{{#advantage}}
-									{{#rollLess() r1 r2}}
-										<span class="italics">Attack: </span><span class="grey">{{r1}}</span><span> | </span><span>{{r2}}</span>
-									{{/rollLess() r1 r2}}
-									{{#rollTotal() r1 r2}}
-										<span class="italics">Attack: </span><span>{{r1}}</span><span> | </span><span>{{r2}}</span>
-									{{/rollTotal() r1 r2}}
-									{{#rollGreater() r1 r2}}
-										<span class="italics">Attack: </span><span>{{r1}}</span><span> | </span><span class="grey">{{r2}}</span>
-									{{/rollGreater() r1 r2}}
-								{{/advantage}}
-								{{#disadvantage}}
-									{{#rollLess() r1 r2}}
-										<span class="italics">Attack: </span><span>{{r1}}</span><span> | </span><span class="grey">{{r2}}</span>
-									{{/rollLess() r1 r2}}
-									{{#rollTotal() r1 r2}}
-										<span class="italics">Attack: </span><span>{{r1}}</span><span> | </span><span>{{r2}}</span>
-									{{/rollTotal() r1 r2}}
-									{{#rollGreater() r1 r2}}
-										<span class="italics">Attack: </span><span class="grey">{{r1}}</span><span> | </span><span>{{r2}}</span>
-									{{/rollGreater() r1 r2}}
-								{{/disadvantage}}
+								<span class="bold">Casting Time:</span> <span>{{castingtime}}</span>
 							</div>
-						{{/attack}}
-						{{#description}}
-							<span class="desc">{{description}}</span>
-						{{/description}}
+						{{/castingtime}}
+						{{#range}}
+							<div class="row">
+								<span class="bold">Range:</span> <span>{{range}}</span>
+							</div>
+						{{/range}}
+						{{#target}}
+							<div class="row">
+								<span class="bold">Target:</span> <span>{{target}}</span>
+							</div>
+						{{/target}}
+						<div class="row">
+							<span class="bold">Components:</span>
+							<span>
+								{{#v}}V{{#s}}, {{/s}}{{^s}}{{#m}}, {{/m}}{{/s}}{{/v}}
+								{{#s}}S{{#m}}, {{/m}}{{/s}}
+								{{#m}}M {{#material}}({{material}}){{/material}}{{/m}}
+							</span>
 						</div>
-						{{#damage}}
-							<div class="container dmgcontainer damagetemplate">
-								<span class="italics">Damage: </span>
-								<span>
-									{{#dmg1flag}}
-										{{dmg1}}
-										{{#normal}}
-											{{#rollWasCrit() r1}} + {{crit1}}{{/rollWasCrit() r1}}
-										{{/normal}}
-										{{#always}}
-											{{#rollLess() r1 r2}}{{#rollWasCrit() r2}} + {{crit1}}{{/rollWasCrit() r2}}{{/rollLess() r1 r2}}
-											{{#rollTotal() r1 r2}}{{#rollWasCrit() r1}} + {{crit1}}{{/rollWasCrit() r1}}{{/rollTotal() r1 r2}}
-											{{#rollGreater() r1 r2}}{{#rollWasCrit() r1}} + {{crit1}}{{/rollWasCrit() r1}}{{/rollGreater() r1 r2}}
-										{{/always}}
-										{{#advantage}}
-											{{#rollLess() r1 r2}}{{#rollWasCrit() r2}} + {{crit1}}{{/rollWasCrit() r2}}{{/rollLess() r1 r2}}
-											{{#rollTotal() r1 r2}}{{#rollWasCrit() r1}} + {{crit1}}{{/rollWasCrit() r1}}{{/rollTotal() r1 r2}}
-											{{#rollGreater() r1 r2}}{{#rollWasCrit() r1}} + {{crit1}}{{/rollWasCrit() r1}}{{/rollGreater() r1 r2}}
-										{{/advantage}}
-										{{#disadvantage}}
-											{{#rollTotal() r1 r2}}{{#rollWasCrit() r1}} + {{crit1}}{{/rollWasCrit() r1}}{{/rollTotal() r1 r2}}
-										{{/disadvantage}}
-										{{dmg1type}}
-									{{/dmg1flag}}
-									{{#dmg1flag}}{{#dmg2flag}}+{{/dmg2flag}}{{/dmg1flag}}
-									{{#dmg2flag}}
-										{{dmg2}}
-										{{#normal}}
-											{{#rollWasCrit() r1}} + {{crit2}}{{/rollWasCrit() r1}}
-										{{/normal}}
-										{{#always}}
-											{{#rollLess() r1 r2}}{{#rollWasCrit() r2}} + {{crit2}}{{/rollWasCrit() r2}}{{/rollLess() r1 r2}}
-											{{#rollTotal() r1 r2}}{{#rollWasCrit() r1}} + {{crit2}}{{/rollWasCrit() r1}}{{/rollTotal() r1 r2}}
-											{{#rollGreater() r1 r2}}{{#rollWasCrit() r1}} + {{crit2}}{{/rollWasCrit() r1}}{{/rollGreater() r1 r2}}
-										{{/always}}
-										{{#advantage}}
-											{{#rollLess() r1 r2}}{{#rollWasCrit() r2}} + {{crit2}}{{/rollWasCrit() r2}}{{/rollLess() r1 r2}}
-											{{#rollTotal() r1 r2}}{{#rollWasCrit() r1}} + {{crit2}}{{/rollWasCrit() r1}}{{/rollTotal() r1 r2}}
-											{{#rollGreater() r1 r2}}{{#rollWasCrit() r1}} + {{crit2}}{{/rollWasCrit() r1}}{{/rollGreater() r1 r2}}
-										{{/advantage}}
-										{{#disadvantage}}
-											{{#rollTotal() r1 r2}}{{#rollWasCrit() r1}} + {{crit2}}{{/rollWasCrit() r1}}{{/rollTotal() r1 r2}}
-										{{/disadvantage}}
-										{{dmg2type}}
-									{{/dmg2flag}}
-								</span>
+						{{#duration}}
+							<div class="row">
+								<span class="bold">Duration:</span> <span>{{#concentration}}<span>Concentration</span> {{/concentration}}{{duration}}</span>
 							</div>
-						{{/damage}}
+						{{/duration}}
+						<div class="spacer"></div>
+						{{#description}}
+							<div class="row">
+								<span class="description">{{description}}</span>
+							</div>
+						{{/description}}
+						{{#athigherlevels}}
+							<div class="row">
+								<span class="bold italics">At Higher Levels</span>. <span class="description">{{athigherlevels}}</span>
+							</div>
+						{{/athigherlevels}}
+					</div>
+				</rolltemplate>
+
+				<rolltemplate class="sheet-rolltemplate-traits">
+					<div class="row header">
+						<span>{{name}}</span>
+					</div>
+					{{#source}}
+					<div class="row subheader">
+						<span class="italics">{{#charname}}{{charname}} {{/charname}}{{source}}</span>
+					</div>
+					{{/source}}
+					{{#description}}
+						<div class="row">
+							<span class="desc">{{description}}</span>
+						</div>
+					{{/description}}
 				</rolltemplate>
 			</div>
 		</div>
+		
 		<script type="text/worker">
 			on("sheet:compendium-drop", function() {
-				getAttrs(["hp_max","npc_senses","token_size","cd_bar1_v","cd_bar1_m","cd_bar1_l","cd_bar2_v","cd_bar2_m","cd_bar2_l","cd_bar3_v","cd_bar3_m","cd_bar3_l"], function(v) {
+				getAttrs(["hp_max", "npc_senses", "token_size", "cd_bar1_v", "cd_bar1_m", "cd_bar1_l", "cd_bar2_v", "cd_bar2_m", "cd_bar2_l", "cd_bar3_v", "cd_bar3_m", "cd_bar3_l"], function(v) {
 
 					var default_attr = {};
 					default_attr["width"] = 70;
 					default_attr["height"] = 70;
-					if(v["npc_senses"].toLowerCase().match(/(darkvision|blindsight|tremorsense|truesight)/)) {
+					if (v["npc_senses"].toLowerCase().match(/(darkvision|blindsight|tremorsense|truesight)/)) {
 						default_attr["light_radius"] = Math.max.apply(Math, v["npc_senses"].match(/\d+/g));
 					}
-					if(v["token_size"]) {
+					if (v["token_size"]) {
 						var squarelength = 70;
-						if(v["token_size"].toString().indexOf(",") > -1) {
+						if (v["token_size"].toString().indexOf(",") > -1) {
 							var setwidth = !isNaN(v["token_size"].split(",")[0]) ? v["token_size"].split(",")[0] : 1;
 							var setheight = !isNaN(v["token_size"].split(",")[1]) ? v["token_size"].split(",")[1] : 1;
 							default_attr["width"] = setwidth * squarelength;
 							default_attr["height"] = setheight * squarelength;
-						}
-						else {
+						} else {
 							default_attr["width"] = squarelength * v["token_size"]
 							default_attr["height"] = squarelength * v["token_size"]
 						};
 					}
 
 					var getList = {};
-					for(x = 1; x<=3; x++) {
+					for (x = 1; x <= 3; x++) {
 						_.each(["v", "m"], function(letter) {
 							var keyname = "cd_bar" + x + "_" + letter;
-							if(v[keyname] != undefined && isNaN(v[keyname])) {
+							if (v[keyname] != undefined && isNaN(v[keyname])) {
 								getList[keyname] = v[keyname];
 							}
 						});
@@ -7574,45 +7746,40 @@
 							v[keyname] = values[getList[keyname]] == undefined ? "" : values[getList[keyname]];
 						});
 
-						if(v["cd_bar1_l"]) {
+						if (v["cd_bar1_l"]) {
 							default_attr["bar1_link"] = v["cd_bar1_l"];
-						}
-						else if(v["cd_bar1_v"] || v["cd_bar1_m"]) {
-							if(v["cd_bar1_v"]) {
+						} else if (v["cd_bar1_v"] || v["cd_bar1_m"]) {
+							if (v["cd_bar1_v"]) {
 								default_attr["bar1_value"] = v["cd_bar1_v"];
 							}
-							if(v["cd_bar1_m"]) {
+							if (v["cd_bar1_m"]) {
 								default_attr["bar1_max"] = v["cd_bar1_m"];
 							}
-						}
-						else {
+						} else {
 							default_attr["bar1_value"] = v["hp_max"];
 							default_attr["bar1_max"] = v["hp_max"];
 						}
 
-						if(v["cd_bar2_l"]) {
+						if (v["cd_bar2_l"]) {
 							default_attr["bar2_link"] = v["cd_bar2_l"];
-						}
-						else if(v["cd_bar2_v"] || v["cd_bar2_m"]) {
-							if(v["cd_bar2_v"]) {
+						} else if (v["cd_bar2_v"] || v["cd_bar2_m"]) {
+							if (v["cd_bar2_v"]) {
 								default_attr["bar2_value"] = v["cd_bar2_v"];
 							}
-							if(v["cd_bar2_m"]) {
+							if (v["cd_bar2_m"]) {
 								default_attr["bar2_max"] = v["cd_bar2_m"];
 							}
-						}
-						else {
+						} else {
 							default_attr["bar2_link"] = "npc_ac";
 						}
 
-						if(v["cd_bar3_l"]) {
+						if (v["cd_bar3_l"]) {
 							default_attr["bar3_link"] = v["cd_bar3_l"];
-						}
-						else if(v["cd_bar3_v"] || v["cd_bar3_m"]) {
-							if(v["cd_bar3_v"]) {
+						} else if (v["cd_bar3_v"] || v["cd_bar3_m"]) {
+							if (v["cd_bar3_v"]) {
 								default_attr["bar3_value"] = v["cd_bar3_v"];
 							}
-							if(v["cd_bar3_m"]) {
+							if (v["cd_bar3_m"]) {
 								default_attr["bar3_max"] = v["cd_bar3_m"];
 							}
 						}
@@ -7622,34 +7789,34 @@
 				});
 			});
 
-			['strength','dexterity','constitution','intelligence','wisdom','charisma'].forEach(attr => {
+			['strength', 'dexterity', 'constitution', 'intelligence', 'wisdom', 'charisma'].forEach(attr => {
 				on(`change:${attr}_base change:${attr}_bonus`, function() {
 					update_attr(`${attr}`);
 
 				});
 			});
 
-			['strength','dexterity','constitution','intelligence','wisdom','charisma'].forEach(attr => {
+			['strength', 'dexterity', 'constitution', 'intelligence', 'wisdom', 'charisma'].forEach(attr => {
 				on(`change:${attr}`, function() {
 					update_mod(`${attr}`);
 
 					const cap = attr.charAt(0).toUpperCase() + attr.slice(1);
 					check_customac(cap);
 
-					(attr === "strength") ? update_weight() : false;
-					(attr === "dexterity") ? update_initiative() : false;
-					(attr === "intelligence") ? update_initiative() : false;
+					(attr === "strength") ? update_weight(): false;
+					(attr === "dexterity") ? update_initiative(): false;
+					(attr === "intelligence") ? update_initiative(): false;
 				});
 			});
 
-			['strength','dexterity','constitution','intelligence','wisdom','charisma'].forEach(attr => {
+			['strength', 'dexterity', 'constitution', 'intelligence', 'wisdom', 'charisma'].forEach(attr => {
 				on(`change:${attr}_mod`, function() {
 					update_save(`${attr}`);
 					update_attacks(`${attr}`);
 					update_tool(`${attr}`);
 					update_spell_info(`${attr}`);
 
-					switch(`${attr}`) {
+					switch (`${attr}`) {
 						case "strength":
 							update_skills(["athletics"]);
 							break;
@@ -7674,32 +7841,40 @@
 				});
 			});
 
-			['strength','dexterity','constitution','intelligence','wisdom','charisma'].forEach(attr => {
+			['strength', 'dexterity', 'constitution', 'intelligence', 'wisdom', 'charisma'].forEach(attr => {
 				on(`change:${attr}_save_prof change:${attr}_save_mod`, function(eventinfo) {
-					if(eventinfo.sourceType === "sheetworker") {return;};
+					if (eventinfo.sourceType === "sheetworker") {
+						return;
+					};
 					update_save(`${attr}`);
 				});
 			});
 
 			on("change:globalsavemod", function(eventinfo) {
-				if(eventinfo.sourceType === "sheetworker") {return;};
+				if (eventinfo.sourceType === "sheetworker") {
+					return;
+				};
 				update_all_saves();
 			});
 
 			on("change:death_save_mod", function(eventinfo) {
-				if(eventinfo.sourceType === "sheetworker") {return;};
+				if (eventinfo.sourceType === "sheetworker") {
+					return;
+				};
 				update_save("death");
 			});
 
-			['acrobatics','animal_handling','arcana','athletics','deception','history','insight','intimidation','investigation', 'medicine','nature','perception','performance','persuasion','religion','sleight_of_hand','stealth','survival'].forEach(attr => {
-				on(`change:${attr}_prof change:${attr}_type change:${attr}_flat`, function(eventinfo) {
-					if(eventinfo.sourceType === "sheetworker") {return;};
+			['acrobatics', 'animal_handling', 'arcana', 'athletics', 'deception', 'history', 'insight', 'intimidation', 'investigation', 'medicine', 'nature', 'perception', 'performance', 'persuasion', 'religion', 'sleight_of_hand', 'stealth', 'survival'].forEach(attr => {
+				on(`change:${attr}_prof change:${attr}_type change:${attr}_flat change:${attr}_attribute`, function(eventinfo) {
+					if (eventinfo.sourceType === "sheetworker") {
+						return;
+					};
 					update_skills([`${attr}`]);
 				});
 			});
 
 			on("change:repeating_tool:toolname change:repeating_tool:toolbonus_base change:repeating_tool:toolattr_base change:repeating_tool:tool_mod", function(eventinfo) {
-				if(eventinfo.sourceType === "sheetworker") {
+				if (eventinfo.sourceType === "sheetworker") {
 					return;
 				}
 				var tool_id = eventinfo.sourceAttribute.substring(15, 35);
@@ -7707,16 +7882,16 @@
 			});
 
 			on("change:repeating_attack:atkname change:repeating_attack:atkflag change:repeating_attack:atkattr_base change:repeating_attack:atkmod change:repeating_attack:atkmagic change:repeating_attack:atkprofflag change:repeating_attack:dmgflag change:repeating_attack:dmgbase change:repeating_attack:dmgattr change:repeating_attack:dmgmod change:repeating_attack:dmgtype change:repeating_attack:dmg2flag change:repeating_attack:dmg2base change:repeating_attack:dmg2attr change:repeating_attack:dmg2mod change:repeating_attack:dmg2type change:repeating_attack:saveflag change:repeating_attack:savedc change:repeating_attack:saveflat change:repeating_attack:dmgcustcrit change:repeating_attack:dmg2custcrit change:repeating_attack:ammo change:repeating_attack:saveattr change:repeating_attack:atkrange", function(eventinfo) {
-				if(eventinfo.sourceType === "sheetworker") {
+				if (eventinfo.sourceType === "sheetworker") {
 					return;
 				}
 
 				var source = eventinfo.sourceAttribute.substr(38);
 				var attackid = eventinfo.sourceAttribute.substring(17, 37);
-				if(source == "atkattr_base" || source == "savedc") {
+				if (source == "atkattr_base" || source == "savedc") {
 					getAttrs(["repeating_attack_spellid", "repeating_attack_spelllevel"], function(v) {
 						set = {};
-						if(v.repeating_attack_spellid && v.repeating_attack_spellid != "" && v.repeating_attack_spelllevel && v.repeating_attack_spelllevel != "") {
+						if (v.repeating_attack_spellid && v.repeating_attack_spellid != "" && v.repeating_attack_spelllevel && v.repeating_attack_spelllevel != "") {
 							var newVal = eventinfo.newValue == "spell" ? "spell" : _.last(eventinfo.newValue.split("_")[0].split("{"));
 							set["repeating_attack_atkattr_base"] = newVal == "spell" ? "spell" : "@{" + newVal + "_mod}";
 							set["repeating_attack_savedc"] = newVal == "spell" ? "spell" : "(@{" + newVal + "_mod}+8+@{pb})";
@@ -7738,8 +7913,8 @@
 			on("change:global_damage_mod_flag", function(eventinfo) {
 				getSectionIDs("damagemod", function(ids) {
 					var update = {};
-					if(eventinfo.newValue === "1") {
-						if(!ids || ids.length === 0) {
+					if (eventinfo.newValue === "1") {
+						if (!ids || ids.length === 0) {
 							var rowid = generateRowID();
 							update[`repeating_damagemod_${rowid}_global_damage_active_flag`] = "1";
 						}
@@ -7753,9 +7928,9 @@
 			});
 
 			on("change:exhaustion_toggle", function(eventinfo) {
-				if(eventinfo.newValue !== "0") {
+				if (eventinfo.newValue !== "0") {
 					getAttrs(["exhaustion_level"], function(attrs) {
-						if(!attrs.exhaustion_level || attrs.exhaustion_level === "") {
+						if (!attrs.exhaustion_level || attrs.exhaustion_level === "") {
 							var update = {};
 							update.exhaustion_level = "0";
 							setAttrs(update);
@@ -7765,23 +7940,31 @@
 			});
 
 			on("change:exhaustion_level", function(eventinfo) {
-				const newValue = parseInt(eventinfo.newValue) || 0, previousValue = parseInt(eventinfo.previousValue) || 0;
+				const newValue = parseInt(eventinfo.newValue) || 0,
+					previousValue = parseInt(eventinfo.previousValue) || 0;
 				let update = {};
 
-				 if (newValue === 0) {
+				if (newValue === 0) {
 					//If exhaustion is 0 the reset exhaustion_1 to "No Effect" and blank the other spans
-					for(let i = 2; i <= 6; i++) { update[`exhaustion_${i}`] = ""}
+					for (let i = 2; i <= 6; i++) {
+						update[`exhaustion_${i}`] = ""
+					}
 					update[`exhaustion_1`] = "• " + getTranslationByKey(`exhaustion-0`)
 				} else if (newValue > previousValue) {
 					//If exhaustion increase then add text to the spans
-					for(let i = previousValue; i <= newValue; i++)
-					{update[`exhaustion_${i}`] = "• " + getTranslationByKey(`exhaustion-${i}`)}
+					for (let i = previousValue; i <= newValue; i++) {
+						update[`exhaustion_${i}`] = "• " + getTranslationByKey(`exhaustion-${i}`)
+					}
 				} else {
 					//If exhaustion decrease remove text from spans
-					for(let i = newValue + 1; i <= previousValue; i++) {update[`exhaustion_${i}`] = ""}
+					for (let i = newValue + 1; i <= previousValue; i++) {
+						update[`exhaustion_${i}`] = ""
+					}
 				};
 
-				setAttrs(update, {silent: true});
+				setAttrs(update, {
+					silent: true
+				});
 			});
 
 			on("change:race change:subrace", function(eventinfo) {
@@ -7789,43 +7972,49 @@
 			});
 
 			on("change:drop_category", function(eventinfo) {
-				if(eventinfo.newValue === "Monsters") {
-					getAttrs(["class","race","speed","hp"], function(v) {
-						if(v["class"] != "" || v["race"] != "" || v["speed"] != "" || v["hp"] != "") {
-							setAttrs({monster_confirm_flag: 1});
-						}
-						else {
+				if (eventinfo.newValue === "Monsters") {
+					getAttrs(["class", "race", "speed", "hp"], function(v) {
+						if (v["class"] != "" || v["race"] != "" || v["speed"] != "" || v["hp"] != "") {
+							setAttrs({
+								monster_confirm_flag: 1
+							});
+						} else {
 							handle_drop(eventinfo.newValue);
 						}
 					});
-				}
-				else {
+				} else {
 					handle_drop(eventinfo.newValue);
 				}
 			});
 
 			on(`change:repeating_inventory:hasattack`, function(eventinfo) {
-				if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {return;};
+				if (eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+					return;
+				};
 
 				const itemid = eventinfo.sourceAttribute.substring(20, 40);
 				getAttrs([`repeating_inventory_${itemid}_itemattackid`], function(v) {
-					const hasattack = eventinfo.newValue, itemattackid = v[`repeating_inventory_${itemid}_itemattackid`];
-					(hasattack == 1) ? create_attack_from_item(itemid) : remove_attack(itemattackid);
+					const hasattack = eventinfo.newValue,
+						itemattackid = v[`repeating_inventory_${itemid}_itemattackid`];
+					(hasattack == 1) ? create_attack_from_item(itemid): remove_attack(itemattackid);
 				});
 			});
 
 			on(`change:repeating_inventory:useasresource`, function(eventinfo) {
-				if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {return;};
+				if (eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+					return;
+				};
 
 				const itemid = eventinfo.sourceAttribute.substring(20, 40);
 				getAttrs([`repeating_inventory_${itemid}_itemresourceid`], function(v) {
-					const useasresource = eventinfo.newValue, itemresourceid = v[`repeating_inventory_${itemid}_itemresourceid`];
-					(useasresource == 1) ? create_resource_from_item(itemid) : remove_resource(itemresourceid);
+					const useasresource = eventinfo.newValue,
+						itemresourceid = v[`repeating_inventory_${itemid}_itemresourceid`];
+					(useasresource == 1) ? create_resource_from_item(itemid): remove_resource(itemresourceid);
 				});
 			});
 
 			on("change:repeating_inventory:itemname change:repeating_inventory:itemproperties change:repeating_inventory:itemmodifiers change:repeating_inventory:itemcount", function(eventinfo) {
-				if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+				if (eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
 					return;
 				}
 
@@ -7833,10 +8022,10 @@
 				getAttrs(["repeating_inventory_" + itemid + "_itemattackid", "repeating_inventory_" + itemid + "_itemresourceid"], function(v) {
 					var attackid = v["repeating_inventory_" + itemid + "_itemattackid"];
 					var resourceid = v["repeating_inventory_" + itemid + "_itemresourceid"];
-					if(attackid) {
+					if (attackid) {
 						update_attack_from_item(itemid, attackid);
 					}
-					if(resourceid) {
+					if (resourceid) {
 						update_resource_from_item(itemid, resourceid);
 					}
 				});
@@ -7844,78 +8033,82 @@
 
 			on("change:other_resource change:other_resource_name change:repeating_resource:resource_left change:repeating_resource:resource_left_name change:repeating_resource:resource_right change:repeating_resource:resource_right_name", function(eventinfo) {
 
-				if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+				if (eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
 					return;
 				}
 
 				var resourceid = eventinfo.sourceAttribute;
-				if(eventinfo.sourceAttribute.indexOf("other") > -1) {
+				if (eventinfo.sourceAttribute.indexOf("other") > -1) {
 					resourceid = "other_resource";
-				}
-				else if(eventinfo.sourceAttribute.substring(eventinfo.sourceAttribute.length - 5) == "_name") {
+				} else if (eventinfo.sourceAttribute.substring(eventinfo.sourceAttribute.length - 5) == "_name") {
 					resourceid = eventinfo.sourceAttribute.substring(0, eventinfo.sourceAttribute.length - 5);
 				};
 
 				getAttrs([resourceid, resourceid + "_name", resourceid + "_itemid"], function(v) {
-					if(!v[resourceid + "_name"]) {
+					if (!v[resourceid + "_name"]) {
 						remove_resource(resourceid);
-					}
-					else if(v[resourceid + "_itemid"] && v[resourceid + "_itemid"] != ""){
+					} else if (v[resourceid + "_itemid"] && v[resourceid + "_itemid"] != "") {
 						update_item_from_resource(resourceid, v[resourceid + "_itemid"]);
 					};
 				});
 
 			});
 
-			on("change:repeating_inventory:itemcontainer change:repeating_inventory:equipped change:repeating_inventory:itemweight change:repeating_inventory:itemcount change:cp change:sp change:ep change:gp change:pp change:currency_other change:encumberance_setting change:size change:carrying_capacity_mod change:use_inventory_slots change:inventory_slots_mod change:repeating_inventory:itemweightfixed change:repeating_inventory:itemslotsfixed change:repeating_inventory:itemsize", function() {
+			on("change:repeating_inventory:itemcontainer change:repeating_inventory:equipped change:repeating_inventory:carried change:repeating_inventory:itemweight change:repeating_inventory:itemcount change:cp change:sp change:ep change:gp change:pp change:currency_other change:encumberance_setting change:size change:carrying_capacity_mod change:use_inventory_slots change:inventory_slots_mod change:repeating_inventory:itemweightfixed change:repeating_inventory:itemslotsfixed change:repeating_inventory:itemsize change:repeating_inventory:itemcontainer_slots_modifier", function() {
 				update_weight();
 			});
 
-			on("change:repeating_inventory:itemmodifiers change:repeating_inventory:equipped", function(eventinfo) {
-				if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+			on("change:repeating_inventory:itemmodifiers change:repeating_inventory:equipped change:repeating_inventory:carried", function(eventinfo) {
+				if (eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
 					return;
 				}
 				var itemid = eventinfo.sourceAttribute.substring(20, 40);
 				getAttrs(["repeating_inventory_" + itemid + "_itemmodifiers"], function(v) {
-					if(v["repeating_inventory_" + itemid + "_itemmodifiers"]) {
+					if (v["repeating_inventory_" + itemid + "_itemmodifiers"]) {
 						check_itemmodifiers(v["repeating_inventory_" + itemid + "_itemmodifiers"], eventinfo.previousValue);
 					};
 				});
 			});
 
 			on("change:custom_ac_flag change:custom_ac_base change:custom_ac_part1 change:custom_ac_part2 change:custom_ac_shield", function(eventinfo) {
-				if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+				if (eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
 					return;
 				}
 				update_ac();
 			});
 
-			['spell-cantrip','spell-1','spell-2','spell-3','spell-4','spell-5','spell-6','spell-7','spell-8','spell-9'].forEach(attr => {
+			['spell-cantrip', 'spell-1', 'spell-2', 'spell-3', 'spell-4', 'spell-5', 'spell-6', 'spell-7', 'spell-8', 'spell-9'].forEach(attr => {
 				on(`change:repeating_${attr}:includedesc change:repeating_${attr}:innate change:repeating_${attr}:spell_ability change:repeating_${attr}:spell_updateflag change:repeating_${attr}:spellathigherlevels change:repeating_${attr}:spellattack change:repeating_${attr}:spelldamage change:repeating_${attr}:spelldamage2 change:repeating_${attr}:spelldamagetype change:repeating_${attr}:spelldamagetype2 change:repeating_${attr}:spelldescription change:repeating_${attr}:spelldmgmod change:repeating_${attr}:spellhealing change:repeating_${attr}:spellhlbonus change:repeating_${attr}:spellhldie change:repeating_${attr}:spellhldietype change:repeating_${attr}:spellname change:repeating_${attr}:spellprepared change:repeating_${attr}:spellrange change:repeating_${attr}:spellsave change:repeating_${attr}:spellsavesuccess change:repeating_${attr}:spelltarget change:repeating_${attr}:spell_damage_progression`, (eventinfo) => {
-					if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") { return; }
+					if (eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+						return;
+					}
 
-					const spellid = eventinfo.sourceAttribute.split("_")[2], repeating_source = `repeating_${attr}_${spellid}`;
+					const spellid = eventinfo.sourceAttribute.split("_")[2],
+						repeating_source = `repeating_${attr}_${spellid}`;
 					getAttrs([repeating_source + "_spellattackid", repeating_source + "_spelllevel"], function(v) {
 						var attackid = v[repeating_source + "_spellattackid"];
-						var lvl			= v[repeating_source + "_spelllevel"];
+						var lvl = v[repeating_source + "_spelllevel"];
 
-						if(attackid && lvl && spellid) {
+						if (attackid && lvl && spellid) {
 							update_attack_from_spell(lvl, spellid, attackid)
 						}
 					});
 				});
 			});
 
-			['spell-cantrip','spell-1','spell-2','spell-3','spell-4','spell-5','spell-6','spell-7','spell-8','spell-9'].forEach(attr => {
+			['spell-cantrip', 'spell-1', 'spell-2', 'spell-3', 'spell-4', 'spell-5', 'spell-6', 'spell-7', 'spell-8', 'spell-9'].forEach(attr => {
 				on(`change:repeating_${attr}:spelloutput`, (eventinfo) => {
-					if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {return;}
+					if (eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+						return;
+					}
 
-					const spellid = eventinfo.sourceAttribute.split("_")[2], repeating_source = `repeating_${attr}_${spellid}`;
+					const spellid = eventinfo.sourceAttribute.split("_")[2],
+						repeating_source = `repeating_${attr}_${spellid}`;
 					getAttrs([`${repeating_source}_spellattackid`, `${repeating_source}_spelllevel`, `${repeating_source}_spellathigherlevels`, "character_id"], function(v) {
-						const attackid		 = v[repeating_source + "_spellattackid"];
+						const attackid = v[repeating_source + "_spellattackid"];
 						const higherlevels = v[repeating_source + "_spellathigherlevels"];
-						const spelloutput	= eventinfo.newValue;
-						let lvl						= v[repeating_source + "_spelllevel"];
+						const spelloutput = eventinfo.newValue;
+						let lvl = v[repeating_source + "_spelllevel"];
 
 						if (spelloutput && spelloutput === "ATTACK") {
 							create_attack_from_spell(lvl, spellid, v["character_id"]);
@@ -7928,15 +8121,18 @@
 				});
 			});
 
-			['spell-cantrip','spell-1','spell-2','spell-3','spell-4','spell-5','spell-6','spell-7','spell-8','spell-9'].forEach(attr => {
+			['spell-cantrip', 'spell-1', 'spell-2', 'spell-3', 'spell-4', 'spell-5', 'spell-6', 'spell-7', 'spell-8', 'spell-9'].forEach(attr => {
 				on(`change:repeating_${attr}:spellathigherlevels`, (eventinfo) => {
-					if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {return;}
+					if (eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+						return;
+					}
 
-					const spellid = eventinfo.sourceAttribute.split("_")[2], repeating_source = `repeating_${attr}_${spellid}`;
+					const spellid = eventinfo.sourceAttribute.split("_")[2],
+						repeating_source = `repeating_${attr}_${spellid}`;
 					getAttrs([`${repeating_source}_spelllevel`, `${repeating_source}_spelloutput`], function(v) {
 						const higherlevels = eventinfo.newValue;
-						const lvl					= parseInt(v[repeating_source + "_spelllevel"], 10);
-						const spelloutput	= v[repeating_source + "_spelloutput"];
+						const lvl = parseInt(v[repeating_source + "_spelllevel"], 10);
+						const spelloutput = v[repeating_source + "_spelloutput"];
 
 						if (spelloutput && spelloutput === "SPELLCARD") {
 							update_spelloutput(higherlevels, lvl, repeating_source, spelloutput);
@@ -7945,12 +8141,12 @@
 				});
 			});
 
-			const update_spelloutput = (higherlevels, lvl, repeating_source, spelloutput)	=> {
+			const update_spelloutput = (higherlevels, lvl, repeating_source, spelloutput) => {
 				let spelllevel = "@{spelllevel}";
 				let update = {};
 
 				if (higherlevels) {
-					for(i = 0; i < 10-lvl; i++) {
+					for (i = 0; i < 10 - lvl; i++) {
 						let tot = parseInt(i, 10) + parseInt(lvl, 10);
 						spelllevel = spelllevel + "|Level " + tot + "," + tot;
 					}
@@ -7958,52 +8154,56 @@
 				}
 				update[repeating_source + "_rollcontent"] = "@{wtype}&{template:spell} {{level=@{spellschool} " + spelllevel + "}} {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}";
 
-				setAttrs(update, {silent: true});
+				setAttrs(update, {
+					silent: true
+				});
 			};
 
-			on("change:class change:custom_class change:cust_classname change:cust_hitdietype change:cust_spellcasting_ability change:cust_spellslots change:cust_strength_save_prof change:cust_dexterity_save_prof change:cust_constitution_save_prof change:cust_intelligence_save_prof change:cust_wisdom_save_prof change:cust_charisma_save_prof change:subclass change:multiclass1 change:multiclass1_subclass change:multiclass2 change:multiclass2_subclass change:multiclass3 change:multiclass3_subclass" , function(eventinfo) {
-				if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+			on("change:class change:custom_class change:cust_classname change:cust_hitdietype change:cust_spellcasting_ability change:cust_spellslots change:cust_strength_save_prof change:cust_dexterity_save_prof change:cust_constitution_save_prof change:cust_intelligence_save_prof change:cust_wisdom_save_prof change:cust_charisma_save_prof change:subclass change:multiclass1 change:multiclass1_subclass change:multiclass2 change:multiclass2_subclass change:multiclass3 change:multiclass3_subclass", function(eventinfo) {
+				if (eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
 					return;
 				}
 				update_class();
 			});
 
 			on("change:base_level change:multiclass1_flag change:multiclass1 change:multiclass1_lvl change:multiclass2_flag change:multiclass2 change:multiclass2_lvl change:multiclass3_flag change:multiclass3 change:multiclass3_lvl change:arcane_fighter change:arcane_rogue", function(eventinfo) {
-				if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+				if (eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
 					return;
 				}
 				set_level();
 			});
 
 			on("change:level_calculations change:caster_level change:lvl1_slots_mod change:lvl2_slots_mod change:lvl3_slots_mod change:lvl4_slots_mod change:lvl5_slots_mod change:lvl6_slots_mod change:lvl7_slots_mod change:lvl8_slots_mod change:lvl9_slots_mod", function(eventinfo) {
-				if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+				if (eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
 					return;
 				}
 				getAttrs(["level_calculations"], function(v) {
-					if(!v["level_calculations"] || v["level_calculations"] == "on") {
+					if (!v["level_calculations"] || v["level_calculations"] == "on") {
 						update_spell_slots();
 					};
 				});
 			});
 
 			on("change:caster_level", function(eventinfo) {
-				getAttrs(["caster_level","npc"], function(v) {
+				getAttrs(["caster_level", "npc"], function(v) {
 					var casterlvl = v["caster_level"] && !isNaN(parseInt(v["caster_level"], 10)) ? parseInt(v["caster_level"], 10) : 0;
-					if(v["npc"] && v["npc"] == 1 && casterlvl > 0) {
-						setAttrs({level: casterlvl})
+					if (v["npc"] && v["npc"] == 1 && casterlvl > 0) {
+						setAttrs({
+							level: casterlvl
+						})
 					};
 				});
 			});
 
 			on("change:pb_type change:pb_custom", function(eventinfo) {
-				if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+				if (eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
 					return;
 				}
 				update_pb();
 			});
 
 			on("change:dtype", function(eventinfo) {
-				if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+				if (eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
 					return;
 				}
 				update_attacks("all");
@@ -8011,7 +8211,7 @@
 			});
 
 			on("change:jack_of_all_trades", function(eventinfo) {
-				if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+				if (eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
 					return;
 				}
 				update_jack_attr();
@@ -8019,14 +8219,14 @@
 			});
 
 			on("change:initmod change:init_tiebreaker change:use_intelligent_initiative", function(eventinfo) {
-				if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+				if (eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
 					return;
 				}
 				update_initiative();
 			});
 
 			on("change:spellcasting_ability change:spell_dc_mod change:globalmagicmod", function(eventinfo) {
-				if(eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+				if (eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
 					return;
 				}
 				update_spell_info();
@@ -8047,39 +8247,39 @@
 			on("change:repeating_npcaction:attack_flag change:repeating_npcaction:attack_type change:repeating_npcaction:attack_range change:repeating_npcaction:attack_target change:repeating_npcaction:attack_tohit change:repeating_npcaction:attack_damage change:repeating_npcaction:attack_damagetype change:repeating_npcaction:attack_damage2 change:repeating_npcaction:attack_damagetype2 change:repeating_npcaction-l:attack_flag change:repeating_npcaction-l:attack_type change:repeating_npcaction-l:attack_range change:repeating_npcaction-l:attack_target change:repeating_npcaction-l:attack_tohit change:repeating_npcaction-l:attack_damage change:repeating_npcaction-l:attack_damagetype change:repeating_npcaction-l:attack_damage2 change:repeating_npcaction-l:attack_damagetype2 change:repeating_npcaction:show_desc change:repeating_npcaction-l:show_desc change:repeating_npcaction:description change:repeating_npcaction-l:description", function(eventinfo) {
 				var actionid = eventinfo.sourceAttribute.substring(20, 40);
 				var legendary = eventinfo.sourceAttribute.indexOf("npcaction-l") > -1 ? true : false;
-				if(legendary) {
+				if (legendary) {
 					actionid = eventinfo.sourceAttribute.substring(22, 42);
 				}
 				update_npc_action(actionid, legendary);
 			});
 
 			on("change:core_die change:halflingluck_flag", function() {
-				getAttrs(["core_die","halflingluck_flag"], function(v) {
+				getAttrs(["core_die", "halflingluck_flag"], function(v) {
 					core = v.core_die && v.core_die != "" ? v.core_die : "1d20";
 					luck = v.halflingluck_flag && v.halflingluck_flag === "1" ? "ro<1" : "";
 					update = {};
 					update["d20"] = core + luck;
-					if(!v.core_die || v.core_die === "") {
+					if (!v.core_die || v.core_die === "") {
 						update["core_die"] = "1d20";
 					}
 					setAttrs(update);
 				});
 			});
 
-			[`ac`,`attack`,'save','skill',].forEach(attr => {
+			[`ac`, `attack`, 'save', 'skill', ].forEach(attr => {
 				on(`change:global_${attr}_mod_flag`, (eventinfo) => {
 					const mod = (attr === "attack") ? "tohitmod" : `${attr}mod`;
-					if(eventinfo.newValue === "1") {
-						const firstAttr	   = (attr === "ac")  ? "val" : "roll";
-						const firstAttrValue  = (attr === "ac")  ? 1 : "1d4";
-						const secondAttrValue = (attr === "ac")  ? "Defense" : (attr === "skill") ? "GUIDANCE" : "BLESS";
+					if (eventinfo.newValue === "1") {
+						const firstAttr = (attr === "ac") ? "val" : "roll";
+						const firstAttrValue = (attr === "ac") ? 1 : "1d4";
+						const secondAttrValue = (attr === "ac") ? "Defense" : (attr === "skill") ? "GUIDANCE" : "BLESS";
 
 						getSectionIDs(mod, (ids) => {
-							if(!ids || ids.length === 0) {
+							if (!ids || ids.length === 0) {
 								var update = {};
 								var rowid = generateRowID();
-								update[`repeating_${mod}_${rowid}_global_${attr}_${firstAttr}`]= `${firstAttrValue}`;
-								update[`repeating_${mod}_${rowid}_global_${attr}_name`]		= `${secondAttrValue}`;
+								update[`repeating_${mod}_${rowid}_global_${attr}_${firstAttr}`] = `${firstAttrValue}`;
+								update[`repeating_${mod}_${rowid}_global_${attr}_name`] = `${secondAttrValue}`;
 								update[`repeating_${mod}_${rowid}_global_${attr}_active_flag`] = "1";
 								setAttrs(update);
 							}
@@ -8114,22 +8314,28 @@
 			});
 
 			on("change:confirm", function(eventinfo) {
-				setAttrs({monster_confirm_flag: ""});
+				setAttrs({
+					monster_confirm_flag: ""
+				});
 				getAttrs(["drop_category"], function(v) {
-					if(v["drop_category"]) {
+					if (v["drop_category"]) {
 						handle_drop(v["drop_category"]);
 					}
 				});
 			});
 
 			on("change:cancel", function(eventinfo) {
-				setAttrs({monster_confirm_flag: ""});
+				setAttrs({
+					monster_confirm_flag: ""
+				});
 				var update = {};
 				update["drop_category"] = "";
 				update["drop_name"] = "";
 				update["drop_data"] = "";
 				update["drop_content"] = "";
-				setAttrs(update, {silent: true});
+				setAttrs(update, {
+					silent: true
+				});
 			});
 
 			on("change:passiveperceptionmod", function(eventinfo) {
@@ -8141,14 +8347,16 @@
 				var attackids = eventinfo.removedInfo && eventinfo.removedInfo["repeating_inventory_" + itemid + "_itemattackid"] ? eventinfo.removedInfo["repeating_inventory_" + itemid + "_itemattackid"] : undefined;
 				var resourceid = eventinfo.removedInfo && eventinfo.removedInfo["repeating_inventory_" + itemid + "_itemresourceid"] ? eventinfo.removedInfo["repeating_inventory_" + itemid + "_itemresourceid"] : undefined;
 
-				if(attackids) {
-					_.each(attackids.split(","), function(value) { remove_attack(value); });
+				if (attackids) {
+					_.each(attackids.split(","), function(value) {
+						remove_attack(value);
+					});
 				}
-				if(resourceid) {
+				if (resourceid) {
 					remove_resource(resourceid);
 				}
 
-				if(eventinfo.removedInfo && eventinfo.removedInfo["repeating_inventory_" + itemid + "_itemmodifiers"]) {
+				if (eventinfo.removedInfo && eventinfo.removedInfo["repeating_inventory_" + itemid + "_itemmodifiers"]) {
 					check_itemmodifiers(eventinfo.removedInfo["repeating_inventory_" + itemid + "_itemmodifiers"]);
 				}
 
@@ -8160,23 +8368,27 @@
 				var itemid = eventinfo.removedInfo["repeating_attack_" + attackid + "_itemid"];
 				var spellid = eventinfo.removedInfo["repeating_attack_" + attackid + "_spellid"];
 				var spelllvl = eventinfo.removedInfo["repeating_attack_" + attackid + "_spelllevel"];
-				if(itemid) {
+				if (itemid) {
 					getAttrs(["repeating_inventory_" + itemid + "_hasattack"], function(v) {
-						if(v["repeating_inventory_" + itemid + "_hasattack"] && v["repeating_inventory_" + itemid + "_hasattack"] == 1) {
+						if (v["repeating_inventory_" + itemid + "_hasattack"] && v["repeating_inventory_" + itemid + "_hasattack"] == 1) {
 							var update = {};
 							update["repeating_inventory_" + itemid + "_itemattackid"] = "";
 							update["repeating_inventory_" + itemid + "_hasattack"] = 0;
-							setAttrs(update, {silent: true});
+							setAttrs(update, {
+								silent: true
+							});
 						}
 					});
 				};
-				if(spellid && spelllvl) {
+				if (spellid && spelllvl) {
 					getAttrs(["repeating_spell-" + spelllvl + "_" + spellid + "_spelloutput"], function(v) {
-						if(v["repeating_spell-" + spelllvl + "_" + spellid + "_spelloutput"] && v["repeating_spell-" + spelllvl + "_" + spellid + "_spelloutput"] == "ATTACK") {
+						if (v["repeating_spell-" + spelllvl + "_" + spellid + "_spelloutput"] && v["repeating_spell-" + spelllvl + "_" + spellid + "_spelloutput"] == "ATTACK") {
 							var update = {};
 							update["repeating_spell-" + spelllvl + "_" + spellid + "_spellattackid"] = "";
 							update["repeating_spell-" + spelllvl + "_" + spellid + "_spelloutput"] = "SPELLCARD";
-							setAttrs(update, {silent: true});
+							setAttrs(update, {
+								silent: true
+							});
 						}
 					});
 				};
@@ -8188,20 +8400,22 @@
 				var left_itemid = eventinfo.removedInfo["repeating_resource_" + resourceid + "_resource_left_itemid"];
 				var right_itemid = eventinfo.removedInfo["repeating_resource_" + resourceid + "_resource_right_itemid"];
 				var update = {};
-				if(left_itemid) {
+				if (left_itemid) {
 					update["repeating_inventory_" + left_itemid + "_useasresource"] = 0;
 					update["repeating_inventory_" + left_itemid + "_itemresourceid"] = "";
 				}
-				if(right_itemid) {
+				if (right_itemid) {
 					update["repeating_inventory_" + right_itemid + "_useasresource"] = 0;
 					update["repeating_inventory_" + right_itemid + "_itemresourceid"] = "";
 				}
-				setAttrs(update, {silent: true});
+				setAttrs(update, {
+					silent: true
+				});
 			});
 
 			on("remove:repeating_spell-cantrip remove:repeating_spell-1 remove:repeating_spell-2 remove:repeating_spell-3 remove:repeating_spell-4 remove:repeating_spell-5 remove:repeating_spell-6 remove:repeating_spell-7 remove:repeating_spell-8 remove:repeating_spell-9", function(eventinfo) {
 				var attackid = eventinfo.removedInfo[eventinfo.sourceAttribute + "_spellattackid"];
-				if(attackid) {
+				if (attackid) {
 					remove_attack(attackid);
 				}
 			});
@@ -8212,7 +8426,7 @@
 
 			var update_attr = function(attr) {
 				var update = {};
-				var attr_fields = [attr + "_base",attr + "_bonus"];
+				var attr_fields = [attr + "_base", attr + "_bonus"];
 				getSectionIDs("repeating_inventory", function(idarray) {
 					_.each(idarray, function(currentID, i) {
 						attr_fields.push("repeating_inventory_" + currentID + "_equipped");
@@ -8224,19 +8438,17 @@
 						var item_base = 0;
 						var item_bonus = 0;
 						_.each(idarray, function(currentID) {
-							if((!v["repeating_inventory_" + currentID + "_equipped"] || v["repeating_inventory_" + currentID + "_equipped"] === "1") && v["repeating_inventory_" + currentID + "_itemmodifiers"] && v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf(attr > -1)) {
+							if ((!v["repeating_inventory_" + currentID + "_equipped"] || v["repeating_inventory_" + currentID + "_equipped"] === "1") && v["repeating_inventory_" + currentID + "_itemmodifiers"] && v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf(attr > -1)) {
 								var mods = v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().split(",");
 								_.each(mods, function(mod) {
-									if(mod.indexOf(attr) > -1 && mod.indexOf("save") === -1) {
-										if(mod.indexOf(":") > -1) {
+									if (mod.indexOf(attr) > -1 && mod.indexOf("save") === -1) {
+										if (mod.indexOf(":") > -1) {
 											var new_base = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
 											item_base = new_base && new_base > item_base ? new_base : item_base;
-										}
-										else if(mod.indexOf("-") > -1) {
+										} else if (mod.indexOf("-") > -1) {
 											var new_mod = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
 											item_bonus = new_mod ? item_bonus - new_mod : item_bonus;
-										}
-										else {
+										} else {
 											var new_mod = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
 											item_bonus = new_mod ? item_bonus + new_mod : item_bonus;
 										}
@@ -8253,9 +8465,9 @@
 				});
 			};
 
-			var update_mod = function (attr) {
+			var update_mod = function(attr) {
 				getAttrs([attr], function(v) {
-					var attr_abr = attr.substring(0,3);
+					var attr_abr = attr.substring(0, 3);
 					var finalattr = v[attr] && isNaN(v[attr]) === false ? Math.floor((parseInt(v[attr], 10) - 10) / 2) : 0;
 					var update = {};
 					update[attr + "_mod"] = finalattr;
@@ -8264,8 +8476,8 @@
 				});
 			};
 
-			var update_save = function (attr) {
-				var save_attrs = [attr + "_mod", attr + "_save_prof", attr + "_save_mod","pb","globalsavemod","pb_type"];
+			var update_save = function(attr) {
+				var save_attrs = [attr + "_mod", attr + "_save_prof", attr + "_save_mod", "pb", "globalsavemod", "pb_type"];
 				getSectionIDs("repeating_inventory", function(idarray) {
 					_.each(idarray, function(currentID, i) {
 						save_attrs.push("repeating_inventory_" + currentID + "_equipped");
@@ -8279,30 +8491,31 @@
 						var global = v["globalsavemod"] && !isNaN(v["globalsavemod"]) ? parseInt(v["globalsavemod"], 10) : 0;
 						var items = 0;
 						_.each(idarray, function(currentID) {
-							if(v["repeating_inventory_" + currentID + "_equipped"] && v["repeating_inventory_" + currentID + "_equipped"] === "1" && v["repeating_inventory_" + currentID + "_itemmodifiers"] && (v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf("saving throws") > -1 || v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf(attr + " save") > -1)) {
+							if (v["repeating_inventory_" + currentID + "_equipped"] && v["repeating_inventory_" + currentID + "_equipped"] === "1" && v["repeating_inventory_" + currentID + "_itemmodifiers"] && (v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf("saving throws") > -1 || v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf(attr + " save") > -1)) {
 								var mods = v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().split(",");
 								_.each(mods, function(mod) {
-									if(mod.indexOf(attr + " save") > -1) {
+									if (mod.indexOf(attr + " save") > -1) {
 										var substr = mod.slice(mod.lastIndexOf(attr + " save") + attr.length + " save".length);
-										var bonus = substr && substr.length > 0 && !isNaN(parseInt(substr,10)) ? parseInt(substr,10) : 0;
-									}
-									else if(mod.indexOf("saving throws") > -1) {
+										var bonus = substr && substr.length > 0 && !isNaN(parseInt(substr, 10)) ? parseInt(substr, 10) : 0;
+									} else if (mod.indexOf("saving throws") > -1) {
 										var substr = mod.slice(mod.lastIndexOf("saving throws") + "saving throws".length);
-										var bonus = substr && substr.length > 0 && !isNaN(parseInt(substr,10)) ? parseInt(substr,10) : 0;
+										var bonus = substr && substr.length > 0 && !isNaN(parseInt(substr, 10)) ? parseInt(substr, 10) : 0;
 									};
-									if(bonus && bonus != 0) {
+									if (bonus && bonus != 0) {
 										items = items + bonus;
 									};
 								});
 							}
 						});
 						var total = attr_mod + prof + save_mod + global + items;
-						if(v["pb_type"] && v["pb_type"] === "die" && v[attr + "_save_prof"] != 0 && attr != "death") {
+						if (v["pb_type"] && v["pb_type"] === "die" && v[attr + "_save_prof"] != 0 && attr != "death") {
 							total = total + "+" + v["pb"];
 						};
 						var update = {};
 						update[attr + "_save_bonus"] = total;
-						setAttrs(update, {silent: true});
+						setAttrs(update, {
+							silent: true
+						});
 					});
 				});
 			};
@@ -8317,23 +8530,24 @@
 				update_save("death");
 			};
 
-			var update_all_ability_checks = function(){
+			var update_all_ability_checks = function() {
 				update_initiative();
-				update_skills(["athletics", "acrobatics", "sleight_of_hand", "stealth", "arcana", "history", "investigation", "nature", "religion", "animal_handling", "insight", "medicine", "perception", "survival","deception", "intimidation", "performance", "persuasion"]);
+				update_skills(["athletics", "acrobatics", "sleight_of_hand", "stealth", "arcana", "history", "investigation", "nature", "religion", "animal_handling", "insight", "medicine", "perception", "survival", "deception", "intimidation", "performance", "persuasion"]);
 			};
 
-			var update_skills = function (skills_array) {
-				var skill_parent = {athletics: "strength", acrobatics: "dexterity", sleight_of_hand: "dexterity", stealth: "dexterity", arcana: "intelligence", history: "intelligence", investigation: "intelligence", nature: "intelligence", religion: "intelligence", animal_handling: "wisdom", insight: "wisdom", medicine: "wisdom", perception: "wisdom", survival: "wisdom", deception: "charisma", intimidation: "charisma", performance: "charisma", persuasion: "charisma"};
-				var attrs_to_get = ["pb","pb_type","jack_of_all_trades","jack"];
+			var update_skills = function(skills_array) {
+				var attrs_to_get = ["pb", "pb_type", "jack_of_all_trades", "jack", "strength_mod", "dexterity_mod", "constitution_mod", "intelligence_mod", "wisdom_mod", "charisma_mod"];
 				var update = {};
 				var callbacks = [];
 
-				if(skills_array.indexOf("perception") > -1) {
-					callbacks.push( function() {update_passive_perception();} )
+				if (skills_array.indexOf("perception") > -1) {
+					callbacks.push(function() {
+						update_passive_perception();
+					})
 				};
 
 				_.each(skills_array, function(s) {
-					if(skill_parent[s] && attrs_to_get.indexOf(skill_parent[s]) === -1) {attrs_to_get.push(skill_parent[s] + "_mod")};
+					attrs_to_get.push(s + "_attribute")
 					attrs_to_get.push(s + "_prof");
 					attrs_to_get.push(s + "_type");
 					attrs_to_get.push(s + "_flat");
@@ -8348,7 +8562,11 @@
 					getAttrs(attrs_to_get, function(v) {
 						_.each(skills_array, function(s) {
 							console.log("UPDATING SKILL: " + s);
-							var attr_mod = v[skill_parent[s] + "_mod"] ? parseInt(v[skill_parent[s] + "_mod"], 10) : 0;
+							var attr_mod = 0;
+							if (v[s + "_attribute"]) {
+								var attribute = v[s + "_attribute"].toLowerCase() + "_mod";
+								attr_mod = parseInt(v[attribute], 10);
+							}
 							var prof = v[s + "_prof"] != 0 && !isNaN(v["pb"]) ? parseInt(v["pb"], 10) : 0;
 							var flat = v[s + "_flat"] && !isNaN(parseInt(v[s + "_flat"], 10)) ? parseInt(v[s + "_flat"], 10) : 0;
 							var type = v[s + "_type"] && !isNaN(parseInt(v[s + "_type"], 10)) ? parseInt(v[s + "_type"], 10) : 1;
@@ -8356,15 +8574,14 @@
 							var item_bonus = 0;
 
 							_.each(idarray, function(currentID) {
-								if(v["repeating_inventory_" + currentID + "_equipped"] && v["repeating_inventory_" + currentID + "_equipped"] === "1" && v["repeating_inventory_" + currentID + "_itemmodifiers"] && (v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().replace(/ /g,"_").indexOf(s) > -1 || v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf("ability checks") > -1)) {
+								if (v["repeating_inventory_" + currentID + "_equipped"] && v["repeating_inventory_" + currentID + "_equipped"] === "1" && v["repeating_inventory_" + currentID + "_itemmodifiers"] && (v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().replace(/ /g, "_").indexOf(s) > -1 || v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf("ability checks") > -1)) {
 									var mods = v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().split(",");
 									_.each(mods, function(mod) {
-										if(mod.replace(/ /g,"_").indexOf(s) > -1 || mod.indexOf("ability checks") > -1) {
-											if(mod.indexOf("-") > -1) {
+										if (mod.replace(/ /g, "_").indexOf(s) > -1 || mod.indexOf("ability checks") > -1) {
+											if (mod.indexOf("-") > -1) {
 												var new_mod = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
 												item_bonus = new_mod ? item_bonus - new_mod : item_bonus;
-											}
-											else {
+											} else {
 												var new_mod = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
 												item_bonus = new_mod ? item_bonus + new_mod : item_bonus;
 											}
@@ -8375,20 +8592,17 @@
 
 							var total = attr_mod + flat + item_bonus;
 
-							if(v["pb_type"] && v["pb_type"] === "die") {
-								if(v[s + "_prof"] != 0) {
+							if (v["pb_type"] && v["pb_type"] === "die") {
+								if (v[s + "_prof"] != 0) {
 									type === 1 ? "" : "2"
 									total = total + "+" + type + v["pb"];
-								}
-								else if(v[s + "_prof"] == 0 && jack != 0) {
+								} else if (v[s + "_prof"] == 0 && jack != 0) {
 									total = total + "+" + jack;
 								};
-							}
-							else {
-								if(v[s + "_prof"] != 0) {
+							} else {
+								if (v[s + "_prof"] != 0) {
 									total = total + (prof * type);
-								}
-								else if(v[s + "_prof"] == 0 && jack != 0) {
+								} else if (v[s + "_prof"] == 0 && jack != 0) {
 									total = total + parseInt(jack, 10);
 								};
 
@@ -8396,21 +8610,25 @@
 							update[s + "_bonus"] = total;
 						});
 
-						setAttrs(update, {silent: true}, function() {callbacks.forEach(function(callback) {callback(); })} );
+						setAttrs(update, {
+							silent: true
+						}, function() {
+							callbacks.forEach(function(callback) {
+								callback();
+							})
+						});
 					});
 				});
 			};
 
 			var update_tool = function(tool_id) {
-				if(tool_id.substring(0,1) === "-" && tool_id.length === 20) {
+				if (tool_id.substring(0, 1) === "-" && tool_id.length === 20) {
 					do_update_tool([tool_id]);
-				}
-				else if(tool_id === "all") {
+				} else if (tool_id === "all") {
 					getSectionIDs("repeating_tool", function(idarray) {
 						do_update_tool(idarray);
 					});
-				}
-				else {
+				} else {
 					getSectionIDs("repeating_tool", function(idarray) {
 						var tool_attribs = [];
 						_.each(idarray, function(id) {
@@ -8419,11 +8637,11 @@
 						getAttrs(tool_attribs, function(v) {
 							var attr_tool_ids = [];
 							_.each(idarray, function(id) {
-								if(v["repeating_tool_" + id + "_toolattr_base"] && v["repeating_tool_" + id + "_toolattr_base"].indexOf(tool_id) > -1) {
+								if (v["repeating_tool_" + id + "_toolattr_base"] && v["repeating_tool_" + id + "_toolattr_base"].indexOf(tool_id) > -1) {
 									attr_tool_ids.push(id);
 								}
 							});
-							if(attr_tool_ids.length > 0) {
+							if (attr_tool_ids.length > 0) {
 								do_update_tool(attr_tool_ids);
 							}
 						});
@@ -8432,7 +8650,7 @@
 			};
 
 			var do_update_tool = function(tool_array) {
-				var tool_attribs = ["pb","pb_type","jack","strength_mod","dexterity_mod","constitution_mod","intelligence_mod","wisdom_mod","charisma_mod"];
+				var tool_attribs = ["pb", "pb_type", "jack", "strength_mod", "dexterity_mod", "constitution_mod", "intelligence_mod", "wisdom_mod", "charisma_mod"];
 				var update = {};
 				_.each(tool_array, function(tool_id) {
 					tool_attribs.push("repeating_tool_" + tool_id + "_toolbonus_base");
@@ -8444,54 +8662,64 @@
 					_.each(tool_array, function(tool_id) {
 						console.log("UPDATING TOOL: " + tool_id);
 						var query = false;
-						if(v["repeating_tool_" + tool_id + "_toolattr_base"] && v["repeating_tool_" + tool_id + "_toolattr_base"].substring(0,2) === "?{") {
+						if (v["repeating_tool_" + tool_id + "_toolattr_base"] && v["repeating_tool_" + tool_id + "_toolattr_base"].substring(0, 2) === "?{") {
 							update["repeating_tool_" + tool_id + "_toolattr"] = "QUERY";
 							var mod = "?{Attribute?|Strength,@{strength_mod}|Dexterity,@{dexterity_mod}|Constitution,@{constitution_mod}|Intelligence,@{intelligence_mod}|Wisdom,@{wisdom_mod}|Charisma,@{charisma_mod}}";
-							if(v["repeating_tool_" + tool_id + "_tool_mod"]) {
+							if (v["repeating_tool_" + tool_id + "_tool_mod"]) {
 								mod = mod + "+" + v["repeating_tool_" + tool_id + "_tool_mod"];
 							}
 							query = true;
-						}
-						else {
+						} else {
 							var attr = v["repeating_tool_" + tool_id + "_toolattr_base"].substring(0, v["repeating_tool_" + tool_id + "_toolattr_base"].length - 5).substr(2);
 							var attr_mod = v[attr + "_mod"] ? parseInt(v[attr + "_mod"], 10) : 0;
 							var tool_mod = v["repeating_tool_" + tool_id + "_tool_mod"] && !isNaN(parseInt(v["repeating_tool_" + tool_id + "_tool_mod"], 10)) ? parseInt(v["repeating_tool_" + tool_id + "_tool_mod"], 10) : 0;
 							var mod = attr_mod + tool_mod;
 							update["repeating_tool_" + tool_id + "_toolattr"] = attr.toUpperCase();
-							if(v["repeating_tool_" + tool_id + "_tool_mod"] && v["repeating_tool_" + tool_id + "_tool_mod"].indexOf("@{") > -1) {
+							if (v["repeating_tool_" + tool_id + "_tool_mod"] && v["repeating_tool_" + tool_id + "_tool_mod"].indexOf("@{") > -1) {
 								update["repeating_tool_" + tool_id + "_toolbonus"] = update["repeating_tool_" + tool_id + "_toolbonus"] + "+" + v["repeating_tool_" + tool_id + "_tool_mod"];
 							}
-							if(!v["repeating_tool_" + tool_id + "_tool_mod"]) {
+							if (!v["repeating_tool_" + tool_id + "_tool_mod"]) {
 								update["repeating_tool_" + tool_id + "_tool_mod"] = 0;
 							}
 						};
 
-						if(v["pb_type"] && v["pb_type"] === "die" ) {
-							if(v["repeating_tool_" + tool_id + "_toolbonus_base"] === "(@{pb})") {update["repeating_tool_" + tool_id + "_toolbonus"] = mod + "+" + v.pb}
-							else if(v["repeating_tool_" + tool_id + "_toolbonus_base"] === "(@{pb}*2)") {update["repeating_tool_" + tool_id + "_toolbonus"] = mod + "+2" + v.pb}
-							else if(v["repeating_tool_" + tool_id + "_toolbonus_base"] === "(floor(@{pb}/2))") {update["repeating_tool_" + tool_id + "_toolbonus"] = mod + "+" + v.jack};
-						}
-						else if(v["repeating_tool_" + tool_id + "_toolattr_base"] && v["repeating_tool_" + tool_id + "_toolattr_base"].substring(0,2) === "?{") {
-							if(v["repeating_tool_" + tool_id + "_toolbonus_base"] === "(@{pb})") {update["repeating_tool_" + tool_id + "_toolbonus"] = mod + "+" + parseInt(v.pb, 10)}
-							else if(v["repeating_tool_" + tool_id + "_toolbonus_base"] === "(@{pb}*2)") {update["repeating_tool_" + tool_id + "_toolbonus"] = mod + "+" + (parseInt(v.pb, 10)*2)}
-							else if(v["repeating_tool_" + tool_id + "_toolbonus_base"] === "(floor(@{pb}/2))") {update["repeating_tool_" + tool_id + "_toolbonus"] = mod + "+" + parseInt(v.jack, 10)};
-						}
-						else {
-							if(v["repeating_tool_" + tool_id + "_toolbonus_base"] === "(@{pb})") {update["repeating_tool_" + tool_id + "_toolbonus"] = mod + parseInt(v.pb, 10)}
-							else if(v["repeating_tool_" + tool_id + "_toolbonus_base"] === "(@{pb}*2)") {update["repeating_tool_" + tool_id + "_toolbonus"] = mod + (parseInt(v.pb, 10)*2)}
-							else if(v["repeating_tool_" + tool_id + "_toolbonus_base"] === "(floor(@{pb}/2))") {update["repeating_tool_" + tool_id + "_toolbonus"] = mod + parseInt(v.jack, 10)};
+						if (v["pb_type"] && v["pb_type"] === "die") {
+							if (v["repeating_tool_" + tool_id + "_toolbonus_base"] === "(@{pb})") {
+								update["repeating_tool_" + tool_id + "_toolbonus"] = mod + "+" + v.pb
+							} else if (v["repeating_tool_" + tool_id + "_toolbonus_base"] === "(@{pb}*2)") {
+								update["repeating_tool_" + tool_id + "_toolbonus"] = mod + "+2" + v.pb
+							} else if (v["repeating_tool_" + tool_id + "_toolbonus_base"] === "(floor(@{pb}/2))") {
+								update["repeating_tool_" + tool_id + "_toolbonus"] = mod + "+" + v.jack
+							};
+						} else if (v["repeating_tool_" + tool_id + "_toolattr_base"] && v["repeating_tool_" + tool_id + "_toolattr_base"].substring(0, 2) === "?{") {
+							if (v["repeating_tool_" + tool_id + "_toolbonus_base"] === "(@{pb})") {
+								update["repeating_tool_" + tool_id + "_toolbonus"] = mod + "+" + parseInt(v.pb, 10)
+							} else if (v["repeating_tool_" + tool_id + "_toolbonus_base"] === "(@{pb}*2)") {
+								update["repeating_tool_" + tool_id + "_toolbonus"] = mod + "+" + (parseInt(v.pb, 10) * 2)
+							} else if (v["repeating_tool_" + tool_id + "_toolbonus_base"] === "(floor(@{pb}/2))") {
+								update["repeating_tool_" + tool_id + "_toolbonus"] = mod + "+" + parseInt(v.jack, 10)
+							};
+						} else {
+							if (v["repeating_tool_" + tool_id + "_toolbonus_base"] === "(@{pb})") {
+								update["repeating_tool_" + tool_id + "_toolbonus"] = mod + parseInt(v.pb, 10)
+							} else if (v["repeating_tool_" + tool_id + "_toolbonus_base"] === "(@{pb}*2)") {
+								update["repeating_tool_" + tool_id + "_toolbonus"] = mod + (parseInt(v.pb, 10) * 2)
+							} else if (v["repeating_tool_" + tool_id + "_toolbonus_base"] === "(floor(@{pb}/2))") {
+								update["repeating_tool_" + tool_id + "_toolbonus"] = mod + parseInt(v.jack, 10)
+							};
 						};
 
-						if(query) {
+						if (query) {
 							update["repeating_tool_" + tool_id + "_toolbonus_display"] = "?";
-						}
-						else {
+						} else {
 							update["repeating_tool_" + tool_id + "_toolbonus_display"] = update["repeating_tool_" + tool_id + "_toolbonus"];
 						};
 
 					});
 
-					setAttrs(update, {silent: true});
+					setAttrs(update, {
+						silent: true
+					});
 				});
 			};
 
@@ -8505,7 +8733,7 @@
 								attrlist.push("repeating_" + thisget.name + "_" + sectionId + "_" + attr);
 							});
 						});
-						if(getobj.length > 0) {
+						if (getobj.length > 0) {
 							getallrepeating(getobj, thiscallback, attrlist);
 						} else {
 							getAttrs(attrlist, function(vals) {
@@ -8514,39 +8742,80 @@
 						};
 					});
 				};
-				var getList = [
-					{name: "proficiencies", list: ["name"]},
-					{name: "tool", list: ["toolname", "toolattr_base"]},
-					{name: "traits", list: ["name", "source", "source_type"]},
-					{name: "resource", list: ["resource_left_name", "resource_right_name"]},
-					{name: "spell-cantrip", list: ["spellname", "spellattackid", "spellsource", "spellattackid"]},
-					{name: "savemod", list: ["global_save_name"]},
-					{name: "tohitmod", list: ["global_attack_name"]},
-					{name: "damagemod", list: ["global_damage_name"]},
-					{name: "acmod", list: ["global_ac_name"]},
-					{name: "skillmod", list: ["global_skill_name"]},
-					{name: "attack", list: ["atkname", "spellid"]},
-					{name: "hpmod", list: ["levels", "source", "mod"]}
+				var getList = [{
+						name: "proficiencies",
+						list: ["name"]
+					},
+					{
+						name: "tool",
+						list: ["toolname", "toolattr_base"]
+					},
+					{
+						name: "traits",
+						list: ["name", "source", "source_type"]
+					},
+					{
+						name: "resource",
+						list: ["resource_left_name", "resource_right_name"]
+					},
+					{
+						name: "spell-cantrip",
+						list: ["spellname", "spellattackid", "spellsource", "spellattackid"]
+					},
+					{
+						name: "savemod",
+						list: ["global_save_name"]
+					},
+					{
+						name: "tohitmod",
+						list: ["global_attack_name"]
+					},
+					{
+						name: "damagemod",
+						list: ["global_damage_name"]
+					},
+					{
+						name: "acmod",
+						list: ["global_ac_name"]
+					},
+					{
+						name: "skillmod",
+						list: ["global_skill_name"]
+					},
+					{
+						name: "attack",
+						list: ["atkname", "spellid"]
+					},
+					{
+						name: "hpmod",
+						list: ["levels", "source", "mod"]
+					}
 				];
-				for(var x=1; x<=9; x++) {
-					getList.push({ name: "spell-" + x, list: ["spellname", "spellattackid", "spellsource", "spellattackid"] });
+				for (var x = 1; x <= 9; x++) {
+					getList.push({
+						name: "spell-" + x,
+						list: ["spellname", "spellattackid", "spellsource", "spellattackid"]
+					});
 				}
-				var repeating = {prof_names: [], traits: []};
+				var repeating = {
+					prof_names: [],
+					traits: []
+				};
 				_.each(getList, function(section) {
-					if(!["proficiencies", "traits"].includes(section.name)) {
+					if (!["proficiencies", "traits"].includes(section.name)) {
 						repeating[section.name] = {};
 					}
 				});
 				getallrepeating(getList, function(vals) {
 					var traitstemp = {};
 					_.each(vals, function(value, name) {
-						if(name.split("_")[1] == "proficiencies") {
+						if (name.split("_")[1] == "proficiencies") {
 							repeating.prof_names.push(value.toLowerCase());
-						} else if(name.split("_")[1] == "tool") {
+						} else if (name.split("_")[1] == "tool") {
 							repeating.tool[name.split("_")[2]] = repeating.tool[name.split("_")[2]] || {};
 							let attr = _.last(name.split("_"));
 							repeating.tool[name.split("_")[2]][attr] = value.toLowerCase();
-							if(attr == "toolname") repeating.prof_names.push(value.toLowerCase());
+							if (attr == "toolname") repeating.prof_names.push(value.toLowerCase());
 						} else if (name.split("_")[1] == "traits") {
 							traitstemp[name.split("_")[2]] = traitstemp[name.split("_")[2]] ? traitstemp[name.split("_")[2]] : {};
 							traitstemp[name.split("_")[2]][_.last(name.split("_"))] = value;
@@ -8581,7 +8850,7 @@
 					var pagedata = {};
 					try {
 						pagedata = JSON.parse(v.drop_data);
-					} catch(e) {
+					} catch (e) {
 						pagedata = v.drop_data;
 					}
 					var page = {
@@ -8592,7 +8861,13 @@
 					var category = page.data["Category"];
 					get_repeating_data(function(repeating) {
 						var results = processDrop(page, v, repeating);
-						setAttrs(results.update, {silent: true}, function() {results.callbacks.forEach(function(callback) {callback(); })} );
+						setAttrs(results.update, {
+							silent: true
+						}, function() {
+							results.callbacks.forEach(function(callback) {
+								callback();
+							})
+						});
 					});
 
 				});
@@ -8604,7 +8879,7 @@
 					var result = {};
 					try {
 						result = JSON.parse(data);
-					} catch(e) {
+					} catch (e) {
 						result = data;
 					}
 					return result;
@@ -8618,7 +8893,7 @@
 							finalAttrib = "@{dexterity_mod}";
 						}
 					} else {
-						switch(modString) {
+						switch (modString) {
 							case "STR":
 								finalAttrib = "@{strength_mod}";
 								break;
@@ -8659,7 +8934,7 @@
 						if (attribMod < 0 || isNaN(attribMod)) attribMod = 0;
 						uses_string = uses_string.replace(attrib, attribMod);
 					});
-					uses_string = uses_string.replace(/half_level/g, Math.floor(classlevel/2));
+					uses_string = uses_string.replace(/half_level/g, Math.floor(classlevel / 2));
 					return uses_string.replace(/level/g, classlevel);
 				};
 				var category = page.data["Category"];
@@ -8673,69 +8948,111 @@
 				update["drop_name"] = "";
 				update["drop_data"] = "";
 				update["drop_content"] = "";
-				if(category === "Items") {
-					if(currentData.npc === "0") {
+				if (category === "Items") {
+					if (currentData.npc === "0") {
 						update["tab"] = "equipment";
-						if(page.name) {update["repeating_inventory_" + id + "_itemname"] = page.name};
-						if(page.data["itemcount"]) {update["repeating_inventory_" + id + "_itemcount"] = page.data["itemcount"]};
-						if(page.data["Weight"]) {update["repeating_inventory_" + id + "_itemweight"] = page.data["Weight"]};
-						if(page.data["Properties"]) {update["repeating_inventory_" + id + "_itemproperties"] = page.data["Properties"]};
-						if(page.content) {update["repeating_inventory_" + id + "_itemcontent"] = page.content};
-						if(!page.data["Item Type"] || page.data["Item Type"] == "") {page.data["Item Type"] = category};
+						if (page.name) {
+							update["repeating_inventory_" + id + "_itemname"] = page.name
+						};
+						if (page.data["itemcount"]) {
+							update["repeating_inventory_" + id + "_itemcount"] = page.data["itemcount"]
+						};
+						if (page.data["Weight"]) {
+							update["repeating_inventory_" + id + "_itemweight"] = page.data["Weight"]
+						};
+						if (page.data["Properties"]) {
+							update["repeating_inventory_" + id + "_itemproperties"] = page.data["Properties"]
+						};
+						if (page.content) {
+							update["repeating_inventory_" + id + "_itemcontent"] = page.content
+						};
+						if (!page.data["Item Type"] || page.data["Item Type"] == "") {
+							page.data["Item Type"] = category
+						};
 						var mods = "Item Type: " + page.data["Item Type"];
-						if(page.data["AC"] && page.data["AC"] != "") {
+						if (page.data["AC"] && page.data["AC"] != "") {
 							mods += ", AC: " + page.data["AC"];
-							if(!looped) {
-								callbacks.push( function() {update_ac();} )
+							if (!looped) {
+								callbacks.push(function() {
+									update_ac();
+								})
 							}
 						};
-						if(page.data["Damage"] && page.data["Damage"] != "") {mods += ", Damage: " + page.data["Damage"]};
-						if(page.data["Damage Type"] && page.data["Damage Type"] != "") {mods += ", Damage Type: " + page.data["Damage Type"]};
-						if(page.data["Secondary Damage"] && page.data["Secondary Damage"] != "") {mods += ", Secondary Damage: " + page.data["Secondary Damage"]};
-						if(page.data["Secondary Damage Type"] && page.data["Secondary Damage Type"] != "") {mods += ", Secondary Damage Type: " + page.data["Secondary Damage Type"]};
-						if(page.data["Alternate Damage"] && page.data["Alternate Damage"] != "") {mods += ", Alternate Damage: " + page.data["Alternate Damage"]};
-						if(page.data["Alternate Damage Type"] && page.data["Alternate Damage Type"] != "") {mods += ", Alternate Damage Type: " + page.data["Alternate Damage Type"]};
-						if(page.data["Alternate Secondary Damage"] && page.data["Alternate Secondary Damage"] != "") {mods += ", Alternate Secondary Damage: " + page.data["Alternate Secondary Damage"]};
-						if(page.data["Alternate Secondary Damage Type"] && page.data["Alternate Secondary Damage Type"] != "") {mods += ", Alternate Secondary Damage Type: " + page.data["Alternate Secondary Damage Type"]};
-						if(page.data["Range"] && page.data["Range"] != "") {mods += ", Range: " + page.data["Range"]};
-						if(page.data["Modifiers"] && page.data["Modifiers"] != "") {mods += ", " + page.data["Modifiers"]};
+						if (page.data["Damage"] && page.data["Damage"] != "") {
+							mods += ", Damage: " + page.data["Damage"]
+						};
+						if (page.data["Damage Type"] && page.data["Damage Type"] != "") {
+							mods += ", Damage Type: " + page.data["Damage Type"]
+						};
+						if (page.data["Secondary Damage"] && page.data["Secondary Damage"] != "") {
+							mods += ", Secondary Damage: " + page.data["Secondary Damage"]
+						};
+						if (page.data["Secondary Damage Type"] && page.data["Secondary Damage Type"] != "") {
+							mods += ", Secondary Damage Type: " + page.data["Secondary Damage Type"]
+						};
+						if (page.data["Alternate Damage"] && page.data["Alternate Damage"] != "") {
+							mods += ", Alternate Damage: " + page.data["Alternate Damage"]
+						};
+						if (page.data["Alternate Damage Type"] && page.data["Alternate Damage Type"] != "") {
+							mods += ", Alternate Damage Type: " + page.data["Alternate Damage Type"]
+						};
+						if (page.data["Alternate Secondary Damage"] && page.data["Alternate Secondary Damage"] != "") {
+							mods += ", Alternate Secondary Damage: " + page.data["Alternate Secondary Damage"]
+						};
+						if (page.data["Alternate Secondary Damage Type"] && page.data["Alternate Secondary Damage Type"] != "") {
+							mods += ", Alternate Secondary Damage Type: " + page.data["Alternate Secondary Damage Type"]
+						};
+						if (page.data["Range"] && page.data["Range"] != "") {
+							mods += ", Range: " + page.data["Range"]
+						};
+						if (page.data["Modifiers"] && page.data["Modifiers"] != "") {
+							mods += ", " + page.data["Modifiers"]
+						};
 						update["repeating_inventory_" + id + "_itemmodifiers"] = mods;
-						if(page.data["Item Type"].indexOf("Weapon") > -1) {
+						if (page.data["Item Type"].indexOf("Weapon") > -1) {
 							update["repeating_inventory_" + id + "_hasattack"] = 1;
-							callbacks.push( function() {
-								if(page.data["Alternate Damage"] && page.data["Alternate Damage"] !== "") {
-									create_attack_from_item(id, {versatile: true});
+							callbacks.push(function() {
+								if (page.data["Alternate Damage"] && page.data["Alternate Damage"] !== "") {
+									create_attack_from_item(id, {
+										versatile: true
+									});
 								} else {
 									create_attack_from_item(id);
 								}
-							} );
-						}
-						else if(page.data["Item Type"].indexOf("Ammunition") > -1) {
+							});
+						} else if (page.data["Item Type"].indexOf("Ammunition") > -1) {
 							update["repeating_inventory_" + id + "_useasresource"] = 1;
-							callbacks.push( function() {create_resource_from_item(id);} );
+							callbacks.push(function() {
+								create_resource_from_item(id);
+							});
 						};
-						if(page.data["Modifiers"]) {
-							callbacks.push( function() {check_itemmodifiers(page.data["Modifiers"]);} );
+						if (page.data["Modifiers"]) {
+							callbacks.push(function() {
+								check_itemmodifiers(page.data["Modifiers"]);
+							});
 						};
-						if(!looped) {
-							callbacks.push( function() {update_weight();} );
+						if (!looped) {
+							callbacks.push(function() {
+								update_weight();
+							});
 						}
-					}
-					else {
-						if(page.data["Item Type"] && new RegExp('\\bweapon\\b', 'i').test(page.data["Item Type"])) {
+					} else {
+						if (page.data["Item Type"] && new RegExp('\\bweapon\\b', 'i').test(page.data["Item Type"])) {
 							var make_npc_attack_from_item = function(rowid, options) {
 								update["repeating_npcaction_" + rowid + "_npc_options-flag"] = "0";
 								update["repeating_npcaction_" + rowid + "_attack_flag"] = "on";
 
-								if(page.name) {
+								if (page.name) {
 									update["repeating_npcaction_" + rowid + "_name"] = page.name;
-									if(options && options.versatile) {
+									if (options && options.versatile) {
 										update["repeating_npcaction_" + rowid + "_name"] += " (" + (options.versatile === 1 ? "One-Handed" : "Two-Handed") + ")";
-									} else if(options && options.thrown) {
+									} else if (options && options.thrown) {
 										update["repeating_npcaction_" + rowid + "_name"] += " (Thrown)";
 									}
 								}
-								if(page.content) { update["repeating_npcaction_" + rowid + "_description"] = page.content; }
+								if (page.content) {
+									update["repeating_npcaction_" + rowid + "_description"] = page.content;
+								}
 
 								update["repeating_npcaction_" + rowid + "_attack_display_flag"] = "{{attack=1}}";
 								update["repeating_npcaction_" + rowid + "_attack_options"] = "{{attack=1}}";
@@ -8743,13 +9060,11 @@
 
 								var thrown = page.data["Properties"] && new RegExp('\\bthrown\\b', 'i').test(page.data["Properties"]);
 
-								if(page.data["Range"] && page.data["Range"] != "" && (!thrown || (options && options.thrown))) {
+								if (page.data["Range"] && page.data["Range"] != "" && (!thrown || (options && options.thrown))) {
 									update["repeating_npcaction_" + rowid + "_attack_range"] = page.data["Range"];
-								}
-								else if(page.data["Properties"] && new RegExp('\\breach\\b', 'i').test(page.data["Properties"])) {
+								} else if (page.data["Properties"] && new RegExp('\\breach\\b', 'i').test(page.data["Properties"])) {
 									update["repeating_npcaction_" + rowid + "_attack_range"] = "10 ft";
-								}
-								else {
+								} else {
 									update["repeating_npcaction_" + rowid + "_attack_range"] = "5 ft";
 								}
 
@@ -8761,209 +9076,307 @@
 								var weapon_attr_mod = use_dex_mod ? currentData.dexterity_mod : currentData.strength_mod;
 								update["repeating_npcaction_" + rowid + "_attack_tohit"] = weapon_attr_mod;
 
-								if(options && options.versatile === 2) {
-									if(page.data["Alternate Damage"]) { update["repeating_npcaction_" + rowid + "_attack_damage"] = page.data["Alternate Damage"] + "+" + weapon_attr_mod; }
-									if(page.data["Alternate Damage Type"]) { update["repeating_npcaction_" + rowid + "_attack_damagetype"] = page.data["Alternate Damage Type"]; }
-									if(page.data["Alternate Secondary Damage"]) { update["repeating_npcaction_" + rowid + "_attack_damage2"] = page.data["Alternate Secondary Damage"]; }
-									if(page.data["Alternate Secondary Damage Type"]) { update["repeating_npcaction_" + rowid + "_attack_damagetype2"] = page.data["Alternate Secondary Damage Type"]; }
-								}
-								else {
-									if(page.data["Damage"]) { update["repeating_npcaction_" + rowid + "_attack_damage"] = page.data["Damage"] + "+" + weapon_attr_mod; }
-									if(page.data["Damage Type"]) {update["repeating_npcaction_" + rowid + "_attack_damagetype"] = page.data["Damage Type"]; }
-									if(page.data["Secondary Damage"]) { update["repeating_npcaction_" + rowid + "_attack_damage2"] = page.data["Secondary Damage"]; }
-									if(page.data["Secondary Damage Type"]) { update["repeating_npcaction_" + rowid + "_attack_damagetype2"] = page.data["Secondary Damage Type"]; }
+								if (options && options.versatile === 2) {
+									if (page.data["Alternate Damage"]) {
+										update["repeating_npcaction_" + rowid + "_attack_damage"] = page.data["Alternate Damage"] + "+" + weapon_attr_mod;
+									}
+									if (page.data["Alternate Damage Type"]) {
+										update["repeating_npcaction_" + rowid + "_attack_damagetype"] = page.data["Alternate Damage Type"];
+									}
+									if (page.data["Alternate Secondary Damage"]) {
+										update["repeating_npcaction_" + rowid + "_attack_damage2"] = page.data["Alternate Secondary Damage"];
+									}
+									if (page.data["Alternate Secondary Damage Type"]) {
+										update["repeating_npcaction_" + rowid + "_attack_damagetype2"] = page.data["Alternate Secondary Damage Type"];
+									}
+								} else {
+									if (page.data["Damage"]) {
+										update["repeating_npcaction_" + rowid + "_attack_damage"] = page.data["Damage"] + "+" + weapon_attr_mod;
+									}
+									if (page.data["Damage Type"]) {
+										update["repeating_npcaction_" + rowid + "_attack_damagetype"] = page.data["Damage Type"];
+									}
+									if (page.data["Secondary Damage"]) {
+										update["repeating_npcaction_" + rowid + "_attack_damage2"] = page.data["Secondary Damage"];
+									}
+									if (page.data["Secondary Damage Type"]) {
+										update["repeating_npcaction_" + rowid + "_attack_damagetype2"] = page.data["Secondary Damage Type"];
+									}
 								}
 
-								if(page.data["Modifiers"]) {
-									if(attack_type === "melee") {
+								if (page.data["Modifiers"]) {
+									if (attack_type === "melee") {
 										var tohit_regex = /(?:melee|weapon) *attacks? *([\\+\\-] *[0-9]+)/i;
 										var melee_damage_regex = /(?:melee|weapon) *damage *([\\+\\-] *[0-9]+)/i;
 										var tohit_match = tohit_regex.exec(page.data["Modifiers"]);
 										var damage_match = melee_damage_regex.exec(page.data["Modifiers"]);
 
-										if(tohit_match && tohit_match[1]) { update[`repeating_npcaction_${rowid}_attack_tohit`] = +update[`repeating_npcaction_${rowid}_attack_tohit`] + +tohit_match[1]; }
-										if(page.data["Damage"] && damage_match && damage_match[1]) { update[`repeating_npcaction_${rowid}_attack_damage`] += damage_match[1]; }
-									} else if(attack_type === "ranged") {
+										if (tohit_match && tohit_match[1]) {
+											update[`repeating_npcaction_${rowid}_attack_tohit`] = +update[`repeating_npcaction_${rowid}_attack_tohit`] + +tohit_match[1];
+										}
+										if (page.data["Damage"] && damage_match && damage_match[1]) {
+											update[`repeating_npcaction_${rowid}_attack_damage`] += damage_match[1];
+										}
+									} else if (attack_type === "ranged") {
 										var tohit_regex = /(?:ranged|weapon) *attacks? *([\\+\\-] *[0-9]+)/i;
 										var ranged_damage_regex = /(?:ranged|weapon) *damage *([\\+\\-] *[0-9]+)/i;
 										var tohit_match = tohit_regex.exec(page.data["Modifiers"]);
 										var damage_match = ranged_damage_regex.exec(page.data["Modifiers"]);
 
-										if(tohit_match && tohit_match[1]) { update[`repeating_npcaction_${rowid}_attack_tohit`] = +update[`repeating_npcaction_${rowid}_attack_tohit`] + +tohit_match[1]; }
-										if(page.data["Damage"] && damage_match && damage_match[1]) { update[`repeating_npcaction_${rowid}_attack_damage`] += damage_match[1]; }
+										if (tohit_match && tohit_match[1]) {
+											update[`repeating_npcaction_${rowid}_attack_tohit`] = +update[`repeating_npcaction_${rowid}_attack_tohit`] + +tohit_match[1];
+										}
+										if (page.data["Damage"] && damage_match && damage_match[1]) {
+											update[`repeating_npcaction_${rowid}_attack_damage`] += damage_match[1];
+										}
 									}
 								}
 							};
 
 							var versatile = page.data["Properties"] && new RegExp('\\bversatile\\b', 'i').test(page.data["Properties"]) ? 1 : undefined;
-							make_npc_attack_from_item(id, {versatile: versatile});
-							if(page.data["Properties"] && new RegExp('\\bthrown\\b', 'i').test(page.data["Properties"])) {
-								make_npc_attack_from_item(generateRowID(), {thrown: true});
+							make_npc_attack_from_item(id, {
+								versatile: versatile
+							});
+							if (page.data["Properties"] && new RegExp('\\bthrown\\b', 'i').test(page.data["Properties"])) {
+								make_npc_attack_from_item(generateRowID(), {
+									thrown: true
+								});
 							}
-							if(versatile && page.data["Alternate Damage"]) {
-								make_npc_attack_from_item(generateRowID(), {versatile:2})
+							if (versatile && page.data["Alternate Damage"]) {
+								make_npc_attack_from_item(generateRowID(), {
+									versatile: 2
+								})
 							}
 
-							callbacks.push(function() { check_itemmodifiers(page.data["Modifiers"]); }, function() { update_npc_action("all"); });
+							callbacks.push(function() {
+								check_itemmodifiers(page.data["Modifiers"]);
+							}, function() {
+								update_npc_action("all");
+							});
 						}
 					}
 				};
-				if(category === "Spells") {
+				if (category === "Spells") {
 					let existing = {};
 					var lvl = page.data["Level"] && page.data["Level"] > 0 ? page.data["Level"] : "cantrip";
-					if(repeating["spell-" + lvl]) {
+					if (repeating["spell-" + lvl]) {
 						_.each(repeating["spell-" + lvl], function(spell, spellid) {
-							if(spell.spellname.toLowerCase() === page.name.toLowerCase()) {
+							if (spell.spellname.toLowerCase() === page.name.toLowerCase()) {
 								id = spellid;
 								existing = spell;
 							}
 						});
 					}
 					update["repeating_spell-" + lvl + "_" + id + "_spelllevel"] = lvl;
-					if(page.data["spellcasting_ability"]) {
+					if (page.data["spellcasting_ability"]) {
 						update["repeating_spell-" + lvl + "_" + id + "_spell_ability"] = "@{" + page.data["spellcasting_ability"].toLowerCase() + "_mod}+";
 					} else {
 						update["repeating_spell-" + lvl + "_" + id + "_spell_ability"] = "spell";
 					}
-					if(page.data["spellclass"]) {
+					if (page.data["spellclass"]) {
 						update["repeating_spell-" + lvl + "_" + id + "_spellclass"] = page.data["spellclass"];
 					}
-					if(page.data["spellsource"]) {
+					if (page.data["spellsource"]) {
 						update["repeating_spell-" + lvl + "_" + id + "_spellsource"] = page.data["spellsource"];
 					}
-					if(page.name) {update["repeating_spell-" + lvl + "_" + id + "_spellname"] = page.name};
-					if(page.data["Ritual"]) {update["repeating_spell-" + lvl + "_" + id + "_spellritual"] = "{{ritual=1}}"};
-					if(page.data["School"]) {update["repeating_spell-" + lvl + "_" + id + "_spellschool"] = page.data["School"].toLowerCase()};
-					if(page.data["Casting Time"]) {update["repeating_spell-" + lvl + "_" + id + "_spellcastingtime"] = page.data["Casting Time"]};
-					if(page.data["Range"]) {update["repeating_spell-" + lvl + "_" + id + "_spellrange"] = page.data["Range"]};
-					if(page.data["Target"]) {update["repeating_spell-" + lvl + "_" + id + "_spelltarget"] = page.data["Target"]};
-					if(page.data["Components"]) {
-						if(page.data["Components"].toLowerCase().indexOf("v") === -1) {update["repeating_spell-" + lvl + "_" + id + "_spellcomp_v"] = "0"};
-						if(page.data["Components"].toLowerCase().indexOf("s") === -1) {update["repeating_spell-" + lvl + "_" + id + "_spellcomp_s"] = "0"};
-						if(page.data["Components"].toLowerCase().indexOf("m") === -1) {update["repeating_spell-" + lvl + "_" + id + "_spellcomp_m"] = "0"};
+					if (page.name) {
+						update["repeating_spell-" + lvl + "_" + id + "_spellname"] = page.name
 					};
-					if(page.data["Material"]) {update["repeating_spell-" + lvl + "_" + id + "_spellcomp_materials"] = page.data["Material"]};
-					if(page.data["Concentration"]) {update["repeating_spell-" + lvl + "_" + id + "_spellconcentration"] = "{{concentration=1}}"};
-					if(page.data["Duration"]) {update["repeating_spell-" + lvl + "_" + id + "_spellduration"] = page.data["Duration"]};
-					if(page.data["Damage"] || page.data["Healing"]) {
+					if (page.data["Ritual"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spellritual"] = "{{ritual=1}}"
+					};
+					if (page.data["School"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spellschool"] = page.data["School"].toLowerCase()
+					};
+					if (page.data["Casting Time"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spellcastingtime"] = page.data["Casting Time"]
+					};
+					if (page.data["Range"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spellrange"] = page.data["Range"]
+					};
+					if (page.data["Target"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spelltarget"] = page.data["Target"]
+					};
+					if (page.data["Components"]) {
+						if (page.data["Components"].toLowerCase().indexOf("v") === -1) {
+							update["repeating_spell-" + lvl + "_" + id + "_spellcomp_v"] = "0"
+						};
+						if (page.data["Components"].toLowerCase().indexOf("s") === -1) {
+							update["repeating_spell-" + lvl + "_" + id + "_spellcomp_s"] = "0"
+						};
+						if (page.data["Components"].toLowerCase().indexOf("m") === -1) {
+							update["repeating_spell-" + lvl + "_" + id + "_spellcomp_m"] = "0"
+						};
+					};
+					if (page.data["Material"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spellcomp_materials"] = page.data["Material"]
+					};
+					if (page.data["Concentration"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spellconcentration"] = "{{concentration=1}}"
+					};
+					if (page.data["Duration"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spellduration"] = page.data["Duration"]
+					};
+					if (page.data["Damage"] || page.data["Healing"]) {
 						update["repeating_spell-" + lvl + "_" + id + "_spelloutput"] = "ATTACK";
-						if(!existing.spellattackid) callbacks.push( function() {create_attack_from_spell(lvl, id, currentData.character_id);} );
-					}
-					else if(page.data["Higher Spell Slot Desc"] && page.data["Higher Spell Slot Desc"] != "") {
+						if (!existing.spellattackid) callbacks.push(function() {
+							create_attack_from_spell(lvl, id, currentData.character_id);
+						});
+					} else if (page.data["Higher Spell Slot Desc"] && page.data["Higher Spell Slot Desc"] != "") {
 						var spelllevel = "?{Cast at what level?";
-						for(i = 0; i < 10-lvl; i++) {
+						for (i = 0; i < 10 - lvl; i++) {
 							spelllevel = spelllevel + "|Level " + (parseInt(i, 10) + parseInt(lvl, 10)) + "," + (parseInt(i, 10) + parseInt(lvl, 10));
 						}
 						spelllevel = spelllevel + "}";
 						update["repeating_spell-" + lvl + "_" + id + "_rollcontent"] = "@{wtype}&{template:spell} {{level=@{spellschool} " + spelllevel + "}} {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}";
 					};
-					if(page.data["Spell Attack"]) {update["repeating_spell-" + lvl + "_" + id + "_spellattack"] = page.data["Spell Attack"]};
-					if(page.data["Damage"]) {update["repeating_spell-" + lvl + "_" + id + "_spelldamage"] = page.data["Damage"]};
-					if(page.data["Damage Type"]) {update["repeating_spell-" + lvl + "_" + id + "_spelldamagetype"] = page.data["Damage Type"]};
-					if(page.data["Secondary Damage"]) {update["repeating_spell-" + lvl + "_" + id + "_spelldamage2"] = page.data["Secondary Damage"]};
-					if(page.data["Secondary Damage Type"]) {update["repeating_spell-" + lvl + "_" + id + "_spelldamagetype2"] = page.data["Secondary Damage Type"]};
-					if(page.data["Healing"]) {update["repeating_spell-" + lvl + "_" + id + "_spellhealing"] = page.data["Healing"];};
-					if(page.data["Add Casting Modifier"]) {update["repeating_spell-" + lvl + "_" + id + "_spelldmgmod"] = page.data["Add Casting Modifier"]};
-					if(page.data["Save"]) {update["repeating_spell-" + lvl + "_" + id + "_spellsave"] = page.data["Save"]};
-					if(page.data["Save Success"]) {update["repeating_spell-" + lvl + "_" + id + "_spellsavesuccess"] = page.data["Save Success"]};
-					if(page.data["Higher Spell Slot Dice"]) {update["repeating_spell-" + lvl + "_" + id + "_spellhldie"] = page.data["Higher Spell Slot Dice"]};
-					if(page.data["Higher Spell Slot Die"]) {update["repeating_spell-" + lvl + "_" + id + "_spellhldietype"] = page.data["Higher Spell Slot Die"]};
-					if(page.data["Higher Spell Slot Bonus"]) {update["repeating_spell-" + lvl + "_" + id + "_spellhlbonus"] = page.data["Higher Spell Slot Bonus"]};
-					if(page.data["Higher Spell Slot Desc"]) {update["repeating_spell-" + lvl + "_" + id + "_spellathigherlevels"] = page.data["Higher Spell Slot Desc"]};
-					if(page.data["data-Cantrip Scaling"] && lvl == "cantrip") {update["repeating_spell-" + lvl + "_" + id + "_spell_damage_progression"] = "Cantrip " + page.data["data-Cantrip Scaling"].charAt(0).toUpperCase() + page.data["data-Cantrip Scaling"].slice(1);};
-					if(page.data["data-description"]) { update["repeating_spell-" + lvl + "_" + id + "_spelldescription"] = page.data["data-description"]};
+					if (page.data["Spell Attack"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spellattack"] = page.data["Spell Attack"]
+					};
+					if (page.data["Damage"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spelldamage"] = page.data["Damage"]
+					};
+					if (page.data["Damage Type"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spelldamagetype"] = page.data["Damage Type"]
+					};
+					if (page.data["Secondary Damage"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spelldamage2"] = page.data["Secondary Damage"]
+					};
+					if (page.data["Secondary Damage Type"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spelldamagetype2"] = page.data["Secondary Damage Type"]
+					};
+					if (page.data["Healing"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spellhealing"] = page.data["Healing"];
+					};
+					if (page.data["Add Casting Modifier"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spelldmgmod"] = page.data["Add Casting Modifier"]
+					};
+					if (page.data["Save"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spellsave"] = page.data["Save"]
+					};
+					if (page.data["Save Success"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spellsavesuccess"] = page.data["Save Success"]
+					};
+					if (page.data["Higher Spell Slot Dice"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spellhldie"] = page.data["Higher Spell Slot Dice"]
+					};
+					if (page.data["Higher Spell Slot Die"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spellhldietype"] = page.data["Higher Spell Slot Die"]
+					};
+					if (page.data["Higher Spell Slot Bonus"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spellhlbonus"] = page.data["Higher Spell Slot Bonus"]
+					};
+					if (page.data["Higher Spell Slot Desc"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spellathigherlevels"] = page.data["Higher Spell Slot Desc"]
+					};
+					if (page.data["data-Cantrip Scaling"] && lvl == "cantrip") {
+						update["repeating_spell-" + lvl + "_" + id + "_spell_damage_progression"] = "Cantrip " + page.data["data-Cantrip Scaling"].charAt(0).toUpperCase() + page.data["data-Cantrip Scaling"].slice(1);
+					};
+					if (page.data["data-description"]) {
+						update["repeating_spell-" + lvl + "_" + id + "_spelldescription"] = page.data["data-description"]
+					};
 					update["repeating_spell-" + lvl + "_" + id + "_options-flag"] = "0";
 				};
-				if(category === "Monsters") {
+				if (category === "Monsters") {
 					update["npc"] = "1";
 					update["npc_options-flag"] = "0";
-					if(page.name && page.name != "") {update["npc_name"] = page.name};
+					if (page.name && page.name != "") {
+						update["npc_name"] = page.name
+					};
 					update["npc_speed"] = page.data["Speed"] ? page.data["Speed"] : "";
-					update["strength_base"] = page.data["STR"] ?	page.data["STR"] : "";
+					update["strength_base"] = page.data["STR"] ? page.data["STR"] : "";
 					update["dexterity_base"] = page.data["DEX"] ? page.data["DEX"] : "";
 					update["constitution_base"] = page.data["CON"] ? page.data["CON"] : "";
 					update["intelligence_base"] = page.data["INT"] ? page.data["INT"] : "";
 					update["wisdom_base"] = page.data["WIS"] ? page.data["WIS"] : "";
 					update["charisma_base"] = page.data["CHA"] ? page.data["CHA"] : "";
-					callbacks.push( function() {update_attr("strength");} );
-					callbacks.push( function() {update_attr("dexterity");} );
-					callbacks.push( function() {update_attr("constitution");} );
-					callbacks.push( function() {update_attr("intelligence");} );
-					callbacks.push( function() {update_attr("wisdom");} );
-					callbacks.push( function() {update_attr("charisma");} );
+					callbacks.push(function() {
+						update_attr("strength");
+					});
+					callbacks.push(function() {
+						update_attr("dexterity");
+					});
+					callbacks.push(function() {
+						update_attr("constitution");
+					});
+					callbacks.push(function() {
+						update_attr("intelligence");
+					});
+					callbacks.push(function() {
+						update_attr("wisdom");
+					});
+					callbacks.push(function() {
+						update_attr("charisma");
+					});
 					update["npc_vulnerabilities"] = page.data["Vulnerabilities"] ? page.data["Vulnerabilities"] : "";
 					update["npc_resistances"] = page.data["Resistances"] ? page.data["Resistances"] : "";
 					update["npc_immunities"] = page.data["Immunities"] ? page.data["Immunities"] : "";
 					update["npc_condition_immunities"] = page.data["Condition Immunities"] ? page.data["Condition Immunities"] : "";
 					update["npc_languages"] = page.data["Languages"] ? page.data["Languages"] : "";
 					update["token_size"] = page.data["Token Size"] ? page.data["Token Size"] : "";
-					if(page.data["Challenge Rating"] && page.data["Challenge Rating"] != "") {
-						callbacks.push( function() {update_challenge();} );
+					if (page.data["Challenge Rating"] && page.data["Challenge Rating"] != "") {
+						callbacks.push(function() {
+							update_challenge();
+						});
 						update["npc_challenge"] = page.data["Challenge Rating"];
-					}
-					else {
+					} else {
 						update["npc_challenge"] = "";
 					}
-					if(page.data["data-XP"]) {
-						update["npc_xp"] = page.data["data-XP"].toString().replace(",","");
+					if (page.data["data-XP"]) {
+						update["npc_xp"] = page.data["data-XP"].toString().replace(",", "");
 					}
 
 					var type = "";
-					if(page.data["Size"]) {type = page.data["Size"]};
-					if(page.data["Type"]) {
-						if(type.length > 0) {
+					if (page.data["Size"]) {
+						type = page.data["Size"]
+					};
+					if (page.data["Type"]) {
+						if (type.length > 0) {
 							type = type + " " + page.data["Type"].toLowerCase();
-						}
-						else {
+						} else {
 							type = page.data["Type"].toLowerCase();
 						}
 					};
-					if(page.data["Alignment"]) {
-						if(type.length > 0) {
+					if (page.data["Alignment"]) {
+						if (type.length > 0) {
 							type = type + ", " + page.data["Alignment"];
-						}
-						else {
+						} else {
 							type = page.data["Alignment"];
 						}
 					};
 					update["npc_type"] = type;
 
-					if(page.data["HP"]) {
-						if(page.data["HP"].toString().indexOf("(") > -1) {
+					if (page.data["HP"]) {
+						if (page.data["HP"].toString().indexOf("(") > -1) {
 							update["hp_max"] = page.data["HP"].toString().split(" (")[0];
 							update["npc_hpformula"] = page.data["HP"].toString().split(" (")[1].slice(0, -1);
-						}
-						else {
+						} else {
 							update["hp_max"] = page.data["HP"]
 							update["npc_hpformula"] = ""
 						};
-					}
-					else {
+					} else {
 						update["hp_max"] = ""
 						update["npc_hpformula"] = ""
 					};
 
-					if(page.data["AC"]) {
-						if(page.data["AC"].toString().indexOf("(") > -1) {
+					if (page.data["AC"]) {
+						if (page.data["AC"].toString().indexOf("(") > -1) {
 							update["npc_ac"] = page.data["AC"].toString().split(" (")[0];
 							update["npc_actype"] = page.data["AC"].toString().split(" (")[1].slice(0, -1);
-						}
-						else {
+						} else {
 							update["npc_ac"] = page.data["AC"];
 							update["npc_actype"] = "";
 						};
-					}
-					else {
+					} else {
 						update["npc_ac"] = "";
 						update["npc_actype"] = "";
 					};
 
 					var senses = page.data["Senses"] ? page.data["Senses"] : "";
-					if(page.data["Passive Perception"]) {
-						if(senses.length > 0) {
+					if (page.data["Passive Perception"]) {
+						if (senses.length > 0) {
 							senses = senses + ", passive Perception " + page.data["Passive Perception"];
-						}
-						else {
+						} else {
 							senses = "passive Perception " + page.data["Passive Perception"];
 						}
 					}
@@ -8975,13 +9388,15 @@
 					update["npc_int_save_base"] = "";
 					update["npc_wis_save_base"] = "";
 					update["npc_cha_save_base"] = "";
-					if(page.data["Saving Throws"] && page.data["Saving Throws"] != "") {
+					if (page.data["Saving Throws"] && page.data["Saving Throws"] != "") {
 						var savearray = page.data["Saving Throws"].split(", ");
 						_.each(savearray, function(save) {
 							kv = save.indexOf("-") > -1 ? save.split(" ") : save.split(" +");
 							update["npc_" + kv[0].toLowerCase() + "_save_base"] = parseInt(kv[1], 10);
 						});
-						callbacks.push( function() {update_npc_saves();} );
+						callbacks.push(function() {
+							update_npc_saves();
+						});
 					};
 
 					update["npc_acrobatics_base"] = "";
@@ -9002,13 +9417,15 @@
 					update["npc_sleight_of_hand_base"] = "";
 					update["npc_stealth_base"] = "";
 					update["npc_survival_base"] = "";
-					if(page.data["Skills"] && page.data["Skills"] != "") {
+					if (page.data["Skills"] && page.data["Skills"] != "") {
 						skillarray = page.data["Skills"].split(", ");
 						_.each(skillarray, function(skill) {
 							kv = skill.indexOf("-") > -1 ? skill.split(" ") : skill.split(" +");
 							update["npc_" + kv[0].toLowerCase().replace(/ /g, '_') + "_base"] = parseInt(kv[1], 10);
 						});
-						callbacks.push( function() {update_npc_skills();} );
+						callbacks.push(function() {
+							update_npc_skills();
+						});
 					}
 
 					getSectionIDs("repeating_npcaction-l", function(idarray) {
@@ -9033,84 +9450,75 @@
 					});
 
 					var contentarray = page.content;
-					if(page.data["data-Legendary Actions"]) {
+					if (page.data["data-Legendary Actions"]) {
 						var legendaryactionsarray = jsonparse(page.data["data-Legendary Actions"]);
 						update["npc_legendary_actions"] = 1;
-						if(page.data["Legendary Actions Desc"]) {
+						if (page.data["Legendary Actions Desc"]) {
 							update["npc_legendary_actions_desc"] = page.data["Legendary Actions Desc"];
-						}
-						else if(currentData.npc_legendary_actions > 0){
+						} else if (currentData.npc_legendary_actions > 0) {
 							update["npc_legendary_actions_desc"] = `The ${page.name} can take ${currentData.npc_legendary_actions}, choosing from the options below. Only one legendary option can be used at a time and only at the end of another creature's turn. The ${page.name} regains spent legendary actions at the start of its turn.`;
-						}
-						else {
+						} else {
 							update["npc_legendary_actions_desc"] = "";
 						}
-					}
-					else if(contentarray && contentarray.indexOf("Legendary Actions") > -1) {
-						if(contentarray.indexOf(/\n Legendary Actions\n/) > -1) {
+					} else if (contentarray && contentarray.indexOf("Legendary Actions") > -1) {
+						if (contentarray.indexOf(/\n Legendary Actions\n/) > -1) {
 							temp = contentarray.split(/\n Legendary Actions\n/)
-						}
-						else {
+						} else {
 							temp = contentarray.split(/Legendary Actions\n/)
 						}
 						var legendaryactionsarray = temp[1];
 						contentarray = temp[0];
 					}
 
-					if(page.data["data-Reactions"]) {
+					if (page.data["data-Reactions"]) {
 						var reactionsarray = jsonparse(page.data["data-Reactions"]);
-					}
-					else if(contentarray && contentarray.indexOf("Reactions") > -1) {
-						if(contentarray.indexOf(/\n Reactions\n/) > -1) {
+					} else if (contentarray && contentarray.indexOf("Reactions") > -1) {
+						if (contentarray.indexOf(/\n Reactions\n/) > -1) {
 							temp = contentarray.split(/\n Reactions\n/)
-						}
-						else {
+						} else {
 							temp = contentarray.split(/Reactions\n/)
 						}
 						var reactionsarray = temp[1];
 						contentarray = temp[0];
 					}
 
-					if(page.data["data-Actions"]) {
+					if (page.data["data-Actions"]) {
 						var actionsarray = jsonparse(page.data["data-Actions"]);
-					}
-					else if(contentarray && contentarray.indexOf("Actions") > -1) {
-						if(contentarray.indexOf("Lair Actions") > -1) {
-							contentarray = contentarray.replace("Lair Actions","Lair Action");
+					} else if (contentarray && contentarray.indexOf("Actions") > -1) {
+						if (contentarray.indexOf("Lair Actions") > -1) {
+							contentarray = contentarray.replace("Lair Actions", "Lair Action");
 						}
-						if(contentarray.indexOf(/\n Actions\n/) > -1) {
+						if (contentarray.indexOf(/\n Actions\n/) > -1) {
 							temp = contentarray.split(/\n Actions\n/)
-						}
-						else {
+						} else {
 							temp = contentarray.split(/Actions\n/)
 						}
 						var actionsarray = temp[1];
 						contentarray = temp[0];
 					}
 
-					if(page.data["data-Traits"]) {
+					if (page.data["data-Traits"]) {
 						var traitsarray = jsonparse(page.data["data-Traits"]);
-					}
-					else if(contentarray && contentarray.indexOf("Traits") > -1) {
-						if(contentarray.indexOf("Lair Traits") > -1) {
-							contentarray = contentarray.replace("Lair Traits","Lair Trait");
+					} else if (contentarray && contentarray.indexOf("Traits") > -1) {
+						if (contentarray.indexOf("Lair Traits") > -1) {
+							contentarray = contentarray.replace("Lair Traits", "Lair Trait");
 						}
-						if(contentarray.indexOf(/\n Traits\n/) > -1) {
+						if (contentarray.indexOf(/\n Traits\n/) > -1) {
 							temp = contentarray.split(/\n Traits\n/)
-						}
-						else {
+						} else {
 							temp = contentarray.split(/Traits\n/)
 						}
 						var traitsarray = temp[1];
 						contentarray = temp[0];
 					}
 
-					if(traitsarray) {
-						if(page.data["data-Traits"]) {
+					if (traitsarray) {
+						if (page.data["data-Traits"]) {
 							var traitsobj = {};
-							traitsarray.forEach(function(val) { traitsobj[val.Name] = val.Desc; });
-						}
-						else {
+							traitsarray.forEach(function(val) {
+								traitsobj[val.Name] = val.Desc;
+							});
+						} else {
 							traitsarray = traitsarray.split("**");
 							traitsarray.shift();
 							var traitsobj = {};
@@ -9122,13 +9530,13 @@
 						_.each(traitsobj, function(desc, name) {
 							newrowid = generateRowID();
 							update["repeating_npctrait_" + newrowid + "_name"] = name + ".";
-							if(desc.substring(0,2) === ": " || encodeURI(desc.substring(0,2)) === ":%C2%A0") {
+							if (desc.substring(0, 2) === ": " || encodeURI(desc.substring(0, 2)) === ":%C2%A0") {
 								desc = desc.substring(2);
 							}
 							update["repeating_npctrait_" + newrowid + "_desc"] = desc.trim();
 							// SPELLCASTING NPCS
-							if(name === "Spellcasting") {
-								var lvl = parseInt(desc.substring(desc.indexOf("-level")-4, desc.indexOf("-level")-2).trim(), 10);
+							if (name === "Spellcasting") {
+								var lvl = parseInt(desc.substring(desc.indexOf("-level") - 4, desc.indexOf("-level") - 2).trim(), 10);
 								lvl = !isNaN(lvl) ? lvl : 1;
 								var ability = desc.match(/casting ability is (.*?) /);
 								ability = ability && ability.length > 1 ? ability[1] : false;
@@ -9139,43 +9547,60 @@
 								update["class"] = "Wizard";
 								update["base_level"] = lvl;
 								update["level"] = lvl;
-								callbacks.push( function() {update_pb();} );
-								callbacks.push( function() {update_spell_slots();} );
+								callbacks.push(function() {
+									update_pb();
+								});
+								callbacks.push(function() {
+									update_spell_slots();
+								});
 							}
 						});
 					}
-					if(actionsarray) {
-						if(page.data["data-Actions"]) {
+					if (actionsarray) {
+						if (page.data["data-Actions"]) {
 							var actionsobj = {};
-							actionsarray.forEach(function(val) { actionsobj[val.Name] = val; });
+							actionsarray.forEach(function(val) {
+								actionsobj[val.Name] = val;
+							});
 
 							_.each(actionsobj, function(action, name) {
 								newrowid = generateRowID();
 								update["repeating_npcaction_" + newrowid + "_npc_options-flag"] = "0";
 								update["repeating_npcaction_" + newrowid + "_name"] = name;
-								if(action["Desc"]) {
+								if (action["Desc"]) {
 									update["repeating_npcaction_" + newrowid + "_description"] = action["Desc"];
 								}
 
-								if(action["Type Attack"]) {
+								if (action["Type Attack"]) {
 									update["repeating_npcaction_" + newrowid + "_attack_flag"] = "on";
 									update["repeating_npcaction_" + newrowid + "_attack_display_flag"] = "{{attack=1}}";
 									update["repeating_npcaction_" + newrowid + "_attack_options"] = "{{attack=1}}";
-									if(action["Type"]) { update["repeating_npcaction_" + newrowid + "_attack_type"] = action["Type"]; }
-									if(action["Reach"]) { update["repeating_npcaction_" + newrowid + "_attack_range"] = action["Reach"]; }
-									if(action["Hit Bonus"]) { update["repeating_npcaction_" + newrowid + "_attack_tohit"] = action["Hit Bonus"]; }
-									if(action["Target"]) { update["repeating_npcaction_" + newrowid + "_attack_target"] = action["Target"]; }
-									if(action["Damage"]) { update["repeating_npcaction_" + newrowid + "_attack_damage"] = action["Damage"]; }
-									if(action["Damage Type"]) { update["repeating_npcaction_" + newrowid + "_attack_damagetype"] = action["Damage Type"]; }
+									if (action["Type"]) {
+										update["repeating_npcaction_" + newrowid + "_attack_type"] = action["Type"];
+									}
+									if (action["Reach"]) {
+										update["repeating_npcaction_" + newrowid + "_attack_range"] = action["Reach"];
+									}
+									if (action["Hit Bonus"]) {
+										update["repeating_npcaction_" + newrowid + "_attack_tohit"] = action["Hit Bonus"];
+									}
+									if (action["Target"]) {
+										update["repeating_npcaction_" + newrowid + "_attack_target"] = action["Target"];
+									}
+									if (action["Damage"]) {
+										update["repeating_npcaction_" + newrowid + "_attack_damage"] = action["Damage"];
+									}
+									if (action["Damage Type"]) {
+										update["repeating_npcaction_" + newrowid + "_attack_damagetype"] = action["Damage Type"];
+									}
 
-									if(action["Damage 2"] && action["Damage 2 Type"]) {
+									if (action["Damage 2"] && action["Damage 2 Type"]) {
 										update["repeating_npcaction_" + newrowid + "_attack_damage2"] = action["Damage 2"];
 										update["repeating_npcaction_" + newrowid + "_attack_damagetype2"] = action["Damage 2 Type"];
 									}
 								}
 							})
-						}
-						else {
+						} else {
 							actionsarray = actionsarray.split("**");
 							actionsarray.shift();
 							var actionsobj = {};
@@ -9187,71 +9612,68 @@
 								newrowid = generateRowID();
 								update["repeating_npcaction_" + newrowid + "_npc_options-flag"] = "0";
 								update["repeating_npcaction_" + newrowid + "_name"] = name;
-								if(desc.substring(0,2) === ": " || encodeURI(desc.substring(0,2)) === ":%C2%A0") {
+								if (desc.substring(0, 2) === ": " || encodeURI(desc.substring(0, 2)) === ":%C2%A0") {
 									desc = desc.substring(2);
 								}
-								if(desc.indexOf(" Attack:") > -1) {
+								if (desc.indexOf(" Attack:") > -1) {
 									update["repeating_npcaction_" + newrowid + "_attack_flag"] = "on";
 									update["repeating_npcaction_" + newrowid + "_attack_display_flag"] = "{{attack=1}}";
 									update["repeating_npcaction_" + newrowid + "_attack_options"] = "{{attack=1}}";
-									if(desc.indexOf(" Weapon Attack:") > -1) {
+									if (desc.indexOf(" Weapon Attack:") > -1) {
 										attacktype = desc.split(" Weapon Attack:")[0];
-									}
-									else if(desc.indexOf(" Spell Attack:") > -1) {
+									} else if (desc.indexOf(" Spell Attack:") > -1) {
 										attacktype = desc.split(" Spell Attack:")[0];
-									}
-									else {
+									} else {
 										console.log("FAILED TO IMPORT ATTACK - NO ATTACK TYPE FOUND (Weapon Attack/Spell Attack)");
 										return;
 									}
 
 									update["repeating_npcaction_" + newrowid + "_attack_type"] = attacktype;
-									if(attacktype === "Melee") {
-										update["repeating_npcaction_" + newrowid + "_attack_range"] = (desc.match(/reach (.*?),/) || ["",""])[1];
+									if (attacktype === "Melee") {
+										update["repeating_npcaction_" + newrowid + "_attack_range"] = (desc.match(/reach (.*?),/) || ["", ""])[1];
+									} else {
+										update["repeating_npcaction_" + newrowid + "_attack_range"] = (desc.match(/range (.*?),/) || ["", ""])[1];
 									}
-									else {
-										update["repeating_npcaction_" + newrowid + "_attack_range"] = (desc.match(/range (.*?),/) || ["",""])[1];
-									}
-									update["repeating_npcaction_" + newrowid + "_attack_tohit"] = (desc.match(/\+(.*) to hit/) || ["",""])[1];
-									update["repeating_npcaction_" + newrowid + "_attack_target"] = (desc.match(/\.,(?!.*\.,)(.*)\. Hit:/) || ["",""])[1];
-									if(desc.toLowerCase().indexOf("damage") > -1) {
-										update["repeating_npcaction_" + newrowid + "_attack_damage"] = (desc.match(/\(([^)]+)\)/) || ["",""])[1];
-										update["repeating_npcaction_" + newrowid + "_attack_damagetype"] = (desc.match(/\) (.*?) damage/) || ["",""])[1];
-										if((desc.match(/\(/g) || []).length > 1 && desc.match(/\((?!.*\()([^)]+)\)/)) {
+									update["repeating_npcaction_" + newrowid + "_attack_tohit"] = (desc.match(/\+(.*) to hit/) || ["", ""])[1];
+									update["repeating_npcaction_" + newrowid + "_attack_target"] = (desc.match(/\.,(?!.*\.,)(.*)\. Hit:/) || ["", ""])[1];
+									if (desc.toLowerCase().indexOf("damage") > -1) {
+										update["repeating_npcaction_" + newrowid + "_attack_damage"] = (desc.match(/\(([^)]+)\)/) || ["", ""])[1];
+										update["repeating_npcaction_" + newrowid + "_attack_damagetype"] = (desc.match(/\) (.*?) damage/) || ["", ""])[1];
+										if ((desc.match(/\(/g) || []).length > 1 && desc.match(/\((?!.*\()([^)]+)\)/)) {
 											var second_match = desc.match(/\((?!.*\()([^)]+)\)/);
-											if(second_match[1] && second_match[1].indexOf(" DC") === -1) {
-												update["repeating_npcaction_" + newrowid + "_attack_damage2"] = (desc.match(/\((?!.*\()([^)]+)\)/) || ["",""])[1];
-												update["repeating_npcaction_" + newrowid + "_attack_damagetype2"] = (desc.match(/\)(?!.*\)) (.*?) damage/) || ["",""])[1];
+											if (second_match[1] && second_match[1].indexOf(" DC") === -1) {
+												update["repeating_npcaction_" + newrowid + "_attack_damage2"] = (desc.match(/\((?!.*\()([^)]+)\)/) || ["", ""])[1];
+												update["repeating_npcaction_" + newrowid + "_attack_damagetype2"] = (desc.match(/\)(?!.*\)) (.*?) damage/) || ["", ""])[1];
 											};
 										};
 										ctest1 = desc.split("damage.")[1];
 										ctest2 = desc.split("damage, ")[1];
-										if(ctest1 && ctest1.length > 0) {
+										if (ctest1 && ctest1.length > 0) {
 											update["repeating_npcaction_" + newrowid + "_description"] = ctest1.trim();
-										}
-										else if(ctest2 && ctest2.length > 0) {
+										} else if (ctest2 && ctest2.length > 0) {
 											update["repeating_npcaction_" + newrowid + "_description"] = ctest2.trim();
 										}
-									}
-									else {
+									} else {
 										update["repeating_npcaction_" + newrowid + "_description"] = desc.split("Hit:")[1].trim();
 									}
-								}
-								else {
+								} else {
 									update["repeating_npcaction_" + newrowid + "_description"] = desc;
 								}
 
 							});
 						}
-						callbacks.push( function() {update_npc_action("all");} );
+						callbacks.push(function() {
+							update_npc_action("all");
+						});
 					}
-					if(reactionsarray) {
+					if (reactionsarray) {
 						update["npcreactionsflag"] = 1;
-						if(page.data["data-Reactions"]) {
+						if (page.data["data-Reactions"]) {
 							var reactionsobj = {};
-							reactionsarray.forEach(function(val) { reactionsobj[val.Name] = val.Desc; });
-						}
-						else {
+							reactionsarray.forEach(function(val) {
+								reactionsobj[val.Name] = val.Desc;
+							});
+						} else {
 							reactionsarray = reactionsarray.split("**");
 							reactionsarray.shift();
 							var reactionsobj = {};
@@ -9263,23 +9685,25 @@
 						_.each(reactionsobj, function(desc, name) {
 							newrowid = generateRowID();
 							update["repeating_npcreaction_" + newrowid + "_name"] = name + ".";
-							if(desc.substring(0,2) === ": " || encodeURI(desc.substring(0,2)) === ":%C2%A0") {
+							if (desc.substring(0, 2) === ": " || encodeURI(desc.substring(0, 2)) === ":%C2%A0") {
 								desc = desc.substring(2);
 							}
 							update["repeating_npcreaction_" + newrowid + "_desc"] = desc.trim();
 						});
 					}
-					if(legendaryactionsarray) {
-						if(page.data["data-Legendary Actions"]) {
+					if (legendaryactionsarray) {
+						if (page.data["data-Legendary Actions"]) {
 							var actionsobj = {};
-							legendaryactionsarray.forEach(function(val) { actionsobj[val.Name] = val; });
+							legendaryactionsarray.forEach(function(val) {
+								actionsobj[val.Name] = val;
+							});
 							_.each(actionsobj, function(action, name) {
 								newrowid = generateRowID();
 								update["repeating_npcaction-l_" + newrowid + "_npc_options-flag"] = "0";
 								update["repeating_npcaction-l_" + newrowid + "_name"] = name;
 								update["repeating_npcaction-l_" + newrowid + "_description"] = action["Desc"];
 
-								if(action["Type Attack"]) {
+								if (action["Type Attack"]) {
 									update["repeating_npcaction-l_" + newrowid + "_attack_flag"] = "on";
 									update["repeating_npcaction-l_" + newrowid + "_attack_display_flag"] = "{{attack=1}}";
 									update["repeating_npcaction-l_" + newrowid + "_attack_options"] = "{{attack=1}}";
@@ -9290,14 +9714,13 @@
 									update["repeating_npcaction-l_" + newrowid + "_attack_damage"] = action["Damage"];
 									update["repeating_npcaction-l_" + newrowid + "_attack_damagetype"] = action["Damage Type"];
 
-									if(action["Damage 2"] && action["Damage 2 Type"]) {
+									if (action["Damage 2"] && action["Damage 2 Type"]) {
 										update["repeating_npcaction-l_" + newrowid + "_attack_damage2"] = action["Damage 2"];
 										update["repeating_npcaction-l_" + newrowid + "_attack_damagetype2"] = action["Damage 2 Type"];
 									}
 								}
 							});
-						}
-						else {
+						} else {
 							var numlegendaryactions = (legendaryactionsarray.match(/\d+/) || [""])[0];
 							update["npc_legendary_actions"] = numlegendaryactions;
 							update["npc_legendary_actions_desc"] = `The ${page.name} can take ${numlegendaryactions}, choosing from the options below. Only one legendary option can be used at a time and only at the end of another creature's turn. The ${page.name} regains spent legendary actions at the start of its turn.`;
@@ -9312,40 +9735,36 @@
 								newrowid = generateRowID();
 								update["repeating_npcaction-l_" + newrowid + "_npc_options-flag"] = "0";
 								update["repeating_npcaction-l_" + newrowid + "_name"] = name;
-								if(desc.substring(0,2) === ": " || encodeURI(desc.substring(0,2)) === ":%C2%A0") {
+								if (desc.substring(0, 2) === ": " || encodeURI(desc.substring(0, 2)) === ":%C2%A0") {
 									desc = desc.substring(2);
 								}
-								if(desc.indexOf(" Attack:") > -1) {
+								if (desc.indexOf(" Attack:") > -1) {
 									update["repeating_npcaction-l_" + newrowid + "_attack_flag"] = "on";
 									update["repeating_npcaction-l_" + newrowid + "_attack_display_flag"] = "{{attack=1}}";
 									update["repeating_npcaction-l_" + newrowid + "_attack_options"] = "{{attack=1}}";
-									if(desc.indexOf(" Weapon Attack:") > -1) {
+									if (desc.indexOf(" Weapon Attack:") > -1) {
 										attacktype = desc.split(" Weapon Attack:")[0];
-									}
-									else if(desc.indexOf(" Spell Attack:") > -1) {
+									} else if (desc.indexOf(" Spell Attack:") > -1) {
 										attacktype = desc.split(" Spell Attack:")[0];
-									}
-									else {
+									} else {
 										console.log("FAILED TO IMPORT ATTACK - NO ATTACK TYPE FOUND (Weapon Attack/Spell Attack)");
 										return;
 									}
 									update["repeating_npcaction-l_" + newrowid + "_attack_type"] = attacktype;
-									if(attacktype === "Melee") {
-										update["repeating_npcaction-l_" + newrowid + "_attack_range"] = (desc.match(/reach (.*?),/) || ["",""])[1];
+									if (attacktype === "Melee") {
+										update["repeating_npcaction-l_" + newrowid + "_attack_range"] = (desc.match(/reach (.*?),/) || ["", ""])[1];
+									} else {
+										update["repeating_npcaction-l_" + newrowid + "_attack_range"] = (desc.match(/range (.*?),/) || ["", ""])[1];
 									}
-									else {
-										update["repeating_npcaction-l_" + newrowid + "_attack_range"] = (desc.match(/range (.*?),/) || ["",""])[1];
+									update["repeating_npcaction-l_" + newrowid + "_attack_tohit"] = (desc.match(/\+(.*) to hit/) || ["", ""])[1];
+									update["repeating_npcaction-l_" + newrowid + "_attack_target"] = (desc.match(/\.,(?!.*\.,)(.*)\. Hit:/) || ["", ""])[1];
+									update["repeating_npcaction-l_" + newrowid + "_attack_damage"] = (desc.match(/\(([^)]+)\)/) || ["", ""])[1];
+									update["repeating_npcaction-l_" + newrowid + "_attack_damagetype"] = (desc.match(/\) (.*?) damage/) || ["", ""])[1];
+									if ((desc.match(/\(/g) || []).length > 1 && (!desc.match(/\((?!.*\()([^)]+)\)/).indexOf(" DC")[1] || desc.match(/\((?!.*\()([^)]+)\)/).indexOf(" DC")[1] === -1)) {
+										update["repeating_npcaction-l_" + newrowid + "_attack_damage2"] = (desc.match(/\((?!.*\()([^)]+)\)/) || ["", ""])[1];
+										update["repeating_npcaction-l_" + newrowid + "_attack_damagetype2"] = (desc.match(/\)(?!.*\)) (.*?) damage/) || ["", ""])[1];
 									}
-									update["repeating_npcaction-l_" + newrowid + "_attack_tohit"] = (desc.match(/\+(.*) to hit/) || ["",""])[1];
-									update["repeating_npcaction-l_" + newrowid + "_attack_target"] = (desc.match(/\.,(?!.*\.,)(.*)\. Hit:/) || ["",""])[1];
-									update["repeating_npcaction-l_" + newrowid + "_attack_damage"] = (desc.match(/\(([^)]+)\)/) || ["",""])[1];
-									update["repeating_npcaction-l_" + newrowid + "_attack_damagetype"] = (desc.match(/\) (.*?) damage/) || ["",""])[1];
-									if((desc.match(/\(/g) || []).length > 1 && (!desc.match(/\((?!.*\()([^)]+)\)/).indexOf(" DC")[1] || desc.match(/\((?!.*\()([^)]+)\)/).indexOf(" DC")[1] === -1)) {
-										update["repeating_npcaction-l_" + newrowid + "_attack_damage2"] = (desc.match(/\((?!.*\()([^)]+)\)/) || ["",""])[1];
-										update["repeating_npcaction-l_" + newrowid + "_attack_damagetype2"] = (desc.match(/\)(?!.*\)) (.*?) damage/) || ["",""])[1];
-									}
-								}
-								else {
+								} else {
 									update["repeating_npcaction-l_" + newrowid + "_description"] = desc;
 								}
 							});
@@ -9353,12 +9772,14 @@
 
 					}
 				};
-				if(category === "Feats") {
+				if (category === "Feats") {
 					update["tab"] = "features";
-					var match = {name: page.name};
+					var match = {
+						name: page.name
+					};
 					var existing = _.findWhere(repeating.traits, match);
 					var newrowid = generateRowID();
-					if(existing) {
+					if (existing) {
 						newrowid = existing.id;
 						existing.name = page.name;
 						existing.source = "Feat";
@@ -9371,123 +9792,145 @@
 						newtrait.type = page.data["Properties"] ? page.data["Properties"] : "";
 						repeating.traits.push(newtrait);
 					}
-					if(page.name) {update["repeating_traits_" + newrowid + "_name"] = page.name};
-					if(page.content) {update["repeating_traits_" + newrowid + "_description"] = page.content};
+					if (page.name) {
+						update["repeating_traits_" + newrowid + "_name"] = page.name
+					};
+					if (page.content) {
+						update["repeating_traits_" + newrowid + "_description"] = page.content
+					};
 					update["repeating_traits_" + newrowid + "_source"] = "Feat";
 					update["repeating_traits_" + newrowid + "_source_type"] = page.data["Properties"] ? page.data["Properties"] : "";
 					update["repeating_traits_" + newrowid + "_options-flag"] = "0";
 					update["repeating_traits_" + newrowid + "_display_flag"] = "on";
 				};
-				if(category === "Proficiencies") {
+				if (category === "Proficiencies") {
 					var newrowid = generateRowID();
 					var type = page.data["Type"] || "";
-					if(type.toLowerCase() === "language" || type.toLowerCase() === "armor"
-						|| type.toLowerCase() === "weapon" || type.toLowerCase() === "other") {
-						if( repeating.prof_names.indexOf(page.name.toLowerCase()) == -1 ) {
+					if (type.toLowerCase() === "language" || type.toLowerCase() === "armor" ||
+						type.toLowerCase() === "weapon" || type.toLowerCase() === "other") {
+						if (repeating.prof_names.indexOf(page.name.toLowerCase()) == -1) {
 							update["repeating_proficiencies_" + newrowid + "_prof_type"] = type.replace("custom", "").toUpperCase();
 							update["repeating_proficiencies_" + newrowid + "_name"] = page.name;
 							update["repeating_proficiencies_" + newrowid + "_options-flag"] = 0;
 							repeating.prof_names.push(page.name.toLowerCase());
 						};
-					}
-					else if(type.toLowerCase() === "tool" || type.toLowerCase() === "skillcustom") {
+					} else if (type.toLowerCase() === "tool" || type.toLowerCase() === "skillcustom") {
 						let existing = {};
 						_.each(repeating.tool, function(tool, id) {
-							if(tool.toolname == page.name.toLowerCase()) {
+							if (tool.toolname == page.name.toLowerCase()) {
 								newrowid = id;
 								existing = tool;
 							}
 						});
-						if(!existing.toolname) repeating.tool[newrowid] = {toolname: page.name.toLowerCase()}
+						if (!existing.toolname) repeating.tool[newrowid] = {
+							toolname: page.name.toLowerCase()
+						}
 						update["repeating_tool_" + newrowid + "_toolname"] = page.name;
-						if(!existing.base) update["repeating_tool_" + newrowid + "_toolattr_base"] = "?{Attribute?|Strength,@{strength_mod}|Dexterity,@{dexterity_mod}|Constitution,@{constitution_mod}|Intelligence,@{intelligence_mod}|Wisdom,@{wisdom_mod}|Charisma,@{charisma_mod}}";
+						if (!existing.base) update["repeating_tool_" + newrowid + "_toolattr_base"] = "?{Attribute?|Strength,@{strength_mod}|Dexterity,@{dexterity_mod}|Constitution,@{constitution_mod}|Intelligence,@{intelligence_mod}|Wisdom,@{wisdom_mod}|Charisma,@{charisma_mod}}";
 						update["repeating_tool_" + newrowid + "_options-flag"] = 0;
-						if(page.data["toolbonus_base"]) update["repeating_tool_" + newrowid + "_toolbonus_base"] = "(@{pb}*2)";
+						if (page.data["toolbonus_base"]) update["repeating_tool_" + newrowid + "_toolbonus_base"] = "(@{pb}*2)";
 						repeating.prof_names.push(page.name.toLowerCase());
-						callbacks.push( function() {update_tool(newrowid);} );
+						callbacks.push(function() {
+							update_tool(newrowid);
+						});
 					}
-					if(type.toLowerCase() === "skill") {
+					if (type.toLowerCase() === "skill") {
 						var skill_string = page.name.toLowerCase().replace(/ /g, '_');
 						update[skill_string + "_prof"] = "(@{pb}*@{" + skill_string + "_type})";
 					};
 				};
-				if(category === "Classes") {
+				if (category === "Classes") {
 					update["tab"] = "core";
-					if(page.data.multiclass) {
-						if(page.name && page.name !== "") { update[page.data.multiclass] = page.name; }
+					if (page.data.multiclass) {
+						if (page.name && page.name !== "") {
+							update[page.data.multiclass] = page.name;
+						}
 						update[page.data.multiclass + "_flag"] = "1";
 						classlevel = parseInt(currentData[page.data.multiclass + "_lvl"]);
 					} else {
-						if(page.name && page.name !== "") { update["class"] = page.name; }
-						if(page.data["Hit Die"] && page.data["Hit Die"] !== "") {
+						if (page.name && page.name !== "") {
+							update["class"] = page.name;
+						}
+						if (page.data["Hit Die"] && page.data["Hit Die"] !== "") {
 							update["base_level"] = currentData.base_level ? currentData.base_level : "1";
 							update["hit_dice_max"] = update["base_level"] + page.data["Hit Die"];
 							update["hit_dice"] = update["base_level"];
 						}
-						if(page.data["Spellcasting Ability"] && page.data["Spellcasting Ability"] !== "") {
+						if (page.data["Spellcasting Ability"] && page.data["Spellcasting Ability"] !== "") {
 							update["spellcasting_ability"] = "@{" + page.data["Spellcasting Ability"].toLowerCase() + "_mod}+";
 						}
 					}
-					if(page.data["data-Saving Throws"] && !page.data.multiclass) {
+					if (page.data["data-Saving Throws"] && !page.data.multiclass) {
 						var saves = jsonparse(page.data["data-Saving Throws"]);
 						_.each(saves, function(value) {
 							update[value.toLowerCase() + "_save_prof"] = "(@{pb})";
 						});
 					}
 
-					if(!looped) {
+					if (!looped) {
 						callbacks.push(update_class);
 					}
 				};
-				if(category === "Subclasses") {
-					if(page.data.multiclass) {
-						if(page.name && page.name !== "") { update[page.data.multiclass + "_subclass"] = page.name; }
+				if (category === "Subclasses") {
+					if (page.data.multiclass) {
+						if (page.name && page.name !== "") {
+							update[page.data.multiclass + "_subclass"] = page.name;
+						}
 						classlevel = parseInt(currentData[page.data.multiclass + "_lvl"]);
 					} else {
-						if(page.name && page.name !== "") { update["subclass"] = page.name; };
+						if (page.name && page.name !== "") {
+							update["subclass"] = page.name;
+						};
 					}
-					if(page.data["Spellcasting Ability"]) {
-						if(page.data.Class == "Fighter") {
+					if (page.data["Spellcasting Ability"]) {
+						if (page.data.Class == "Fighter") {
 							update["arcane_fighter"] = "1";
-						} else if(page.data.Class == "Rogue") {
+						} else if (page.data.Class == "Rogue") {
 							update["arcane_rogue"] = "1";
 						}
 					}
-					if(!looped) {
+					if (!looped) {
 						callbacks.push(update_class);
 					};
 				};
-				if(category === "Races" || category === "Subraces") {
+				if (category === "Races" || category === "Subraces") {
 					update["tab"] = "core";
-					if(category === "Races") {
+					if (category === "Races") {
 						update["race"] = page.name;
 						if (page.name == "Halfling") {
 							update["halflingluck_flag"] = "1";
 						}
-					}
-					else {
+					} else {
 						update["subrace"] = page.name;
 					};
-					if(page.data["Speed"]) {update["speed"] = page.data["Speed"]};
-					if(page.data["Size"]) {update["size"] = page.data["Size"]};
-					if(!looped) {
+					if (page.data["Speed"]) {
+						update["speed"] = page.data["Speed"]
+					};
+					if (page.data["Size"]) {
+						update["size"] = page.data["Size"]
+					};
+					if (!looped) {
 						callbacks.push(update_race_display);
 					}
 				};
-				if(category === "Backgrounds") {
+				if (category === "Backgrounds") {
 					update["tab"] = "features";
-					if(page.name && page.name !== "") { update["background"] = page.name; };
+					if (page.name && page.name !== "") {
+						update["background"] = page.name;
+					};
 				};
 
-				if(page.data.theseblobs) {
+				if (page.data.theseblobs) {
 					_.each(page.data.theseblobs, function(blobname) {
-						if(page.data.blobs[blobname]) blobs[blobname] = page.data.blobs[blobname];
+						if (page.data.blobs[blobname]) blobs[blobname] = page.data.blobs[blobname];
 					});
 				} else {
-					blobs = filterBlobs(page.data.blobs, {"Level": "1"});
+					blobs = filterBlobs(page.data.blobs, {
+						"Level": "1"
+					});
 				}
 				_.each(blobs, function(blob, blobname) {
-					if(blob["Traits"]) {
+					if (blob["Traits"]) {
 						var traitsource = "";
 						switch (category) {
 							case "Races":
@@ -9502,15 +9945,20 @@
 								traitsource = "Background";
 						}
 						var trait_array = jsonparse(blob["Traits"]);
-						if(trait_array && trait_array.length) {
+						if (trait_array && trait_array.length) {
 							_.each(trait_array, function(trait) {
-								if(!trait.Input) {
-									var match = {name: trait["Name"], type: page.name};
-									if(trait["Replace"]) {
-										match = {name: trait["Replace"]};
+								if (!trait.Input) {
+									var match = {
+										name: trait["Name"],
+										type: page.name
+									};
+									if (trait["Replace"]) {
+										match = {
+											name: trait["Replace"]
+										};
 									}
 									var existing = _.findWhere(repeating.traits, match);
-									if(existing) {
+									if (existing) {
 										newrowid = existing.id;
 										existing.name = trait["Name"];
 										existing.source = traitsource;
@@ -9534,12 +9982,12 @@
 							});
 						};
 					};
-					if(blob["Language Proficiency"] || blob["Weapon Proficiency"] || blob["Armor Proficiency"] || blob["Tool Proficiency"]) {
-						if(blob["Language Proficiency"]) {
+					if (blob["Language Proficiency"] || blob["Weapon Proficiency"] || blob["Armor Proficiency"] || blob["Tool Proficiency"]) {
+						if (blob["Language Proficiency"]) {
 							var lang_array = jsonparse(blob["Language Proficiency"]);
-							if(lang_array["Proficiencies"] && lang_array["Proficiencies"].length) {
+							if (lang_array["Proficiencies"] && lang_array["Proficiencies"].length) {
 								_.each(lang_array["Proficiencies"], function(prof) {
-									if( repeating.prof_names.indexOf(prof.toLowerCase()) == -1 ) {
+									if (repeating.prof_names.indexOf(prof.toLowerCase()) == -1) {
 										newrowid = generateRowID();
 										update["repeating_proficiencies_" + newrowid + "_prof_type"] = "LANGUAGE";
 										update["repeating_proficiencies_" + newrowid + "_name"] = prof;
@@ -9549,11 +9997,11 @@
 								});
 							}
 						};
-						if(blob["Weapon Proficiency"]) {
+						if (blob["Weapon Proficiency"]) {
 							var weap_array = jsonparse(blob["Weapon Proficiency"]);
-							if(weap_array["Proficiencies"] && weap_array["Proficiencies"].length) {
+							if (weap_array["Proficiencies"] && weap_array["Proficiencies"].length) {
 								_.each(weap_array["Proficiencies"], function(prof) {
-									if( repeating.prof_names.indexOf(prof.toLowerCase()) == -1 ) {
+									if (repeating.prof_names.indexOf(prof.toLowerCase()) == -1) {
 										newrowid = generateRowID();
 										update["repeating_proficiencies_" + newrowid + "_prof_type"] = "WEAPON";
 										update["repeating_proficiencies_" + newrowid + "_name"] = prof;
@@ -9563,11 +10011,11 @@
 								});
 							}
 						};
-						if(blob["Armor Proficiency"]) {
+						if (blob["Armor Proficiency"]) {
 							var armor_array = jsonparse(blob["Armor Proficiency"]);
-							if(armor_array["Proficiencies"] && armor_array["Proficiencies"].length) {
+							if (armor_array["Proficiencies"] && armor_array["Proficiencies"].length) {
 								_.each(armor_array["Proficiencies"], function(prof) {
-									if( repeating.prof_names.indexOf(prof.toLowerCase()) == -1 ) {
+									if (repeating.prof_names.indexOf(prof.toLowerCase()) == -1) {
 										newrowid = generateRowID();
 										update["repeating_proficiencies_" + newrowid + "_prof_type"] = "ARMOR";
 										update["repeating_proficiencies_" + newrowid + "_name"] = prof;
@@ -9577,51 +10025,57 @@
 								});
 							}
 						};
-						if(blob["Tool Proficiency"]) {
+						if (blob["Tool Proficiency"]) {
 							var tool_array = jsonparse(blob["Tool Proficiency"]);
-							if(tool_array["Proficiencies"] && tool_array["Proficiencies"].length) {
+							if (tool_array["Proficiencies"] && tool_array["Proficiencies"].length) {
 								_.each(tool_array["Proficiencies"], function(prof) {
 									let existing = {};
 									_.each(repeating.tool, function(tool, id) {
-										if(tool.toolname == prof.toLowerCase()) {
+										if (tool.toolname == prof.toLowerCase()) {
 											newrowid = id;
 											existing = tool;
 										}
 									});
-									if(!existing.toolname) repeating.tool[newrowid] = {toolname: prof.toLowerCase()}
+									if (!existing.toolname) repeating.tool[newrowid] = {
+										toolname: prof.toLowerCase()
+									}
 									update["repeating_tool_" + newrowid + "_toolname"] = prof;
-									if(!existing.base) update["repeating_tool_" + newrowid + "_toolattr_base"] = "?{Attribute?|Strength,@{strength_mod}|Dexterity,@{dexterity_mod}|Constitution,@{constitution_mod}|Intelligence,@{intelligence_mod}|Wisdom,@{wisdom_mod}|Charisma,@{charisma_mod}}";
+									if (!existing.base) update["repeating_tool_" + newrowid + "_toolattr_base"] = "?{Attribute?|Strength,@{strength_mod}|Dexterity,@{dexterity_mod}|Constitution,@{constitution_mod}|Intelligence,@{intelligence_mod}|Wisdom,@{wisdom_mod}|Charisma,@{charisma_mod}}";
 									update["repeating_tool_" + newrowid + "_options-flag"] = 0;
 									repeating.prof_names.push(page.name.toLowerCase());
-									callbacks.push( function() {update_tool(newrowid);} );
+									callbacks.push(function() {
+										update_tool(newrowid);
+									});
 								});
 							}
 						};
 					};
-					if(blob["Skill Proficiency"]) {
+					if (blob["Skill Proficiency"]) {
 						var skill_array = jsonparse(blob["Skill Proficiency"]);
-						if(skill_array["Proficiencies"] && skill_array["Proficiencies"].length) {
-							 _.each(skill_array["Proficiencies"], function(prof) {
+						if (skill_array["Proficiencies"] && skill_array["Proficiencies"].length) {
+							_.each(skill_array["Proficiencies"], function(prof) {
 								var skill_string = prof.toLowerCase().replace(/ /g, '_');
 								update[skill_string + "_prof"] = "(@{pb}*@{" + skill_string + "_type})";
 							});
 						};
 					};
-					if(blob["Actions"]) {
+					if (blob["Actions"]) {
 						var actionsobj = {};
-						jsonparse(blob["Actions"]).forEach(function(val) { actionsobj[val.Name] = val; });
+						jsonparse(blob["Actions"]).forEach(function(val) {
+							actionsobj[val.Name] = val;
+						});
 						_.each(actionsobj, function(action, name) {
 							newrowid = generateRowID();
 							_.each(repeating.attack, function(atk, atkid) {
-								if(atk.atkname === name) newrowid = atkid;
+								if (atk.atkname === name) newrowid = atkid;
 							});
 							update["repeating_attack_" + newrowid + "_options-flag"] = "0";
 							update["repeating_attack_" + newrowid + "_atkname"] = name;
-							if(action["Desc"]) {
+							if (action["Desc"]) {
 								update["repeating_attack_" + newrowid + "_atk_desc"] = action["Desc"];
 							}
 
-							if(action["Type Attack"]) {
+							if (action["Type Attack"]) {
 								if (action["Type"] == "Spell") {
 									update["repeating_attack_" + newrowid + "_atkflag"] = "0";
 									update["repeating_attack_" + newrowid + "_attack_options"] = "";
@@ -9631,21 +10085,33 @@
 									update["repeating_attack_" + newrowid + "_atkflag"] = "{{attack=1}}";
 									update["repeating_attack_" + newrowid + "_attack_options"] = "{{attack=1}}";
 								}
-								if(action["Reach"]) { update["repeating_attack_" + newrowid + "_atkrange"] = action["Reach"]; }
+								if (action["Reach"]) {
+									update["repeating_attack_" + newrowid + "_atkrange"] = action["Reach"];
+								}
 
-								if(action["Damage"]) { update["repeating_attack_" + newrowid + "_dmgbase"] = action["Damage"]; }
-								if(action["Damage Type"]) { update["repeating_attack_" + newrowid + "_dmgtype"] = action["Damage Type"]; }
+								if (action["Damage"]) {
+									update["repeating_attack_" + newrowid + "_dmgbase"] = action["Damage"];
+								}
+								if (action["Damage Type"]) {
+									update["repeating_attack_" + newrowid + "_dmgtype"] = action["Damage Type"];
+								}
 								if (action["Modifier"]) {
 									update["repeating_attack_" + newrowid + "_dmgattr"] = modStringToAttrib(action["Modifier"]);
 									update["repeating_attack_" + newrowid + "_atkattr_base"] = modStringToAttrib(action["Modifier"]);
 								} else {
 									update["repeating_attack_" + newrowid + "_dmgattr"] = "0";
 								}
-								if (action["Save"]) { update["repeating_attack_" + newrowid + "_saveattr"] = action["Save"] }
-								if (action["Save DC"]) { update["repeating_attack_" + newrowid + "_savedc"] = "(" + modStringToAttrib(action["Save DC"]) + "+8+@{pb})" }
-								if (action["Save Effect"]) { update["repeating_attack_" + newrowid + "_saveeffect"] = action["Save Effect"] }
+								if (action["Save"]) {
+									update["repeating_attack_" + newrowid + "_saveattr"] = action["Save"]
+								}
+								if (action["Save DC"]) {
+									update["repeating_attack_" + newrowid + "_savedc"] = "(" + modStringToAttrib(action["Save DC"]) + "+8+@{pb})"
+								}
+								if (action["Save Effect"]) {
+									update["repeating_attack_" + newrowid + "_saveeffect"] = action["Save Effect"]
+								}
 
-								if(action["Damage 2"] && action["Damage 2 Type"]) {
+								if (action["Damage 2"] && action["Damage 2 Type"]) {
 									update["repeating_attack_" + newrowid + "_dmg2flag"] = "{{damage=1}} {{dmg2flag=1}}";
 									update["repeating_attack_" + newrowid + "_atk_dmg2base"] = action["Damage 2"];
 									update["repeating_attack_" + newrowid + "_attack_damagetype2"] = action["Damage 2 Type"];
@@ -9658,106 +10124,111 @@
 							}
 						});
 					};
-					if(blob["Global Damage"]) {
+					if (blob["Global Damage"]) {
 						var dmgmod = jsonparse(blob["Global Damage"]);
 						var id = generateRowID();
 						_.each(repeating.damagemod, function(name, rowid) {
-							if(name.toLowerCase() === dmgmod["Name"].toLowerCase()) id = rowid;
+							if (name.toLowerCase() === dmgmod["Name"].toLowerCase()) id = rowid;
 						});
 						update["repeating_damagemod_" + id + "_global_damage_name"] = `${dmgmod["Name"]}`;
 						update["repeating_damagemod_" + id + "_global_damage_damage"] = `${parseValues(dmgmod["Damage"])}`;
-						if(dmgmod["Active"] == "true") update["repeating_damagemod_" + id + "_global_damage_active_flag"] = "1";
+						if (dmgmod["Active"] == "true") update["repeating_damagemod_" + id + "_global_damage_active_flag"] = "1";
 						update["repeating_damagemod_" + id + "_options-flag"] = "0";
 						update["repeating_damagemod_" + id + "_global_damage_type"] = dmgmod["Type"] ? dmgmod["Type"] : dmgmod["Name"];
 						update["global_damage_mod_flag"] = "1";
 						repeating.damagemod[id] = dmgmod["Name"];
 					};
-					if(blob["Resources"]) {
+					if (blob["Resources"]) {
 						var resources = jsonparse(blob["Resources"]);
 						_.each(resources, function(value) {
 							var section = "";
-							if(currentData["class_resource_name"] == "" || currentData["class_resource_name"] == value["Name"]) {
+							if (currentData["class_resource_name"] == "" || currentData["class_resource_name"] == value["Name"]) {
 								section = "class_resource";
 							} else if (currentData["other_resource_name"] == "" || currentData["other_resource_name"] == value["Name"]) {
 								section = "other_resource";
 							} else {
 								_.each(repeating.resource, function(resource, id) {
-									if(resource.left == "" && section == "" || resource.left == value["Name"]) {
+									if (resource.left == "" && section == "" || resource.left == value["Name"]) {
 										section = "repeating_resource_" + id + "_resource_left";
 									}
-									if(resource.right == "" && section == "" || resource.right == value["Name"]) {
+									if (resource.right == "" && section == "" || resource.right == value["Name"]) {
 										section = "repeating_resource_" + id + "_resource_right";
 									}
 								})
 							}
-							if(section === "") {
+							if (section === "") {
 								var id = generateRowID();
 								section = "repeating_resource_" + id + "_resource_left";
-								repeating.resource[id] = {left: value["Name"], right: ""};
+								repeating.resource[id] = {
+									left: value["Name"],
+									right: ""
+								};
 							}
 							update[section + "_name"] = value["Name"];
-							if(value["Uses"]) update[section] = numUses(value["Uses"]);
+							if (value["Uses"]) update[section] = numUses(value["Uses"]);
 							update[section + "_max"] = value["Max"] ? numUses(value["Max"]) : numUses(value["Uses"]);
 						});
 					};
-					if(blob["Custom AC"]) {
+					if (blob["Custom AC"]) {
 						var customac = jsonparse(blob["Custom AC"]);
 						update["custom_ac_flag"] = "1";
 						update["custom_ac_base"] = customac.Base;
 						update["custom_ac_part1"] = customac["Attribute 1"];
 						update["custom_ac_part2"] = customac["Attribute 2"] ? customac["Attribute 2"] : "";
 						update["custom_ac_shield"] = customac.Shields;
-						if(!looped) {
-							callbacks.push( function() {update_ac();} )
+						if (!looped) {
+							callbacks.push(function() {
+								update_ac();
+							})
 						}
 					};
-					if(blob["Hit Points Per Level"]) {
+					if (blob["Hit Points Per Level"]) {
 						var id = generateRowID();
 						update["repeating_hpmod_" + id + "_mod"] = blob["Hit Points Per Level"];
 						update["repeating_hpmod_" + id + "_source"] = page.name ? page.name : "Subclass";
-						if(category === "Races" || category === "Subraces") {
+						if (category === "Races" || category === "Subraces") {
 							update["repeating_hpmod_" + id + "_levels"] = "total";
 						} else {
 							update["repeating_hpmod_" + id + "_levels"] = "base";
 						}
 					};
-					if(blob["Global AC Mod"]) {
+					if (blob["Global AC Mod"]) {
 						var globalac = jsonparse(blob["Global AC Mod"]);
 						var id = generateRowID();
 						_.each(repeating.acmod, function(name, rowid) {
-							if(name.toLowerCase() === globalac["Name"].toLowerCase()) id = rowid;
+							if (name.toLowerCase() === globalac["Name"].toLowerCase()) id = rowid;
 						});
 						update["repeating_acmod_" + id + "_global_ac_val"] = globalac.Bonus;
-						if(globalac["Active"] !== "false") update["repeating_acmod_" + id + "_global_ac_active_flag"] = "1";
+						if (globalac["Active"] !== "false") update["repeating_acmod_" + id + "_global_ac_active_flag"] = "1";
 						update["repeating_acmod_" + id + "_options-flag"] = "0";
 						update["repeating_acmod_" + id + "_global_ac_name"] = globalac.Name;
 						update["global_ac_mod_flag"] = "1";
 					};
-					if(blob["Global Save"]) {
+					if (blob["Global Save"]) {
 						var globalsave = jsonparse(blob["Global Save Mod"]);
 						var id = generateRowID();
 						_.each(repeating.savemod, function(name, rowid) {
-							if(name.toLowerCase() === globalsave["Name"].toLowerCase()) id = rowid;
+							if (name.toLowerCase() === globalsave["Name"].toLowerCase()) id = rowid;
 						});
 						update["repeating_savemod_" + id + "_global_save_roll"] = globalsave.Bonus;
-						if(globalsave["Active"] !== "false") update["repeating_savemod_" + id + "_global_save_active_flag"] = "1";
+						if (globalsave["Active"] !== "false") update["repeating_savemod_" + id + "_global_save_active_flag"] = "1";
 						update["repeating_savemod_" + id + "_options-flag"] = "0";
 						update["repeating_savemod_" + id + "_global_save_name"] = globalsave.Name;
 						update["global_save_mod_flag"] = "1";
 					}
-					if(blob["Global Attack"]) {
+					if (blob["Global Attack"]) {
 						var globalattack = jsonparse(blob["Global Attack"]);
 						var id = generateRowID();
 						_.each(repeating.tohitmod, function(name, rowid) {
-							if(name.toLowerCase() === globalattack["Name"].toLowerCase()) id = rowid;
+							if (name.toLowerCase() === globalattack["Name"].toLowerCase()) id = rowid;
 						});
 						update["repeating_tohitmod_" + id + "_global_attack_rollstring"] = `${globalattack["Bonus"]}[${globalattack["Name"]}]`;
-						if(globalattack["Active"] !== "false") update["repeating_tohitmod_" + id + "_global_attack_active_flag"] = "1";
+						if (globalattack["Active"] !== "false") update["repeating_tohitmod_" + id + "_global_attack_active_flag"] = "1";
 						update["repeating_tohitmod_" + id + "_options-flag"] = "0";
 						update["global_attack_mod_flag"] = "1";
 					};
-					if(blob["Initiative"]) {
-						if(blob["Initiative"].toLowerCase() === "advantage") {
+					if (blob["Initiative"]) {
+						if (blob["Initiative"].toLowerCase() === "advantage") {
 							update["initiative_style"] = "{@{d20},@{d20}}kh1";
 						} else if (blob["Initiative"].toLowerCase() === "disadvantage") {
 							update["initiative_style"] = "{@{d20},@{d20}}kl1";
@@ -9765,11 +10236,11 @@
 							update.initmod = numUses(blob["Initiative"]);
 						}
 					};
-					if(blob["Carry Multiplier"]) {
+					if (blob["Carry Multiplier"]) {
 						update["carrying_capacity_mod"] = "*" + blob["Carry Multiplier"];
 					};
-					if(blob["Speed"]) {
-						if(blob["Speed"][0] === "+") {
+					if (blob["Speed"]) {
+						if (blob["Speed"][0] === "+") {
 							let prevspeed = update["speed"] || currentData["speed"];
 							prevspeed = prevspeed && !isNaN(parseInt(prevspeed)) ? parseInt(prevspeed) : 0;
 							update["speed"] = prevspeed + parseInt(blob["Speed"]);
@@ -9777,87 +10248,140 @@
 							update["speed"] = parseInt(blob["Speed"]);
 						}
 					};
-					if(blob["Jack of All Trades"]) {
+					if (blob["Jack of All Trades"]) {
 						update["jack_of_all_trades"] = "@{jack}";
 					};
-					if(blob["Saving Throws"]) {
+					if (blob["Saving Throws"]) {
 						var saves = jsonparse(blob["Saving Throws"]);
 						_.each(saves, function(value) {
 							update[value.toLowerCase() + "_save_prof"] = "(@{pb})";
 						});
 					};
-					if(blob["Custom Spells"]) {
+					if (blob["Custom Spells"]) {
 						let spells = jsonparse(blob["Custom Spells"]);
 						_.each(spells, function(spell) {
 							var lvl = spell["Level"] && spell["Level"] > 0 ? spell["Level"] : "cantrip";
 							let id = generateRowID();
-							if(repeating["spell-" + lvl]) {
+							if (repeating["spell-" + lvl]) {
 								_.each(repeating["spell-" + lvl], function(spell, spellid) {
-									if(spell.spellname.toLowerCase() === page.name.toLowerCase()) {
+									if (spell.spellname.toLowerCase() === page.name.toLowerCase()) {
 										id = spellid;
 									}
 								});
 							}
 							update["repeating_spell-" + lvl + "_" + id + "_spelllevel"] = lvl;
-							if(spell["spellcasting_ability"]) {
+							if (spell["spellcasting_ability"]) {
 								update["repeating_spell-" + lvl + "_" + id + "_spell_ability"] = "@{" + spell["spellcasting_ability"].toLowerCase() + "_mod}+";;
 							} else {
 								update["repeating_spell-" + lvl + "_" + id + "_spell_ability"] = "spell";
 							}
-							if(spell["spellclass"]) {
+							if (spell["spellclass"]) {
 								update["repeating_spell-" + lvl + "_" + id + "_spellclass"] = spell["spellclass"];
 							}
-							if(spell["spellsource"]) {
+							if (spell["spellsource"]) {
 								update["repeating_spell-" + lvl + "_" + id + "_spellsource"] = spell["spellsource"];
 							}
 							update["repeating_spell-" + lvl + "_" + id + "_spellname"] = spell.Name;
-							if(spell["Ritual"]) {update["repeating_spell-" + lvl + "_" + id + "_spellritual"] = "{{ritual=1}}"};
-							if(spell["School"]) {update["repeating_spell-" + lvl + "_" + id + "_spellschool"] = spell["School"].toLowerCase()};
-							if(spell["Casting Time"]) {update["repeating_spell-" + lvl + "_" + id + "_spellcastingtime"] = spell["Casting Time"]};
-							if(spell["Range"]) {update["repeating_spell-" + lvl + "_" + id + "_spellrange"] = spell["Range"]};
-							if(spell["Target"]) {update["repeating_spell-" + lvl + "_" + id + "_spelltarget"] = spell["Target"]};
-							if(spell["Components"]) {
-								if(spell["Components"].toLowerCase().indexOf("v") === -1) {update["repeating_spell-" + lvl + "_" + id + "_spellcomp_v"] = "0"};
-								if(spell["Components"].toLowerCase().indexOf("s") === -1) {update["repeating_spell-" + lvl + "_" + id + "_spellcomp_s"] = "0"};
-								if(spell["Components"].toLowerCase().indexOf("m") === -1) {update["repeating_spell-" + lvl + "_" + id + "_spellcomp_m"] = "0"};
+							if (spell["Ritual"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spellritual"] = "{{ritual=1}}"
 							};
-							if(spell["Material"]) {update["repeating_spell-" + lvl + "_" + id + "_spellcomp_materials"] = spell["Material"]};
-							if(spell["Concentration"]) {update["repeating_spell-" + lvl + "_" + id + "_spellconcentration"] = "{{concentration=1}}"};
-							if(spell["Duration"]) {update["repeating_spell-" + lvl + "_" + id + "_spellduration"] = spell["Duration"]};
-							if(spell["Damage"] || spell["Healing"]) {
+							if (spell["School"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spellschool"] = spell["School"].toLowerCase()
+							};
+							if (spell["Casting Time"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spellcastingtime"] = spell["Casting Time"]
+							};
+							if (spell["Range"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spellrange"] = spell["Range"]
+							};
+							if (spell["Target"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spelltarget"] = spell["Target"]
+							};
+							if (spell["Components"]) {
+								if (spell["Components"].toLowerCase().indexOf("v") === -1) {
+									update["repeating_spell-" + lvl + "_" + id + "_spellcomp_v"] = "0"
+								};
+								if (spell["Components"].toLowerCase().indexOf("s") === -1) {
+									update["repeating_spell-" + lvl + "_" + id + "_spellcomp_s"] = "0"
+								};
+								if (spell["Components"].toLowerCase().indexOf("m") === -1) {
+									update["repeating_spell-" + lvl + "_" + id + "_spellcomp_m"] = "0"
+								};
+							};
+							if (spell["Material"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spellcomp_materials"] = spell["Material"]
+							};
+							if (spell["Concentration"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spellconcentration"] = "{{concentration=1}}"
+							};
+							if (spell["Duration"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spellduration"] = spell["Duration"]
+							};
+							if (spell["Damage"] || spell["Healing"]) {
 								update["repeating_spell-" + lvl + "_" + id + "_spelloutput"] = "ATTACK";
-								callbacks.push( function() {create_attack_from_spell(lvl, id, currentData.character_id);} );
-							}
-							else if(spell["Higher Spell Slot Desc"] && spell["Higher Spell Slot Desc"] != "") {
+								callbacks.push(function() {
+									create_attack_from_spell(lvl, id, currentData.character_id);
+								});
+							} else if (spell["Higher Spell Slot Desc"] && spell["Higher Spell Slot Desc"] != "") {
 								var spelllevel = "?{Cast at what level?";
-								for(i = 0; i < 10-lvl; i++) {
+								for (i = 0; i < 10 - lvl; i++) {
 									spelllevel = spelllevel + "|Level " + (parseInt(i, 10) + parseInt(lvl, 10)) + "," + (parseInt(i, 10) + parseInt(lvl, 10));
 								}
 								spelllevel = spelllevel + "}";
 								update["repeating_spell-" + lvl + "_" + id + "_rollcontent"] = "@{wtype}&{template:spell} {{level=@{spellschool} " + spelllevel + "}} {{name=@{spellname}}} {{castingtime=@{spellcastingtime}}} {{range=@{spellrange}}} {{target=@{spelltarget}}} @{spellcomp_v} @{spellcomp_s} @{spellcomp_m} {{material=@{spellcomp_materials}}} {{duration=@{spellduration}}} {{description=@{spelldescription}}} {{athigherlevels=@{spellathigherlevels}}} @{spellritual} {{innate=@{innate}}} @{spellconcentration} @{charname_output}";
 							};
-							if(spell["Spell Attack"]) {update["repeating_spell-" + lvl + "_" + id + "_spellattack"] = spell["Spell Attack"]};
-							if(spell["Damage"]) {update["repeating_spell-" + lvl + "_" + id + "_spelldamage"] = spell["Damage"]};
-							if(spell["Damage Type"]) {update["repeating_spell-" + lvl + "_" + id + "_spelldamagetype"] = spell["Damage Type"]};
-							if(spell["Secondary Damage"]) {update["repeating_spell-" + lvl + "_" + id + "_spelldamage2"] = spell["Secondary Damage"]};
-							if(spell["Secondary Damage Type"]) {update["repeating_spell-" + lvl + "_" + id + "_spelldamagetype2"] = spell["Secondary Damage Type"]};
-							if(spell["Healing"]) {update["repeating_spell-" + lvl + "_" + id + "_spellhealing"] = spell["Healing"];};
-							if(spell["Add Casting Modifier"]) {update["repeating_spell-" + lvl + "_" + id + "_spelldmgmod"] = spell["Add Casting Modifier"]};
-							if(spell["Save"]) {update["repeating_spell-" + lvl + "_" + id + "_spellsave"] = spell["Save"]};
-							if(spell["Save Success"]) {update["repeating_spell-" + lvl + "_" + id + "_spellsavesuccess"] = spell["Save Success"]};
-							if(spell["Higher Spell Slot Dice"]) {update["repeating_spell-" + lvl + "_" + id + "_spellhldie"] = spell["Higher Spell Slot Dice"]};
-							if(spell["Higher Spell Slot Die"]) {update["repeating_spell-" + lvl + "_" + id + "_spellhldietype"] = spell["Higher Spell Slot Die"]};
-							if(spell["Higher Spell Slot Bonus"]) {update["repeating_spell-" + lvl + "_" + id + "_spellhlbonus"] = spell["Higher Spell Slot Bonus"]};
-							if(spell["Higher Spell Slot Desc"]) {update["repeating_spell-" + lvl + "_" + id + "_spellathigherlevels"] = spell["Higher Spell Slot Desc"]};
-							if(spell["data-Cantrip Scaling"] && lvl == "cantrip") {update["repeating_spell-" + lvl + "_" + id + "_spell_damage_progression"] = "Cantrip " + spell["data-Cantrip Scaling"].charAt(0).toUpperCase() + spell["data-Cantrip Scaling"].slice(1);};
-							if(spell["data-description"]) { update["repeating_spell-" + lvl + "_" + id + "_spelldescription"] = spell["data-description"]};
+							if (spell["Spell Attack"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spellattack"] = spell["Spell Attack"]
+							};
+							if (spell["Damage"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spelldamage"] = spell["Damage"]
+							};
+							if (spell["Damage Type"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spelldamagetype"] = spell["Damage Type"]
+							};
+							if (spell["Secondary Damage"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spelldamage2"] = spell["Secondary Damage"]
+							};
+							if (spell["Secondary Damage Type"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spelldamagetype2"] = spell["Secondary Damage Type"]
+							};
+							if (spell["Healing"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spellhealing"] = spell["Healing"];
+							};
+							if (spell["Add Casting Modifier"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spelldmgmod"] = spell["Add Casting Modifier"]
+							};
+							if (spell["Save"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spellsave"] = spell["Save"]
+							};
+							if (spell["Save Success"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spellsavesuccess"] = spell["Save Success"]
+							};
+							if (spell["Higher Spell Slot Dice"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spellhldie"] = spell["Higher Spell Slot Dice"]
+							};
+							if (spell["Higher Spell Slot Die"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spellhldietype"] = spell["Higher Spell Slot Die"]
+							};
+							if (spell["Higher Spell Slot Bonus"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spellhlbonus"] = spell["Higher Spell Slot Bonus"]
+							};
+							if (spell["Higher Spell Slot Desc"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spellathigherlevels"] = spell["Higher Spell Slot Desc"]
+							};
+							if (spell["data-Cantrip Scaling"] && lvl == "cantrip") {
+								update["repeating_spell-" + lvl + "_" + id + "_spell_damage_progression"] = "Cantrip " + spell["data-Cantrip Scaling"].charAt(0).toUpperCase() + spell["data-Cantrip Scaling"].slice(1);
+							};
+							if (spell["data-description"]) {
+								update["repeating_spell-" + lvl + "_" + id + "_spelldescription"] = spell["data-description"]
+							};
 							update["repeating_spell-" + lvl + "_" + id + "_options-flag"] = "0";
 						})
 					};
-					if(blob["Global Save Mod"]) {
+					if (blob["Global Save Mod"]) {
 						update["globalsavemod"] = numUses(blob["Global Save Mod"]);
 					};
-					if(blob["Proficiency Bonus"]) {
+					if (blob["Proficiency Bonus"]) {
 						var bonus = jsonparse(blob["Proficiency Bonus"]);
 						_.each(bonus, function(value, prof) {
 							update[prof.replace(/ /g, "_").toLowerCase() + "_flat"] = numUses(value);
@@ -9875,39 +10399,107 @@
 
 			var check_itemmodifiers = function(modifiers, previousValue) {
 				var mods = modifiers.toLowerCase().split(",");
-				if(previousValue) {
+				if (previousValue) {
 					prevmods = previousValue.toLowerCase().split(",");
 					mods = _.union(mods, prevmods);
 				};
 				_.each(mods, function(mod) {
-					if(mod.indexOf("ac:") > -1 || mod.indexOf("ac +") > -1 || mod.indexOf("ac -") > -1) {update_ac();};
-					if(mod.indexOf("spell") > -1) {update_spell_info();};
-					if(mod.indexOf("saving throws") > -1) {update_all_saves();};
-					if(mod.indexOf("strength save") > -1) {update_save("strength");} else if(mod.indexOf("strength") > -1) {update_attr("strength");};
-					if(mod.indexOf("dexterity save") > -1) {update_save("dexterity");} else if(mod.indexOf("dexterity") > -1) {update_attr("dexterity");};
-					if(mod.indexOf("constitution save") > -1) {update_save("constitution");} else if(mod.indexOf("constitution") > -1) {update_attr("constitution");};
-					if(mod.indexOf("intelligence save") > -1) {update_save("intelligence");} else if(mod.indexOf("intelligence") > -1) {update_attr("intelligence");};
-					if(mod.indexOf("wisdom save") > -1) {update_save("wisdom");} else if(mod.indexOf("wisdom") > -1) {update_attr("wisdom");};
-					if(mod.indexOf("charisma save") > -1) {update_save("charisma");} else if(mod.indexOf("charisma") > -1) {update_attr("charisma");};
-					if(mod.indexOf("ability checks") > -1) {update_all_ability_checks();};
-					if(mod.indexOf("acrobatics") > -1) {update_skills(["acrobatics"]);};
-					if(mod.indexOf("animal handling") > -1) {update_skills(["animal_handling"]);};
-					if(mod.indexOf("arcana") > -1) {update_skills(["arcana"]);};
-					if(mod.indexOf("athletics") > -1) {update_skills(["athletics"]);};
-					if(mod.indexOf("deception") > -1) {update_skills(["deception"]);};
-					if(mod.indexOf("history") > -1) {update_skills(["history"]);};
-					if(mod.indexOf("insight") > -1) {update_skills(["insight"]);};
-					if(mod.indexOf("intimidation") > -1) {update_skills(["intimidation"]);};
-					if(mod.indexOf("investigation") > -1) {update_skills(["investigation"]);};
-					if(mod.indexOf("medicine") > -1) {update_skills(["medicine"]);};
-					if(mod.indexOf("nature") > -1) {update_skills(["nature"]);};
-					if(mod.indexOf("perception") > -1) {update_skills(["perception"]);};
-					if(mod.indexOf("performance") > -1) {update_skills(["performance"]);};
-					if(mod.indexOf("persuasion") > -1) {update_skills(["persuasion"]);};
-					if(mod.indexOf("religion") > -1) {update_skills(["religion"]);};
-					if(mod.indexOf("sleight of hand") > -1) {update_skills(["sleight_of_hand"]);};
-					if(mod.indexOf("stealth") > -1) {update_skills(["stealth"]);};
-					if(mod.indexOf("survival") > -1) {update_skills(["survival"]);};
+					if (mod.indexOf("ac:") > -1 || mod.indexOf("ac +") > -1 || mod.indexOf("ac -") > -1) {
+						update_ac();
+					};
+					if (mod.indexOf("spell") > -1) {
+						update_spell_info();
+					};
+					if (mod.indexOf("saving throws") > -1) {
+						update_all_saves();
+					};
+					if (mod.indexOf("strength save") > -1) {
+						update_save("strength");
+					} else if (mod.indexOf("strength") > -1) {
+						update_attr("strength");
+					};
+					if (mod.indexOf("dexterity save") > -1) {
+						update_save("dexterity");
+					} else if (mod.indexOf("dexterity") > -1) {
+						update_attr("dexterity");
+					};
+					if (mod.indexOf("constitution save") > -1) {
+						update_save("constitution");
+					} else if (mod.indexOf("constitution") > -1) {
+						update_attr("constitution");
+					};
+					if (mod.indexOf("intelligence save") > -1) {
+						update_save("intelligence");
+					} else if (mod.indexOf("intelligence") > -1) {
+						update_attr("intelligence");
+					};
+					if (mod.indexOf("wisdom save") > -1) {
+						update_save("wisdom");
+					} else if (mod.indexOf("wisdom") > -1) {
+						update_attr("wisdom");
+					};
+					if (mod.indexOf("charisma save") > -1) {
+						update_save("charisma");
+					} else if (mod.indexOf("charisma") > -1) {
+						update_attr("charisma");
+					};
+					if (mod.indexOf("ability checks") > -1) {
+						update_all_ability_checks();
+					};
+					if (mod.indexOf("acrobatics") > -1) {
+						update_skills(["acrobatics"]);
+					};
+					if (mod.indexOf("animal handling") > -1) {
+						update_skills(["animal_handling"]);
+					};
+					if (mod.indexOf("arcana") > -1) {
+						update_skills(["arcana"]);
+					};
+					if (mod.indexOf("athletics") > -1) {
+						update_skills(["athletics"]);
+					};
+					if (mod.indexOf("deception") > -1) {
+						update_skills(["deception"]);
+					};
+					if (mod.indexOf("history") > -1) {
+						update_skills(["history"]);
+					};
+					if (mod.indexOf("insight") > -1) {
+						update_skills(["insight"]);
+					};
+					if (mod.indexOf("intimidation") > -1) {
+						update_skills(["intimidation"]);
+					};
+					if (mod.indexOf("investigation") > -1) {
+						update_skills(["investigation"]);
+					};
+					if (mod.indexOf("medicine") > -1) {
+						update_skills(["medicine"]);
+					};
+					if (mod.indexOf("nature") > -1) {
+						update_skills(["nature"]);
+					};
+					if (mod.indexOf("perception") > -1) {
+						update_skills(["perception"]);
+					};
+					if (mod.indexOf("performance") > -1) {
+						update_skills(["performance"]);
+					};
+					if (mod.indexOf("persuasion") > -1) {
+						update_skills(["persuasion"]);
+					};
+					if (mod.indexOf("religion") > -1) {
+						update_skills(["religion"]);
+					};
+					if (mod.indexOf("sleight of hand") > -1) {
+						update_skills(["sleight_of_hand"]);
+					};
+					if (mod.indexOf("stealth") > -1) {
+						update_skills(["stealth"]);
+					};
+					if (mod.indexOf("survival") > -1) {
+						update_skills(["survival"]);
+					};
 				});
 			};
 
@@ -9915,116 +10507,145 @@
 				var update = {};
 				var newrowid = generateRowID();
 				update["repeating_inventory_" + itemid + "_itemattackid"] = newrowid;
-				if(options && options.versatile) {
+				if (options && options.versatile) {
 					var newrowid2 = generateRowID();
 					update["repeating_inventory_" + itemid + "_itemattackid"] += "," + newrowid2;
 					setAttrs(update, {}, function() {
-						update_attack_from_item(itemid, newrowid, {newattack: true, versatile: "primary"});
-						update_attack_from_item(itemid, newrowid2, {newattack: true, versatile: "secondary"});
+						update_attack_from_item(itemid, newrowid, {
+							newattack: true,
+							versatile: "primary"
+						});
+						update_attack_from_item(itemid, newrowid2, {
+							newattack: true,
+							versatile: "secondary"
+						});
 					});
-				}
-				else {
-					setAttrs(update, {}, update_attack_from_item(itemid, newrowid, {newattack: true}));
+				} else {
+					setAttrs(update, {}, update_attack_from_item(itemid, newrowid, {
+						newattack: true
+					}));
 				}
 			};
 
 			var update_attack_from_item = function(itemid, attackid, options) {
-				getAttrs(["repeating_inventory_" + itemid + "_itemname","repeating_inventory_" + itemid + "_itemproperties","repeating_inventory_" + itemid + "_itemmodifiers", "strength", "dexterity"], function(v) {
-					var update = {}; var itemtype; var damage; var damagetype; var damage2; var damagetype2; var attackmod; var damagemod; var range;
+				getAttrs(["repeating_inventory_" + itemid + "_itemname", "repeating_inventory_" + itemid + "_itemproperties", "repeating_inventory_" + itemid + "_itemmodifiers", "strength", "dexterity"], function(v) {
+					var update = {};
+					var itemtype;
+					var damage;
+					var damagetype;
+					var damage2;
+					var damagetype2;
+					var attackmod;
+					var damagemod;
+					var range;
 					var alt = {};
 
-					if(options && options.newattack) {
+					if (options && options.newattack) {
 						update["repeating_attack_" + attackid + "_options-flag"] = "0";
 						update["repeating_attack_" + attackid + "_itemid"] = itemid;
 					}
 
-					if(v["repeating_inventory_" + itemid + "_itemmodifiers"] && v["repeating_inventory_" + itemid + "_itemmodifiers"] != "") {
+					if (v["repeating_inventory_" + itemid + "_itemmodifiers"] && v["repeating_inventory_" + itemid + "_itemmodifiers"] != "") {
 						var mods = v["repeating_inventory_" + itemid + "_itemmodifiers"].split(",");
 						_.each(mods, function(mod) {
-							if(mod.indexOf("Item Type:") > -1) {itemtype = mod.split(":")[1].trim()}
-							else if(mod.indexOf("Alternate Secondary Damage Type:") > -1) {alt.damagetype2 = mod.split(":")[1].trim();}
-							else if(mod.indexOf("Alternate Secondary Damage:") > -1) {alt.damage2 = mod.split(":")[1].trim();}
-							else if(mod.indexOf("Alternate Damage Type:") > -1) {alt.damagetype = mod.split(":")[1].trim();}
-							else if(mod.indexOf("Alternate Damage:") > -1) {alt.damage = mod.split(":")[1].trim();}
-							else if(mod.indexOf("Secondary Damage Type:") > -1) {damagetype2 = mod.split(":")[1].trim()}
-							else if(mod.indexOf("Secondary Damage:") > -1) {damage2 = mod.split(":")[1].trim()}
-							else if(mod.indexOf("Damage Type:") > -1) {damagetype = mod.split(":")[1].trim()}
-							else if(mod.indexOf("Damage:") > -1) {damage = mod.split(":")[1].trim()}
-							else if(mod.indexOf("Range:") > -1) {range = mod.split(":")[1].trim()}
-							else if(mod.indexOf(" Attacks ") > -1) {attackmod = mod.split(" Attacks ")[1].trim()}
-							else if(mod.indexOf(" Damage ") > -1) {damagemod = mod.split(" Damage ")[1].trim()}
+							if (mod.indexOf("Item Type:") > -1) {
+								itemtype = mod.split(":")[1].trim()
+							} else if (mod.indexOf("Alternate Secondary Damage Type:") > -1) {
+								alt.damagetype2 = mod.split(":")[1].trim();
+							} else if (mod.indexOf("Alternate Secondary Damage:") > -1) {
+								alt.damage2 = mod.split(":")[1].trim();
+							} else if (mod.indexOf("Alternate Damage Type:") > -1) {
+								alt.damagetype = mod.split(":")[1].trim();
+							} else if (mod.indexOf("Alternate Damage:") > -1) {
+								alt.damage = mod.split(":")[1].trim();
+							} else if (mod.indexOf("Secondary Damage Type:") > -1) {
+								damagetype2 = mod.split(":")[1].trim()
+							} else if (mod.indexOf("Secondary Damage:") > -1) {
+								damage2 = mod.split(":")[1].trim()
+							} else if (mod.indexOf("Damage Type:") > -1) {
+								damagetype = mod.split(":")[1].trim()
+							} else if (mod.indexOf("Damage:") > -1) {
+								damage = mod.split(":")[1].trim()
+							} else if (mod.indexOf("Range:") > -1) {
+								range = mod.split(":")[1].trim()
+							} else if (mod.indexOf(" Attacks ") > -1) {
+								attackmod = mod.split(" Attacks ")[1].trim()
+							} else if (mod.indexOf(" Damage ") > -1) {
+								damagemod = mod.split(" Damage ")[1].trim()
+							}
 						});
 					}
 
-					if(v["repeating_inventory_" + itemid + "_itemname"] && v["repeating_inventory_" + itemid + "_itemname"] != "") {
+					if (v["repeating_inventory_" + itemid + "_itemname"] && v["repeating_inventory_" + itemid + "_itemname"] != "") {
 						update["repeating_attack_" + attackid + "_atkname"] = v["repeating_inventory_" + itemid + "_itemname"];
-						if(options && options.versatile === "primary") {
+						if (options && options.versatile === "primary") {
 							update["repeating_attack_" + attackid + "_atkname"] += " (One-Handed)";
-						} else if(options && options.versatile === "secondary") {
+						} else if (options && options.versatile === "secondary") {
 							update["repeating_attack_" + attackid + "_atkname"] += " (Two-Handed)";
 						}
 					}
-					if(options && options.versatile === "secondary") {
-						if(alt.damage) {
+					if (options && options.versatile === "secondary") {
+						if (alt.damage) {
 							update["repeating_attack_" + attackid + "_dmgbase"] = alt.damage;
 						}
-						if(alt.damagetype) {
+						if (alt.damagetype) {
 							update["repeating_attack_" + attackid + "_dmgtype"] = alt.damagetype;
 						}
-						if(alt.damage2) {
+						if (alt.damage2) {
 							update["repeating_attack_" + attackid + "_dmg2base"] = alt.damage2;
 							update["repeating_attack_" + attackid + "_dmg2attr"] = 0;
 							update["repeating_attack_" + attackid + "_dmg2flag"] = "{{damage=1}} {{dmg2flag=1}}";
 						}
-						if(alt.damagetype2) {
+						if (alt.damagetype2) {
 							update["repeating_attack_" + attackid + "_dmg2type"] = alt.damagetype2;
 						}
 						update["repeating_attack_" + attackid + "_versatile_alt"] = "1";
-					}
-					else {
-						if(damage) {
+					} else {
+						if (damage) {
 							update["repeating_attack_" + attackid + "_dmgbase"] = damage;
 						}
-						if(damagetype) {
+						if (damagetype) {
 							update["repeating_attack_" + attackid + "_dmgtype"] = damagetype;
 						}
-						if(damage2) {
+						if (damage2) {
 							update["repeating_attack_" + attackid + "_dmg2base"] = damage2;
 							update["repeating_attack_" + attackid + "_dmg2attr"] = 0;
 							update["repeating_attack_" + attackid + "_dmg2flag"] = "{{damage=1}} {{dmg2flag=1}}";
 						}
-						if(damagetype2) {
+						if (damagetype2) {
 							update["repeating_attack_" + attackid + "_dmg2type"] = damagetype2;
 						}
 					}
-					if(range) {
+					if (range) {
 						update["repeating_attack_" + attackid + "_atkrange"] = range;
 					}
 					var finesse = v["repeating_inventory_" + itemid + "_itemproperties"] && /finesse/i.test(v["repeating_inventory_" + itemid + "_itemproperties"]);
-					if( (itemtype && itemtype.indexOf("Ranged") > -1) || (finesse && +v.dexterity > +v.strength)) {
+					if ((itemtype && itemtype.indexOf("Ranged") > -1) || (finesse && +v.dexterity > +v.strength)) {
 						update["repeating_attack_" + attackid + "_atkattr_base"] = "@{dexterity_mod}";
 						update["repeating_attack_" + attackid + "_dmgattr"] = "@{dexterity_mod}";
-					}
-					else {
+					} else {
 						update["repeating_attack_" + attackid + "_atkattr_base"] = "@{strength_mod}";
 						update["repeating_attack_" + attackid + "_dmgattr"] = "@{strength_mod}";
 					}
-					if(attackmod && damagemod && attackmod == damagemod) {
+					if (attackmod && damagemod && attackmod == damagemod) {
 						update["repeating_attack_" + attackid + "_atkmagic"] = parseInt(attackmod, 10);
 						update["repeating_attack_" + attackid + "_atkmod"] = "";
 						update["repeating_attack_" + attackid + "_dmgmod"] = "";
-					}
-					else {
-						if(attackmod) {
+					} else {
+						if (attackmod) {
 							update["repeating_attack_" + attackid + "_atkmod"] = parseInt(attackmod, 10);
 						}
-						if(damagemod) {
+						if (damagemod) {
 							update["repeating_attack_" + attackid + "_dmgmod"] = parseInt(damagemod, 10);
 						}
 						update["repeating_attack_" + attackid + "_atkmagic"] = "";
 					}
-					var callback = function() {update_attacks(attackid, "item")};
-					setAttrs(update, {silent: true}, callback);
+					var callback = function() {
+						update_attacks(attackid, "item")
+					};
+					setAttrs(update, {
+						silent: true
+					}, callback);
 				});
 			};
 
@@ -10033,17 +10654,15 @@
 				var newrowid = generateRowID();
 
 				getAttrs(["other_resource_name"], function(x) {
-					if(!x.other_resource_name || x.other_resource_name == "") {
+					if (!x.other_resource_name || x.other_resource_name == "") {
 						update["repeating_inventory_" + itemid + "_itemresourceid"] = "other_resource";
 						setAttrs(update, {}, update_resource_from_item(itemid, "other_resource", true));
-					}
-					else {
+					} else {
 						getSectionIDs("repeating_resource", function(idarray) {
-							if(idarray.length == 0) {
+							if (idarray.length == 0) {
 								update["repeating_inventory_" + itemid + "_itemresourceid"] = newrowid + "_resource_left";
 								setAttrs(update, {}, update_resource_from_item(itemid, newrowid + "_resource_left", true));
-							}
-							else {
+							} else {
 								var resource_names = [];
 								_.each(idarray, function(currentID, i) {
 									resource_names.push("repeating_resource_" + currentID + "_resource_left_name");
@@ -10053,18 +10672,17 @@
 								getAttrs(resource_names, function(y) {
 									var existing = false;
 									_.each(idarray, function(currentID, i) {
-										if((!y["repeating_resource_" + currentID + "_resource_left_name"] || y["repeating_resource_" + currentID + "_resource_left_name"] === "") && existing == false) {
+										if ((!y["repeating_resource_" + currentID + "_resource_left_name"] || y["repeating_resource_" + currentID + "_resource_left_name"] === "") && existing == false) {
 											update["repeating_inventory_" + itemid + "_itemresourceid"] = currentID + "_resource_left";
 											setAttrs(update, {}, update_resource_from_item(itemid, currentID + "_resource_left", true));
 											existing = true;
-										}
-										else if((!y["repeating_resource_" + currentID + "_resource_right_name"] || y["repeating_resource_" + currentID + "_resource_right_name"] === "") && existing == false) {
+										} else if ((!y["repeating_resource_" + currentID + "_resource_right_name"] || y["repeating_resource_" + currentID + "_resource_right_name"] === "") && existing == false) {
 											update["repeating_inventory_" + itemid + "_itemresourceid"] = currentID + "_resource_right";
 											setAttrs(update, {}, update_resource_from_item(itemid, currentID + "_resource_right", true));
 											existing = true;
 										};
 									});
-									if(!existing) {
+									if (!existing) {
 										update["repeating_inventory_" + itemid + "_itemresourceid"] = newrowid + "_resource_left";
 										setAttrs(update, {}, update_resource_from_item(itemid, newrowid + "_resource_left", true));
 									}
@@ -10078,33 +10696,35 @@
 			};
 
 			var update_resource_from_item = function(itemid, resourceid, newresource) {
-				getAttrs(["repeating_inventory_" + itemid + "_itemname","repeating_inventory_" + itemid + "_itemcount"], function(v) {
-					var update = {}; var id;
+				getAttrs(["repeating_inventory_" + itemid + "_itemname", "repeating_inventory_" + itemid + "_itemcount"], function(v) {
+					var update = {};
+					var id;
 
-					if(resourceid && resourceid == "other_resource") {
+					if (resourceid && resourceid == "other_resource") {
 						id = resourceid;
-					}
-					else {
+					} else {
 						id = "repeating_resource_" + resourceid;
 					};
 
-					if(newresource) {
+					if (newresource) {
 						update[id + "_itemid"] = itemid;
-					} ;
+					};
 
-					if(!v["repeating_inventory_" + itemid + "_itemname"]) {
+					if (!v["repeating_inventory_" + itemid + "_itemname"]) {
 						update["repeating_inventory_" + itemid + "_useasresource"] = 0;
 						update["repeating_inventory_" + itemid + "_itemresourceid"] = "";
 						remove_resource(resourceid);
 					};
-					if(v["repeating_inventory_" + itemid + "_itemname"] && v["repeating_inventory_" + itemid + "_itemname"] != "") {
+					if (v["repeating_inventory_" + itemid + "_itemname"] && v["repeating_inventory_" + itemid + "_itemname"] != "") {
 						update[id + "_name"] = v["repeating_inventory_" + itemid + "_itemname"];
 					};
-					if(v["repeating_inventory_" + itemid + "_itemcount"] && v["repeating_inventory_" + itemid + "_itemcount"] != "") {
+					if (v["repeating_inventory_" + itemid + "_itemcount"] && v["repeating_inventory_" + itemid + "_itemcount"] != "") {
 						update[id] = v["repeating_inventory_" + itemid + "_itemcount"];
 					};
 
-					setAttrs(update, {silent: true});
+					setAttrs(update, {
+						silent: true
+					});
 
 				});
 			};
@@ -10114,7 +10734,11 @@
 				getAttrs([resourceid, resourceid + "_name"], function(v) {
 					update["repeating_inventory_" + itemid + "_itemcount"] = v[resourceid];
 					update["repeating_inventory_" + itemid + "_itemname"] = v[resourceid + "_name"];
-					setAttrs(update, {silent: true}, function() {update_weight()});
+					setAttrs(update, {
+						silent: true
+					}, function() {
+						update_weight()
+					});
 				});
 			};
 
@@ -10149,164 +10773,152 @@
 					"repeating_spell-" + lvl + "_" + spellid + "_spell_damage_progression",
 					"repeating_spell-" + lvl + "_" + spellid + "_innate",
 					"repeating_spell-" + lvl + "_" + spellid + "_spell_ability",
-					"spellcasting_ability"], function(v) {
+					"spellcasting_ability"
+				], function(v) {
 					var update = {};
 					var description = "";
 					var spellAbility = v["repeating_spell-" + lvl + "_" + spellid + "_spell_ability"] != "spell" ? v["repeating_spell-" + lvl + "_" + spellid + "_spell_ability"].slice(0, -1) : "spell";
 					update["repeating_attack_" + attackid + "_atkattr_base"] = spellAbility;
 
-					if(newattack) {
+					if (newattack) {
 						update["repeating_attack_" + attackid + "_options-flag"] = "0";
 						update["repeating_attack_" + attackid + "_spellid"] = spellid;
 						update["repeating_attack_" + attackid + "_spelllevel"] = lvl;
 					}
 
-					if(v["repeating_spell-" + lvl + "_" + spellid + "_spell_ability"] == "spell") {
+					if (v["repeating_spell-" + lvl + "_" + spellid + "_spell_ability"] == "spell") {
 						update["repeating_attack_" + attackid + "_savedc"] = "(@{spell_save_dc})";
 					} else if (v["repeating_spell-" + lvl + "_" + spellid + "_spell_ability"]) {
 						update["repeating_attack_" + attackid + "_savedc"] = "(" + spellAbility + "+8+@{spell_dc_mod}+@{pb})";
 					}
 
-					if(v["repeating_spell-" + lvl + "_" + spellid + "_spellname"] && v["repeating_spell-" + lvl + "_" + spellid + "_spellname"] != "") {
+					if (v["repeating_spell-" + lvl + "_" + spellid + "_spellname"] && v["repeating_spell-" + lvl + "_" + spellid + "_spellname"] != "") {
 						update["repeating_attack_" + attackid + "_atkname"] = v["repeating_spell-" + lvl + "_" + spellid + "_spellname"];
 					}
-					if(!v["repeating_spell-" + lvl + "_" + spellid + "_spellattack"] || v["repeating_spell-" + lvl + "_" + spellid + "_spellattack"] === "None") {
+					if (!v["repeating_spell-" + lvl + "_" + spellid + "_spellattack"] || v["repeating_spell-" + lvl + "_" + spellid + "_spellattack"] === "None") {
 						update["repeating_attack_" + attackid + "_atkflag"] = "0";
-					}
-					else {
+					} else {
 						update["repeating_attack_" + attackid + "_atkflag"] = "{{attack=1}}";
 						description = description + v["repeating_spell-" + lvl + "_" + spellid + "_spellattack"] + " Spell Attack. ";
 					}
 
-					if(v["repeating_spell-" + lvl + "_" + spellid + "_spelldamage"] && v["repeating_spell-" + lvl + "_" + spellid + "_spelldamage"] != "") {
+					if (v["repeating_spell-" + lvl + "_" + spellid + "_spelldamage"] && v["repeating_spell-" + lvl + "_" + spellid + "_spelldamage"] != "") {
 						update["repeating_attack_" + attackid + "_dmgflag"] = "{{damage=1}} {{dmg1flag=1}}";
-						if(v["repeating_spell-" + lvl + "_" + spellid + "_spell_damage_progression"] && v["repeating_spell-" + lvl + "_" + spellid + "_spell_damage_progression"] === "Cantrip Dice") {
+						if (v["repeating_spell-" + lvl + "_" + spellid + "_spell_damage_progression"] && v["repeating_spell-" + lvl + "_" + spellid + "_spell_damage_progression"] === "Cantrip Dice") {
 							update["repeating_attack_" + attackid + "_dmgbase"] = "[[round((@{level} + 1) / 6 + 0.5)]]" + v["repeating_spell-" + lvl + "_" + spellid + "_spelldamage"].substring(1);
-						}
-						else {
+						} else {
 							update["repeating_attack_" + attackid + "_dmgbase"] = v["repeating_spell-" + lvl + "_" + spellid + "_spelldamage"];
 						}
-					}
-					else {
+					} else {
 						update["repeating_attack_" + attackid + "_dmgflag"] = "0"
 					}
-					if(v["repeating_spell-" + lvl + "_" + spellid + "_spelldmgmod"] && v["repeating_spell-" + lvl + "_" + spellid + "_spelldmgmod"] === "Yes") {
+					if (v["repeating_spell-" + lvl + "_" + spellid + "_spelldmgmod"] && v["repeating_spell-" + lvl + "_" + spellid + "_spelldmgmod"] === "Yes") {
 						update["repeating_attack_" + attackid + "_dmgattr"] = spellAbility;
-					}
-					else {
+					} else {
 						update["repeating_attack_" + attackid + "_dmgattr"] = "0";
 					}
-					if(v["repeating_spell-" + lvl + "_" + spellid + "_spelldamagetype"]) {
+					if (v["repeating_spell-" + lvl + "_" + spellid + "_spelldamagetype"]) {
 						update["repeating_attack_" + attackid + "_dmgtype"] = v["repeating_spell-" + lvl + "_" + spellid + "_spelldamagetype"];
-					}
-					else {
+					} else {
 						update["repeating_attack_" + attackid + "_dmgtype"] = "";
 					}
-					if(v["repeating_spell-" + lvl + "_" + spellid + "_spelldamage2"]) {
+					if (v["repeating_spell-" + lvl + "_" + spellid + "_spelldamage2"]) {
 						update["repeating_attack_" + attackid + "_dmg2base"] = v["repeating_spell-" + lvl + "_" + spellid + "_spelldamage2"];
 						update["repeating_attack_" + attackid + "_dmg2attr"] = 0;
 						update["repeating_attack_" + attackid + "_dmg2flag"] = "{{damage=1}} {{dmg2flag=1}}";
-					}
-					else {
+					} else {
 						update["repeating_attack_" + attackid + "_dmg2base"] = "";
 						update["repeating_attack_" + attackid + "_dmg2attr"] = 0;
 						update["repeating_attack_" + attackid + "_dmg2flag"] = "0";
 					}
-					if(v["repeating_spell-" + lvl + "_" + spellid + "_spelldamagetype2"]) {
+					if (v["repeating_spell-" + lvl + "_" + spellid + "_spelldamagetype2"]) {
 						update["repeating_attack_" + attackid + "_dmg2type"] = v["repeating_spell-" + lvl + "_" + spellid + "_spelldamagetype2"];
-					}
-					else {
+					} else {
 						update["repeating_attack_" + attackid + "_dmg2type"] = "";
 					}
-					if(v["repeating_spell-" + lvl + "_" + spellid + "_spellrange"]) {
+					if (v["repeating_spell-" + lvl + "_" + spellid + "_spellrange"]) {
 						update["repeating_attack_" + attackid + "_atkrange"] = v["repeating_spell-" + lvl + "_" + spellid + "_spellrange"];
-					}
-					else {
+					} else {
 						update["repeating_attack_" + attackid + "_atkrange"] = "";
 					}
-					if(v["repeating_spell-" + lvl + "_" + spellid + "_spellrange"]) {
+					if (v["repeating_spell-" + lvl + "_" + spellid + "_spellrange"]) {
 						update["repeating_attack_" + attackid + "_atkrange"] = v["repeating_spell-" + lvl + "_" + spellid + "_spellrange"];
-					}
-					else {
+					} else {
 						update["repeating_attack_" + attackid + "_atkrange"] = "";
 					}
-					if(v["repeating_spell-" + lvl + "_" + spellid + "_spellsave"]) {
+					if (v["repeating_spell-" + lvl + "_" + spellid + "_spellsave"]) {
 						update["repeating_attack_" + attackid + "_saveflag"] = "{{save=1}} {{saveattr=@{saveattr}}} {{savedesc=@{saveeffect}}} {{savedc=[[[[@{savedc}]][SAVE]]]}}";
 						update["repeating_attack_" + attackid + "_saveattr"] = v["repeating_spell-" + lvl + "_" + spellid + "_spellsave"];
-					}
-					else {
+					} else {
 						update["repeating_attack_" + attackid + "_saveflag"] = "0";
 					}
-					if(v["repeating_spell-" + lvl + "_" + spellid + "_spellsavesuccess"]) {
+					if (v["repeating_spell-" + lvl + "_" + spellid + "_spellsavesuccess"]) {
 						update["repeating_attack_" + attackid + "_saveeffect"] = v["repeating_spell-" + lvl + "_" + spellid + "_spellsavesuccess"];
-					}
-					else {
+					} else {
 						update["repeating_attack_" + attackid + "_saveeffect"] = "";
 					}
-					if(v["repeating_spell-" + lvl + "_" + spellid + "_spellhldie"] && v["repeating_spell-" + lvl + "_" + spellid + "_spellhldie"] != "" && v["repeating_spell-" + lvl + "_" + spellid + "_spellhldietype"] && v["repeating_spell-" + lvl + "_" + spellid + "_spellhldietype"] != "") {
+					if (v["repeating_spell-" + lvl + "_" + spellid + "_spellhldie"] && v["repeating_spell-" + lvl + "_" + spellid + "_spellhldie"] != "" && v["repeating_spell-" + lvl + "_" + spellid + "_spellhldietype"] && v["repeating_spell-" + lvl + "_" + spellid + "_spellhldietype"] != "") {
 						var bonus = "";
 						var spelllevel = v["repeating_spell-" + lvl + "_" + spellid + "_spelllevel"];
 						var query = "?{Cast at what level?";
-						for(i = 0; i < 10-spelllevel; i++) {
+						for (i = 0; i < 10 - spelllevel; i++) {
 							query = query + "|Level " + (parseInt(i, 10) + parseInt(spelllevel, 10)) + "," + i;
 						}
 						query = query + "}";
-						if(v["repeating_spell-" + lvl + "_" + spellid + "_spellhlbonus"] && v["repeating_spell-" + lvl + "_" + spellid + "_spellhlbonus"] != "") {
+						if (v["repeating_spell-" + lvl + "_" + spellid + "_spellhlbonus"] && v["repeating_spell-" + lvl + "_" + spellid + "_spellhlbonus"] != "") {
 							bonus = "+(" + v["repeating_spell-" + lvl + "_" + spellid + "_spellhlbonus"] + "*" + query + ")";
 						}
 						update["repeating_attack_" + attackid + "_hldmg"] = "{{hldmg=[[(" + v["repeating_spell-" + lvl + "_" + spellid + "_spellhldie"] + "*" + query + ")" + v["repeating_spell-" + lvl + "_" + spellid + "_spellhldietype"] + bonus + "]]}}";
-					}
-					else {
+					} else {
 						update["repeating_attack_" + attackid + "_hldmg"] = "";
 					}
-					if(v["repeating_spell-" + lvl + "_" + spellid + "_spellhealing"] && v["repeating_spell-" + lvl + "_" + spellid + "_spellhealing"] != "") {
-						if(!v["repeating_spell-" + lvl + "_" + spellid + "_spelldamage"] || v["repeating_spell-" + lvl + "_" + spellid + "_spelldamage"] === "") {
+					if (v["repeating_spell-" + lvl + "_" + spellid + "_spellhealing"] && v["repeating_spell-" + lvl + "_" + spellid + "_spellhealing"] != "") {
+						if (!v["repeating_spell-" + lvl + "_" + spellid + "_spelldamage"] || v["repeating_spell-" + lvl + "_" + spellid + "_spelldamage"] === "") {
 							update["repeating_attack_" + attackid + "_dmgbase"] = v["repeating_spell-" + lvl + "_" + spellid + "_spellhealing"];
 							update["repeating_attack_" + attackid + "_dmgflag"] = "{{damage=1}} {{dmg1flag=1}}";
 							update["repeating_attack_" + attackid + "_dmgtype"] = "Healing";
-						}
-						else if(!v["repeating_spell-" + lvl + "_" + spellid + "_spelldamage2"] || v["repeating_spell-" + lvl + "_" + spellid + "_spelldamage2"] === "") {
+						} else if (!v["repeating_spell-" + lvl + "_" + spellid + "_spelldamage2"] || v["repeating_spell-" + lvl + "_" + spellid + "_spelldamage2"] === "") {
 							update["repeating_attack_" + attackid + "_dmg2base"] = v["repeating_spell-" + lvl + "_" + spellid + "_spellhealing"];
 							update["repeating_attack_" + attackid + "_dmg2flag"] = "{{damage=1}} {{dmg2flag=1}}";
 							update["repeating_attack_" + attackid + "_dmg2type"] = "Healing";
 						}
 					}
-					if(v["repeating_spell-" + lvl + "_" + spellid + "_innate"]) {
+					if (v["repeating_spell-" + lvl + "_" + spellid + "_innate"]) {
 						update["repeating_attack_" + attackid + "_spell_innate"] = v["repeating_spell-" + lvl + "_" + spellid + "_innate"];
-					}
-					else {
+					} else {
 						update["repeating_attack_" + attackid + "_spell_innate"] = "";
 					}
-					if(v["repeating_spell-" + lvl + "_" + spellid + "_spelltarget"]) {
+					if (v["repeating_spell-" + lvl + "_" + spellid + "_spelltarget"]) {
 						description = description + v["repeating_spell-" + lvl + "_" + spellid + "_spelltarget"] + ". ";
 					}
-					if(v["repeating_spell-" + lvl + "_" + spellid + "_includedesc"] && v["repeating_spell-" + lvl + "_" + spellid + "_includedesc"] === "on") {
+					if (v["repeating_spell-" + lvl + "_" + spellid + "_includedesc"] && v["repeating_spell-" + lvl + "_" + spellid + "_includedesc"] === "on") {
 						description = v["repeating_spell-" + lvl + "_" + spellid + "_spelldescription"];
-						if(v["repeating_spell-" + lvl + "_" + spellid + "_spellathigherlevels"] && v["repeating_spell-" + lvl + "_" + spellid + "_spellathigherlevels"] != "") {
+						if (v["repeating_spell-" + lvl + "_" + spellid + "_spellathigherlevels"] && v["repeating_spell-" + lvl + "_" + spellid + "_spellathigherlevels"] != "") {
 							description = description + "\n\nAt Higher Levels: " + v["repeating_spell-" + lvl + "_" + spellid + "_spellathigherlevels"];
 						}
-					}
-					else if(v["repeating_spell-" + lvl + "_" + spellid + "_includedesc"] && v["repeating_spell-" + lvl + "_" + spellid + "_includedesc"] === "off") {
+					} else if (v["repeating_spell-" + lvl + "_" + spellid + "_includedesc"] && v["repeating_spell-" + lvl + "_" + spellid + "_includedesc"] === "off") {
 						description = "";
 					};
 					update["repeating_attack_" + attackid + "_atk_desc"] = description;
 
-					var callback = function() {update_attacks(attackid, "spell")};
-					setAttrs(update, {silent: true}, callback);
+					var callback = function() {
+						update_attacks(attackid, "spell")
+					};
+					setAttrs(update, {
+						silent: true
+					}, callback);
 				});
 			};
 
 			var update_attacks = function(update_id, source) {
 				console.log("DOING UPDATE_ATTACKS: " + update_id);
-				if(update_id.substring(0,1) === "-" && update_id.length === 20) {
+				if (update_id.substring(0, 1) === "-" && update_id.length === 20) {
 					do_update_attack([update_id], source);
-				}
-				else if(["strength","dexterity","constitution","intelligence","wisdom","charisma","spells","all"].indexOf(update_id) > -1) {
+				} else if (["strength", "dexterity", "constitution", "intelligence", "wisdom", "charisma", "spells", "all"].indexOf(update_id) > -1) {
 					getSectionIDs("repeating_attack", function(idarray) {
-						if(update_id === "all") {
+						if (update_id === "all") {
 							do_update_attack(idarray);
-						}
-						else if(update_id === "spells") {
+						} else if (update_id === "spells") {
 							var attack_attribs = [];
 							_.each(idarray, function(id) {
 								attack_attribs.push("repeating_attack_" + id + "_spellid", "repeating_attack_" + id + "_spelllevel");
@@ -10322,11 +10934,12 @@
 										spell_lvl: v["repeating_attack_" + attack_id + "_spelllevel"]
 									};
 								});
-								_.each(spell_attacks, function(data, attack_id) { update_attack_from_spell(data.spell_lvl, data.spell_id, attack_id); });
+								_.each(spell_attacks, function(data, attack_id) {
+									update_attack_from_spell(data.spell_lvl, data.spell_id, attack_id);
+								});
 							});
 
-						}
-						else {
+						} else {
 							var attack_attribs = ["spellcasting_ability"];
 							_.each(idarray, function(id) {
 								attack_attribs.push("repeating_attack_" + id + "_atkattr_base");
@@ -10337,11 +10950,11 @@
 							getAttrs(attack_attribs, function(v) {
 								var attr_attack_ids = [];
 								_.each(idarray, function(id) {
-									if((v["repeating_attack_" + id + "_atkattr_base"] && v["repeating_attack_" + id + "_atkattr_base"].indexOf(update_id) > -1) || (v["repeating_attack_" + id + "_dmgattr"] && v["repeating_attack_" + id + "_dmgattr"].indexOf(update_id) > -1) || (v["repeating_attack_" + id + "_dmg2attr"] && v["repeating_attack_" + id + "_dmg2attr"].indexOf(update_id) > -1) || (v["repeating_attack_" + id + "_savedc"] && v["repeating_attack_" + id + "_savedc"].indexOf(update_id) > -1) || (v["repeating_attack_" + id + "_savedc"] && v["repeating_attack_" + id + "_savedc"] === "(@{spell_save_dc})" && v["spellcasting_ability"] && v["spellcasting_ability"].indexOf(update_id) > -1)) {
+									if ((v["repeating_attack_" + id + "_atkattr_base"] && v["repeating_attack_" + id + "_atkattr_base"].indexOf(update_id) > -1) || (v["repeating_attack_" + id + "_dmgattr"] && v["repeating_attack_" + id + "_dmgattr"].indexOf(update_id) > -1) || (v["repeating_attack_" + id + "_dmg2attr"] && v["repeating_attack_" + id + "_dmg2attr"].indexOf(update_id) > -1) || (v["repeating_attack_" + id + "_savedc"] && v["repeating_attack_" + id + "_savedc"].indexOf(update_id) > -1) || (v["repeating_attack_" + id + "_savedc"] && v["repeating_attack_" + id + "_savedc"] === "(@{spell_save_dc})" && v["spellcasting_ability"] && v["spellcasting_ability"].indexOf(update_id) > -1)) {
 										attr_attack_ids.push(id);
 									}
 								});
-								if(attr_attack_ids.length > 0) {
+								if (attr_attack_ids.length > 0) {
 									do_update_attack(attr_attack_ids);
 								}
 							});
@@ -10351,7 +10964,7 @@
 			};
 
 			var do_update_attack = function(attack_array, source) {
-				var attack_attribs = ["level","d20","pb","pb_type","pbd_safe","dtype","globalmagicmod","strength_mod","dexterity_mod","constitution_mod","intelligence_mod","wisdom_mod","charisma_mod","spellcasting_ability","spell_save_dc","spell_attack_mod", "spell_dc_mod", "global_damage_mod_roll", "global_damage_mod_crit"];
+				var attack_attribs = ["level", "d20", "pb", "pb_type", "pbd_safe", "dtype", "globalmagicmod", "strength_mod", "dexterity_mod", "constitution_mod", "intelligence_mod", "wisdom_mod", "charisma_mod", "spellcasting_ability", "spell_save_dc", "spell_attack_mod", "spell_dc_mod", "global_damage_mod_roll", "global_damage_mod_crit"];
 				_.each(attack_array, function(attackid) {
 					attack_attribs.push("repeating_attack_" + attackid + "_atkflag");
 					attack_attribs.push("repeating_attack_" + attackid + "_atkname");
@@ -10403,15 +11016,15 @@
 						var pbd_safe = v["pbd_safe"] ? v["pbd_safe"] : "";
 						var global_crit = v["repeating_attack_" + attackid + "_global_damage_mod_field"] && v["repeating_attack_" + attackid + "_global_damage_mod_field"] != "" ? "@{global_damage_mod_crit}" : "";
 						var hldmgcrit = v["repeating_attack_" + attackid + "_hldmg"] && v["repeating_attack_" + attackid + "_hldmg"] != "" ? v["repeating_attack_" + attackid + "_hldmg"].slice(0, 7) + "crit" + v["repeating_attack_" + attackid + "_hldmg"].slice(7) : "";
-						if(v["repeating_attack_" + attackid + "_spellid"] && v["repeating_attack_" + attackid + "_spellid"] != "") {
+						if (v["repeating_attack_" + attackid + "_spellid"] && v["repeating_attack_" + attackid + "_spellid"] != "") {
 							spellattack = true;
-							magicattackmod = v["spell_attack_mod"] && !isNaN(parseInt(v["spell_attack_mod"],10)) ? parseInt(v["spell_attack_mod"],10) : 0;
-							magicsavemod = v["spell_dc_mod"] && !isNaN(parseInt(v["spell_dc_mod"],10)) ? parseInt(v["spell_dc_mod"],10) : 0;
+							magicattackmod = v["spell_attack_mod"] && !isNaN(parseInt(v["spell_attack_mod"], 10)) ? parseInt(v["spell_attack_mod"], 10) : 0;
+							magicsavemod = v["spell_dc_mod"] && !isNaN(parseInt(v["spell_dc_mod"], 10)) ? parseInt(v["spell_dc_mod"], 10) : 0;
 						};
 
-						if(!v["repeating_attack_" + attackid + "_atkattr_base"] || v["repeating_attack_" + attackid + "_atkattr_base"] === "0") {
+						if (!v["repeating_attack_" + attackid + "_atkattr_base"] || v["repeating_attack_" + attackid + "_atkattr_base"] === "0") {
 							atkattr_base = 0
-						} else if(v["repeating_attack_" + attackid + "_atkattr_base"] && v["repeating_attack_" + attackid + "_atkattr_base"] === "spell") {
+						} else if (v["repeating_attack_" + attackid + "_atkattr_base"] && v["repeating_attack_" + attackid + "_atkattr_base"] === "spell") {
 							atkattr_base = parseInt(v[v["spellcasting_ability"].substring(2, v["spellcasting_ability"].length - 2)], 10);
 							atkattr_abrev = v["spellcasting_ability"].substring(2, 5).toUpperCase();
 						} else {
@@ -10419,111 +11032,103 @@
 							atkattr_abrev = v["repeating_attack_" + attackid + "_atkattr_base"].substring(2, 5).toUpperCase();
 						};
 
-						if(!v["repeating_attack_" + attackid + "_dmgattr"] || v["repeating_attack_" + attackid + "_dmgattr"] === "0") {
+						if (!v["repeating_attack_" + attackid + "_dmgattr"] || v["repeating_attack_" + attackid + "_dmgattr"] === "0") {
 							dmgattr = 0;
-						} else if(v["repeating_attack_" + attackid + "_dmgattr"] && v["repeating_attack_" + attackid + "_dmgattr"] === "spell") {
+						} else if (v["repeating_attack_" + attackid + "_dmgattr"] && v["repeating_attack_" + attackid + "_dmgattr"] === "spell") {
 							dmgattr = parseInt(v[v["spellcasting_ability"].substring(2, v["spellcasting_ability"].length - 2)], 10);
 							dmgattr_abrev = v["spellcasting_ability"].substring(2, 5).toUpperCase();
 						} else {
 							dmgattr = parseInt(v[v["repeating_attack_" + attackid + "_dmgattr"].substring(2, v["repeating_attack_" + attackid + "_dmgattr"].length - 1)], 10);
-							dmgattr_abrev =v["repeating_attack_" + attackid + "_dmgattr"].substring(2, 5).toUpperCase();
+							dmgattr_abrev = v["repeating_attack_" + attackid + "_dmgattr"].substring(2, 5).toUpperCase();
 						};
 
-						if(!v["repeating_attack_" + attackid + "_dmg2attr"] || v["repeating_attack_" + attackid + "_dmg2attr"] === "0") {
+						if (!v["repeating_attack_" + attackid + "_dmg2attr"] || v["repeating_attack_" + attackid + "_dmg2attr"] === "0") {
 							dmg2attr = 0;
-						} else if(v["repeating_attack_" + attackid + "_dmg2attr"] && v["repeating_attack_" + attackid + "_dmg2attr"] === "spell") {
+						} else if (v["repeating_attack_" + attackid + "_dmg2attr"] && v["repeating_attack_" + attackid + "_dmg2attr"] === "spell") {
 							dmg2attr = parseInt(v[v["spellcasting_ability"].substring(2, v["spellcasting_ability"].length - 2)], 10);
 							dmg2attr_abrev = v["spellcasting_ability"].substring(2, 5).toUpperCase();
 						} else {
 							dmg2attr = parseInt(v[v["repeating_attack_" + attackid + "_dmg2attr"].substring(2, v["repeating_attack_" + attackid + "_dmg2attr"].length - 1)], 10);
-							dmg2attr_abrev =v["repeating_attack_" + attackid + "_dmg2attr"].substring(2, 5).toUpperCase();
+							dmg2attr_abrev = v["repeating_attack_" + attackid + "_dmg2attr"].substring(2, 5).toUpperCase();
 						};
 
 						var dmgbase = v["repeating_attack_" + attackid + "_dmgbase"] && v["repeating_attack_" + attackid + "_dmgbase"] != "" ? v["repeating_attack_" + attackid + "_dmgbase"] : 0;
 						var dmg2base = v["repeating_attack_" + attackid + "_dmg2base"] && v["repeating_attack_" + attackid + "_dmg2base"] != "" ? v["repeating_attack_" + attackid + "_dmg2base"] : 0;
-						var dmgmod = v["repeating_attack_" + attackid + "_dmgmod"] && isNaN(parseInt(v["repeating_attack_" + attackid + "_dmgmod"],10)) === false ? parseInt(v["repeating_attack_" + attackid + "_dmgmod"],10) : 0;
-						var dmg2mod = v["repeating_attack_" + attackid + "_dmg2mod"] && isNaN(parseInt(v["repeating_attack_" + attackid + "_dmg2mod"],10)) === false ? parseInt(v["repeating_attack_" + attackid + "_dmg2mod"],10) : 0;
+						var dmgmod = v["repeating_attack_" + attackid + "_dmgmod"] && isNaN(parseInt(v["repeating_attack_" + attackid + "_dmgmod"], 10)) === false ? parseInt(v["repeating_attack_" + attackid + "_dmgmod"], 10) : 0;
+						var dmg2mod = v["repeating_attack_" + attackid + "_dmg2mod"] && isNaN(parseInt(v["repeating_attack_" + attackid + "_dmg2mod"], 10)) === false ? parseInt(v["repeating_attack_" + attackid + "_dmg2mod"], 10) : 0;
 						var dmgtype = v["repeating_attack_" + attackid + "_dmgtype"] ? v["repeating_attack_" + attackid + "_dmgtype"] + " " : "";
 						var dmg2type = v["repeating_attack_" + attackid + "_dmg2type"] ? v["repeating_attack_" + attackid + "_dmg2type"] + " " : "";
 						var pb = v["repeating_attack_" + attackid + "_atkprofflag"] && v["repeating_attack_" + attackid + "_atkprofflag"] != 0 && v.pb ? v.pb : 0;
-						var atkmod = v["repeating_attack_" + attackid + "_atkmod"] && v["repeating_attack_" + attackid + "_atkmod"] != "" ? parseInt(v["repeating_attack_" + attackid + "_atkmod"],10) : 0;
-						var atkmag = v["repeating_attack_" + attackid + "_atkmagic"] && v["repeating_attack_" + attackid + "_atkmagic"] != "" ? parseInt(v["repeating_attack_" + attackid + "_atkmagic"],10) : 0;
+						var atkmod = v["repeating_attack_" + attackid + "_atkmod"] && v["repeating_attack_" + attackid + "_atkmod"] != "" ? parseInt(v["repeating_attack_" + attackid + "_atkmod"], 10) : 0;
+						var atkmag = v["repeating_attack_" + attackid + "_atkmagic"] && v["repeating_attack_" + attackid + "_atkmagic"] != "" ? parseInt(v["repeating_attack_" + attackid + "_atkmagic"], 10) : 0;
 						var dmgmag = isNaN(atkmag) === false && atkmag != 0 && ((v["repeating_attack_" + attackid + "_dmgflag"] && v["repeating_attack_" + attackid + "_dmgflag"] != 0) || (v["repeating_attack_" + attackid + "_dmg2flag"] && v["repeating_attack_" + attackid + "_dmg2flag"] != 0)) ? "+ " + atkmag + " Magic Bonus" : "";
-						if(v["repeating_attack_" + attackid + "_atkflag"] && v["repeating_attack_" + attackid + "_atkflag"] != 0) {
+						if (v["repeating_attack_" + attackid + "_atkflag"] && v["repeating_attack_" + attackid + "_atkflag"] != 0) {
 							bonus_mod = atkattr_base + atkmod + atkmag + magicattackmod;
-							if(v["pb_type"] && v["pb_type"] === "die") {
+							if (v["pb_type"] && v["pb_type"] === "die") {
 								plus_minus = bonus_mod > -1 ? "+" : "";
 								bonus = bonus_mod + "+" + pb;
-							}
-							else {
+							} else {
 								bonus_mod = bonus_mod + parseInt(pb, 10);
 								plus_minus = bonus_mod > -1 ? "+" : "";
 								bonus = plus_minus + bonus_mod;
 							};
-						}
-						else if(v["repeating_attack_" + attackid + "_saveflag"] && v["repeating_attack_" + attackid + "_saveflag"] != 0) {
-							if(!v["repeating_attack_" + attackid + "_savedc"] || (v["repeating_attack_" + attackid + "_savedc"] && v["repeating_attack_" + attackid + "_savedc"] === "(@{spell_save_dc})")) {
+						} else if (v["repeating_attack_" + attackid + "_saveflag"] && v["repeating_attack_" + attackid + "_saveflag"] != 0) {
+							if (!v["repeating_attack_" + attackid + "_savedc"] || (v["repeating_attack_" + attackid + "_savedc"] && v["repeating_attack_" + attackid + "_savedc"] === "(@{spell_save_dc})")) {
 								var tempdc = v["spell_save_dc"];
-							}
-							else if(v["repeating_attack_" + attackid + "_savedc"] && v["repeating_attack_" + attackid + "_savedc"] === "(@{saveflat})") {
+							} else if (v["repeating_attack_" + attackid + "_savedc"] && v["repeating_attack_" + attackid + "_savedc"] === "(@{saveflat})") {
 								var tempdc = isNaN(parseInt(v["repeating_attack_" + attackid + "_saveflat"])) === false ? parseInt(v["repeating_attack_" + attackid + "_saveflat"]) : "0";
-							}
-							else {
-								var savedcattr = v["repeating_attack_" + attackid + "_savedc"].replace(/^[^{]*{/,"").replace(/\_.*$/,"");
-								var safe_pb = v["pb_type"] && v["pb_type"] === "die" ? parseInt(pb.substring(1), 10) / 2 : parseInt(pb,10);
-								var safe_attr = v[savedcattr + "_mod"] ? parseInt(v[savedcattr + "_mod"],10) : 0;
+							} else {
+								var savedcattr = v["repeating_attack_" + attackid + "_savedc"].replace(/^[^{]*{/, "").replace(/\_.*$/, "");
+								var safe_pb = v["pb_type"] && v["pb_type"] === "die" ? parseInt(pb.substring(1), 10) / 2 : parseInt(pb, 10);
+								var safe_attr = v[savedcattr + "_mod"] ? parseInt(v[savedcattr + "_mod"], 10) : 0;
 								var tempdc = 8 + safe_attr + safe_pb + magicsavemod;
 							};
 							bonus = "DC" + tempdc;
-						}
-						else {
+						} else {
 							bonus = "-";
 						}
-						if(v["repeating_attack_" + attackid + "_dmgflag"] && v["repeating_attack_" + attackid + "_dmgflag"] != 0) {
-							if(spellattack === true && dmgbase.indexOf("[[round((@{level} + 1) / 6 + 0.5)]]") > -1) {
+						if (v["repeating_attack_" + attackid + "_dmgflag"] && v["repeating_attack_" + attackid + "_dmgflag"] != 0) {
+							if (spellattack === true && dmgbase.indexOf("[[round((@{level} + 1) / 6 + 0.5)]]") > -1) {
 								// SPECIAL CANTRIP DAMAGE
 								dmgdiestring = Math.round(((parseInt(v["level"], 10) + 1) / 6) + 0.5).toString()
 								dmg = dmgdiestring + dmgbase.substring(dmgbase.lastIndexOf("d"));
-								if(dmgattr + dmgmod != 0) {
+								if (dmgattr + dmgmod != 0) {
 									dmg = dmg + "+" + (dmgattr + dmgmod);
 								}
 								dmg = dmg + " " + dmgtype;
-							}
-							else {
-								if(dmgbase === 0 && (dmgattr + dmgmod === 0)){
+							} else {
+								if (dmgbase === 0 && (dmgattr + dmgmod === 0)) {
 									dmg = 0;
 								}
-								if(dmgbase != 0) {
+								if (dmgbase != 0) {
 									dmg = dmgbase;
 								}
-								if(dmgbase != 0 && (dmgattr + dmgmod != 0)){
+								if (dmgbase != 0 && (dmgattr + dmgmod != 0)) {
 									dmg = dmgattr + dmgmod > 0 ? dmg + "+" : dmg;
 								}
-								if(dmgattr + dmgmod != 0) {
+								if (dmgattr + dmgmod != 0) {
 									dmg = dmg + (dmgattr + dmgmod);
 								}
 								dmg = dmg + " " + dmgtype;
 							}
-						}
-						else {
+						} else {
 							dmg = "";
 						};
-						if(v["repeating_attack_" + attackid + "_dmg2flag"] && v["repeating_attack_" + attackid + "_dmg2flag"] != 0) {
-							if(dmg2base === 0 && (dmg2attr + dmg2mod === 0)){
+						if (v["repeating_attack_" + attackid + "_dmg2flag"] && v["repeating_attack_" + attackid + "_dmg2flag"] != 0) {
+							if (dmg2base === 0 && (dmg2attr + dmg2mod === 0)) {
 								dmg2 = 0;
 							}
-							if(dmg2base != 0) {
+							if (dmg2base != 0) {
 								dmg2 = dmg2base;
 							}
-							if(dmg2base != 0 && (dmg2attr + dmg2mod != 0)){
+							if (dmg2base != 0 && (dmg2attr + dmg2mod != 0)) {
 								dmg2 = dmg2attr + dmg2mod > 0 ? dmg2 + "+" : dmg2;
 							}
-							if(dmg2attr + dmg2mod != 0) {
+							if (dmg2attr + dmg2mod != 0) {
 								dmg2 = dmg2 + (dmg2attr + dmg2mod);
 							}
 							dmg2 = dmg2 + " " + dmg2type;
-						}
-						else {
+						} else {
 							dmg2 = "";
 						};
 						dmgspacer = v["repeating_attack_" + attackid + "_dmgflag"] && v["repeating_attack_" + attackid + "_dmgflag"] != 0 && v["repeating_attack_" + attackid + "_dmg2flag"] && v["repeating_attack_" + attackid + "_dmg2flag"] != 0 ? "+ " : "";
@@ -10531,48 +11136,62 @@
 						crit2 = v["repeating_attack_" + attackid + "_dmg2custcrit"] && v["repeating_attack_" + attackid + "_dmg2custcrit"] != "" ? v["repeating_attack_" + attackid + "_dmg2custcrit"] : dmg2base;
 						r1 = v["repeating_attack_" + attackid + "_atkflag"] && v["repeating_attack_" + attackid + "_atkflag"] != 0 ? "@{d20}" : "0d20";
 						r2 = v["repeating_attack_" + attackid + "_atkflag"] && v["repeating_attack_" + attackid + "_atkflag"] != 0 ? "@{rtype}" : "{{r2=[[0d20";
-						if(v["repeating_attack_" + attackid + "_atkflag"] && v["repeating_attack_" + attackid + "_atkflag"] != 0) {
-							if(magicattackmod != 0) {hbonus = " + " + magicattackmod + "[SPELLATK]" + hbonus};
-							if(atkmag != 0) {hbonus = " + " + atkmag + "[MAGIC]" + hbonus};
-							if(pb != 0) {hbonus = " + " + pb + pbd_safe + "[PROF]" + hbonus};
-							if(atkmod != 0) {hbonus = " + " + atkmod + "[MOD]" + hbonus};
-							if(atkattr_base != 0) {hbonus = " + " + atkattr_base + "[" + atkattr_abrev + "]" + hbonus};
-						}
-						else {
+						if (v["repeating_attack_" + attackid + "_atkflag"] && v["repeating_attack_" + attackid + "_atkflag"] != 0) {
+							if (magicattackmod != 0) {
+								hbonus = " + " + magicattackmod + "[SPELLATK]" + hbonus
+							};
+							if (atkmag != 0) {
+								hbonus = " + " + atkmag + "[MAGIC]" + hbonus
+							};
+							if (pb != 0) {
+								hbonus = " + " + pb + pbd_safe + "[PROF]" + hbonus
+							};
+							if (atkmod != 0) {
+								hbonus = " + " + atkmod + "[MOD]" + hbonus
+							};
+							if (atkattr_base != 0) {
+								hbonus = " + " + atkattr_base + "[" + atkattr_abrev + "]" + hbonus
+							};
+						} else {
 							hbonus = "";
 						}
-						if(v["repeating_attack_" + attackid + "_dmgflag"] && v["repeating_attack_" + attackid + "_dmgflag"] != 0) {
-							if(atkmag != 0) {hdmg1 = " + " + atkmag + "[MAGIC]" + hdmg1};
-							if(dmgmod != 0) {hdmg1 = " + " + dmgmod + "[MOD]" + hdmg1};
-							if(dmgattr != 0) {hdmg1 = " + " + dmgattr + "[" + dmgattr_abrev + "]" + hdmg1};
+						if (v["repeating_attack_" + attackid + "_dmgflag"] && v["repeating_attack_" + attackid + "_dmgflag"] != 0) {
+							if (atkmag != 0) {
+								hdmg1 = " + " + atkmag + "[MAGIC]" + hdmg1
+							};
+							if (dmgmod != 0) {
+								hdmg1 = " + " + dmgmod + "[MOD]" + hdmg1
+							};
+							if (dmgattr != 0) {
+								hdmg1 = " + " + dmgattr + "[" + dmgattr_abrev + "]" + hdmg1
+							};
 							hdmg1 = dmgbase + hdmg1;
-						}
-						else {
+						} else {
 							hdmg1 = "0";
 						}
-						if(v["repeating_attack_" + attackid + "_dmg2flag"] && v["repeating_attack_" + attackid + "_dmg2flag"] != 0) {
-							if(dmg2mod != 0) {hdmg2 = " + " + dmg2mod + "[MOD]" + hdmg2};
-							if(dmg2attr != 0) {hdmg2 = " + " + dmg2attr + "[" + dmg2attr_abrev + "]" + hdmg2};
+						if (v["repeating_attack_" + attackid + "_dmg2flag"] && v["repeating_attack_" + attackid + "_dmg2flag"] != 0) {
+							if (dmg2mod != 0) {
+								hdmg2 = " + " + dmg2mod + "[MOD]" + hdmg2
+							};
+							if (dmg2attr != 0) {
+								hdmg2 = " + " + dmg2attr + "[" + dmg2attr_abrev + "]" + hdmg2
+							};
 							hdmg2 = dmg2base + hdmg2;
-						}
-						else {
+						} else {
 							hdmg2 = "0";
 						}
 						var globaldamage = `[[${v.global_damage_mod_roll && v.global_damage_mod_roll !== "" ? v.global_damage_mod_roll : "0"}]]`;
 						var globaldamagecrit = `[[${v.global_damage_mod_crit && v.global_damage_mod_crit !== "" ? v.global_damage_mod_crit : "0"}]]`;
-						if(v.dtype === "full") {
+						if (v.dtype === "full") {
 							pickbase = "full";
 							rollbase = "@{wtype}&{template:atkdmg} {{mod=@{atkbonus}}} {{rname=@{atkname}}} {{r1=[[" + r1 + "cs>@{atkcritrange}" + hbonus + "]]}} " + r2 + "cs>@{atkcritrange}" + hbonus + "]]}} @{atkflag} {{range=@{atkrange}}} @{dmgflag} {{dmg1=[[" + hdmg1 + "]]}} {{dmg1type=" + dmgtype + "}} @{dmg2flag} {{dmg2=[[" + hdmg2 + "]]}} {{dmg2type=" + dmg2type + "}} {{crit1=[[" + crit1 + "[CRIT]]]}} {{crit2=[[" + crit2 + "[CRIT]]]}} @{saveflag} {{desc=@{atk_desc}}} @{hldmg} " + hldmgcrit + " {{spelllevel=@{spelllevel}}} {{innate=@{spell_innate}}} {{globalattack=@{global_attack_mod}}} {{globaldamage=" + globaldamage + "}} {{globaldamagecrit=" + globaldamagecrit + "}} {{globaldamagetype=@{global_damage_mod_type}}} ammo=@{ammo} @{charname_output}";
-						}
-						else if(v["repeating_attack_" + attackid + "_atkflag"] && v["repeating_attack_" + attackid + "_atkflag"] != 0) {
+						} else if (v["repeating_attack_" + attackid + "_atkflag"] && v["repeating_attack_" + attackid + "_atkflag"] != 0) {
 							pickbase = "pick";
 							rollbase = "@{wtype}&{template:atk} {{mod=@{atkbonus}}} {{rname=[@{atkname}](~repeating_attack_attack_dmg)}} {{rnamec=[@{atkname}](~repeating_attack_attack_crit)}} {{r1=[[" + r1 + "cs>@{atkcritrange}" + hbonus + "]]}} " + r2 + "cs>@{atkcritrange}" + hbonus + "]]}} {{range=@{atkrange}}} {{desc=@{atk_desc}}} {{spelllevel=@{spelllevel}}} {{innate=@{spell_innate}}} {{globalattack=@{global_attack_mod}}} ammo=@{ammo} @{charname_output}";
-						}
-						else if(v["repeating_attack_" + attackid + "_dmgflag"] && v["repeating_attack_" + attackid + "_dmgflag"] != 0) {
+						} else if (v["repeating_attack_" + attackid + "_dmgflag"] && v["repeating_attack_" + attackid + "_dmgflag"] != 0) {
 							pickbase = "dmg";
 							rollbase = "@{wtype}&{template:dmg} {{rname=@{atkname}}} @{atkflag} {{range=@{atkrange}}} @{dmgflag} {{dmg1=[[" + hdmg1 + "]]}} {{dmg1type=" + dmgtype + "}} @{dmg2flag} {{dmg2=[[" + hdmg2 + "]]}} {{dmg2type=" + dmg2type + "}} @{saveflag} {{desc=@{atk_desc}}} @{hldmg} {{spelllevel=@{spelllevel}}} {{innate=@{spell_innate}}} {{globaldamage=" + globaldamage + "}} {{globaldamagetype=@{global_damage_mod_type}}} ammo=@{ammo} @{charname_output}"
-						}
-						else {
+						} else {
 							pickbase = "empty";
 							rollbase = "@{wtype}&{template:dmg} {{rname=@{atkname}}} @{atkflag} {{range=@{atkrange}}} @{saveflag} {{desc=@{atk_desc}}} {{spelllevel=@{spelllevel}}} {{innate=@{spell_innate}}} ammo=@{ammo} @{charname_output}"
 						}
@@ -10581,16 +11200,26 @@
 						update["repeating_attack_" + attackid + "_atkbonus"] = bonus;
 						update["repeating_attack_" + attackid + "_atkdmgtype"] = dmg + dmgspacer + dmg2 + dmgmag + " ";
 						update["repeating_attack_" + attackid + "_rollbase"] = rollbase;
-						if(v["repeating_attack_" + attackid + "_spellid"] && v["repeating_attack_" + attackid + "_spellid"] != "" && (!source || source && source != "spell") && v["repeating_attack_" + attackid + "_spellid"].length == 20) {
+						if (v["repeating_attack_" + attackid + "_spellid"] && v["repeating_attack_" + attackid + "_spellid"] != "" && (!source || source && source != "spell") && v["repeating_attack_" + attackid + "_spellid"].length == 20) {
 							var spellid = v["repeating_attack_" + attackid + "_spellid"];
 							var lvl = v["repeating_attack_" + attackid + "_spelllevel"];
-							callbacks.push( function() {update_spell_from_attack(lvl, spellid, attackid);} );
+							callbacks.push(function() {
+								update_spell_from_attack(lvl, spellid, attackid);
+							});
 						}
-						if(v["repeating_attack_" + attackid + "_itemid"] && v["repeating_attack_" + attackid + "_itemid"] != "" && (!source || source && source != "item")) {
+						if (v["repeating_attack_" + attackid + "_itemid"] && v["repeating_attack_" + attackid + "_itemid"] != "" && (!source || source && source != "item")) {
 							var itemid = v["repeating_attack_" + attackid + "_itemid"];
-							callbacks.push( function() {update_item_from_attack(itemid, attackid);} );
+							callbacks.push(function() {
+								update_item_from_attack(itemid, attackid);
+							});
 						}
-						setAttrs(update, {silent: true}, function() {callbacks.forEach(function(callback) {callback(); })} );
+						setAttrs(update, {
+							silent: true
+						}, function() {
+							callbacks.forEach(function(callback) {
+								callback();
+							})
+						});
 					});
 				});
 			};
@@ -10599,65 +11228,58 @@
 				var update = {};
 				getAttrs(["repeating_attack_" + attackid + "_atkname", "repeating_attack_" + attackid + "_atkrange", "repeating_attack_" + attackid + "_atkflag", "repeating_attack_" + attackid + "_atkattr_base", "repeating_attack_" + attackid + "_dmgbase", "repeating_attack_" + attackid + "_dmgtype", "repeating_attack_" + attackid + "_dmg2base", "repeating_attack_" + attackid + "_dmg2type", "repeating_attack_" + attackid + "_saveflag", "repeating_attack_" + attackid + "_saveattr", "repeating_attack_" + attackid + "_saveeffect"], function(v) {
 					update["repeating_spell-" + lvl + "_" + spellid + "_spellname"] = v["repeating_attack_" + attackid + "_atkname"];
-					if(v["repeating_attack_" + attackid + "_atkrange"] && v["repeating_attack_" + attackid + "_atkrange"] != "") {
+					if (v["repeating_attack_" + attackid + "_atkrange"] && v["repeating_attack_" + attackid + "_atkrange"] != "") {
 						update["repeating_spell-" + lvl + "_" + spellid + "_spellrange"] = v["repeating_attack_" + attackid + "_atkrange"];
-					}
-					else {
+					} else {
 						update["repeating_spell-" + lvl + "_" + spellid + "_spellrange"] = "";
 					};
 
-					if(v["repeating_attack_" + attackid + "_dmgtype"] && v["repeating_attack_" + attackid + "_dmgtype"].toLowerCase() == "healing") {
-						if(v["repeating_attack_" + attackid + "_dmgbase"] && v["repeating_attack_" + attackid + "_dmgbase"] != "") {
+					if (v["repeating_attack_" + attackid + "_dmgtype"] && v["repeating_attack_" + attackid + "_dmgtype"].toLowerCase() == "healing") {
+						if (v["repeating_attack_" + attackid + "_dmgbase"] && v["repeating_attack_" + attackid + "_dmgbase"] != "") {
 							update["repeating_spell-" + lvl + "_" + spellid + "_spellhealing"] = v["repeating_attack_" + attackid + "_dmgbase"];
 						}
-					}
-					else {
-						if(v["repeating_attack_" + attackid + "_dmgbase"] && v["repeating_attack_" + attackid + "_dmgbase"] != "" && v["repeating_attack_" + attackid + "_dmgbase"].indexOf("[[round((@{level} + 1) / 6 + 0.5)]]") === -1) {
+					} else {
+						if (v["repeating_attack_" + attackid + "_dmgbase"] && v["repeating_attack_" + attackid + "_dmgbase"] != "" && v["repeating_attack_" + attackid + "_dmgbase"].indexOf("[[round((@{level} + 1) / 6 + 0.5)]]") === -1) {
 							update["repeating_spell-" + lvl + "_" + spellid + "_spelldamage"] = v["repeating_attack_" + attackid + "_dmgbase"];
-						}
-						else if(!v["repeating_attack_" + attackid + "_dmgbase"] || v["repeating_attack_" + attackid + "_dmgbase"] === "") {
+						} else if (!v["repeating_attack_" + attackid + "_dmgbase"] || v["repeating_attack_" + attackid + "_dmgbase"] === "") {
 							update["repeating_spell-" + lvl + "_" + spellid + "_spelldamage"] = "";
 						}
-						if(v["repeating_attack_" + attackid + "_dmgtype"] && v["repeating_attack_" + attackid + "_dmgtype"] != "") {
+						if (v["repeating_attack_" + attackid + "_dmgtype"] && v["repeating_attack_" + attackid + "_dmgtype"] != "") {
 							update["repeating_spell-" + lvl + "_" + spellid + "_spelldamagetype"] = v["repeating_attack_" + attackid + "_dmgtype"];
-						}
-						else {
+						} else {
 							update["repeating_spell-" + lvl + "_" + spellid + "_spelldamagetype"] = "";
 						}
 					};
-					if(v["repeating_attack_" + attackid + "_dmg2type"] && v["repeating_attack_" + attackid + "_dmg2type"].toLowerCase() == "healing") {
-						if(v["repeating_attack_" + attackid + "_dmgbase"] && v["repeating_attack_" + attackid + "_dmgbase"] != "") {
+					if (v["repeating_attack_" + attackid + "_dmg2type"] && v["repeating_attack_" + attackid + "_dmg2type"].toLowerCase() == "healing") {
+						if (v["repeating_attack_" + attackid + "_dmgbase"] && v["repeating_attack_" + attackid + "_dmgbase"] != "") {
 							update["repeating_spell-" + lvl + "_" + spellid + "_spellhealing"] = v["repeating_attack_" + attackid + "_dmgbase"];
 						}
-					}
-					else {
-						if(v["repeating_attack_" + attackid + "_dmg2base"] && v["repeating_attack_" + attackid + "_dmg2base"] != "") {
+					} else {
+						if (v["repeating_attack_" + attackid + "_dmg2base"] && v["repeating_attack_" + attackid + "_dmg2base"] != "") {
 							update["repeating_spell-" + lvl + "_" + spellid + "_spelldamage2"] = v["repeating_attack_" + attackid + "_dmg2base"];
-						}
-						else {
+						} else {
 							update["repeating_spell-" + lvl + "_" + spellid + "_spelldamage2"] = "";
 						}
-						if(v["repeating_attack_" + attackid + "_dmg2type"] && v["repeating_attack_" + attackid + "_dmg2type"] != "") {
+						if (v["repeating_attack_" + attackid + "_dmg2type"] && v["repeating_attack_" + attackid + "_dmg2type"] != "") {
 							update["repeating_spell-" + lvl + "_" + spellid + "_spelldamagetype2"] = v["repeating_attack_" + attackid + "_dmg2type"];
-						}
-						else {
+						} else {
 							update["repeating_spell-" + lvl + "_" + spellid + "_spelldamagetype2"] = "";
 						}
 					};
 
-					if(v["repeating_attack_" + attackid + "_saveflag"] && v["repeating_attack_" + attackid + "_saveflag"] != "0") {
+					if (v["repeating_attack_" + attackid + "_saveflag"] && v["repeating_attack_" + attackid + "_saveflag"] != "0") {
 						update["repeating_spell-" + lvl + "_" + spellid + "_spellsave"] = v["repeating_attack_" + attackid + "_saveattr"];
-					}
-					else {
+					} else {
 						update["repeating_spell-" + lvl + "_" + spellid + "_spellsave"] = "";
 					};
-					if(v["repeating_attack_" + attackid + "_saveeffect"] && v["repeating_attack_" + attackid + "_saveeffect"] != "") {
+					if (v["repeating_attack_" + attackid + "_saveeffect"] && v["repeating_attack_" + attackid + "_saveeffect"] != "") {
 						update["repeating_spell-" + lvl + "_" + spellid + "_spellsavesuccess"] = v["repeating_attack_" + attackid + "_saveeffect"];
-					}
-					else {
+					} else {
 						update["repeating_spell-" + lvl + "_" + spellid + "_spellsavesuccess"] = "";
 					};
-					setAttrs(update, {silent: true});
+					setAttrs(update, {
+						silent: true
+					});
 				});
 			};
 
@@ -10676,7 +11298,7 @@
 					var atktype = "";
 					var altprefix = v["repeating_attack_" + attackid + "_versatile_alt"] === "1" ? "Alternate " : "";
 
-					if(/Alternate Damage:/i.test(v["repeating_inventory_" + itemid + "_itemmodifiers"])) {
+					if (/Alternate Damage:/i.test(v["repeating_inventory_" + itemid + "_itemmodifiers"])) {
 						update["repeating_inventory_" + itemid + "_itemname"] = v["repeating_attack_" + attackid + "_atkname"].replace(/\s*(?:\(One-Handed\)|\(Two-Handed\))/, "");
 					} else {
 						update["repeating_inventory_" + itemid + "_itemname"] = v["repeating_attack_" + attackid + "_atkname"];
@@ -10685,7 +11307,7 @@
 					var attack_type_regex = /(?:^|,)\s*Item Type: (Melee|Ranged) Weapon(?:,|$)/i;
 					var attack_type_results = attack_type_regex.exec(v["repeating_inventory_" + itemid + "_itemmodifiers"]);
 					atktype = attack_type_results ? attack_type_results[1] : "";
-					if(mods) {
+					if (mods) {
 						mods = mods.split(",");
 					} else {
 						mods = [];
@@ -10693,9 +11315,9 @@
 
 					var damage_regex = new RegExp("^\\s*" + altprefix + "Damage:\\s*(.+)$", "i");
 					var damage_found = false;
-					for(var i = 0; i < mods.length; i++) {
-						if(damage_found = damage_regex.exec(mods[i])) {
-							if(damage !== 0) {
+					for (var i = 0; i < mods.length; i++) {
+						if (damage_found = damage_regex.exec(mods[i])) {
+							if (damage !== 0) {
 								mods[i] = mods[i].replace(damage_found[1], damage);
 							} else {
 								mods.splice(i, 1);
@@ -10703,15 +11325,15 @@
 							break;
 						}
 					}
-					if(!damage_found && damage !== 0) {
+					if (!damage_found && damage !== 0) {
 						mods.push(altprefix + "Damage: " + damage);
 					}
 
 					var damage2_regex = new RegExp("^\\s*" + altprefix + "Secondary Damage:\\s*(.+)$", "i");
 					var damage2_found = false;
-					for(var i = 0; i < mods.length; i++) {
-						if(damage2_found = damage2_regex.exec(mods[i])) {
-							if(damage2 !== 0) {
+					for (var i = 0; i < mods.length; i++) {
+						if (damage2_found = damage2_regex.exec(mods[i])) {
+							if (damage2 !== 0) {
 								mods[i] = mods[i].replace(damage2_found[1], damage2);
 							} else {
 								mods.splice(i, 1);
@@ -10719,15 +11341,15 @@
 							break;
 						}
 					}
-					if(!damage2_found && damage2 !== 0) {
+					if (!damage2_found && damage2 !== 0) {
 						mods.push(altprefix + "Secondary Damage: " + damage2);
 					}
 
 					var dmgtype_regex = new RegExp("^\\s*" + altprefix + "Damage Type:\\s*(.+)$", "i");
 					var dmgtype_found = false;
-					for(var i = 0; i < mods.length; i++) {
-						if(dmgtype_found = dmgtype_regex.exec(mods[i])) {
-							if(damagetype !== 0) {
+					for (var i = 0; i < mods.length; i++) {
+						if (dmgtype_found = dmgtype_regex.exec(mods[i])) {
+							if (damagetype !== 0) {
 								mods[i] = mods[i].replace(dmgtype_found[1], damagetype);
 							} else {
 								mods.splice(i, 1);
@@ -10735,15 +11357,15 @@
 							break;
 						}
 					}
-					if(!dmgtype_found && damagetype !== 0) {
+					if (!dmgtype_found && damagetype !== 0) {
 						mods.push(altprefix + "Damage Type: " + damagetype);
 					}
 
 					var dmgtype2_regex = new RegExp("^\\s*" + altprefix + "Secondary Damage Type:\\s*(.+)$", "i");
 					var dmgtype2_found = false;
-					for(var i = 0; i < mods.length; i++) {
-						if(dmgtype2_found = dmgtype2_regex.exec(mods[i])) {
-							if(damagetype2 !== 0) {
+					for (var i = 0; i < mods.length; i++) {
+						if (dmgtype2_found = dmgtype2_regex.exec(mods[i])) {
+							if (damagetype2 !== 0) {
 								mods[i] = mods[i].replace(dmgtype_found[1], damagetype);
 							} else {
 								mods.splice(i, 1);
@@ -10751,14 +11373,14 @@
 							break;
 						}
 					}
-					if(!dmgtype2_found && damagetype2 !== 0) {
+					if (!dmgtype2_found && damagetype2 !== 0) {
 						mods.push(altprefix + "Secondary Damage Type: " + damagetype2);
 					}
 
 					var range_found = false;
-					for(var i = 0; i < mods.length; i++) {
-						if(range_found = /^\s*Range:\s*(.+)$/i.exec(mods[i])) {
-							if(range !== 0) {
+					for (var i = 0; i < mods.length; i++) {
+						if (range_found = /^\s*Range:\s*(.+)$/i.exec(mods[i])) {
+							if (range !== 0) {
 								mods[i] = mods[i].replace(range_found[1], range);
 							} else {
 								mods.splice(i, 1);
@@ -10766,15 +11388,15 @@
 							break;
 						}
 					}
-					if(!range_found && range !== 0) {
+					if (!range_found && range !== 0) {
 						mods.push("Range: " + range);
 					}
 
 					var attackmod_regex = new RegExp("^\\s*(?:" + (atktype !== "" ? atktype + "|" : "") + "Weapon) Attacks \\+?(.+)$", "i");
 					var attackmod_found = false;
-					for(var i = 0; i < mods.length; i++) {
-						if(attackmod_found = attackmod_regex.exec(mods[i])) {
-							if(magicmod !== 0 || attackmod !== 0) {
+					for (var i = 0; i < mods.length; i++) {
+						if (attackmod_found = attackmod_regex.exec(mods[i])) {
+							if (magicmod !== 0 || attackmod !== 0) {
 								mods[i] = mods[i].replace(attackmod_found[1], magicmod !== 0 ? magicmod : attackmod);
 							} else {
 								mods.splice(i, 1);
@@ -10782,21 +11404,20 @@
 							break;
 						}
 					}
-					if(!attackmod_found && (magicmod !== 0 || attackmod !== 0)) {
+					if (!attackmod_found && (magicmod !== 0 || attackmod !== 0)) {
 						var properties = v["repeating_inventory_" + itemid + "_itemproperties"];
-						if(properties && /Thrown/i.test(properties)) {
+						if (properties && /Thrown/i.test(properties)) {
 							mods.push("Weapon Attacks: " + (magicmod !== 0 ? magicmod : attackmod));
-						}
-						else {
+						} else {
 							mods.push(atktype + " Attacks: " + (magicmod !== 0 ? magicmod : attackmod));
 						}
 					}
 
 					var damagemod_regex = new RegExp("^\\s*(?:" + (atktype !== "" ? atktype + "|" : "") + "Weapon) Damage \\+?(.+)$", "i");
 					var damagemod_found = false;
-					for(var i = 0; i < mods.length; i++) {
-						if(damagemod_found = damagemod_regex.exec(mods[i])) {
-							if(magicmod !== 0 || damagemod !== 0) {
+					for (var i = 0; i < mods.length; i++) {
+						if (damagemod_found = damagemod_regex.exec(mods[i])) {
+							if (magicmod !== 0 || damagemod !== 0) {
 								mods[i] = mods[i].replace(damagemod_found[1], magicmod !== 0 ? magicmod : attackmod);
 							} else {
 								mods.splice(i, 1);
@@ -10804,19 +11425,20 @@
 							break;
 						}
 					}
-					if(!damagemod_found && (magicmod !== 0 || damagemod !== 0)) {
+					if (!damagemod_found && (magicmod !== 0 || damagemod !== 0)) {
 						var properties = v["repeating_inventory_" + itemid + "_itemproperties"];
-						if(properties && /Thrown/i.test(properties)) {
+						if (properties && /Thrown/i.test(properties)) {
 							mods.push("Weapon Damage: " + (magicmod !== 0 ? magicmod : damagemod));
-						}
-						else {
+						} else {
 							mods.push(atktype + " Damage: " + (magicmod !== 0 ? magicmod : damagemod));
 						}
 					}
 
 					update["repeating_inventory_" + itemid + "_itemmodifiers"] = mods.join(",");
 
-					setAttrs(update, {silent: true});
+					setAttrs(update, {
+						silent: true
+					});
 				});
 			};
 
@@ -10828,28 +11450,30 @@
 				var update = {};
 				getAttrs([id + "_itemid"], function(v) {
 					var itemid = v[id + "_itemid"];
-					if(itemid) {
+					if (itemid) {
 						update["repeating_inventory_" + itemid + "_useasresource"] = 0;
 						update["repeating_inventory_" + itemid + "_itemresourceid"] = "";
 					};
-					if(id == "other_resource") {
+					if (id == "other_resource") {
 						update["other_resource"] = "";
 						update["other_resource_name"] = "";
 						update["other_resource_itemid"] = "";
-						setAttrs(update, {silent: true});
-					}
-					else {
-						var baseid = id.replace("repeating_resource_", "").substring(0,20);
+						setAttrs(update, {
+							silent: true
+						});
+					} else {
+						var baseid = id.replace("repeating_resource_", "").substring(0, 20);
 						var resource_names = ["repeating_resource_" + baseid + "_resource_left_name", "repeating_resource_" + baseid + "_resource_right_name"];
 						getAttrs(resource_names, function(v) {
-							if((id.indexOf("left") > -1 && !v["repeating_resource_" + baseid + "_resource_right_name"]) || (id.indexOf("right") > -1 && !v["repeating_resource_" + baseid + "_resource_left_name"])) {
+							if ((id.indexOf("left") > -1 && !v["repeating_resource_" + baseid + "_resource_right_name"]) || (id.indexOf("right") > -1 && !v["repeating_resource_" + baseid + "_resource_left_name"])) {
 								removeRepeatingRow("repeating_resource_" + baseid);
-							}
-							else {
+							} else {
 								update["repeating_resource_" + id.replace("repeating_resource_", "")] = "";
 								update["repeating_resource_" + id.replace("repeating_resource_", "") + "_name"] = "";
 							};
-							setAttrs(update, {silent: true});
+							setAttrs(update, {
+								silent: true
+							});
 						});
 
 					};
@@ -10867,9 +11491,11 @@
 						weight_attrs.push("repeating_inventory_" + currentID + "_itemcount");
 						weight_attrs.push("repeating_inventory_" + currentID + "_itemsize");
 						weight_attrs.push("repeating_inventory_" + currentID + "_equipped");
+						weight_attrs.push("repeating_inventory_" + currentID + "_carried");
 						weight_attrs.push("repeating_inventory_" + currentID + "_itemcontainer");
 						weight_attrs.push("repeating_inventory_" + currentID + "_itemweightfixed");
 						weight_attrs.push("repeating_inventory_" + currentID + "_itemslotsfixed");
+						weight_attrs.push("repeating_inventory_" + currentID + "_itemcontainer_slots_modifier");
 					});
 					getAttrs(weight_attrs, function(v) {
 						cp = isNaN(parseInt(v.cp, 10)) === false ? parseInt(v.cp, 10) : 0;
@@ -10880,25 +11506,50 @@
 						currencyOther = isNaN(parseInt(v.currency_value, 10)) === false ? parseInt(v.currency_value, 10) : 0;
 						wtotal = wtotal + ((cp + sp + ep + gp + pp + currencyOther) / 50);
 						stotal += Math.floor(Math.max(0, cp + sp + ep + gp + pp + currencyOther - 1) / 100);
+						var slots_modifier = 0;
 
 						_.each(idarray, function(currentID, i) {
-							if (v["repeating_inventory_" + currentID + "_equipped"] == 1 && !(v["repeating_inventory_" + currentID + "_itemcontainer"] == 1)) {
-								// UPDATE WEIGHT
-								if (v["repeating_inventory_" + currentID + "_itemweight"] && isNaN(parseInt(v["repeating_inventory_" + currentID + "_itemweight"], 10)) === false) {
-									if (v["repeating_inventory_" + currentID + "_itemweightfixed"] == 1) {
-										wtotal += parseFloat(v["repeating_inventory_" + currentID + "_itemweight"]);
-									} else {
-										count = v["repeating_inventory_" + currentID + "_itemcount"] && isNaN(parseFloat(v["repeating_inventory_" + currentID + "_itemcount"])) === false ? parseFloat(v["repeating_inventory_" + currentID + "_itemcount"]) : 1;
-										wtotal = wtotal + (parseFloat(v["repeating_inventory_" + currentID + "_itemweight"]) * count);
+							if (v["repeating_inventory_" + currentID + "_equipped"] == 1 || v["repeating_inventory_" + currentID + "_carried"] == 1) {
+								if (v["repeating_inventory_" + currentID + "_itemcontainer"] == 1) {
+									// GET SLOTS MODIFIER IF EQUIPPED
+									if (v["repeating_inventory_" + currentID + "_equipped"] == 1) {
+										var field_id = "repeating_inventory_" + currentID + "_itemcontainer_slots_modifier";
+										if (v[field_id]) {
+											if (["+", "-"].indexOf(v[field_id]) > -1) {
+												var operator = v[field_id].substring(0, 1);
+												var value = v[field_id].substring(1);
+												if (isNaN(parseInt(value, 10)) === false) {
+													if (operator == "+") {
+														slots_modifier += parseInt(value, 10);
+													} else if (operator == "-") {
+														slots_modifier -= parseInt(value, 10);
+													}
+												}
+											} else {
+												if (isNaN(parseInt(v[field_id], 10)) === false) {
+													slots_modifier += parseInt(v[field_id], 10);
+												}
+											}
+										}
 									}
-								}
-								// UPDATE SLOTS
-								if (v["repeating_inventory_" + currentID + "_itemsize"] && isNaN(parseInt(v["repeating_inventory_" + currentID + "_itemsize"], 10)) === false) {
-									if (v["repeating_inventory_" + currentID + "_itemslotsfixed"] == 1) {
-										stotal += parseFloat(v["repeating_inventory_" + currentID + "_itemsize"]);
-									} else {
-										count = v["repeating_inventory_" + currentID + "_itemcount"] && isNaN(parseFloat(v["repeating_inventory_" + currentID + "_itemcount"])) === false ? parseFloat(v["repeating_inventory_" + currentID + "_itemcount"]) : 1;
-										stotal = stotal + (parseFloat(v["repeating_inventory_" + currentID + "_itemsize"]) * count);
+								} else {
+									// UPDATE WEIGHT
+									if (v["repeating_inventory_" + currentID + "_itemweight"] && isNaN(parseInt(v["repeating_inventory_" + currentID + "_itemweight"], 10)) === false) {
+										if (v["repeating_inventory_" + currentID + "_itemweightfixed"] == 1) {
+											wtotal += parseFloat(v["repeating_inventory_" + currentID + "_itemweight"]);
+										} else {
+											count = v["repeating_inventory_" + currentID + "_itemcount"] && isNaN(parseFloat(v["repeating_inventory_" + currentID + "_itemcount"])) === false ? parseFloat(v["repeating_inventory_" + currentID + "_itemcount"]) : 1;
+											wtotal = wtotal + (parseFloat(v["repeating_inventory_" + currentID + "_itemweight"]) * count);
+										}
+									}
+									// UPDATE SLOTS
+									if (v["repeating_inventory_" + currentID + "_itemsize"] && isNaN(parseInt(v["repeating_inventory_" + currentID + "_itemsize"], 10)) === false) {
+										if (v["repeating_inventory_" + currentID + "_itemslotsfixed"] == 1) {
+											stotal += parseFloat(v["repeating_inventory_" + currentID + "_itemsize"]);
+										} else {
+											count = v["repeating_inventory_" + currentID + "_itemcount"] && isNaN(parseFloat(v["repeating_inventory_" + currentID + "_itemcount"])) === false ? parseFloat(v["repeating_inventory_" + currentID + "_itemcount"]) : 1;
+											stotal = stotal + (parseFloat(v["repeating_inventory_" + currentID + "_itemsize"]) * count);
+										}
 									}
 								}
 							}
@@ -10935,14 +11586,16 @@
 								var value = v.inventory_slots_mod.substring(1);
 								if (["*", "x", "+", "-"].indexOf(operator) > -1 && isNaN(parseInt(value, 10)) === false) {
 									if (operator == "*" || operator == "x") {
-										size_slots = size_slots * parseInt(value, 10);
+										size_slots *= parseInt(value, 10);
 									} else if (operator == "+") {
-										size_slots = size_slots + parseInt(value, 10);
+										size_slots += parseInt(value, 10);
 									} else if (operator == "-") {
-										size_slots = size_slots - parseInt(value, 10);
+										size_slots -= parseInt(value, 10);
 									}
 								}
 							}
+
+							size_slots += slots_modifier;
 
 							update["slotsmaximum"] = size_slots;
 							if (stotal > size_slots) {
@@ -10972,11 +11625,11 @@
 								var value = v.carrying_capacity_mod.substring(1);
 								if (["*", "x", "+", "-"].indexOf(operator) > -1 && isNaN(parseInt(value, 10)) === false) {
 									if (operator == "*" || operator == "x") {
-										str = str * parseInt(value, 10);
+										str *= parseInt(value, 10);
 									} else if (operator == "+") {
-										str = str + parseInt(value, 10);
+										str += parseInt(value, 10);
 									} else if (operator == "-") {
-										str = str - parseInt(value, 10);
+										str -= parseInt(value, 10);
 									}
 								}
 							}
@@ -11012,12 +11665,11 @@
 
 			var update_ac = function() {
 				getAttrs(["custom_ac_flag"], function(v) {
-					if(v.custom_ac_flag === "2") {
+					if (v.custom_ac_flag === "2") {
 						return;
-					}
-					else {
+					} else {
 						var update = {};
-						var ac_attrs = ["simpleinventory","custom_ac_base","custom_ac_part1","custom_ac_part2","strength_mod","dexterity_mod","constitution_mod","intelligence_mod","wisdom_mod","charisma_mod", "custom_ac_shield"];
+						var ac_attrs = ["simpleinventory", "custom_ac_base", "custom_ac_part1", "custom_ac_part2", "strength_mod", "dexterity_mod", "constitution_mod", "intelligence_mod", "wisdom_mod", "charisma_mod", "custom_ac_shield"];
 						getSectionIDs("repeating_acmod", function(acidarray) {
 							_.each(acidarray, function(currentID, i) {
 								ac_attrs.push("repeating_acmod_" + currentID + "_global_ac_val");
@@ -11030,7 +11682,7 @@
 								});
 								getAttrs(ac_attrs, function(b) {
 									var custom_total = 0;
-									if(v.custom_ac_flag === "1") {
+									if (v.custom_ac_flag === "1") {
 										var base = isNaN(parseInt(b.custom_ac_base, 10)) === false ? parseInt(b.custom_ac_base, 10) : 10;
 										var part1attr = b.custom_ac_part1.toLowerCase();
 										var part2attr = b.custom_ac_part2.toLowerCase();
@@ -11040,7 +11692,7 @@
 									}
 									var globalacmod = 0;
 									_.each(acidarray, function(currentID, i) {
-										if(b["repeating_acmod_" + currentID + "_global_ac_active_flag"] == "1") {
+										if (b["repeating_acmod_" + currentID + "_global_ac_active_flag"] == "1") {
 											globalacmod += parseInt(b["repeating_acmod_" + currentID + "_global_ac_val"], 10);
 										}
 									});
@@ -11049,54 +11701,57 @@
 									var armorcount = 0;
 									var shieldcount = 0;
 									var armoritems = [];
-									if(b.simpleinventory === "complex") {
+									if (b.simpleinventory === "complex") {
 										_.each(idarray, function(currentID, i) {
-											if(b["repeating_inventory_" + currentID + "_equipped"] && b["repeating_inventory_" + currentID + "_equipped"] === "1" && b["repeating_inventory_" + currentID + "_itemmodifiers"] && b["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf("ac") > -1) {
+											if (b["repeating_inventory_" + currentID + "_equipped"] && b["repeating_inventory_" + currentID + "_equipped"] === "1" && b["repeating_inventory_" + currentID + "_itemmodifiers"] && b["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf("ac") > -1) {
 												var mods = b["repeating_inventory_" + currentID + "_itemmodifiers"].split(",");
 												var ac = 0;
 												var type = "mod";
 												_.each(mods, function(mod) {
-													if(mod.substring(0,10) === "Item Type:") {
+													if (mod.substring(0, 10) === "Item Type:") {
 														type = mod.substring(11, mod.length).trim().toLowerCase();
 													}
-													if(mod.toLowerCase().indexOf("ac:") > -1 || mod.toLowerCase().indexOf("ac +") > -1 || mod.toLowerCase().indexOf("ac+") > -1) {
+													if (mod.toLowerCase().indexOf("ac:") > -1 || mod.toLowerCase().indexOf("ac +") > -1 || mod.toLowerCase().indexOf("ac+") > -1) {
 														var regex = mod.replace(/[^0-9]/g, "");
-														var bonus = regex && regex.length > 0 && isNaN(parseInt(regex,10)) === false ? parseInt(regex,10) : 0;
+														var bonus = regex && regex.length > 0 && isNaN(parseInt(regex, 10)) === false ? parseInt(regex, 10) : 0;
 														ac = ac + bonus;
 													}
-													if(mod.toLowerCase().indexOf("ac -") > -1 || mod.toLowerCase().indexOf("ac-") > -1) {
+													if (mod.toLowerCase().indexOf("ac -") > -1 || mod.toLowerCase().indexOf("ac-") > -1) {
 														var regex = mod.replace(/[^0-9]/g, "");
-														var bonus = regex && regex.length > 0 && isNaN(parseInt(regex,10)) === false ? parseInt(regex,10) : 0;
+														var bonus = regex && regex.length > 0 && isNaN(parseInt(regex, 10)) === false ? parseInt(regex, 10) : 0;
 														ac = ac - bonus;
 													}
 												});
-												armoritems.push({type: type, ac: ac});
+												armoritems.push({
+													type: type,
+													ac: ac
+												});
 											}
 										});
-										armorcount = armoritems.filter(function(item){ return item["type"].indexOf("armor") > -1 }).length;
-										shieldcount = armoritems.filter(function(item){ return item["type"].indexOf("shield") > -1 }).length;
+										armorcount = armoritems.filter(function(item) {
+											return item["type"].indexOf("armor") > -1
+										}).length;
+										shieldcount = armoritems.filter(function(item) {
+											return item["type"].indexOf("shield") > -1
+										}).length;
 										var base = dexmod;
 										var armorac = 10;
 										var shieldac = 0;
 										var modac = 0;
 
 										_.each(armoritems, function(item) {
-											if(item["type"].indexOf("light armor") > -1) {
+											if (item["type"].indexOf("light armor") > -1) {
 												armorac = item["ac"];
 												base = dexmod;
-											}
-											else if(item["type"].indexOf("medium armor") > -1) {
+											} else if (item["type"].indexOf("medium armor") > -1) {
 												armorac = item["ac"];
 												base = Math.min(dexmod, 2);
-											}
-											else if(item["type"].indexOf("heavy armor") > -1) {
+											} else if (item["type"].indexOf("heavy armor") > -1) {
 												armorac = item["ac"];
 												base = 0;
-											}
-											else if(item["type"].indexOf("shield") > -1) {
+											} else if (item["type"].indexOf("shield") > -1) {
 												shieldac = item["ac"];
-											}
-											else {
+											} else {
 												modac = modac + item["ac"]
 											}
 										});
@@ -11106,20 +11761,21 @@
 									};
 									update["armorwarningflag"] = "hide";
 									update["customacwarningflag"] = "hide";
-									if(armorcount > 1 || shieldcount > 1) {
+									if (armorcount > 1 || shieldcount > 1) {
 										update["armorwarningflag"] = "show";
 									}
 									update["ac"] = total + globalacmod;
-									if(custom_total > 0) {
-										if(armorcount > 0 || (shieldcount > 0 && b.custom_ac_shield != "yes")) {
+									if (custom_total > 0) {
+										if (armorcount > 0 || (shieldcount > 0 && b.custom_ac_shield != "yes")) {
 											update["customacwarningflag"] = "show";
-										}
-										else {
+										} else {
 											update["ac"] = b.custom_ac_shield == "yes" ? custom_total + shieldac + globalacmod + modac : custom_total + globalacmod + modac;
 										}
 									}
 									console.log("total: " + total);
-									setAttrs(update, {silent: true});
+									setAttrs(update, {
+										silent: true
+									});
 								});
 							});
 						});
@@ -11128,16 +11784,16 @@
 			};
 
 			var check_customac = function(attr) {
-				getAttrs(["custom_ac_flag","custom_ac_part1","custom_ac_part2"], function(v) {
-					if(v["custom_ac_flag"] && v["custom_ac_flag"] === "1" && ((v["custom_ac_part1"] && v["custom_ac_part1"] === attr) || (v["custom_ac_part2"] && v["custom_ac_part2"] === attr))) {
+				getAttrs(["custom_ac_flag", "custom_ac_part1", "custom_ac_part2"], function(v) {
+					if (v["custom_ac_flag"] && v["custom_ac_flag"] === "1" && ((v["custom_ac_part1"] && v["custom_ac_part1"] === attr) || (v["custom_ac_part2"] && v["custom_ac_part2"] === attr))) {
 						update_ac();
 					}
 				});
 			};
 
 			var update_initiative = function() {
-				var attrs_to_get = ["dexterity","dexterity_mod","intelligence_mod","initmod","jack_of_all_trades","jack","init_tiebreaker","pb_type","use_intelligent_initiative"];
-				getSectionIDs("repeating_inventory", function(idarray){
+				var attrs_to_get = ["dexterity", "dexterity_mod", "intelligence_mod", "initmod", "jack_of_all_trades", "jack", "init_tiebreaker", "pb_type", "use_intelligent_initiative"];
+				getSectionIDs("repeating_inventory", function(idarray) {
 					_.each(idarray, function(currentID, i) {
 						attrs_to_get.push("repeating_inventory_" + currentID + "_equipped");
 						attrs_to_get.push("repeating_inventory_" + currentID + "_itemmodifiers");
@@ -11145,34 +11801,32 @@
 					getAttrs(attrs_to_get, function(v) {
 						var update = {};
 						var final_init = parseInt(v["dexterity_mod"], 10);
-						if(v["use_intelligent_initiative"] && v["use_intelligent_initiative"] != 0) {
+						if (v["use_intelligent_initiative"] && v["use_intelligent_initiative"] != 0) {
 							final_init = parseInt(v["intelligence_mod"], 10);
 						}
-						if(v["initmod"] && !isNaN(parseInt(v["initmod"], 10))) {
+						if (v["initmod"] && !isNaN(parseInt(v["initmod"], 10))) {
 							final_init = final_init + parseInt(v["initmod"], 10);
 						}
-						if(v["init_tiebreaker"] && v["init_tiebreaker"] != 0) {
-							final_init = final_init + (parseInt(v["dexterity"], 10)/100);
+						if (v["init_tiebreaker"] && v["init_tiebreaker"] != 0) {
+							final_init = final_init + (parseInt(v["dexterity"], 10) / 100);
 						}
-						if(v["jack_of_all_trades"] && v["jack_of_all_trades"] != 0) {
-							if(v["pb_type"] && v["pb_type"] === "die" && v["jack"]) {
+						if (v["jack_of_all_trades"] && v["jack_of_all_trades"] != 0) {
+							if (v["pb_type"] && v["pb_type"] === "die" && v["jack"]) {
 								// final_init = final_init + Math.floor(parseInt(v["jack"].substring(1),10)/2);
 								final_init = final_init + "+" + v["jack"];
-							}
-							else if(v["jack"] && !isNaN(parseInt(v["jack"], 10))) {
+							} else if (v["jack"] && !isNaN(parseInt(v["jack"], 10))) {
 								final_init = final_init + parseInt(v["jack"], 10);
 							}
 						}
-						_.each(idarray, function(currentID){
-							if(v["repeating_inventory_" + currentID + "_equipped"] && v["repeating_inventory_" + currentID + "_equipped"] === "1" && v["repeating_inventory_" + currentID + "_itemmodifiers"] && v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf("ability checks") > -1) {
+						_.each(idarray, function(currentID) {
+							if (v["repeating_inventory_" + currentID + "_equipped"] && v["repeating_inventory_" + currentID + "_equipped"] === "1" && v["repeating_inventory_" + currentID + "_itemmodifiers"] && v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf("ability checks") > -1) {
 								var mods = v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().split(",");
 								_.each(mods, function(mod) {
-									if(mod.indexOf("ability checks") > -1) {
-										if(mod.indexOf("-") > -1) {
+									if (mod.indexOf("ability checks") > -1) {
+										if (mod.indexOf("-") > -1) {
 											var new_mod = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
 											final_init = new_mod ? final_init - new_mod : final_init;
-										}
-										else {
+										} else {
 											var new_mod = !isNaN(parseInt(mod.replace(/[^0-9]/g, ""), 10)) ? parseInt(mod.replace(/[^0-9]/g, ""), 10) : false;
 											final_init = new_mod ? final_init + new_mod : final_init;
 										}
@@ -11180,21 +11834,23 @@
 								});
 							}
 						});
-						if(final_init % 1 != 0) {
+						if (final_init % 1 != 0) {
 							final_init = parseFloat(final_init.toPrecision(12)); // ROUNDING ERROR BUGFIX
 						}
 						update["initiative_bonus"] = final_init;
-						setAttrs(update, {silent: true});
+						setAttrs(update, {
+							silent: true
+						});
 					});
 				});
 			};
 
 			var update_class = function() {
-				getAttrs(["class","base_level","custom_class","cust_classname","cust_hitdietype","cust_spellcasting_ability","cust_strength_save_prof","cust_dexterity_save_prof","cust_constitution_save_prof","cust_intelligence_save_prof","cust_wisdom_save_prof","cust_charisma_save_prof","strength_save_prof","dexterity_save_prof","constitution_save_prof","intelligence_save_prof","wisdom_save_prof","charisma_save_prof","subclass","multiclass1","multiclass1_subclass","multiclass2","multiclass2_subclass","multiclass3","multiclass3_subclass","npc"], function(v) {
-					if(v.npc && v.npc == "1") {
+				getAttrs(["class", "base_level", "custom_class", "cust_classname", "cust_hitdietype", "cust_spellcasting_ability", "cust_strength_save_prof", "cust_dexterity_save_prof", "cust_constitution_save_prof", "cust_intelligence_save_prof", "cust_wisdom_save_prof", "cust_charisma_save_prof", "strength_save_prof", "dexterity_save_prof", "constitution_save_prof", "intelligence_save_prof", "wisdom_save_prof", "charisma_save_prof", "subclass", "multiclass1", "multiclass1_subclass", "multiclass2", "multiclass2_subclass", "multiclass3", "multiclass3_subclass", "npc"], function(v) {
+					if (v.npc && v.npc == "1") {
 						return;
 					}
-					if(v.custom_class && v.custom_class != "0") {
+					if (v.custom_class && v.custom_class != "0") {
 						setAttrs({
 							hitdietype: v.cust_hitdietype,
 							spellcasting_ability: v.cust_spellcasting_ability,
@@ -11205,10 +11861,9 @@
 							wisdom_save_prof: v.cust_wisdom_save_prof,
 							charisma_save_prof: v.cust_charisma_save_prof
 						});
-					}
-					else {
+					} else {
 						update = {};
-						switch(v.class) {
+						switch (v.class) {
 							case "":
 								update["hitdietype"] = 6;
 								update["spellcasting_ability"] = "0*";
@@ -11340,48 +11995,52 @@
 								update["charisma_save_prof"] = 0;
 								break;
 						}
-						setAttrs(update, {silent: true});
+						setAttrs(update, {
+							silent: true
+						});
 					};
 				});
 				set_level();
 			};
 
 			var set_level = function() {
-				getAttrs(["base_level","multiclass1_flag","multiclass2_flag","multiclass3_flag","multiclass1_lvl","multiclass2_lvl","multiclass3_lvl","class","multiclass1","multiclass2","multiclass3", "arcane_fighter", "arcane_rogue", "custom_class", "cust_spellslots", "cust_classname", "level_calculations", "class", "subclass", "multiclass1_subclass","multiclass2_subclass","multiclass3_subclass"], function(v) {
+				getAttrs(["base_level", "multiclass1_flag", "multiclass2_flag", "multiclass3_flag", "multiclass1_lvl", "multiclass2_lvl", "multiclass3_lvl", "class", "multiclass1", "multiclass2", "multiclass3", "arcane_fighter", "arcane_rogue", "custom_class", "cust_spellslots", "cust_classname", "level_calculations", "class", "subclass", "multiclass1_subclass", "multiclass2_subclass", "multiclass3_subclass"], function(v) {
 					var update = {};
 					var callbacks = [];
 					var multiclass = (v.multiclass1_flag && v.multiclass1_flag === "1") || (v.multiclass2_flag && v.multiclass2_flag === "1") || (v.multiclass3_flag && v.multiclass3_flag === "1") ? true : false;
 					var finalclass = v["custom_class"] && v["custom_class"] != "0" ? v["cust_spellslots"] : v["class"];
-					var finallevel = (v.base_level && v.base_level > 0) ? parseInt(v.base_level,10) : 1;
+					var finallevel = (v.base_level && v.base_level > 0) ? parseInt(v.base_level, 10) : 1;
 					var charclass = v.custom_class && v.custom_class != "0" ? v["cust_classname"] : v["class"];
 					var hitdie_final = multiclass ? "?{Hit Die Class|" + charclass + ",@{hitdietype}" : "@{hitdietype}";
 					var subclass = v.subclass ? v.subclass + " " : "";
 					var class_display = subclass + charclass + " " + finallevel;
 
 					// This nested array is used to determine the overall spellcasting level for the character.
-					var classes = [ [finalclass.toLowerCase(), v["base_level"]] ];
+					var classes = [
+						[finalclass.toLowerCase(), v["base_level"]]
+					];
 
-					if(v.multiclass1_flag && v.multiclass1_flag === "1") {
+					if (v.multiclass1_flag && v.multiclass1_flag === "1") {
 						var multiclasslevel = (v["multiclass1_lvl"] && v["multiclass1_lvl"] > 0) ? parseInt(v["multiclass1_lvl"], 10) : 1;
 						finallevel = finallevel + multiclasslevel;
 						hitdie_final = hitdie_final + "|" + v["multiclass1"].charAt(0).toUpperCase() + v["multiclass1"].slice(1) + "," + checkHitDie(v["multiclass1"]);
-						classes.push([ v["multiclass1"], multiclasslevel ]);
+						classes.push([v["multiclass1"], multiclasslevel]);
 						var subclass = v.multiclass1_subclass ? v.multiclass1_subclass + " " : "";
 						class_display = class_display + ", " + subclass + v.multiclass1 + " " + multiclasslevel;
 					};
-					if(v.multiclass2_flag && v.multiclass2_flag === "1") {
+					if (v.multiclass2_flag && v.multiclass2_flag === "1") {
 						var multiclasslevel = (v["multiclass2_lvl"] && v["multiclass2_lvl"] > 0) ? parseInt(v["multiclass2_lvl"], 10) : 1;
 						finallevel = finallevel + multiclasslevel;
 						hitdie_final = hitdie_final + "|" + v["multiclass2"].charAt(0).toUpperCase() + v["multiclass2"].slice(1) + "," + checkHitDie(v["multiclass2"]);
-						classes.push([ v["multiclass2"], multiclasslevel ]);
+						classes.push([v["multiclass2"], multiclasslevel]);
 						var subclass = v.multiclass2_subclass ? v.multiclass2_subclass + " " : "";
 						class_display = class_display + ", " + subclass + v.multiclass2 + " " + multiclasslevel;
 					};
-					if(v.multiclass3_flag && v.multiclass3_flag === "1") {
+					if (v.multiclass3_flag && v.multiclass3_flag === "1") {
 						var multiclasslevel = (v["multiclass3_lvl"] && v["multiclass3_lvl"] > 0) ? parseInt(v["multiclass3_lvl"], 10) : 1;
 						finallevel = finallevel + multiclasslevel;
 						hitdie_final = hitdie_final + "|" + v["multiclass3"].charAt(0).toUpperCase() + v["multiclass3"].slice(1) + "," + checkHitDie(v["multiclass3"]);
-						classes.push([ v["multiclass3"], multiclasslevel ]);
+						classes.push([v["multiclass3"], multiclasslevel]);
 						var subclass = v.multiclass3_subclass ? v.multiclass3_subclass + " " : "";
 						class_display = class_display + ", " + subclass + v.multiclass3 + " " + multiclasslevel;
 					};
@@ -11393,13 +12052,25 @@
 					update["caster_level"] = casterlevel;
 					update["class_display"] = class_display;
 
-					if(!v["level_calculations"] || v["level_calculations"] == "on") {
+					if (!v["level_calculations"] || v["level_calculations"] == "on") {
 						update["hit_dice_max"] = finallevel;
-						callbacks.push( function() {update_spell_slots();} );
+						callbacks.push(function() {
+							update_spell_slots();
+						});
 					}
-					callbacks.push( function() {update_pb();} );
-					callbacks.push( function() {update_leveler_display();} );
-					setAttrs(update, {silent: true}, function() {callbacks.forEach(function(callback) {callback(); })} );
+					callbacks.push(function() {
+						update_pb();
+					});
+					callbacks.push(function() {
+						update_leveler_display();
+					});
+					setAttrs(update, {
+						silent: true
+					}, function() {
+						callbacks.forEach(function(callback) {
+							callback();
+						})
+					});
 				});
 			};
 
@@ -11408,9 +12079,9 @@
 				var multicaster = false;
 				_.each(classes, function(multiclass) {
 					var caster = getCasterType(multiclass[0], multiclass[1], arcane_fighter, arcane_rogue) > 0;
-					if(caster && singlecaster) {
+					if (caster && singlecaster) {
 						multicaster = true;
-					} else if(caster) {
+					} else if (caster) {
 						singlecaster = true;
 					}
 				});
@@ -11418,15 +12089,15 @@
 			};
 
 			var getCasterType = function(class_string, levels, arcane_fighter, arcane_rogue) {
-				var full = ["bard","cleric","druid","sorcerer","wizard","full"];
-				var half = ["paladin","ranger","half"];
+				var full = ["bard", "cleric", "druid", "sorcerer", "wizard", "full"];
+				var half = ["paladin", "ranger", "half"];
 				class_string = class_string.toLowerCase();
-				if(full.indexOf(class_string) != -1) {
+				if (full.indexOf(class_string) != -1) {
 					return 1;
-				} else if(half.indexOf(class_string) != -1) {
-					return (levels == 1) ? 0 : (1/2);
-				} else if(class_string === "third" || (class_string === "fighter" && arcane_fighter === "1") || (class_string === "rogue" && arcane_rogue === "1")) {
-					return (levels == 1 || levels == 2) ? 0 : (1/3);
+				} else if (half.indexOf(class_string) != -1) {
+					return (levels == 1) ? 0 : (1 / 2);
+				} else if (class_string === "third" || (class_string === "fighter" && arcane_fighter === "1") || (class_string === "rogue" && arcane_rogue === "1")) {
+					return (levels == 1 || levels == 2) ? 0 : (1 / 3);
 				} else {
 					return 0;
 				}
@@ -11446,40 +12117,48 @@
 			};
 
 			var checkHitDie = function(class_string) {
-				var d10class = ["fighter","paladin","ranger"];
-				var d8class = ["bard","cleric","druid","monk","rogue","warlock"];
-				var d6class = ["sorcerer","wizard"];
+				var d10class = ["fighter", "paladin", "ranger"];
+				var d8class = ["bard", "cleric", "druid", "monk", "rogue", "warlock"];
+				var d6class = ["sorcerer", "wizard"];
 				class_string = class_string.toLowerCase();
-				if(class_string === "barbarian") {return "12"}
-				else if (d10class.indexOf(class_string) != -1) {return "10"}
-				else if (d8class.indexOf(class_string) != -1) {return "8"}
-				else if (d6class.indexOf(class_string) != -1) {return "6"}
-				else {return "0"};
+				if (class_string === "barbarian") {
+					return "12"
+				} else if (d10class.indexOf(class_string) != -1) {
+					return "10"
+				} else if (d8class.indexOf(class_string) != -1) {
+					return "8"
+				} else if (d6class.indexOf(class_string) != -1) {
+					return "6"
+				} else {
+					return "0"
+				};
 			};
 
-			var update_leveler_display = function () {
-				getAttrs(["experience","level"], function(v) {
+			var update_leveler_display = function() {
+				getAttrs(["experience", "level"], function(v) {
 					let lvl = 0;
 					let exp = 0;
 					let update = {};
 					update["showleveler"] = 0;
-					if(v["level"] && !isNaN(parseInt(v["level"], 10)) && parseInt(v["level"], 10) > 0) {
+					if (v["level"] && !isNaN(parseInt(v["level"], 10)) && parseInt(v["level"], 10) > 0) {
 						lvl = parseInt(v["level"], 10);
 					}
-					if(v["experience"] && !isNaN(parseInt(v["experience"], 10)) && parseInt(v["experience"], 10) > 0) {
+					if (v["experience"] && !isNaN(parseInt(v["experience"], 10)) && parseInt(v["experience"], 10) > 0) {
 						exp = parseInt(v["experience"], 10);
 					}
-					if(lvl > 0 && exp > 0) {
-						if((lvl === 1 && exp >= 300) || (lvl === 2 && exp >= 900) || (lvl === 3 && exp >= 2700) || (lvl === 4 && exp >= 6500) || (lvl === 5 && exp >= 14000) || (lvl === 6 && exp >= 23000) || (lvl === 7 && exp >= 34000) || (lvl === 8 && exp >= 48000) || (lvl === 9 && exp >= 64000) || (lvl === 10 && exp >= 85000) || (lvl === 11 && exp >= 100000) || (lvl === 12 && exp >= 120000) || (lvl === 13 && exp >= 140000) || (lvl === 14 && exp >= 165000) || (lvl === 15 && exp >= 195000) || (lvl === 16 && exp >= 225000) || (lvl === 17 && exp >= 265000) || (lvl === 18 && exp >= 305000) || (lvl === 19 && exp >= 355000)) {
+					if (lvl > 0 && exp > 0) {
+						if ((lvl === 1 && exp >= 300) || (lvl === 2 && exp >= 900) || (lvl === 3 && exp >= 2700) || (lvl === 4 && exp >= 6500) || (lvl === 5 && exp >= 14000) || (lvl === 6 && exp >= 23000) || (lvl === 7 && exp >= 34000) || (lvl === 8 && exp >= 48000) || (lvl === 9 && exp >= 64000) || (lvl === 10 && exp >= 85000) || (lvl === 11 && exp >= 100000) || (lvl === 12 && exp >= 120000) || (lvl === 13 && exp >= 140000) || (lvl === 14 && exp >= 165000) || (lvl === 15 && exp >= 195000) || (lvl === 16 && exp >= 225000) || (lvl === 17 && exp >= 265000) || (lvl === 18 && exp >= 305000) || (lvl === 19 && exp >= 355000)) {
 							update["showleveler"] = 1;
 						};
 					};
-					setAttrs(update, {silent: true});
+					setAttrs(update, {
+						silent: true
+					});
 				});
 			};
 
 			var update_spell_slots = function() {
-				getAttrs(["lvl1_slots_mod","lvl2_slots_mod","lvl3_slots_mod","lvl4_slots_mod","lvl5_slots_mod","lvl6_slots_mod","lvl7_slots_mod","lvl8_slots_mod","lvl9_slots_mod","caster_level"], function(v) {
+				getAttrs(["lvl1_slots_mod", "lvl2_slots_mod", "lvl3_slots_mod", "lvl4_slots_mod", "lvl5_slots_mod", "lvl6_slots_mod", "lvl7_slots_mod", "lvl8_slots_mod", "lvl9_slots_mod", "caster_level"], function(v) {
 					var update = {};
 					var lvl = v["caster_level"] && !isNaN(parseInt(v["caster_level"], 10)) ? parseInt(v["caster_level"], 10) : 0;
 					var l1 = v["lvl1_slots_mod"] && !isNaN(parseInt(v["lvl1_slots_mod"], 10)) ? parseInt(v["lvl1_slots_mod"], 10) : 0;
@@ -11491,16 +12170,64 @@
 					var l7 = v["lvl7_slots_mod"] && !isNaN(parseInt(v["lvl7_slots_mod"], 10)) ? parseInt(v["lvl7_slots_mod"], 10) : 0;
 					var l8 = v["lvl8_slots_mod"] && !isNaN(parseInt(v["lvl8_slots_mod"], 10)) ? parseInt(v["lvl8_slots_mod"], 10) : 0;
 					var l9 = v["lvl9_slots_mod"] && !isNaN(parseInt(v["lvl9_slots_mod"], 10)) ? parseInt(v["lvl9_slots_mod"], 10) : 0;
-					if(lvl > 0) {
-						l1 = l1 + Math.min((lvl + 1),4);
-						if(lvl < 3) {l2 = l2 + 0;} else if(lvl === 3) {l2 = l2 + 2;} else {l2 = l2 + 3;};
-						if(lvl < 5) {l3 = l3 + 0;} else if(lvl === 5) {l3 = l3 + 2;} else {l3 = l3 + 3;};
-						if(lvl < 7) {l4 = l4 + 0;} else if(lvl === 7) {l4 = l4 + 1;} else if(lvl === 8) {l4 = l4 + 2;} else {l4 = l4 + 3;};
-						if(lvl < 9) {l5 = l5 + 0;} else if(lvl === 9) {l5 = l5 + 1;} else if(lvl < 18) {l5 = l5 + 2;} else {l5 = l5 + 3;};
-						if(lvl < 11) {l6 = l6 + 0;} else if(lvl < 19) {l6 = l6 + 1;} else {l6 = l6 + 2;};
-						if(lvl < 13) {l7 = l7 + 0;} else if(lvl < 20) {l7 = l7 + 1;} else {l7 = l7 + 2;};
-						if(lvl < 15) {l8 = l8 + 0;} else {l8 = l8 + 1;};
-						if(lvl < 17) {l9 = l9 + 0;} else {l9 = l9 + 1;};
+					if (lvl > 0) {
+						l1 = l1 + Math.min((lvl + 1), 4);
+						if (lvl < 3) {
+							l2 = l2 + 0;
+						} else if (lvl === 3) {
+							l2 = l2 + 2;
+						} else {
+							l2 = l2 + 3;
+						};
+						if (lvl < 5) {
+							l3 = l3 + 0;
+						} else if (lvl === 5) {
+							l3 = l3 + 2;
+						} else {
+							l3 = l3 + 3;
+						};
+						if (lvl < 7) {
+							l4 = l4 + 0;
+						} else if (lvl === 7) {
+							l4 = l4 + 1;
+						} else if (lvl === 8) {
+							l4 = l4 + 2;
+						} else {
+							l4 = l4 + 3;
+						};
+						if (lvl < 9) {
+							l5 = l5 + 0;
+						} else if (lvl === 9) {
+							l5 = l5 + 1;
+						} else if (lvl < 18) {
+							l5 = l5 + 2;
+						} else {
+							l5 = l5 + 3;
+						};
+						if (lvl < 11) {
+							l6 = l6 + 0;
+						} else if (lvl < 19) {
+							l6 = l6 + 1;
+						} else {
+							l6 = l6 + 2;
+						};
+						if (lvl < 13) {
+							l7 = l7 + 0;
+						} else if (lvl < 20) {
+							l7 = l7 + 1;
+						} else {
+							l7 = l7 + 2;
+						};
+						if (lvl < 15) {
+							l8 = l8 + 0;
+						} else {
+							l8 = l8 + 1;
+						};
+						if (lvl < 17) {
+							l9 = l9 + 0;
+						} else {
+							l9 = l9 + 1;
+						};
 					};
 
 					update["lvl1_slots_total"] = l1;
@@ -11512,81 +12239,116 @@
 					update["lvl7_slots_total"] = l7;
 					update["lvl8_slots_total"] = l8;
 					update["lvl9_slots_total"] = l9;
-					setAttrs(update, {silent: true});
+					setAttrs(update, {
+						silent: true
+					});
 				});
 			};
 
 			var update_pb = function() {
 				callbacks = [];
-				getAttrs(["level","pb_type","pb_custom"], function(v) {
+				getAttrs(["level", "pb_type", "pb_custom"], function(v) {
 					var update = {};
 					var pb = 2;
-					var lvl = parseInt(v["level"],10);
-					if(lvl < 5) {pb = "2"} else if(lvl < 9) {pb = "3"} else if(lvl < 13) {pb = "4"} else if(lvl < 17) {pb = "5"} else {pb = "6"}
-					var jack = Math.floor(pb/2);
-					if(v["pb_type"] === "die") {
+					var lvl = parseInt(v["level"], 10);
+					if (lvl < 5) {
+						pb = "2"
+					} else if (lvl < 9) {
+						pb = "3"
+					} else if (lvl < 13) {
+						pb = "4"
+					} else if (lvl < 17) {
+						pb = "5"
+					} else {
+						pb = "6"
+					}
+					var jack = Math.floor(pb / 2);
+					if (v["pb_type"] === "die") {
 						update["jack"] = "d" + pb;
-						update["pb"] = "d" + pb*2;
+						update["pb"] = "d" + pb * 2;
 						update["pbd_safe"] = "cs0cf0";
-					}
-					else if(v["pb_type"] === "custom" && v["pb_custom"] && v["pb_custom"] != "") {
+					} else if (v["pb_type"] === "custom" && v["pb_custom"] && v["pb_custom"] != "") {
 						update["pb"] = v["pb_custom"]
-						update["jack"] = !isNaN(parseInt(v["pb_custom"],10)) ? Math.floor(parseInt(v["pb_custom"],10)/2) : jack;
+						update["jack"] = !isNaN(parseInt(v["pb_custom"], 10)) ? Math.floor(parseInt(v["pb_custom"], 10) / 2) : jack;
 						update["pbd_safe"] = "";
-					}
-					else {
+					} else {
 						update["pb"] = pb;
 						update["jack"] = jack;
 						update["pbd_safe"] = "";
 					};
-					callbacks.push( function() {update_attacks("all");} );
-					callbacks.push( function() {update_spell_info();} );
-					callbacks.push( function() {update_jack_attr();} );
-					callbacks.push( function() {update_initiative();} );
-					callbacks.push( function() {update_tool("all");} );
-					callbacks.push( function() {update_all_saves();} );
-					callbacks.push( function() {update_skills(["athletics", "acrobatics", "sleight_of_hand", "stealth", "arcana", "history", "investigation", "nature", "religion", "animal_handling", "insight", "medicine", "perception", "survival","deception", "intimidation", "performance", "persuasion"]);} );
+					callbacks.push(function() {
+						update_attacks("all");
+					});
+					callbacks.push(function() {
+						update_spell_info();
+					});
+					callbacks.push(function() {
+						update_jack_attr();
+					});
+					callbacks.push(function() {
+						update_initiative();
+					});
+					callbacks.push(function() {
+						update_tool("all");
+					});
+					callbacks.push(function() {
+						update_all_saves();
+					});
+					callbacks.push(function() {
+						update_skills(["athletics", "acrobatics", "sleight_of_hand", "stealth", "arcana", "history", "investigation", "nature", "religion", "animal_handling", "insight", "medicine", "perception", "survival", "deception", "intimidation", "performance", "persuasion"]);
+					});
 
-					setAttrs(update, {silent: true}, function() {callbacks.forEach(function(callback) {callback(); })} );
+					setAttrs(update, {
+						silent: true
+					}, function() {
+						callbacks.forEach(function(callback) {
+							callback();
+						})
+					});
 				});
 			};
 
 			var update_jack_attr = function() {
 				var update = {};
-				getAttrs(["jack_of_all_trades","jack"], function(v) {
-					if(v["jack_of_all_trades"] && v["jack_of_all_trades"] != 0) {
+				getAttrs(["jack_of_all_trades", "jack"], function(v) {
+					if (v["jack_of_all_trades"] && v["jack_of_all_trades"] != 0) {
 						update["jack_bonus"] = "+" + v["jack"];
 						update["jack_attr"] = "+" + v["jack"] + "@{pbd_safe}";
-					}
-					else {
+					} else {
 						update["jack_bonus"] = "";
 						update["jack_attr"] = "";
 					}
-					setAttrs(update, {silent: true});
+					setAttrs(update, {
+						silent: true
+					});
 				});
 			};
 
 			var update_spell_info = function(attr) {
 				var update = {};
-				getAttrs(["spellcasting_ability","spell_dc_mod","globalmagicmod","strength_mod","dexterity_mod","constitution_mod","intelligence_mod","wisdom_mod","charisma_mod"], function(v) {
-					if(attr && v["spellcasting_ability"] && v["spellcasting_ability"].indexOf(attr) === -1) {
+				getAttrs(["spellcasting_ability", "spell_dc_mod", "globalmagicmod", "strength_mod", "dexterity_mod", "constitution_mod", "intelligence_mod", "wisdom_mod", "charisma_mod"], function(v) {
+					if (attr && v["spellcasting_ability"] && v["spellcasting_ability"].indexOf(attr) === -1) {
 						return
 					};
-					if(!v["spellcasting_ability"] || (v["spellcasting_ability"] && v["spellcasting_ability"] === "0*")) {
+					if (!v["spellcasting_ability"] || (v["spellcasting_ability"] && v["spellcasting_ability"] === "0*")) {
 						update["spell_attack_bonus"] = "0";
 						update["spell_save_dc"] = "0";
-						var callback = function() {update_attacks("spells")};
-						setAttrs(update, {silent: true}, callback);
+						var callback = function() {
+							update_attacks("spells")
+						};
+						setAttrs(update, {
+							silent: true
+						}, callback);
 						return
 					};
 					var attr = attr ? attr : "";
 					console.log("UPDATING SPELL INFO: " + attr);
 
-					var ability = parseInt(v[v["spellcasting_ability"].substring(2,v["spellcasting_ability"].length-2)],10);
+					var ability = parseInt(v[v["spellcasting_ability"].substring(2, v["spellcasting_ability"].length - 2)], 10);
 					var spell_mod = v["globalmagicmod"] && !isNaN(parseInt(v["globalmagicmod"], 10)) ? parseInt(v["globalmagicmod"], 10) : 0;
 					var atk = v["globalmagicmod"] && !isNaN(parseInt(v["globalmagicmod"], 10)) ? ability + parseInt(v["globalmagicmod"], 10) : ability;
 					var dc = v["spell_dc_mod"] && !isNaN(parseInt(v["spell_dc_mod"], 10)) ? 8 + ability + parseInt(v["spell_dc_mod"], 10) : 8 + ability;
-					var itemfields = ["pb_type","pb"];
+					var itemfields = ["pb_type", "pb"];
 
 					getSectionIDs("repeating_inventory", function(idarray) {
 						_.each(idarray, function(currentID, i) {
@@ -11595,54 +12357,59 @@
 						});
 						getAttrs(itemfields, function(v) {
 							_.each(idarray, function(currentID) {
-								if((!v["repeating_inventory_" + currentID + "_equipped"] || v["repeating_inventory_" + currentID + "_equipped"] === "1") && v["repeating_inventory_" + currentID + "_itemmodifiers"] && v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf("spell" > -1)) {
+								if ((!v["repeating_inventory_" + currentID + "_equipped"] || v["repeating_inventory_" + currentID + "_equipped"] === "1") && v["repeating_inventory_" + currentID + "_itemmodifiers"] && v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().indexOf("spell" > -1)) {
 									var mods = v["repeating_inventory_" + currentID + "_itemmodifiers"].toLowerCase().split(",");
 									_.each(mods, function(mod) {
-										if(mod.indexOf("spell attack") > -1) {
+										if (mod.indexOf("spell attack") > -1) {
 											var substr = mod.slice(mod.lastIndexOf("spell attack") + "spell attack".length);
-											atk = substr && substr.length > 0 && !isNaN(parseInt(substr,10)) ? atk + parseInt(substr,10) : atk;
-											spell_mod = substr && substr.length > 0 && !isNaN(parseInt(substr,10)) ? spell_mod + parseInt(substr,10) : spell_mod;
+											atk = substr && substr.length > 0 && !isNaN(parseInt(substr, 10)) ? atk + parseInt(substr, 10) : atk;
+											spell_mod = substr && substr.length > 0 && !isNaN(parseInt(substr, 10)) ? spell_mod + parseInt(substr, 10) : spell_mod;
 										};
-										if(mod.indexOf("spell dc") > -1) {
+										if (mod.indexOf("spell dc") > -1) {
 											var substr = mod.slice(mod.lastIndexOf("spell dc") + "spell dc".length);
-											dc = substr && substr.length > 0 && !isNaN(parseInt(substr,10)) ? dc + parseInt(substr,10) : dc;
+											dc = substr && substr.length > 0 && !isNaN(parseInt(substr, 10)) ? dc + parseInt(substr, 10) : dc;
 										};
 									});
 								};
 							});
 
-							if(v["pb_type"] && v["pb_type"] === "die") {
+							if (v["pb_type"] && v["pb_type"] === "die") {
 								atk = atk + "+" + v["pb"];
 								dc = dc + parseInt(v["pb"].substring(1), 10) / 2;
-							}
-							else {
+							} else {
 								atk = parseInt(atk, 10) + parseInt(v["pb"], 10);
 								dc = parseInt(dc, 10) + parseInt(v["pb"], 10);
 							};
 							update["spell_attack_mod"] = spell_mod;
 							update["spell_attack_bonus"] = atk;
 							update["spell_save_dc"] = dc;
-							var callback = function() {update_attacks("spells")};
-							setAttrs(update, {silent: true}, callback);
+							var callback = function() {
+								update_attacks("spells")
+							};
+							setAttrs(update, {
+								silent: true
+							}, callback);
 						});
 					});
 				});
 			};
 
 			var update_passive_perception = function() {
-				getAttrs(["pb_type","passiveperceptionmod","perception_bonus"], function(v) {
+				getAttrs(["pb_type", "passiveperceptionmod", "perception_bonus"], function(v) {
 					var passive_perception = 10;
-					var mod = !isNaN(parseInt(v["passiveperceptionmod"],10)) ? parseInt(v["passiveperceptionmod"],10) : 0;
-					var bonus = !isNaN(parseInt(v["perception_bonus"],10)) ? parseInt(v["perception_bonus"],10) : 0;
-					if(v["pb_type"] && v["pb_type"] === "die" && v["perception_bonus"] && isNaN(v["perception_bonus"]) && v["perception_bonus"].indexOf("+") > -1) {
+					var mod = !isNaN(parseInt(v["passiveperceptionmod"], 10)) ? parseInt(v["passiveperceptionmod"], 10) : 0;
+					var bonus = !isNaN(parseInt(v["perception_bonus"], 10)) ? parseInt(v["perception_bonus"], 10) : 0;
+					if (v["pb_type"] && v["pb_type"] === "die" && v["perception_bonus"] && isNaN(v["perception_bonus"]) && v["perception_bonus"].indexOf("+") > -1) {
 						var pieces = v["perception_bonus"].split(/\+|d/);
-						var base = !isNaN(parseInt(pieces[0],10)) ? parseInt(pieces[0],10) : 0;
-						var num_dice = !isNaN(parseInt(pieces[1],10)) ? parseInt(pieces[1],10) : 1;
-						var half_pb_die = !isNaN(parseInt(pieces[2],10)) ? parseInt(pieces[2],10)/2 : 2;
+						var base = !isNaN(parseInt(pieces[0], 10)) ? parseInt(pieces[0], 10) : 0;
+						var num_dice = !isNaN(parseInt(pieces[1], 10)) ? parseInt(pieces[1], 10) : 1;
+						var half_pb_die = !isNaN(parseInt(pieces[2], 10)) ? parseInt(pieces[2], 10) / 2 : 2;
 						bonus = base + (num_dice * half_pb_die);
 					}
 					passive_perception = passive_perception + bonus + mod;
-					setAttrs({passive_wisdom: passive_perception})
+					setAttrs({
+						passive_wisdom: passive_perception
+					})
 				});
 			};
 
@@ -11650,8 +12417,12 @@
 				getAttrs(["race", "subrace"], function(v) {
 					var final_race = "";
 					final_race = v.subrace ? v.subrace : v.race;
-					if(v.race.toLowerCase() === "dragonborn") { final_race = v.race; };
-					setAttrs({race_display: final_race});
+					if (v.race.toLowerCase() === "dragonborn") {
+						final_race = v.race;
+					};
+					setAttrs({
+						race_display: final_race
+					});
 				});
 			};
 
@@ -11669,9 +12440,8 @@
 						}).sortBy(function(id) {
 							return v["repeating_proficiencies_" + id + "_prof_type"];
 						}).value();
-						_.each(final_array, function(id) {
-						});
-						if(final_array && final_array.length > 0) {
+						_.each(final_array, function(id) {});
+						if (final_array && final_array.length > 0) {
 							setSectionOrder("proficiencies", final_array);
 						};
 					});
@@ -11683,7 +12453,7 @@
 					var update = {};
 					var xp = 0;
 					var pb = 0;
-					switch(v.npc_challenge.toString()) {
+					switch (v.npc_challenge.toString()) {
 						case "0":
 							xp = "10";
 							pb = 2;
@@ -11824,21 +12594,103 @@
 					update["npc_xp"] = xp;
 					update["pb_custom"] = pb;
 					update["pb_type"] = "custom";
-					setAttrs(update, {silent: true}, function() {update_pb()});
+					setAttrs(update, {
+						silent: true
+					}, function() {
+						update_pb()
+					});
 				});
 			};
 
 			var update_npc_saves = function() {
-				getAttrs(["npc_str_save_base","npc_dex_save_base","npc_con_save_base","npc_int_save_base","npc_wis_save_base","npc_cha_save_base"], function(v) {
+				getAttrs(["npc_str_save_base", "npc_dex_save_base", "npc_con_save_base", "npc_int_save_base", "npc_wis_save_base", "npc_cha_save_base"], function(v) {
 					var update = {};
-					var last_save = 0; var cha_save_flag = 0; var cha_save = ""; var wis_save_flag = 0; var wis_save = ""; var int_save_flag = 0; var int_save = ""; var con_save_flag = 0; var con_save = ""; var dex_save_flag = 0; var dex_save = ""; var str_save_flag = 0; var str_save = "";
+					var last_save = 0;
+					var cha_save_flag = 0;
+					var cha_save = "";
+					var wis_save_flag = 0;
+					var wis_save = "";
+					var int_save_flag = 0;
+					var int_save = "";
+					var con_save_flag = 0;
+					var con_save = "";
+					var dex_save_flag = 0;
+					var dex_save = "";
+					var str_save_flag = 0;
+					var str_save = "";
 					// 1 = Positive, 2 = Last, 3 = Negative, 4 = Last Negative
-					if(v.npc_cha_save_base && v.npc_cha_save_base != "@{charisma_mod}") {cha_save = parseInt(v.npc_cha_save_base, 10); if(last_save === 0) {last_save = 1; cha_save_flag = cha_save < 0 ? 4 : 2;} else {cha_save_flag = cha_save < 0 ? 3 : 1;} } else {cha_save_flag = 0; cha_save = "";};
-					if(v.npc_wis_save_base && v.npc_wis_save_base != "@{wisdom_mod}") {wis_save = parseInt(v.npc_wis_save_base, 10); if(last_save === 0) {last_save = 1; wis_save_flag = wis_save < 0 ? 4 : 2;} else {wis_save_flag = wis_save < 0 ? 3 : 1;} } else {wis_save_flag = 0; wis_save = "";};
-					if(v.npc_int_save_base && v.npc_int_save_base != "@{intelligence_mod}") {int_save = parseInt(v.npc_int_save_base, 10); if(last_save === 0) {last_save = 1; int_save_flag = int_save < 0 ? 4 : 2;} else {int_save_flag = int_save < 0 ? 3 : 1;} } else {int_save_flag = 0; int_save = "";};
-					if(v.npc_con_save_base && v.npc_con_save_base != "@{constitution_mod}") {con_save = parseInt(v.npc_con_save_base, 10); if(last_save === 0) {last_save = 1; con_save_flag = con_save < 0 ? 4 : 2;} else {con_save_flag = con_save < 0 ? 3 : 1;} } else {con_save_flag = 0; con_save = "";};
-					if(v.npc_dex_save_base && v.npc_dex_save_base != "@{dexterity_mod}") {dex_save = parseInt(v.npc_dex_save_base, 10); if(last_save === 0) {last_save = 1; dex_save_flag = dex_save < 0 ? 4 : 2;} else {dex_save_flag = dex_save < 0 ? 3 : 1;} } else {dex_save_flag = 0; dex_save = "";};
-					if(v.npc_str_save_base && v.npc_str_save_base != "@{strength_mod}") {str_save = parseInt(v.npc_str_save_base, 10); if(last_save === 0) {last_save = 1; str_save_flag = str_save < 0 ? 4 : 2;} else {str_save_flag = str_save < 0 ? 3 : 1;} } else {str_save_flag = 0; str_save = "";};
+					if (v.npc_cha_save_base && v.npc_cha_save_base != "@{charisma_mod}") {
+						cha_save = parseInt(v.npc_cha_save_base, 10);
+						if (last_save === 0) {
+							last_save = 1;
+							cha_save_flag = cha_save < 0 ? 4 : 2;
+						} else {
+							cha_save_flag = cha_save < 0 ? 3 : 1;
+						}
+					} else {
+						cha_save_flag = 0;
+						cha_save = "";
+					};
+					if (v.npc_wis_save_base && v.npc_wis_save_base != "@{wisdom_mod}") {
+						wis_save = parseInt(v.npc_wis_save_base, 10);
+						if (last_save === 0) {
+							last_save = 1;
+							wis_save_flag = wis_save < 0 ? 4 : 2;
+						} else {
+							wis_save_flag = wis_save < 0 ? 3 : 1;
+						}
+					} else {
+						wis_save_flag = 0;
+						wis_save = "";
+					};
+					if (v.npc_int_save_base && v.npc_int_save_base != "@{intelligence_mod}") {
+						int_save = parseInt(v.npc_int_save_base, 10);
+						if (last_save === 0) {
+							last_save = 1;
+							int_save_flag = int_save < 0 ? 4 : 2;
+						} else {
+							int_save_flag = int_save < 0 ? 3 : 1;
+						}
+					} else {
+						int_save_flag = 0;
+						int_save = "";
+					};
+					if (v.npc_con_save_base && v.npc_con_save_base != "@{constitution_mod}") {
+						con_save = parseInt(v.npc_con_save_base, 10);
+						if (last_save === 0) {
+							last_save = 1;
+							con_save_flag = con_save < 0 ? 4 : 2;
+						} else {
+							con_save_flag = con_save < 0 ? 3 : 1;
+						}
+					} else {
+						con_save_flag = 0;
+						con_save = "";
+					};
+					if (v.npc_dex_save_base && v.npc_dex_save_base != "@{dexterity_mod}") {
+						dex_save = parseInt(v.npc_dex_save_base, 10);
+						if (last_save === 0) {
+							last_save = 1;
+							dex_save_flag = dex_save < 0 ? 4 : 2;
+						} else {
+							dex_save_flag = dex_save < 0 ? 3 : 1;
+						}
+					} else {
+						dex_save_flag = 0;
+						dex_save = "";
+					};
+					if (v.npc_str_save_base && v.npc_str_save_base != "@{strength_mod}") {
+						str_save = parseInt(v.npc_str_save_base, 10);
+						if (last_save === 0) {
+							last_save = 1;
+							str_save_flag = str_save < 0 ? 4 : 2;
+						} else {
+							str_save_flag = str_save < 0 ? 3 : 1;
+						}
+					} else {
+						str_save_flag = 0;
+						str_save = "";
+					};
 
 					update["npc_saving_flag"] = "" + cha_save + wis_save + int_save + con_save + dex_save + str_save;
 					update["npc_str_save"] = str_save;
@@ -11853,35 +12705,272 @@
 					update["npc_wis_save_flag"] = wis_save_flag;
 					update["npc_cha_save"] = cha_save;
 					update["npc_cha_save_flag"] = cha_save_flag;
-					setAttrs(update, {silent: true});
+					setAttrs(update, {
+						silent: true
+					});
 				});
 			};
 
 			var update_npc_skills = function() {
-				getAttrs(["npc_acrobatics_base","npc_animal_handling_base","npc_arcana_base","npc_athletics_base","npc_deception_base","npc_history_base","npc_insight_base","npc_intimidation_base","npc_investigation_base","npc_medicine_base","npc_nature_base","npc_perception_base","npc_performance_base","npc_persuasion_base","npc_religion_base","npc_sleight_of_hand_base","npc_stealth_base","npc_survival_base"], function(v) {
+				getAttrs(["npc_acrobatics_base", "npc_animal_handling_base", "npc_arcana_base", "npc_athletics_base", "npc_deception_base", "npc_history_base", "npc_insight_base", "npc_intimidation_base", "npc_investigation_base", "npc_medicine_base", "npc_nature_base", "npc_perception_base", "npc_performance_base", "npc_persuasion_base", "npc_religion_base", "npc_sleight_of_hand_base", "npc_stealth_base", "npc_survival_base"], function(v) {
 					var update = {};
 					var last_skill = 0;
-					var survival_flag = 0; var survival = ""; var stealth_flag = 0; var stealth = ""; var sleight_of_hand_flag = 0; var sleight_of_hand = ""; var religion_flag = 0; var religion = ""; var persuasion_flag = 0; var persuasion = ""; var performance_flag = 0; var sperformance = ""; var perception_flag = 0; var perception = ""; var perception_flag = 0; var perception = ""; var nature_flag = 0; var nature = ""; var medicine_flag = 0; var medicine = ""; var investigation_flag = 0; var investigation = ""; var intimidation_flag = 0; var intimidation = ""; var insight_flag = 0; var insight = ""; var history_flag = 0; var history = ""; var deception_flag = 0; var deception = ""; var athletics_flag = 0; var athletics = ""; var arcana_flag = 0; var arcana = ""; var animal_handling_flag = 0; var animal_handling = ""; var acrobatics_flag = 0; var acrobatics = "";
+					var survival_flag = 0;
+					var survival = "";
+					var stealth_flag = 0;
+					var stealth = "";
+					var sleight_of_hand_flag = 0;
+					var sleight_of_hand = "";
+					var religion_flag = 0;
+					var religion = "";
+					var persuasion_flag = 0;
+					var persuasion = "";
+					var performance_flag = 0;
+					var sperformance = "";
+					var perception_flag = 0;
+					var perception = "";
+					var perception_flag = 0;
+					var perception = "";
+					var nature_flag = 0;
+					var nature = "";
+					var medicine_flag = 0;
+					var medicine = "";
+					var investigation_flag = 0;
+					var investigation = "";
+					var intimidation_flag = 0;
+					var intimidation = "";
+					var insight_flag = 0;
+					var insight = "";
+					var history_flag = 0;
+					var history = "";
+					var deception_flag = 0;
+					var deception = "";
+					var athletics_flag = 0;
+					var athletics = "";
+					var arcana_flag = 0;
+					var arcana = "";
+					var animal_handling_flag = 0;
+					var animal_handling = "";
+					var acrobatics_flag = 0;
+					var acrobatics = "";
 
 					// 1 = Positive, 2 = Last, 3 = Negative, 4 = Last Negative
-					if(v.npc_survival_base && v.npc_survival_base != "@{wisdom_mod}") {survival = parseInt(v.npc_survival_base, 10); if(last_skill === 0) {last_skill = 1; survival_flag = survival < 0 ? 4 : 2;} else {survival_flag = survival < 0 ? 3 : 1;} } else {survival_flag = 0; survival = "";};
-					if(v.npc_stealth_base && v.npc_stealth_base != "@{dexterity_mod}") {stealth = parseInt(v.npc_stealth_base, 10); if(last_skill === 0) {last_skill = 1; stealth_flag = stealth < 0 ? 4 : 2;} else {stealth_flag = stealth < 0 ? 3 : 1;} } else {stealth_flag = 0; stealth = "";};
-					if(v.npc_sleight_of_hand_base && v.npc_sleight_of_hand_base != "@{dexterity_mod}") {sleight_of_hand = parseInt(v.npc_sleight_of_hand_base, 10); if(last_skill === 0) {last_skill = 1; sleight_of_hand_flag = sleight_of_hand < 0 ? 4 : 2;} else {sleight_of_hand_flag = sleight_of_hand < 0 ? 3 : 1;} } else {sleight_of_hand_flag = 0; sleight_of_hand = "";};
-					if(v.npc_religion_base && v.npc_religion_base != "@{intelligence_mod}") {religion = parseInt(v.npc_religion_base, 10); if(last_skill === 0) {last_skill = 1; religion_flag = religion < 0 ? 4 : 2;} else {religion_flag = religion < 0 ? 3 : 1;} } else {religion_flag = 0; religion = "";};
-					if(v.npc_persuasion_base && v.npc_persuasion_base != "@{charisma_mod}") {persuasion = parseInt(v.npc_persuasion_base, 10); if(last_skill === 0) {last_skill = 1; persuasion_flag = persuasion < 0 ? 4 : 2;} else {persuasion_flag = persuasion < 0 ? 3 : 1;} } else {persuasion_flag = 0; persuasion = "";};
-					if(v.npc_performance_base && v.npc_performance_base != "@{charisma_mod}") {sperformance = parseInt(v.npc_performance_base, 10); if(last_skill === 0) {last_skill = 1; performance_flag = sperformance < 0 ? 4 : 2;} else {performance_flag = sperformance < 0 ? 3 : 1;} } else {performance_flag = 0; sperformance = "";};
-					if(v.npc_perception_base && v.npc_perception_base != "@{wisdom_mod}") {perception = parseInt(v.npc_perception_base, 10); if(last_skill === 0) {last_skill = 1; perception_flag = perception < 0 ? 4 : 2;} else {perception_flag = perception < 0 ? 3 : 1;} } else {perception_flag = 0; perception = "";};
-					if(v.npc_nature_base && v.npc_nature_base != "@{intelligence_mod}") {nature = parseInt(v.npc_nature_base, 10); if(last_skill === 0) {last_skill = 1; nature_flag = nature < 0 ? 4 : 2;} else {nature_flag = nature < 0 ? 3 : 1;} } else {nature_flag = 0; nature = "";};
-					if(v.npc_medicine_base && v.npc_medicine_base != "@{wisdom_mod}") {medicine = parseInt(v.npc_medicine_base, 10); if(last_skill === 0) {last_skill = 1; medicine_flag = medicine < 0 ? 4 : 2;} else {medicine_flag = medicine < 0 ? 3 : 1;} } else {medicine_flag = 0; medicine = "";};
-					if(v.npc_investigation_base && v.npc_investigation_base != "@{intelligence_mod}") {investigation = parseInt(v.npc_investigation_base, 10); if(last_skill === 0) {last_skill = 1; investigation_flag = investigation < 0 ? 4 : 2;} else {investigation_flag = investigation < 0 ? 3 : 1;} } else {investigation_flag = 0; investigation = "";};
-					if(v.npc_intimidation_base && v.npc_intimidation_base != "@{charisma_mod}") {intimidation = parseInt(v.npc_intimidation_base, 10); if(last_skill === 0) {last_skill = 1; intimidation_flag = intimidation < 0 ? 4 : 2;} else {intimidation_flag = intimidation < 0 ? 3 : 1;} } else {intimidation_flag = 0; intimidation = "";};
-					if(v.npc_insight_base && v.npc_insight_base != "@{wisdom_mod}") {insight = parseInt(v.npc_insight_base, 10); if(last_skill === 0) {last_skill = 1; insight_flag = insight < 0 ? 4 : 2;} else {insight_flag = insight < 0 ? 3 : 1;} } else {insight_flag = 0; insight = "";};
-					if(v.npc_history_base && v.npc_history_base != "@{intelligence_mod}") {history = parseInt(v.npc_history_base, 10); if(last_skill === 0) {last_skill = 1; history_flag = history < 0 ? 4 : 2;} else {history_flag = history < 0 ? 3 : 1;} } else {history_flag = 0; history = "";};
-					if(v.npc_deception_base && v.npc_deception_base != "@{charisma_mod}") {deception = parseInt(v.npc_deception_base, 10); if(last_skill === 0) {last_skill = 1; deception_flag = deception < 0 ? 4 : 2;} else {deception_flag = deception < 0 ? 3 : 1;} } else {deception_flag = 0; deception = "";};
-					if(v.npc_athletics_base && v.npc_athletics_base != "@{strength_mod}") {athletics = parseInt(v.npc_athletics_base, 10); if(last_skill === 0) {last_skill = 1; athletics_flag = athletics < 0 ? 4 : 2;} else {athletics_flag = athletics < 0 ? 3 : 1;} } else {athletics_flag = 0; athletics = "";};
-					if(v.npc_arcana_base && v.npc_arcana_base != "@{intelligence_mod}") {arcana = parseInt(v.npc_arcana_base, 10); if(last_skill === 0) {last_skill = 1; arcana_flag = arcana < 0 ? 4 : 2;} else {arcana_flag = arcana < 0 ? 3 : 1;} } else {arcana_flag = 0; arcana = "";};
-					if(v.npc_animal_handling_base && v.npc_animal_handling_base != "@{wisdom_mod}") {animal_handling = parseInt(v.npc_animal_handling_base, 10); if(last_skill === 0) {last_skill = 1; animal_handling_flag = animal_handling < 0 ? 4 : 2;} else {animal_handling_flag = animal_handling < 0 ? 3 : 1;} } else {animal_handling_flag = 0; animal_handling = "";};
-					if(v.npc_acrobatics_base && v.npc_acrobatics_base != "@{dexterity_mod}") {acrobatics = parseInt(v.npc_acrobatics_base, 10); if(last_skill === 0) {last_skill = 1; acrobatics_flag = acrobatics < 0 ? 4 : 2;} else {acrobatics_flag = acrobatics < 0 ? 3 : 1;} } else {acrobatics_flag = 0; acrobatics = "";};
+					if (v.npc_survival_base && v.npc_survival_base != "@{wisdom_mod}") {
+						survival = parseInt(v.npc_survival_base, 10);
+						if (last_skill === 0) {
+							last_skill = 1;
+							survival_flag = survival < 0 ? 4 : 2;
+						} else {
+							survival_flag = survival < 0 ? 3 : 1;
+						}
+					} else {
+						survival_flag = 0;
+						survival = "";
+					};
+					if (v.npc_stealth_base && v.npc_stealth_base != "@{dexterity_mod}") {
+						stealth = parseInt(v.npc_stealth_base, 10);
+						if (last_skill === 0) {
+							last_skill = 1;
+							stealth_flag = stealth < 0 ? 4 : 2;
+						} else {
+							stealth_flag = stealth < 0 ? 3 : 1;
+						}
+					} else {
+						stealth_flag = 0;
+						stealth = "";
+					};
+					if (v.npc_sleight_of_hand_base && v.npc_sleight_of_hand_base != "@{dexterity_mod}") {
+						sleight_of_hand = parseInt(v.npc_sleight_of_hand_base, 10);
+						if (last_skill === 0) {
+							last_skill = 1;
+							sleight_of_hand_flag = sleight_of_hand < 0 ? 4 : 2;
+						} else {
+							sleight_of_hand_flag = sleight_of_hand < 0 ? 3 : 1;
+						}
+					} else {
+						sleight_of_hand_flag = 0;
+						sleight_of_hand = "";
+					};
+					if (v.npc_religion_base && v.npc_religion_base != "@{intelligence_mod}") {
+						religion = parseInt(v.npc_religion_base, 10);
+						if (last_skill === 0) {
+							last_skill = 1;
+							religion_flag = religion < 0 ? 4 : 2;
+						} else {
+							religion_flag = religion < 0 ? 3 : 1;
+						}
+					} else {
+						religion_flag = 0;
+						religion = "";
+					};
+					if (v.npc_persuasion_base && v.npc_persuasion_base != "@{charisma_mod}") {
+						persuasion = parseInt(v.npc_persuasion_base, 10);
+						if (last_skill === 0) {
+							last_skill = 1;
+							persuasion_flag = persuasion < 0 ? 4 : 2;
+						} else {
+							persuasion_flag = persuasion < 0 ? 3 : 1;
+						}
+					} else {
+						persuasion_flag = 0;
+						persuasion = "";
+					};
+					if (v.npc_performance_base && v.npc_performance_base != "@{charisma_mod}") {
+						sperformance = parseInt(v.npc_performance_base, 10);
+						if (last_skill === 0) {
+							last_skill = 1;
+							performance_flag = sperformance < 0 ? 4 : 2;
+						} else {
+							performance_flag = sperformance < 0 ? 3 : 1;
+						}
+					} else {
+						performance_flag = 0;
+						sperformance = "";
+					};
+					if (v.npc_perception_base && v.npc_perception_base != "@{wisdom_mod}") {
+						perception = parseInt(v.npc_perception_base, 10);
+						if (last_skill === 0) {
+							last_skill = 1;
+							perception_flag = perception < 0 ? 4 : 2;
+						} else {
+							perception_flag = perception < 0 ? 3 : 1;
+						}
+					} else {
+						perception_flag = 0;
+						perception = "";
+					};
+					if (v.npc_nature_base && v.npc_nature_base != "@{intelligence_mod}") {
+						nature = parseInt(v.npc_nature_base, 10);
+						if (last_skill === 0) {
+							last_skill = 1;
+							nature_flag = nature < 0 ? 4 : 2;
+						} else {
+							nature_flag = nature < 0 ? 3 : 1;
+						}
+					} else {
+						nature_flag = 0;
+						nature = "";
+					};
+					if (v.npc_medicine_base && v.npc_medicine_base != "@{wisdom_mod}") {
+						medicine = parseInt(v.npc_medicine_base, 10);
+						if (last_skill === 0) {
+							last_skill = 1;
+							medicine_flag = medicine < 0 ? 4 : 2;
+						} else {
+							medicine_flag = medicine < 0 ? 3 : 1;
+						}
+					} else {
+						medicine_flag = 0;
+						medicine = "";
+					};
+					if (v.npc_investigation_base && v.npc_investigation_base != "@{intelligence_mod}") {
+						investigation = parseInt(v.npc_investigation_base, 10);
+						if (last_skill === 0) {
+							last_skill = 1;
+							investigation_flag = investigation < 0 ? 4 : 2;
+						} else {
+							investigation_flag = investigation < 0 ? 3 : 1;
+						}
+					} else {
+						investigation_flag = 0;
+						investigation = "";
+					};
+					if (v.npc_intimidation_base && v.npc_intimidation_base != "@{charisma_mod}") {
+						intimidation = parseInt(v.npc_intimidation_base, 10);
+						if (last_skill === 0) {
+							last_skill = 1;
+							intimidation_flag = intimidation < 0 ? 4 : 2;
+						} else {
+							intimidation_flag = intimidation < 0 ? 3 : 1;
+						}
+					} else {
+						intimidation_flag = 0;
+						intimidation = "";
+					};
+					if (v.npc_insight_base && v.npc_insight_base != "@{wisdom_mod}") {
+						insight = parseInt(v.npc_insight_base, 10);
+						if (last_skill === 0) {
+							last_skill = 1;
+							insight_flag = insight < 0 ? 4 : 2;
+						} else {
+							insight_flag = insight < 0 ? 3 : 1;
+						}
+					} else {
+						insight_flag = 0;
+						insight = "";
+					};
+					if (v.npc_history_base && v.npc_history_base != "@{intelligence_mod}") {
+						history = parseInt(v.npc_history_base, 10);
+						if (last_skill === 0) {
+							last_skill = 1;
+							history_flag = history < 0 ? 4 : 2;
+						} else {
+							history_flag = history < 0 ? 3 : 1;
+						}
+					} else {
+						history_flag = 0;
+						history = "";
+					};
+					if (v.npc_deception_base && v.npc_deception_base != "@{charisma_mod}") {
+						deception = parseInt(v.npc_deception_base, 10);
+						if (last_skill === 0) {
+							last_skill = 1;
+							deception_flag = deception < 0 ? 4 : 2;
+						} else {
+							deception_flag = deception < 0 ? 3 : 1;
+						}
+					} else {
+						deception_flag = 0;
+						deception = "";
+					};
+					if (v.npc_athletics_base && v.npc_athletics_base != "@{strength_mod}") {
+						athletics = parseInt(v.npc_athletics_base, 10);
+						if (last_skill === 0) {
+							last_skill = 1;
+							athletics_flag = athletics < 0 ? 4 : 2;
+						} else {
+							athletics_flag = athletics < 0 ? 3 : 1;
+						}
+					} else {
+						athletics_flag = 0;
+						athletics = "";
+					};
+					if (v.npc_arcana_base && v.npc_arcana_base != "@{intelligence_mod}") {
+						arcana = parseInt(v.npc_arcana_base, 10);
+						if (last_skill === 0) {
+							last_skill = 1;
+							arcana_flag = arcana < 0 ? 4 : 2;
+						} else {
+							arcana_flag = arcana < 0 ? 3 : 1;
+						}
+					} else {
+						arcana_flag = 0;
+						arcana = "";
+					};
+					if (v.npc_animal_handling_base && v.npc_animal_handling_base != "@{wisdom_mod}") {
+						animal_handling = parseInt(v.npc_animal_handling_base, 10);
+						if (last_skill === 0) {
+							last_skill = 1;
+							animal_handling_flag = animal_handling < 0 ? 4 : 2;
+						} else {
+							animal_handling_flag = animal_handling < 0 ? 3 : 1;
+						}
+					} else {
+						animal_handling_flag = 0;
+						animal_handling = "";
+					};
+					if (v.npc_acrobatics_base && v.npc_acrobatics_base != "@{dexterity_mod}") {
+						acrobatics = parseInt(v.npc_acrobatics_base, 10);
+						if (last_skill === 0) {
+							last_skill = 1;
+							acrobatics_flag = acrobatics < 0 ? 4 : 2;
+						} else {
+							acrobatics_flag = acrobatics < 0 ? 3 : 1;
+						}
+					} else {
+						acrobatics_flag = 0;
+						acrobatics = "";
+					};
 
 					update["npc_skills_flag"] = "" + acrobatics + animal_handling + arcana + athletics + deception + history + insight + intimidation + investigation + medicine + nature + perception + sperformance + persuasion + religion + sleight_of_hand + stealth + survival;
 					update["npc_stealth_flag"] = stealth_flag;
@@ -11922,25 +13011,28 @@
 					update["npc_stealth_flag"] = stealth_flag;
 					update["npc_survival"] = survival;
 					update["npc_survival_flag"] = survival_flag;
-					setAttrs(update, {silent: true});
+					setAttrs(update, {
+						silent: true
+					});
 				});
 			};
 
 			var update_npc_action = function(update_id, legendary) {
-				if(update_id.substring(0,1) === "-" && update_id.length === 20) {
+				if (update_id.substring(0, 1) === "-" && update_id.length === 20) {
 					do_update_npc_action([update_id], legendary);
-				}
-				else if(update_id === "all") {
+				} else if (update_id === "all") {
 					var legendary_array = [];
 					var actions_array = [];
 					getSectionIDs("repeating_npcaction-l", function(idarray) {
 						legendary_array = idarray;
-						if(legendary_array.length > 0) {
+						if (legendary_array.length > 0) {
 							do_update_npc_action(legendary_array, true);
 						}
 						getSectionIDs("repeating_npcaction", function(idarray) {
-							actions_array = idarray.filter(function(i) {return legendary_array.indexOf(i) < 0;});
-							if(actions_array.length > 0) {
+							actions_array = idarray.filter(function(i) {
+								return legendary_array.indexOf(i) < 0;
+							});
+							if (actions_array.length > 0) {
 								do_update_npc_action(actions_array, false);
 							};
 						});
@@ -11973,8 +13065,12 @@
 						var range = "";
 						var attack_flag = v[repvar + actionid + "_attack_flag"] && v[repvar + actionid + "_attack_flag"] != "0" ? "{{attack=1}}" : "";
 						var tohit = v[repvar + actionid + "_attack_tohit"] && isNaN(parseInt(v[repvar + actionid + "_attack_tohit"], 10)) === false ? parseInt(v[repvar + actionid + "_attack_tohit"], 10) : 0;
-						if(v[repvar + actionid + "_attack_type"] && v[repvar + actionid + "_attack_range"]) {
-							if(v[repvar + actionid + "_attack_type"] === "Melee") {var rangetype = "Reach";} else {var rangetype = "Range";};
+						if (v[repvar + actionid + "_attack_type"] && v[repvar + actionid + "_attack_range"]) {
+							if (v[repvar + actionid + "_attack_type"] === "Melee") {
+								var rangetype = "Reach";
+							} else {
+								var rangetype = "Range";
+							};
 							range = ", " + rangetype + " " + v[repvar + actionid + "_attack_range"];
 						}
 						var target = v[repvar + actionid + "_attack_target"] && v[repvar + actionid + "_attack_target"] != "" ? ", " + v[repvar + actionid + "_attack_target"] : ""
@@ -11988,20 +13084,26 @@
 						var parsed_dmg1 = parse_roll_string(dmg1);
 						var parsed_dmg2 = parse_roll_string(dmg2);
 
-						if(dmg1 != "") {
+						if (dmg1 != "") {
 							onhit = onhit + parsed_dmg1.avg + " (" + dmg1 + ")" + dmg1type + " damage";
 						};
 						dmgspacer = dmg1 != "" && dmg2 != "" ? " plus " : "";
 						onhit = onhit + dmgspacer;
-						if(dmg2 != "") {
+						if (dmg2 != "") {
 							onhit = onhit + parsed_dmg2.avg + " (" + dmg2 + ")" + dmg2type + " damage";
 						};
-						if(dmg1 != "" || dmg2 != "") {damage_flag = damage_flag + "{{damage=1}} "};
-						if(dmg1 != "") {damage_flag = damage_flag + "{{dmg1flag=1}} "};
-						if(dmg2 != "") {damage_flag = damage_flag + "{{dmg2flag=1}} "};
+						if (dmg1 != "" || dmg2 != "") {
+							damage_flag = damage_flag + "{{damage=1}} "
+						};
+						if (dmg1 != "") {
+							damage_flag = damage_flag + "{{dmg1flag=1}} "
+						};
+						if (dmg2 != "") {
+							damage_flag = damage_flag + "{{dmg2flag=1}} "
+						};
 
 						var crit1 = "";
-						if(parsed_dmg1.rolls.length > 0){
+						if (parsed_dmg1.rolls.length > 0) {
 							parsed_dmg1.rolls.forEach(function(value) {
 								crit1 += parsed_dmg1.array[value] + "+";
 							});
@@ -12009,7 +13111,7 @@
 						}
 
 						var crit2 = "";
-						if(parsed_dmg2.rolls.length > 0){
+						if (parsed_dmg2.rolls.length > 0) {
 							parsed_dmg2.rolls.forEach(function(value) {
 								crit2 += parsed_dmg2.array[value] + "+";
 							});
@@ -12017,21 +13119,17 @@
 						}
 
 						var rollbase = "";
-						if(v.dtype === "full") {
+						if (v.dtype === "full") {
 							rollbase = "@{wtype}&{template:npcaction} " + attack_flag + " @{damage_flag} @{npc_name_flag} {{rname=@{name}}} {{r1=[[@{d20}+(@{attack_tohit}+0)]]}} @{rtype}+(@{attack_tohit}+0)]]}} {{dmg1=[[@{attack_damage}+0]]}} {{dmg1type=@{attack_damagetype}}} {{dmg2=[[@{attack_damage2}+0]]}} {{dmg2type=@{attack_damagetype2}}} {{crit1=[[@{attack_crit}+0]]}} {{crit2=[[@{attack_crit2}+0]]}} {{description=@{show_desc}}} @{charname_output}";
-						}
-						else if(v[repvar + actionid + "_attack_flag"] && v[repvar + actionid + "_attack_flag"] != "0") {
-							if(legendary) {
+						} else if (v[repvar + actionid + "_attack_flag"] && v[repvar + actionid + "_attack_flag"] != "0") {
+							if (legendary) {
 								rollbase = "@{wtype}&{template:npcatk} " + attack_flag + " @{damage_flag} @{npc_name_flag} {{rname=[@{name}](~repeating_npcaction-l_npc_dmg)}} {{rnamec=[@{name}](~repeating_npcaction-l_npc_crit)}} {{type=[Attack](~repeating_npcaction-l_npc_dmg)}} {{typec=[Attack](~repeating_npcaction-l_npc_crit)}} {{r1=[[@{d20}+(@{attack_tohit}+0)]]}} @{rtype}+(@{attack_tohit}+0)]]}} {{description=@{show_desc}}} @{charname_output}"
-							}
-							else {
+							} else {
 								rollbase = "@{wtype}&{template:npcatk} " + attack_flag + " @{damage_flag} @{npc_name_flag} {{rname=[@{name}](~repeating_npcaction_npc_dmg)}} {{rnamec=[@{name}](~repeating_npcaction_npc_crit)}} {{type=[Attack](~repeating_npcaction_npc_dmg)}} {{typec=[Attack](~repeating_npcaction_npc_crit)}} {{r1=[[@{d20}+(@{attack_tohit}+0)]]}} @{rtype}+(@{attack_tohit}+0)]]}} {{description=@{show_desc}}} @{charname_output}";
 							}
-						}
-						else if(dmg1 || dmg2) {
+						} else if (dmg1 || dmg2) {
 							rollbase = "@{wtype}&{template:npcdmg} @{damage_flag} {{dmg1=[[@{attack_damage}+0]]}} {{dmg1type=@{attack_damagetype}}} {{dmg2=[[@{attack_damage2}+0]]}} {{dmg2type=@{attack_damagetype2}}} {{crit1=[[@{attack_crit}+0]]}} {{crit2=[[@{attack_crit2}+0]]}} @{charname_output}"
-						}
-						else {
+						} else {
 							rollbase = "@{wtype}&{template:npcaction} @{npc_name_flag} {{rname=@{name}}} {{description=@{show_desc}}} @{charname_output}"
 						}
 
@@ -12041,15 +13139,21 @@
 						update[repvar + actionid + "_attack_crit"] = crit1;
 						update[repvar + actionid + "_attack_crit2"] = crit2;
 						update[repvar + actionid + "_rollbase"] = rollbase;
-						setAttrs(update, {silent: true});
+						setAttrs(update, {
+							silent: true
+						});
 					});
 				});
 			};
 
 			var parse_roll_string = function(rollstring) {
-				var out = {array: [], avg: 0, rolls: []};
+				var out = {
+					array: [],
+					avg: 0,
+					rolls: []
+				};
 
-				if(!rollstring || rollstring === "") {
+				if (!rollstring || rollstring === "") {
 					return out;
 				}
 
@@ -12058,11 +13162,11 @@
 				var rs_nospace = rollstring.replace(/\s/g, '');
 				var rs_initial = rs_regex_initial.exec(rs_nospace);
 
-				if(rs_initial) {
+				if (rs_initial) {
 					out.array.push(rs_initial[1]);
 					rs_regex_repeating.lastIndex = rs_regex_initial.lastIndex;
 					var rs_repeating;
-					while(rs_repeating = rs_regex_repeating.exec(rs_nospace)) {
+					while (rs_repeating = rs_regex_repeating.exec(rs_nospace)) {
 						out.array.push(rs_repeating[1], rs_repeating[2]);
 					}
 				}
@@ -12072,18 +13176,18 @@
 				var dice;
 
 				out.array.forEach(function(value, index, array) {
-					if(value === "+") {
+					if (value === "+") {
 						add = true;
-					} else if(value === "-") {
+					} else if (value === "-") {
 						add = false;
-					} else if(dice = dice_regex.exec(value)){
+					} else if (dice = dice_regex.exec(value)) {
 						// this value is a die roll
 						var dice_avg = Math.floor(+dice[1] * (+dice[2] / 2 + 0.5));
 						out.avg += add ? dice_avg : -dice_avg;
 						out.rolls.push(index);
 					} else {
 						// this value is a number
-						out.avg += add ? +value : -+value;
+						out.avg += add ? +value : - +value;
 					}
 				})
 
@@ -12093,13 +13197,13 @@
 			var get_class_level = function(class_name, callback) {
 				getAttrs(["class", "base_level", "multiclass1_flag", "multiclass1", "multiclass1_lvl", "multiclass2_flag", "multiclass2", "multiclass2_lvl", "multiclass3_flag", "multiclass3", "multiclass3_lvl"], function(attrs) {
 					var regex = new RegExp(class_name, "i");
-					if(regex.test(attrs["class"])) {
+					if (regex.test(attrs["class"])) {
 						callback(attrs.base_level);
-					} else if(attrs.multiclass1_flag && attrs.multiclass1_flag !== "0" && regex.test(attrs.multiclass1)) {
+					} else if (attrs.multiclass1_flag && attrs.multiclass1_flag !== "0" && regex.test(attrs.multiclass1)) {
 						callback(attrs.multiclass1_lvl);
-					} else if(attrs.multiclass2_flag && attrs.multiclass2_flag !== "0" && regex.test(attrs.multiclass2)) {
+					} else if (attrs.multiclass2_flag && attrs.multiclass2_flag !== "0" && regex.test(attrs.multiclass2)) {
 						callback(attrs.multiclass2_lvl);
-					} else if(attrs.multiclass3_flag && attrs.multiclass3_flag !== "0" && regex.test(attrs.multiclass3)) {
+					} else if (attrs.multiclass3_flag && attrs.multiclass3_flag !== "0" && regex.test(attrs.multiclass3)) {
 						callback(attrs.multiclass3_lvl);
 					} else {
 						callback("0");
@@ -12109,7 +13213,7 @@
 
 			var update_globaldamage = function(callback) {
 				getSectionIDs("damagemod", function(ids) {
-					if(ids) {
+					if (ids) {
 						var fields = {};
 						var attr_name_list = [];
 						ids.forEach(function(id) {
@@ -12121,18 +13225,26 @@
 							var regex = /^repeating_damagemod_(.+)_global_damage_(active_flag|name|damage|type)$/;
 							_.each(attrs, function(obj, name) {
 								var r = regex.exec(name);
-								if(r) {
+								if (r) {
 									fields[r[1]][r[2]] = obj;
 								};
 							});
 
-							var update = {global_damage_mod_roll: "", global_damage_mod_crit: "", global_damage_mod_type: ""};
+							var update = {
+								global_damage_mod_roll: "",
+								global_damage_mod_crit: "",
+								global_damage_mod_type: ""
+							};
 
 							console.log("GLOBALDAMAGE");
 							_.each(fields, function(element) {
-								if(element.active_flag != "0") {
-									if(element.name && element.name !== "") { update["global_damage_mod_roll"] += element.damage + '[' + element.name + ']' + "+"; }
-									if(element.type && element.type !== "") { update["global_damage_mod_type"] += element.type + "/"; }
+								if (element.active_flag != "0") {
+									if (element.name && element.name !== "") {
+										update["global_damage_mod_roll"] += element.damage + '[' + element.name + ']' + "+";
+									}
+									if (element.type && element.type !== "") {
+										update["global_damage_mod_type"] += element.type + "/";
+									}
 								}
 							});
 
@@ -12145,9 +13257,11 @@
 								// If what was just replace removed the first damage modifier, remove any now precending plus signs
 								.replace(/(?:^\+)/i, '');
 
-							setAttrs(update, {silent:true}, function() {
+							setAttrs(update, {
+								silent: true
+							}, function() {
 								update_attacks("all");
-								if(typeof callback == "function") callback();
+								if (typeof callback == "function") callback();
 							});
 						});
 					}
@@ -12156,7 +13270,7 @@
 
 			var update_globalattack = function(callback) {
 				getSectionIDs("tohitmod", function(ids) {
-					if(ids) {
+					if (ids) {
 						var fields = {};
 						var attr_name_list = [];
 						ids.forEach(function(id) {
@@ -12167,23 +13281,29 @@
 							var regex = /^repeating_tohitmod_(.+)_global_attack_(active_flag|roll|name)$/;
 							_.each(attrs, function(obj, name) {
 								var r = regex.exec(name);
-								if(r) {
+								if (r) {
 									fields[r[1]][r[2]] = obj;
 								}
 							});
 
-							var update = {global_attack_mod: ""};
+							var update = {
+								global_attack_mod: ""
+							};
 							console.log("GLOBALATTACK");
 							_.each(fields, function(element) {
-								if(element.active_flag != "0") {
-									if(element.roll && element.roll !== "") { update["global_attack_mod"] += element.roll + "[" + element.name + "]" + "+"; }
+								if (element.active_flag != "0") {
+									if (element.roll && element.roll !== "") {
+										update["global_attack_mod"] += element.roll + "[" + element.name + "]" + "+";
+									}
 								}
 							});
-							if(update["global_attack_mod"] !== "") {
+							if (update["global_attack_mod"] !== "") {
 								update["global_attack_mod"] = "[[" + update["global_attack_mod"].replace(/\+(?=$)/, '') + "]]";
 							}
-							setAttrs(update, {silent:true}, function() {
-								if(typeof callback == "function") callback();
+							setAttrs(update, {
+								silent: true
+							}, function() {
+								if (typeof callback == "function") callback();
 							});
 						});
 					}
@@ -12192,7 +13312,7 @@
 
 			var update_globalsaves = function(callback) {
 				getSectionIDs("savemod", function(ids) {
-					if(ids) {
+					if (ids) {
 						var fields = {};
 						var attr_name_list = [];
 						ids.forEach(function(id) {
@@ -12203,23 +13323,29 @@
 							var regex = /^repeating_savemod_(.+)_global_save_(active_flag|roll|name)$/;
 							_.each(attrs, function(obj, name) {
 								var r = regex.exec(name);
-								if(r) {
+								if (r) {
 									fields[r[1]][r[2]] = obj;
 								}
 							});
 
-							var update = {global_save_mod: ""};
+							var update = {
+								global_save_mod: ""
+							};
 							console.log("GLOBAL SAVES");
 							_.each(fields, function(element) {
-								if(element.active_flag != "0") {
-									if(element.roll && element.roll !== "") { update["global_save_mod"] += element.roll + "[" + element.name + "]" + "+"; }
+								if (element.active_flag != "0") {
+									if (element.roll && element.roll !== "") {
+										update["global_save_mod"] += element.roll + "[" + element.name + "]" + "+";
+									}
 								}
 							});
-							if(update["global_save_mod"] !== "") {
+							if (update["global_save_mod"] !== "") {
 								update["global_save_mod"] = "[[" + update["global_save_mod"].replace(/\+(?=$)/, '') + "]]";
 							}
-							setAttrs(update, {silent:true}, function() {
-								if(typeof callback == "function") callback();
+							setAttrs(update, {
+								silent: true
+							}, function() {
+								if (typeof callback == "function") callback();
 							});
 						});
 					}
@@ -12228,7 +13354,7 @@
 
 			var update_globalskills = function(callback) {
 				getSectionIDs("skillmod", function(ids) {
-					if(ids) {
+					if (ids) {
 						var fields = {};
 						var attr_name_list = [];
 						ids.forEach(function(id) {
@@ -12239,23 +13365,29 @@
 							var regex = /^repeating_skillmod_(.+)_global_skill_(active_flag|roll|name)$/;
 							_.each(attrs, function(obj, name) {
 								var r = regex.exec(name);
-								if(r) {
+								if (r) {
 									fields[r[1]][r[2]] = obj;
 								}
 							});
 
-							var update = {global_skill_mod: ""};
+							var update = {
+								global_skill_mod: ""
+							};
 							console.log("GLOBAL SKILLS");
 							_.each(fields, function(element) {
-								if(element.active_flag != "0") {
-									if(element.roll && element.roll !== "") { update["global_skill_mod"] += element.roll + "[" + element.name + "]" + "+"; }
+								if (element.active_flag != "0") {
+									if (element.roll && element.roll !== "") {
+										update["global_skill_mod"] += element.roll + "[" + element.name + "]" + "+";
+									}
 								}
 							});
-							if(update["global_skill_mod"] !== "") {
+							if (update["global_skill_mod"] !== "") {
 								update["global_skill_mod"] = "[[" + update["global_skill_mod"].replace(/\+(?=$)/, '') + "]]";
 							}
-							setAttrs(update, {silent:true}, function() {
-								if(typeof callback == "function") callback();
+							setAttrs(update, {
+								silent: true
+							}, function() {
+								if (typeof callback == "function") callback();
 							});
 						});
 					}
@@ -12286,38 +13418,38 @@
 				delete filters.multiclass;
 				delete filters.slide;
 				_.each(blobs, function(blob, name) {
-						var match = true;
-						if(blob.Group && !filters.Group && !filters.name) match = false;
-						_.each(filters, function(v, k) {
-								if(k == "name") {
-										if(name != v) match = false;
-								} else if(v[0] === "<" && !isNaN(parseInt(v.substring(1)))) {
-										let blobval = isNaN(parseInt(blob[k])) ? 0 : parseInt(blob[k]);
-										if(blobval > parseInt(v.substring(1))) match = false;
-								} else {
-										if(blob[k] != v) match = false;
-								}
-						});
-						if(match && name.split("(")[0].toLowerCase() != "spell slots") results[name] = blob;
+					var match = true;
+					if (blob.Group && !filters.Group && !filters.name) match = false;
+					_.each(filters, function(v, k) {
+						if (k == "name") {
+							if (name != v) match = false;
+						} else if (v[0] === "<" && !isNaN(parseInt(v.substring(1)))) {
+							let blobval = isNaN(parseInt(blob[k])) ? 0 : parseInt(blob[k]);
+							if (blobval > parseInt(v.substring(1))) match = false;
+						} else {
+							if (blob[k] != v) match = false;
+						}
+					});
+					if (match && name.split("(")[0].toLowerCase() != "spell slots") results[name] = blob;
 				});
 				_.each(results, function(blob, name) {
-						if(blob.Multiclass == remove) {
-								delete results[name];
-						}
+					if (blob.Multiclass == remove) {
+						delete results[name];
+					}
 				});
 				return results;
 			};
 
 			// CHANGE SURVIVAL CONDITIONS
 
-			on("change:condition_temperature change:condition_hunger change:condition_thirst change:condition_fatigue", function () {
+			on("change:condition_temperature change:condition_hunger change:condition_thirst change:condition_fatigue", function() {
 				let field1 = "condition_temperature";
 				let field2 = "condition_hunger";
 				let field3 = "condition_thirst";
 				let field4 = "condition_fatigue";
 				let exhaustionMod = 0;
 
-				getAttrs([field1, field2, field3, field4], function (v) {
+				getAttrs([field1, field2, field3, field4], function(v) {
 
 					[field1, field2, field3, field4].forEach(function(field) {
 						let value = toInt(v[field]);
@@ -12332,13 +13464,13 @@
 
 			// CHANGE EXHAUSTION
 
-			on("change:exhaustion_base change:exhaustion_wounds change:exhaustion_conditions change:show_survival_conditions", function () {
+			on("change:exhaustion_base change:exhaustion_wounds change:exhaustion_conditions change:show_survival_conditions", function() {
 				let field1 = "exhaustion_base";
 				let field2 = "exhaustion_wounds";
 				let field3 = "exhaustion_conditions";
 				let field4 = "show_survival_conditions";
 
-				getAttrs([field1, field2, field3, field4], function (v) {
+				getAttrs([field1, field2, field3, field4], function(v) {
 					let update = {};
 					let exhaustionTotal = clamp(toInt(v[field1]) + toInt(v[field2]) + toInt(v[field3]), 0, 6);
 					update["exhaustion_total"] = exhaustionTotal;
@@ -12352,20 +13484,20 @@
 
 			// CHANGE WOUND TREATMENT
 
-			on("change:repeating_wounds remove:repeating_wounds", function (eventinfo) {
+			on("change:repeating_wounds remove:repeating_wounds", function(eventinfo) {
 
-				getSectionIDs('repeating_wounds', function (ids) {
+				getSectionIDs('repeating_wounds', function(ids) {
 					let fields = [];
 
-					ids.forEach(function (id) {
+					ids.forEach(function(id) {
 						fields.push("repeating_wounds_" + id + "_wound_untreated");
 					});
 
-					getAttrs(fields, function (v) {
+					getAttrs(fields, function(v) {
 
 						let untreated_wounds = 0;
 
-						ids.forEach(function (id) {
+						ids.forEach(function(id) {
 							let attribute = v["repeating_wounds_" + id + "_wound_untreated"];
 							if (isDefined(attribute) && attribute == 1) {
 								untreated_wounds += 1;
@@ -12381,7 +13513,7 @@
 
 			// CHANGE STRESS
 
-			on("change:stress", function (eventinfo) {
+			on("change:stress", function(eventinfo) {
 				let stress = toInt(eventinfo.newValue);
 				let update = {};
 				if (stress >= 20) {
@@ -12401,13 +13533,13 @@
 
 			// CHANGE HIT POINTS
 
-			on("change:hit_dice change:hit_dice_max change:hp change:hp_max", function () {
+			on("change:hit_dice change:hit_dice_max change:hp change:hp_max", function() {
 				let field1 = "hp";
 				let field2 = "hp_max";
 				let field3 = "hit_dice_max";
 				let field4 = "hit_dice";
 
-				getAttrs([field1, field2, field3, field4], function (v) {
+				getAttrs([field1, field2, field3, field4], function(v) {
 					let conditionHealth = "";
 					let hp = toInt(v[field1]);
 					let hpMax = toInt(v[field2]);
@@ -12428,7 +13560,7 @@
 						if (hpPercentage > 0.5) {
 							conditionHealth = 3;
 						} else if (hp == 1) {
-							 conditionHealth = 6;
+							conditionHealth = 6;
 						} else if (hpPercentage >= 0.25) {
 							conditionHealth = 4;
 						} else if (hpPercentage >= 0.1) {
@@ -12444,15 +13576,15 @@
 				});
 			});
 
-			let toInt = function (value) {
+			let toInt = function(value) {
 				return (value && !isNaN(value)) ? parseInt(value) : 0;
 			};
 
-			let clamp = function (value, min, max) {
+			let clamp = function(value, min, max) {
 				return Math.min(Math.max(value, min), max);
 			};
 
-			let isDefined = function (value) {
+			let isDefined = function(value) {
 				return value !== null && typeof(value) !== 'undefined';
 			};
 		</script>


### PR DESCRIPTION
Bug fixes and new features for the Darker Dungeons sheet.

## Changes / Comments

- Fixed missing HTML span elements and indentation.
- Applied basic beautifying to HTML/CSS sheet.
- Fixed NPC reactions bug: Reactions now display correctly.
- Can now edit equipment quantity/slots/notches directly on the equipment panel.
- Containers can now add extra inventory slots.
- Items can now be marked as carried-but-not-equipped.
- Feature details can now be hidden/condensed.
- Currency names can now be changed.
- Added open skills to PC sheet.