### PR TITLE
Correct fire damage for Monster of the Week Spell-Slinger

### DIFF
--- a/Monster of the Week/MotWHTML.html
+++ b/Monster of the Week/MotWHTML.html
@@ -1420,7 +1420,7 @@
                     &nbsp;  <input type="checkbox" class="sheet-Magic-Spellslinger" name="attr_Magic-Spellslinger3"> Missile (1 harm, magic, far, obvious,<br> &nbsp; &nbsp; &nbsp;  loud)<br>
                     &nbsp;  <input type="checkbox" class="sheet-Magic-Spellslinger" name="attr_Magic-Spellslinger4"> Wall (1 harm, magic, barrier, close,<br> &nbsp; &nbsp; &nbsp;  1 armour, obvious, loud)<br>
                     Effects:<br>
-                    &nbsp;  <input type="checkbox" class="sheet-Magic-Spellslinger" name="attr_Magic-Spellslinger5"> Fire (Add '+1 harm, fire' to a base) If<br> &nbsp; &nbsp; &nbsp;  you get a 10+ on a combat magic roll,<br> &nbsp; &nbsp; &nbsp;  the fire won't spread)<br>
+                    &nbsp;  <input type="checkbox" class="sheet-Magic-Spellslinger" name="attr_Magic-Spellslinger5"> Fire (Add '+2 harm, fire' to a base) If<br> &nbsp; &nbsp; &nbsp;  you get a 10+ on a combat magic roll,<br> &nbsp; &nbsp; &nbsp;  the fire won't spread)<br>
                     &nbsp;  <input type="checkbox" class="sheet-Magic-Spellslinger" name="attr_Magic-Spellslinger6"> Force or Wind (Add '+1 harm, forceful'<br> &nbsp; &nbsp; &nbsp;  to a base or '+1 armour' to a wall)<br>
                     &nbsp;  <input type="checkbox" class="sheet-Magic-Spellslinger" name="attr_Magic-Spellslinger7"> Lightning or Entropy (Add '1 harm,<br> &nbsp; &nbsp; &nbsp;  messy' to a base)<br>
                     &nbsp;  <input type="checkbox" class="sheet-Magic-Spellslinger" name="attr_Magic-Spellslinger8"> Frost or Ice (Add '-1 harm, +2 armour'<br> &nbsp; &nbsp; &nbsp;  to a wall, or '+1 harm, restraining' to<br> &nbsp; &nbsp; &nbsp;  other bases) <br>


### PR DESCRIPTION
The MotW playbooks specify that the spell-slinger's fire magic gives +2 damage, not +1. This corrects that.

## Changes / Comments

From the revised playbooks and the revised rulebook:

![image](https://user-images.githubusercontent.com/16296823/76707776-922aeb00-66c8-11ea-9044-b730b84706e4.png)
![image](https://user-images.githubusercontent.com/16296823/76707777-95be7200-66c8-11ea-8157-3962f94c752c.png)