### PR TITLE
[RunequestGQS] Magic modifier calculated wrong

### DIFF
--- a/RunequestGQS/RunequestGQS.html
+++ b/RunequestGQS/RunequestGQS.html
@@ -4846,7 +4846,7 @@ wpn 3 HP 12</textarea>
 						BonusMod = BonusMod + -5;
 					}else if (curChr >16 && curChr < 21){
 						BonusMod = BonusMod + 5;
-					}else if (curPow >20){
+					}else if (curChr >20){
 						BonusMod = BonusMod + (5+(Math.ceil((curChr-20)/4)*5));
 					}
 					console.log("BonusMod value1: " + BonusMod);


### PR DESCRIPTION
The Magic modifier was calculated wrong. curPow was used in a place where curChr was the characteristic to check.

## Changes / Comments






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
