### PR TITLE
[Pendragon5thEdition] Update ternary in attributeSumDivide to determine the correct divisor

### DIFF
--- a/Pendragon5thEdition/pendragon.html
+++ b/Pendragon5thEdition/pendragon.html
@@ -62,7 +62,7 @@ const totalAttributes = values => {
 
 const attributeSumDivide = (attributes, set) => {
     getAttrs(attributes, (values) => {
-    	const divide = 'damage' ? 6 : 10;
+    	const divide = set == 'damage' ? 6 : 10;
     	let sum = totalAttributes(values);
     	sum = divideBy(sum, divide) ;
 

--- a/Pendragon5thEdition/src/js/scripts.js
+++ b/Pendragon5thEdition/src/js/scripts.js
@@ -60,7 +60,7 @@ const totalAttributes = values => {
 
 const attributeSumDivide = (attributes, set) => {
     getAttrs(attributes, (values) => {
-    	const divide = 'damage' ? 6 : 10;
+    	const divide = set == 'damage' ? 6 : 10;
     	let sum = totalAttributes(values);
     	sum = divideBy(sum, divide) ;
 


### PR DESCRIPTION
## Changes / Comments

The derived attribute in question was mistakenly left out of the ternary determining what divisor to use - "damage" is supposed to use a divisor of 6 while "healing" and "movement" use 10.

Due to this and the boolean status of strings, the ternary condition was always true. All three derived attributes used a divisor of 6.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
