### PR TITLE
[Delta Green] Bug fix Change relative path of images to absolute

### DIFF
--- a/DeltaGreenRPG/delta_green.css
+++ b/DeltaGreenRPG/delta_green.css
@@ -340,7 +340,7 @@ table.sheet-attacktable {
             padding: 0px;
             background-color: white;
 
-            background-image: url('img/folder.jpg'); 
+            background-image: url('https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/folder.jpg?raw=true'); 
          	background-repeat: no-repeat;
             background-size: 860px 1370px;
             position: relative;
@@ -377,7 +377,7 @@ table.sheet-attacktable {
 }
 .sheet-paper {
 		background-color: transparent;
-		background-image: url('img/paper.jpg');
+		background-image: url('https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/paper.jpg?raw=true');
     	background-size: cover;
         background-repeat: no-repeat;
         /*background-attachment: fixed;*/
@@ -392,7 +392,7 @@ table.sheet-attacktable {
 }
 .sheet-paper1 {
 		background-color: transparent;
-		background-image: url('img/paper.jpg');
+		background-image: url('https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/paper.jpg?raw=true');
 		/*debug background-color: blue;*/
     	background-size: cover;
         background-repeat: no-repeat;
@@ -518,7 +518,7 @@ table.sheet-attacktable {
     color:white;
 	font-weight: bold;
 	margin-left: -90%;
-	background-image: url("img/Agent.png");
+	background-image: url("https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/Agent.png?raw=true");
 	background-size: 100% 100%;
     background-repeat: no-repeat;
     /*background-attachment: fixed;*/
@@ -528,7 +528,7 @@ table.sheet-attacktable {
 
 
 .charsheet input.sheet-switch-sheet:checked ~ span.sheet-is-npc-tab{
-	background-image: url("img/Threat.jpg");
+	background-image: url("https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/Threat.png?raw=true");
 	/*debug background-color: black;*/
 	background-size: 100% 100%;
     background-repeat: no-repeat;

--- a/DeltaGreenRPG/delta_green.html
+++ b/DeltaGreenRPG/delta_green.html
@@ -2289,7 +2289,7 @@ setAttrs({totalgeneralmod: sum});
                             <div class="maindiv" style="height:60px">
                             
                             <label class='sectionHeader '>
-                                   <input type="radio" style=name="attr_flipnpc" class="switch-page2" value="off"  checked disabled/><img  src="img/header.png" style="height:60px;width:100%;margin-left:-12px;object-fit: cover;" style="align:center" alignk>
+                                   <input type="radio" style=name="attr_flipnpc" class="switch-page2" value="off"  checked disabled/><img  src="https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/header.png?raw=true" style="height:60px;width:100%;margin-left:-12px;object-fit: cover;" style="align:center" alignk>
                                     </label>
                             </div>
                             <span class="spacer"></span>
@@ -3425,7 +3425,7 @@ setAttrs({totalgeneralmod: sum});
                             <span class="spacer2"></span>
                             <div class="maindiv" style="height:60px;">
                             <label class='sectionHeader '>
-                                    <input type="radio" style=name="attr_flipagent" class="switch-page" value="off"/><img class="switch-page" src="img/header.png" style="height:60px;width:100%;margin-left:-12px;object-fit: cover;" style="align:center">
+                                    <input type="radio" style=name="attr_flipagent" class="switch-page" value="off"/><img class="switch-page" src="https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/header.png?raw=true" style="height:60px;width:100%;margin-left:-12px;object-fit: cover;" style="align:center">
                                     </label>
                             </div>
                             <span class="spacer"></span>
@@ -4447,7 +4447,7 @@ setAttrs({totalgeneralmod: sum});
                             
                              <div class="maindiv" style="height:40px;">
                             <label class='sectionHeader '>
-                                    <input type="radio" name="attr_flipagent" class="switch-page" value="off"/><img class="switch-page" src="img/footer2.png"    style="height:40px;width:100%;margin-left:-12px;object-fit: cover;" style="align:left">
+                                    <input type="radio" name="attr_flipagent" class="switch-page" value="off"/><img class="switch-page" src="https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/footer2.png?raw=true"    style="height:40px;width:100%;margin-left:-12px;object-fit: cover;" style="align:left">
                             </label>
                             </div>   
                             
@@ -4461,7 +4461,7 @@ setAttrs({totalgeneralmod: sum});
                             <span class="spacer2"></span>
                             <div class="maindiv" style="height:60px;">
                             <label class='sectionHeader '>
-                                    <input type="radio" name="attr_flipagent" class="switch-page" value="on"/><img class="switch-page" src="img/header.png" style="height:60px;width:100%;margin-left:-12px;object-fit: cover;" style="align:left">
+                                    <input type="radio" name="attr_flipagent" class="switch-page" value="on"/><img class="switch-page" src="https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/header.png?raw=true" style="height:60px;width:100%;margin-left:-12px;object-fit: cover;" style="align:left">
                             </label>
                             </div>
                             <span class="spacer"></span>
@@ -5150,7 +5150,7 @@ setAttrs({totalgeneralmod: sum});
                             <span class="spacer2"></span>
                              <div class="maindiv" style="height:40px;">
                             <label class='sectionHeader '>
-                                    <input type="radio" name="attr_flipagent" class="switch-page" value="on"/><img class="switch-page" src="img/footer1.png"  style="height:40px;width:100%;margin-left:-12px;object-fit: cover;" style="align:left">
+                                    <input type="radio" name="attr_flipagent" class="switch-page" value="on"/><img class="switch-page" src="https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/footer1.png?raw=true"  style="height:40px;width:100%;margin-left:-12px;object-fit: cover;" style="align:left">
                             </label>
                             </div>      
                                 
@@ -5581,16 +5581,16 @@ setAttrs({totalgeneralmod: sum});
     <table>
         <caption> {{name}} <br> (skill: {{skillname}}) <br> 
         {{#rollTotal() aim 20}}
-            <img src="img/aim.png" style="width:20px;height:20px;">
+            <img src="https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/aim.png?raw=true" style="width:20px;height:20px;">
         {{/rollTotal() aim 20}} 
         
         {{#rollLess() callshot 0}}
             
-            <img src="img/calledshot.png" style="width:20px;height:20px;">
+            <img src="https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/calledshot.png?raw=true" style="width:20px;height:20px;">
         {{/rollLess() callshot 0}} 
         
         {{#rollLess() callshot -20}}
-            <img src="img/calledshot.png" style="width:20px;height:20px;">
+            <img src="https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/calledshot.png?raw=true" style="width:20px;height:20px;">
         {{/rollLess() callshot -20}} 
         
         </caption>
@@ -10730,16 +10730,16 @@ setAttrs({totalgeneralmod: sum});
     <table>
         <caption> {{name}} <br> (skill: {{skillname}}) <br> 
         {{#rollTotal() aim 20}}
-            <img src="img/aim.png" style="width:20px;height:20px;">
+            <img src="https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/aim.png?raw=true" style="width:20px;height:20px;">
         {{/rollTotal() aim 20}} 
         
         {{#rollLess() callshot 0}}
             
-            <img src="img/calledshot.png" style="width:20px;height:20px;">
+            <img src="https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/calledshot.png?raw=true" style="width:20px;height:20px;">
         {{/rollLess() callshot 0}} 
         
         {{#rollLess() callshot -20}}
-            <img src="img/calledshot.png" style="width:20px;height:20px;">
+            <img src="https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/calledshot.png?raw=true" style="width:20px;height:20px;">
         {{/rollLess() callshot -20}} 
         
         </caption>
@@ -11057,16 +11057,16 @@ setAttrs({totalgeneralmod: sum});
     <table>
         <caption> {{name}} <br> (skill: {{skillname}}) <br> 
         {{#rollTotal() aim 20}}
-            <img src="img/aim.png" style="width:20px;height:20px;">
+            <img src="https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/aim.png?raw=true" style="width:20px;height:20px;">
         {{/rollTotal() aim 20}} 
         
         {{#rollLess() callshot 0}}
             
-            <img src="img/calledshot.png" style="width:20px;height:20px;">
+            <img src="https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/calledshot.png?raw=true" style="width:20px;height:20px;">
         {{/rollLess() callshot 0}} 
         
         {{#rollLess() callshot -20}}
-            <img src="img/calledshot.png" style="width:20px;height:20px;">
+            <img src="https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/calledshot.png?raw=true" style="width:20px;height:20px;">
         {{/rollLess() callshot -20}} 
         
         </caption>
@@ -11484,16 +11484,16 @@ setAttrs({totalgeneralmod: sum});
     <table>
         <caption> {{name}} <br> (skill: {{skillname}}) <br> 
         {{#rollTotal() aim 20}}
-            <img src="img/aim.png" style="width:20px;height:20px;">
+            <img src="https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/aim.png?raw=true" style="width:20px;height:20px;">
         {{/rollTotal() aim 20}} 
         
         {{#rollLess() callshot 0}}
             
-            <img src="img/calledshot.png" style="width:20px;height:20px;">
+            <img src="https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/calledshot.png?raw=true" style="width:20px;height:20px;">
         {{/rollLess() callshot 0}} 
         
         {{#rollLess() callshot -20}}
-            <img src="img/calledshot.png" style="width:20px;height:20px;">
+            <img src="https://github.com/Roll20/roll20-character-sheets/blob/master/DeltaGreenRPG/img/calledshot.png?raw=true" style="width:20px;height:20px;">
         {{/rollLess() callshot -20}} 
         
         </caption>


### PR DESCRIPTION
substitute the relative path to the absolute relative to github for showing the art
I used relative path for all the images, resulting in art not showing up on roll20. I've updated all the relative path to an absolute one with respect to the absolute path on github (i.e. https://github.com/Roll20/roll20-character-sheets/DeltaGreenRPG/img/<nameimage>?raw=true) 
## Changes / Comments






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
