### PR TITLE
[Shadowrun5thEdition] Fixing a typo on electronicwarfare

### DIFF
--- a/Shadowrun5thEdition/Shadowrun5thEdition.html
+++ b/Shadowrun5thEdition/Shadowrun5thEdition.html
@@ -544,7 +544,7 @@
 <option value="Cybercombat" data-i18n="cybercombat">Cybercombat</option>
 <option value="Cybertechnology" data-i18n="cybertechnology">Cybertechnology</option>
 <option value="Demolitions" data-i18n="demolitions">Demolitions</option>
-<option value="Electronic Warfare" data-i18n="eletronicwarfare">Electronic Warfare</option>
+<option value="Electronic Warfare" data-i18n="electronicwarfare">Electronic Warfare</option>
 <option value="First Aid" data-i18n="firstaid">First Aid</option>
 <option value="Forgery" data-i18n="forgery">Forgery</option>
 <option value="Hacking" data-i18n="hacking">Hacking</option>


### PR DESCRIPTION
## Changes / Comments

Fixing a typo on 'electronicwarfare' (was 'eletronicwarfare') which broke the skill display on the character sheets.


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
