### PR TITLE
Duplicate classname fix.

### DIFF
--- a/Star Wars Revised RPG/SWRRPG.html
+++ b/Star Wars Revised RPG/SWRRPG.html
@@ -619,7 +619,7 @@
         </table>
     </fieldset>
     <b>Knowledge</b><br>
-    <fieldset class="repeating_craft">
+    <fieldset class="repeating_knowledge">
         <table style="width: 350px;">
             <tr><td><input type='checkbox' name='attr_knowledgecheckbox' value='1' /><span></span></td><td class="sheet-skillsbox"><input type="text" name=attr_knowledgename style="width: 100px" ></td><td><input type="number" name="attr_knowledgetotal" style="width: 45px; font-weight: bolder" value="@{intmod}+@{knowledgeranks}+@{knowledgemiscmod}" disabled="true"></td><td><input type="number" name="attr_knowledgeabilitymod" style="width: 45px;" value="@{intmod}" disabled="true"></td><td><input type="number" name="attr_knowledgeranks" value="0" style="width: 45px;"></td><td><input type="number" name="attr_knowledgemiscmod" value="0" style="width: 45px;"></td><td><button type="roll" value="&{template:check} {{name=Knowledge: @{knowledgename}}} {{Roll=[[@{knowledgetotal}+1d20]]}}" name="roll_knowledgecheck"</button> </td></tr>
         </table>


### PR DESCRIPTION
Duplicate classname caused to add a craft and knowledge skill when adding either skill.