### PR TITLE
Fix roll again behavior by removing trailling 8, NWOD-Hunter The Vigil

### DIFF
--- a/NWOD-Hunter The Vigil/NWOD-Hunter.html
+++ b/NWOD-Hunter The Vigil/NWOD-Hunter.html
@@ -654,7 +654,7 @@
      
      "X-AGAIN" Rolls &nbsp;&nbsp;&nbsp;
      <input type="number" name="attr_AgainRule" value="0" min="-99" max="99" style="width: 42px;"> &nbsp;&nbsp;&nbsp;
-     <button type='roll' value="@{GM_Attack} does [[{@{FinalDicePool}d10!>8@{AgainRule}}>8]] @{Damage_Type} damage">Attack!</button>
+     <button type='roll' value="@{GM_Attack} does [[{@{FinalDicePool}d10!>@{AgainRule}}>8]] @{Damage_Type} damage">Attack!</button>
     
      &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Public <input type='radio' value='/em' name='attr_GM_Attack' checked="true">
      GM Only <input type='radio' value='/w gm @{Name}' name='attr_GM_Attack'>


### PR DESCRIPTION
Feel free to tell me if this is breaking, i took a look at the page and couldn't find issues related to said change.

## Changes / Comments






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
Yes
- [ ] Is this a bug fix?
Yes
- [ ] Does this add functional enhancements (new features or extending existing features) ?
Nope
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
Nope
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
N/A
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?
N/A

If you do not know English. Please leave a comment in your native language.
