### PR TITLE
[DCC_Tabbed_Sheet] Remove critical hits from Dwarven shield bash

### DIFF
--- a/DCC_Tabbed_Sheet/DCC_Tabbed_Sheet.html
+++ b/DCC_Tabbed_Sheet/DCC_Tabbed_Sheet.html
@@ -1253,7 +1253,7 @@
 									<div class="sheet-col-1-14 sheet-small-label sheet-center" Title="Bonus is Strength Mod + Lucky Roll (if any) + Damage Bonus"><input class="sheet-underlined sheet-center" type="number" name="attr_shieldBashDmg" value="[[ ([[@{strMod}]] + @{shieldBashDmgBonus}  + @{dmgLuckyRoll} + @{meleeDmgLuckyRoll}) ]]" disabled="disabled"><br/>Total Bonus</div>
 									<div class="sheet-col-1-9">
 				                        <button type='roll' class="sheet-roll" title="Dwarven Shield Bash"
-				                        value="&{template:DccTabbed} {{background=[[0]]}} {{combat=1}} {{name=@{character_name}}} {{title=Dwarven Shield Bash}} {{attack=[[ @{shieldBashDie}cs>@{critThreat} [To Hit Roll] + (?{Deed/Smite Die roll|0}) [Deed/Smite] + @{shieldBashAtk} ]]}} {{damage=[[ @{shieldBashDmgDie} [Base damage] + (?{Deed/Smite Die roll|0}) [Deed/Smite Die] + @{shieldBashDmg} ]]}} {{crit=[[ @{CritDie} + [[@{luckMod}]] + @{critLuckyRoll} ]]}} {{crittable=@{CritDie_max}}} {{fumble=[[ @{armorFumbleDie} + [[@{fumbleCheck}]] + [[@{fumbleLuckyRoll}]] ]]}}" >Shield Bash</button>
+				                        value="&{template:DccTabbed} {{background=[[0]]}} {{combat=1}} {{name=@{character_name}}} {{title=Dwarven Shield Bash}} {{attack=[[ @{shieldBashDie} [To Hit Roll] + (?{Deed/Smite Die roll|0}) [Deed/Smite] + @{shieldBashAtk} ]]}} {{damage=[[ @{shieldBashDmgDie} [Base damage] + (?{Deed/Smite Die roll|0}) [Deed/Smite Die] + @{shieldBashDmg} ]]}} {{fumble=[[ @{armorFumbleDie} + [[@{fumbleCheck}]] + [[@{fumbleLuckyRoll}]] ]]}}" >Shield Bash</button>
 				                    </div>
 
 								</div>


### PR DESCRIPTION
## Changes / Comments

Remove critical hits from Dwarven shield bash.

The current code is broken. `critThreat` does not exist as an attribute.

Per the rulebook, a d14 scoring a critical hit is never mentioned, so I don't see that this is needed.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?

- [ ] Does this add functional enhancements (new features or extending existing features) ?
No

- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
No

- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
Not necessary

- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?
Not necessary
