### PR TITLE
[Shadowrun 5th] Fixed the sample macros

### DIFF
--- a/Shadowrun5thEdition/README.md
+++ b/Shadowrun5thEdition/README.md
@@ -258,3 +258,6 @@ The built in sheet buttons do not cover all of the rolls in Shadowrun 5e by a lo
 * **Primary Range**. This macro requires you to have selected a Primary weapon in your Arms tab.
 
 ```@{gm_toggle} &{template:rolls}{{header=@{primary_range_weapon}}}{{base=Base}}{{mod=[[@{modifiers_toggle}]]}}{{wound=[[@{wounds_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{dice=[[((@{primary_range_weapon_skill}+@{primary_range_weapon_dicepool})+@{agility}+@{wounds_toggle}+@{modifiers_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}{{desc=Mode @{primary_range_weapon_mode}, ACC @{primary_range_weapon_acc}, DV @{primary_range_weapon_damage}, AP @{primary_range_weapon_ap}}}```
+
+* **Primary Melee**. This macro requires you to have selected a Primary (melee) weapon in your Arms tab.
+```@{gm_toggle} &{template:rolls}{{header=@{primary_melee_weapon}}}{{base=Base}}{{mod=[[@{modifiers_toggle}]]}}{{wound=[[@{wounds_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{dice=[[((@{primary_melee_weapon_skill}+@{primary_melee_weapon_dicepool})+@{agility}+@{wounds_toggle}+@{modifiers_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}{{desc=ACC @{primary_melee_weapon_acc}, DV @{primary_melee_weapon_damage}, AP @{primary_melee_weapon_ap}}}```

--- a/Shadowrun5thEdition/README.md
+++ b/Shadowrun5thEdition/README.md
@@ -240,21 +240,21 @@ The built in sheet buttons do not cover all of the rolls in Shadowrun 5e by a lo
 
 * **Drain**. This is a sample for a Drain macro. You'll want to replace Logic with your appropriate attribute such as @{intuition}, @{magic}, @{charisma} ...
 
-```@{gm_toggle} &{template:rolls}{{header=Drain}}{{base=Base}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}@{modifier_toggle}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{willpower}+@{logic}+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}```
+```@{gm_toggle} &{template:rolls}{{header=Drain}}{{base=Base}}{{mod=[[@{modifiers_toggle}]]}}{{wound=[[@{wounds_toggle}]]}}@{modifiers_toggle}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{willpower}+@{logic}+@{wounds_toggle}+@{modifiers_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}```
 
 * **Defense**
 
-```@{gm_toggle} &{template:rolls}{{header=Defense}}{{base=Base}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{defense}+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}```
+```@{gm_toggle} &{template:rolls}{{header=Defense}}{{base=Base}}{{mod=[[@{modifiers_toggle}]]}}{{wound=[[@{wounds_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{defense}+@{wounds_toggle}+@{modifiers_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}```
 
 
 * **Initiative**
 
-```@{gm_toggle} &{template:rolls}{{header=Initiative}}{{base=Base}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{initiative_mod}+@{wound_toggle}+@{modifier_toggle})+(@{initiative_dice})d6cf0 &{tracker}]]}}```
+```@{gm_toggle} &{template:rolls}{{header=Initiative}}{{base=Base}}{{mod=[[@{modifiers_toggle}]]}}{{wound=[[@{wounds_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{initiative_mod}+@{wounds_toggle}+@{modifiers_toggle})+(@{initiative_dice})d6cf0 &{tracker}]]}}```
 
 * **Soak** 
 
-```@{gm_toggle} &{template:rolls}{{header=Soak}}{{base=Base}}{{mod=[[@{modifier_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{soak}+@{modifier_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}```
+```@{gm_toggle} &{template:rolls}{{header=Soak}}{{base=Base}}{{mod=[[@{modifiers_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{dice=[[(@{soak}+@{modifiers_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}```
 
 * **Primary Range**. This macro requires you to have selected a Primary weapon in your Arms tab.
 
-```@{gm_toggle} &{template:rolls}{{header=@{primary_range_weapon}}}{{base=Base}}{{mod=[[@{modifier_toggle}]]}}{{wound=[[@{wound_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{dice=[[((@{primary_range_weapon_skill}+@{primary_range_weapon_dicepool})+@{agility}+@{wound_toggle}+@{modifier_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}{{desc=Mode @{primary_range_weapon_mode}, ACC @{primary_range_weapon_acc}, DV @{primary_range_weapon_damage}, AP @{primary_range_weapon_ap}}}```
+```@{gm_toggle} &{template:rolls}{{header=@{primary_range_weapon}}}{{base=Base}}{{mod=[[@{modifiers_toggle}]]}}{{wound=[[@{wounds_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{dice=[[((@{primary_range_weapon_skill}+@{primary_range_weapon_dicepool})+@{agility}+@{wounds_toggle}+@{modifiers_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}{{desc=Mode @{primary_range_weapon_mode}, ACC @{primary_range_weapon_acc}, DV @{primary_range_weapon_damage}, AP @{primary_range_weapon_ap}}}```


### PR DESCRIPTION
Macros were using modifier_toggle and wound_toggle instead of modifiers_toggle and wounds_toggle, causing them to cause an error on roll

## Changes / Comments






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
