### PR TITLE
[Das_schwarze_Auge_5] - Wound treshold corrected

### DIFF
--- a/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_5/dsa5_character_sheet_roll20.html
@@ -6769,7 +6769,7 @@
 						<span data-i18n="LE"> LE</span><input type="number" name="attr_LE_Wert" style='width: 3em' value="@{LE_Wert}" />
 					</th>
 					<th>
-						<span data-i18n="WS"> WS</span><input type="number" name="attr_WS_Kampf" style='width: 3em' value="round(@{KO_Wert}/2)" disabled="true" />
+					<span data-i18n="WS"> WS</span><input type="number" name="attr_WS_Kampf" style='width: 3em' value="round(@{KO_Wert}/2) + @{vorteil_eisern} - @{nachteil_glaesern}" disabled="true" />
 					</th>
 					<th>
 						<span data-i18n="Schips"> Schips</span><input type="number" name="attr_Schicksal_Wert" style='width: 3em' />


### PR DESCRIPTION
## Changes / Comments
Small Bugfix. Would Treshold on Fighting-Site was wrong. Corrected it to show the same values as on the main stats page.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
