### PR TITLE
[Ironsworn] [Fix] Added Missing Endure Stress Oracle

### DIFF
--- a/Ironsworn/Ironsworn.html
+++ b/Ironsworn/Ironsworn.html
@@ -11443,7 +11443,7 @@
                     <div class="sheet-button-container">
                         <button type="roll" id="siteNamePlaceOracleRoll" title="Site Name: Place"
                             name="rollsiteNamePlaceoracle"
-                            value="&{template:ironsworndelveoracles} {{header=siteNamePlace}} {{siteNamePlace=[[d100]]}}"></button>
+                            value="&{template:ironsworndelveoracles} {{header=Site Name: Place}} {{siteNamePlace=[[d100]]}}"></button>
                     </div>
                     <label class="sheet-oracle-show" for="siteNamePlaceOracle">Place</label>
                 </div>
@@ -18340,6 +18340,25 @@
             </td>
         </tr>
         {{/endureHarm}}
+        {{#endureStress}}
+        <tr>
+            <td class="sheet-oracle-dice"><span>{{endureStress}}</span></td>
+            <td class="sheet-oracle-table-text">
+                {{#rollBetween() endureStress 1 10}}
+                <span>You are overwhelmed. <em>Face Desolation.</em></span>
+                {{/rollBetween() endureStress 1 10}}
+                {{#rollBetween() endureStress 11 25}}
+                <span>You give up. <em>Forsake Your Vow</em> (if possible, one relevant to your current crisis).</span>
+                {{/rollBetween() endureStress 11 25}}
+                {{#rollBetween() endureStress 26 50}}
+                <span>You give in to a fear or compulsion, and act against your better instincts.</span>
+                {{/rollBetween() endureStress 26 50}}
+                {{#rollBetween() endureStress 51 100}}
+                <span>You persevere.</span>
+                {{/rollBetween() endureStress 51 100}}
+            </td>
+        </tr>
+        {{/endureStress}}
     </table>
 </rolltemplate>
 


### PR DESCRIPTION
## Changes / Comments
### Current Behaviour:
<img width="262" alt="Screenshot 2020-04-27 at 12 49 35" src="https://user-images.githubusercontent.com/19798820/80369155-b52eea00-8885-11ea-9b47-16fea2e89e22.png">

The endure stress oracle roll template had been missed when implementing the oracles. This now works as expected.

### New Behaviour
<img width="258" alt="Screenshot 2020-04-27 at 12 48 44" src="https://user-images.githubusercontent.com/19798820/80369205-cd9f0480-8885-11ea-99cc-2ef6823479fe.png">

### Minor Fixes
- Fixed the Site Name oracle header to no longer be camel-case.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
