### PR TITLE
[Old-School Essentials - AAC] Fix encounter movement rate and missing weaponDescription

### DIFF
--- a/Old School Essentials - AAC/OSE-AAC.css
+++ b/Old School Essentials - AAC/OSE-AAC.css
@@ -140,7 +140,11 @@ input[type="number"] {
 .charsheet input[type="text"].sheet-input-as-number,
 .charsheet input[type="number"] {
   text-align: center;
-  width: 3.5rem;
+  width: 3.5em;
+}
+
+.charsheet input[type="text"].sheet-double {
+  width: 7em;
 }
 
 /* Remove input number arrows*/
@@ -565,7 +569,7 @@ input[name="attr_armor_class_method"][value="aac"] ~ .sheet-dac-only {
   margin-left: 10px;
   box-sizing: border-box;
   border: 1px solid #333;
-  line-height: 3.5rem;
+  line-height: 3.5em;
   padding: 0 15px;
   margin-bottom: -1px;
 }

--- a/Old School Essentials - AAC/OSE-AAC.css
+++ b/Old School Essentials - AAC/OSE-AAC.css
@@ -493,7 +493,7 @@ input[name="attr_armor_class_method"][value="aac"] ~ .sheet-dac-only {
 }
 
 .sheet-weapons-grid {
-  grid-template-columns: 35px 3.5fr 1fr 1fr 1fr 1fr 1fr;
+  grid-template-columns: 35px 2.5fr 1fr 1fr 1fr 1fr 1fr 1fr;
 }
 
 .sheet-abilities-grid {

--- a/Old School Essentials - AAC/OSE-AAC.html
+++ b/Old School Essentials - AAC/OSE-AAC.html
@@ -285,7 +285,7 @@
             <tr>
               <td>
                 <input disabled type="number" name="attr_movementEncounter" data-i18n-title="movement-encounter"
-                  title="Movement - Encounter" value="floor(@{movementExploration}/4)" />
+                  title="Movement - Encounter" value="floor(@{movementExploration}/3)" />
               </td>
               <td>
                 <input type="number" name="attr_movementExploration" data-i18n-title="movement-exploration"
@@ -539,7 +539,7 @@
           <tbody>
             <tr>
               <td>
-                <input disabled type="number" name="attr_movementEncounter" value="floor(@{movementExploration}/4)" />
+                <input disabled type="number" name="attr_movementEncounter" value="floor(@{movementExploration}/3)" />
               </td>
               <td>
                 <input type="number" name="attr_movementExploration" value="120" />

--- a/Old School Essentials - AAC/OSE-AAC.html
+++ b/Old School Essentials - AAC/OSE-AAC.html
@@ -335,7 +335,7 @@
           <option selected value="[[@{BonusSTR}]]">Strength</option>
           <option value="[[@{BonusDEX}]]">Dexterity</option>
         </select>
-        <input type="number" name="attr_weaponAttackBonus" value="0">
+        <input type="number" name="attr_weaponAttackBonus" value="0" />
         <select name="attr_weaponDamageDie" class="half-input">
           <option value="d4">d4</option>
           <option selected value="d6">d6</option>
@@ -344,8 +344,9 @@
           <option value="d12">d12</option>
         </select>
         <input type="number" name="attr_weaponDamageBonus" value="0" />
-        <input type="number" name="attr_weaponWeight" placeholder="100">
+        <input type="number" name="attr_weaponWeight" placeholder="100" />
       </div>
+      <input type="hidden" name="attr_weaponDescription" value="" />
     </fieldset>
   </div>
 

--- a/Old School Essentials - AAC/OSE-AAC.html
+++ b/Old School Essentials - AAC/OSE-AAC.html
@@ -42,7 +42,7 @@
           <input type="text" name="attr_title" data-i18n-placeholder="title" placeholder="Title" />
         </label>
       </div>
-      <div class="flex">
+      <div class="flex roll">
         <label class="inline-flex">
           <span data-i18n="experience-abbr">XP</span>
           <input type="number" name="attr_XP" value="0" />
@@ -57,12 +57,11 @@
           <input type="number" name="attr_ExpPercentage" value="0" />
         </label>
         <label class="inline-flex">
-          <span data-i18n="hit-dice-abbr">HD</span>
-          <input readonly type="number" name="attr_hitdice" value="0" />
-        </label>
-        <label class="inline-flex">
-          <span>±</span>
-          <input type="number" name="attr_HPMod" value="0" title="HP Modifier" data-i18n-title="hitdice-modifier" />
+          <button type="roll" data-i18n="hit-dice-abbr" title="Hit Dice" data-i18n-title="hit-dice"
+            value="&{template:simple} {{roll=HP for @{character_name}}} {{result=[[@{hitdice}+[[@{HPConMod}*{@{level}, 9}kl1]]]]}}">HD</button>
+          <input type="text" name="attr_hitdice" value="0" placeholder="9d6+2" class="input-as-number double" />
+          <span data-i18n="constitution-abbr-mod">± CON</span>
+          <input readonly type="number" name="attr_HPConMod" value="0" />
         </label>
       </div>
     </div>
@@ -250,10 +249,6 @@
           <label class="inline-flex">
             <span data-i18n="max">Max</span>
             <input type="number" name="attr_HP_max" value="0" />
-          </label>
-          <label class="inline-flex">
-            <span data-i18n="constitution-abbr-mod">± CON</span>
-            <input readonly type="number" name="attr_HPConMod" value="0" />
           </label>
         </div>
         <div class="flex hp">
@@ -977,12 +972,6 @@
           });
         };
      });
-  });
-
-  on("change:level", function() {
-    getAttrs(["level", "hitdice"], function(values) {
-      setAttrs({ hitdice: Math.min(9, values.level) });
-    });
   });
 
   on('sheet:opened change:repeating_armor remove:repeating_armor', function() {

--- a/Old School Essentials - AAC/OSE-AAC.html
+++ b/Old School Essentials - AAC/OSE-AAC.html
@@ -321,6 +321,7 @@
       <span></span>
       <span data-i18n="name">Name</span>
       <span data-i18n="attribute">Attribute</span>
+      <span data-i18n="typeofattack">Type of Attack</span>
       <span data-i18n="attack-modifier">+Attack</span>
       <span data-i18n="damage-die">Damage Die</span>
       <span data-i18n="damage-modifier">+Damage</span>
@@ -329,11 +330,15 @@
     <fieldset class="repeating_weapons">
       <div class="weapons-grid">
         <button type="roll" name="attr_weaponAttack"
-          value="&{template:simple} {{roll=Attack with @{weaponName}}} {{attack=[[1d20+@{weaponAttributeBonus}+@{weaponAttackBonus}+@{modquery}]]}} {{damage=[[{[[@{weaponDamageDie}+@{weaponDamageBonus}+@{weaponAttributeBonus}]], 1}kh1]]}}"></button>
+          value="&{template:simple} {{roll=Attack with @{weaponName}}} {{attack=[[1d20+@{weaponAttributeBonus}+@{weaponAttackBonus}+@{modquery}]]}} {{damage=[[{[[@{weaponDamageDie}+@{weaponDamageBonus}+@{weaponAttributeBonusDamage}]], 1}kh1]]}}"></button>
         <input type="text" name="attr_weaponName" placeholder="Weapon" />
         <select name="attr_weaponAttributeBonus">
           <option selected value="[[@{BonusSTR}]]">Strength</option>
           <option value="[[@{BonusDEX}]]">Dexterity</option>
+        </select>
+        <select name="attr_weaponAttributeBonusDamage">
+          <option selected value="[[@{BonusSTR}]]">Melee</option>
+          <option value="0">Ranged</option>
         </select>
         <input type="number" name="attr_weaponAttackBonus" value="0" />
         <select name="attr_weaponDamageDie" class="half-input">

--- a/Old School Essentials - AAC/translation.json
+++ b/Old School Essentials - AAC/translation.json
@@ -58,7 +58,7 @@
   "silver-piece-sp-u": "SP",
   "copper-piece-cp-u": "CP",
   "encumbrance": "Encumbrance",
-  "typeofattack": "Type of attack",
+  "typeofattack": "Type of Attack",
   "melee": "Melee",
   "missile": "Missile",
   "modifier": "Threshold modifier",


### PR DESCRIPTION
## Changes / Comments

- Encounter movement rate should be exploration * 1/3, not 1/4
- Missing `weaponDescription` caused error in Character tab
- Add "Type of Attack" to weapon table to only add DEX bonus to attack and not damage
- Change hit point and HD fields for characters to be more flexible and roll using a button

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [X] Does this add functional enhancements (new features or extending existing features) ?
- ~~Does this add or change functional aesthetics (such as layout or color scheme) ?~~
- ~~If changing or removing attributes, what steps have you taken, if any, to preserve player data?~~
- ~~If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?~~

If you do not know English. Please leave a comment in your native language.
