### PR TITLE
[Ironsworn] Removed Shadow-kin Option from Swear an Iron Vow

### DIFF
--- a/Ironsworn/Ironsworn.html
+++ b/Ironsworn/Ironsworn.html
@@ -8008,7 +8008,7 @@
                 <div class="sheet-move">
                     <div class="sheet-button-container">
                         <button type="roll" title="Swear an Iron Vow Move" name="rollSwearVowMove"
-                            value="&{template:ironsworn} {{header=@{character_name}}} {{name=Swear an Iron Vow}} {{action=[[1d6+?{Stat|Heart&#44;@{heart}|Shadow - Shadow-kin&#44;@{shadow}|God's Stat - Devotant&#44;?{God's Stat&amp;#124;0&amp;#125;&#125;+(?{Modifier&#124;0&#125;)]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}}  {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}} {{fake_roll=[[0-(@{momentum})]]}} {{momentum_cancel=[[(?{Stat}+(?{Modifier|0}))-(@{momentum})]]}}"></button>
+                            value="&{template:ironsworn} {{header=@{character_name}}} {{name=Swear an Iron Vow}} {{action=[[1d6+?{Stat|Heart&#44;@{heart}|God's Stat - Devotant&#44;?{God's Stat&amp;#124;0&amp;#125;&#125;+(?{Modifier&#124;0&#125;)]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}}  {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}} {{fake_roll=[[0-(@{momentum})]]}} {{momentum_cancel=[[(?{Stat}+(?{Modifier|0}))-(@{momentum})]]}}"></button>
                     </div>
                     <label class="sheet-move-show" for="swearVowMove">Swear an Iron Vow</label>
                 </div>


### PR DESCRIPTION
## Changes / Comments
There was a drop-down option for Shadow-Kin included in the Swear an Iron Vow Move roll query. This was accidently added and should be removed.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
