### PR TITLE
[Supers RED] v1.2 url fix + Request to correct Sheet Category in dropdown

### DIFF
--- a/Supers-Revised-Edition/supers-revised.css
+++ b/Supers-Revised-Edition/supers-revised.css
@@ -164,7 +164,7 @@ div.sheet-name h6{
 
 div.sheet-logo{
   grid-area: logo;
-  background-image: url(https://raw.githubusercontent.com/Anduh/roll20-character-sheets/Supers-RED-v1-00/Supers-Revised-Edition/images/logo.png);
+  background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/Supers-RED-v1-00/Supers-Revised-Edition/images/logo.png);
   background-size: 344px 150px;
   background-repeat: no-repeat;
   background-position: center;
@@ -267,7 +267,7 @@ div.sheet-tracker{
 }
 
 div.sheet-def-tracker{
-  background-image: url(https://raw.githubusercontent.com/Anduh/roll20-character-sheets/Supers-RED-v1-00/Supers-Revised-Edition/images/Original-Tracker.png);
+  background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/Supers-RED-v1-00/Supers-Revised-Edition/images/Original-Tracker.png);
   background-size: 490px 180px;
   background-repeat: no-repeat;
   height: 180px;
@@ -275,7 +275,7 @@ div.sheet-def-tracker{
 }
 
 div.sheet-alt-tracker{
-  background-image: url(https://raw.githubusercontent.com/Anduh/roll20-character-sheets/Supers-RED-v1-00/Supers-Revised-Edition/images/alternate-tracker.png);
+  background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/Supers-RED-v1-00/Supers-Revised-Edition/images/alternate-tracker.png);
   background-size: 490px 180px;
   background-repeat: no-repeat;
   height: 180px;

--- a/Supers-Revised-Edition/supers-revised.html
+++ b/Supers-Revised-Edition/supers-revised.html
@@ -12,7 +12,7 @@
 
     <!-- logo -->
     <div class="section logo">
-        <span>Sheet Version 1.1</span>
+        <span>Sheet Version 1.2</span>
     </div>
 
     <!-- resistances -->


### PR DESCRIPTION
## Changes / Comments
- change img urls to point to Roll20's repo 
- The sheet is incorrectly categorized under "GURPS". The game is standalone and have no conection to GURPS, and should be in a category by itself under the games own name.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
