### PR TITLE
ADnD1e update

### DIFF
--- a/ADnD_1E/1ESheet.css
+++ b/ADnD_1E/1ESheet.css
@@ -191,6 +191,13 @@ textarea.sheet-macro-text {width:5.5em; resize:vertical; height:1.3em; overflow:
 	text-shadow: -1px -1px 0 #000,  1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
 }
 
+.sheet-rolltemplate-general .sheet-text {
+	padding:2px;
+	line-height:1em;
+	vertical-align:top;
+	text-align:left;
+}
+
 .sheet-rolltemplate-attacks.sheet-color-white th,
 .sheet-rolltemplate-attacks.sheet-color-white .sheet-subheader,
 .sheet-rolltemplate-general.sheet-color-white th,

--- a/ADnD_1E/1ESheet.html
+++ b/ADnD_1E/1ESheet.html
@@ -126,9 +126,9 @@
 						<td><input type="text" class="sheet-input-small" name="attr_DmgBonus" title="@{DmgBonus}" value="0" /></td>
 						<td class="sheet-right">Encumbrance:</td>
 						<td><input type="text" class="sheet-input-small" name="attr_EncumbranceBonus" title="@{EncumbranceBonus}" value="0" /></td>
-						<td class="sheet-right"><button class="sheet-button" type="roll" name="attr_MinorStrengthFeat-roll" title="%{selected|MinorStrengthFeat-roll}" value="&{template:general} {{name=@{character_name}}} {{subtag=Minor Strength Feat}} {{1d6 Roll=[[1d6cs<@{MinorStrengthFeat}cf>@{MinorStrengthFeat}]] }}" >&nbsp;Open Doors</button></td>
+						<td class="sheet-right"><button class="sheet-button" type="roll" name="attr_MinorStrengthFeat-roll" title="%{selected|MinorStrengthFeat-roll}" value="&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Minor Strength Feat}} {{1d6 Roll=[[1d6cs<@{MinorStrengthFeat}cf>@{MinorStrengthFeat}]] }}" >&nbsp;Open Doors</button></td>
 						<td><input type="text" class="sheet-input-small" name="attr_MinorStrengthFeat" title="@{MinorStrengthFeat}" value="0" /></td>
-						<td class="sheet-right"><button class="sheet-button" type="roll" name="attr_MajorStrengthFeat-roll" title="%{selected|MajorStrengthFeat-roll}" value="&{template:general} {{name=@{character_name}}} {{subtag=Major Strength Feat}} {{ Major STR Feat=[[1d100cs<@{MajorStrengthFeat}cf>@{MajorStrengthFeat} ]] %}}" >&nbsp;Bend Bars</button></td>
+						<td class="sheet-right"><button class="sheet-button" type="roll" name="attr_MajorStrengthFeat-roll" title="%{selected|MajorStrengthFeat-roll}" value="&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Major Strength Feat}} {{ Major STR Feat=[[1d100cs<@{MajorStrengthFeat}cf>@{MajorStrengthFeat} ]] %}}" >&nbsp;Bend Bars</button></td>
 						<td><input type="text" class="sheet-input-small" name="attr_MajorStrengthFeat" title="@{MajorStrengthFeat}" value="0" /></td>
 					</tr>
 					<tr>
@@ -137,7 +137,7 @@
 						(<input type="text" name="attr_ExceptionalIntelligence" title="@{ExceptionalIntelligence}" value="0" min="0" max="100" style="width:2.5em;">)</td>
 						<td class="sheet-right">Add. Lang:</td>
 						<td><input type="text" class="sheet-input-small" name="attr_BonusLanguages" title="@{BonusLanguages}" value="0" /></td>
-						<td class="sheet-right"><button class="sheet-button" type="roll" name="attr_KnowSpell-roll" title="%{selected|KnowSpell-roll}"value="&{template:general} {{name=@{character_name}}} {{subtag=Chance to Know Spell}} {{Roll=[[1d100cs>@{KnowSpell}cf<@{KnowSpell}]] %}}" >&nbsp;Know Spell</button></td>
+						<td class="sheet-right"><button class="sheet-button" type="roll" name="attr_KnowSpell-roll" title="%{selected|KnowSpell-roll}"value="&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Chance to Know Spell}} {{Roll=[[1d100cs>@{KnowSpell}cf<@{KnowSpell}]] %}}" >&nbsp;Know Spell</button></td>
 						<td><input type="text" class="sheet-input-small" name="attr_KnowSpell" title="@{KnowSpell}" value="0" /></td>
 						<td class="sheet-right">Min Spells:</td>
 						<td><input type="text" class="sheet-input-small" name="attr_minSpells" title="@{minSpells}" value="0" /></td>
@@ -150,11 +150,11 @@
 						<td class="sheet-center"><span class="sheet-text-large">WIS</span></td>
 						<td><input type="text" class="sheet-input-small" name="attr_Wisdom" title="@{Wisdom}" value="10" />
 						(<input type="text" name="attr_ExceptionalWisdom" title="@{ExceptionalWisdom}" value="0" min="0" max="100" style="width:2.5em;">)</td>
-						<td class="sheet-right"><button class="sheet-button" type="roll" name="attr_MentalSave-roll" title="%{selected|MentalSave-roll}"value="&{template:general} {{name=@{character_name}}} {{subtag=Mental Save}} {{Roll=[[1d20cs>@{MentalSaveBonus}cf<@{MentalSaveBonus}]]}}" >&nbsp;Mental Save</button></td>
+						<td class="sheet-right"><button class="sheet-button" type="roll" name="attr_MentalSave-roll" title="%{selected|MentalSave-roll}"value="&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Mental Save}} {{Roll=[[1d20cs>@{MentalSaveBonus}cf<@{MentalSaveBonus}]]}}" >&nbsp;Mental Save</button></td>
 						<td><input type="text" class="sheet-input-small" name="attr_MentalSaveBonus" title="@{MentalSaveBonus}" value="0" /></td>
 						<td class="sheet-right">Spell Bonus:</td>
 						<td><input type="text" class="sheet-input-small" name="attr_SpellBonus" title="@{SpellBonus}" value="0" /></td>
-						<td class="sheet-right"><button class="sheet-button" type="roll" name="attr_SpellFailure-roll" title="%{selected|SpellFailure-roll}"value="&{template:general} {{name=@{character_name}}} {{subtag=Chance of Spell Failure}} {{Roll=[[1d100cs>@{SpellFailure}cf<@{SpellFailure}]] %}}" >&nbsp;Spell Fail</button></td>
+						<td class="sheet-right"><button class="sheet-button" type="roll" name="attr_SpellFailure-roll" title="%{selected|SpellFailure-roll}"value="&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Chance of Spell Failure}} {{Roll=[[1d100cs>@{SpellFailure}cf<@{SpellFailure}]] %}}" >&nbsp;Spell Fail</button></td>
 						<td><input type="text" class="sheet-input-small" name="attr_SpellFailure" title="@{SpellFailure}" value="0" /></td>
 						<td></td>
 						<td></td>
@@ -165,13 +165,13 @@
 						<td class="sheet-center"><span class="sheet-text-large">DEX</span></td>
 						<td><input type="text" class="sheet-input-small" name="attr_Dexterity" title="@{Dexterity}" value="10" />
 						(<input type="text" name="attr_ExceptionalDexterity" title="@{ExceptionalDexterity}" value="0" min="0" max="100" style="width:2.5em;">)</td>
-						<td class="sheet-right"><button class="sheet-button" type="roll" name="attr_surprise-roll" title="%{selected|surprise-roll}" value="&{template:general} {{name=@{character_name}}} {{subtag=Surprise}} {{Roll=[[ 1d6 + @{SurpriseBonus}[BON] + ?{Modifier?|0}[MOD] ]]}}" >&nbsp;Surprise</button></td>
+						<td class="sheet-right"><button class="sheet-button" type="roll" name="attr_surprise-roll" title="%{selected|surprise-roll}" value="&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Surprise}} {{Roll=[[ 1d6 + @{SurpriseBonus}[BON] + ?{Modifier?|0}[MOD] ]]}}" >&nbsp;Surprise</button></td>
 						<td><input type="text" class="sheet-input-small" name="attr_SurpriseBonus" title="@{SurpriseBonus}" value="0" /></td>
 						<td class="sheet-right">Missile Hit:</td>
 						<td><input type="text" class="sheet-input-small" name="attr_RangedBonus" title="@{RangedBonus}" value="0" /></td>
 						<td class="sheet-right">AC Bonus:</td>
 						<td><input type="text" class="sheet-input-small" name="attr_ArmorBonus" title="@{ArmorBonus}" value="0" /></td>
-						<td class="sheet-right"><button class="sheet-button" style="margin-right:-50px;" type="roll" name="attr_init-roll" title="%{selected|init-roll}" value="&{template:general} {{name=@{character_name}}} {{subtag=Initiative!}} {{Roll=[[ 1d6 + @{SurpriseBonus}[BON] + ?{Modifier?|0}[MOD] ]]}}" >&nbsp;INITIATIVE</button></td>
+						<td class="sheet-right"><button class="sheet-button" style="margin-right:-50px;" type="roll" name="attr_init-roll" title="%{selected|init-roll}" value="&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Initiative!}} {{Roll=[[ 1d6 + @{SurpriseBonus}[BON] + ?{Modifier?|0}[MOD] ]]}}" >&nbsp;INITIATIVE</button></td>
 						<td></td>
 						<td></td>
 						<td></td>							
@@ -182,9 +182,9 @@
 						(<input type="text" name="attr_ExceptionalConstitution" title="@{ExceptionalConstitution}" value="0" min="0" max="100" style="width:2.5em;">)</td>
 						<td class="sheet-right">HP Bonus:</td>
 						<td><input type="text" class="sheet-input-small" name="attr_HitPointBonus" title="@{HitPointBonus}" value="0" /></td>
-						<td class="sheet-right"><button class="sheet-button" type="roll" name="attr_SystemShock-roll" title="%{selected|SystemShock-roll}" value="&{template:general} {{name=@{character_name}}} {{subtag=System Shock Survival}} {{ Roll=[[1d100cs<@{SystemShock}cf>@{SystemShock} ]] %}}" >&nbsp;Sys Shock</button></td>
+						<td class="sheet-right"><button class="sheet-button" type="roll" name="attr_SystemShock-roll" title="%{selected|SystemShock-roll}" value="&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=System Shock Survival}} {{ Roll=[[1d100cs<@{SystemShock}cf>@{SystemShock} ]] %}}" >&nbsp;Sys Shock</button></td>
 						<td><input type="text" class="sheet-input-small" name="attr_SystemShock" title="@{SystemShock}" value="0" /></td>
-						<td class="sheet-right"><button class="sheet-button" type="roll" name="attr_ResurrectionSurvival-roll" title="%{selected|ResurrectionSurvival-roll}" value="&{template:general} {{name=@{character_name}}} {{subtag=Resurrection Survival}} {{Roll=[[ 1d100cs<@{ResurrectionSurvival}cf>@{ResurrectionSurvival} ]] %}}" >&nbsp;Res Survive</button></td>
+						<td class="sheet-right"><button class="sheet-button" type="roll" name="attr_ResurrectionSurvival-roll" title="%{selected|ResurrectionSurvival-roll}" value="&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Resurrection Survival}} {{Roll=[[ 1d100cs<@{ResurrectionSurvival}cf>@{ResurrectionSurvival} ]] %}}" >&nbsp;Res Survive</button></td>
 						<td><input type="text" class="sheet-input-small" name="attr_ResurrectionSurvival" title="@{ResurrectionSurvival}" value="0" /></td>
 						<td></td>
 						<td></td>
@@ -197,9 +197,9 @@
 						(<input type="text" name="attr_ExceptionalCharisma" title="@{ExceptionalCharisma}" value="0" min="0" max="100" style="width:2.5em;">)</td>
 						<td class="sheet-right">Max Hench:</td>
 						<td><input type="text" class="sheet-input-small" name="attr_MaximumHenchmen" title="@{MaximumHenchmen}" value="0" /></td>
-						<td class="sheet-right"><button class="sheet-button" type="roll" name="attr_Loyalty-roll" title="%{selected|Loyalty-roll}" value="&{template:general} {{name=@{character_name}}} {{subtag=Loyalty}} {{Roll=[[ 1d100 + @{LoyaltyBonus}[BON] ]] %}}" >&nbsp;Loyalty</button></td>
+						<td class="sheet-right"><button class="sheet-button" type="roll" name="attr_Loyalty-roll" title="%{selected|Loyalty-roll}" value="&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Loyalty}} {{Roll=[[ 1d100 + @{LoyaltyBonus}[BON] ]] %}}" >&nbsp;Loyalty</button></td>
 						<td><input type="text" class="sheet-input-small" name="attr_LoyaltyBonus" title="@{LoyaltyBonus}" value="0" /></td>
-						<td class="sheet-right"><button class="sheet-button" type="roll" name="attr_reaction-roll" title="%{selected|reaction-roll}" value="&{template:general} {{name=@{character_name}}} {{subtag=Reaction}} {{Roll=[[ 1d100 + @{ReactionBonus}[BON] ]] %}}" >&nbsp;React</button></td>
+						<td class="sheet-right"><button class="sheet-button" type="roll" name="attr_reaction-roll" title="%{selected|reaction-roll}" value="&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Reaction}} {{Roll=[[ 1d100 + @{ReactionBonus}[BON] ]] %}}" >&nbsp;React</button></td>
 						<td><input type="text" class="sheet-input-small" name="attr_ReactionBonus" title="@{ReactionBonus}" value="0" /></td>
 						<td></td>
 						<td></td>
@@ -257,11 +257,11 @@
 				<input type="checkbox" class="sheet-sect-show" title="@{saves-info-show}" name="attr_saves-info-show" value="1" style="opacity: 0;width: 90px;height: 20px; position: relative; top: 0; left: 0;margin: 0 -20px 0 -60px; cursor: pointer; z-index: 1" checked="checked" /><span></span>
 				<table class="sheet-sect sheet-center">
 					<tr>
-						<td colspan="2">Paralysis, Poison, and Death<br><button class="sheet-button" type="roll" value="/me must make a saving throw!&#x00A;&{template:general} {{name=@{character_name}}} {{subtag=Saving Throw}} {{Paralysis, Poison, Death=[[?{Mod?|0}+1d20cs>@{SaveParalysisPoisonDeath}cf<@{SaveParalysisPoisonDeath}]]}} {{Mod Applied=?{Mod?|0}}}" name="roll_SaveParalysisPoisonDeath" title="%{selected|SaveParalysisPoisonDeath}"> Roll</button><input type="text" class="sheet-input-small" name="attr_SaveParalysisPoisonDeath" title="@{SaveParalysisPoisonDeath}" value="0" /></td>
-						<td colspan="2">Petrification, Polymorph<br><button class="sheet-button" type="roll" value="/me must make a saving throw!&#x00A;&{template:general} {{name=@{character_name}}} {{subtag=Saving Throw}} {{Petrification, Polymorph=[[?{Mod?|0}+1d20cs>@{SavePetrificationPolymorph}cf<@{SavePetrificationPolymorph}]]}} {{Mod Applied=?{Mod?|0}}}" name="roll_SavePetrificationPolymorph" title="%{selected|SavePetrificationPolymorph}"> Roll</button><input type="text" class="sheet-input-small" name="attr_SavePetrificationPolymorph" title="@{SavePetrificationPolymorph}" value="0" /></td>
-						<td colspan="2">Rods, Staves, and Wands<br><button class="sheet-button" type="roll" value="/me must make a saving throw!&#x00A;&{template:general} {{name=@{character_name}}} {{subtag=Saving Throw}} {{Rods, Staves, Wands=[[?{Mod?|0}+1d20cs>@{SaveRodsStavesWands}cf<@{SaveRodsStavesWands}]]}} {{Mod Applied=?{Mod?|0}}}" name="roll_SaveRodsStavesWands" title="%{selected|SaveRodsStavesWands}"> Roll</button><input type="text" class="sheet-input-small" name="attr_SaveRodsStavesWands" title="@{SaveRodsStavesWands}" value="0" /></td>
-						<td colspan="2">Breath Weapon<br><button class="sheet-button" type="roll" value="/me must make a saving throw!&#x00A;&{template:general} {{name=@{character_name}}} {{subtag=Saving Throw}} {{Breath Weapons=[[?{Mod?|0}+1d20cs>@{SaveBreathWeapons}cf<@{SaveBreathWeapons}]]}} {{Mod Applied=?{Mod?|0}}}" name="roll_SaveBreathWeapons" title="%{selected|SaveBreathWeapons}"> Roll</button><input type="text" class="sheet-input-small" name="attr_SaveBreathWeapons" title="@{SaveBreathWeapons}" value="0" /></td>
-						<td colspan="2">Spells<br><button class="sheet-button" type="roll" value="/me must make a saving throw!&#x00A;&{template:general} {{name=@{character_name}}} {{subtag=Saving Throw}} {{Spells=[[?{Mod?|0}+1d20cs>@{SaveSpells}cf<@{SaveSpells}]]}} {{Mod Applied=?{Mod?|0}}}" name="roll_SaveSpells" title="%{selected|SaveSpells}"> Roll</button><input type="text" class="sheet-input-small" name="attr_SaveSpells" title="@{SaveSpells}" value="0" /></td>
+						<td colspan="2">Paralysis, Poison, and Death<br><button class="sheet-button" type="roll" value="/me must make a saving throw!&#x00A;&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Saving Throw}} {{Paralysis, Poison, Death=[[?{Mod?|0}+1d20cs>@{SaveParalysisPoisonDeath}cf<@{SaveParalysisPoisonDeath}]]}} {{Mod Applied=?{Mod?|0}}}" name="roll_SaveParalysisPoisonDeath" title="%{selected|SaveParalysisPoisonDeath}"> Roll</button><input type="text" class="sheet-input-small" name="attr_SaveParalysisPoisonDeath" title="@{SaveParalysisPoisonDeath}" value="0" /></td>
+						<td colspan="2">Petrification, Polymorph<br><button class="sheet-button" type="roll" value="/me must make a saving throw!&#x00A;&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Saving Throw}} {{Petrification, Polymorph=[[?{Mod?|0}+1d20cs>@{SavePetrificationPolymorph}cf<@{SavePetrificationPolymorph}]]}} {{Mod Applied=?{Mod?|0}}}" name="roll_SavePetrificationPolymorph" title="%{selected|SavePetrificationPolymorph}"> Roll</button><input type="text" class="sheet-input-small" name="attr_SavePetrificationPolymorph" title="@{SavePetrificationPolymorph}" value="0" /></td>
+						<td colspan="2">Rods, Staves, and Wands<br><button class="sheet-button" type="roll" value="/me must make a saving throw!&#x00A;&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Saving Throw}} {{Rods, Staves, Wands=[[?{Mod?|0}+1d20cs>@{SaveRodsStavesWands}cf<@{SaveRodsStavesWands}]]}} {{Mod Applied=?{Mod?|0}}}" name="roll_SaveRodsStavesWands" title="%{selected|SaveRodsStavesWands}"> Roll</button><input type="text" class="sheet-input-small" name="attr_SaveRodsStavesWands" title="@{SaveRodsStavesWands}" value="0" /></td>
+						<td colspan="2">Breath Weapon<br><button class="sheet-button" type="roll" value="/me must make a saving throw!&#x00A;&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Saving Throw}} {{Breath Weapons=[[?{Mod?|0}+1d20cs>@{SaveBreathWeapons}cf<@{SaveBreathWeapons}]]}} {{Mod Applied=?{Mod?|0}}}" name="roll_SaveBreathWeapons" title="%{selected|SaveBreathWeapons}"> Roll</button><input type="text" class="sheet-input-small" name="attr_SaveBreathWeapons" title="@{SaveBreathWeapons}" value="0" /></td>
+						<td colspan="2">Spells<br><button class="sheet-button" type="roll" value="/me must make a saving throw!&#x00A;&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Saving Throw}} {{Spells=[[?{Mod?|0}+1d20cs>@{SaveSpells}cf<@{SaveSpells}]]}} {{Mod Applied=?{Mod?|0}}}" name="roll_SaveSpells" title="%{selected|SaveSpells}"> Roll</button><input type="text" class="sheet-input-small" name="attr_SaveSpells" title="@{SaveSpells}" value="0" /></td>
 					</tr>
 				</table>	
 				<hr>
@@ -286,7 +286,7 @@
 										<option value="&nbsp;">no</option>
 									</select>
 								</td>
-								<td><textarea name="attr_macro-text" title="@{repeating_weapon_$X_macro-text}" class="sheet-macro-text" style="width:96%; margin:5px 0 0 0;">&{template:attacks} {{name=@{character_name}}} {{subtag=@{WeaponName}}} {{attack1=[[1d20 + @{ToHitBonus}[BON] + @{MagicBonus}[MAG] + ?{To Hit Modifier?|0}[MOD]) ]]}} {{damage1vsSM=[[@{DamageSmallMedium} + @{AttackDmgBonus}[BON] + @{MagicBonus}[MAG] + ?{Damage Modifier?|0}[MOD] ]]}} {{damage1vsL=[[@{DamageLarge} + @{AttackDmgBonus}[BON] + @{MagicBonus}[MAG] + ?{Damage Modifier?|0}[MOD] ]]}} {{WeaponNotes=@{WeaponNotes}}} @{whisper_to-hit}</textarea><br>Macro-Text</td>
+								<td><textarea name="attr_macro-text" title="@{repeating_weapon_$X_macro-text}" class="sheet-macro-text" style="width:96%; margin:5px 0 0 0;">&{template:attacks} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=@{WeaponName}}} {{attack1=[[1d20 + @{ToHitBonus}[BON] + @{MagicBonus}[MAG] + ?{To Hit Modifier?|0}[MOD]) ]]}} {{damage1vsSM=[[@{DamageSmallMedium} + @{AttackDmgBonus}[BON] + @{MagicBonus}[MAG] + ?{Damage Modifier?|0}[MOD] ]]}} {{damage1vsL=[[@{DamageLarge} + @{AttackDmgBonus}[BON] + @{MagicBonus}[MAG] + ?{Damage Modifier?|0}[MOD] ]]}} {{WeaponNotes=@{WeaponNotes}}} @{whisper_to-hit}</textarea><br>Macro-Text</td>
 							</tr>								
 							<tr>
 								<td><input type="text" class="sheet-input-small" name="attr_DamageSmallMedium" title="@{repeating_weapon_$X_DamageSmallMedium} e.g. '1d4'" value="0" /><br>DMG vs S/M</td>
@@ -378,32 +378,32 @@
 				<input type="checkbox" class="sheet-sect-show" title="@{thief_skills-info-show}" name="attr_thief_skills-info-show" value="1" style="opacity: 0;width: 135px;height: 20px;position: relative;top: 0;left: 0;margin: 0 -20px 0 -105px; cursor: pointer; z-index: 1" /><span></span>
 				<table class="sheet-sect">
 					<tr>
-						<td class="sheet-right"><button class="sheet-button" type="roll" name="roll_PickPockets" title="%{selected|PickPockets}" value="&{template:general} {{name=@{character_name}}} {{subtag=Ability Check}} {{Pick Pockets=[[1d100cs<@{PickPockets}cf>@{PickPockets}]] %}}"> Roll</button></td>
+						<td class="sheet-right"><button class="sheet-button" type="roll" name="roll_PickPockets" title="%{selected|PickPockets}" value="&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Ability Check}} {{Pick Pockets=[[1d100cs<@{PickPockets}cf>@{PickPockets}]] %}}"> Roll</button></td>
 						<td style="width: 47px;"><input type="text" name="attr_PickPockets" class="sheet-input-small" title="@{PickPockets}" value="0" /></td>
 						<td>Pick Pockets</td>
-						<td class="sheet-right"><button class="sheet-button" type="roll" name="roll_MoveQuietly" title="%{selected|MoveQuietly}" value="&{template:general} {{name=@{character_name}}} {{subtag=Ability Check}} {{Move Quietly=[[1d100cs<@{MoveQuietly}cf>@{MoveQuietly}]] %}}"> Roll</button></td>
+						<td class="sheet-right"><button class="sheet-button" type="roll" name="roll_MoveQuietly" title="%{selected|MoveQuietly}" value="&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Ability Check}} {{Move Quietly=[[1d100cs<@{MoveQuietly}cf>@{MoveQuietly}]] %}}"> Roll</button></td>
 						<td style="width: 47px;"><input type="text" name="attr_MoveQuietly" class="sheet-input-small" title="@{MoveQuietly}" value="0" /></td>
 						<td>Move Silently</td>
-						<td class="sheet-right"><button class="sheet-button" type="roll" name="roll_ClimbWalls" title="%{selected|ClimbWalls}" value="&{template:general} {{name=@{character_name}}} {{subtag=Ability Check}} {{Climb Walls=[[1d100cs<@{ClimbWalls}cf>@{ClimbWalls}]] %}}"> Roll</button></td>
+						<td class="sheet-right"><button class="sheet-button" type="roll" name="roll_ClimbWalls" title="%{selected|ClimbWalls}" value="&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Ability Check}} {{Climb Walls=[[1d100cs<@{ClimbWalls}cf>@{ClimbWalls}]] %}}"> Roll</button></td>
 						<td style="width: 47px;"><input type="text" name="attr_ClimbWalls" class="sheet-input-small" title="@{ClimbWalls}" value="0" /></td>
 						<td>Climb Walls</td>
 					</tr>
 					<tr>
-						<td class="sheet-right"><button class="sheet-button" type="roll" name="roll_OpenLocks" title="%{selected|OpenLocks}" value="&{template:general} {{name=@{character_name}}} {{subtag=Ability Check}} {{Open Locks=[[1d100cs<@{OpenLocks}cf>@{OpenLocks}]] %}}"> Roll</button></td>
+						<td class="sheet-right"><button class="sheet-button" type="roll" name="roll_OpenLocks" title="%{selected|OpenLocks}" value="&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Ability Check}} {{Open Locks=[[1d100cs<@{OpenLocks}cf>@{OpenLocks}]] %}}"> Roll</button></td>
 						<td><input type="text" name="attr_OpenLocks" class="sheet-input-small" title="@{OpenLocks}" value="0" /></td>
 						<td>Open Locks</td>
-						<td class="sheet-right"><button class="sheet-button" type="roll" name="roll_HideInShadows" title="%{selected|HideInShadows}" value="&{template:general} {{name=@{character_name}}} {{subtag=Ability Check}} {{Hide In Shadows=[[1d100cs<@{HideInShadows}cf>@{HideInShadows}]] %}}"> Roll</button></td>
+						<td class="sheet-right"><button class="sheet-button" type="roll" name="roll_HideInShadows" title="%{selected|HideInShadows}" value="&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Ability Check}} {{Hide In Shadows=[[1d100cs<@{HideInShadows}cf>@{HideInShadows}]] %}}"> Roll</button></td>
 						<td><input type="text" name="attr_HideInShadows" class="sheet-input-small" title="@{HideInShadows}" value="0" /></td>
 						<td>Hide In Shadows</td>
-						<td class="sheet-right"><button class="sheet-button" type="roll" name="roll_ReadLanguages" title="%{selected|ReadLanguages}" value="&{template:general} {{name=@{character_name}}} {{subtag=Ability Check}} {{Read Languages=[[1d100cs<@{ReadLanguages}cf>@{ReadLanguages}]] %}}"> Roll</button></td>
+						<td class="sheet-right"><button class="sheet-button" type="roll" name="roll_ReadLanguages" title="%{selected|ReadLanguages}" value="&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Ability Check}} {{Read Languages=[[1d100cs<@{ReadLanguages}cf>@{ReadLanguages}]] %}}"> Roll</button></td>
 						<td><input type="text" name="attr_ReadLanguages" class="sheet-input-small" title="@{ReadLanguages}" value="0" /></td>
 						<td>Read Languages</td>
 					</tr>
 					<tr>
-						<td class="sheet-right"><button class="sheet-button" type="roll" name="roll_FindTraps" title="%{selected|FindTraps}" value="&{template:general} {{name=@{character_name}}} {{subtag=Ability Check}} {{Find/Remove Traps=[[1d100cs<@{FindTraps}cf>@{FindTraps}]] %}}"> Roll</button></td>
+						<td class="sheet-right"><button class="sheet-button" type="roll" name="roll_FindTraps" title="%{selected|FindTraps}" value="&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Ability Check}} {{Find/Remove Traps=[[1d100cs<@{FindTraps}cf>@{FindTraps}]] %}}"> Roll</button></td>
 						<td><input type="text" name="attr_FindTraps" class="sheet-input-small" title="@{FindTraps}" value="0" /></td>
 						<td>Find/Remove Traps</td>
-						<td class="sheet-right"><button class="sheet-button" type="roll" name="roll_HearNoise" title="%{selected|HearNoise}" value="&{template:general} {{name=@{character_name}}} {{subtag=Ability Check}} {{Hear Noise=[[1d100cs<@{HearNoise}cf>@{HearNoise}]] %}}"> Roll</button></td>
+						<td class="sheet-right"><button class="sheet-button" type="roll" name="roll_HearNoise" title="%{selected|HearNoise}" value="&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Ability Check}} {{Hear Noise=[[1d100cs<@{HearNoise}cf>@{HearNoise}]] %}}"> Roll</button></td>
 						<td><input type="text" name="attr_HearNoise" class="sheet-input-small" title="@{HearNoise}" value="0" /></td>
 						<td>Hear Noise</td>
 						<td></td>
@@ -556,7 +556,7 @@
 									<td style="width:8%;"><input type="text" name="attr_current_max" title="@{repeating_ability_$X_current|max}" value="0" class="sheet-input-small" /><br>Max</td>
 									<!--attr_max kept as hidden attribute in order migrate attribute data to-->
 									<input type="hidden" name="attr_max" value="1">
-									<td style="width:10%;"><textarea name="attr_macro-text" title="@{repeating_ability_$X_macro-text}" class="sheet-macro-text" style="width:90%; height:1em;" >&{template:general} {{name=@{character_name}}} {{subtag=Special Ability: @{name}}} {{=@{short_description}}}</textarea><br>Macro-Text</td>
+									<td style="width:10%;"><textarea name="attr_macro-text" title="@{repeating_ability_$X_macro-text}" class="sheet-macro-text" style="width:90%; height:1em;" >&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Special Ability: @{name}}} {{=@{short_description}}}</textarea><br>Macro-Text</td>
 								</tr>
 							</table>
 							<b style="margin-left:20px;">Ability Description</b>
@@ -605,10 +605,7 @@
 									<td>/<br><span style="opacity: 0;margin: 2px;">/</span></td>
 									<td><input type="number" name="attr_rModifier" title="@{repeating_nonweaponproficiencies_$X_rmodifier}" value="0" class="sheet-input-small" style="margin-bottom: 6px;"/><br>Modifier</td>
 									<td>
-										<!-- OLDER MACRO
-										<textarea name="attr_macro-text" title="@{repeating_nonweaponproficiencies_$X_macro-text}" class="sheet-macro-text" style="width:90%; height:1em;">&{template:general} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{=@{short_description}}}{{Success Amount=[[((@{rAttribute})+(@{rSlots}-1)-1d20)cs&gt;1cf&lt;-1]]}}</textarea>
-										-->
-										<textarea name="attr_macro-text" title="@{repeating_nonweaponproficiencies_$X_macro-text}" class="sheet-macro-text" style="width:90%; height:1em;">&{template:general} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{Proficiency Check=[[ 1d20cs<[[ @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ]][ATTR+MODS]cf>[[ { ( @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ),19}kl1 ]] ]] vs [[ @{rAttribute}[ATTR] + (-1*(@{rmodifier}[MOD] + ?{Modifier?|0}[MOD])) ]]}} {{freetext=@{short_description}}}</textarea>
+										<textarea name="attr_macro-text" title="@{repeating_nonweaponproficiencies_$X_macro-text}" class="sheet-macro-text" style="width:90%; height:1em;">&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{Proficiency Check=[[ 1d20cs<[[ @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ]][ATTR+MODS]cf>[[ { ( @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ),19}kl1 ]] ]] vs [[ @{rAttribute}[ATTR] + (-1*(@{rmodifier}[MOD] + ?{Modifier?|0}[MOD])) ]]}} {{freetext=@{short_description}}}</textarea>
 										<br>Macro-Text
 									</td>
 								</tr>
@@ -689,7 +686,7 @@
 									<td style="width:5%;"><input type="text" name="attr_components" title="@{repeating_spells_$X_components}" style="width:100%; height:1.8em;" value="N/A" /><br>Comp</td>
 									<td style="width:5%;"><input type="text" name="attr_ct" title="@{repeating_spells_$X_ct}" style="width:100%; height:1.8em;" value="N/A" /><br>CT</td>
 									<td style="width:5%;"><input type="text" name="attr_save" title="@{repeating_spells_$X_save}" style="width:100%; height:1.8em;" value="N/A" /><br>Save</td>
-									<td style="width:10%;"><textarea name="attr_macro-text" title="@{repeating_spells_$X_macro-text}" class="sheet-macro-text" style="width:90%; height:1em;" >&{template:general} {{name=@{character_name}}} {{subtag=Casts: @{name}}} {{Range:=@{range}}} {{Duration:=@{duration}}} {{AOE:=@{aoe}}} {{Save:=@{save}}}</textarea><br>Macro-Text</td>
+									<td style="width:10%;"><textarea name="attr_macro-text" title="@{repeating_spells_$X_macro-text}" class="sheet-macro-text" style="width:90%; height:1em;" >&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Casts: @{name}}} {{Range:=@{range}}} {{Duration:=@{duration}}} {{AOE:=@{aoe}}} {{Save:=@{save}}}</textarea><br>Macro-Text</td>
 								</tr>
 							</table>
 							<b style="margin-left:20px;">Spell Description</b>
@@ -737,9 +734,32 @@
 					</div>
 				</div>
 				<div class="sheet-options sheet-text-small">
-					Background:
-					<input type="radio" class="sheet-useBackground" name="attr_background" value="1" title="No background image." checked />Off
-					<input type="radio" class="sheet-useBackground" name="attr_background" value="2" title="Enable background image." />On
+					<span style="margin-right: 2em;">
+						Background:
+						<input type="radio" class="sheet-useBackground" name="attr_background" value="1" title="No background image." checked="">Off
+						<input type="radio" class="sheet-useBackground" name="attr_background" value="2" title="Enable background image.">On
+					</span>
+					<span>
+						Roll Template Color:
+						<select name="attr_color_option" title="@{color_option}" style="width: 8em;">
+							<option value="black" selected>black</option>
+							<option value="grey">grey</option>
+							<option value="darkgrey">darkgrey</option>
+							<option value="white">white</option>
+							<option value="red">red</option>
+							<option value="darkred">darkred</option>
+							<option value="orange">orange</option>
+							<option value="darkorange">darkorange</option>
+							<option value="yellow">yellow</option>
+							<option value="darkyellow">darkyellow</option>
+							<option value="green">green</option>
+							<option value="darkgreen">darkgreen</option>
+							<option value="blue">blue</option>
+							<option value="darkblue">darkblue</option>
+							<option value="purple">purple</option>
+							<option value="darkpurple">darkpurple</option>
+						</select>
+					</span>
 				</div>
 			</div>
 
@@ -1584,7 +1604,7 @@
 				getAttrs(attrs, function(v) {
 					_.each(idarray, function(id) {
 						update["repeating_nonweaponproficiencies_" + id + "_macro-text"] = v["repeating_nonweaponproficiencies_" + id + "_macro-text"].replace('&{template:general} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{=@{short_description}}}{{Success Amount=[[((@{rAttribute})+(@{rSlots}-1)-1d20)cs>1cf<-1]]}}',
-						'&{template:general} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{Proficiency Check=[[ 1d20cs<[[ @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ]][ATTR+MODS]cf>[[ { ( @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ),19}kl1 ]] ]] vs [[ @{rAttribute}[ATTR] + (-1*(@{rmodifier}[MOD] + ?{Modifier?|0}[MOD])) ]]}} {{freetext=@{short_description}}}');
+						'&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{Proficiency Check=[[ 1d20cs<[[ @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ]][ATTR+MODS]cf>[[ { ( @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ),19}kl1 ]] ]] vs [[ @{rAttribute}[ATTR] + (-1*(@{rmodifier}[MOD] + ?{Modifier?|0}[MOD])) ]]}} {{freetext=@{short_description}}}');
 					});
 					console.log("nwpMacroUpdate check completed on: " +attrs);
 					setAttrs(update,{silent:true});

--- a/ADnD_1E/1ESheet.html
+++ b/ADnD_1E/1ESheet.html
@@ -605,7 +605,7 @@
 									<td>/<br><span style="opacity: 0;margin: 2px;">/</span></td>
 									<td><input type="number" name="attr_rModifier" title="@{repeating_nonweaponproficiencies_$X_rmodifier}" value="0" class="sheet-input-small" style="margin-bottom: 6px;"/><br>Modifier</td>
 									<td>
-										<textarea name="attr_macro-text" title="@{repeating_nonweaponproficiencies_$X_macro-text}" class="sheet-macro-text" style="width:90%; height:1em;">&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{Proficiency Check=[[ 1d20cs<[[ @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ]][ATTR+MODS]cf>[[ { ( @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ),19}kl1 ]] ]] vs [[ @{rAttribute}[ATTR] + (-1*(@{rmodifier}[MOD] + ?{Modifier?|0}[MOD])) ]]}} {{freetext=@{short_description}}}</textarea>
+										<textarea name="attr_macro-text" title="@{repeating_nonweaponproficiencies_$X_macro-text}" class="sheet-macro-text" style="width:90%; height:1em;">&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{Proficiency Check=[[ 1d20 + [[@{rmodifier}]][MOD] + [[?{Additional modifier?|0}]][MOD] ]] vs [[ @{rAttribute}[ATTR] ]]}}{{freetext=@{short_description}}}</textarea>
 										<br>Macro-Text
 									</td>
 								</tr>
@@ -1604,7 +1604,7 @@
 				getAttrs(attrs, function(v) {
 					_.each(idarray, function(id) {
 						update["repeating_nonweaponproficiencies_" + id + "_macro-text"] = v["repeating_nonweaponproficiencies_" + id + "_macro-text"].replace('&{template:general} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{=@{short_description}}}{{Success Amount=[[((@{rAttribute})+(@{rSlots}-1)-1d20)cs>1cf<-1]]}}',
-						'&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{Proficiency Check=[[ 1d20cs<[[ @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ]][ATTR+MODS]cf>[[ { ( @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ),19}kl1 ]] ]] vs [[ @{rAttribute}[ATTR] + (-1*(@{rmodifier}[MOD] + ?{Modifier?|0}[MOD])) ]]}} {{freetext=@{short_description}}}');
+						'&{template:general} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{Proficiency Check=[[ 1d20 + [[@{rmodifier}]][MOD] + [[?{Additional modifier?|0}]][MOD] ]] vs [[ @{rAttribute}[ATTR] ]]}}{{freetext=@{short_description}}}');
 					});
 					console.log("nwpMacroUpdate check completed on: " +attrs);
 					setAttrs(update,{silent:true});

--- a/ADnD_1E/1ESheet.html
+++ b/ADnD_1E/1ESheet.html
@@ -281,8 +281,8 @@
 								<td colspan="2" style="width:11%;"><input type="text" class="sheet-input-small" name="attr_AttackDmgBonus" title="@{repeating_weapon_$X_AttackDmgBonus}" value="0" /><br>DMG Bonus</td><input type="hidden" name="attr_DmgBonus" value="0" />
 								<td><b title="Include '/w gm to-hit AC table or THACO'?">/w gm?</b><br>
 									<select name="attr_whisper_to-hit" style="width:100%; height:2em;">
-										<option value="&#x00A;/w gm &amp;{template:attacks} {{name=@{character_name}}} {{subtag=To Hit Armor Class}} {{ToHitAC-10to0=[[ @{THAC-10} ]]|[[ @{THAC-9} ]]|[[ @{THAC-8} ]]|[[ @{THAC-7} ]]|[[ @{THAC-6} ]]|[[ @{THAC-5} ]]|[[ @{THAC-4} ]]|[[ @{THAC-3} ]]|[[ @{THAC-2} ]]|[[ @{THAC-1} ]]|[[ @{THAC0} ]]}} {{ToHitAC1to10=[[ @{THAC0} ]]|[[ @{THAC1} ]]|[[ @{THAC2} ]]|[[ @{THAC3} ]]|[[ @{THAC4} ]]|[[ @{THAC5} ]]|[[ @{THAC6} ]]|[[ @{THAC7} ]]|[[ @{THAC8} ]]|[[ @{THAC9} ]]|[[ @{THAC10} ]] }}" selected="">Table</option>
-										<option value="&#x00A;/w gm &amp;{template:attacks} {{name=@{character_name}}} {{subtag=THACO}} {{ToHitAC-10to0=@{THAC0-10}|@{THAC0-9}|@{THAC0-8}|@{THAC0-7}|@{THAC0-6}|@{THAC0-5}|@{THAC0-4}|@{THAC0-3}|@{THAC0-2}|@{THAC0-1}|**@{THAC00}**}} {{ToHitAC1to10=**@{THAC00}**|@{THAC01}|@{THAC02}|@{THAC03}|@{THAC04}|@{THAC05}|@{THAC06}|@{THAC07}|@{THAC08}|@{THAC09}|@{THAC010} }}">THACO</option>
+										<option value="&#x00A;/w gm &{template:attacks} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=To Hit Armor Class}} {{ToHitAC-10to0=[[ @{THAC-10} ]]|[[ @{THAC-9} ]]|[[ @{THAC-8} ]]|[[ @{THAC-7} ]]|[[ @{THAC-6} ]]|[[ @{THAC-5} ]]|[[ @{THAC-4} ]]|[[ @{THAC-3} ]]|[[ @{THAC-2} ]]|[[ @{THAC-1} ]]|[[ @{THAC0} ]]}} {{ToHitAC1to10=[[ @{THAC0} ]]|[[ @{THAC1} ]]|[[ @{THAC2} ]]|[[ @{THAC3} ]]|[[ @{THAC4} ]]|[[ @{THAC5} ]]|[[ @{THAC6} ]]|[[ @{THAC7} ]]|[[ @{THAC8} ]]|[[ @{THAC9} ]]|[[ @{THAC10} ]] }}" selected="">Table</option>
+										<option value="&#x00A;/w gm &{template:attacks} {{color=@{color_option}}} {{name=@{character_name}}} {{subtag=THACO}} {{ToHitAC-10to0=@{THAC0-10}|@{THAC0-9}|@{THAC0-8}|@{THAC0-7}|@{THAC0-6}|@{THAC0-5}|@{THAC0-4}|@{THAC0-3}|@{THAC0-2}|@{THAC0-1}|**@{THAC00}**}} {{ToHitAC1to10=**@{THAC00}**|@{THAC01}|@{THAC02}|@{THAC03}|@{THAC04}|@{THAC05}|@{THAC06}|@{THAC07}|@{THAC08}|@{THAC09}|@{THAC010} }}">THACO</option>
 										<option value="&nbsp;">no</option>
 									</select>
 								</td>
@@ -1611,6 +1611,54 @@
 				});
 			});
 		},
+//add {{color=@{color}}} to repeating section macro-text
+		colorUpdate = function() {
+		//update repeating_weapon_
+			var updateWeapon = {}, attrsWeapon = [];
+			getSectionIDs("repeating_weapon", function(idarray) {
+				_.each(idarray, function(itemid) {
+					attrsWeapon.push("repeating_weapon_" + itemid + "_macro-text");
+				});
+				getAttrs(attrsWeapon, function(v) {
+					_.each(idarray, function(id) {
+						updateWeapon["repeating_weapon_" + id + "_macro-text"] = v["repeating_weapon_" + id + "_macro-text"].replace('&{template:attacks} {{name=@{character_name}}}',
+						'&{template:attacks} {{color=@{color_option}}} {{name=@{character_name}}}');
+					});
+					console.log("colorUpdate check completed on: " +attrsWeapon);
+					setAttrs(updateWeapon,{silent:true});
+				});
+			});
+		//update repeating_ability_
+			var updateAbility = {}, attrsAbility = [];
+			getSectionIDs("repeating_ability", function(idarray) {
+				_.each(idarray, function(itemid) {
+					attrsAbility.push("repeating_ability_" + itemid + "_macro-text");
+				});
+				getAttrs(attrsAbility, function(v) {
+					_.each(idarray, function(id) {
+						updateAbility["repeating_ability_" + id + "_macro-text"] = v["repeating_ability_" + id + "_macro-text"].replace('&{template:general} {{name=@{character_name}}}',
+						'&{template:general} {{color=@{color_option}}} {{name=@{character_name}}}');
+					});
+					console.log("colorUpdate check completed on: " +attrsAbility);
+					setAttrs(updateAbility,{silent:true});
+				});
+			});
+		//update repeating_spells_
+			var updateSpells = {}, attrsSpells = [];
+			getSectionIDs("repeating_spells", function(idarray) {
+				_.each(idarray, function(itemid) {
+					attrsSpells.push("repeating_spells_" + itemid + "_macro-text");
+				});
+				getAttrs(attrsSpells, function(v) {
+					_.each(idarray, function(id) {
+						updateSpells["repeating_spells_" + id + "_macro-text"] = v["repeating_spells_" + id + "_macro-text"].replace('&{template:general} {{name=@{character_name}}}',
+						'&{template:general} {{color=@{color_option}}} {{name=@{character_name}}}');
+					});
+					console.log("colorUpdate check completed on: " +attrsSpells);
+					setAttrs(updateSpells,{silent:true});
+				});
+			});
+		},
 	
 	/* recalculateSheet */
 		recalculateSheet = function(oldversion) {
@@ -1623,6 +1671,7 @@
 			}
 			if (oldversion < 1.5) {
 				nwpMacroUpdate();
+				colorUpdate();
 			}
 		},
 		
@@ -1666,7 +1715,8 @@
 			checkForUpdate:checkForUpdate,
 			dmgSwap:dmgSwap,
 			maxSwap:maxSwap,
-			nwpMacroUpdate:nwpMacroUpdate
+			nwpMacroUpdate:nwpMacroUpdate,
+			colorUpdate:colorUpdate
 		};
 	}());
 	

--- a/ADnD_1E/1ESheet.html
+++ b/ADnD_1E/1ESheet.html
@@ -1569,6 +1569,24 @@
 				});
 			});
 		},
+
+//replace default macro-text of non weapon proficiencies ONLY IF they haven't been edited
+		nwpMacroUpdate = function() {
+			var update = {}, attrs = [];
+			getSectionIDs("repeating_nonweaponproficiencies", function(idarray) {
+				_.each(idarray, function(itemid) {
+					attrs.push("repeating_nonweaponproficiencies_" + itemid + "_macro-text");
+				});
+				getAttrs(attrs, function(v) {
+					_.each(idarray, function(id) {
+						update["repeating_nonweaponproficiencies_" + id + "_macro-text"] = v["repeating_nonweaponproficiencies_" + id + "_macro-text"].replace('&{template:general} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{=@{short_description}}}{{Success Amount=[[((@{rAttribute})+(@{rSlots}-1)-1d20)cs>1cf<-1]]}}',
+						'&{template:general} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{Proficiency Check=[[ 1d20cs<[[ @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ]] [attr + mod]cf>[[ { ( @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ),19}kl1 ]] ]] vs [[ @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ]]}} {{freetext=@{short_description}}}');
+					});
+					console.log("nwpMacroUpdate check completed on: " +attrs);
+					setAttrs(update,{silent:true});
+				});
+			});
+		},
 	
 	/* recalculateSheet */
 		recalculateSheet = function(oldversion) {
@@ -1578,6 +1596,9 @@
 			}
 			if (oldversion < 1.2) {
 				maxSwap();
+			}
+			if (oldversion < 1.5) {
+				nwpMacroUpdate();
 			}
 		},
 		
@@ -1609,7 +1630,7 @@
 					setAny=1;
 				}
 				if (setAny) {
-					 setAttrs( setter);
+					setAttrs( setter);
 				}
 				if (recalc) {
 					recalculateSheet(currVer);
@@ -1620,7 +1641,8 @@
 			version:version,
 			checkForUpdate:checkForUpdate,
 			dmgSwap:dmgSwap,
-			maxSwap:maxSwap
+			maxSwap:maxSwap,
+			nwpMacroUpdate:nwpMacroUpdate
 		};
 	}());
 	

--- a/ADnD_1E/1ESheet.html
+++ b/ADnD_1E/1ESheet.html
@@ -608,7 +608,7 @@
 										<!-- OLDER MACRO
 										<textarea name="attr_macro-text" title="@{repeating_nonweaponproficiencies_$X_macro-text}" class="sheet-macro-text" style="width:90%; height:1em;">&{template:general} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{=@{short_description}}}{{Success Amount=[[((@{rAttribute})+(@{rSlots}-1)-1d20)cs&gt;1cf&lt;-1]]}}</textarea>
 										-->
-										<textarea name="attr_macro-text" title="@{repeating_nonweaponproficiencies_$X_macro-text}" class="sheet-macro-text" style="width:90%; height:1em;">&{template:general} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{Proficiency Check=[[ 1d20cs<[[ @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ]] [attr + mod]cf>[[ { ( @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ),19}kl1 ]] ]] vs [[ @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ]]}} {{freetext=@{short_description}}}</textarea>
+										<textarea name="attr_macro-text" title="@{repeating_nonweaponproficiencies_$X_macro-text}" class="sheet-macro-text" style="width:90%; height:1em;">&{template:general} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{Proficiency Check=[[ 1d20cs<[[ @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ]][ATTR+MODS]cf>[[ { ( @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ),19}kl1 ]] ]] vs [[ @{rAttribute}[ATTR] + (-1*(@{rmodifier}[MOD] + ?{Modifier?|0}[MOD])) ]]}} {{freetext=@{short_description}}}</textarea>
 										<br>Macro-Text
 									</td>
 								</tr>
@@ -773,23 +773,27 @@
 			{{#ToHitAC-10to0}}<tr><td class="sheet-ToHit">-10|-9|-8|-7|-6|-5|-4|-3|-2|-1|&nbsp;**0**<br>{{ToHitAC-10to0}}</td></tr>{{/ToHitAC-10to0}}
 			{{#ToHitAC1to10}}<tr><td class="sheet-ToHit"> **0**| 1| 2| 3| 4| 5| 6| 7| 8| 9|10<br>{{ToHitAC1to10}}</td></tr>{{/ToHitAC1to10}}
 			
-			{{#allprops() name subtag color attack1 attack2 attack3 attack4 damage1vsSM damage2vsSM damage3vsSM damage4vsSM damage1vsL damage2vsL damage3vsL damage4vsL ToHitAC-10to0 ToHitAC1to10 WeaponNotes}}
+			{{#allprops() name subtag color attack1 attack2 attack3 attack4 damage1vsSM damage2vsSM damage3vsSM damage4vsSM damage1vsL damage2vsL damage3vsL damage4vsL ToHitAC-10to0 ToHitAC1to10 WeaponNotes freetext}}
 			<tr><td><span class="sheet-tcat">{{key}} = </span>{{value}}</td></tr>
-			{{/allprops() name subtag color attack1 attack2 attack3 attack4 damage1vsSM damage2vsSM damage3vsSM damage4vsSM damage1vsL damage2vsL damage3vsL damage4vsL ToHitAC-10to0 ToHitAC1to10 WeaponNotes}}
+			{{/allprops() name subtag color attack1 attack2 attack3 attack4 damage1vsSM damage2vsSM damage3vsSM damage4vsSM damage1vsL damage2vsL damage3vsL damage4vsL ToHitAC-10to0 ToHitAC1to10 WeaponNotes freetext}}
 			
 			{{#WeaponNotes}}<tr><td class="sheet-text">**Notes:** {{WeaponNotes}}</td></tr>{{/WeaponNotes}}
+			{{#freetext}}<tr><td colspan="2" class="sheet-text">{{freetext}}</td></tr>{{/freetext}}
+
 		</table>
 	</rolltemplate>
 	<!-- General Roll Template -->
 	<rolltemplate class="sheet-rolltemplate-general">
 		<table class="sheet-rolltemplate-general  {{#color}}color-{{color}}{{/color}}">
 			{{#name}}<tr><th colspan="2">{{name}}</th></tr>{{/name}}
-			{{#subtag}}<tr><td colspan="2" class="sheet-subheader">{{subtag}}</td></tr>{{/subtag}}
-			{{#freetext}}<tr><td colspan="2" class="sheet-text">{{freetext}}</td></tr>{{/freetext}}
+			{{#subtag}}<tr><td colspan="2" class="sheet-subheader">{{subtag}}</td></tr>{{/subtag}}			
 
 			{{#allprops() name subtag freetext color}}
 			<tr><td style="vertical-align:middle;"><span class="sheet-tcat">{{key}}</span></td><td>{{value}}</td></tr>
 			{{/allprops() name subtag freetext color}}
+			
+			{{#freetext}}<tr><td colspan="2" class="sheet-text">{{freetext}}</td></tr>{{/freetext}}
+
 		</table>
 	</rolltemplate>
 </div>
@@ -1580,7 +1584,7 @@
 				getAttrs(attrs, function(v) {
 					_.each(idarray, function(id) {
 						update["repeating_nonweaponproficiencies_" + id + "_macro-text"] = v["repeating_nonweaponproficiencies_" + id + "_macro-text"].replace('&{template:general} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{=@{short_description}}}{{Success Amount=[[((@{rAttribute})+(@{rSlots}-1)-1d20)cs>1cf<-1]]}}',
-						'&{template:general} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{Proficiency Check=[[ 1d20cs<[[ @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ]] [attr + mod]cf>[[ { ( @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ),19}kl1 ]] ]] vs [[ @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ]]}} {{freetext=@{short_description}}}');
+						'&{template:general} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{Proficiency Check=[[ 1d20cs<[[ @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ]][ATTR+MODS]cf>[[ { ( @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ),19}kl1 ]] ]] vs [[ @{rAttribute}[ATTR] + (-1*(@{rmodifier}[MOD] + ?{Modifier?|0}[MOD])) ]]}} {{freetext=@{short_description}}}');
 					});
 					console.log("nwpMacroUpdate check completed on: " +attrs);
 					setAttrs(update,{silent:true});

--- a/ADnD_1E/1ESheet.html
+++ b/ADnD_1E/1ESheet.html
@@ -1,6 +1,6 @@
 <div class="sheet-useBackground">
-	<input type="radio" class="sheet-useBackground" style="display:none;" name="attr_background" value="1" checked />
-	<input type="radio" class="sheet-useBackground" style="display:none;" name="attr_background" value="2" />
+	<input type="checkbox" class="sheet-useBackground" style="display:none;" name="attr_background" value="1" checked />
+	<input type="checkbox" class="sheet-useBackground" style="display:none;" name="attr_background" value="2" />
 	<div class="sheet-background">
 		<div class="sheet-wrapper">
 			<div class="sheet-center" style="padding-top:10px;"><img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ADnD_1E/images/logo.png" /></div>
@@ -103,6 +103,11 @@
 									<td><input type="text" class="sheet-input-medium" name="attr_Hair" title="@{Hair}" placeholder="Color" /></td>
 								</tr>
 							</table>
+						</td>
+					</tr>
+					<tr>
+						<td colspan="2" style="white-space: nowrap;">Languages:
+							<input type="text" name="attr_languages" placeholder="languages known" style="width: 87%;">
 						</td>
 					</tr>
 				</table>
@@ -499,6 +504,12 @@
 											<td><input type="text" class="sheet-input-medium" name="attr_max_load" title="@{max_load} Minimum amount for a max/encumbered load(defaults to 'Very heavy load' + 1)." value="(@{very_heavy_load}+1)" disabled /><b class="sheet-text-large">+</b><br>Max&nbsp;
 											<input type="checkbox" name="attr_current_encumbrance" value="3" readonly="readonly" /></td>
 										</tr>
+										<tr>
+											<td colspan="5">
+												Strength Encumbrance Bonus:
+												<input class="sheet-input-small" name="attr_EncumbranceBonus" title="@{EncumbranceBonus}" value="0" readonly="">&nbsp;&nbsp;<b>hint:</b> increases carrying capacity limits.
+											</td>
+										</tr>
 									</table>
 								</td>
 								<td style="width:10%;" class="sheet-right">Equipment:</td>
@@ -517,7 +528,7 @@
 							</tr>
 							<tr>
 								<td class="sheet-right">Coins:</td>
-								<td><input type="text" style="width:100%;" name="attr_total_coin_weight" title="@{total_coin_weight} 10 coins=1lbs" value="0" readonly="readonly" /></td>
+								<td><input type="text" style="width:100%;" name="attr_total_coin_weight" title="@{total_coin_weight}" value="0" readonly="readonly" /></td>
 								<td class="sheet-center"><b>&nbsp;-&nbsp;-&nbsp;-&nbsp;</b></td>	
 							</tr>
 							<tr>
@@ -586,14 +597,20 @@
 											<option value="@{Constitution}">Constitution</option>
 											<option value="@{Intelligence}">Intelligence</option>
 											<option value="@{Wisdom}">Wisdom</option>
-											<option value="@{Charisma}">Strength</option>
-										</select>										
+											<option value="@{Charisma}">Charisma</option>
+										</select>
 									</td>
-									<td><textarea name="attr_short_description" title="@{repeating_nonweaponproficiencies_$X_short_description}" class="sheet-weapons" style="width:100%;" placeholder="Short Description"></textarea><br>Short Description</td>
-									<td><input type="text" name="attr_rSlots" title="@{repeating_nonweaponproficiencies_$X_current}" value="0" class="sheet-input-small" /><br>Slots</td>
-									<td>/<br>/</td>
-									<td><input type="text" name="attr_rModifier" title="@{repeating_nonweaponproficiencies_$X_rmodifier}" value="0" class="sheet-input-small" /><br>Modifier</td>
-									<td><textarea name="attr_macro-text" title="@{repeating_nonweaponproficiencies_$X_macro-text}" class="sheet-macro-text" style="width:90%; height:1em;">&{template:general} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{=@{short_description}}}{{Success Amount=[[((@{rAttribute})+(@{rSlots}-1)-1d20)cs&gt;1cf&lt;-1]]}}</textarea><br>Macro-Text</td>
+									<td><textarea name="attr_short_description" title="@{repeating_nonweaponproficiencies_$X_short_description}" class="sheet-weapons" style="width:90%;" placeholder="Short Description"></textarea><br>Short Description</td>
+									<td><input type="number" name="attr_rSlots" title="@{repeating_nonweaponproficiencies_$X_rSlots}" value="0" class="sheet-input-small" style="margin-bottom: 6px;"/><br>Slots</td>
+									<td>/<br><span style="opacity: 0;margin: 2px;">/</span></td>
+									<td><input type="number" name="attr_rModifier" title="@{repeating_nonweaponproficiencies_$X_rmodifier}" value="0" class="sheet-input-small" style="margin-bottom: 6px;"/><br>Modifier</td>
+									<td>
+										<!-- OLDER MACRO
+										<textarea name="attr_macro-text" title="@{repeating_nonweaponproficiencies_$X_macro-text}" class="sheet-macro-text" style="width:90%; height:1em;">&{template:general} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{=@{short_description}}}{{Success Amount=[[((@{rAttribute})+(@{rSlots}-1)-1d20)cs&gt;1cf&lt;-1]]}}</textarea>
+										-->
+										<textarea name="attr_macro-text" title="@{repeating_nonweaponproficiencies_$X_macro-text}" class="sheet-macro-text" style="width:90%; height:1em;">&{template:general} {{name=@{character_name}}} {{subtag=Non Weapon Proficiency: @{name}}} {{Proficiency Check=[[ 1d20cs<[[ @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ]] [attr + mod]cf>[[ { ( @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ),19}kl1 ]] ]] vs [[ @{rAttribute} + (-1*(@{rmodifier} + ?{Modifier?|0})) ]]}} {{freetext=@{short_description}}}</textarea>
+										<br>Macro-Text
+									</td>
 								</tr>
 							</table>
 							<b style="margin-left:20px;">Non Weapon Proficiency Description</b>
@@ -711,7 +728,7 @@
 				<div class="sheet-table sheet-text-small">
 					<div class="sheet-table-row">
 						<span class="sheet-data sheet-center">Original Author: Adam Ness | Contributions by: Vince, &amp; Roll20 Community. | sheet ver. <input name="attr_sheet_version" type="text" value="0" class="sheet-version" readonly />
-							&nbsp;<i>4.11.20</i>&nbsp;
+							&nbsp;<i>5.2.20</i>&nbsp;
 							Recalc: <input name="attr_recalc1" type="checkbox" title="RECALC" style="width: 1.25em;">
 						</span>
 					</div>
@@ -721,13 +738,12 @@
 				</div>
 				<div class="sheet-options sheet-text-small">
 					Background:
-					<input type="checkbox" class="sheet-useBackground" name="attr_background" value="1" title="No background image." checked="checked" />Off
-					<input type="checkbox" class="sheet-useBackground" name="attr_background" value="2" title="Enable background image." />On
-					</div>
+					<input type="radio" class="sheet-useBackground" name="attr_background" value="1" title="No background image." checked />Off
+					<input type="radio" class="sheet-useBackground" name="attr_background" value="2" title="Enable background image." />On
 				</div>
-			</div>			
-		
-		</div>		
+			</div>
+
+		</div>
 	</div>
 </div>
 
@@ -769,10 +785,11 @@
 		<table class="sheet-rolltemplate-general  {{#color}}color-{{color}}{{/color}}">
 			{{#name}}<tr><th colspan="2">{{name}}</th></tr>{{/name}}
 			{{#subtag}}<tr><td colspan="2" class="sheet-subheader">{{subtag}}</td></tr>{{/subtag}}
+			{{#freetext}}<tr><td colspan="2" class="sheet-text">{{freetext}}</td></tr>{{/freetext}}
 
-			{{#allprops() name subtag color}}
+			{{#allprops() name subtag freetext color}}
 			<tr><td style="vertical-align:middle;"><span class="sheet-tcat">{{key}}</span></td><td>{{value}}</td></tr>
-			{{/allprops() name subtag color}}
+			{{/allprops() name subtag freetext color}}
 		</table>
 	</rolltemplate>
 </div>
@@ -1481,27 +1498,27 @@
 			.execute();
 	});
 	
-	on('change:pp change:gp change:ep change:sp change:cp change:armor_weight change:armor_cost', function(){
+	on('sheet:opened change:pp change:gp change:ep change:sp change:cp change:armor_weight change:armor_cost', function(){
 		getAttrs(['pp','gp','ep','sp','cp','armor_weight','armor_cost'], function(values){
 		  setAttrs({
-			total_coin_weight: Math.round(((parseFloat(values.pp) + parseFloat(values.gp) + parseFloat(values.ep) + parseFloat(values.sp) + parseFloat(values.cp)))/10),
+			total_coin_weight: Math.round(((parseFloat(values.pp) + parseFloat(values.gp) + parseFloat(values.ep) + parseFloat(values.sp) + parseFloat(values.cp)))),
 			total_armor_weight: (parseFloat(values.armor_weight)),
 			total_armor_cost: (parseFloat(values["armor_cost"],10)).toFixed(2)
 		  });
 	   });
 	});
 	
-	on('change:total_armor_weight change:total_weapon_weight change:total_coin_weight change:total_equipment_weight change:repeating_equipment remove:repeating_equipment change:repeating_weapon remove:repeating_weapon change:pp change:gp change:ep change:sp change:cp change:armor_weight change:armor_cost change:total_armor_cost change:total_weapon_cost change:total_equipment_cost', function(){
+	on('sheet:opened change:total_armor_weight change:total_weapon_weight change:total_coin_weight change:total_equipment_weight change:repeating_equipment remove:repeating_equipment change:repeating_weapon remove:repeating_weapon change:pp change:gp change:ep change:sp change:cp change:armor_weight change:armor_cost change:total_armor_cost change:total_weapon_cost change:total_equipment_cost', function(){
 		getAttrs(['total_armor_weight','total_weapon_weight','total_coin_weight','total_equipment_weight','total_armor_cost','total_weapon_cost','total_equipment_cost'], function(values){
 		  setAttrs({
-			total_weight: (parseFloat(values.total_armor_weight) + parseFloat(values.total_weapon_weight) + parseFloat(values.total_coin_weight) + parseFloat(values.total_equipment_weight)),
+			total_weight: Math.round(parseFloat(values.total_armor_weight) + parseFloat(values.total_weapon_weight) + parseFloat(values.total_coin_weight) + parseFloat(values.total_equipment_weight)),
 			total_cost: (parseFloat(values["total_armor_cost"],10) + parseFloat(values["total_weapon_cost"],10) + parseFloat(values["total_equipment_cost"],10)).toFixed(2)
 		  });
 	   });
 	});
 	
 	/* check and set encumbrance */
-	on('change:normal_load change:heavy_load change:very_heavy_load change:max_load change:total_weight', function(){
+	on('sheet:opened change:normal_load change:heavy_load change:very_heavy_load change:max_load change:total_weight', function(){
 		getAttrs(['normal_load','heavy_load','very_heavy_load','max_load','total_weight'], function(values){
 		if(values.total_weight <= values.normal_load) {setAttrs({current_encumbrance:0}); console.log("===== Encumbrance is Normal =====");}
 		else if(values.total_weight > values.normal_load && values.total_weight <= values.heavy_load) {setAttrs({current_encumbrance:1}); console.log("===== Encumbrance is Heavy =====");}
@@ -1512,7 +1529,7 @@
 	
 	var Sheet = Sheet || (function() {
 	
-		var version = 1.4,
+		var version = 1.5,
 		Debug = false,
 	
 	// copy DmgBonus value to AttackDmgBonus


### PR DESCRIPTION
## Changes / Comments

- added languages field.
- fixed typo in non weapon prof ability selector (Charisma was listed as Strength).
- updated macro used for non weapon prof check.  Existing macro did not utilize @{rmodifier}. New macro will roll 1d20 vs proficiency check threshold (@{rAttribute}+@{rmodifier}+modifier query).
- removed coin conversion to lbs.  All weight is tracked in gp's.
- changed sheet background checkbox to a radio selector.
- small updates to title text.
- added Strength Encumbrance bonus under Carrying Capacity as a reminder it should be included when determining thresholds.
- versioning routine included to check if existing nwp macro-text has been edited so that only unedited(default) macro-text will be replaced with the new macro-text.


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
