### PR TITLE
Html syntax error, attribute not closed

### DIFF
--- a/D&D_3-5/charsheet_3-5.html
+++ b/D&D_3-5/charsheet_3-5.html
@@ -1546,7 +1546,7 @@
 					<tr>
 						<td class="sheet-statlabel-encumbrance" style="width: 80px;" data-i18n="weight-carried"> Weight Carried </td>
 						<td class="sheet-statlabel-encumbrance" style="width: 165px;" data-i18n="character-size-a"> Char Size </td>
-						<td class="sheet-statlabel-encumbrance" style="width: 80px;" data-i18n=" data-i18n="load"> Load </td>
+						<td class="sheet-statlabel-encumbrance" style="width: 80px;" data-i18n="load"> Load </td>
 						<td class="sheet-statlabel-encumbrance sheet-table-load" data-i18n="maximum-dexterity-a"> Max Dex </td>
 						<td class="sheet-statlabel-encumbrance sheet-table-load" data-i18n="check-penalty"> Check Penalty </td>
 						<td class="sheet-statlabel-encumbrance sheet-table-load" data-i18n="speed-30ft"> Speed (30 ft.)</td>


### PR DESCRIPTION
## Changes / Comments
from:
```
... data-i18n=" data-i18n="load" ...
```
to:
```
... data-i18n="load" ...
```


## Roll20 Requests

I agreed to an incorrect html attribute, and wanted to try my first PULL request :) .

it is a very small error, I don't think it gives real problems, as far as newer browsers are concerned, they are able to automatically correct this syntax error.

I wanted to give my support, as a thank you for the work done by Diana

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
