### PR TITLE
[Naheulbeuk] Fix minor typos

### DIFF
--- a/Naheulbeuk/Naheulbeuk.html
+++ b/Naheulbeuk/Naheulbeuk.html
@@ -1431,7 +1431,7 @@
 											<div class="sheet-col-3">
 												<select name="attr_Magie_EpreuveCible_Jet">
 													<option value="" selected="selected"></option>
-													<option value="Resits. Magie">Résist. Magie</option>
+													<option value="Resist. Magie">Résist. Magie</option>
 													<option value="Magie Phy.">Magie Phys.</option>
 													<option value="Magie Psy.">Magie Psy.</option>
 													<option value="INT">INT</option>
@@ -2490,7 +2490,7 @@
 							<textarea class="sheet-code" rows="1">@{selected|displayJet} &{template:default} {{name=Parade de @{selected|Personnage_Nom} avec @{selected|repeating_PNJarmes_$0_Arme_Nom} }} {{ PRD=@{selected|Stats_Parade_total} + @{selected|repeating_PNJarmes_$0_Arme_PRD} }} {{ Résultat=[[1d20cs<1cf>20]] }}</textarea>
 							<b>Dégats de l'Arme N°1 :</b><br />
 							<textarea class="sheet-code" rows="1">@{selected|displayJet} &{template:default} {{name=Dégats de @{selected|Personnage_Nom} avec @{selected|repeating_PNJarmes_$0_Arme_Nom}}} {{ Cible = @{target|Personnage_Nom} }} {{ Dégats=[[@{selected|repeating_PNJarmes_$0_Arme_Degats} + @{selected|BonusDegatsForce}]] }}</textarea>
-							<span class="sheet-hint">Pour utiliser l'armre N°2, remplacer $0 par $1 et ainsi de suite.</span>
+							<span class="sheet-hint">Pour utiliser l'arme N°2, remplacer $0 par $1 et ainsi de suite.</span>
 						</div>
 					</div>
 				</div>

--- a/Naheulbeuk/readme.md
+++ b/Naheulbeuk/readme.md
@@ -31,7 +31,7 @@ La fiche reprend les éléments de la feuille de personnage officielle réorgani
 - Compagnons
 	* Permet de gérer montures ou animaux de compagnies
 
-Il est possible de basculter les feuilles en un affichage plus compacte pour les PNJ en cliquant sur le bouton PJ en haut à gauche.
+Il est possible de basculer les feuilles en un affichage plus compacte pour les PNJ en cliquant sur le bouton PJ en haut à gauche.
 
 Il est également possible d'exporter toutes les données de la fiche en un format texte que vous pourrez sauvegarder, puis l'importer dans une fiche vierge d'une autre campagne pour la préremplir.
 


### PR DESCRIPTION
## Changes / Comments

Correct some typographic errors from Naheulbeuk sheets.
* `Resits` by `Resist`
* `armre` by `arme`
* `basculter` by `basculer`

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.