### PR TITLE
[10 Different Sheets] change image link to point at Roll20 repo

### DIFF
--- a/AllforOne/AllforOne.html
+++ b/AllforOne/AllforOne.html
@@ -222,7 +222,7 @@
                     <span data-i18n="Motivation">Motivation</span>
                 </div>
                 <div class="sheet-img-logo">
-                    <img class="sheet-hexlogo" src="https://github.com/Lockbox313/Roll20-Testing/blob/master/AllforOne/Graphics/allforone-logo
+                    <img class="sheet-hexlogo" src="https://github.com/Roll20/Roll20-Testing/blob/master/AllforOne/Graphics/allforone-logo
 					.png?raw=true" />
                 </div>
             </div>
@@ -265,7 +265,7 @@
                     </div>
                 </div>
                 <!-- Secondary Attributes -->
-				<img style="width:100%,height:auto;" src="https://raw.githubusercontent.com/Lockbox313/Roll20-Testing/master/AllforOne/Graphics/bordera1b.png">				
+				<img style="width:100%,height:auto;" src="https://raw.githubusercontent.com/Roll20/Roll20-Testing/master/AllforOne/Graphics/bordera1b.png">				
                 <h1 class="sheet-top-separator" data-i18n="Secondary-Attributes">Secondary Attributes</h1>
                 <div class="sheet-2colrow">
                     <div class="sheet-col sheet-collapse-margin">
@@ -321,7 +321,7 @@
                     </div>
                 </div>
                 <!-- Skills -->
-				<img style="width:100%,height:auto;" src="https://raw.githubusercontent.com/Lockbox313/Roll20-Testing/master/AllforOne/Graphics/bordera1b.png">
+				<img style="width:100%,height:auto;" src="https://raw.githubusercontent.com/Roll20/Roll20-Testing/master/AllforOne/Graphics/bordera1b.png">
                 <div class="sheet-top-separator sheet-heading-with-columns">
                     <h1 data-i18n="Skills">Skills</h1>
                     <div class="sheet-column-headings">
@@ -355,7 +355,7 @@
                     <p class="sheet-footnote" data-i18n="star-specialized-skill">* specialized skill</p>
                 </div>
                 <!-- Fencing Styles -->
-				<img style="width:100%,height:auto;" src="https://raw.githubusercontent.com/Lockbox313/Roll20-Testing/master/AllforOne/Graphics/bordera1b.png">
+				<img style="width:100%,height:auto;" src="https://raw.githubusercontent.com/Roll20/Roll20-Testing/master/AllforOne/Graphics/bordera1b.png">
                 <div class="sheet-top-separator sheet-heading-with-columns">
                     <h1 data-i18n="Fencing-Styles">Fencing Styles</h1>
                     <div class="sheet-column-headings">
@@ -392,7 +392,7 @@
 				
 				
                 <!-- Weapons -->
-				<img style="width:100%,height:auto;" src="https://raw.githubusercontent.com/Lockbox313/Roll20-Testing/master/AllforOne/Graphics/bordera1b.png">				
+				<img style="width:100%,height:auto;" src="https://raw.githubusercontent.com/Roll20/Roll20-Testing/master/AllforOne/Graphics/bordera1b.png">				
                 <div class="sheet-top-separator sheet-bottom-separator sheet-heading-with-columns sheet-weapons">
                     <h1 data-i18n="Weapons">Weapons</h1>
                     <fieldset class="repeating_weapons">
@@ -453,7 +453,7 @@
                     </fieldset>
                 </div>
                 <!-- Talents -->
-				<img style="width:100%,height:auto;" src="https://raw.githubusercontent.com/Lockbox313/Roll20-Testing/master/AllforOne/Graphics/bordera1b.png">				
+				<img style="width:100%,height:auto;" src="https://raw.githubusercontent.com/Roll20/Roll20-Testing/master/AllforOne/Graphics/bordera1b.png">				
                 <h1 class="sheet-top-separator" data-i18n="Talents">Talents</h1>
                 <fieldset class="repeating_talents">
                     <textarea type="text" name="attr_talent"></textarea>
@@ -470,7 +470,7 @@
                 </fieldset>
 
                 <!-- Languages, Money, Encumbrance -->
-				<img style="width:100%,height:auto;" src="https://raw.githubusercontent.com/Lockbox313/Roll20-Testing/master/AllforOne/Graphics/bordera1b.png">				
+				<img style="width:100%,height:auto;" src="https://raw.githubusercontent.com/Roll20/Roll20-Testing/master/AllforOne/Graphics/bordera1b.png">				
                 <div class="sheet-2colrow sheet-top-separator">
                     <div class="sheet-col sheet-languages-money">
                         <h1 data-i18n="Languages">Languages</h1>
@@ -503,7 +503,7 @@
                     </div>
                 </div>
                 <!-- Equipment -->
-				<img style="width:100%,height:auto;" src="https://raw.githubusercontent.com/Lockbox313/Roll20-Testing/master/AllforOne/Graphics/bordera1b.png">
+				<img style="width:100%,height:auto;" src="https://raw.githubusercontent.com/Roll20/Roll20-Testing/master/AllforOne/Graphics/bordera1b.png">
                 <div class="sheet-top-separator sheet-heading-with-columns">
                     <h1 data-i18n="Equipment">Equipment</h1>
                     <div class="sheet-column-headings">
@@ -579,7 +579,7 @@
 </div>
 <rolltemplate class="sheet-rolltemplate-basic">
 <div style="background-color:white">
-	<img src="https://github.com/Lockbox313/Roll20-Testing/blob/master/AllforOne/Graphics/template%20border.png?raw=true">
+	<img src="https://github.com/Roll20/Roll20-Testing/blob/master/AllforOne/Graphics/template%20border.png?raw=true">
 	<br>
 	<div style="padding: 5px 0 5px 0;background-color:black;text-align:center;">
 		<div style="margin-bottom:5px;"><span style="font-size:large;width:100%;display:inline-bloc;color:white">{{character_name}}</span></div>
@@ -601,6 +601,6 @@
 		<span style="margin-bottom:5px;text-align:right;width:50%;display:inline-block">Modifier:</span><span style="text-align:center;width:50%;display:inline-block"><b>{{Modifier}}</b></span>
 	</div>		
 	<br>
-	<img src="https://github.com/Lockbox313/Roll20-Testing/blob/master/AllforOne/Graphics/template%20border.png?raw=true">
+	<img src="https://github.com/Roll20/Roll20-Testing/blob/master/AllforOne/Graphics/template%20border.png?raw=true">
 </div>
 </rolltemplate>

--- a/BakerStreet/BakerStreet.html
+++ b/BakerStreet/BakerStreet.html
@@ -36,7 +36,7 @@
 			</div>
 		</div>
 
-		<div class="sheet-divider"><img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/BakerStreet/divider.png"></div>
+		<div class="sheet-divider"><img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/BakerStreet/divider.png"></div>
 		<br />
 
 
@@ -66,7 +66,7 @@
 
 
 
-		<div class="sheet-divider"><img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/BakerStreet/divider.png"></div>
+		<div class="sheet-divider"><img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/BakerStreet/divider.png"></div>
 		<br />
 		
 		<div style="width:98%;text-align:center">
@@ -112,7 +112,7 @@
 			<br />
 		</fieldset>
 		
-		<div class="sheet-divider"><img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/BakerStreet/divider.png"></div>
+		<div class="sheet-divider"><img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/BakerStreet/divider.png"></div>
 		<br />		
 		<div class='sheet-2colrow'>
 			<div class="sheet-col">		
@@ -404,23 +404,23 @@
 		<br />
 		<div>
 			{{#rollTotal() shrlckDie 1}}	
-				<div><img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/BakerStreet/1.png"></div>
+				<div><img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/BakerStreet/1.png"></div>
 				<div> 1's are successes</div>
 			{{/rollTotal() shrlckDie 1}}		
 			{{#rollTotal() shrlckDie 2}}	
-				<div><img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/BakerStreet/2.png"></div>
+				<div><img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/BakerStreet/2.png"></div>
 				<div> 2's are successes</div>
 			{{/rollTotal() shrlckDie 2}}		
 			{{#rollTotal() shrlckDie 3}}	
-				<div><img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/BakerStreet/3.png"></div>
+				<div><img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/BakerStreet/3.png"></div>
 				<div> 3's are successes</div>
 			{{/rollTotal() shrlckDie 3}}			
 			{{#rollTotal() shrlckDie 4}}	
-				<div><img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/BakerStreet/holmes.png"></div>
+				<div><img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/BakerStreet/holmes.png"></div>
 				<div>Choose 1's, 2's or 3's as successes</div>
 			{{/rollTotal() shrlckDie 4}}			
 			{{#rollTotal() shrlckDie 5}}	
-				<div><img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/BakerStreet/watson.png"></div>
+				<div><img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/BakerStreet/watson.png"></div>
 				{{#rollTotal() damage 0}}
 					<div>Plus 1 success or free action Assist</div>
 				{{/rollTotal() damage 0}}
@@ -432,7 +432,7 @@
 				
 			{{/rollTotal() shrlckDie 5}}			
 			{{#rollTotal() shrlckDie 6}}	
-				<div><img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/BakerStreet/moriarty.png"></div>
+				<div><img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/BakerStreet/moriarty.png"></div>
 				<div>Each fail removes 1 success</div>
 			{{/rollTotal() shrlckDie 6}}
 

--- a/Call_of_Cthulhu_DA/Call_of_Cthulhu_Dark_Ages.html
+++ b/Call_of_Cthulhu_DA/Call_of_Cthulhu_Dark_Ages.html
@@ -209,7 +209,7 @@
 			<input type="checkbox" style="display:none" class="sheet-showskills" name="attr_showskills" value="4">
 			<div class="sheet-skills4">
 				<div style="margin:auto;width:50%;padding-top:14px">
-					<img src="https://github.com/Lockbox313/roll20-character-sheets/blob/master/Call_of_Cthulhu_DA/Gaslight2.jpg?raw=true">
+					<img src="https://github.com/Roll20/roll20-character-sheets/blob/master/Call_of_Cthulhu_DA/Gaslight2.jpg?raw=true">
 				</div>
 			</div>
         </div>

--- a/Elric/Elric.css
+++ b/Elric/Elric.css
@@ -521,7 +521,7 @@ input.sheet-spellHgt {
 
 .sheet-allFrame1{
 	background-size: 100% auto;
-	background-image: url('https://raw.githubusercontent.com/Lockbox313/imagedump/master/Elric/allFrameTest2.png');
+	background-image: url('https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Elric/Graphics/allFrameTest2.png');
 	background-repeat: no-repeat;
 }
 
@@ -538,39 +538,39 @@ input.sheet-spellHgt {
 
 .sheet-shieldDivider{
 	background-size: 100% auto;
-	background-image: url('https://raw.githubusercontent.com/Lockbox313/imagedump/master/Elric/shieldBorderTest1.png');
+	background-image: url('https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Elric/Graphics/shieldBorderTest1.png');
 	background-repeat: no-repeat
 }
 
 
 .sheet-storageInscribedDivider{
 	background-size: 100% auto;
-	background-image: url('https://raw.githubusercontent.com/Lockbox313/imagedump/master/Elric/hpBorderTest1.png');
+	background-image: url('https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Elric/Graphics/hpBorderTest1.png');
 	background-repeat: no-repeat
 }
 
 
 .sheet-hpDivider{
 	background-size: 100% auto;
-	background-image: url('https://raw.githubusercontent.com/Lockbox313/imagedump/master/Elric/hpBorderTest1.png');
+	background-image: url('https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Elric/Graphics/hpBorderTest1.png');
 	background-repeat: no-repeat
 }
 
 
 .sheet-gearDivider{
 	background-size: 100% auto;
-	background-image: url('https://raw.githubusercontent.com/Lockbox313/imagedump/master/Elric/borderTest6.png');
+	background-image: url('https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Elric/Graphics/borderTest6.png');
 	background-repeat: no-repeat
 }
 
 .sheet-fullDivider{
-	background-image: url('https://raw.githubusercontent.com/Lockbox313/imagedump/master/Elric/borderTest5.png');
+	background-image: url('https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Elric/Graphics/borderTest5.png');
 	background-repeat: no-repeat
 }
 
 .sheet-spellsDivider{
 	background-size: 100% auto;
-	background-image: url('https://raw.githubusercontent.com/Lockbox313/imagedump/master/Elric/shieldBorderTest1.png');
+	background-image: url('https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Elric/Graphics/shieldBorderTest1.png');
 	background-repeat: no-repeat
 }
 

--- a/Heroquest_Glorantha/Heroquest_Glorantha.html
+++ b/Heroquest_Glorantha/Heroquest_Glorantha.html
@@ -17,7 +17,7 @@
 			
 
 				<div class="sheet-section_div" style="border: 1px solid black"> 
-					<div class="sheet-section_header">Unspent Additional Abilities:<input  class="sheet-text_input sheet-twodigits type="text" name="attr_abilities"/> Ability Points: <input  class="sheet-text_input sheet-twodigits type="text" name="attr_ability_points"/> Magic Points: <input  class="sheet-text_input sheet-twodigits" type="text" name="attr_magic_points"/><span style="float:right">Hero Points: <input  class="sheet-text_input sheet-twodigits" type="text" name="attr_hero_points"/><span></div>
+					<div class="sheet-section_header">Unspent Additional Abilities:<input  class="sheet-text_input sheet-twodigits" type="text" name="attr_abilities"/> Ability Points: <input  class="sheet-text_input sheet-twodigits" type="text" name="attr_ability_points"/> Magic Points: <input  class="sheet-text_input sheet-twodigits" type="text" name="attr_magic_points"/><span style="float:right">Hero Points: <input  class="sheet-text_input sheet-twodigits" type="text" name="attr_hero_points"/><span></div>
 				
 				</div>
 				
@@ -99,7 +99,7 @@
 								
 								<!-- <input type="checkbox" name="attr_rune_mastery_chk1"  style="display:block;margin-left:50%" /> -->
 								<div>
-									<img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
+									<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
 									<input class="sheet-twodigits"  type="number" name="attr_rune_masteries1"  value="0" />
 									<button type="roll" value="&{template:abilityRoll} {{name=@{character_name}}} {{Keyword=@{rune1} @{dumyxxx}}} {{Breakout=}} {{target=[[{[[(@{totalscore1}+?{mods|0})%20]],0}}]]}} {{Masteries=[[floor((@{totalscore1}+?{mods|0})/20)]] }} {{roll=[[1d20cs1cf20]]}} " ></button>
 								</div>
@@ -194,7 +194,7 @@
 								
 								<!-- <input type="checkbox" name="attr_rune_mastery_chk1"  style="display:block;margin-left:50%" /> -->
 								<div>
-									<img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
+									<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
 									<input class="sheet-twodigits"  type="number" name="attr_rune_masteries2"  value="0" />
 									<button type="roll" value="&{template:abilityRoll} {{name=@{character_name}}} {{Keyword=@{rune2} @{dumyxxx}}} {{Breakout=}}{{target=[[{[[(@{totalscore2}+?{mods|0})%20]],0}}]]}} {{Masteries=[[floor((@{totalscore2}+?{mods|0})/20)]] }} {{roll=[[1d20cs1cf20]]}} " ></button>
 								</div>
@@ -289,7 +289,7 @@
 								
 								<!-- <input type="checkbox" name="attr_rune_mastery_chk1"  style="display:block;margin-left:50%" /> -->
 								<div>
-									<img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
+									<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
 									<input class="sheet-twodigits"  type="number" name="attr_rune_masteries3"  value="0" />
 									<button type="roll" value="&{template:abilityRoll} {{name=@{character_name}}} {{Keyword=@{rune3} @{dumyxxx}}}{{target=[[{[[(@{totalscore3}+?{mods|0})%20]],0}}]]}} {{Masteries=[[floor((@{totalscore3}+?{mods|0})/20)]] }} {{roll=[[1d20cs1cf20]]}} " ></button>
 								</div>
@@ -338,7 +338,7 @@
 						<p  class="sheet-section_header sheet-distingchar">Distinguishing<br>Characteristic:</p>
 							<input type="text" style="width:142px;" placeholder=""  class="sheet-text_input" name="attr_disting_char" />
 							<input class="sheet-twodigits " style="width:3.75em" type="number" name="attr_distingchar_score" value="1" />					
-							<img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
+							<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
 							<input class="sheet-twodigits"  type="number" name="attr_dstingchar_masteries1"  value="0" />						
 							<button type="roll" value="&{template:abilityRoll} {{name=@{character_name}}} {{Keyword=@{disting_char} }}{{target=[[{[[(@{totaldistingscore1}+?{mods|0})%20]],0}}]]}} {{Masteries=[[floor((@{totaldistingscore1}+?{mods|0})/20)]] }} {{roll=[[1d20cs1cf20]]}} "></button>
 							<input style="display:none" type="number" name="attr_totaldistingscore1" value="0" />						
@@ -365,7 +365,7 @@
 					<div style="padding:3px;border:1px solid black;border-radius: 10px">
 						<input class="sheet-keytext_input" placeholder="Keyword 1" type="text" class="sheet-keyword_name" name="attr_keyword1"   />
 						<input class="sheet-twodigits" type="number" name="attr_keyword_score1" value="0"/>
-						<img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
+						<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
 						<input class="sheet-twodigits"  type="number" name="attr_keyword_masteries1"  value="0" />
 						<button type="roll" value="&{template:abilityRoll} {{name=@{character_name}}} {{Keyword=@{keyword1} }}{{target=[[{[[(@{totalkeyscore1}+?{mods|0})%20]],0}}]]}} {{Masteries=[[floor((@{totalkeyscore1}+?{mods|0})/20)]] }} {{roll=[[1d20cs1cf20]]}} " ></button>
 
@@ -382,7 +382,7 @@
 					<div style="padding:3px;border:1px solid black;border-radius: 10px"><!-- Keyword 2 -->
 						<input class="sheet-keytext_input" placeholder="Keyword 2" type="text" class="sheet-keyword_name" name="attr_keyword2"   />
 						<input class="sheet-twodigits" type="number" name="attr_keyword_score2" value="0"/>
-						<img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
+						<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
 						<input class="sheet-twodigits"  type="number" name="attr_keyword_masteries2"  value="0" />
 						<button type="roll" value="&{template:abilityRoll} {{name=Ability Roll}} {{name=@{character_name}}} {{Keyword=@{keyword2} }} {{target=[[{[[(@{totalkeyscore2}+?{mods|0})%20]],0}}]]}} {{Masteries=[[floor((@{totalkeyscore2}+?{mods|0})/20)]] }} {{roll=[[1d20cs1cf20]]}} " ></button>
 
@@ -399,7 +399,7 @@
 					<div style="padding:3px;border:1px solid black;border-radius: 10px"><!-- Keyword 3 -->
 						<input class="sheet-keytext_input" placeholder="Keyword 3" type="text" class="sheet-keyword_name" name="attr_keyword3"   />
 						<input class="sheet-twodigits" type="number" name="attr_keyword_score3" value="0"/>
-						<img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
+						<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
 						<input class="sheet-twodigits"  type="number" name="attr_keyword_masteries3"  value="0" />
 						<button type="roll" value="&{template:abilityRoll}{{name=@{character_name}}} {{Keyword=@{keyword3}}} {{target=[[{[[(@{totalkeyscore3}+?{mods|0})%20]],0}}]]}} {{Masteries=[[floor((@{totalkeyscore3}+?{mods|0})/20)]] }} {{roll=[[1d20cs1cf20]]}} " ></button>
 
@@ -416,7 +416,7 @@
 					<div style="padding:3px;border:1px solid black;border-radius: 10px"><!-- Keyword 4 -->
 						<input class="sheet-keytext_input" placeholder="Keyword 4" type="text" class="sheet-keyword_name" name="attr_keyword4"   />
 						<input class="sheet-twodigits" type="number" name="attr_keyword_score4" value="0"/>
-						<img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
+						<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
 						<input class="sheet-twodigits"  type="number" name="attr_keyword_masteries4"  value="0" />
 						<button type="roll" value="&{template:abilityRoll} {{name=@{character_name}}} {{Keyword=@{keyword4}}} {{target=[[{[[(@{totalkeyscore4}+?{mods|0})%20]],0}}]]}} {{Masteries=[[floor((@{totalkeyscore4}+?{mods|0})/20)]] }} {{roll=[[1d20cs1cf20]]}} " ></button>
 
@@ -433,7 +433,7 @@
 					<div style="padding:3px;border:1px solid black;border-radius: 10px"><!-- Keyword 5 -->
 						<input class="sheet-keytext_input" placeholder="Keyword 5" type="text" class="sheet-keyword_name" name="attr_keyword5"   />
 						<input class="sheet-twodigits" type="number" name="attr_keyword_score5" value="0"/>
-						<img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
+						<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
 						<input class="sheet-twodigits"  type="number" name="attr_keyword_masteries5"  value="0" />
 						<button type="roll" value="&{template:abilityRoll} {{name=@{character_name}}} {{Keyword=@{keyword5}}} {{target=[[{[[(@{totalkeyscore5}+?{mods|0})%20]],0}}]]}} {{Masteries=[[floor((@{totalkeyscore5}+?{mods|0})/20)]] }} {{roll=[[1d20cs1cf20]]}} " ></button>
 
@@ -458,7 +458,7 @@
 						<fieldset class="repeating_otherabilities" style="display:inline">		
 							<input placeholder="Abiltiy or item" class="sheet-keytext_input" type="text" name="attr_otherability_name" />
 							<input class="sheet-twodigits" type="number" name="attr_otherability_score1" value="0"/>
-							<img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
+							<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
 							<input class="sheet-twodigits"  type="number" name="attr_otherability_masteries1"  value="0" />
 							<button type="roll" value="&{template:abilityRoll} {{name=@{character_name}}} {{Keyword=@{otherability_name}}} {{target=[[{[[(@{totalotherscore1}+?{mods|0})%20]],0}}]]}} {{Masteries=[[floor((@{totalotherscore1}+?{mods|0})/20)]] }} {{roll=[[1d20cs1cf20]]}} " ></button>
 							<input  style="display:none" type="number" name="attr_totalotherscore1" value="0" />						
@@ -472,7 +472,7 @@
 							<fieldset class="repeating_flaws" style="display:inline">		
 								<input placeholder="flaw" class="sheet-keytext_input" type="text" name="attr_flaw_name" />
 								<input class="sheet-twodigits" type="number" name="attr_flaw_score1" value="0"/>
-								<img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
+								<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
 								<input class="sheet-twodigits"  type="number" name="attr_flaw_masteries1"  value="0" />
 								<button type="roll" value="&{template:abilityRoll} {{name=@{character_name}}} {{Keyword=@{flaw_name}}} {{target=[[{[[(@{totalflawscore1}+?{mods|0})%20]],0}}]]}} {{Masteries=[[floor((@{totalflawscore1}+?{mods|0})/20)]] }} {{roll=[[1d20cs1cf20]]}} " ></button>
 								<input style="display:none"  type="number" name="attr_totalflawscore1" value="0" />						
@@ -497,7 +497,7 @@
 	<!--
 							<input type="text" style="width:142px;" placeholder=""  class="sheet-text_input" name="attr_disting_char" />
 							<input class="sheet-twodigits " style="width:3.75em" type="number" name="attr_distingchar_score" value="1" />					
-							<img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
+							<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="10" height="10" />
 							<input class="sheet-twodigits"  type="number" name="attr_dstingchar_masteries1"  value="0" />						
 							<button type="roll"></button>
 							<input type="number" name="attr_totaldistingscore1" value="0" />	
@@ -805,11 +805,11 @@
 		
 			<div >
 				<div style="display:inline-block">{{target}}</div>
-				<div style="display:inline-block"><img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Heroquest_Glorantha/target.png" width="25" height="25" /></div>
+				<div style="display:inline-block"><img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Heroquest_Glorantha/target.png" width="25" height="25" /></div>
 				<div style="display:inline-block">{{roll}}</div>
-				<div style="display:inline-block"><img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Heroquest_Glorantha/d20_2.png" width="25" height="25" /></div>
+				<div style="display:inline-block"><img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Heroquest_Glorantha/d20_2.png" width="25" height="25" /></div>
 				<div style="margin-left:15px;display:inline-block"> {{Masteries}} </div>
-				<div style="display:inline-block"><img src="https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="25" height="25" /></div>			
+				<div style="display:inline-block"><img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Heroquest_Glorantha/mastery.png" width="25" height="25" /></div>			
 			</div>
 			
 			<div style="margin-top:14px;margin-bottom:14px; ">

--- a/Our Last Best Hope/ourlastbesthope.html
+++ b/Our Last Best Hope/ourlastbesthope.html
@@ -1,7 +1,7 @@
 <div class="charsheet">
     
 <div class="logo">
-    <img src="https://raw.githubusercontent.com/stephanieroll20/roll20-character-sheets/sb-ourlastbesthope/Our%20Last%20Best%20Hope/logo.png" alt="Our Last Best Hope logo"/>
+    <img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/sb-ourlastbesthope/Our%20Last%20Best%20Hope/logo.png" alt="Our Last Best Hope logo"/>
 </div>
 <div class="body">
     <p class="header">

--- a/Sengoku/Sengoku.css
+++ b/Sengoku/Sengoku.css
@@ -185,7 +185,7 @@ input.sheet-showBushi:checked ~ div.sheet-Bushi{
     width: 275px;
 	background-size: 265px 139px;
     background-repeat: no-repeat;	
-	background-image: url(https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Sengoku/logo.png);
+	background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Sengoku/logo.png);
 	
 }
 
@@ -313,7 +313,7 @@ input.sheet-showBushi:checked ~ div.sheet-Bushi{
 	font-family:Tahoma;
 	background-size: 226px;
 	background-repeat: no-repeat;
-	background-image: url(https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Sengoku/border3.png);
+	background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Sengoku/border3.png);
 	
 	
 }
@@ -349,7 +349,7 @@ input.sheet-showBushi:checked ~ div.sheet-Bushi{
 	font-family:Tahoma;
 	background-size: 226px;
 	background-repeat: no-repeat;
-	background-image: url(https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Sengoku/border3.png);
+	background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Sengoku/border3.png);
 	
 	
 }
@@ -383,7 +383,7 @@ input.sheet-showBushi:checked ~ div.sheet-Bushi{
 	font-family:Tahoma;
 	background-size: 226px;
 	background-repeat: no-repeat;
-	background-image: url(https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Sengoku/border3.png);
+	background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Sengoku/border3.png);
 	
 	
 }
@@ -423,7 +423,7 @@ input.sheet-showBushi:checked ~ div.sheet-Bushi{
 	font-family:Tahoma;
 	background-size: 226px;
 	background-repeat: no-repeat;
-	background-image: url(https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Sengoku/border3.png);
+	background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Sengoku/border3.png);
 	
 	
 }
@@ -461,7 +461,7 @@ input.sheet-showBushi:checked ~ div.sheet-Bushi{
 	font-family:Tahoma;
 	background-size: 226px;
 	background-repeat: no-repeat;
-	background-image: url(https://raw.githubusercontent.com/Lockbox313/roll20-character-sheets/master/Sengoku/border3.png);
+	background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Sengoku/border3.png);
 	
 	
 }

--- a/Stargate-RPG/Readme.md
+++ b/Stargate-RPG/Readme.md
@@ -1,2 +1,11 @@
 ## Stargate RPG
 Offical Roll20 Character sheet for "Stargate RPG" by Wyvern Gaming (Full release: Aug 2020, Quickstart: February 2020)
+
+
+### Changelog
+
+**v.1.01 (2020-05-13)**
+* update img links to point to Roll20's repo
+
+**v.1.00 (2020-03-09)**
+* initial release

--- a/Stargate-RPG/stargate.css
+++ b/Stargate-RPG/stargate.css
@@ -228,7 +228,7 @@ div.sheet-page1 {
                       "attr attacks attacks attacks  "; 
   width: 850px;
   height: 1000px;
-  background-image: url(https://raw.githubusercontent.com/Anduh/roll20-character-sheets/StarGate-v01/Stargate-RPG/images/bg.png);
+  background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Stargate-RPG/images/bg.png);
   background-repeat: no-repeat;
   background-size: 700px 700px;
   background-position: center;
@@ -245,7 +245,7 @@ div.sheet-page2 {
                       "prof   notes    ";
   width: 840px;
   height: 990px;
-  background-image: url(https://raw.githubusercontent.com/Anduh/roll20-character-sheets/StarGate-v01/Stargate-RPG/images/bg.png);
+  background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Stargate-RPG/images/bg.png);
   background-repeat: no-repeat;
   background-size: 700px 700px;
   background-position: center;
@@ -283,7 +283,7 @@ div.sheet-attr{
   grid-area: attr;
 }
 div.sheet-attr .sheet-stat{
-  background-image: url(https://raw.githubusercontent.com/Anduh/roll20-character-sheets/StarGate-v01/Stargate-RPG/images/attr.png);
+  background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Stargate-RPG/images/attr.png);
   background-repeat: no-repeat;
   background-size: 124px 113px;
   width: 120px;

--- a/Terre 2/Terre 2.css
+++ b/Terre 2/Terre 2.css
@@ -1086,7 +1086,7 @@ div.sheet-menu
 	display:none;
 	
 	color:#4F3F35;	
-	background-image: url("https://raw.githubusercontent.com/Zakarik/roll20-character-sheets/master/Terre%202/images/Background.jpg");
+	background-image: url("https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Terre%202/images/Background.jpg");
 	background-position:0px -21px;
 	border: 1px solid black;
 	border-bottom-right-radius: 30px;

--- a/vampire-v5/VTM_Dice_Mechanics.js
+++ b/vampire-v5/VTM_Dice_Mechanics.js
@@ -329,7 +329,7 @@ function processVampireDiceScript(run, dc) {
 		}
 	}
 
-	let thebeast = '<img src="https://raw.githubusercontent.com/Kirintale/roll20-character-sheets/master/vampire-v5/Banners/TheBeast.png" title="The Beast" height="20" width="228"/>';
+	let thebeast = '<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/vampire-v5/Banners/TheBeast.png" title="The Beast" height="20" width="228"/>';
 
 	if (run.rouseStatRoll) {
 		if (diceTotals.successScore > 0) {
@@ -381,11 +381,11 @@ function addRollDeclarations(diceTotals, outputMessage, endTemplateSection, theb
 	if (diceTotals.successScore == 0 && vtmGlobal.luckydice) {
 		let lastResort = '<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/vampire-v5/Banners/lastresort.png" title="Miss" height="20" width="228"/>';
 		outputMessage += "{{Fate=" + lastResort + endTemplateSection;
-		let miss = '<img src="https://raw.githubusercontent.com/Kirintale/roll20-character-sheets/master/vampire-v5/Banners/MissFail.png" title="Miss" height="20" width="228"/>';
+		let miss = '<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/vampire-v5/Banners/MissFail.png" title="Miss" height="20" width="228"/>';
 		outputMessage += "{{Miss=" + miss + endTemplateSection;
 	} else if (diceTotals.successScore == 0) {
 		//outputMessage += "{{Fate=" + "Total failure" + endTemplateSection;
-		let miss = '<img src="https://raw.githubusercontent.com/Kirintale/roll20-character-sheets/master/vampire-v5/Banners/MissFail.png" title="Miss" height="20" width="228"/>';
+		let miss = '<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/vampire-v5/Banners/MissFail.png" title="Miss" height="20" width="228"/>';
 		outputMessage += "{{Miss=" + miss + endTemplateSection;
 	} else if (vtmGlobal.luckydice) {
 		let lastResort = '<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/vampire-v5/Banners/lastresort.png" title="Miss" height="20" width="228"/>';
@@ -393,10 +393,10 @@ function addRollDeclarations(diceTotals, outputMessage, endTemplateSection, theb
 	}
 
 	if ((diceTotals.muddyCritScore >= 2) || (diceTotals.muddyCritScore === 1 && (diceTotals.critScore >= 1))) {
-		let messy = '<img src="https://raw.githubusercontent.com/Kirintale/roll20-character-sheets/master/vampire-v5/Banners/MessyCritical.png" title="Messy" height="20" width="228"/>';
+		let messy = '<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/vampire-v5/Banners/MessyCritical.png" title="Messy" height="20" width="228"/>';
 		outputMessage += "{{Messy=" + messy + endTemplateSection;
 	} else if (diceTotals.critScore >= 2) {
-		let crit = '<img src="https://raw.githubusercontent.com/Kirintale/roll20-character-sheets/master/vampire-v5/Banners/CriticalHit.png" title="Crit" height="20" width="228"/>';
+		let crit = '<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/vampire-v5/Banners/CriticalHit.png" title="Crit" height="20" width="228"/>';
 		outputMessage += "{{Crit=" + crit + endTemplateSection;
 	}
 


### PR DESCRIPTION
## Changes / Comments
* change several sheets that had image link pointing to the creator's repo so they now point at the images' location in the Roll20 repo. Tested the unsure cases

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
