### PR TITLE
Starfinder (simple): Correct 'Perception' spelling in NPC sheet

### DIFF
--- a/Starfinder (simple)/Starfinder (simple).html
+++ b/Starfinder (simple)/Starfinder (simple).html
@@ -4561,7 +4561,7 @@ to foil enemy targeting arrays and incoming projectiles forcing gunners onboard 
 				<span class="sheet-table-data-left" style="width:5%;"><input type="number" title="npc-init-misc" name="attr_npc-init-misc" value="0"/></span>
 				<span class="sheet-table-data-center" style="width:10%;"><b>Senses </b></span>
 				<span class="sheet-table-data-center"><input type="text" title="npc-senses" name="attr_npc-senses"/></span>
-				<span class="sheet-table-data-right" style="width:10%;"><button style="font-size:100%;" title="NPC-Perception-Roll" type="roll" name="roll_NPC-Perception-Roll" value="?{Hide this roll?|No, |Yes,/w GM} &{template:pf_check} {{name=@{character_name}'s}} {{check=Perception check}} {{skill_chk=[[1d20 + [[@{Perception-npc}]] ]]}}">Percecption</button></span>
+				<span class="sheet-table-data-right" style="width:10%;"><button style="font-size:100%;" title="NPC-Perception-Roll" type="roll" name="roll_NPC-Perception-Roll" value="?{Hide this roll?|No, |Yes,/w GM} &{template:pf_check} {{name=@{character_name}'s}} {{check=Perception check}} {{skill_chk=[[1d20 + [[@{Perception-npc}]] ]]}}">Perception</button></span>
 				<span class="sheet-table-data-center" style="width:5%;"><input type="number" title="Perception-npc" name="attr_Perception-npc" value="(@{WIS-bonus} + @{Perception-npc-misc})" disabled></span>
 			</div>
 		</div>


### PR DESCRIPTION
## Changes / Comments
The 'Perception' button for NPCs was misspelled.

## Roll20 Requests
- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
