### PR TITLE
Starfinder (Simple): minor spelling correction on starship tab

### DIFF
--- a/Starfinder (simple)/Starfinder (simple).html
+++ b/Starfinder (simple)/Starfinder (simple).html
@@ -4350,7 +4350,7 @@ to foil enemy targeting arrays and incoming projectiles forcing gunners onboard 
 				        <span class="sheet-table-subheader">modifier</span>
 			        </div>
 			        <div class="sheet-table-row">
-				        <span class="sheet-table-data-center" style="width:55%;"><input type="text" title="starship-sensors" name="attr_starship-sensor" placeholder="Senors"></span>
+				        <span class="sheet-table-data-center" style="width:55%;"><input type="text" title="starship-sensors" name="attr_starship-sensor" placeholder="Sensors"></span>
 				        <span class="sheet-table-data-center" style="width:30%;"><select title="starship-sensors-range" name="attr_starship-sensors-range">
 				            <option value="5" selected>short</option>
 				            <option value="10">medium</option>


### PR DESCRIPTION
This is a minor spelling fix on the Starships tab of the character sheet from 'senors' to 'sensors'.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?
