### PR TITLE
[Band of Blades] Critical roll template hotfix

### DIFF
--- a/Band of Blades Official/blades.css
+++ b/Band of Blades Official/blades.css
@@ -3344,7 +3344,7 @@ button.sheet-generatebutton .sheet-optional {
 }
 
 .sheet-rolltemplate-blades .sheet-holder.sheet-action .fullcrit ~ .fullcrit ~ .sheet-background {
-  background-image: url("https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Band%20of%20Blades%20Official/Assets/rolltemplate/action_critical.gif");
+  background-image: url("https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Band%20of%20Blades%20Official/Assets/rolltemplate/action.gif");
 }
 
 .sheet-rolltemplate-blades .sheet-holder.sheet-fortune {


### PR DESCRIPTION
Temporarily replace the critical background by the normal background until the image proxy is no longer broken.

Fixes #6541.