### PR TITLE
[PokemonTabletopUnited] Fix frozen status not saving correctly

### DIFF
--- a/PokemonTabletopUnited/ptu.html
+++ b/PokemonTabletopUnited/ptu.html
@@ -1424,7 +1424,7 @@ on("change:struggle_type change:move1_type change:move2_type change:move3_type c
                 <td class='sheet-table-header'>Burned:</td>
                 <td><input type='checkbox' value=1 name='attr_st_burn'/></td>
                 <td class='sheet-table-header'>Frozen:</td>
-                <td><input type='checkbox' name='attr_st_froz'/></td>
+                <td><input type='checkbox' value=1 name='attr_st_froz'/></td>
             </tr>
             <tr>
                 <td class='sheet-table-header'>Paralysis:</td>
@@ -3100,7 +3100,7 @@ on("change:struggle_type change:move1_type change:move2_type change:move3_type c
                 <td class='sheet-table-header'>Burned:</td>
                 <td><input type='checkbox' value=1 name='attr_st_burn'/></td>
                 <td class='sheet-table-header'>Frozen:</td>
-                <td><input type='checkbox' name='attr_st_froz'/></td>
+                <td><input type='checkbox' value=1 name='attr_st_froz'/></td>
             </tr>
             <tr>
                 <td class='sheet-table-header'>Paralysis:</td>


### PR DESCRIPTION
Added value=1 to attr_st_froz so when the Frozen checkbox is ticked, attr_st_froz returns 1 instead of  on. This brings it in line with other statuses which already have value=1 in them.
