### PR TITLE
[Scion2e] Rolls fixed to use exploding dice

### DIFF
--- a/Scion2e/scion2e.html
+++ b/Scion2e/scion2e.html
@@ -52,44 +52,44 @@
 			<label>
 				<h4>Attribute</h4>
 				<select name="attr_attribute">
-					<option value="{{attribute=}} {{roll=[[ [[0" selected></option>
+					<option value="{{attribute=}} {{roll=[[ {[[0" selected></option>
 					<optgroup label="Mental">
-						<option value="{{attribute=Intellect}} {{roll=[[ [[@{intellect}">Intellect</option>
-						<option value="{{attribute=Cunning}} {{roll=[[ [[@{cunning}">Cunning</option>
-						<option value="{{attribute=Resolve}} {{roll=[[ [[@{resolve}">Resolve</option>
+						<option value="{{attribute=Intellect}} {{roll=[[ {[[@{intellect}">Intellect</option>
+						<option value="{{attribute=Cunning}} {{roll=[[ {[[@{cunning}">Cunning</option>
+						<option value="{{attribute=Resolve}} {{roll=[[ {[[@{resolve}">Resolve</option>
 					</optgroup>
 					<optgroup label="Physical">
-						<option value="{{attribute=Might}} {{roll=[[ [[@{might}">Might</option>
-						<option value="{{attribute=Dexterity}} {{roll=[[ [[@{dexterity}">Dexterity</option>
-						<option value="{{attribute=Stamina}} {{roll=[[ [[@{stamina}">Stamina</option>
+						<option value="{{attribute=Might}} {{roll=[[ {[[@{might}">Might</option>
+						<option value="{{attribute=Dexterity}} {{roll=[[ {[[@{dexterity}">Dexterity</option>
+						<option value="{{attribute=Stamina}} {{roll=[[ {[[@{stamina}">Stamina</option>
 					</optgroup>
 					<optgroup label="Social">
-						<option value="{{attribute=Presence}} {{roll=[[ [[@{presence}">Presence</option>
-						<option value="{{attribute=Manipulation}} {{roll=[[ [[@{manipulation}">Manipulation</option>
-						<option value="{{attribute=Composure}} {{roll=[[ [[@{composure}">Composure</option>
+						<option value="{{attribute=Presence}} {{roll=[[ {[[@{presence}">Presence</option>
+						<option value="{{attribute=Manipulation}} {{roll=[[ {[[@{manipulation}">Manipulation</option>
+						<option value="{{attribute=Composure}} {{roll=[[ {[[@{composure}">Composure</option>
 					</optgroup>
 				</select>
 			</label>
 			<label>
 				<h4>Skill</h4>
 				<select name="attr_skill">
-					<option value="0]]d10>[[@{targetnumber}]]]]}} {{skill=}}" selected></option>
-					<option value="@{academics}]]d10>[[@{targetnumber}]]]]}} {{skill=Academics}}">Academics</option>
-					<option value="@{athletics}]]d10>[[@{targetnumber}]]]]}} {{skill=Athletics}}">Athletics</option>
-					<option value="@{closecombat}]]d10>[[@{targetnumber}]]]]}} {{skill=Close Combat}}">Close Combat</option>
-					<option value="@{culture}]]d10>[[@{targetnumber}]]]]}} {{skill=Culture}}">Culture</option>
-					<option value="@{empathy}]]d10>[[@{targetnumber}]]]]}} {{skill=Empathy}}">Empathy</option>
-					<option value="@{firearms}]]d10>[[@{targetnumber}]]]]}} {{skill=Firearms}}">Firearms</option>
-					<option value="@{integrity}]]d10>[[@{targetnumber}]]]]}} {{skill=Integrity}}">Integrity</option>
-					<option value="@{leadership}]]d10>[[@{targetnumber}]]]]}} {{skill=Leadership}}">Leadership</option>
-					<option value="@{medicine}]]d10>[[@{targetnumber}]]]]}} {{skill=Medicine}}">Medicine</option>
-					<option value="@{occult}]]d10>[[@{targetnumber}]]]]}} {{skill=Occult}}">Occult</option>
-					<option value="@{persuasion}]]d10>[[@{targetnumber}]]]]}} {{skill=Persuasion}}">Persuasion</option>
-					<option value="@{pilot}]]d10>[[@{targetnumber}]]]]}} {{skill=Pilot}}">Pilot</option>
-					<option value="@{science}]]d10>[[@{targetnumber}]]]]}} {{skill=Science}}">Science</option>
-					<option value="@{subterfuge}]]d10>[[@{targetnumber}]]]]}} {{skill=Subterfuge}}">Subterfuge</option>
-					<option value="@{survival}]]d10>[[@{targetnumber}]]]]}} {{skill=Survival}}">Survival</option>
-					<option value="@{technology}]]d10>[[@{targetnumber}]]]]}} {{skill=Technology}}">Technology</option>
+					<option value="0]]d10!}>[[@{targetnumber}]]]]}} {{skill=}}" selected></option>
+					<option value="@{academics}]]d10!}>[[@{targetnumber}]]]]}} {{skill=Academics}}">Academics</option>
+					<option value="@{athletics}]]d10!}>[[@{targetnumber}]]]]}} {{skill=Athletics}}">Athletics</option>
+					<option value="@{closecombat}]]d10!}>[[@{targetnumber}]]]]}} {{skill=Close Combat}}">Close Combat</option>
+					<option value="@{culture}]]d10!}>[[@{targetnumber}]]]]}} {{skill=Culture}}">Culture</option>
+					<option value="@{empathy}]]d10!}>[[@{targetnumber}]]]]}} {{skill=Empathy}}">Empathy</option>
+					<option value="@{firearms}]]d10!}>[[@{targetnumber}]]]]}} {{skill=Firearms}}">Firearms</option>
+					<option value="@{integrity}]]d10!}>[[@{targetnumber}]]]]}} {{skill=Integrity}}">Integrity</option>
+					<option value="@{leadership}]]d10!}>[[@{targetnumber}]]]]}} {{skill=Leadership}}">Leadership</option>
+					<option value="@{medicine}]]d10!}>[[@{targetnumber}]]]]}} {{skill=Medicine}}">Medicine</option>
+					<option value="@{occult}]]d10!}>[[@{targetnumber}]]]]}} {{skill=Occult}}">Occult</option>
+					<option value="@{persuasion}]]d10!}>[[@{targetnumber}]]]]}} {{skill=Persuasion}}">Persuasion</option>
+					<option value="@{pilot}]]d10!}>[[@{targetnumber}]]]]}} {{skill=Pilot}}">Pilot</option>
+					<option value="@{science}]]d10!}>[[@{targetnumber}]]]]}} {{skill=Science}}">Science</option>
+					<option value="@{subterfuge}]]d10!}>[[@{targetnumber}]]]]}} {{skill=Subterfuge}}">Subterfuge</option>
+					<option value="@{survival}]]d10!}>[[@{targetnumber}]]]]}} {{skill=Survival}}">Survival</option>
+					<option value="@{technology}]]d10!}>[[@{targetnumber}]]]]}} {{skill=Technology}}">Technology</option>
 				</select>
 			</label>
 			<button type="roll" name="roll_rollBase" value="&{template:roll} @{attribute}+@{skill}"></button>


### PR DESCRIPTION
## Changes / Comments

Modified the attributes used to build the roll for the roll template to use exploding dice (d10!) instead of normal d10's. Also added the curly brackets needed for the roll engine to understand that we want to explode normally, not based on the target number. This changes the behavior of the embedded roll template to match the Storypath system rules, excerpt: "If a player rolls a 10, that die gives one success and is rolled again. This is called 10-again, and it continues until no dice show a 10. "

Whether this means that the change is a bug fix or not depends on philosophical questions I shan't ponder here.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [YES] Does the pull request title have the sheet name(s)? Include each sheet name.
- [SORT OF] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
