### PR TITLE
LANCER RPG (1.8): Fix bonus damage display

### DIFF
--- a/LANCER RPG (1.8)/LANCER.html
+++ b/LANCER RPG (1.8)/LANCER.html
@@ -1501,11 +1501,11 @@ on("sheet:opened change:acc_diff change:frame_save_target change:frame_class cha
 								<input type="text" class="underline"value="0"  style="width:60px;text-align:center;margin-left:4px;font-weight:bold;color:#444;font-size:16px" name="attr_base_framewep1_damage2"/>
 								<select name="attr_base_framewep1_dmgtype2"class="underline" style="width:110px;height:25px;margin-left:4px;padding-top:5px;padding-bottom:0px;font-size:14px;color:#444">
 									<option value="N/A">N/A</option>
-									<option value="kinetic">KINETIC</option>
-									<option value="explosive">EXPLOSIVE</option>
-									<option value="energy">ENERGY</option>
-									<option value="heat">HEAT</option>
-									<option value="burn">BURN</option>
+									<option value="bonus_kinetic">KINETIC</option>
+									<option value="bonus_explosive">EXPLOSIVE</option>
+									<option value="bonus_energy">ENERGY</option>
+									<option value="bonus_heat">HEAT</option>
+									<option value="bonus_burn">BURN</option>
 								</select>
 							</div>
 						</div>
@@ -1590,11 +1590,11 @@ on("sheet:opened change:acc_diff change:frame_save_target change:frame_class cha
 								<input type="text" class="underline" value="0" style="width:60px;text-align:center;margin-left:4px;font-weight:bold;color:#444;font-size:16px" name="attr_framewep_damage2"/>
 								<select name="attr_framewep_dmgtype2"class="underline" style="width:110px;height:25px;margin-left:4px;padding-top:5px;padding-bottom:0px;font-size:14px;color:#444">
 									<option value="N/A">N/A</option>
-									<option value="kinetic">KINETIC</option>
-									<option value="explosive">EXPLOSIVE</option>
-									<option value="energy">ENERGY</option>
-									<option value="heat">HEAT</option>
-									<option value="burn">BURN</option>
+									<option value="bonus_kinetic">KINETIC</option>
+									<option value="bonus_explosive">EXPLOSIVE</option>
+									<option value="bonus_energy">ENERGY</option>
+									<option value="bonus_heat">HEAT</option>
+									<option value="bonus_burn">BURN</option>
 								</select>
 							</div>
 						</div>
@@ -1760,11 +1760,16 @@ on("sheet:opened change:acc_diff change:frame_save_target change:frame_class cha
 			{{#explosive}}[ {{explosive}}<img class="sheet-icon" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/LANCER RPG (1.8)/images/explosive.png" /> ] {{/explosive}}
 			{{#heat}}[ {{heat}}<img class="sheet-icon" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/LANCER RPG (1.8)/images/heat.png" /> ] {{/heat}}
 			{{#burn}}[ {{burn}}<img class="sheet-icon" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/LANCER RPG (1.8)/images/burn.png" /> ] {{/burn}}
-			</div>
-		{{#allprops() N/A name tags effect color to-hit acc-diff range threat cone burst line blast kinetic energy explosive heat burn}}
+			{{#bonus_kinetic}}[ {{bonus_kinetic}}<img class="sheet-icon" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/LANCER RPG (1.8)/images/kinetic.png" /> ] {{/bonus_kinetic}}
+			{{#bonus_energy}}[ {{bonus_energy}}<img class="sheet-icon" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/LANCER RPG (1.8)/images/energy.png" /> ] {{/bonus_energy}}
+			{{#bonus_explosive}}[ {{bonus_explosive}}<img class="sheet-icon" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/LANCER RPG (1.8)/images/explosive.png" /> ] {{/bonus_explosive}}
+			{{#bonus_heat}}[ {{bonus_heat}}<img class="sheet-icon" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/LANCER RPG (1.8)/images/heat.png" /> ] {{/bonus_heat}}
+			{{#bonus_burn}}[ {{bonus_burn}}<img class="sheet-icon" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/LANCER RPG (1.8)/images/burn.png" /> ] {{/bonus_burn}}
+		</div>
+		{{#allprops() N/A name tags effect color to-hit acc-diff range threat cone burst line blast kinetic energy explosive heat burn bonus_kinetic bonus_energy bonus_explosive bonus_heat bonus_burn}}
 		<div class="sheet-key">{{key}}</div>
 		<div class="sheet-value">{{value}}</div>
-		{{/allprops() N/A name tags effect color to-hit acc-diff range threat cone burst line blast kinetic energy explosive heat burn}}
+		{{/allprops() N/A name tags effect color to-hit acc-diff range threat cone burst line blast kinetic energy explosive heat burn bonus_kinetic bonus_energy bonus_explosive bonus_heat bonus_burn}}
 		{{#effect}}<div class="sheet-effect">{{effect}}</div>{{/effect}}
 		</div>
 	</div>


### PR DESCRIPTION
## Changes / Comments
When base damage and bonus damage were the same type, only the bonus
damage would display. This adds additional template variables to let
the bonus damage always display separately.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [Y] Does the pull request title have the sheet name(s)? Include each sheet name.
- [Y] Is this a bug fix?
- [N] Does this add functional enhancements (new features or extending existing features) ?
- [N] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [n/a] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [n/a] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
