### PR TITLE
[Cyberpunk2020] html corrections

### DIFF
--- a/Cyberpunk 2020/Cyberpunk2020.html
+++ b/Cyberpunk 2020/Cyberpunk2020.html
@@ -84,23 +84,23 @@
       <table style="width:830px;">
          <tr>
             <td style="width:50px;"></td>
-            <th><button type='roll' class="sheet-skillroll sheet-front" value='&{template:general} {{roll=@{Handle} ^{rolls} ^{int} [[1d10! + [[@{Int}]] ]]}}'
+            <th><button type='roll' class="sheet-skillroll sheet-front" value='&{template:general} {{roll=@{Handle} ^{rolls} ^{int} [[1d10!! + [[@{Int}]] ]]}}'
                   data-i18n="intelligence-abbr">Int</button></th>
-            <th><button type='roll' class="sheet-skillroll sheet-front" value='&{template:general} {{roll=@{Handle} ^{rolls} ^{ref} [[1d10! + [[@{Ref}]] ]]}}'
+            <th><button type='roll' class="sheet-skillroll sheet-front" value='&{template:general} {{roll=@{Handle} ^{rolls} ^{ref} [[1d10!! + [[@{Ref}]] ]]}}'
                   data-i18n="reflexes-abbr">Ref</button></th>
-            <th><button type='roll' class="sheet-skillroll sheet-front" value='&{template:general} {{roll=@{Handle} ^{rolls} ^{tech} [[1d10! + [[@{Tech}]] ]]}}'
+            <th><button type='roll' class="sheet-skillroll sheet-front" value='&{template:general} {{roll=@{Handle} ^{rolls} ^{tech} [[1d10!! + [[@{Tech}]] ]]}}'
                   data-i18n="technical-ability-abbr">Tech</button></th>
-            <th><button type='roll' class="sheet-skillroll sheet-front" value='&{template:general} {{roll=@{Handle} ^{rolls} ^{cool} [[1d10! + [[@{Cool}]] ]]}}'
+            <th><button type='roll' class="sheet-skillroll sheet-front" value='&{template:general} {{roll=@{Handle} ^{rolls} ^{cool} [[1d10!! + [[@{Cool}]] ]]}}'
                   data-i18n="cool">Cool</button></th>
-            <th><button type='roll' class="sheet-skillroll sheet-front" value='&{template:general} {{roll=@{Handle} ^{rolls} ^{attr} [[1d10! + [[@{Attr}]] ]]}}'
+            <th><button type='roll' class="sheet-skillroll sheet-front" value='&{template:general} {{roll=@{Handle} ^{rolls} ^{attr} [[1d10!! + [[@{Attr}]] ]]}}'
                   data-i18n="attractiveness-abbr">Attr</button></th>
-            <th><button type='roll' class="sheet-skillroll sheet-front" value='&{template:general} {{roll=@{Handle} ^{rolls} ^{luck} [[1d10! + [[@{Luck}]] ]]}}'
+            <th><button type='roll' class="sheet-skillroll sheet-front" value='&{template:general} {{roll=@{Handle} ^{rolls} ^{luck} [[1d10!! + [[@{Luck}]] ]]}}'
                   data-i18n="luck">Luck</button></th>
-            <th><button type='roll' class="sheet-skillroll sheet-front" value='&{template:general} {{roll=@{Handle} ^{rolls} ^{ma} [[1d10! + [[@{Ma}]] ]]}}'
+            <th><button type='roll' class="sheet-skillroll sheet-front" value='&{template:general} {{roll=@{Handle} ^{rolls} ^{ma} [[1d10!! + [[@{Ma}]] ]]}}'
                   data-i18n="movement-allowence-abbr">Ma</button></th>
-            <th><button type='roll' class="sheet-skillroll sheet-front" value='&{template:general} {{roll=@{Handle} ^{rolls} ^{body} [[1d10! + [[@{Body}]] ]]}}'
+            <th><button type='roll' class="sheet-skillroll sheet-front" value='&{template:general} {{roll=@{Handle} ^{rolls} ^{body} [[1d10!! + [[@{Body}]] ]]}}'
                   data-i18n="body-type">Body Type</button></th>
-            <th><button type='roll' class="sheet-skillroll sheet-front" value='&{template:general} {{roll=@{Handle} ^{rolls} ^{emp} [[1d10! + [[@{Emp}]] ]]}}'
+            <th><button type='roll' class="sheet-skillroll sheet-front" value='&{template:general} {{roll=@{Handle} ^{rolls} ^{emp} [[1d10!! + [[@{Emp}]] ]]}}'
                   data-i18n="empathy-abbr">Emp</button></th>
          </tr>
          <tr>
@@ -744,7 +744,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_AuthorityChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-spec}{{skill= ^{authority}}}{{character= @{handle} }}{{total= [[1d10!+@{Authority_Skill}+[[@{Cool}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-spec}{{skill= ^{authority}}}{{character= @{handle} }}{{total= [[1d10!!+@{Authority_Skill}+[[@{Cool}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
                                     data-i18n="authority">Authority</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Authority_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Authority_IP" /></td>
@@ -758,7 +758,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_CharismaticLeadershipChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-spec}{{skill= ^{charismatic-leadership}}}{{character= @{handle} }}{{total= [[1d10!+@{Charismatic_Leadership_Skill}+[[@{Cool}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-spec}{{skill= ^{charismatic-leadership}}}{{character= @{handle} }}{{total= [[1d10!!+@{Charismatic_Leadership_Skill}+[[@{Cool}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
                                     data-i18n="charismatic-leadership">Charismatic Leadership</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Charismatic_Leadership_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Charismatic_Leadership_IP" /></td>
@@ -772,7 +772,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_CombatSenseChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-spec}{{skill= ^{combat-sense}}}{{character= @{handle} }}{{total= [[1d10!+@{Combat_Sense_Skill}+[[@{Int}+@{Awareness_Skill}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-spec}{{skill= ^{combat-sense}}}{{character= @{handle} }}{{total= [[1d10!!+@{Combat_Sense_Skill}+[[@{Int}+@{Awareness_Skill}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }} '><label
                                     data-i18n="combat-sense">Combat Sense</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Combat_Sense_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Combat_Sense_IP" /></td>
@@ -786,7 +786,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_Credibility' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-spec}{{skill= ^{credibility}}}{{character= @{handle} }}{{total= [[1d10!+@{Credibility_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-spec}{{skill= ^{credibility}}}{{character= @{handle} }}{{total= [[1d10!!+@{Credibility_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
                                     data-i18n="credibility">Credibility</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Credibility_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Credibility_IP" /></td>
@@ -800,7 +800,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_Family' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-spec}{{skill= ^{family}}}{{character= @{handle} }}{{total= [[1d10!+@{Family_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-spec}{{skill= ^{family}}}{{character= @{handle} }}{{total= [[1d10!!+@{Family_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
                                     data-i18n="family">Family</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Family_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Family_IP" /></td>
@@ -814,7 +814,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_InterfaceChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-spec}{{skill= ^{interface}}}{{character= @{handle} }}{{total= [[1d10!+@{Interface_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-spec}{{skill= ^{interface}}}{{character= @{handle} }}{{total= [[1d10!!+@{Interface_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }} '><label
                                     data-i18n="interface">Interface</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Interface_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Interface_IP" /></td>
@@ -828,7 +828,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_JuryRigChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-spec}{{skill= ^{jury-rig}}}{{character= @{handle} }}{{total= [[1d10!+@{Jury_Rig_Skill}+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-spec}{{skill= ^{jury-rig}}}{{character= @{handle} }}{{total= [[1d10!!+@{Jury_Rig_Skill}+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }} '><label
                                     data-i18n="jury-rig">Jury Rig</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Jury_Rig_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Jury_Rig_IP" /></td>
@@ -842,7 +842,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_MedicalTechChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-spec}{{skill= ^{medical-tech}}}{{character= @{handle} }}{{total= [[1d10!+@{Medical_Tech_Skill}+[[@{Tech}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-spec}{{skill= ^{medical-tech}}}{{character= @{handle} }}{{total= [[1d10!!+@{Medical_Tech_Skill}+[[@{Tech}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }} '><label
                                     data-i18n="medical-tech">Medical Tech</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Medical_Tech_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Medical_Tech_IP" /></td>
@@ -856,7 +856,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_ResoursesChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-spec}{{skill= ^{resources}}}{{character= @{handle} }}{{total= [[1d10!+@{Resourses_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-general}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-spec}{{skill= ^{resources}}}{{character= @{handle} }}{{total= [[1d10!!+@{Resourses_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-general}]] }} '><label
                                     data-i18n="resources">Resources</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Resourses_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Resourses_IP" /></td>
@@ -870,7 +870,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_StreetdealChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-spec}{{skill= ^{streetdeal}}}{{character= @{handle} }}{{total= [[1d10!+@{Streetdeal_Skill}+[[@{Cool}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-spec}{{skill= ^{streetdeal}}}{{character= @{handle} }}{{total= [[1d10!!+@{Streetdeal_Skill}+[[@{Cool}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
                                     data-i18n="streetdeal">Streetdeal</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Streetdeal_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Streetdeal_IP" /></td>
@@ -898,7 +898,7 @@
                               <td><input type='checkbox' class="sheet-chipped" name='attr_OtherSpecialAbilitiesChip'
                                     value='1'><span></span></td>
                               <td>
-                                 <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-spec}{{skill=  @{OtherSpecialAbilities}}}{{character= @{handle} }}{{total= [[1d10!+@{OtherSpecialAbilities_Skill}+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label>
+                                 <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-spec}{{skill=  @{OtherSpecialAbilities}}}{{character= @{handle} }}{{total= [[1d10!!+@{OtherSpecialAbilities_Skill}+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label>
                                        <div class="sheet-subskill" data-i18n="roll">Roll</div>
                                     </label></button>
                                  <input type="text" class="sheet-language" style="width: 100px;" name="attr_OtherSpecialAbilities">
@@ -932,7 +932,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_HumanPerceptionChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{human-perception}}}{{character= @{handle} }}{{total= [[1d10!+@{Human_Perception_Skill}+[[@{Emp}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{human-perception}}}{{character= @{handle} }}{{total= [[1d10!!+@{Human_Perception_Skill}+[[@{Emp}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
                                     data-i18n="human-perception">Human Perception</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Human_Perception_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Human_Perception_IP" /></td>
@@ -946,7 +946,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_InterviewChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{interview}}}{{character= @{handle} }}{{total= [[1d10!+@{Interview_Skill}+[[@{Emp}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{interview}}}{{character= @{handle} }}{{total= [[1d10!!+@{Interview_Skill}+[[@{Emp}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
                                     data-i18n="interview">Interview</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Interview_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Interview_IP" /></td>
@@ -960,7 +960,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_LeadershipChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{leadership}}}{{character= @{handle} }}{{total= [[1d10!+@{Leadership_Skill}+[[@{Emp}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{leadership}}}{{character= @{handle} }}{{total= [[1d10!!+@{Leadership_Skill}+[[@{Emp}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
                                     data-i18n="leadership">Leadership</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Leadership_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Leadership_IP" /></td>
@@ -974,7 +974,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_SeductionChipROFL' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{seduction}}}{{character= @{handle} }}{{total= [[1d10!+@{Seduction_Skill}+[[@{Emp}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{seduction}}}{{character= @{handle} }}{{total= [[1d10!!+@{Seduction_Skill}+[[@{Emp}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
                                     data-i18n="seduction">Seduction</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Seduction_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Seduction_IP" /></td>
@@ -988,7 +988,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_SocialChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{social}}}{{character= @{handle} }}{{total= [[1d10!+@{Social_Skill}+[[@{Emp}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{social}}}{{character= @{handle} }}{{total= [[1d10!!+@{Social_Skill}+[[@{Emp}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
                                     data-i18n="social">Social</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Social_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Social_IP" /></td>
@@ -1002,7 +1002,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_PersuasionFastTalkChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{persuasion}}}{{character= @{handle} }}{{total= [[1d10!+@{Persuasion_Skill}+[[@{Emp}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{persuasion}}}{{character= @{handle} }}{{total= [[1d10!!+@{Persuasion_Skill}+[[@{Emp}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
                                     data-i18n="persuasion">Persuasion & Fast Talk</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Persuasion_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Persuasion_IP" /></td>
@@ -1016,7 +1016,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_PerformChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{perform}}}{{character= @{handle} }}{{total= [[1d10!+@{Perform_Skill}+[[@{Emp}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{perform}}}{{character= @{handle} }}{{total= [[1d10!!+@{Perform_Skill}+[[@{Emp}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
                                     data-i18n="perform">Perform</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Perform_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Perform_IP" /></td>
@@ -1042,7 +1042,7 @@
                            <tr>
                               <td><input type='checkbox' class="sheet-chipped" name='attr_OtherEmpChip' value='1'><span></span></td>
                               <td>
-                                 <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill= @{OtherEmp}}}{{character= @{handle} }}{{total= [[1d10!+@{OtherEmp_Skill}+[[@{Emp}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label>
+                                 <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill= @{OtherEmp}}}{{character= @{handle} }}{{total= [[1d10!!+@{OtherEmp_Skill}+[[@{Emp}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label>
                                        <div class="sheet-subskill" data-i18n="roll">Roll</div>
                                     </label></button>
                                  <input type="text" class="sheet-language" style="width: 100px;" name="attr_OtherEmp">
@@ -1076,7 +1076,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_ArcheryChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{archery}}}{{character= @{handle} }}{{total= [[1d10!+@{Archery_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{archery}}}{{character= @{handle} }}{{total= [[1d10!!+@{Archery_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
                                     data-i18n="archery">Archery</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Archery_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Archery_IP" /></td>
@@ -1090,7 +1090,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_AthleticsChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{athletics}}}{{character= @{handle} }}{{total= [[1d10!+@{Athletics_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-athletics}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{athletics}}}{{character= @{handle} }}{{total= [[1d10!!+@{Athletics_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-athletics}]] }} '><label
                                     data-i18n="athletics">Athletics</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Athletics_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Athletics_IP" /></td>
@@ -1104,7 +1104,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_BrawlingChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{brawling}}}{{character= @{handle} }}{{total= [[1d10!+@{Brawling_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{brawling}}}{{character= @{handle} }}{{total= [[1d10!!+@{Brawling_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
                                     data-i18n="brawling">Brawling</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Brawling_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Brawling_IP" /></td>
@@ -1118,7 +1118,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_DanceChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{dance}}}{{character= @{handle} }}{{total= [[1d10!+@{Dance_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-athletics}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{dance}}}{{character= @{handle} }}{{total= [[1d10!!+@{Dance_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-athletics}]] }} '><label
                                     data-i18n="dance">Dance</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Dance_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Dance_IP" /></td>
@@ -1132,7 +1132,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_DodgeEscapeChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{skill= ^{dodge}}}{{character= @{handle} }}{{total= [[1d10!+@{Dodge_And_Escape_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-athletics}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{skill= ^{dodge}}}{{character= @{handle} }}{{total= [[1d10!!+@{Dodge_And_Escape_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-athletics}]] }} '><label
                                     data-i18n="dodge">Dodge & Escape</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Dodge_And_Escape_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Dodge_And_Escape_IP" /></td>
@@ -1146,7 +1146,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_DrivingChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{driving}}}{{character= @{handle} }}{{total= [[1d10!+@{Driving_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-drive}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{driving}}}{{character= @{handle} }}{{total= [[1d10!!+@{Driving_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-drive}]] }} '><label
                                     data-i18n="driving">Driving</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Driving_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Driving_IP" /></td>
@@ -1160,7 +1160,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_FencingChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{fencing}}}{{character= @{handle} }}{{total= [[1d10!+@{Fencing_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{fencing}}}{{character= @{handle} }}{{total= [[1d10!!+@{Fencing_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
                                     data-i18n="fencing">Fencing</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Fencing_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Fencing_IP" /></td>
@@ -1174,7 +1174,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_HandgunChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{handgun}}}{{character= @{handle} }}{{total= [[1d10!+@{Handgun_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{handgun}}}{{character= @{handle} }}{{total= [[1d10!!+@{Handgun_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
                                     data-i18n="handgun">Handgun</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Handgun_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Handgun_IP" /></td>
@@ -1188,7 +1188,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_HeavyWeaponsChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{heavy-weapons}}}{{character= @{handle} }}{{total= [[1d10!+@{Heavy_Weapons_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{heavy-weapons}}}{{character= @{handle} }}{{total= [[1d10!!+@{Heavy_Weapons_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
                                     data-i18n="heavy-weapons">Heavy Weapons</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Heavy_Weapons_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Heavy_Weapons_IP" /></td>
@@ -1218,7 +1218,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_AikidoChip' value='1'><span></span></td>
                            <td style="text-align:right;"><button type='roll' class="sheet-skillroll sheet-sub_skill"
-                                 value='&{template:skill-general}{{skill= ^{aikido}}}{{character= @{handle} }}{{total= [[1d10!+@{Aikido_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
+                                 value='&{template:skill-general}{{skill= ^{aikido}}}{{character= @{handle} }}{{total= [[1d10!!+@{Aikido_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
                                     data-i18n="aikido-3">Aikido (3)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Aikido_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Aikido_IP" /></td>
@@ -1233,7 +1233,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_AnimalKungFuChip' value='1'><span></span></td>
                            <td style="text-align:right;"><button type='roll' class="sheet-skillroll sheet-sub_skill"
-                                 value='&{template:skill-general}{{skill= ^{animal-kung-fu}}}{{character= @{handle} }}{{total= [[1d10!+@{Animal_Kung_Fu_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
+                                 value='&{template:skill-general}{{skill= ^{animal-kung-fu}}}{{character= @{handle} }}{{total= [[1d10!!+@{Animal_Kung_Fu_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
                                     data-i18n="animal-kung-fu-3">Animal Kung Fu (3)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Animal_Kung_Fu_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Animal_Kung_Fu_IP" /></td>
@@ -1248,7 +1248,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_BoxingChip' value='1'><span></span></td>
                            <td style="text-align:right;"><button type='roll' class="sheet-skillroll sheet-sub_skill"
-                                 value='&{template:skill-general}{{skill= ^{boxing}}}{{character= @{handle} }}{{total= [[1d10!+@{Boxing_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
+                                 value='&{template:skill-general}{{skill= ^{boxing}}}{{character= @{handle} }}{{total= [[1d10!!+@{Boxing_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
                                     data-i18n="boxing-1">Boxing (1)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Boxing_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Boxing_IP" /></td>
@@ -1263,7 +1263,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_CapoeriaChip' value='1'><span></span></td>
                            <td style="text-align:right;"><button type='roll' class="sheet-skillroll sheet-sub_skill"
-                                 value='&{template:skill-general}{{skill= ^{capoeria}}}{{character= @{handle} }}{{total= [[1d10!+@{Capoeria_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
+                                 value='&{template:skill-general}{{skill= ^{capoeria}}}{{character= @{handle} }}{{total= [[1d10!!+@{Capoeria_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
                                     data-i18n="capoeria-3">Capoeria (3)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Capoeria_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Capoeria_IP" /></td>
@@ -1278,7 +1278,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_ChoiLiFutChip' value='1'><span></span></td>
                            <td style="text-align:right;"><button type='roll' class="sheet-skillroll sheet-sub_skill"
-                                 value='&{template:skill-general}{{skill= ^{choi-li-fut}}}{{character= @{handle} }}{{total= [[1d10!+@{Choi_Li_Fut_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
+                                 value='&{template:skill-general}{{skill= ^{choi-li-fut}}}{{character= @{handle} }}{{total= [[1d10!!+@{Choi_Li_Fut_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
                                     data-i18n="choi-li-fut-3">Choi Li Fut (3)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Choi_Li_Fut_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Choi_Li_Fut_IP" /></td>
@@ -1293,7 +1293,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_JudoChip' value='1'><span></span></td>
                            <td style="text-align:right;"><button type='roll' class="sheet-skillroll sheet-sub_skill"
-                                 value='&{template:skill-general}{{skill= ^{judo}}}{{character= @{handle} }}{{total= [[1d10!+@{Judo_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
+                                 value='&{template:skill-general}{{skill= ^{judo}}}{{character= @{handle} }}{{total= [[1d10!!+@{Judo_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
                                     data-i18n="judo-1">Judo (1)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Judo_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Judo_IP" /></td>
@@ -1308,7 +1308,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_KarateChip' value='1'><span></span></td>
                            <td style="text-align:right;"><button type='roll' class="sheet-skillroll sheet-sub_skill"
-                                 value='&{template:skill-general}{{skill= ^{karate}}}{{character= @{handle} }}{{total= [[1d10!+@{Karate_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
+                                 value='&{template:skill-general}{{skill= ^{karate}}}{{character= @{handle} }}{{total= [[1d10!!+@{Karate_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
                                     data-i18n="karate-2">Karate (2)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Karate_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Karate_IP" /></td>
@@ -1323,7 +1323,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_SavateChip' value='1'><span></span></td>
                            <td style="text-align:right;"><button type='roll' class="sheet-skillroll sheet-sub_skill"
-                                 value='&{template:skill-general}{{skill= ^{savate}}}{{character= @{handle} }}{{total= [[1d10!+@{Savate_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
+                                 value='&{template:skill-general}{{skill= ^{savate}}}{{character= @{handle} }}{{total= [[1d10!!+@{Savate_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
                                     data-i18n="savate-2">Savate (2)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Savate_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Savate_IP" /></td>
@@ -1338,7 +1338,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_TaeKwonDoChip' value='1'><span></span></td>
                            <td style="text-align:right;"><button type='roll' class="sheet-skillroll sheet-sub_skill"
-                                 value='&{template:skill-general}{{skill= ^{tae-kwon-do}}}{{character= @{handle} }}{{total= [[1d10!+@{Tae_Kwon_Do_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
+                                 value='&{template:skill-general}{{skill= ^{tae-kwon-do}}}{{character= @{handle} }}{{total= [[1d10!!+@{Tae_Kwon_Do_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
                                     data-i18n="tae-kwon-do-3">Tae Kwon Do (3)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Tae_Kwon_Do_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Tae_Kwon_Do_IP" /></td>
@@ -1353,7 +1353,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_ThaiKickBoxingChip' value='1'><span></span></td>
                            <td style="text-align:right;"><button type='roll' class="sheet-skillroll sheet-sub_skill"
-                                 value='&{template:skill-general}{{skill= ^{thai-kick-boxing}}}{{character= @{handle} }}{{total= [[1d10!+@{Thai_Kick_Boxing_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
+                                 value='&{template:skill-general}{{skill= ^{thai-kick-boxing}}}{{character= @{handle} }}{{total= [[1d10!!+@{Thai_Kick_Boxing_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
                                     data-i18n="thai-kick-boxing-4"> Thai Kick Boxing (4)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Thai_Kick_Boxing_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Thai_Kick_Boxing_IP" /></td>
@@ -1368,7 +1368,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_WrestlingChip' value='1'><span></span></td>
                            <td style="text-align:right;"><button type='roll' class="sheet-skillroll sheet-sub_skill"
-                                 value='&{template:skill-general}{{skill= ^{wrestling}}}{{character= @{handle} }}{{total= [[1d10!+@{Wrestling_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
+                                 value='&{template:skill-general}{{skill= ^{wrestling}}}{{character= @{handle} }}{{total= [[1d10!!+@{Wrestling_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
                                     data-i18n="wrestling-1">Wrestling (1)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Wrestling_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Wrestling_IP" /></td>
@@ -1382,7 +1382,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_MeleeChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{melee}}}{{character= @{handle} }}{{total= [[1d10!+@{Melee_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{melee}}}{{character= @{handle} }}{{total= [[1d10!!+@{Melee_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
                                     data-i18n="melee">Melee</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Melee_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Melee_IP" /></td>
@@ -1396,7 +1396,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_MotorcycleChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{motorcycle}}}{{character= @{handle} }}{{total= [[1d10!+@{Motorcycle_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-drive}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{motorcycle}}}{{character= @{handle} }}{{total= [[1d10!!+@{Motorcycle_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-drive}]] }} '><label
                                     data-i18n="motorcycle">Motorcycle</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Motorcycle_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Motorcycle_IP" /></td>
@@ -1410,7 +1410,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_OperateHeavyMachineryChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{operate-heavy-machine}}}{{character= @{handle} }}{{total= [[1d10!+@{Operate_Heavy_Machinery_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-drive}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{operate-heavy-machine}}}{{character= @{handle} }}{{total= [[1d10!!+@{Operate_Heavy_Machinery_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-drive}]] }} '><label
                                     data-i18n="operate-heavy-machine">Operate Heavy Machinery</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Operate_Heavy_Machinery_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Operate_Heavy_Machinery_IP" /></td>
@@ -1440,7 +1440,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_PilotGyroChip' value='1'><span></span></td>
                            <td style="text-align:right;"><button type='roll' class="sheet-skillroll sheet-sub_skill"
-                                 value='&{template:skill-general}{{skill= ^{gyro}}}{{character= @{handle} }}{{total= [[1d10!+@{Pilot_Gyro_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-drive}]] }} '><label
+                                 value='&{template:skill-general}{{skill= ^{gyro}}}{{character= @{handle} }}{{total= [[1d10!!+@{Pilot_Gyro_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-drive}]] }} '><label
                                     data-i18n="gyro-3">Gyro (3)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Pilot_Gyro_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Pilot_Gyro_IP" /></td>
@@ -1455,7 +1455,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_PilotFixedWingChip' value='1'><span></span></td>
                            <td style="text-align:right;"><button type='roll' class="sheet-skillroll sheet-sub_skill"
-                                 value='&{template:skill-general}{{skill= ^{fixed-wing}}}{{character= @{handle} }}{{total= [[1d10!+@{Pilot_Fixed_Wing_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-drive}]] }} '><label
+                                 value='&{template:skill-general}{{skill= ^{fixed-wing}}}{{character= @{handle} }}{{total= [[1d10!!+@{Pilot_Fixed_Wing_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-drive}]] }} '><label
                                     data-i18n="fixed-wing-2">Fixed Wing (2)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Pilot_Fixed_Wing_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Pilot_Fixed_Wing_IP" /></td>
@@ -1470,7 +1470,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_PilotDirigibleChip' value='1'><span></span></td>
                            <td style="text-align:right;"><button type='roll' class="sheet-skillroll sheet-sub_skill"
-                                 value='&{template:skill-general}{{skill= ^{dirigible}}}{{character= @{handle} }}{{total= [[1d10!+@{Pilot_Dirigible_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-drive}]] }} '><label
+                                 value='&{template:skill-general}{{skill= ^{dirigible}}}{{character= @{handle} }}{{total= [[1d10!!+@{Pilot_Dirigible_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-drive}]] }} '><label
                                     data-i18n="dirigible-2">Dirigible (2)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Pilot_Dirigible_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Pilot_Dirigible_IP" /></td>
@@ -1487,7 +1487,7 @@
                            <td><input type='checkbox' class="sheet-chipped" name='attr_PilotVectoredThrustVehicleChip'
                                  value='1'><span></span></td>
                            <td style="text-align:right;"><button type='roll' class="sheet-skillroll sheet-sub_skill"
-                                 value='&{template:skill-general}{{skill= ^{vectored-thrust-vehicle}}}{{character= @{handle} }}{{total= [[1d10!+@{Pilot_Vectored_Thrust_Vehicle_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-drive}]] }} '><label
+                                 value='&{template:skill-general}{{skill= ^{vectored-thrust-vehicle}}}{{character= @{handle} }}{{total= [[1d10!!+@{Pilot_Vectored_Thrust_Vehicle_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-drive}]] }} '><label
                                     data-i18n="vectored-thrust-vehicle-3">Vectored Thrust Vehicle (3)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Pilot_Vectored_Thrust_Vehicle_Skill"
                                  Value="0" /></td>
@@ -1502,7 +1502,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_RifleChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{rifle}}}{{character= @{handle} }}{{total= [[1d10!+@{Rifle_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{rifle}}}{{character= @{handle} }}{{total= [[1d10!!+@{Rifle_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
                                     data-i18n="rifle">Rifle</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Rifle_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Rifle_IP" /></td>
@@ -1516,7 +1516,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_StealthChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general} {{skill= ^{stealth} }} {{character= @{handle} }} {{total= [[1d10!+@{Stealth_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-athletics}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general} {{skill= ^{stealth} }} {{character= @{handle} }} {{total= [[1d10!!+@{Stealth_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-athletics}]] }} '><label
                                     data-i18n="stealth-2">Stealth (2)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Stealth_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Stealth_IP" /></td>
@@ -1530,7 +1530,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_SubmachinegunChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{submachinegun}}}{{character= @{handle} }}{{total= [[1d10!+@{Submachinegun_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{submachinegun}}}{{character= @{handle} }}{{total= [[1d10!!+@{Submachinegun_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-combat}]] }} '><label
                                     data-i18n="submachinegun">Submachinegun</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Submachinegun_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Submachinegun_IP" /></td>
@@ -1556,7 +1556,7 @@
                            <tr>
                               <td><input type='checkbox' class="sheet-chipped" name='attr_OtherReflexChip' value='1'><span></span></td>
                               <td style="width:220px;">
-                                 <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill=  @{OtherReflex}}}{{character= @{handle} }}{{total= [[1d10!+@{OtherReflex_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-general}]] }} '><label>
+                                 <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill=  @{OtherReflex}}}{{character= @{handle} }}{{total= [[1d10!!+@{OtherReflex_Skill}+[[@{Ref}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-general}]] }} '><label>
                                        <div class="sheet-subskill" data-i18n="roll">Roll</div>
                                     </label></button>
                                  <input type="text" class="sheet-language" style="width: 100px;" name="attr_OtherReflex">
@@ -1596,7 +1596,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_PersonalGroomingChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{personal-grooming}}}{{character= @{handle} }}{{total= [[1d10!+@{Personal_Grooming_Skill}+[[@{Attr}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{personal-grooming}}}{{character= @{handle} }}{{total= [[1d10!!+@{Personal_Grooming_Skill}+[[@{Attr}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }} '><label
                                     data-i18n="personal-grooming">Personal Grooming</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Personal_Grooming_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Personal_Grooming_IP" /></td>
@@ -1610,7 +1610,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_WardrobeStyleChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{wardrobe}}}{{character= @{handle} }}{{total= [[1d10!+@{Wardrobe_Style_Skill}+[[@{Attr}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{wardrobe}}}{{character= @{handle} }}{{total= [[1d10!!+@{Wardrobe_Style_Skill}+[[@{Attr}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }}'><label
                                     data-i18n="wardrobe">Wardrobe & Style</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Wardrobe_Style_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Wardrobe_Style_IP" /></td>
@@ -1638,7 +1638,7 @@
                               <td><input type='checkbox' class="sheet-chipped" name='attr_OtherAttractivenessChip'
                                     value='1'><span></span></td>
                               <td style="width:220px;"><button type='roll' class="sheet-skillroll" style="width: 40px;"
-                                    value='&{template:skill-general}{{skill= @{OtherAttractiveness}}}{{character= @{handle} }}{{total= [[1d10!+@{OtherAttractiveness_Skill}+[[@{Attr}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }}'><label
+                                    value='&{template:skill-general}{{skill= @{OtherAttractiveness}}}{{character= @{handle} }}{{total= [[1d10!!+@{OtherAttractiveness_Skill}+[[@{Attr}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-social}]] }}'><label
                                        data-i18n="roll">Roll</label></button>
                                  <input type="text" class="sheet-language" style="width: 100px;" name="attr_OtherAttractiveness"></td>
                               <td><input type="text" style="width: 45px;" name="attr_OtherAttractiveness_Skill" Value="0" /></td>
@@ -1670,7 +1670,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_EnduranceChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{endurance}}}{{character= @{handle} }}{{total= [[1d10!+@{Endurance_Skill}+[[@{Body}]]+?{Modifier|0}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{endurance}}}{{character= @{handle} }}{{total= [[1d10!!+@{Endurance_Skill}+[[@{Body}]]+?{Modifier|0}]] }} '><label
                                     data-i18n="endurance">Endurance</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Endurance_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Endurance_IP" /></td>
@@ -1684,7 +1684,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_StrengthFeatChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{strength-feat}}}{{character= @{handle} }}{{total= [[1d10!+@{Strength_Feat_Skill}+[[@{Body}]]+?{Modifier|0}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{strength-feat}}}{{character= @{handle} }}{{total= [[1d10!!+@{Strength_Feat_Skill}+[[@{Body}]]+?{Modifier|0}]] }} '><label
                                     data-i18n="strength-feat">Strength Feat</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Strength_Feat_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Strength_Feat_IP" /></td>
@@ -1698,7 +1698,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_SwimmingChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{swimming}}}{{character= @{handle} }}{{total= [[1d10!+@{Swimming_Skill}+[[@{Body}]]+?{Modifier|0}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{swimming}}}{{character= @{handle} }}{{total= [[1d10!!+@{Swimming_Skill}+[[@{Body}]]+?{Modifier|0}]] }} '><label
                                     data-i18n="swimming">Swimming</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Swimming_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Swimming_IP" /></td>
@@ -1724,7 +1724,7 @@
                            <tr>
                               <td><input type='checkbox' class="sheet-chipped" name='attr_OtherBodyChip' value='1'><span></span></td>
                               <td style="width:220px;"><button type='roll' class="sheet-skillroll" style="width: 40px;"
-                                    value='&{template:skill-general}{{skill= @{OtherBody}}}{{character= @{handle} }}{{total= [[1d10!+@{OtherBody_Skill}+[[@{Body}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-general}]] }}'><label
+                                    value='&{template:skill-general}{{skill= @{OtherBody}}}{{character= @{handle} }}{{total= [[1d10!!+@{OtherBody_Skill}+[[@{Body}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-general}]] }}'><label
                                        data-i18n="roll">Roll</label></button>
                                  <input type="text" class="sheet-language" style="width: 100px;" name="attr_OtherBody"></td>
                               <td><input type="text" style="width: 45px;" name="attr_OtherBody_Skill" Value="0" /></td>
@@ -1756,7 +1756,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_InterrogationChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{interrogation}}}{{character= @{handle} }}{{total= [[1d10!+@{Interrogation_Skill}+[[@{Cool}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-general}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{interrogation}}}{{character= @{handle} }}{{total= [[1d10!!+@{Interrogation_Skill}+[[@{Cool}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-general}]] }} '><label
                                     data-i18n="interrogation">Interrogation</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Interrogation_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Interrogation_IP" /></td>
@@ -1770,7 +1770,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_IntimidateChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{intimidate}}}{{character= @{handle} }}{{total= [[1d10!+@{Intimidate_Skill}+[[@{Cool}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-general}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{intimidate}}}{{character= @{handle} }}{{total= [[1d10!!+@{Intimidate_Skill}+[[@{Cool}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-general}]] }} '><label
                                     data-i18n="intimidate">Intimidate</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Intimidate_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Intimidate_IP" /></td>
@@ -1784,7 +1784,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_OratoryChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{oratory}}}{{character= @{handle} }}{{total= [[1d10!+@{Oratory_Skill}+[[@{Cool}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-general}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{oratory}}}{{character= @{handle} }}{{total= [[1d10!!+@{Oratory_Skill}+[[@{Cool}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-general}]] }} '><label
                                     data-i18n="oratory">Oratory</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Oratory_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Oratory_IP" /></td>
@@ -1798,7 +1798,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_ResistTortureChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{resist-torture}}}{{character= @{handle} }}{{total= [[1d10!+@{Resist_Skill}+[[@{Cool}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-general}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{resist-torture}}}{{character= @{handle} }}{{total= [[1d10!!+@{Resist_Skill}+[[@{Cool}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-general}]] }} '><label
                                     data-i18n="resist-torture">Resist Torture/Drugs</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Resist_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Resist_IP" /></td>
@@ -1812,7 +1812,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_StreetwiseChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{streetwise}}}{{character= @{handle} }}{{total= [[1d10!+@{Streetwise_Skill}+[[@{Cool}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-general}]] }} '><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{streetwise}}}{{character= @{handle} }}{{total= [[1d10!!+@{Streetwise_Skill}+[[@{Cool}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-general}]] }} '><label
                                     data-i18n="streetwise">Streetwise</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Streetwise_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Streetwise_IP" /></td>
@@ -1838,7 +1838,7 @@
                            <tr>
                               <td><input type='checkbox' class="sheet-chipped" name='attr_OtherCoolChip' value='1'><span></span></td>
                               <td style="width:220px;"><button type='roll' class="sheet-skillroll" style="width: 40px;"
-                                    value='&{template:skill-general}{{skill= @{OtherCool}}}{{character= @{handle} }}{{total= [[1d10!+@{OtherCool_Skill}+[[@{Cool}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-general}]] }}'><label
+                                    value='&{template:skill-general}{{skill= @{OtherCool}}}{{character= @{handle} }}{{total= [[1d10!!+@{OtherCool_Skill}+[[@{Cool}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-general}]] }}'><label
                                        data-i18n="roll">Roll</label></button>
                                  <input type="text" class="sheet-language" style="width: 100px;" name="attr_OtherCool"></td>
                               <td><input type="text" style="width: 45px;" name="attr_OtherCool_Skill" Value="0" /></td>
@@ -1870,7 +1870,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_AccountingChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{accounting}}}{{character= @{handle} }}{{total= [[1d10!+@{Accounting_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{accounting}}}{{character= @{handle} }}{{total= [[1d10!!+@{Accounting_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="accounting">Accounting</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Accounting_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Accounting_IP" /></td>
@@ -1884,7 +1884,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_AnthropologyChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{anthropology}}}{{character= @{handle} }}{{total= [[1d10!+@{Anthropology_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{anthropology}}}{{character= @{handle} }}{{total= [[1d10!!+@{Anthropology_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="anthropology">Anthropology</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Anthropology_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Anthropology_IP" /></td>
@@ -1898,7 +1898,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_AwarnessChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{awareness}}}{{character= @{handle} }}{{total= [[1d10!+@{Awareness_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{awareness}}}{{character= @{handle} }}{{total= [[1d10!!+@{Awareness_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="awareness">Awareness/Notice</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Awareness_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Awareness_IP" /></td>
@@ -1912,7 +1912,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_BiologyChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{biology}}}{{character= @{handle} }}{{total= [[1d10!+@{Biology_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{biology}}}{{character= @{handle} }}{{total= [[1d10!!+@{Biology_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="biology">Biology</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Biology_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Biology_IP" /></td>
@@ -1926,7 +1926,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_BotanyChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{botany}}}{{character= @{handle} }}{{total= [[1d10!+@{Botany_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{botany}}}{{character= @{handle} }}{{total= [[1d10!!+@{Botany_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="botany">Botany</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Botany_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Botany_IP" /></td>
@@ -1940,7 +1940,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_ChemistryChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{chemistry}}}{{character= @{handle} }}{{total= [[1d10!+@{Chemistry_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{chemistry}}}{{character= @{handle} }}{{total= [[1d10!!+@{Chemistry_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="chemistry">Chemistry</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Chemistry_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Chemistry_IP" /></td>
@@ -1954,7 +1954,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_CompositionChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{composition}}}{{character= @{handle} }}{{total= [[1d10!+@{Composition_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{composition}}}{{character= @{handle} }}{{total= [[1d10!!+@{Composition_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="composition">Composition</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Composition_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Composition_IP" /></td>
@@ -1968,7 +1968,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_DiagnoseIllnessChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{diagnose-illness}}}{{character= @{handle} }}{{total= [[1d10!+@{Diagnose_Illness_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{diagnose-illness}}}{{character= @{handle} }}{{total= [[1d10!!+@{Diagnose_Illness_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="diagnose-illness">Diagnose Illness</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Diagnose_Illness_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Diagnose_Illnesss_IP" /></td>
@@ -1982,7 +1982,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_EducationChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{education}}}{{character= @{handle} }}{{total= [[1d10!+@{Education_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{education}}}{{character= @{handle} }}{{total= [[1d10!!+@{Education_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="education">Education & General Knowledge</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Education_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Education_IP" /></td>
@@ -2005,7 +2005,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_Expert1Chip' value='1'><span></span></td>
                            <td>
-                              <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill= @{Expert1} }}{{character= @{handle} }}{{total= [[1d10!+@{Expert1_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label>
+                              <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill= @{Expert1} }}{{character= @{handle} }}{{total= [[1d10!!+@{Expert1_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label>
                                     <div class="sheet-subskill" data-i18n="roll">Roll</div>
                                  </label></button>
                               <input type="text" class="sheet-language" style="width: 100px;" name="attr_Expert1">
@@ -2016,7 +2016,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_Expert2Chip' value='1'><span></span></td>
                            <td>
-                              <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill= @{Expert2} }}{{character= @{handle} }}{{total= [[1d10!+@{Expert2_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label>
+                              <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill= @{Expert2} }}{{character= @{handle} }}{{total= [[1d10!!+@{Expert2_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label>
                                     <div class="sheet-subskill" data-i18n="roll">Roll</div>
                                  </label></button>
                               <input type="text" class="sheet-language" style="width: 100px;" name="attr_Expert2">
@@ -2027,7 +2027,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_Expert3Chip' value='1'><span></span></td>
                            <td>
-                              <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill= @{Expert3} }}{{character= @{handle} }}{{total= [[1d10!+@{Expert3_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label>
+                              <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill= @{Expert3} }}{{character= @{handle} }}{{total= [[1d10!!+@{Expert3_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label>
                                     <div class="sheet-subskill" data-i18n="roll">Roll</div>
                                  </label></button>
                               <input type="text" class="sheet-language" style="width: 100px;" name="attr_Expert3">
@@ -2038,7 +2038,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_Expert4Chip' value='1'><span></span></td>
                            <td>
-                              <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill= @{Expert4} }}{{character= @{handle} }}{{total= [[1d10!+@{Expert4_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label>
+                              <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill= @{Expert4} }}{{character= @{handle} }}{{total= [[1d10!!+@{Expert4_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label>
                                     <div class="sheet-subskill" data-i18n="roll">Roll</div>
                                  </label></button>
                               <input type="text" class="sheet-language" style="width: 100px;" name="attr_Expert4">
@@ -2055,7 +2055,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_GambleChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{gamble}}}{{character= @{handle} }}{{total= [[1d10!+@{Gamble_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{gamble}}}{{character= @{handle} }}{{total= [[1d10!!+@{Gamble_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="gamble">Gamble</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Gamble_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Gamble_IP" /></td>
@@ -2069,7 +2069,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_GeologyChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{geology}}}{{character= @{handle} }}{{total= [[1d10!+@{Geology_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{geology}}}{{character= @{handle} }}{{total= [[1d10!!+@{Geology_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="geology">Geology</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Geology_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Geology_IP" /></td>
@@ -2083,7 +2083,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_HideEvadeChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{hide}}}{{character= @{handle} }}{{total= [[1d10!+@{Hide_Evade_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{hide}}}{{character= @{handle} }}{{total= [[1d10!!+@{Hide_Evade_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="hide">Hide/Evade</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Hide_Evade_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Hide_Evade_IP" /></td>
@@ -2097,7 +2097,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_HistoryChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{history}}}{{character= @{handle} }}{{total= [[1d10!+@{History_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{history}}}{{character= @{handle} }}{{total= [[1d10!!+@{History_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="history">History</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_History_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_History_IP" /></td>
@@ -2120,7 +2120,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_KnowLanguage1Chip' value='1'><span></span></td>
                            <td>
-                              <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill= @{SpokenLanguage1} }}{{character= @{handle} }}{{total= [[1d10!+@{SpokenLanguage1_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label>
+                              <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill= @{SpokenLanguage1} }}{{character= @{handle} }}{{total= [[1d10!!+@{SpokenLanguage1_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label>
                                     <div class="sheet-subskill" data-i18n="roll">Roll</div>
                                  </label></button>
                               <input type="text" class="sheet-language" style="width: 100px;" name="attr_SpokenLanguage1">
@@ -2131,7 +2131,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_KnowLanguage2Chip' value='1'><span></span></td>
                            <td>
-                              <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill= @{SpokenLanguage2} }}{{character= @{handle} }}{{total= [[1d10!+@{SpokenLanguage2_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label>
+                              <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill= @{SpokenLanguage2} }}{{character= @{handle} }}{{total= [[1d10!!+@{SpokenLanguage2_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label>
                                     <div class="sheet-subskill" data-i18n="roll">Roll</div>
                                  </label></button>
                               <input type="text" class="sheet-language" style="width: 100px;" name="attr_SpokenLanguage2">
@@ -2142,7 +2142,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_KnowLanguage3Chip' value='1'><span></span></td>
                            <td>
-                              <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill= @{SpokenLanguage3} }}{{character= @{handle} }}{{total= [[1d10!+@{SpokenLanguage3_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label>
+                              <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill= @{SpokenLanguage3} }}{{character= @{handle} }}{{total= [[1d10!!+@{SpokenLanguage3_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label>
                                     <div class="sheet-subskill" data-i18n="roll">Roll</div>
                                  </label></button>
                               <input type="text" class="sheet-language" style="width: 100px;" name="attr_SpokenLanguage3">
@@ -2153,7 +2153,7 @@
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_KnowLanguage4Chip' value='1'><span></span></td>
                            <td>
-                              <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill= @{SpokenLanguage4} }}{{character= @{handle} }}{{total= [[1d10!+@{SpokenLanguage4_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label>
+                              <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill= @{SpokenLanguage4} }}{{character= @{handle} }}{{total= [[1d10!!+@{SpokenLanguage4_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label>
                                     <div class="sheet-subskill" data-i18n="roll">Roll</div>
                                  </label></button>
                               <input type="text" class="sheet-language" style="width: 100px;" name="attr_SpokenLanguage4">
@@ -2170,7 +2170,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_LibrarySearchChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{library-search}}}{{character= @{handle} }}{{total= [[1d10!+@{Library_Search_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{library-search}}}{{character= @{handle} }}{{total= [[1d10!!+@{Library_Search_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="library-search">Library Search</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Library_Search_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Library_Search_IP" /></td>
@@ -2184,7 +2184,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_MathematicsChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{mathematics}}}{{character= @{handle} }}{{total= [[1d10!+@{Mathematics_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{mathematics}}}{{character= @{handle} }}{{total= [[1d10!!+@{Mathematics_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="mathematics">Mathematics</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Mathematics_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Mathematics_IP" /></td>
@@ -2198,7 +2198,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_PhysicsChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{physics}}}{{character= @{handle} }}{{total= [[1d10!+@{Physics_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{physics}}}{{character= @{handle} }}{{total= [[1d10!!+@{Physics_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="physics">Physics</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Physics_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Physics_IP" /></td>
@@ -2212,7 +2212,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_ProgrammingChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{programming}}}{{character= @{handle} }}{{total= [[1d10!+@{Programming_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{programming}}}{{character= @{handle} }}{{total= [[1d10!!+@{Programming_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="programming">Programming</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Programming_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Programming_IP" /></td>
@@ -2226,7 +2226,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_ShadowChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{shadow}}}{{character= @{handle} }}{{total= [[1d10!+@{Shadow_Track_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{shadow}}}{{character= @{handle} }}{{total= [[1d10!!+@{Shadow_Track_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="shadow">Shadow/Track</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Shadow_Track_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Shadow_Track_IP" /></td>
@@ -2240,7 +2240,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_StockMarketChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{stock-market}}}{{character= @{handle} }}{{total= [[1d10!+@{Stock_Market_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{stock-market}}}{{character= @{handle} }}{{total= [[1d10!!+@{Stock_Market_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="stock-market">Stock Market</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Stock_Market_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Stock_Market_IP" /></td>
@@ -2254,7 +2254,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_SystemKnowledgeChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{system-knowledge}}}{{character= @{handle} }}{{total= [[1d10!+@{System_Knowledge_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{system-knowledge}}}{{character= @{handle} }}{{total= [[1d10!!+@{System_Knowledge_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="system-knowledge">System Knowledge</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_System_Knowledge_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_System_Knowledge_IP" /></td>
@@ -2268,7 +2268,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_Teaching' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{teaching}}}{{character= @{handle} }}{{total= [[1d10!+@{Teaching_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{teaching}}}{{character= @{handle} }}{{total= [[1d10!!+@{Teaching_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="teaching">Teaching</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Teaching_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Teaching_IP" /></td>
@@ -2282,7 +2282,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_WildernessSurvivalChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{wilderness-survival}}}{{character= @{handle} }}{{total= [[1d10!+@{Wilderness_Survival_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{wilderness-survival}}}{{character= @{handle} }}{{total= [[1d10!!+@{Wilderness_Survival_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="wilderness-survival">Wilderness Survival</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Wilderness_Survival_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Wilderness_Survival_IP" /></td>
@@ -2296,7 +2296,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_ZoologyChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{zoology}}}{{character= @{handle} }}{{total= [[1d10!+@{Zoology_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{zoology}}}{{character= @{handle} }}{{total= [[1d10!!+@{Zoology_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                     data-i18n="zoology">Zoology</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Zoology_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Zoology_IP" /></td>
@@ -2323,7 +2323,7 @@
                            <tr>
                               <td><input type='checkbox' class="sheet-chipped" name='attr_OtherIntChip' value='1'><span></span></td>
                               <td style="width:220px;"><button type='roll' class="sheet-skillroll" style="width: 40px;"
-                                    value='&{template:skill-general}{{skill= @{OtherInt}}}{{character= @{handle} }}{{total= [[1d10!+@{OtherInt_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
+                                    value='&{template:skill-general}{{skill= @{OtherInt}}}{{character= @{handle} }}{{total= [[1d10!!+@{OtherInt_Skill}+[[@{Int}]]+?{Modifier|0}]] }} {{fumble= [[@{fumble-int}]] }}'><label
                                        data-i18n="roll">Roll</label></button>
                                  <input type="text" class="sheet-language" style="width: 100px;" name="attr_OtherInt"></td>
                               <td><input type="text" style="width: 45px;" name="attr_OtherInt_Skill" Value="0" /></td>
@@ -2355,7 +2355,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_AreoTechChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{aero-tech}}}{{character= @{handle}}}{{total= [[1d10!+@{Aero_Tech_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{aero-tech}}}{{character= @{handle}}}{{total= [[1d10!!+@{Aero_Tech_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
                                     data-i18n="aero-tech-2">Aero Tech (2)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Aero_Tech_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Aero_Tech_IP" /></td>
@@ -2369,7 +2369,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_AVTechChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{av-tech}}}{{character= @{handle}}}{{total= [[1d10!+@{AV_Tech_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{av-tech}}}{{character= @{handle}}}{{total= [[1d10!!+@{AV_Tech_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
                                     data-i18n="av-tech-3">AV Tech (3)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_AV_Tech_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_AV_Tech_IP" /></td>
@@ -2383,7 +2383,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_BasicTechChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{basic-tech}}}{{character= @{handle}}}{{total= [[1d10!+@{Basic_Tech_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{basic-tech}}}{{character= @{handle}}}{{total= [[1d10!!+@{Basic_Tech_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
                                     data-i18n="basic-tech-2">Basic Tech (2)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Basic_Tech_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Basic_Tech_IP" /></td>
@@ -2397,7 +2397,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_CryotankOperationChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{cryotank-operation}}}{{character= @{handle}}}{{total= [[1d10!+@{Cryotank_Operation_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{cryotank-operation}}}{{character= @{handle}}}{{total= [[1d10!!+@{Cryotank_Operation_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
                                     data-i18n="cryotank-operation">Cryotank Operation</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Cryotank_Operation_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Cryotank_Operation_IP" /></td>
@@ -2411,7 +2411,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_CyberdeckDesignChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{cyberdeck-design}}}{{character= @{handle}}}{{total= [[1d10!+@{Cyberdeck_Design_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{cyberdeck-design}}}{{character= @{handle}}}{{total= [[1d10!!+@{Cyberdeck_Design_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
                                     data-i18n="cyberdeck-design-2">Cyberdeck Design (2)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Cyberdeck_Design_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Cyberdeck_Design_IP" /></td>
@@ -2425,7 +2425,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_CyberTechChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{cybertech}}}{{character= @{handle}}}{{total= [[1d10!+@{Cybertech_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{cybertech}}}{{character= @{handle}}}{{total= [[1d10!!+@{Cybertech_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
                                     data-i18n="cybertech-2">Cybertech (2)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_CyberTech_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_CyberTech_IP" /></td>
@@ -2439,7 +2439,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_DemolitionsChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{demolitions}}}{{character= @{handle}}}{{total= [[1d10!+@{Demolitions_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{demolitions}}}{{character= @{handle}}}{{total= [[1d10!!+@{Demolitions_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
                                     data-i18n="demolitions-2">Demolitions (2)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Demolitions_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Demolitions_IP" /></td>
@@ -2453,7 +2453,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_DisguiseChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{disguise}}}{{character= @{handle}}}{{total= [[1d10!+@{Disguise_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{disguise}}}{{character= @{handle}}}{{total= [[1d10!!+@{Disguise_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
                                     data-i18n="disguise">Disguise</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Disguise_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Disguise_IP" /></td>
@@ -2467,7 +2467,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_ElectronicsChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{electronics}}}{{character= @{handle}}}{{total= [[1d10!+@{Electronics_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{electronics}}}{{character= @{handle}}}{{total= [[1d10!!+@{Electronics_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
                                     data-i18n="electronics">Electronics</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Electronics_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Electronics_IP" /></td>
@@ -2481,7 +2481,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_ElectronicsSecurityChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{electronic-security}}}{{character= @{handle}}}{{total= [[1d10!+@{Electronic_Security_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{electronic-security}}}{{character= @{handle}}}{{total= [[1d10!!+@{Electronic_Security_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
                                     data-i18n="electronic-security-2">Electronics Security (2)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Electronic_Security_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Electronic_Security_IP" /></td>
@@ -2495,7 +2495,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_FirstAidChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{first-aid}}}{{character= @{handle}}}{{total= [[1d10!+@{First_Aid_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{first-aid}}}{{character= @{handle}}}{{total= [[1d10!!+@{First_Aid_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
                                     data-i18n="first-aid">First Aid</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_First_Aid_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_First_Aid_IP" /></td>
@@ -2509,7 +2509,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_ForgeryChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{forgery}}}{{character= @{handle}}}{{total= [[1d10!+@{Forgery_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{forgery}}}{{character= @{handle}}}{{total= [[1d10!!+@{Forgery_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
                                     data-i18n="forgery">Forgery</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Forgery_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Forgery_IP" /></td>
@@ -2523,7 +2523,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_GyroTechChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{gyro-tech}}}{{character= @{handle}}}{{total= [[1d10!+@{Gyro_Tech_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{gyro-tech}}}{{character= @{handle}}}{{total= [[1d10!!+@{Gyro_Tech_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
                                     data-i18n="gyro-tech-3">Gyro Tech (3)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Gyro_Tech_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Gyro_Tech_IP" /></td>
@@ -2537,7 +2537,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_PaintorDrawChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{paint-or-draw}}}{{character= @{handle}}}{{total= [[1d10!+@{Paint_or_Draw_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{paint-or-draw}}}{{character= @{handle}}}{{total= [[1d10!!+@{Paint_or_Draw_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
                                     data-i18n="paint-or-draw">Paint or Draw</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Paint_or_Draw_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Paint_or_Draw_IP" /></td>
@@ -2551,7 +2551,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_PhotographyFilmChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{photography-and-film}}}{{character= @{handle}}}{{total= [[1d10!+@{Photography_and_Film_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{photography-and-film}}}{{character= @{handle}}}{{total= [[1d10!!+@{Photography_and_Film_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
                                     data-i18n="photography-and-film">Photography and Film</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Photography_and_Film_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Photography_and_Film_IP" /></td>
@@ -2565,7 +2565,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_PharmaceuticalsChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{pharmaceuticals}}}{{character= @{handle}}}{{total= [[1d10!+@{Pharmaceuticals_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{pharmaceuticals}}}{{character= @{handle}}}{{total= [[1d10!!+@{Pharmaceuticals_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
                                     data-i18n="pharmaceuticals-2">Pharmaceuticals (2)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Pharmaceuticals_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Pharmaceuticals_IP" /></td>
@@ -2579,7 +2579,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_PickLockChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{pick-lock}}}{{character= @{handle}}}{{total= [[1d10!+@{Pick_Lock_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{pick-lock}}}{{character= @{handle}}}{{total= [[1d10!!+@{Pick_Lock_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
                                     data-i18n="pick-lock">Pick Lock</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Pick_Lock_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Pick_Lock_IP" /></td>
@@ -2593,7 +2593,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_PickPocketChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{pick-pocket}}}{{character= @{handle}}}{{total= [[1d10!+@{Pick_Pocket_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{pick-pocket}}}{{character= @{handle}}}{{total= [[1d10!!+@{Pick_Pocket_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
                                     data-i18n="pick-pocket">Pick Pocket</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Pick_Pocket_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Pick_Pocket_IP" /></td>
@@ -2607,7 +2607,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_PlayInstrumentChip' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{play-instrument}}}{{character= @{handle}}}{{total= [[1d10!+@{Play_Instrument_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{play-instrument}}}{{character= @{handle}}}{{total= [[1d10!!+@{Play_Instrument_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
                                     data-i18n="play-instrument">Play Instrument</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Play_Instrument_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Play_Instrument_IP" /></td>
@@ -2621,7 +2621,7 @@
                      <table style="width:390px;">
                         <tr>
                            <td><input type='checkbox' class="sheet-chipped" name='attr_Weaponsmith' value='1'><span></span></td>
-                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{weaponsmith}}}{{character= @{handle}}}{{total= [[1d10!+@{Weaponsmith_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
+                           <td><button type='roll' class="sheet-skillroll sheet-set" value='&{template:skill-general}{{skill= ^{weaponsmith}}}{{character= @{handle}}}{{total= [[1d10!!+@{Weaponsmith_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label
                                     data-i18n="weaponsmith-2">Weaponsmith (2)</label></button></td>
                            <td><input type="text" style="width: 45px;" name="attr_Weaponsmith_Skill" Value="0" /></td>
                            <td><input type="text" style="width: 45px;" name="attr_Weaponsmith_IP" /></td>
@@ -2648,7 +2648,7 @@
                            <tr>
                               <td><input type='checkbox' class="sheet-chipped" name='attr_OtherTechChip' value='1'><span></span></td>
                               <td style="width:220px;">
-                                 <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill= @{OtherTech}}}{{character= @{handle}}}{{total= [[1d10!+@{OtherTech_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label>
+                                 <button type='roll' class="sheet-skillroll" style="width: 40px;" value='&{template:skill-general}{{skill= @{OtherTech}}}{{character= @{handle}}}{{total= [[1d10!!+@{OtherTech_Skill}+[[@{Tech}]]+?{Modifier|0}]]}}{{fumble= [[@{fumble-tech}]] }}'><label>
                                        <div class="sheet-subskill" data-i18n="roll">Roll</div>
                                     </label></button>
                                  <input type="text" class="sheet-language" style="width: 100px;" name="attr_OtherTech">
@@ -2833,7 +2833,7 @@
                <td data-i18n="modifier">Modifier</td>
             </tr>
             <tr>
-               <td><button type='roll' class="sheet-skillroll" style="width:120px;" value='&{template:initiative} {{character= @{Handle} }}{{init= [[1d10!+[[@{initiative}]] &{tracker}]]}}'>
+               <td><button type='roll' class="sheet-skillroll" style="width:120px;" value='&{template:initiative} {{character= @{Handle} }}{{init= [[1d10!!+[[@{initiative}]] &{tracker}]]}}'>
                      <h3 class="sheet-front" data-i18n="initiative">Initiative</h3>
                   </button></td>
                <td><input type="number" class="sheet-stat" name="attr_initiative" value="(@{Ref}) + @{Combat_Sense_Skill} + @{initiative_mod}"
@@ -2917,12 +2917,12 @@
          <tr>
             <th>
                <div class="sheet-tooltips" style="width:75%">
-                  <button type='roll' style="width:30px;" class="sheet-weaponroll" value='&{template:ranged} {{skill= @{WeaponSkill} }} {{character= @{Handle} }} {{weapon= @{WeaponName} }} {{target-token_name= at @{target|token_name} }} {{attack= [[1d10!+[[@{Weaponskill}]] + [[ @{Ref} ]] + @{WA} + [[@{Modifier-total} ]]+?{Modifier|0}]] }} {{damage= [[@{WeaponDamage}]] }}{{hit-location= [[@{hit-loc}]] }} {{fumble=[[ @{fumble-combat} ]]}} {{notes= @{WeaponNotes} }} {{short-range= [[@{WeaponRange}/4]] }} {{medium-range= [[@{WeaponRange}/2]] }} {{long-range= [[@{WeaponRange}]] }} {{extreme-range= [[@{WeaponRange}*2]] }} } '></button>
+                  <button type='roll' style="width:30px;" class="sheet-weaponroll" value='&{template:ranged} {{skill= @{WeaponSkill} }} {{character= @{Handle} }} {{weapon= @{WeaponName} }} {{target-token_name= at @{target|token_name} }} {{attack= [[1d10!!+[[@{Weaponskill}]] + [[ @{Ref} ]] + @{WA} + [[@{Modifier-total} ]]+?{Modifier|0}]] }} {{damage= [[@{WeaponDamage}]] }}{{hit-location= [[@{hit-loc}]] }} {{fumble=[[ @{fumble-combat} ]]}} {{notes= @{WeaponNotes} }} {{short-range= [[@{WeaponRange}/4]] }} {{medium-range= [[@{WeaponRange}/2]] }} {{long-range= [[@{WeaponRange}]] }} {{extreme-range= [[@{WeaponRange}*2]] }} } '></button>
                   <span data-i18n="requires-a-target-token">Requires a target token</span>
                </div>
             </th>
             <th>
-               <button type='roll' style="width:30px;" class="sheet-weaponroll" value='&{template:ranged} {{skill= @{WeaponSkill} }} {{character= @{Handle} }} {{weapon= @{WeaponName} }} {{attack= [[1d10!+[[@{Weaponskill}]] + [[ @{Ref} ]] + @{WA} + [[@{Modifier-total} ]]+?{Modifier|0}]] }} {{damage= [[@{WeaponDamage}]] }}{{hit-location= [[@{hit-loc}]] }} {{fumble= [[@{fumble-combat}]] }} {{notes= @{WeaponNotes} }} {{short-range= [[@{WeaponRange}/4]] }} {{medium-range= [[@{WeaponRange}/2]] }} {{long-range= [[@{WeaponRange}]] }} {{extreme-range= [[@{WeaponRange}*2]] }} } '></button>
+               <button type='roll' style="width:30px;" class="sheet-weaponroll" value='&{template:ranged} {{skill= @{WeaponSkill} }} {{character= @{Handle} }} {{weapon= @{WeaponName} }} {{attack= [[1d10!!+[[@{Weaponskill}]] + [[ @{Ref} ]] + @{WA} + [[@{Modifier-total} ]]+?{Modifier|0}]] }} {{damage= [[@{WeaponDamage}]] }}{{hit-location= [[@{hit-loc}]] }} {{fumble= [[@{fumble-combat}]] }} {{notes= @{WeaponNotes} }} {{short-range= [[@{WeaponRange}/4]] }} {{medium-range= [[@{WeaponRange}/2]] }} {{long-range= [[@{WeaponRange}]] }} {{extreme-range= [[@{WeaponRange}*2]] }} } '></button>
             </th>
             <th><input type="text" name="attr_WeaponName" /></th>
             <th>
@@ -3278,7 +3278,7 @@
             <td data-i18n="modifier">Modifier</td>
          </tr>
          <tr>
-            <td><button type='roll' class="sheet-skillroll" style="width:120px;" value='&{template:skill-general}{{skill= ^{cyber-deck} ^{initiative} }}{{character= @{handle} }}{{total= [[1d10!+@{cyber_Initiative_attrib} + @{cyber_Initiative_Deck_Speed} + @{cyber_Initiative_mod}]] }} {{fumble= [[@{fumble-hack}]] }}'><label
+            <td><button type='roll' class="sheet-skillroll" style="width:120px;" value='&{template:skill-general}{{skill= ^{cyber-deck} ^{initiative} }}{{character= @{handle} }}{{total= [[1d10!!+@{cyber_Initiative_attrib} + @{cyber_Initiative_Deck_Speed} + @{cyber_Initiative_mod}]] }} {{fumble= [[@{fumble-hack}]] }}'><label
                      data-i18n="initiative">Initiative</label></button></td>
             <td></td>
             <td>=</td>
@@ -3317,7 +3317,7 @@
                <th style="width:44px;" data-i18n="mod">Mod</th>
             </tr>
             <tr>
-               <td><button type='roll' class="sheet-skillroll" style="width:90px;" value='&{template:skill-general}{{skill= @{ProgramClass}:@{ProgramName} }}{{character= @{handle} }}{{total= [[1d10!+ @{ProgramStr} + @{Program_attrib} + @{Program_skill} + @{Program_mod}]] }} {{notes= @{Program_note}}} {{fumble= [[@{fumble-hack}]] }}'><label
+               <td><button type='roll' class="sheet-skillroll" style="width:90px;" value='&{template:skill-general}{{skill= @{ProgramClass}:@{ProgramName} }}{{character= @{handle} }}{{total= [[1d10!!+ @{ProgramStr} + @{Program_attrib} + @{Program_skill} + @{Program_mod}]] }} {{notes= @{Program_note}}} {{fumble= [[@{fumble-hack}]] }}'><label
                         data-i18n="run-program">Run Program</label></button></td>
                <th><input type="text" name="attr_ProgramName" /></th>
                <th>
@@ -3412,7 +3412,7 @@
    <fieldset class="repeating_templateweapons">
       <table class="sheet-skilltable_wide">
          <tr>
-            <td><button type='roll' style="width:30px;" class="sheet-weaponroll" value='&{template:netcombat} {{skill= @{Interface_Skill}}} {{character= @{Handle}}} {{Cmd= @{Command}}} {{Tgt=@{CommandTarget}}} {{ProgNotes=@{ProgNotes}}}  {{netattack= [[1d10! +@{CmdPts} +@{TgtPts} +@{Int} +?{Modifier|0} ]] }}'></button></td>
+            <td><button type='roll' style="width:30px;" class="sheet-weaponroll" value='&{template:netcombat} {{skill= @{Interface_Skill}}} {{character= @{Handle}}} {{Cmd= @{Command}}} {{Tgt=@{CommandTarget}}} {{ProgNotes=@{ProgNotes}}}  {{netattack= [[1d10!! +@{CmdPts} +@{TgtPts} +@{Int} +?{Modifier|0} ]] }}'></button></td>
             <td><select name="attr_Command" style="width:150px;">
                   <option value=""></option>
                   <option value="Detect/Conceal" data-i18n="detect">Detect/Conceal</option>
@@ -3512,11 +3512,11 @@
 			{{/rollWasFumble() attack}}
 		</table>
     </rolltemplate>
-    
+
     <rolltemplate class="sheet-rolltemplate-save">
 		<table>
 			<tr>
-				<th colspan="3" data-i18n="save">Save</th> 
+				<th colspan="3" data-i18n="save">Save</th>
 			</tr>
 			<tr>
 				<td colspan="3"><i><b>{{character}}</b> <span data-i18n="tries-to-stay-in-the-fight">tries to stay in the fight!</span> </i></td>
@@ -3538,7 +3538,7 @@
 			</tr>
 		</table>
     </rolltemplate>
-    
+
     <rolltemplate class="sheet-rolltemplate-initiative">
 		<table class="sheet-initiative">
 			<tr>
@@ -3552,7 +3552,7 @@
 			</tr>
 		</table>
     </rolltemplate>
-    
+
     <rolltemplate class="sheet-rolltemplate-netcombat">
 		<table class="sheet-netcombat">
 			<tr>
@@ -3575,7 +3575,7 @@
 			</tr>
 		</table>
     </rolltemplate>
-	
+
     <rolltemplate class="sheet-rolltemplate-general">
         <table class="sheet-general">
 			{{#name}}<tr><th colspan="2">{{name}}</th></tr>{{/name}}
@@ -3586,7 +3586,7 @@
 			{{/allprops() name roll notes}}
         </table>
     </rolltemplate>
-   
+
     <rolltemplate class="sheet-rolltemplate-skill-general">
         <table class="sheet-skill-general">
             <tr>
@@ -3610,7 +3610,7 @@
             {{/notes}}
         </table>
     </rolltemplate>
-    
+
     <rolltemplate class="sheet-rolltemplate-skill-spec">
     <table class="sheet-skill-spec">
         <tr>
@@ -3629,7 +3629,7 @@
         {{/rollWasFumble() total}}
     </table>
     </rolltemplate>
-    
+
     <rolltemplate class="sheet-rolltemplate-autofire">
     <table class="sheet-skill-autofire">
         <tr>
@@ -3704,92 +3704,92 @@
     </rolltemplate>
 </div>
 
-<script type="text/worker"> 
+<script type="text/worker">
 
     //Body Type Damage
 on("change:Body sheet:opened", function() {
     getAttrs(["Body","damage_bonus", "BTM"], function(values) {
 
         if (values.Body == 2) {
-            setAttrs({ 
+            setAttrs({
                 damage_bonus: -2,
                 BTM: 0
             })
         }
 		else if (values.Body == 3) {
-            setAttrs({ 
+            setAttrs({
 				damage_bonus: -1,
                 BTM: -1
             })
         }
 		else if (values.Body == 4) {
-            setAttrs({ 
+            setAttrs({
 				damage_bonus: -1,
                 BTM: -1
             })
         }
 		else if (values.Body == 5) {
-            setAttrs({ 
+            setAttrs({
 				damage_bonus: 0,
                 BTM: -2
             })
         }
 		else if (values.Body == 6) {
-            setAttrs({ 
+            setAttrs({
 				damage_bonus: 0,
                 BTM: -2
             })
         }
 		else if (values.Body == 7) {
-            setAttrs({ 
+            setAttrs({
 				damage_bonus: 0,
                 BTM: -2
             })
         }
 		else if (values.Body == 8) {
-            setAttrs({ 
+            setAttrs({
 				damage_bonus: 1,
                 BTM: -3
             })
         }
 		else if (values.Body == 9) {
-            setAttrs({ 
+            setAttrs({
 				damage_bonus: 1,
                 BTM: -3
             })
         }
 		else if (values.Body == 10) {
-            setAttrs({ 
+            setAttrs({
 				damage_bonus: 2,
                 BTM: -4
             })
         }
 		else if (values.Body == 11) {
-            setAttrs({ 
+            setAttrs({
 				damage_bonus: 4,
                 BTM: -5
             })
         }
 		else if (values.Body == 12) {
-            setAttrs({ 
+            setAttrs({
 				damage_bonus: 4,
                 BTM: -5
             })
         }
 		else if (values.Body == 13) {
-            setAttrs({ 
+            setAttrs({
 				damage_bonus: 6,
                 BTM: -5
             })
         }
 		else if (values.Body == 14) {
-            setAttrs({ 
+            setAttrs({
 				damage_bonus: 6,
                 BTM: -5
             })
         }
 		else if (values.Body >= 15) {
-            setAttrs({ 
+            setAttrs({
 				damage_bonus: 8,
                 BTM: -5
             })
@@ -3833,12 +3833,12 @@ on("change:repeating_cybernetics:toggle_Cybernote_1 sheet:opened", function() {
     getAttrs(["repeating_cybernetics_toggle_Cybernote_1","repeating_cybernetics_toggle_Cybernote_2"], function(values) {
 
         if (values.repeating_cybernetics_toggle_Cybernote_1 == 1) {
-            setAttrs({ 
+            setAttrs({
                 repeating_cybernetics_toggle_Cybernote_2: 1
             })
         }
         else if (values.repeating_cybernetics_toggle_Cybernote_1 == 0) {
-            setAttrs({ 
+            setAttrs({
     			repeating_cybernetics_toggle_Cybernote_2: 0
             })
         }
@@ -3850,12 +3850,12 @@ on("change:repeating_templateweapons:toggle_weaponnote_1 sheet:opened", function
     getAttrs(["repeating_templateweapons_toggle_weaponnote_1","repeating_templateweapons_toggle_weaponnote_2"], function(values) {
 
         if (values.repeating_templateweapons_toggle_weaponnote_1 == 1) {
-            setAttrs({ 
+            setAttrs({
                 repeating_templateweapons_toggle_weaponnote_2: 1
             })
         }
         else if (values.repeating_templateweapons_toggle_weaponnote_1 == 0) {
-            setAttrs({ 
+            setAttrs({
     			repeating_templateweapons_toggle_weaponnote_2: 0
             })
         }
@@ -3866,39 +3866,39 @@ on("change:repeating_programs:toggle_programnote_1 sheet:opened", function() {
     getAttrs(["repeating_programs_toggle_programnote_1","repeating_programnote_toggle_programnote_2"], function(values) {
 
         if (values.repeating_programs_toggle_programnote_1 == 1) {
-            setAttrs({ 
+            setAttrs({
                 repeating_programnote_toggle_programnote_2: 1
             })
         }
         else if (values.repeating_programs_toggle_programnote_1 == 0) {
-            setAttrs({ 
+            setAttrs({
     			repeating_programnote_toggle_programnote_2: 0
             })
         }
     });
 });
 
-    //Auto Wound Check- Serious 
+    //Auto Wound Check- Serious
 on("change:Wound sheet:opened", function() {
     getAttrs(["Wound","SeriousWound"], function(values) {
 
         if (values.Wound == 1.011) {
-            setAttrs({ 
+            setAttrs({
                 SeriousWound: 2
             })
         }
         else if (values.Wound == 1.012) {
-            setAttrs({ 
+            setAttrs({
     			SeriousWound: 2
             })
         }
         else if (values.Wound == 1.013) {
-            setAttrs({ 
+            setAttrs({
         		SeriousWound: 2
             })
         }
         else if (values.Wound == 1.014) {
-            setAttrs({ 
+            setAttrs({
         		SeriousWound: 2
             })
         }
@@ -3924,43 +3924,43 @@ on("change:Wound sheet:opened", function() {
             Mortal5Wounded: 0,
             Mortal6Wounded: 0
         };
-        
+
         if (values.Wound >= 1.001) {
             attrs.LightlyWounded = 1;
         }
-        
+
         if (values.Wound >= 1.011) {
             attrs.SeriouslyWounded = 1;
         }
-        
+
         if (values.Wound >= 2.001) {
             attrs.CriticallyWounded = 1;
         }
-        
+
         if (values.Wound >= 3.001) {
             attrs.Mortal0Wounded = 1;
         }
-        
+
         if (values.Wound >= 3.011) {
             attrs.Mortal1Wounded = 1;
         }
-        
+
         if (values.Wound >= 3.021) {
             attrs.Mortal2Wounded = 1;
         }
-        
+
         if (values.Wound >= 3.031) {
             attrs.Mortal3Wounded = 1;
         }
-        
+
         if (values.Wound >= 3.041) {
             attrs.Mortal4Wounded = 1;
         }
-        
+
         if (values.Wound >= 3.051) {
             attrs.Mortal5Wounded = 1;
         }
-        
+
         if (values.Wound >= 3.061) {
             attrs.Mortal6Wounded = 1;
         }
@@ -4152,11 +4152,11 @@ var TAS = TAS || (function(){
                 '%c '+label+': %c '+message + ' ',
                 'background-color: '+lBGColor+';color: '+lTxtColor+'; font-weight:bold;',
                 'background-color: '+mBGColor+';color: '+mTxtColor+';'
-            ); 
+            );
         };
         return function(){
             if('TAS'===key || config.logging[key]){
-               dataLogger(coloredLoggerFunction,function(m){console.log(m);},_.toArray(arguments)); 
+               dataLogger(coloredLoggerFunction,function(m){console.log(m);},_.toArray(arguments));
             }
         };
     },
@@ -4195,7 +4195,7 @@ var TAS = TAS || (function(){
         );
         config=newconf;
     },
-    
+
     debugMode = function(){
         config.logging.debug=true;
         config.debugMode = true;
@@ -4220,7 +4220,7 @@ var TAS = TAS || (function(){
                logCSA( '===================='+(csa.label ? '> '+csa.label+' <' : '')+'====================');
                logCallstackSub(csa.stack);
                return true;
-            } 
+            }
             logCS(line);
             return false;
         });
@@ -4251,10 +4251,10 @@ var TAS = TAS || (function(){
                 };
             }(callback,context));
         }
-        
+
         callstack = getCallstack();
         callstack.shift();
-        
+
         return (function(cb,ctx,cs,lbl){
             var ctxref=registerCallstack(cs,lbl);
 
@@ -4345,7 +4345,7 @@ var TAS = TAS || (function(){
 					return pvalue;
 				}
 			});
-            
+
             // string value
 			Object.defineProperty(obj.S, pname, {
                 enumerable: true,
@@ -4408,7 +4408,7 @@ var TAS = TAS || (function(){
 
 		}());
 	},
-	
+
 	repeating = function( section ) {
 		return (function(s){
 			var sectionName = s,
@@ -4416,7 +4416,7 @@ var TAS = TAS || (function(){
 				fieldNames = [],
 				operations = [],
                 after = [],
-			
+
 			repAttrs = function TAS_Repeating_Attrs(){
 				attrNames = namesFromArgs(arguments,attrNames);
 				return this;
@@ -4425,7 +4425,7 @@ var TAS = TAS || (function(){
 				fieldNames = namesFromArgs(arguments,fieldNames);
 				return this;
 			},
-			repReduce = function TAS_Repeating_Reduce(func, initial, final, context) { 
+			repReduce = function TAS_Repeating_Reduce(func, initial, final, context) {
 				operations.push({
                     type: 'reduce',
                     func: (func && _.isFunction(func) && func) || _.noop,
@@ -4482,7 +4482,7 @@ var TAS = TAS || (function(){
 					fieldIds = ids;
 					fullFieldNames = _.reduce(fieldIds,function(memo,id){
 						return memo.concat(_.map(fieldNames,function(name){
-							return 'repeating_'+sectionName+'_'+id+'_'+name;  
+							return 'repeating_'+sectionName+'_'+id+'_'+name;
 						}));
 					},[]);
 					getAttrs( _.uniq(attrNames.concat(fullFieldNames)), function(values){
@@ -4496,7 +4496,7 @@ var TAS = TAS || (function(){
 							var r={};
 							addId(r,id);
 							_.each(fieldNames,function(name){
-								var fn = 'repeating_'+sectionName+'_'+id+'_'+name;  
+								var fn = 'repeating_'+sectionName+'_'+id+'_'+name;
 								addProp(r,name,values[fn],fn);
 							});
 
@@ -4544,7 +4544,7 @@ var TAS = TAS || (function(){
 					});
 				});
 			};
-				
+
 			return {
 				attrs: repAttrs,
 				attr: repAttrs,
@@ -4649,15 +4649,15 @@ stats.forEach(stat => {
 on("change:SpecialAbilities_display", function() {
     getAttrs(["SpecialAbilities_display"], function(values) {
         setAttrs({
-            Authority_display: +values.SpecialAbilities_display, 
-            CharismaticLeadership_display: +values.SpecialAbilities_display, 
-            CombatSense_display: +values.SpecialAbilities_display, 
-            Credibility_display: +values.SpecialAbilities_display, 
-            Family_display: +values.SpecialAbilities_display, 
-            Interface_display: +values.SpecialAbilities_display, 
-            JuryRig_display: +values.SpecialAbilities_display, 
-            MedicalTech_display: +values.SpecialAbilities_display, 
-            Resourses_display: +values.SpecialAbilities_display, 
+            Authority_display: +values.SpecialAbilities_display,
+            CharismaticLeadership_display: +values.SpecialAbilities_display,
+            CombatSense_display: +values.SpecialAbilities_display,
+            Credibility_display: +values.SpecialAbilities_display,
+            Family_display: +values.SpecialAbilities_display,
+            Interface_display: +values.SpecialAbilities_display,
+            JuryRig_display: +values.SpecialAbilities_display,
+            MedicalTech_display: +values.SpecialAbilities_display,
+            Resourses_display: +values.SpecialAbilities_display,
             Streetdeal_display: +values.SpecialAbilities_display,
             OtherSpecialAbilities_display: +values.OtherSpecialAbilities_display
         });
@@ -4666,12 +4666,12 @@ on("change:SpecialAbilities_display", function() {
 on("change:Empathy_display", function() {
     getAttrs(["Empathy_display"], function(values) {
         setAttrs({
-            HumanPerception_display: +values.Empathy_display, 
-            Interview_display: +values.Empathy_display, 
-            Leadership_display: +values.Empathy_display, 
-            Seduction_display: +values.Empathy_display, 
-            Social_display: +values.Empathy_display, 
-            PersuasionFastTalk_display: +values.Empathy_display, 
+            HumanPerception_display: +values.Empathy_display,
+            Interview_display: +values.Empathy_display,
+            Leadership_display: +values.Empathy_display,
+            Seduction_display: +values.Empathy_display,
+            Social_display: +values.Empathy_display,
+            PersuasionFastTalk_display: +values.Empathy_display,
             Perform_display: +values.Empathy_display,
             OtherEmpathy_display: +values.Empathy_display
         });
@@ -4680,37 +4680,37 @@ on("change:Empathy_display", function() {
 on("change:Reflex_display", function() {
     getAttrs(["Reflex_display"], function(values) {
         setAttrs({
-            Archery_display: +values.Reflex_display, 
-            Athletics_display: +values.Reflex_display, 
-            Brawling_display: +values.Reflex_display, 
-            Dance_display: +values.Reflex_display, 
-            DodgeEscape_display: +values.Reflex_display, 
-            Driving_display: +values.Reflex_display, 
-            Fencing_display: +values.Reflex_display, 
-            Handgun_display: +values.Reflex_display, 
-            HeavyWeapons_display: +values.Reflex_display, 
-            MartialArts_display: +values.Reflex_display, 
-            Aikido_display: +values.Reflex_display, 
-            AnimalKungFu_display: +values.Reflex_display, 
-            Boxing_display: +values.Reflex_display, 
-            Capoeria_display: +values.Reflex_display, 
-            ChoiLiFut_display: +values.Reflex_display, 
-            Judo_display: +values.Reflex_display, 
-            Karate_display: +values.Reflex_display, 
-            Savate_display: +values.Reflex_display, 
-            TaeKwonDo_display: +values.Reflex_display, 
-            ThaiKickBoxing_display: +values.Reflex_display, 
-            Wrestling_display: +values.Reflex_display, 
-            Melee_display: +values.Reflex_display, 
-            Motorcycle_display: +values.Reflex_display, 
-            OperateHeavyMachinery_display: +values.Reflex_display, 
-            Pilot_display: +values.Reflex_display, 
-            PilotGyro_display: +values.Reflex_display, 
-            PilotFixedWing_display: +values.Reflex_display, 
-            PilotDirigible_display: +values.Reflex_display, 
-            PilotVectoredThrustVehicle_display: +values.Reflex_display, 
-            Rifle_display: +values.Reflex_display, 
-            Stealth_display: +values.Reflex_display, 
+            Archery_display: +values.Reflex_display,
+            Athletics_display: +values.Reflex_display,
+            Brawling_display: +values.Reflex_display,
+            Dance_display: +values.Reflex_display,
+            DodgeEscape_display: +values.Reflex_display,
+            Driving_display: +values.Reflex_display,
+            Fencing_display: +values.Reflex_display,
+            Handgun_display: +values.Reflex_display,
+            HeavyWeapons_display: +values.Reflex_display,
+            MartialArts_display: +values.Reflex_display,
+            Aikido_display: +values.Reflex_display,
+            AnimalKungFu_display: +values.Reflex_display,
+            Boxing_display: +values.Reflex_display,
+            Capoeria_display: +values.Reflex_display,
+            ChoiLiFut_display: +values.Reflex_display,
+            Judo_display: +values.Reflex_display,
+            Karate_display: +values.Reflex_display,
+            Savate_display: +values.Reflex_display,
+            TaeKwonDo_display: +values.Reflex_display,
+            ThaiKickBoxing_display: +values.Reflex_display,
+            Wrestling_display: +values.Reflex_display,
+            Melee_display: +values.Reflex_display,
+            Motorcycle_display: +values.Reflex_display,
+            OperateHeavyMachinery_display: +values.Reflex_display,
+            Pilot_display: +values.Reflex_display,
+            PilotGyro_display: +values.Reflex_display,
+            PilotFixedWing_display: +values.Reflex_display,
+            PilotDirigible_display: +values.Reflex_display,
+            PilotVectoredThrustVehicle_display: +values.Reflex_display,
+            Rifle_display: +values.Reflex_display,
+            Stealth_display: +values.Reflex_display,
             Submachinegun_display: +values.Reflex_display,
             OtherReflex_display: +values.Reflex_display
         });
@@ -4719,11 +4719,11 @@ on("change:Reflex_display", function() {
 on("change:Cool_display", function() {
     getAttrs(["Cool_display"], function(values) {
         setAttrs({
-            Interrogation_display: +values.Cool_display, 
-            Intimidate_display: +values.Cool_display, 
-            Oratory_display: +values.Cool_display, 
-            ResistTorture_display: +values.Cool_display, 
-            Streetwise_display: +values.Cool_display, 
+            Interrogation_display: +values.Cool_display,
+            Intimidate_display: +values.Cool_display,
+            Oratory_display: +values.Cool_display,
+            ResistTorture_display: +values.Cool_display,
+            Streetwise_display: +values.Cool_display,
             OtherCool_display: +values.Cool_display
         });
     });
@@ -4731,9 +4731,9 @@ on("change:Cool_display", function() {
 on("change:Body_display", function() {
     getAttrs(["Body_display"], function(values) {
         setAttrs({
-            Endurance_display: +values.Body_display, 
-            StrengthFeat_display: +values.Body_display, 
-            Swimming_display: +values.Body_display, 
+            Endurance_display: +values.Body_display,
+            StrengthFeat_display: +values.Body_display,
+            Swimming_display: +values.Body_display,
             OtherBody_display: +values.Body_display
         });
     });
@@ -4741,8 +4741,8 @@ on("change:Body_display", function() {
 on("change:Attractiveness_display", function() {
     getAttrs(["Attractiveness_display"], function(values) {
         setAttrs({
-            PersonalGrooming_display: +values.Attractiveness_display, 
-            WardrobeStyle_display: +values.Attractiveness_display, 
+            PersonalGrooming_display: +values.Attractiveness_display,
+            WardrobeStyle_display: +values.Attractiveness_display,
             OtherAttractiveness_display: +values.Attractiveness_display
         });
     });
@@ -4750,31 +4750,31 @@ on("change:Attractiveness_display", function() {
 on("change:Intelligence_display", function() {
     getAttrs(["Intelligence_display"], function(values) {
         setAttrs({
-            Accounting_display: +values.Intelligence_display, 
-            Anthropology_display: +values.Intelligence_display, 
-            Awarness_display: +values.Intelligence_display, 
-            Biology_display: +values.Intelligence_display, 
-            Botany_display: +values.Intelligence_display, 
-            Chemistry_display: +values.Intelligence_display, 
-            Composition_display: +values.Intelligence_display, 
-            DiagnoseIllness_display: +values.Intelligence_display, 
-            Education_display: +values.Intelligence_display, 
-            Expert_display: +values.Intelligence_display, 
-            Gamble_display: +values.Intelligence_display, 
-            Geology_display: +values.Intelligence_display, 
-            HideEvade_display: +values.Intelligence_display, 
-            History_display: +values.Intelligence_display, 
-            KnowLanguages_display: +values.Intelligence_display, 
-            LibrarySearch_display: +values.Intelligence_display, 
-            Mathematics_display: +values.Intelligence_display, 
-            Programming_display: +values.Intelligence_display, 
-            Physics_display: +values.Intelligence_display, 
-            Shadow_display: +values.Intelligence_display, 
-            StockMarket_display: +values.Intelligence_display, 
-            SystemKnowledge_display: +values.Intelligence_display, 
-            Teaching_display: +values.Intelligence_display, 
-            WildernessSurvival_display: +values.Intelligence_display, 
-            Zoology_display: +values.Intelligence_display, 
+            Accounting_display: +values.Intelligence_display,
+            Anthropology_display: +values.Intelligence_display,
+            Awarness_display: +values.Intelligence_display,
+            Biology_display: +values.Intelligence_display,
+            Botany_display: +values.Intelligence_display,
+            Chemistry_display: +values.Intelligence_display,
+            Composition_display: +values.Intelligence_display,
+            DiagnoseIllness_display: +values.Intelligence_display,
+            Education_display: +values.Intelligence_display,
+            Expert_display: +values.Intelligence_display,
+            Gamble_display: +values.Intelligence_display,
+            Geology_display: +values.Intelligence_display,
+            HideEvade_display: +values.Intelligence_display,
+            History_display: +values.Intelligence_display,
+            KnowLanguages_display: +values.Intelligence_display,
+            LibrarySearch_display: +values.Intelligence_display,
+            Mathematics_display: +values.Intelligence_display,
+            Programming_display: +values.Intelligence_display,
+            Physics_display: +values.Intelligence_display,
+            Shadow_display: +values.Intelligence_display,
+            StockMarket_display: +values.Intelligence_display,
+            SystemKnowledge_display: +values.Intelligence_display,
+            Teaching_display: +values.Intelligence_display,
+            WildernessSurvival_display: +values.Intelligence_display,
+            Zoology_display: +values.Intelligence_display,
             OtherIntelligence_display: +values.Intelligence_display
         });
     });
@@ -4782,26 +4782,26 @@ on("change:Intelligence_display", function() {
 on("change:Technical_display", function() {
     getAttrs(["Technical_display"], function(values) {
         setAttrs({
-            AreoTech_display: +values.Technical_display, 
-            AVTech_display: +values.Technical_display, 
-            BasicTech_display: +values.Technical_display, 
-            CryotankOperation_display: +values.Technical_display, 
-            CyberdeckDesign_display: +values.Technical_display, 
-            Cybertech_display: +values.Technical_display, 
-            Demolitions_display: +values.Technical_display, 
-            Disguise_display: +values.Technical_display, 
-            Electronics_display: +values.Technical_display, 
-            ElectronicsSecurity_display: +values.Technical_display, 
-            FirstAid_display: +values.Technical_display, 
-            Forgery_display: +values.Technical_display, 
-            GyroTech_display: +values.Technical_display, 
-            PaintorDraw_display: +values.Technical_display, 
-            PhotographyFilm_display: +values.Technical_display, 
-            Pharmaceuticals_display: +values.Technical_display, 
-            PickLock_display: +values.Technical_display, 
-            PickPocket_display: +values.Technical_display, 
-            PlayInstrument_display: +values.Technical_display, 
-            Weaponsmith_display: +values.Technical_display, 
+            AreoTech_display: +values.Technical_display,
+            AVTech_display: +values.Technical_display,
+            BasicTech_display: +values.Technical_display,
+            CryotankOperation_display: +values.Technical_display,
+            CyberdeckDesign_display: +values.Technical_display,
+            Cybertech_display: +values.Technical_display,
+            Demolitions_display: +values.Technical_display,
+            Disguise_display: +values.Technical_display,
+            Electronics_display: +values.Technical_display,
+            ElectronicsSecurity_display: +values.Technical_display,
+            FirstAid_display: +values.Technical_display,
+            Forgery_display: +values.Technical_display,
+            GyroTech_display: +values.Technical_display,
+            PaintorDraw_display: +values.Technical_display,
+            PhotographyFilm_display: +values.Technical_display,
+            Pharmaceuticals_display: +values.Technical_display,
+            PickLock_display: +values.Technical_display,
+            PickPocket_display: +values.Technical_display,
+            PlayInstrument_display: +values.Technical_display,
+            Weaponsmith_display: +values.Technical_display,
             OtherTechnical_display: +values.Technical_display
         });
     });


### PR DESCRIPTION
Change 1d10! to 1d10!!

If you roll in 1d10 10 and critic as 1, mark with pifia
----------
Cambiado el commando de 1d10! por 1d10!!

Si lanzas 1d10 y el critico es 1, lo marca como pifia. (en las tiradas de armas)

## Changes / Comments






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
