### PR TITLE
Mongoose Traveller 2e - fixed repeating section rolls

### DIFF
--- a/Mongoose_Traveller2e/MongooseTraveller.html
+++ b/Mongoose_Traveller2e/MongooseTraveller.html
@@ -432,7 +432,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Animalsspec" style="width:800px">
+                        <fieldset class="repeating_animalsspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -489,7 +489,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Athleticsspec" style="width:800px">
+                        <fieldset class="repeating_athleticsspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -545,7 +545,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Artspec" style="width:800px">
+                        <fieldset class="repeating_artspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -766,7 +766,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Drivespec" style="width:800px">
+                        <fieldset class="repeating_drivespec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -822,7 +822,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Electronicsspec" style="width:800px">
+                        <fieldset class="repeating_electronicsspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -878,7 +878,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Engineerspec" style="width:800px">
+                        <fieldset class="repeating_engineerspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -967,7 +967,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Flyerspec" style="width:800px">
+                        <fieldset class="repeating_flyerspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1056,7 +1056,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Gunnerspec" style="width:800px">
+                        <fieldset class="repeating_gunnerspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1112,7 +1112,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_GunCombatspec" style="width:800px">
+                        <fieldset class="repeating_guncombatspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1168,7 +1168,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_HeavyWeaponsspec" style="width:800px">
+                        <fieldset class="repeating_heavyweaponsspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1290,7 +1290,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Languagespec" style="width:800px">
+                        <fieldset class="repeating_languagespec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1445,7 +1445,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Meleespec" style="width:800px">
+                        <fieldset class="repeating_meleespec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1567,7 +1567,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Pilotspec" style="width:800px">
+                        <fieldset class="repeating_pilotspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1623,7 +1623,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Professionspec" style="width:800px">
+                        <fieldset class="repeating_professionspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1712,7 +1712,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Sciencespec" style="width:800px">
+                        <fieldset class="repeating_sciencespec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1768,7 +1768,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Seafarerspec" style="width:800px">
+                        <fieldset class="repeating_seafarerspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1956,7 +1956,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Tacticsspec" style="width:800px">
+                        <fieldset class="repeating_tacticsspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>


### PR DESCRIPTION
The specialty skills have an upper case letter in their fieldset name, causing button rolls to fail when called in macros. Fixed.

## Changes / Comments






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
