### PR TITLE
Mongoose Traveller 1e - fixed repeating section rolls

### DIFF
--- a/Mongoose_Traveller/MongooseTraveller.html
+++ b/Mongoose_Traveller/MongooseTraveller.html
@@ -461,7 +461,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Animalsspec" style="width:800px">
+                        <fieldset class="repeating_animalsspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -521,7 +521,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Athleticsspec" style="width:800px">
+                        <fieldset class="repeating_athleticsspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -580,7 +580,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Artspec" style="width:800px">
+                        <fieldset class="repeating_artspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -902,7 +902,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Drivespec" style="width:800px">
+                        <fieldset class="repeating_drivespec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -960,7 +960,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Engineerspec" style="width:800px">
+                        <fieldset class="repeating_engineerspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1051,7 +1051,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Flyerspec" style="width:800px">
+                        <fieldset class="repeating_flyerspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1142,7 +1142,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Gunnerspec" style="width:800px">
+                        <fieldset class="repeating_gunnerspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1203,7 +1203,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_GunCombatspec" style="width:800px">
+                        <fieldset class="repeating_guncombatspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1262,7 +1262,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_HeavyWeaponsspec" style="width:800px">
+                        <fieldset class="repeating_heavyweaponsspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1385,7 +1385,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Languagespec" style="width:800px">
+                        <fieldset class="repeating_languagespec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1476,7 +1476,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_LifeSciencesspec" style="width:800px">
+                        <fieldset class="repeating_lifesciencesspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1600,7 +1600,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Meleespec" style="width:800px">
+                        <fieldset class="repeating_meleespec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1724,7 +1724,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Pilotspec" style="width:800px">
+                        <fieldset class="repeating_pilotspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1781,7 +1781,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_PhysicalSciencesspec" style="width:800px">
+                        <fieldset class="repeating_physicalsciencesspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1905,7 +1905,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Seafarerspec" style="width:800px">
+                        <fieldset class="repeating_seafarerspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -1995,7 +1995,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_SocialSciencesspec" style="width:800px">
+                        <fieldset class="repeating_socialsciencesspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -2053,7 +2053,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_SpaceSciencesspec" style="width:800px">
+                        <fieldset class="repeating_spacesciencesspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -2243,7 +2243,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Tacticsspec" style="width:800px">
+                        <fieldset class="repeating_tacticsspec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -2301,7 +2301,7 @@
                                 <th style="width:55px;">Total</th>
                             </tr>
                         </table>
-                        <fieldset class="repeating_Tradespec" style="width:800px">
+                        <fieldset class="repeating_tradespec" style="width:800px">
                             <table>
                                 <tr>
                                     <th style="width:55px;"></th>
@@ -3041,7 +3041,7 @@
                     <td><div style="width:60px;">Cost</div></td>
                 </tr>
             </table>
-            <fieldset class="repeating_Manipulator">
+            <fieldset class="repeating_manipulator">
                 <table class="sheet-bio">
                     <tr>
                         <th style="width:100px;"></th>
@@ -3076,7 +3076,7 @@
                     <td><div style="width:60px;">Cost</div></td>
                 </tr>
             </table>
-            <fieldset class="repeating_Transportation">
+            <fieldset class="repeating_transportation">
                 <table class="sheet-bio">
                     <tr>
                         <th style="width:100px;"></th>
@@ -3111,7 +3111,7 @@
                     <td><div style="width:60px;">Cost</div></td>
                 </tr>
             </table>
-            <fieldset class="repeating_CommunicationInput">
+            <fieldset class="repeating_communicationinput">
                 <table class="sheet-bio">
                     <tr>
                         <th style="width:100px;"></th>
@@ -3132,7 +3132,7 @@
                     </tr>
                 </table>
             </fieldset>
-            <fieldset class="repeating_CommunicationOutput">
+            <fieldset class="repeating_communicationoutput">
                 <table class="sheet-bio">
                     <tr>
                         <th style="width:100px;"></th>
@@ -3210,7 +3210,7 @@
                     <td><div style="width:60px;">Cost</div></td>
                 </tr>
             </table>
-            <fieldset class="repeating_Gadgets">
+            <fieldset class="repeating_gadgets">
                 <table class="sheet-bio">
                     <tr>
                         <th style="width:100px;"></th>
@@ -3274,7 +3274,7 @@
                     <td><div style="width:60px;">Cost</div></td>
                 </tr>
             </table>
-            <fieldset class="repeating_Software">
+            <fieldset class="repeating_software">
                 <table class="sheet-bio">
                     <tr>
                         <th style="width:100px;"></th>


### PR DESCRIPTION
The specialty skills have an upper case letter in their fieldset name, causing button rolls to fail when called in macros. Fixed.

## Changes / Comments






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
