### PR TITLE
[Torchbearer] Magic and Beginner's Luck improvements

### DIFF
--- a/Torchbearer/torchbearer.css
+++ b/Torchbearer/torchbearer.css
@@ -341,14 +341,18 @@
 }
 .sheet-section.sheet-section-traveling-spellbook table tr th:nth-child(1),
 .sheet-section.sheet-section-traveling-spellbook table tr td:nth-child(1) {
-  width: 25%;
+  width: 20%;
 }
 .sheet-section.sheet-section-traveling-spellbook table tr th:nth-child(2),
 .sheet-section.sheet-section-traveling-spellbook table tr td:nth-child(2) {
-  width: 15%;
+  width: 10%;
 }
 .sheet-section.sheet-section-traveling-spellbook table tr th:nth-child(3),
 .sheet-section.sheet-section-traveling-spellbook table tr td:nth-child(3) {
+  width: 10%;
+}
+.sheet-section.sheet-section-traveling-spellbook table tr th:nth-child(4),
+.sheet-section.sheet-section-traveling-spellbook table tr td:nth-child(4) {
   width: 60%;
 }
 .sheet-section.sheet-section-traveling-spellbook table tr th select,

--- a/Torchbearer/torchbearer.html
+++ b/Torchbearer/torchbearer.html
@@ -444,7 +444,7 @@
 						</th>
                         <td>
 							<input type="number" name="attr_will_rating" value="2"/>
-							<button type='roll' name='roll_will_bl_test' value="&{template:default} {{name=Beginner's Luck based on Will}}{{Successes=[[ [[ floor( (@{will_rating} + ?{Help, wises, supplies and gear modifiers|0}) / 2 ) + ?{Traits, persona, tapped Nature, Fresh and other modifiers|0} ]]d6>4]]}}{{Ob=[[?{Obstacle|0}]]}}{{Important=Check Pass or Fail after roll!}}">
+							<button type='roll' name='roll_will_bl_test' value="&{template:default} {{name=Beginner's Luck based on Will}}{{Successes=[[ [[ ceil( (@{will_rating} + ?{Help, wises, supplies and gear modifiers|0}) / 2 ) + ?{Traits, persona, tapped Nature, Fresh and other modifiers|0} ]]d6>4]]}}{{Ob=[[?{Obstacle|0}]]}}{{Important=Check skill advancement after roll!}}">
 								<span data-i18n="BeginnersLuck">BL</span>
 							</button>
 						</td>
@@ -476,7 +476,7 @@
 						</th>
                         <td>
 							<input type="number" name="attr_health_rating" value="2"/>
-							<button type='roll' name='roll_health_bl_test' value="&{template:default} {{name=Beginner's Luck based on Health}}{{Successes=[[ [[ floor( (@{health_rating} + ?{Help, wises, supplies and gear modifiers|0}) / 2 ) + ?{Traits, persona, tapped Nature, Fresh and other modifiers|0} ]]d6>4]]}}{{Ob=[[?{Obstacle|0}]]}}{{Important=Check Pass or Fail after roll!}}">
+							<button type='roll' name='roll_health_bl_test' value="&{template:default} {{name=Beginner's Luck based on Health}}{{Successes=[[ [[ ceil( (@{health_rating} + ?{Help, wises, supplies and gear modifiers|0}) / 2 ) + ?{Traits, persona, tapped Nature, Fresh and other modifiers|0} ]]d6>4]]}}{{Ob=[[?{Obstacle|0}]]}}{{Important=Check skill advancement after roll!}}">
 								<span data-i18n="BeginnersLuck">BL</span>
 							</button>
 						</td>
@@ -1624,6 +1624,10 @@
                     <td>
                         <label for="attr_spell_name"><span data-i18n="SpellName">Spell Name</span></label>
                         <input type="text" name="attr_spell_name" />
+                    </td>
+                    <td>
+                        <label for="attr_spell_memory"><span data-i18n="Spellbook">Spellbook</span></label>
+                        <input type="checkbox" name="attr_spell_spellbook" />
                     </td>
                     <td>
                         <label for="attr_spell_memory"><span data-i18n="Memory">Memory</span></label>

--- a/Torchbearer/torchbearer.html
+++ b/Torchbearer/torchbearer.html
@@ -444,7 +444,7 @@
 						</th>
                         <td>
 							<input type="number" name="attr_will_rating" value="2"/>
-							<button type='roll' name='roll_will_bl_test' value="&{template:default} {{name=Beginner's Luck based on Will}}{{Successes=[[ [[ ceil( (@{will_rating} + ?{Help, wises, supplies and gear modifiers|0}) / 2 ) + ?{Traits, persona, tapped Nature, Fresh and other modifiers|0} ]]d6>4]]}}{{Ob=[[?{Obstacle|0}]]}}{{Important=Check skill advancement after roll!}}">
+							<button type='roll' name='roll_will_bl_test' value="&{template:default} {{name=Beginner's Luck based on Will}}{{Successes=[[ [[ ceil( (@{will_rating} + ?{Help, wises, supplies and gear modifiers|0}) / 2 ) + ?{Traits, persona, tapped Nature, Fresh and other modifiers|0} ]]d6>4]]}}{{Ob=[[?{Obstacle|0}]]}}{{Important=Check skill advancement after roll!}}" data-i18n-title="BeginnersLuckFull" title="Beginner s Luck!">
 								<span data-i18n="BeginnersLuck">BL</span>
 							</button>
 						</td>
@@ -476,7 +476,7 @@
 						</th>
                         <td>
 							<input type="number" name="attr_health_rating" value="2"/>
-							<button type='roll' name='roll_health_bl_test' value="&{template:default} {{name=Beginner's Luck based on Health}}{{Successes=[[ [[ ceil( (@{health_rating} + ?{Help, wises, supplies and gear modifiers|0}) / 2 ) + ?{Traits, persona, tapped Nature, Fresh and other modifiers|0} ]]d6>4]]}}{{Ob=[[?{Obstacle|0}]]}}{{Important=Check skill advancement after roll!}}">
+							<button type='roll' name='roll_health_bl_test' value="&{template:default} {{name=Beginner's Luck based on Health}}{{Successes=[[ [[ ceil( (@{health_rating} + ?{Help, wises, supplies and gear modifiers|0}) / 2 ) + ?{Traits, persona, tapped Nature, Fresh and other modifiers|0} ]]d6>4]]}}{{Ob=[[?{Obstacle|0}]]}}{{Important=Check skill advancement after roll!}}" data-i18n-title="BeginnersLuckFull" title="Beginner s Luck!">
 								<span data-i18n="BeginnersLuck">BL</span>
 							</button>
 						</td>

--- a/Torchbearer/translation.json
+++ b/Torchbearer/translation.json
@@ -138,6 +138,7 @@
 	"FifthCircle": "Fifth Circle",
 	"TravelingSpellbook": "Traveling Spellbook",
 	"SpellName": "Spell Name",
+	"Spellbook": "Spellbook",
 	"Memory": "Memory",
 	"SpellRulesPlaceholder": "Spell Rules",
 	"LevelRequirementsAndBenefits": "Level Requirements &amp; Benefits",

--- a/Torchbearer/translation.json
+++ b/Torchbearer/translation.json
@@ -144,5 +144,6 @@
 	"LevelRequirementsAndBenefits": "Level Requirements &amp; Benefits",
 	"LevelTitleAndBenefits": "Level Title &amp; Benefits",
 	"GrindConditionsOrder":"The Grind",
-	"BeginnersLuck":"BL"
+	"BeginnersLuck":"BL",
+	"BeginnersLuckFull":"Beginner s Luck!"
 }


### PR DESCRIPTION
## Changes / Comments
- Fixed rounding in Beginner's Luck macros from floor() to ceil()
- Added title to Beginner's Luck button since it's noted only as abbreviation and it was hard to recognize for some players
- Added Spellbook checkbox into magic section for better user expirience of magic-users. This checkbox required because of the wizard's known spells (written in the sheet) is not the same as the spells in the traveling spellbook (it has limited space).

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
