### PR TITLE
correcting Fallout mechanic button

### DIFF
--- a/Heart-the-City-Beneath-mk2/Heart.html
+++ b/Heart-the-City-Beneath-mk2/Heart.html
@@ -64,18 +64,11 @@
             <option value="supplies" data-i18n="supplies-label">Supplies</option>
             <option value="all" data-i18n="all-stress-label">All Stress</option>
           </select>
-          <button type="action" title="Clear Stress" name="act_clear_stress">Clear</button>
+          <button type="action" title="Clear Stress" name="act_clear_stress"><span data-i18n="clear-label">Clear</span></button>
         </div>
         <h4 class="redtext" data-i18n="fallout-test-label">Fallout Test</h4>
         <div>
-          <select name="attr_falloutstress" class="fullwide">
-            <option value="@{blood_stress}" data-i18n="blood-label" selected>Blood</option>
-            <option value="@{mind_stress}" data-i18n="mind-label">Mind</option>
-            <option value="@{echo_stress}" data-i18n="echo-label">Echo</option>
-            <option value="@{fortune_stress}" data-i18n="fortune-label">Fortune</option>
-            <option value="@{supplies_stress}" data-i18n="supplies-label">Supplies</option>
-          </select>
-          <button type="roll" title="Receive fallout?" name="roll_fallout" value="/em @{check-fallout-msg}: [[1d12 > @{falloutstress}]] vs. @{falloutstress}">Fallout</button>
+          <button type="roll" title="Receive fallout?" name="roll_fallout" value="/em @{check-fallout-msg}: [[1d12 > {@{blood_stress} + @{echo_stress} + @{mind_stress} + @{fortune_stress} + @{supplies_stress}}]] vs. [[(@{blood_stress} + @{mind_stress} + @{echo_stress} + @{fortune_stress} + @{supplies_stress})]]"><span data-i18n="fallout-label">Fallout</span></button>
         </div>
       </div>
       <div class="flex flex-even">

--- a/Heart-the-City-Beneath-mk2/Heart.html
+++ b/Heart-the-City-Beneath-mk2/Heart.html
@@ -20,19 +20,19 @@
       <div class="thirdwide flex flex-end">
         <h3 class="redtext" data-i18n="stress-label">Stress</h3>
         <div class="flex flex-between">
-          <span class="redtext" data-i18n="blood-label">Blood</span> <input type="number" placeholder="0" min="0" max="10" name="attr_blood_stress"/>
+          <span class="redtext" data-i18n="blood-label">Blood</span> <input type="number" value="0" min="0" max="10" name="attr_blood_stress"/>
         </div>
         <div class="flex flex-between">
-          <span class="redtext" data-i18n="mind-label">Mind</span> <input type="number" placeholder="0" min="0" max="10" name="attr_mind_stress"/>
+          <span class="redtext" data-i18n="mind-label">Mind</span> <input type="number" value="0" min="0" max="10" name="attr_mind_stress"/>
         </div>
         <div class="flex flex-between">
-          <span class="redtext" data-i18n="echo-label">Echo</span> <input type="number" placeholder="0" min="0" max="10" name="attr_echo_stress"/>
+          <span class="redtext" data-i18n="echo-label">Echo</span> <input type="number" value="0" min="0" max="10" name="attr_echo_stress"/>
         </div>
         <div class="flex flex-between">
-          <span class="redtext" data-i18n="fortune-label">Fortune</span> <input type="number" placeholder="0" min="0" max="10" name="attr_fortune_stress"/>
+          <span class="redtext" data-i18n="fortune-label">Fortune</span> <input type="number" value="0" min="0" max="10" name="attr_fortune_stress"/>
         </div>
         <div class="flex flex-between">
-          <span class="redtext" data-i18n="supplies-label">Supplies</span> <input type="number" placeholder="0" min="0" max="10" name="attr_supplies_stress"/>
+          <span class="redtext" data-i18n="supplies-label">Supplies</span> <input type="number" value="0" min="0" max="10" name="attr_supplies_stress"/>
         </div>
       </div>
       <div class="quarterwide">
@@ -68,7 +68,7 @@
         </div>
         <h4 class="redtext" data-i18n="fallout-test-label">Fallout Test</h4>
         <div>
-          <button type="roll" title="Receive fallout?" name="roll_fallout" value="/em @{check-fallout-msg}: [[1d12 > {@{blood_stress} + @{echo_stress} + @{mind_stress} + @{fortune_stress} + @{supplies_stress}}]] vs. [[(@{blood_stress} + @{mind_stress} + @{echo_stress} + @{fortune_stress} + @{supplies_stress})]]"><span data-i18n="fallout-label">Fallout</span></button>
+          <button type="roll" title="Receive fallout?" name="roll_fallout" value="/em @{check-fallout-msg}: [[1d12 > {@{blood_stress} + @{mind_stress} + @{echo_stress} + @{fortune_stress} + @{supplies_stress}}]] vs. [[(@{blood_stress} + @{mind_stress} + @{echo_stress} + @{fortune_stress} + @{supplies_stress})]]"><span data-i18n="fallout-label">Fallout</span></button>
         </div>
       </div>
       <div class="flex flex-even">

--- a/Heart-the-City-Beneath-mk2/translation.json
+++ b/Heart-the-City-Beneath-mk2/translation.json
@@ -24,6 +24,7 @@
 "domains-label":"Domains",
 "abilities-label":"Abilities",
 "fallout-label":"Fallout",
+"clear-label":"Clear",
 "notes-label":"Notes",
 "howmanydice-msg":"How many dice?",
 "difficulty-msg":"Difficulty",


### PR DESCRIPTION
## Changes / Comments

Correcting the button roll mechanic for Fallout tests, which should take into account all stress tracks rather than individual stress tracks.

Also added internationalization support for two button labels.

(As an aside, please forgive me for the earlier PR-related hiccups that I couldn't quite seem to smoothe out without just starting a new PR altogether.)

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [X] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
