### PR TITLE
[Monsterhearts 2] Additional Skins added (Chosen, Serpentine, Cerberus, Disciple)

### DIFF
--- a/Monsterhearts-2/Monsterhearts-2.html
+++ b/Monsterhearts-2/Monsterhearts-2.html
@@ -15,6 +15,10 @@
                 <option class="sheet-SkinSelect" value="8" data-i18n="lbl-vampire"> Vampire</option>
                 <option class="sheet-SkinSelect" value="9" data-i18n="lbl-werewolf"> Werewolf</option>
                 <option class="sheet-SkinSelect" value="10" data-i18n="lbl-witch"> Witch</option>
+                <option class="sheet-SkinSelect" value="11" data-il8n="lbl-chosen"> Chosen</option>
+                <option class="sheet-SkinSelect" value="12" data-il8n="lbl-serpentine"> Serpentine</option>
+                <option class="sheet-SkinSelect" value="13" data-il8n="lbl-cerberus"> Cerberus</option>
+                <option class="sheet-SkinSelect" value="14" data-il8n="lbl-disciple"> Disciple</option>
                 <option class="sheet-SkinSelect" value="99" data-i18n="lbl-customskin"> Custom Skin</option>
             </select>
     </p></div>
@@ -1325,6 +1329,519 @@
         </div>
     </div>
 
+<!-- CHOSEN --> 
+
+    <div class="sheet-Chosen" name="sheet-Chosen">
+        <hr>
+        <div class="sheet-Stats-Chosen">
+            <p align="center">
+                <b><span data-i18n="lbl-Hot">Hot</span>:</b> &nbsp;<input type="number" name="attr_Hot" min="-3" max="3" value="0" style="width: 50px"><button type='roll' value='&{template:mh2} {{name=@{CharName}}} {{roll_name=Hot}} {{roll_mod=@{hot}}} {{comment=?{@{commentprompt}|@{commentexample}}}} {{result=[[2d6 + @{hot}+?{@{macrobonus}|0}]]}}' name='roll_dsuf'></button> &nbsp;   
+                <b><span data-i18n="lbl-Cold">Cold</span>:</b> &nbsp;<input type="number" name="attr_Cold" min="-3" max="3" value="0" style="width: 50px"><button type='roll' value='&{template:mh2} {{name=@{CharName}}} {{roll_name=Cold}} {{roll_mod=@{Cold}}} {{comment=?{@{commentprompt}|@{commentexample}}}} {{result=[[2d6 + @{Cold}+?{@{macrobonus}|0}]]}}' name='roll_dsuf'></button> &nbsp;   
+                <b><span data-i18n="lbl-Volatile">Volatile</span>:</b> &nbsp;<input type="number" name="attr_Volatile" min="-3" max="3" value="0" style="width: 50px"><button type='roll' value='&{template:mh2} {{name=@{CharName}}} {{roll_name=Volatile}} {{roll_mod=@{Volatile}}} {{comment=?{@{commentprompt}|@{commentexample}}}} {{result=[[2d6 + @{Volatile}+?{@{macrobonus}|0}]]}}' name='roll_dsuf'></button> &nbsp;   
+                <b><span data-i18n="lbl-Dark">Dark</span>:</b> &nbsp;<input type="number" name="attr_Dark" min="-3" max="3" value="0" style="width: 50px"><button type='roll' value='&{template:mh2} {{name=@{CharName}}} {{roll_name=Dark}} {{roll_mod=@{Dark}}} {{comment=?{@{commentprompt}|@{commentexample}}}} {{result=[[2d6 + @{Dark}+?{@{macrobonus}|0}]]}}' name='roll_dsuf'></button> &nbsp;   
+            </p>
+        </div>
+        <hr>
+        <div class="sheet-Etc-Chosen">
+            <div class='sheet-3colrow'>
+                <div class='sheet-col'>
+                    <div class="sheet-Chosen-Backstory"  name="sheet-Chosen-Backstory"><h1><span data-i18n="lbl-backstory">Your Backstory</span></h1>
+                    <span data-i18n="text-Chosenbackstory">You have two friends who you rely on for monster-slaying or crime-fighting support. Take a String on each. <br>
+                    <br>
+                    There's someone who knows that you're the Chosen one, and wants you dead. Describe them. The MC will give them a name and two Strings on you. 
+                    </span></div>
+                    <br>
+                    <div class="sheet-StrTo-Chosen"><h1><span data-i18n="lbl-strings">Strings</span></h1>
+                        <fieldset class="repeating_StringsTo">
+                            <input type="text" name="attr_Strings" style="width: 100%"> 
+                        </fieldset>
+                    </div>
+            
+                    <hr>
+                    <div class="harm-stuff"><h1><span data-i18n="lbl-harm">Harm</span></h1> <p align="center">
+                    <input type="checkbox" class="sheet-Harm-taken" name="attr_Harm_Taken1">
+                    <input type="checkbox" class="sheet-Harm-taken" name="attr_Harm_Taken2">
+                    <input type="checkbox" class="sheet-Harm-taken" name="attr_Harm_Taken3">
+                    <input type="checkbox" class="sheet-Harm-taken" name="attr_Harm_Taken4">
+                    <br><i><span data-i18n="text-harminfo">At four Harm, Skirt Death.</span></i><br></p>
+                    </div>
+                    <div class="sheet-Conds-Chosen"><h1><span data-i18n="lbl-conditions">Conditions</span></h1>
+                        <fieldset class="repeating_Conditions">
+                        <input type="text" name="attr_Condition" style="width: 100%"><br> 
+                        </fieldset></p>
+                    </div>
+                    <hr>
+                    <div class="sheet-Notes-Chosen"><h1><span data-i18n="lbl-notes">Notes</span></h1>
+                    <textarea name="attr_Notes" rows="5" cols="30"></textarea><br>
+                    </div>
+                </div>
+                <div class="sheet-col">
+                    <h1><span data-i18n="lbl-Chosen">Chosen</span> <span data-i18n="lbl-moves">Moves</span></h1>
+                        <i><span data-i18n="text-Choseninfo">Choose two:</span></i>
+                        <div class="sheet-Moves-Chosen">
+                            
+                            <p><input type="checkbox" class="sheet-Moves-Chosen" name="attr_Moves-Chosen1"> <b><span data-i18n="text-Chosen-move1name">Growing Pains</span>:</b><span data-i18n="text-Chosen-move1desc"> When you fail to protect your friends, mark experience.</span></p>
+
+                            <p><input type="checkbox" class="sheet-Moves-Chosen" name="attr_Moves-Chosen2"> <b><span data-i18n="text-Chosen-move2name">Mercy</span>:</b><span data-i18n="text-Chosen-move2desc"> YWhen you decide to spare someone you have reason to kill, take a String on them.</span></p>
+                              
+                            <p><input type="checkbox" class="sheet-Moves-Chosen" name="attr_Moves-Chosen3"> <b><span data-i18n="text-Chosen-move3name">Final Showdown</span>:</b><span data-i18n="text-Chosen-move3desc"> Spend 4 Strings on a side character to kill them. They are totally and irrevocably dead.</span></p>
+                            
+                            <p><input type="checkbox" class="sheet-Moves-Chosen" name="attr_Moves-Chosen4"> <b><span data-i18n="text-Chosen-move4name">To The Books</span>:</b><span data-i18n="text-Chosen-move4desc"> When the chips are down and your enemies seem unbeatable, you can turn to your friends for research help. Doing so counts as <i>Gazing Into the Abyss</i>. Add 1 to your roll for each friend who really dives into the work, even when it gets monotonous. On a 10 up, in addition to other results, the visions show you your enemy's secret weakness and you gain a String on them.</span></p>
+                            
+                            <p><input type="checkbox" class="sheet-Moves-Chosen" name="attr_Moves-Chosen5"> <b><span data-i18n="text-Chosen-move5name">Take the Blow</span>:</b><span data-i18n="text-Chosen-move5desc"> When you leap into the way and take the blow instead of someone else, roll with Volatile. On a 10 up, you take the harm instead of them, but reduce it by 1. • On a 7-9, you take the harm instead of them.</span></p>
+
+                            <p><input type="checkbox" class="sheet-Moves-Chosen" name="attr_Moves-Chosen6"> <b><span data-i18n="text-Chosen-move6name">Light the Way</span>:</b><span data-i18n="text-Chosen-move6desc"> Whenever your friends follow your commands or your lead, they add 1 to their rolls.</span></p>
+                 
+                        </div>
+
+            <div class="sheet-OtherMoves-Chosen">
+                        <h1><span data-i18n="lbl-other">Other</span> <span data-i18n="lbl-moves">Moves</span></h1>
+                        <fieldset class="repeating_OtherMoves">
+                        <input type="text" name="attr_OtherMoveName" placeholder="Name"> 
+                        <textarea name="attr_OtherMoveDescrip" placeholder="Description" rows="3" cols="30"></textarea><br></fieldset>
+                        </div>
+                </div>
+                <div class="sheet-col">
+                <div class="sheet-SexMove-Chosen">
+                        <h1><span data-i18n="lbl-sexmove">Sex Move</span></h1>
+                        <span data-i18n="text-Chosen-sexmove">When you have sex, heal all of your wounds, and cure all of your Conditions. If they disgust you, give them a String. If you disgust yourself, give them a String. 
+                    </span></div>
+                    <div class="sheet-DarkestSelf-Chosen">
+                        <h1><span data-i18n="lbl-darkestself">Darkest Self</span></h1>
+                        <span data-i18n="text-Chosen-darkestself">None of your friends can help. They're not strong like you are. You need to chase down the biggest threat imaginable, immediately and alone. Any challenges or dangers that you encounter must be faced head on, even if they might kill you. You escape your Darkest Self when someone comes to your rescue or you wake up in the hospital, whichever comes first.
+                        </span></div>
+                    <hr>
+                    <div class="harm-stuff"><h1><span data-i18n="lbl-experience">Experience</span></h1><p align="center">
+                    <input type="checkbox" class="sheet-Exp-gained" name="attr_Exp_Gained1">
+                    <input type="checkbox" class="sheet-Exp-gained" name="attr_Exp_Gained2">
+                    <input type="checkbox" class="sheet-Exp-gained" name="attr_Exp_Gained3">
+                    <input type="checkbox" class="sheet-Exp-gained" name="attr_Exp_Gained4">
+                    <input type="checkbox" class="sheet-Exp-gained" name="attr_Exp_Gained5"></p>
+                    <i><span data-i18n="text-expinfo">When you have five experience points, erase them and choose one advancement from the list below:</span></i>
+                    </div><br>
+                    <div class="sheet-Advs-Chosen">
+                        <input type="checkbox" class="sheet-Advs-Chosen" name="attr_Advs-Chosen1"><span data-i18n="text-Chosen-advance1"> Add +1 to one of your stats.</span><br>
+                        <input type="checkbox" class="sheet-Advs-Chosen" name="attr_Advs-Chosen2"><span data-i18n="text-Chosen-advance2"> Take another Chosen move.</span><br>
+                        <input type="checkbox" class="sheet-Advs-Chosen" name="attr_Advs-Chosen3"><span data-i18n="text-Chosen-advance3"> Take another Chosen move.</span><br>
+                        <input type="checkbox" class="sheet-Advs-Chosen" name="attr_Advs-Chosen4"><span data-i18n="text-Chosen-advance4"> Take a move from any Skin.</span><br>
+                        <input type="checkbox" class="sheet-Advs-Chosen" name="attr_Advs-Chosen5"><span data-i18n="text-Chosen-advance5"> Take a move from any Skin.</span><br>
+                        <input type="checkbox" class="sheet-Advs-Chosen" name="attr_Advs-Chosen6"><span data-i18n="text-Chosen-advance6"> You have <b>Unholy Allies</b>.</span><br>
+                        <br>
+                        <i><span data-i18n="text-expreminder">Don't forget to manually add any advancements to your sheet. Check any you've already taken.</span></i>
+                    </div>
+                    <div class="sheet-Seasons">
+                        <h1><span data-i18n="lbl-seasonadvances">Season Advances</span></h1>
+                        <input type="checkbox" class="sheet-Advs-Skin" name="attr_SeasonAdvs0"> <span data-i18n="lbl-unlocked">Unlocked</span><br>
+                        <br>
+                        <i><span data-i18n="text-seasonadvancesinfo">Once someone has taken their fifth advance, the Season Advances are unlocked for everybody. There's one more session left after the current one, and then the season ends.</span></i><br>
+                        <br>
+                        <div class="sheet-SeasonAdvs">
+                        <input type="checkbox" class="sheet-SeasonAdvs-ChosenName" name="attr_SeasonAdvs1"><span data-i18n="text-seasonadvances1"> Change your character's Skin.</span><br> 
+                        <input type="checkbox" class="sheet-SeasonAdvs-ChosenName" name="attr_SeasonAdvs2"><span data-i18n="text-seasonadvances2"> Rewrite your Darkest Self.</span><br> 
+                        <input type="checkbox" class="sheet-SeasonAdvs-ChosenName" name="attr_SeasonAdvs3"><span data-i18n="text-seasonadvances3"> Retire your character and start a new one.</span><br> 
+                        <input type="checkbox" class="sheet-SeasonAdvs-ChosenName" name="attr_SeasonAdvs4"><span data-i18n="text-seasonadvances4"> Gain two of the Growing Up moves.</span><br> 
+                        </div>
+                        <div class="sheet-DarkestSelf-Rewritten" name="sheet-DarkestSelf-Rewritten">
+                            <h1><span data-i18n="lbl-rewritten">Rewritten Darkest Self</span></h1>
+                            <textarea name="attr_DarkestSelf-Rewritten" rows="3" cols="30"></textarea> 
+                        </div>                      
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+<!-- SERPENTINE -->
+
+    <div class="sheet-Serpentine" name="sheet-Serpentine">
+        <hr>
+        <div class="sheet-Stats-Serpentine">
+            <p align="center">
+                <b><span data-i18n="lbl-Hot">Hot</span>:</b> &nbsp;<input type="number" name="attr_Hot" min="-3" max="3" value="0" style="width: 50px"><button type='roll' value='&{template:mh2} {{name=@{CharName}}} {{roll_name=Hot}} {{roll_mod=@{hot}}} {{comment=?{@{commentprompt}|@{commentexample}}}} {{result=[[2d6 + @{hot}+?{@{macrobonus}|0}]]}}' name='roll_dsuf'></button> &nbsp;   
+                <b><span data-i18n="lbl-Cold">Cold</span>:</b> &nbsp;<input type="number" name="attr_Cold" min="-3" max="3" value="0" style="width: 50px"><button type='roll' value='&{template:mh2} {{name=@{CharName}}} {{roll_name=Cold}} {{roll_mod=@{Cold}}} {{comment=?{@{commentprompt}|@{commentexample}}}} {{result=[[2d6 + @{Cold}+?{@{macrobonus}|0}]]}}' name='roll_dsuf'></button> &nbsp;   
+                <b><span data-i18n="lbl-Volatile">Volatile</span>:</b> &nbsp;<input type="number" name="attr_Volatile" min="-3" max="3" value="0" style="width: 50px"><button type='roll' value='&{template:mh2} {{name=@{CharName}}} {{roll_name=Volatile}} {{roll_mod=@{Volatile}}} {{comment=?{@{commentprompt}|@{commentexample}}}} {{result=[[2d6 + @{Volatile}+?{@{macrobonus}|0}]]}}' name='roll_dsuf'></button> &nbsp;   
+                <b><span data-i18n="lbl-Dark">Dark</span>:</b> &nbsp;<input type="number" name="attr_Dark" min="-3" max="3" value="0" style="width: 50px"><button type='roll' value='&{template:mh2} {{name=@{CharName}}} {{roll_name=Dark}} {{roll_mod=@{Dark}}} {{comment=?{@{commentprompt}|@{commentexample}}}} {{result=[[2d6 + @{Dark}+?{@{macrobonus}|0}]]}}' name='roll_dsuf'></button> &nbsp;   
+            </p>
+        </div>
+        <hr>
+        <div class="sheet-Etc-Serpentine">
+            <div class='sheet-3colrow'>
+                <div class='sheet-col'>
+                    <div class="sheet-Serpentine-Backstory"  name="sheet-Serpentine-Backstory"><h1><span data-i18n="lbl-backstory">Your Backstory</span></h1>
+                    <span data-i18n="text-Serpentinebackstory">You've been watching someone, trying to learn from them what it means to be human. Gain two Strings on them. <br>
+                    <br>
+                    Your family seeks to control your every move, and they will not be denied. The head of your family gains two Strings on you. 
+                    </span></div>
+                    <br>
+                    <div class="sheet-StrTo-Serpentine"><h1><span data-i18n="lbl-strings">Strings</span></h1>
+                        <fieldset class="repeating_StringsTo">
+                            <input type="text" name="attr_Strings" style="width: 100%"> 
+                        </fieldset>
+                    </div>
+            
+                    <hr>
+                    <div class="harm-stuff"><h1><span data-i18n="lbl-harm">Harm</span></h1> <p align="center">
+                    <input type="checkbox" class="sheet-Harm-taken" name="attr_Harm_Taken1">
+                    <input type="checkbox" class="sheet-Harm-taken" name="attr_Harm_Taken2">
+                    <input type="checkbox" class="sheet-Harm-taken" name="attr_Harm_Taken3">
+                    <input type="checkbox" class="sheet-Harm-taken" name="attr_Harm_Taken4">
+                    <br><i><span data-i18n="text-harminfo">At four Harm, Skirt Death.</span></i><br></p>
+                    </div>
+                    <div class="sheet-Conds-Serpentine"><h1><span data-i18n="lbl-conditions">Conditions</span></h1>
+                        <fieldset class="repeating_Conditions">
+                        <input type="text" name="attr_Condition" style="width: 100%"><br> 
+                        </fieldset></p>
+                    </div>
+                    <hr>
+                    <div class="sheet-Notes-Serpentine"><h1><span data-i18n="lbl-notes">Notes</span></h1>
+                    <textarea name="attr_Notes" rows="5" cols="30"></textarea><br>
+                    </div>
+                </div>
+                <div class="sheet-col">
+                    <h1><span data-i18n="lbl-Serpentine">Serpentine</span> <span data-i18n="lbl-moves">Moves</span></h1>
+                        <i><span data-i18n="text-Serpentineinfo">You get Failing Dynasty, and choose one more:</span></i>
+                        <div class="sheet-Moves-Serpentine">
+                            
+                            <p><input type="checkbox" class="sheet-Moves-Serpentine" name="attr_Moves-Serpentine1" checked="checked" disabled="disabled"> <b><span data-i18n="text-Serpentine-move1name">Failing Dynasty</span>:</b><span data-i18n="text-Serpentine-move1desc"> In the age of serpents, your family was powerful and prolific. Now, they live in a shadow of their former glory. They want to regain (choose one):<br>
+                                &#10022; &nbsp; their political clout,
+                                &#10022; &nbsp; their old wealth,
+                                &#10022; &nbsp; their failing beauty,
+                                &#10022; &nbsp; their secret allies.<br>
+                            <br>
+                            Whenever you are convinced to do the bidding of a family member, take 1 Forward to doing it and that family memeber gains a String on you. Whenever you help your family regain some of their former glory, mark experience.</span></p>
+
+                            <p><input type="checkbox" class="sheet-Moves-Serpentine" name="attr_Moves-Serpentine2"> <b><span data-i18n="text-Serpentine-move2name">Mesmerizing</span>:</b><span data-i18n="text-Serpentine-move2desc"> When you stare at someone without blinking, roll with Hot. On a 10 up, they freeze up until you blink or someone touches them, and afterwards they don't really remember anything unusual happening. • On a 7-9, it'll still work, but only if you hiss loudly the entire time (and they'll definitely know something weird happened).</span></p>
+                              
+                            <p><input type="checkbox" class="sheet-Moves-Serpentine" name="attr_Moves-Serpentine3"> <b><span data-i18n="text-Serpentine-move3name">The Big Reveal</span>:</b><span data-i18n="text-Serpentine-move3desc"> When you reveal your true form to someone, they gain a String on you. If they accept you as you truly are, they mark experience. If they reject you, take 1 Forward against them.</span></p>
+                            
+                            <p><input type="checkbox" class="sheet-Moves-Serpentine" name="attr_Moves-Serpentine4"> <b><span data-i18n="text-Serpentine-move4name">The New Order</span>:</b><span data-i18n="text-Serpentine-move4desc"> When you learn to meet one of your needs within human society rather than within your family, mark experience. When others help you fit in better with human society, they mark experience.</span></p>
+                            
+                            <p><input type="checkbox" class="sheet-Moves-Serpentine" name="attr_Moves-Serpentine5"> <b><span data-i18n="text-Serpentine-move5name">Patience is a Virtue</span>:</b><span data-i18n="text-Serpentine-move5desc"> When you bite your tongue and don't respond to an antagonist, roll with Cold. On a 10 up, gain a String on them. • On a 7-9, take 1 Forward to striking the next time you see them.</span></p>
+                 
+                        </div>
+
+            <div class="sheet-OtherMoves-Serpentine">
+                        <h1><span data-i18n="lbl-other">Other</span> <span data-i18n="lbl-moves">Moves</span></h1>
+                        <fieldset class="repeating_OtherMoves">
+                        <input type="text" name="attr_OtherMoveName" placeholder="Name"> 
+                        <textarea name="attr_OtherMoveDescrip" placeholder="Description" rows="3" cols="30"></textarea><br></fieldset>
+                        </div>
+                </div>
+                <div class="sheet-col">
+                <div class="sheet-SexMove-Serpentine">
+                        <h1><span data-i18n="lbl-sexmove">Sex Move</span></h1>
+                        <span data-i18n="text-Serpentine-sexmove">If your family learns that you've had sex with someone, that person becomes part of your family's <i>Failing Dynasty</i>. If they're a main character, they add the move to their sheet. 
+                    </span></div>
+                    <div class="sheet-DarkestSelf-Serpentine">
+                        <h1><span data-i18n="lbl-darkestself">Darkest Self</span></h1>
+                        <span data-i18n="text-Serpentine-darkestself">The human and serpent worlds are too different, and you'll never be able to reconcile their demands. The only way out is to choose a side, as decisively and irrevocably as possible. Watch carefully and quietly for an opportunity, and then strike, regardless of who needs to be hobbled or devoured in the process. It's the only way to make the world simple again, and find your place at last. You escape your Darkest Self when you accept your complicated place in the world, or when you moult.
+                        </span></div>
+                    <hr>
+                    <div class="harm-stuff"><h1><span data-i18n="lbl-experience">Experience</span></h1><p align="center">
+                    <input type="checkbox" class="sheet-Exp-gained" name="attr_Exp_Gained1">
+                    <input type="checkbox" class="sheet-Exp-gained" name="attr_Exp_Gained2">
+                    <input type="checkbox" class="sheet-Exp-gained" name="attr_Exp_Gained3">
+                    <input type="checkbox" class="sheet-Exp-gained" name="attr_Exp_Gained4">
+                    <input type="checkbox" class="sheet-Exp-gained" name="attr_Exp_Gained5"></p>
+                    <i><span data-i18n="text-expinfo">When you have five experience points, erase them and choose one advancement from the list below:</span></i>
+                    </div><br>
+                    <div class="sheet-Advs-Serpentine">
+                        <input type="checkbox" class="sheet-Advs-Serpentine" name="attr_Advs-Serpentine1"><span data-i18n="text-Serpentine-advance1"> Add +1 to one of your stats.</span><br>
+                        <input type="checkbox" class="sheet-Advs-Serpentine" name="attr_Advs-Serpentine2"><span data-i18n="text-Serpentine-advance2"> Take another Serpentine move.</span><br>
+                        <input type="checkbox" class="sheet-Advs-Serpentine" name="attr_Advs-Serpentine3"><span data-i18n="text-Serpentine-advance3"> Take another Serpentine move.</span><br>
+                        <input type="checkbox" class="sheet-Advs-Serpentine" name="attr_Advs-Serpentine4"><span data-i18n="text-Serpentine-advance4"> Take a move from any Skin.</span><br>
+                        <input type="checkbox" class="sheet-Advs-Serpentine" name="attr_Advs-Serpentine5"><span data-i18n="text-Serpentine-advance5"> Take a move from any Skin.</span><br>
+                        <input type="checkbox" class="sheet-Advs-Serpentine" name="attr_Advs-Serpentine6"><span data-i18n="text-Serpentine-advance6"> You belong to a <b>Nest of Humans</b>.</span><br>
+                        <br>
+                        <i><span data-i18n="text-expreminder">Don't forget to manually add any advancements to your sheet. Check any you've already taken.</span></i>
+                    </div>
+                    <div class="sheet-Seasons">
+                        <h1><span data-i18n="lbl-seasonadvances">Season Advances</span></h1>
+                        <input type="checkbox" class="sheet-Advs-Skin" name="attr_SeasonAdvs0"> <span data-i18n="lbl-unlocked">Unlocked</span><br>
+                        <br>
+                        <i><span data-i18n="text-seasonadvancesinfo">Once someone has taken their fifth advance, the Season Advances are unlocked for everybody. There's one more session left after the current one, and then the season ends.</span></i><br>
+                        <br>
+                        <div class="sheet-SeasonAdvs">
+                        <input type="checkbox" class="sheet-SeasonAdvs-SerpentineName" name="attr_SeasonAdvs1"><span data-i18n="text-seasonadvances1"> Change your character's Skin.</span><br> 
+                        <input type="checkbox" class="sheet-SeasonAdvs-SerpentineName" name="attr_SeasonAdvs2"><span data-i18n="text-seasonadvances2"> Rewrite your Darkest Self.</span><br> 
+                        <input type="checkbox" class="sheet-SeasonAdvs-SerpentineName" name="attr_SeasonAdvs3"><span data-i18n="text-seasonadvances3"> Retire your character and start a new one.</span><br> 
+                        <input type="checkbox" class="sheet-SeasonAdvs-SerpentineName" name="attr_SeasonAdvs4"><span data-i18n="text-seasonadvances4"> Gain two of the Growing Up moves.</span><br> 
+                        </div>
+                        <div class="sheet-DarkestSelf-Rewritten" name="sheet-DarkestSelf-Rewritten">
+                            <h1><span data-i18n="lbl-rewritten">Rewritten Darkest Self</span></h1>
+                            <textarea name="attr_DarkestSelf-Rewritten" rows="3" cols="30"></textarea> 
+                        </div>                      
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+<!-- CERBERUS -->
+
+    <div class="sheet-Cerberus" name="sheet-Cerberus">
+        <hr>
+        <div class="sheet-Stats-Cerberus">
+            <p align="center">
+                <b><span data-i18n="lbl-Hot">Hot</span>:</b> &nbsp;<input type="number" name="attr_Hot" min="-3" max="3" value="0" style="width: 50px"><button type='roll' value='&{template:mh2} {{name=@{CharName}}} {{roll_name=Hot}} {{roll_mod=@{hot}}} {{comment=?{@{commentprompt}|@{commentexample}}}} {{result=[[2d6 + @{hot}+?{@{macrobonus}|0}]]}}' name='roll_dsuf'></button> &nbsp;   
+                <b><span data-i18n="lbl-Cold">Cold</span>:</b> &nbsp;<input type="number" name="attr_Cold" min="-3" max="3" value="0" style="width: 50px"><button type='roll' value='&{template:mh2} {{name=@{CharName}}} {{roll_name=Cold}} {{roll_mod=@{Cold}}} {{comment=?{@{commentprompt}|@{commentexample}}}} {{result=[[2d6 + @{Cold}+?{@{macrobonus}|0}]]}}' name='roll_dsuf'></button> &nbsp;   
+                <b><span data-i18n="lbl-Volatile">Volatile</span>:</b> &nbsp;<input type="number" name="attr_Volatile" min="-3" max="3" value="0" style="width: 50px"><button type='roll' value='&{template:mh2} {{name=@{CharName}}} {{roll_name=Volatile}} {{roll_mod=@{Volatile}}} {{comment=?{@{commentprompt}|@{commentexample}}}} {{result=[[2d6 + @{Volatile}+?{@{macrobonus}|0}]]}}' name='roll_dsuf'></button> &nbsp;   
+                <b><span data-i18n="lbl-Dark">Dark</span>:</b> &nbsp;<input type="number" name="attr_Dark" min="-3" max="3" value="0" style="width: 50px"><button type='roll' value='&{template:mh2} {{name=@{CharName}}} {{roll_name=Dark}} {{roll_mod=@{Dark}}} {{comment=?{@{commentprompt}|@{commentexample}}}} {{result=[[2d6 + @{Dark}+?{@{macrobonus}|0}]]}}' name='roll_dsuf'></button> &nbsp;   
+            </p>
+        </div>
+        <hr>
+        <div class="sheet-Etc-Cerberus">
+            <div class='sheet-3colrow'>
+                <div class='sheet-col'>
+                    <div class="sheet-Cerberus-Backstory"  name="sheet-Cerberus-Backstory"><h1><span data-i18n="lbl-backstory">Your Backstory</span></h1>
+                    <span data-i18n="text-Cerberusbackstory">Someone managed to slip past you, a damned and wicked soul hiding among the pure. You've tracked them down. Gain two Strings on them. <br>
+                    <br>
+                    You don't fit in. Give yourself a Condition. 
+                    </span></div>
+                    <br>
+                    <div class="sheet-StrTo-Cerberus"><h1><span data-i18n="lbl-strings">Strings</span></h1>
+                        <fieldset class="repeating_StringsTo">
+                            <input type="text" name="attr_Strings" style="width: 100%"> 
+                        </fieldset>
+                    </div>
+                    <div class="sheet-Master-Cerberus"><h1><span data-i18n="lbl-master">Master</span></h1> 
+                            <input type="text" name="attr_Master" style="width: 100%"> 
+                        </div>
+                    <hr>
+                    <div class="harm-stuff"><h1><span data-i18n="lbl-harm">Harm</span></h1> <p align="center">
+                    <input type="checkbox" class="sheet-Harm-taken" name="attr_Harm_Taken1">
+                    <input type="checkbox" class="sheet-Harm-taken" name="attr_Harm_Taken2">
+                    <input type="checkbox" class="sheet-Harm-taken" name="attr_Harm_Taken3">
+                    <input type="checkbox" class="sheet-Harm-taken" name="attr_Harm_Taken4">
+                    <br><i><span data-i18n="text-harminfo">At four Harm, Skirt Death.</span></i><br></p>
+                    </div>
+                    <div class="sheet-Conds-Cerberus"><h1><span data-i18n="lbl-conditions">Conditions</span></h1>
+                        <fieldset class="repeating_Conditions">
+                        <input type="text" name="attr_Condition" style="width: 100%"><br> 
+                        </fieldset></p>
+                    </div>
+                    <hr>
+                    <div class="sheet-Notes-Cerberus"><h1><span data-i18n="lbl-notes">Notes</span></h1>
+                    <textarea name="attr_Notes" rows="5" cols="30"></textarea><br>
+                    </div>
+                </div>
+                <div class="sheet-col">
+                    <h1><span data-i18n="lbl-Cerberus">Cerberus</span> <span data-i18n="lbl-moves">Moves</span></h1>
+                        <i><span data-i18n="text-Cerberusinfo">You get Watch Dog, and choose one more:</span></i>
+                        <div class="sheet-Moves-Cerberus">
+                            
+                            <p><input type="checkbox" class="sheet-Moves-Cerberus" name="attr_Moves-Cerberus1" checked="checked" disabled="disabled"> <b><span data-i18n="text-Cerberus-move1name">Watch Dog</span>:</b><span data-i18n="text-Cerberus-move1desc"> You exist in the liminal space between two communities: one is resplendent with light, the other is damned to the shadows. It is your duty to guard the boundary.<br>
+                            <br>
+                            Mark experience whenever you weed out someone on the wrong side of the divide and put them in their place.</span></p>
+
+                            <p><input type="checkbox" class="sheet-Moves-Cerberus" name="attr_Moves-Cerberus2"> <b><span data-i18n="text-Cerberus-move2name">Arbiter</span>:</b><span data-i18n="text-Cerberus-move2desc"> When you give someone a Condition, mark experience.</span></p>
+                              
+                            <p><input type="checkbox" class="sheet-Moves-Cerberus" name="attr_Moves-Cerberus3"> <b><span data-i18n="text-Cerberus-move3name">Dig Deeper</span>:</b><span data-i18n="text-Cerberus-move3desc"> When you <i>Gaze Into the Abyss</i> by snooping around for dirt on someone, add 1 to your roll. On a 10 up, the owner of that character will tell you a secret, and you can choose to give them a Condition to reflect what you've learned.</span></p>
+                            
+                            <p><input type="checkbox" class="sheet-Moves-Cerberus" name="attr_Moves-Cerberus4"> <b><span data-i18n="text-Cerberus-move4name">Loyal</span>:</b><span data-i18n="text-Cerberus-move4desc"> Whoever currently has the most Strings on you is your Master. When you take action to protect or help your Master, add 1 to your roll and they gain a String on you.<br>
+                            <br>
+                            When you become your Darkest Self, your current Master loses all Strings on you.</span></p>
+                            
+                            <p><input type="checkbox" class="sheet-Moves-Cerberus" name="attr_Moves-Cerberus5"> <b><span data-i18n="text-Cerberus-move5name">Bark, Then Bite</span>:</b><span data-i18n="text-Cerberus-move5desc"> When you take advantage of a Condition that you gave to someone, it adds 2 to your roll instead of 1.</span></p>
+
+                            <p><input type="checkbox" class="sheet-Moves-Cerberus" name="attr_Moves-Cerberus6"> <b><span data-i18n="text-Cerberus-move6name">Doomed Outsider</span>:</b><span data-i18n="text-Cerberus-move6desc"> When trying to drive others away from you, or escape their care, you can take advantage of your own Conditions to add to your roll.</span></p>
+
+                            <p><input type="checkbox" class="sheet-Moves-Cerberus" name="attr_Moves-Cerberus7"> <b><span data-i18n="text-Cerberus-move7name">Hot Take</span>:</b><span data-i18n="text-Cerberus-move7desc"> When you discover an injustice that has long been hidden or covered up, add 1 to your rolls to bring it to light and to justice as immediately as possible.</span></p>
+                 
+                        </div>
+
+            <div class="sheet-OtherMoves-Cerberus">
+                        <h1><span data-i18n="lbl-other">Other</span> <span data-i18n="lbl-moves">Moves</span></h1>
+                        <fieldset class="repeating_OtherMoves">
+                        <input type="text" name="attr_OtherMoveName" placeholder="Name"> 
+                        <textarea name="attr_OtherMoveDescrip" placeholder="Description" rows="3" cols="30"></textarea><br></fieldset>
+                        </div>
+                </div>
+                <div class="sheet-col">
+                <div class="sheet-SexMove-Cerberus">
+                        <h1><span data-i18n="lbl-sexmove">Sex Move</span></h1>
+                        <span data-i18n="text-Cerberus-sexmove">When you have sex with someone, tell them why you don't belong in their world. If they agree, give yourself a Condition to reflect. If they disagree, you gain a String on them. 
+                    </span></div>
+                    <div class="sheet-DarkestSelf-Cerberus">
+                        <h1><span data-i18n="lbl-darkestself">Darkest Self</span></h1>
+                        <span data-i18n="text-Cerberus-darkestself">You do your best to be a good boy, but you come from a very bad place. Let's face it: you're a mangy, unloveable beast from hell. You were born to snarl and to bite. Anyone who's gotten close to you needs to be driven away, violently if necessary. You must return to the shadows, dragging the damned back down there with you. You escape your Darkest Self when disrupted by a virtuous hero, or when the power of true love tempers your resolve.
+                        </span></div>
+                    <hr>
+                    <div class="harm-stuff"><h1><span data-i18n="lbl-experience">Experience</span></h1><p align="center">
+                    <input type="checkbox" class="sheet-Exp-gained" name="attr_Exp_Gained1">
+                    <input type="checkbox" class="sheet-Exp-gained" name="attr_Exp_Gained2">
+                    <input type="checkbox" class="sheet-Exp-gained" name="attr_Exp_Gained3">
+                    <input type="checkbox" class="sheet-Exp-gained" name="attr_Exp_Gained4">
+                    <input type="checkbox" class="sheet-Exp-gained" name="attr_Exp_Gained5"></p>
+                    <i><span data-i18n="text-expinfo">When you have five experience points, erase them and choose one advancement from the list below:</span></i>
+                    </div><br>
+                    <div class="sheet-Advs-Cerberus">
+                        <input type="checkbox" class="sheet-Advs-Cerberus" name="attr_Advs-Cerberus1"><span data-i18n="text-Cerberus-advance1"> Add +1 to one of your stats.</span><br>
+                        <input type="checkbox" class="sheet-Advs-Cerberus" name="attr_Advs-Cerberus2"><span data-i18n="text-Cerberus-advance2"> Take another Cerberus move.</span><br>
+                        <input type="checkbox" class="sheet-Advs-Cerberus" name="attr_Advs-Cerberus3"><span data-i18n="text-Cerberus-advance3"> Take another Cerberus move.</span><br>
+                        <input type="checkbox" class="sheet-Advs-Cerberus" name="attr_Advs-Cerberus4"><span data-i18n="text-Cerberus-advance4"> Take a move from any Skin.</span><br>
+                        <input type="checkbox" class="sheet-Advs-Cerberus" name="attr_Advs-Cerberus5"><span data-i18n="text-Cerberus-advance5"> Take a move from any Skin.</span><br>
+                        <input type="checkbox" class="sheet-Advs-Cerberus" name="attr_Advs-Cerberus6"><span data-i18n="text-Cerberus-advance6"> You have <b>Serpents at Your Back</b>.</span><br>
+                        <br>
+                        <i><span data-i18n="text-expreminder">Don't forget to manually add any advancements to your sheet. Check any you've already taken.</span></i>
+                    </div>
+                    <div class="sheet-Seasons">
+                        <h1><span data-i18n="lbl-seasonadvances">Season Advances</span></h1>
+                        <input type="checkbox" class="sheet-Advs-Skin" name="attr_SeasonAdvs0"> <span data-i18n="lbl-unlocked">Unlocked</span><br>
+                        <br>
+                        <i><span data-i18n="text-seasonadvancesinfo">Once someone has taken their fifth advance, the Season Advances are unlocked for everybody. There's one more session left after the current one, and then the season ends.</span></i><br>
+                        <br>
+                        <div class="sheet-SeasonAdvs">
+                        <input type="checkbox" class="sheet-SeasonAdvs-CerberusName" name="attr_SeasonAdvs1"><span data-i18n="text-seasonadvances1"> Change your character's Skin.</span><br> 
+                        <input type="checkbox" class="sheet-SeasonAdvs-CerberusName" name="attr_SeasonAdvs2"><span data-i18n="text-seasonadvances2"> Rewrite your Darkest Self.</span><br> 
+                        <input type="checkbox" class="sheet-SeasonAdvs-CerberusName" name="attr_SeasonAdvs3"><span data-i18n="text-seasonadvances3"> Retire your character and start a new one.</span><br> 
+                        <input type="checkbox" class="sheet-SeasonAdvs-CerberusName" name="attr_SeasonAdvs4"><span data-i18n="text-seasonadvances4"> Gain two of the Growing Up moves.</span><br> 
+                        </div>
+                        <div class="sheet-DarkestSelf-Rewritten" name="sheet-DarkestSelf-Rewritten">
+                            <h1><span data-i18n="lbl-rewritten">Rewritten Darkest Self</span></h1>
+                            <textarea name="attr_DarkestSelf-Rewritten" rows="3" cols="30"></textarea> 
+                        </div>                      
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+<!-- DISCIPLE -->
+
+    <div class="sheet-Disciple" name="sheet-Disciple">
+        <hr>
+        <div class="sheet-Stats-Disciple">
+            <p align="center">
+                <b><span data-i18n="lbl-Hot">Hot</span>:</b> &nbsp;<input type="number" name="attr_Hot" min="-3" max="3" value="0" style="width: 50px"><button type='roll' value='&{template:mh2} {{name=@{CharName}}} {{roll_name=Hot}} {{roll_mod=@{hot}}} {{comment=?{@{commentprompt}|@{commentexample}}}} {{result=[[2d6 + @{hot}+?{@{macrobonus}|0}]]}}' name='roll_dsuf'></button> &nbsp;   
+                <b><span data-i18n="lbl-Cold">Cold</span>:</b> &nbsp;<input type="number" name="attr_Cold" min="-3" max="3" value="0" style="width: 50px"><button type='roll' value='&{template:mh2} {{name=@{CharName}}} {{roll_name=Cold}} {{roll_mod=@{Cold}}} {{comment=?{@{commentprompt}|@{commentexample}}}} {{result=[[2d6 + @{Cold}+?{@{macrobonus}|0}]]}}' name='roll_dsuf'></button> &nbsp;   
+                <b><span data-i18n="lbl-Volatile">Volatile</span>:</b> &nbsp;<input type="number" name="attr_Volatile" min="-3" max="3" value="0" style="width: 50px"><button type='roll' value='&{template:mh2} {{name=@{CharName}}} {{roll_name=Volatile}} {{roll_mod=@{Volatile}}} {{comment=?{@{commentprompt}|@{commentexample}}}} {{result=[[2d6 + @{Volatile}+?{@{macrobonus}|0}]]}}' name='roll_dsuf'></button> &nbsp;   
+                <b><span data-i18n="lbl-Dark">Dark</span>:</b> &nbsp;<input type="number" name="attr_Dark" min="-3" max="3" value="0" style="width: 50px"><button type='roll' value='&{template:mh2} {{name=@{CharName}}} {{roll_name=Dark}} {{roll_mod=@{Dark}}} {{comment=?{@{commentprompt}|@{commentexample}}}} {{result=[[2d6 + @{Dark}+?{@{macrobonus}|0}]]}}' name='roll_dsuf'></button> &nbsp;   
+            </p>
+        </div>
+        <hr>
+        <div class="sheet-Etc-Disciple">
+            <div class='sheet-3colrow'>
+                <div class='sheet-col'>
+                    <div class="sheet-Disciple-Backstory"  name="sheet-Disciple-Backstory"><h1><span data-i18n="lbl-backstory">Your Backstory</span></h1>
+                    <span data-i18n="text-Disciplebackstory">You've sworn a pact of secrecy with someone. Over what? You gain 2 Strings on each other. <br>
+                    <br>
+                    One of the adults in your life is worried about you. They gain a String on you. 
+                    </span></div>
+                    <br>
+                    <div class="sheet-StrTo-Disciple"><h1><span data-i18n="lbl-strings">Strings</span></h1>
+                        <fieldset class="repeating_StringsTo">
+                            <input type="text" name="attr_Strings" style="width: 100%"> 
+                        </fieldset>
+                    </div>
+                    <div class="sheet-WickedMaster-Disciple"><h1><span data-i18n="lbl-wickedmaster">Wicked Master</span></h1> 
+                            <input type="text" name="attr_WickedMaster" style="width: 100%"> 
+                        </div>
+                    <hr>
+                    <div class="harm-stuff"><h1><span data-i18n="lbl-harm">Harm</span></h1> <p align="center">
+                    <input type="checkbox" class="sheet-Harm-taken" name="attr_Harm_Taken1">
+                    <input type="checkbox" class="sheet-Harm-taken" name="attr_Harm_Taken2">
+                    <input type="checkbox" class="sheet-Harm-taken" name="attr_Harm_Taken3">
+                    <input type="checkbox" class="sheet-Harm-taken" name="attr_Harm_Taken4">
+                    <br><i><span data-i18n="text-harminfo">At four Harm, Skirt Death.</span></i><br></p>
+                    </div>
+                    <div class="sheet-Conds-Disciple"><h1><span data-i18n="lbl-conditions">Conditions</span></h1>
+                        <fieldset class="repeating_Conditions">
+                        <input type="text" name="attr_Condition" style="width: 100%"><br> 
+                        </fieldset></p>
+                    </div>
+                    <hr>
+                    <div class="sheet-Notes-Disciple"><h1><span data-i18n="lbl-notes">Notes</span></h1>
+                    <textarea name="attr_Notes" rows="5" cols="30"></textarea><br>
+                    </div>
+                </div>
+                <div class="sheet-col">
+                    <h1><span data-i18n="lbl-Disciple">Disciple</span> <span data-i18n="lbl-moves">Moves</span></h1>
+                        <i><span data-i18n="text-Discipleinfo">You get End of the World and Idols, and choose one more:</span></i>
+                        <div class="sheet-Moves-Disciple">
+                            
+                            <p><input type="checkbox" class="sheet-Moves-Disciple" name="attr_Moves-Disciple1" checked="checked" disabled="disabled"> <b><span data-i18n="text-Disciple-move1name">End of the World</span>:</b><span data-i18n="text-Disciple-move1desc"> You have sworn fealty to a Wicked Master. Once it has accumulated six hundred sixty-six Strings, it can fully materialize in this realm, possessing immeasurable power.</span></p>
+
+                            <p><input type="checkbox" class="sheet-Moves-Disciple" name="attr_Moves-Disciple2" checked="checked" disabled="disabled"> <b><span data-i18n="text-Disciple-move2name">Idols</span>:</b><span data-i18n="text-Disciple-move2desc"> You create idols to your Wicked Master, in the form of (choose 1):
+                                &#10022; &nbsp; cloth dolls,
+                                &#10022; &nbsp; carved sigils,
+                                &#10022; &nbsp; statues,
+                                &#10022; &nbsp; videos,
+                                &#10022; &nbsp; ritual performances,
+                                &#10022; &nbsp; ceremonial fires,
+                                &#10022; &nbsp; dark poems.<br>
+                            <br>
+                            Each idol counts as a String on you, held by the Wicked Master unless someone else seizes control of it or destroys it.</span></p>
+                              
+                            <p><input type="checkbox" class="sheet-Moves-Disciple" name="attr_Moves-Disciple3"> <b><span data-i18n="text-Disciple-move3name">Blood Offerings</span>:</b><span data-i18n="text-Disciple-move3desc"> Every time you suffer Harm, the Wicked Master gains a String on you and you mark experience.</span></p>
+                            
+                            <p><input type="checkbox" class="sheet-Moves-Disciple" name="attr_Moves-Disciple4"> <b><span data-i18n="text-Disciple-move4name">Spoken For</span>:</b><span data-i18n="text-Disciple-move4desc"> Whenever someone else gains a String on you, your Wicked Master gains a String on them.</span></p>
+                            
+                            <p><input type="checkbox" class="sheet-Moves-Disciple" name="attr_Moves-Disciple5"> <b><span data-i18n="text-Disciple-move5name">Secret Mission</span>:</b><span data-i18n="text-Disciple-move5desc"> Whenever you lie to someone about your true motives, and they foolishly believe you, gain a String on them.</span></p>
+
+                            <p><input type="checkbox" class="sheet-Moves-Disciple" name="attr_Moves-Disciple6"> <b><span data-i18n="text-Disciple-move6name">Incantations</span>:</b><span data-i18n="text-Disciple-move6desc"> When you <i>Gaze Into the Abyss</i> to entreat the Wicked Master, it gains a String on you. On a 10 up, the Wicked Master reveals the next stage of its plan, and you take ongoing 1 Forward to all rolls made to enact this bidding.</span></p>
+
+                            <p><input type="checkbox" class="sheet-Moves-Disciple" name="attr_Moves-Disciple7"> <b><span data-i18n="text-Disciple-move7name">Soul Recruiter</span>:</b><span data-i18n="text-Disciple-move7desc"> When you bring an innocent soul to the Wicked Master, mark experience.</span></p>
+                 
+                        </div>
+
+            <div class="sheet-OtherMoves-Disciple">
+                        <h1><span data-i18n="lbl-other">Other</span> <span data-i18n="lbl-moves">Moves</span></h1>
+                        <fieldset class="repeating_OtherMoves">
+                        <input type="text" name="attr_OtherMoveName" placeholder="Name"> 
+                        <textarea name="attr_OtherMoveDescrip" placeholder="Description" rows="3" cols="30"></textarea><br></fieldset>
+                        </div>
+                </div>
+                <div class="sheet-col">
+                <div class="sheet-SexMove-Disciple">
+                        <h1><span data-i18n="lbl-sexmove">Heart Move</span></h1>
+                        <span data-i18n="text-Disciple-sexmove">When you allow yourself to fall in love with someone, truly fall in love, and that person loves you back, erase half of the Strings that your Wicked Master holds on you, rounded up. 
+                    </span></div>
+                    <div class="sheet-DarkestSelf-Disciple">
+                        <h1><span data-i18n="lbl-darkestself">Darkest Self</span></h1>
+                        <span data-i18n="text-Disciple-darkestself">They're fools to ignore you and mistreat you. When the world goes up in flames, you'll make sure they are among the first to burn. Do whatever it takes to summon your otherworldly patron, and drive off anyone who gets in your way. You escape your Darkest Self when the Wicked Master fully materializes in this realm, or when a narrow miss convinces you it would be better to return to keeping a low profile and bid your time.
+                        </span></div>
+                    <hr>
+                    <div class="harm-stuff"><h1><span data-i18n="lbl-experience">Experience</span></h1><p align="center">
+                    <input type="checkbox" class="sheet-Exp-gained" name="attr_Exp_Gained1">
+                    <input type="checkbox" class="sheet-Exp-gained" name="attr_Exp_Gained2">
+                    <input type="checkbox" class="sheet-Exp-gained" name="attr_Exp_Gained3">
+                    <input type="checkbox" class="sheet-Exp-gained" name="attr_Exp_Gained4">
+                    <input type="checkbox" class="sheet-Exp-gained" name="attr_Exp_Gained5"></p>
+                    <i><span data-i18n="text-expinfo">When you have five experience points, erase them and choose one advancement from the list below:</span></i>
+                    </div><br>
+                    <div class="sheet-Advs-Disciple">
+                        <input type="checkbox" class="sheet-Advs-Disciple" name="attr_Advs-Disciple1"><span data-i18n="text-Disciple-advance1"> Add +1 to one of your stats.</span><br>
+                        <input type="checkbox" class="sheet-Advs-Disciple" name="attr_Advs-Disciple2"><span data-i18n="text-Disciple-advance2"> Take another Disciple move.</span><br>
+                        <input type="checkbox" class="sheet-Advs-Disciple" name="attr_Advs-Disciple3"><span data-i18n="text-Disciple-advance3"> Take another Disciple move.</span><br>
+                        <input type="checkbox" class="sheet-Advs-Disciple" name="attr_Advs-Disciple4"><span data-i18n="text-Disciple-advance4"> Take a move from any Skin.</span><br>
+                        <input type="checkbox" class="sheet-Advs-Disciple" name="attr_Advs-Disciple5"><span data-i18n="text-Disciple-advance5"> Take a move from any Skin.</span><br>
+                        <input type="checkbox" class="sheet-Advs-Disciple" name="attr_Advs-Disciple6"><span data-i18n="text-Disciple-advance6"> Join an <b>Ascension Group</b>.</span><br>
+                        <br>
+                        <i><span data-i18n="text-expreminder">Don't forget to manually add any advancements to your sheet. Check any you've already taken.</span></i>
+                    </div>
+                    <div class="sheet-Seasons">
+                        <h1><span data-i18n="lbl-seasonadvances">Season Advances</span></h1>
+                        <input type="checkbox" class="sheet-Advs-Skin" name="attr_SeasonAdvs0"> <span data-i18n="lbl-unlocked">Unlocked</span><br>
+                        <br>
+                        <i><span data-i18n="text-seasonadvancesinfo">Once someone has taken their fifth advance, the Season Advances are unlocked for everybody. There's one more session left after the current one, and then the season ends.</span></i><br>
+                        <br>
+                        <div class="sheet-SeasonAdvs">
+                        <input type="checkbox" class="sheet-SeasonAdvs-DiscipleName" name="attr_SeasonAdvs1"><span data-i18n="text-seasonadvances1"> Change your character's Skin.</span><br> 
+                        <input type="checkbox" class="sheet-SeasonAdvs-DiscipleName" name="attr_SeasonAdvs2"><span data-i18n="text-seasonadvances2"> Rewrite your Darkest Self.</span><br> 
+                        <input type="checkbox" class="sheet-SeasonAdvs-DiscipleName" name="attr_SeasonAdvs3"><span data-i18n="text-seasonadvances3"> Retire your character and start a new one.</span><br> 
+                        <input type="checkbox" class="sheet-SeasonAdvs-DiscipleName" name="attr_SeasonAdvs4"><span data-i18n="text-seasonadvances4"> Gain two of the Growing Up moves.</span><br> 
+                        </div>
+                        <div class="sheet-DarkestSelf-Rewritten" name="sheet-DarkestSelf-Rewritten">
+                            <h1><span data-i18n="lbl-rewritten">Rewritten Darkest Self</span></h1>
+                            <textarea name="attr_DarkestSelf-Rewritten" rows="3" cols="30"></textarea> 
+                        </div>                      
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
 <!-- CUSTOM -->
 
     <div class="sheet-Custom" name="sheet-Custom">
@@ -1438,7 +1955,8 @@
         </div>				
     </div>
 <br><br><br>
-<font size="0.5">sheet version 0.0.1 for Monsterhearts 2 by Trips and Jada. Based on the Monsterhearts sheet by Allie B. (@madpierrot)</font>
+<font size="0.5">sheet version 0.0.1 for Monsterhearts 2 by Trips and Jada. Based on the Monsterhearts sheet by Allie B. (@madpierrot)<br>
+bonus Skins (Chosen, Serpentine, Cerberus, Disciple) added by Kit D. (@ughjonnjonzz)</font>
 </div>
 
 


### PR DESCRIPTION
Four Skins (read: character classes) that were released after the game's original launch were missing from the selection. They're now included for players to choose from.
[Chosen](http://buriedwithoutceremony.com/wp-content/uploads/2017/05/the-chosen.pdf) • [Serpentine](http://buriedwithoutceremony.com/wp-content/uploads/2017/05/the-serpentine1.pdf) • [Cerberus](https://buriedwithoutceremony.com/wp-content/uploads/2019/03/The-Cerberus.pdf) • [Disciple](https://buriedwithoutceremony.com/wp-content/uploads/2020/01/The-Disciple.pdf)

## Changes / Comments

Absolutely nothing was changed from the original code besides the added Skins and a credit for my work alongside the existing names.




## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
