### PR TITLE
[All Flesh Must Be Eaten] Revert recently removed stat

### DIFF
--- a/Unisystem-All Flesh Must Be Eaten/All Flesh Must Be Eaten.css
+++ b/Unisystem-All Flesh Must Be Eaten/All Flesh Must Be Eaten.css
@@ -45,6 +45,7 @@ div.sheet-tab-content
 input.sheet-tab1:checked ~ div.sheet-tab1,
 input.sheet-tab2:checked ~ div.sheet-tab2,
 input.sheet-tab3:checked ~ div.sheet-tab3,
+input.sheet-tab4:checked ~ div.sheet-tab4,
 input.sheet-tab5:checked ~ div.sheet-tab5,
 input.sheet-tab6:checked ~ div.sheet-tab6
 {
@@ -533,22 +534,4 @@ input.sheet-gore[type="radio"]:checked + span::before {
     color:black;
     background:red;
 }
-
-
-    
-    
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/Unisystem-All Flesh Must Be Eaten/All Flesh Must Be Eaten.html
+++ b/Unisystem-All Flesh Must Be Eaten/All Flesh Must Be Eaten.html
@@ -1,16 +1,18 @@
 <input type="radio" class="sheet-new sheet-gore" name="attr_sheet_type1" value="0" checked/><span></span>
 <input type="radio" class="sheet-old sheet-gore" name="attr_sheet_type1"  value="1" /><span></span>
-    <div class="sheet-all">
+
+<div class="sheet-all">
 
     <input type="radio" name="attr_tab" class="sheet-tab sheet-tab1" value="1" title="Personagem" checked="checked" /><span></span>
     <input type="radio" name="attr_tab" class="sheet-tab sheet-tab2" value="2" title="Skills & Powers" /><span></span>
     <input type="radio" name="attr_tab" class="sheet-tab sheet-tab3" value="3" title="Combat" /><span></span>
+    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab4" value="4" title="Possessions" /><span></span>
     <input type="radio" name="attr_tab" class="sheet-tab sheet-tab5" value="5" title="Notes" /><span></span>
     <br>
     <input type="radio" class="sheet-new sheet-hidden" name="attr_sheet_type3" value="0" checked/><span></span>
     <input type="radio" class="sheet-old sheet-hidden" name="attr_sheet_type3"  value="1" /><span></span>
     
-    <!--TAB 1 -->
+<!--TAB 1 -->
     <div class="sheet-tab-content sheet-tab1">
         <div class="sheet-center">
             <input type="text" class="sheet-bigname" name="attr_character_name" placeholder="Character Name"/><br>
@@ -202,7 +204,7 @@
         </div>
     </div>
     
-    <!--TAB 2 -->
+<!--TAB 2 -->
     <div class="sheet-tab-content sheet-tab2">
         <h3>Skills</h3>
         <br>
@@ -907,9 +909,14 @@
             </tr>
         </table>
     </div>
+ 
+<!--TAB 4 -->
+    <div class="sheet-tab-content sheet-tab4">
+        <h3>Possessions</h3>
+        <textarea class="sheet-textarea" name="attr_equipment"></textarea>
+    </div>   
     
-    
-    <!--TAB 5-->
+<!--TAB 5-->
     <div class="sheet-tab-content sheet-tab5">
         <h3>Character History</h3>
         <textarea class="sheet-textarea" name="attr_Character_History"></textarea>
@@ -919,6 +926,8 @@
         <textarea class="sheet-textarea" name="attr_Notes"></textarea>
     </div>
 </div>
+
+
 
 <!--Roll Templates-->
 <div class="sheet-hidden">


### PR DESCRIPTION
## Changes / Comments
- Add back 'Posession'-tab that was removed without migrating measures in #6778 by @ChristianMCGarcia. 
- Was brought up by user in this [forum post](https://app.roll20.net/forum/post/8873104/character-sheet-changed-during-use) as it removed a used feature/stat of the sheet for them. As the change was removing a feature of the sheet without migrating the stat anywhere, it should have never been approved, considering it wasn't an upgrade to the sheet. If an *option* to hide the tab had been made, or moved the stat to the last tab, it would have been better. 

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
