### PR TITLE
various fixes for mythic 3.5

### DIFF
--- a/Halo_Mythic_3dot5/HaloMythic3dot5.css
+++ b/Halo_Mythic_3dot5/HaloMythic3dot5.css
@@ -548,7 +548,7 @@ ______________________________ start of equipment tab __________________________
 	'e3 e3 e3';
 }
 
-.sheet-equipment_ranged_weapons { grid-area: e1; background:#475f85; border-radius: 10px; padding: 2px; }
+.sheet-equipment_ranged_weapons { grid-area: e1; background:#475f85; border-radius: 10px; padding: 2px; z-index: 1;}
 .sheet-equipment_melee_weapons { grid-area: e2; background:#475f85; border-radius: 10px; padding: 2px; }
 .sheet-equipment_numerics { grid-area: e3; margin-top: 10px; }
 .sheet-equipment_ranged_weapons_rep { background:#475f85; border:1px solid white; border-radius: 10px; padding: 2px; }

--- a/Halo_Mythic_3dot5/HaloMythic3dot5.html
+++ b/Halo_Mythic_3dot5/HaloMythic3dot5.html
@@ -369,7 +369,648 @@
   <!-- ______________________________ start of tab Core ______________________________ -->
 
   <div class='core box radius_border_box'>
-    <!-- Core Data -->
+
+    <!-- Core Data Standard -->
+    <input type='checkbox' name='attr_firefox' class='collapsible_entity_switch hidden' value="1" checked/>
+    <div class='collapsible_entity_block'>
+      <div class='core_lists '>
+
+        <div class='core_lists1 edge_padding table radius_border'>
+          <h3 class='radius_border_heading'><b>Skillset</b></h3>
+          <div class='skill_header'>
+            <p class='bold_text'>Name</p>
+            <p class='bold_text'></p>
+            <p class='bold_text'>Char</p>
+            <p class='bold_text'>Mod</p>
+            <p class='bold_text'>T</p>
+            <p class='bold_text'>+10</p>
+            <p class='bold_text'>+20</p>
+            <p class='bold_text'>Roll</p>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Appeal</p>
+            <p class='bold_text skills_text'></p>
+            <select name='attr_mod1_appeal' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' >INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' selected='selected'>CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_mod2_appeal' type='number' value='0' />
+            <input name='attr_mod3_appeal' type='checkbox' value='20' class='skills_item' />
+            <input name='attr_mod3_appeal' type='checkbox' value='30' class='skills_item' />
+            <input name='attr_mod3_appeal' type='checkbox' value='40' class='skills_item' />
+            <button type='roll' name='appeal_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Appeal}} {{roll=[[floor(([[@{mod1_appeal}]]+@{mod2_appeal}+[[@{mod3_appeal} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_appeal_total' value='@{mod1_appeal}+@{mod2_appeal}+@{mod3_appeal}-20' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Athletics</p>
+            <p class='bold_text skills_text'></p>
+            <select name='attr_mod1_athletics' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' selected='selected'>STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' >INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_mod2_athletics' type='number' value='0' />
+            <input name='attr_mod3_athletics' type='checkbox' value='20' class='skills_item' />
+            <input name='attr_mod3_athletics' type='checkbox' value='30' class='skills_item' />
+            <input name='attr_mod3_athletics' type='checkbox' value='40' class='skills_item' />
+            <button type='roll' name='athletics_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Athletics}} {{roll=[[floor(([[@{mod1_athletics}]]+@{mod2_athletics}+[[@{mod3_athletics} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_athletics_total' value='@{mod1_athletics}+@{mod2_athletics}+@{mod3_athletics}-20' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Camouflage</p>
+            <p class='bold_text skills_text'></p>
+            <select name='attr_mod1_camouflage' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' >INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' selected='selected'>PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_mod2_camouflage' type='number' value='0' />
+            <input name='attr_mod3_camouflage' type='checkbox' value='20' class='skills_item' />
+            <input name='attr_mod3_camouflage' type='checkbox' value='30' class='skills_item' />
+            <input name='attr_mod3_camouflage' type='checkbox' value='40' class='skills_item' />
+            <button type='roll' name='camouflage_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Camouflage}} {{roll=[[floor(([[@{mod1_camouflage}]]+@{mod2_camouflage}+[[@{mod3_camouflage} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_camouflage_total' value='@{mod1_camouflage}+@{mod2_camouflage}+@{mod3_camouflage}-20' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Command</p>
+            <p class='bold_text skills_text'></p>
+            <select name='attr_mod1_command' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' >INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' selected='selected'>LD</option>
+            </select>
+            <input name='attr_mod2_command' type='number' value='0' />
+            <input name='attr_mod3_command' type='checkbox' value='20' class='skills_item' />
+            <input name='attr_mod3_command' type='checkbox' value='30' class='skills_item' />
+            <input name='attr_mod3_command' type='checkbox' value='40' class='skills_item' />
+            <button type='roll' name='command_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Command}} {{roll=[[floor(([[@{mod1_command}]]+@{mod2_command}+[[@{mod3_command} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_command_total' value='@{mod1_command}+@{mod2_command}+@{mod3_command}-20' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Cryptography</p>
+            <p class='bold_text skills_text skills_diff'>Adv.</p>
+            <select name='attr_mod1_cryptography' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' selected='selected'>INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_mod2_cryptography' type='number' value='0' />
+            <input name='attr_mod3_cryptography' type='checkbox' value='40' class='skills_item' />
+            <input name='attr_mod3_cryptography' type='checkbox' value='50' class='skills_item' />
+            <input name='attr_mod3_cryptography' type='checkbox' value='60' class='skills_item' />
+            <button type='roll' name='cryptography_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Cryptography}} {{roll=[[floor(([[@{mod1_cryptography}]]+@{mod2_cryptography}+[[@{mod3_cryptography} -40]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_cryptography_total' value='@{mod1_cryptography}+@{mod2_cryptography}+@{mod3_cryptography}-40' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Deception</p>
+            <p class='bold_text skills_text'></p>
+            <select name='attr_mod1_deception' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' >INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' selected='selected'>CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_mod2_deception' type='number' value='0' />
+            <input name='attr_mod3_deception' type='checkbox' value='20' class='skills_item' />
+            <input name='attr_mod3_deception' type='checkbox' value='30' class='skills_item' />
+            <input name='attr_mod3_deception' type='checkbox' value='40' class='skills_item' />
+            <button type='roll' name='deception_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Deception}} {{roll=[[floor(([[@{mod1_deception}]]+@{mod2_deception}+[[@{mod3_deception} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_deception_total' value='@{mod1_deception}+@{mod2_deception}+@{mod3_deception}-20' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Demolition</p>
+            <p class='bold_text skills_text skills_diff'>Adv.</p>
+            <select name='attr_mod1_demolition' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' selected='selected'>INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_mod2_demolition' type='number' value='0' />
+            <input name='attr_mod3_demolition' type='checkbox' value='40' class='skills_item' />
+            <input name='attr_mod3_demolition' type='checkbox' value='50' class='skills_item' />
+            <input name='attr_mod3_demolition' type='checkbox' value='60' class='skills_item' />
+            <button type='roll' name='demolition_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Demolition}} {{roll=[[floor(([[@{mod1_demolition}]]+@{mod2_demolition}+[[@{mod3_demolition} -40]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_demolition_total' value='@{mod1_demolition}+@{mod2_demolition}+@{mod3_demolition}-40' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Evasion</p>
+            <p class='bold_text skills_text'></p>
+            <select name='attr_mod1_evasion' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' selected='selected'>AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' >INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_mod2_evasion' type='number' value='0' />
+            <input name='attr_mod3_evasion' type='checkbox' value='20' class='skills_item' />
+            <input name='attr_mod3_evasion' type='checkbox' value='30' class='skills_item' />
+            <input name='attr_mod3_evasion' type='checkbox' value='40' class='skills_item' />
+            <button type='roll' name='evasion_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Evasion}} {{roll=[[floor(([[@{mod1_evasion}]]+@{mod2_evasion}+[[@{mod3_evasion} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_evasion_total' value='@{mod1_evasion}+@{mod2_evasion}+@{mod3_evasion}-20' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Gambling</p>
+            <p class='bold_text skills_text'></p>
+            <select name='attr_mod1_gambling' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' >INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' selected='selected'>CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_mod2_gambling' type='number' value='0' />
+            <input name='attr_mod3_gambling' type='checkbox' value='20' class='skills_item' />
+            <input name='attr_mod3_gambling' type='checkbox' value='30' class='skills_item' />
+            <input name='attr_mod3_gambling' type='checkbox' value='40' class='skills_item' />
+            <button type='roll' name='gambling_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Gambling}} {{roll=[[floor(([[@{mod1_gambling}]]+@{mod2_gambling}+[[@{mod3_gambling} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_gambling_total' value='@{mod1_gambling}+@{mod2_gambling}+@{mod3_gambling}-20' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Interrogation</p>
+            <p class='bold_text skills_text'></p>
+            <select name='attr_mod1_interrogation' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' >INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' selected='selected'>LD</option>
+            </select>
+            <input name='attr_mod2_interrogation' type='number' value='0' />
+            <input name='attr_mod3_interrogation' type='checkbox' value='20' class='skills_item' />
+            <input name='attr_mod3_interrogation' type='checkbox' value='30' class='skills_item' />
+            <input name='attr_mod3_interrogation' type='checkbox' value='40' class='skills_item' />
+            <button type='roll' name='interrogation_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Interrogation}} {{roll=[[floor(([[@{mod1_interrogation}]]+@{mod2_interrogation}+[[@{mod3_interrogation} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_interrogation_total' value='@{mod1_interrogation}+@{mod2_interrogation}+@{mod3_interrogation}-20' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Intimidation</p>
+            <p class='bold_text skills_text'></p>
+            <select name='attr_mod1_intimidation' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' >INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' selected='selected'>LD</option>
+            </select>
+            <input name='attr_mod2_intimidation' type='number' value='0' />
+            <input name='attr_mod3_intimidation' type='checkbox' value='20' class='skills_item' />
+            <input name='attr_mod3_intimidation' type='checkbox' value='30' class='skills_item' />
+            <input name='attr_mod3_intimidation' type='checkbox' value='40' class='skills_item' />
+            <button type='roll' name='intimidation_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Intimidation}} {{roll=[[floor(([[@{mod1_intimidation}]]+@{mod2_intimidation}+[[@{mod3_intimidation} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_intimidation_total' value='@{mod1_intimidation}+@{mod2_intimidation}+@{mod3_intimidation}-20' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Investigation</p>
+            <p class='bold_text skills_text'></p>
+            <select name='attr_mod1_investigation' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' >INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' selected='selected'>PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_mod2_investigation' type='number' value='0' />
+            <input name='attr_mod3_investigation' type='checkbox' value='20' class='skills_item' />
+            <input name='attr_mod3_investigation' type='checkbox' value='30' class='skills_item' />
+            <input name='attr_mod3_investigation' type='checkbox' value='40' class='skills_item' />
+            <button type='roll' name='investigation_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Investigation}} {{roll=[[floor(([[@{mod1_investigation}]]+@{mod2_investigation}+[[@{mod3_investigation} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_investigation_total' value='@{mod1_investigation}+@{mod2_investigation}+@{mod3_investigation}-20' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Medication</p>
+            <p class='bold_text skills_text skills_diff'>Adv.</p>
+            <select name='attr_mod1_medication' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' selected='selected'>INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_mod2_medication' type='number' value='0' />
+            <input name='attr_mod3_medication' type='checkbox' value='40' class='skills_item' />
+            <input name='attr_mod3_medication' type='checkbox' value='50' class='skills_item' />
+            <input name='attr_mod3_medication' type='checkbox' value='60' class='skills_item' />
+            <button type='roll' name='medication_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Medication}} {{roll=[[floor(([[@{mod1_medication}]]+@{mod2_medication}+[[@{mod3_medication} -40]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_medication_total' value='@{mod1_medication}+@{mod2_medication}+@{mod3_medication}-40' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Nav Air</p>
+            <p class='bold_text skills_text'></p>
+            <select name='attr_mod1_nav_air' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' >INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' selected='selected'>PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_mod2_nav_air' type='number' value='0' />
+            <input name='attr_mod3_nav_air' type='checkbox' value='20' class='skills_item' />
+            <input name='attr_mod3_nav_air' type='checkbox' value='30' class='skills_item' />
+            <input name='attr_mod3_nav_air' type='checkbox' value='40' class='skills_item' />
+            <button type='roll' name='nav_air_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=nav_air}} {{roll=[[floor(([[@{mod1_nav_air}]]+@{mod2_nav_air}+[[@{mod3_nav_air} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_nav_air_total' value='@{mod1_nav_air}+@{mod2_nav_air}+@{mod3_nav_air}-20' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Nav Land</p>
+            <p class='bold_text skills_text'></p>
+            <select name='attr_mod1_nav_land' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' >INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' selected='selected'>PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_mod2_nav_land' type='number' value='0' />
+            <input name='attr_mod3_nav_land' type='checkbox' value='20' class='skills_item' />
+            <input name='attr_mod3_nav_land' type='checkbox' value='30' class='skills_item' />
+            <input name='attr_mod3_nav_land' type='checkbox' value='40' class='skills_item' />
+            <button type='roll' name='nav_land_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=nav_land}} {{roll=[[floor(([[@{mod1_nav_land}]]+@{mod2_nav_land}+[[@{mod3_nav_land} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_nav_land_total' value='@{mod1_nav_land}+@{mod2_nav_land}+@{mod3_nav_land}-20' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Nav Space</p>
+            <p class='bold_text skills_text'></p>
+            <select name='attr_mod1_nav_space' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' >INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' selected='selected'>PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_mod2_nav_space' type='number' value='0' />
+            <input name='attr_mod3_nav_space' type='checkbox' value='20' class='skills_item' />
+            <input name='attr_mod3_nav_space' type='checkbox' value='30' class='skills_item' />
+            <input name='attr_mod3_nav_space' type='checkbox' value='40' class='skills_item' />
+            <button type='roll' name='nav_space_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=nav_space}} {{roll=[[floor(([[@{mod1_nav_space}]]+@{mod2_nav_space}+[[@{mod3_nav_space} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_nav_space_total' value='@{mod1_nav_space}+@{mod2_nav_space}+@{mod3_nav_space}-20' class='input_background' disabled /></button>
+          </div>
+
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Negotiation</p>
+            <p class='bold_text skills_text'></p>
+            <select name='attr_mod1_negotiation' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' >INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' selected='selected'>LD</option>
+            </select>
+            <input name='attr_mod2_negotiation' type='number' value='0' />
+            <input name='attr_mod3_negotiation' type='checkbox' value='20' class='skills_item' />
+            <input name='attr_mod3_negotiation' type='checkbox' value='30' class='skills_item' />
+            <input name='attr_mod3_negotiation' type='checkbox' value='40' class='skills_item' />
+            <button type='roll' name='negotiation_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Negotiation}} {{roll=[[floor(([[@{mod1_negotiation}]]+@{mod2_negotiation}+[[@{mod3_negotiation} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_negotiation_total' value='@{mod1_negotiation}+@{mod2_negotiation}+@{mod3_negotiation}-20' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Pilot Air</p>
+            <p class='bold_text skills_text'></p>
+            <select name='attr_mod1_pilot_air' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' selected='selected'>INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_mod2_pilot_air' type='number' value='0' />
+            <input name='attr_mod3_pilot_air' type='checkbox' value='20' class='skills_item' />
+            <input name='attr_mod3_pilot_air' type='checkbox' value='30' class='skills_item' />
+            <input name='attr_mod3_pilot_air' type='checkbox' value='40' class='skills_item' />
+            <button type='roll' name='pilot_air_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=pilot_air}} {{roll=[[floor(([[@{mod1_pilot_air}]]+@{mod2_pilot_air}+[[@{mod3_pilot_air} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_pilot_air_total' value='@{mod1_pilot_air}+@{mod2_pilot_air}+@{mod3_pilot_air}-20' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Pilot Land</p>
+            <p class='bold_text skills_text'></p>
+            <select name='attr_mod1_pilot_land' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' selected='selected'>INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_mod2_pilot_land' type='number' value='0' />
+            <input name='attr_mod3_pilot_land' type='checkbox' value='20' class='skills_item' />
+            <input name='attr_mod3_pilot_land' type='checkbox' value='30' class='skills_item' />
+            <input name='attr_mod3_pilot_land' type='checkbox' value='40' class='skills_item' />
+            <button type='roll' name='pilot_land_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=pilot_land}} {{roll=[[floor(([[@{mod1_pilot_land}]]+@{mod2_pilot_land}+[[@{mod3_pilot_land} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_pilot_land_total' value='@{mod1_pilot_land}+@{mod2_pilot_land}+@{mod3_pilot_land}-20' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Pilot Space</p>
+            <p class='bold_text skills_text'></p>
+            <select name='attr_mod1_pilot_space' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' selected='selected'>INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_mod2_pilot_space' type='number' value='0' />
+            <input name='attr_mod3_pilot_space' type='checkbox' value='20' class='skills_item' />
+            <input name='attr_mod3_pilot_space' type='checkbox' value='30' class='skills_item' />
+            <input name='attr_mod3_pilot_space' type='checkbox' value='40' class='skills_item' />
+            <button type='roll' name='pilot_space_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=pilot_space}} {{roll=[[floor(([[@{mod1_pilot_space}]]+@{mod2_pilot_space}+[[@{mod3_pilot_space} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_pilot_space_total' value='@{mod1_pilot_space}+@{mod2_pilot_space}+@{mod3_pilot_space}-20' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Security</p>
+            <p class='bold_text skills_text skills_diff'>Adv.</p>
+            <select name='attr_mod1_security' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' selected='selected'>INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_mod2_security' type='number' value='0' />
+            <input name='attr_mod3_security' type='checkbox' value='40' class='skills_item' />
+            <input name='attr_mod3_security' type='checkbox' value='50' class='skills_item' />
+            <input name='attr_mod3_security' type='checkbox' value='60' class='skills_item' />
+            <button type='roll' name='security_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Security}} {{roll=[[floor(([[@{mod1_security}]]+@{mod2_security}+[[@{mod3_security} -40]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_security_total' value='@{mod1_security}+@{mod2_security}+@{mod3_security}-40' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Stunting</p>
+            <p class='bold_text skills_text'></p>
+            <select name='attr_mod1_stunting' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' selected='selected'>AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' >INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_mod2_stunting' type='number' value='0' />
+            <input name='attr_mod3_stunting' type='checkbox' value='20' class='skills_item' />
+            <input name='attr_mod3_stunting' type='checkbox' value='30' class='skills_item' />
+            <input name='attr_mod3_stunting' type='checkbox' value='40' class='skills_item' />
+            <button type='roll' name='stunting_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Stunting}} {{roll=[[floor(([[@{mod1_stunting}]]+@{mod2_stunting}+[[@{mod3_stunting} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_stunting_total' value='@{mod1_stunting}+@{mod2_stunting}+@{mod3_stunting}-20' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Survival</p>
+            <p class='bold_text skills_text'></p>
+            <select name='attr_mod1_survival' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' >INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' selected='selected'>PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_mod2_survival' type='number' value='0' />
+            <input name='attr_mod3_survival' type='checkbox' value='20' class='skills_item' />
+            <input name='attr_mod3_survival' type='checkbox' value='30' class='skills_item' />
+            <input name='attr_mod3_survival' type='checkbox' value='40' class='skills_item' />
+            <button type='roll' name='survival_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Survival}} {{roll=[[floor(([[@{mod1_survival}]]+@{mod2_survival}+[[@{mod3_survival} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_survival_total' value='@{mod1_survival}+@{mod2_survival}+@{mod3_survival}-20' class='input_background' disabled /></button>
+          </div>
+          <div class='skill_grid'>
+            <p class='bold_text skills_text'>Technology</p>
+            <p class='bold_text skills_text skills_diff'>Adv.</p>
+            <select name='attr_mod1_technology' class='full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' selected='selected'>INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_mod2_technology' type='number' value='0' />
+            <input name='attr_mod3_technology' type='checkbox' value='40' class='skills_item' />
+            <input name='attr_mod3_technology' type='checkbox' value='50' class='skills_item' />
+            <input name='attr_mod3_technology' type='checkbox' value='60' class='skills_item' />
+            <button type='roll' name='technology_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Technology}} {{roll=[[floor(([[@{mod1_technology}]]+@{mod2_technology}+[[@{mod3_technology} -40]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_technology_total' value='@{mod1_technology}+@{mod2_technology}+@{mod3_technology}-40' class='input_background' disabled /></button>
+          </div>
+          <fieldset name='skills' class='repeating_skills'>
+            <div class='skill_grid'>
+              <input name='attr_skill_R_name' type='text' value='' class='full_width text_left' />
+              <select name='attr_skill_R_mod4' class='full_width full_height'>
+                <option value='0' ></option>
+                <option value='20' >Adv.</option>
+              </select>
+              <select name='attr_skill_R_mod1' class='full_width full_height'>
+                <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}'>STR</option>
+                <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+                <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+                <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+                <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+                <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' >INT</option>
+                <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+                <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+                <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' selected='selected'>CH</option>
+                <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+              </select>
+              <input name='attr_skill_R_mod2' type='number' value='0' />
+              <input name='attr_skill_R_mod3' type='checkbox' value='20+@{skill_R_mod4}' class='skills_item' />
+              <input name='attr_skill_R_mod3' type='checkbox' value='30+@{skill_R_mod4}' class='skills_item' />
+              <input name='attr_skill_R_mod3' type='checkbox' value='40+@{skill_R_mod4}' class='skills_item' />
+              <button type='roll' name='skill_Roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=@{skill_R_name} }} {{roll=[[floor(([[@{skill_R_mod1}]]+@{skill_R_mod2}+[[@{skill_R_mod3}-(20+@{skill_R_mod4})]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_skill_R_total' value='@{skill_R_mod1}]]+@{skill_R_mod2}+[[@{skill_R_mod3}-(20+@{skill_R_mod4})' class='input_background' disabled /></button>
+            </div>
+          </fieldset>
+        </div>
+
+        <div class='core_lists2 edge_padding table radius_border'>
+          <h3 class='radius_border_heading'><b>Education</b></h3>
+          <div class='education_header'>
+            <p class='bold_text'>Name</p>
+            <p class='bold_text'>Char</p>
+            <p class='bold_text'>Mod</p>
+            <p class='bold_text'>+5</p>
+            <p class='bold_text'>+10</p>
+            <p class='bold_text'>Roll</p>
+          </div>
+          <div class='education_grid'>
+            <input name='attr_education_name' type='text' class='full_width text_left' />
+            <select name='attr_education_mod1' class=' full_width full_height'>
+              <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+              <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+              <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+              <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+              <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+              <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' selected='selected'>INT</option>
+              <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+              <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+              <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+              <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+            </select>
+            <input name='attr_education_mod2' type='number' value='0' />
+            <div class='education4'><input name='attr_education_mod3' type='checkbox' value='5' class='skills_item ' /></div>
+            <div class='education5'><input name='attr_education_mod3' type='checkbox' value='10' class='skills_item' /></div>
+            <button name='education_roll' type='roll' class='clear'
+            value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=@{education_name} }} {{roll=[[floor(([[@{education_mod1}]]+@{education_mod2}+@{education_mod3}+@{inlinemod-toggle}-1d100)/10)]]}}'>
+            <input name='attr_education_total' value='@{education_mod1}+@{education_mod2}+@{education_mod3}' class='input_background' disabled /></button>
+          </div>
+          <fieldset name='education' class='repeating_education'>
+            <div class='education_grid'>
+              <input name='attr_education_name' type='text' class='full_width text_left' />
+              <select name='attr_education_r_mod1' class=' full_width full_height'>
+                <option value='@{STR} + @{STR_advancement} + @{fatigue_mod}' >STR</option>
+                <option value='@{TOU} + @{TOU_advancement} + @{fatigue_mod}' >TOU</option>
+                <option value='@{AGI} + @{AGI_advancement} + @{fatigue_mod}' >AGI</option>
+                <option value='@{WFR} + @{WFR_advancement} + @{fatigue_mod}' >WFR</option>
+                <option value='@{WFM} + @{WFM_advancement} + @{fatigue_mod}' >WFM</option>
+                <option value='@{INT} + @{INT_advancement} + @{fatigue_mod}' selected='selected'>INT</option>
+                <option value='@{PER} + @{PER_advancement} + @{fatigue_mod}' >PER</option>
+                <option value='@{CR} + @{CR_advancement} + @{fatigue_mod}' >CR</option>
+                <option value='@{CH} + @{CH_advancement} + @{fatigue_mod}' >CH</option>
+                <option value='@{LD} + @{LD_advancement} + @{fatigue_mod}' >LD</option>
+              </select>
+              <input name='attr_education_r_mod2' type='number' value='0' />
+              <div class='education4'><input name='attr_education_r_mod3' type='checkbox' value='5' class='skills_item ' /></div>
+              <div class='education5'><input name='attr_education_r_mod3' type='checkbox' value='10' class='skills_item' /></div>
+              <button name='education_roll' type='roll' class='clear'
+              value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=@{education_name} }} {{roll=[[floor(([[@{education_r_mod1}]]+@{education_r_mod2}+@{education_r_mod3}+@{inlinemod-toggle}-1d100)/10)]]}}'>
+              <input name='attr_education_r_total' value='@{education_r_mod1}+@{education_r_mod2}+@{education_r_mod3}' class='input_background' disabled /></button>
+            </div>
+          </fieldset>
+        </div>
+
+        <div class='core_lists3 table edge_padding radius_border'>
+          <h3 class='radius_border_heading'><b>Languages</b></h3>
+          <fieldset name='language' class='repeating_languages'>
+            <input name='attr_language' type='text' class='full_width text_left' />
+          </fieldset>
+        </div>
+
+      </div>
+      <br>
+
+
+
+      <h2>Abilities</h2>
+      <p class='abilities_checkbox_pointer'><b>Expand or collapse ability's descriptor block ⯆</b></p>
+      <div class='edge_padding ssc'>
+        <input name='attr_ability' type='text' placeholder='SQUAD UP' class='full_width_49px' />
+        <label class='margin_adjust'><input type='checkbox' name='attr_collapse' value='2' class='collapsible_entity_switch select_button hidden' /><span class='select_text'>▼</span></label>
+        <label class='margin_adjust2'><button type='roll' value='@{to-gm}&{template:mythic} {{name=@{ability} }} {{description=@{ability_desc} }}' class='hidden'></button><span class='select_text'>❖</span></label>
+        <input name='attr_collapse' type='checkbox'  value='2' class='collapsible_entity_switch hidden' />
+        <textarea name='attr_ability_desc' class='collapsible_entity_block'
+        placeholder='Prerequisites: Race Human, Faction Type U.N.S.C. Military Branch&#10;&#10;Benefit: When with others from the Army, Marine, Air Force, Navy, ORION, ODST, Militiaman, and Spartan IV Soldier Types: these characters gain a +5 Bonus to Courage. The Characters also gain a +10 Bonus to Warfare Melee and Warfare Range Tests when taking Combined Actions.'></textarea>
+        <fieldset name='abilities' class='repeating_abilities'>
+          <input name='attr_ability_r' type='text' placeholder='Name' class='full_width_49px' />
+          <label class='margin_adjust'><input type='checkbox' name='attr_collapse' value='3' class='collapsible_entity_switch select_button hidden' /><span class='select_text '>▼</span></label>
+          <label class='margin_adjust2'><button type='roll' value='@{to-gm}&{template:mythic} {{name=@{ability_r} }} {{description=@{ability_desc_r} }}' class='hidden'></button><span class='select_text'>❖</span></label>
+          <input name='attr_collapse' type='checkbox'  value='3' class='collapsible_entity_switch hidden' />
+          <textarea name='attr_ability_desc_r' class='collapsible_entity_block'></textarea>
+        </fieldset>
+      </div>
+
+
+  </div>
+
+  <input type='checkbox' name='attr_firefox' class='collapsible_entity_switch hidden' value="1" checked/>
+  <div class='collapsible_entity_toggle'>
     <div class='core_lists '>
 
       <div class='core_lists1 edge_padding table radius_border'>
@@ -403,7 +1044,7 @@
           <input name='attr_mod3_appeal' type='checkbox' value='20' class='skills_item' />
           <input name='attr_mod3_appeal' type='checkbox' value='30' class='skills_item' />
           <input name='attr_mod3_appeal' type='checkbox' value='40' class='skills_item' />
-          <button type='roll' name='appeal_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Appeal}} {{roll=[[floor(([[@{mod1_appeal}]]+@{mod2_appeal}+[[@{mod3_appeal} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_appeal_total' value='@{mod1_appeal}+@{mod2_appeal}+@{mod3_appeal}-20' class='input_background' disabled /></button>
+          <button type='roll' name='appeal_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Appeal}} {{roll=[[floor(([[@{mod1_appeal}]]+@{mod2_appeal}+[[@{mod3_appeal} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Athletics</p>
@@ -424,7 +1065,7 @@
           <input name='attr_mod3_athletics' type='checkbox' value='20' class='skills_item' />
           <input name='attr_mod3_athletics' type='checkbox' value='30' class='skills_item' />
           <input name='attr_mod3_athletics' type='checkbox' value='40' class='skills_item' />
-          <button type='roll' name='athletics_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Athletics}} {{roll=[[floor(([[@{mod1_athletics}]]+@{mod2_athletics}+[[@{mod3_athletics} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_athletics_total' value='@{mod1_athletics}+@{mod2_athletics}+@{mod3_athletics}-20' class='input_background' disabled /></button>
+          <button type='roll' name='athletics_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Athletics}} {{roll=[[floor(([[@{mod1_athletics}]]+@{mod2_athletics}+[[@{mod3_athletics} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Camouflage</p>
@@ -445,7 +1086,7 @@
           <input name='attr_mod3_camouflage' type='checkbox' value='20' class='skills_item' />
           <input name='attr_mod3_camouflage' type='checkbox' value='30' class='skills_item' />
           <input name='attr_mod3_camouflage' type='checkbox' value='40' class='skills_item' />
-          <button type='roll' name='camouflage_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Camouflage}} {{roll=[[floor(([[@{mod1_camouflage}]]+@{mod2_camouflage}+[[@{mod3_camouflage} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_camouflage_total' value='@{mod1_camouflage}+@{mod2_camouflage}+@{mod3_camouflage}-20' class='input_background' disabled /></button>
+          <button type='roll' name='camouflage_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Camouflage}} {{roll=[[floor(([[@{mod1_camouflage}]]+@{mod2_camouflage}+[[@{mod3_camouflage} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Command</p>
@@ -466,7 +1107,7 @@
           <input name='attr_mod3_command' type='checkbox' value='20' class='skills_item' />
           <input name='attr_mod3_command' type='checkbox' value='30' class='skills_item' />
           <input name='attr_mod3_command' type='checkbox' value='40' class='skills_item' />
-          <button type='roll' name='command_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Command}} {{roll=[[floor(([[@{mod1_command}]]+@{mod2_command}+[[@{mod3_command} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_command_total' value='@{mod1_command}+@{mod2_command}+@{mod3_command}-20' class='input_background' disabled /></button>
+          <button type='roll' name='command_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Command}} {{roll=[[floor(([[@{mod1_command}]]+@{mod2_command}+[[@{mod3_command} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Cryptography</p>
@@ -487,7 +1128,7 @@
           <input name='attr_mod3_cryptography' type='checkbox' value='40' class='skills_item' />
           <input name='attr_mod3_cryptography' type='checkbox' value='50' class='skills_item' />
           <input name='attr_mod3_cryptography' type='checkbox' value='60' class='skills_item' />
-          <button type='roll' name='cryptography_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Cryptography}} {{roll=[[floor(([[@{mod1_cryptography}]]+@{mod2_cryptography}+[[@{mod3_cryptography} -40]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_cryptography_total' value='@{mod1_cryptography}+@{mod2_cryptography}+@{mod3_cryptography}-40' class='input_background' disabled /></button>
+          <button type='roll' name='cryptography_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Cryptography}} {{roll=[[floor(([[@{mod1_cryptography}]]+@{mod2_cryptography}+[[@{mod3_cryptography} -40]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Deception</p>
@@ -508,7 +1149,7 @@
           <input name='attr_mod3_deception' type='checkbox' value='20' class='skills_item' />
           <input name='attr_mod3_deception' type='checkbox' value='30' class='skills_item' />
           <input name='attr_mod3_deception' type='checkbox' value='40' class='skills_item' />
-          <button type='roll' name='deception_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Deception}} {{roll=[[floor(([[@{mod1_deception}]]+@{mod2_deception}+[[@{mod3_deception} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_deception_total' value='@{mod1_deception}+@{mod2_deception}+@{mod3_deception}-20' class='input_background' disabled /></button>
+          <button type='roll' name='deception_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Deception}} {{roll=[[floor(([[@{mod1_deception}]]+@{mod2_deception}+[[@{mod3_deception} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Demolition</p>
@@ -529,7 +1170,7 @@
           <input name='attr_mod3_demolition' type='checkbox' value='40' class='skills_item' />
           <input name='attr_mod3_demolition' type='checkbox' value='50' class='skills_item' />
           <input name='attr_mod3_demolition' type='checkbox' value='60' class='skills_item' />
-          <button type='roll' name='demolition_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Demolition}} {{roll=[[floor(([[@{mod1_demolition}]]+@{mod2_demolition}+[[@{mod3_demolition} -40]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_demolition_total' value='@{mod1_demolition}+@{mod2_demolition}+@{mod3_demolition}-40' class='input_background' disabled /></button>
+          <button type='roll' name='demolition_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Demolition}} {{roll=[[floor(([[@{mod1_demolition}]]+@{mod2_demolition}+[[@{mod3_demolition} -40]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Evasion</p>
@@ -550,7 +1191,7 @@
           <input name='attr_mod3_evasion' type='checkbox' value='20' class='skills_item' />
           <input name='attr_mod3_evasion' type='checkbox' value='30' class='skills_item' />
           <input name='attr_mod3_evasion' type='checkbox' value='40' class='skills_item' />
-          <button type='roll' name='evasion_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Evasion}} {{roll=[[floor(([[@{mod1_evasion}]]+@{mod2_evasion}+[[@{mod3_evasion} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_evasion_total' value='@{mod1_evasion}+@{mod2_evasion}+@{mod3_evasion}-20' class='input_background' disabled /></button>
+          <button type='roll' name='evasion_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Evasion}} {{roll=[[floor(([[@{mod1_evasion}]]+@{mod2_evasion}+[[@{mod3_evasion} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Gambling</p>
@@ -571,7 +1212,7 @@
           <input name='attr_mod3_gambling' type='checkbox' value='20' class='skills_item' />
           <input name='attr_mod3_gambling' type='checkbox' value='30' class='skills_item' />
           <input name='attr_mod3_gambling' type='checkbox' value='40' class='skills_item' />
-          <button type='roll' name='gambling_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Gambling}} {{roll=[[floor(([[@{mod1_gambling}]]+@{mod2_gambling}+[[@{mod3_gambling} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_gambling_total' value='@{mod1_gambling}+@{mod2_gambling}+@{mod3_gambling}-20' class='input_background' disabled /></button>
+          <button type='roll' name='gambling_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Gambling}} {{roll=[[floor(([[@{mod1_gambling}]]+@{mod2_gambling}+[[@{mod3_gambling} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Interrogation</p>
@@ -592,7 +1233,7 @@
           <input name='attr_mod3_interrogation' type='checkbox' value='20' class='skills_item' />
           <input name='attr_mod3_interrogation' type='checkbox' value='30' class='skills_item' />
           <input name='attr_mod3_interrogation' type='checkbox' value='40' class='skills_item' />
-          <button type='roll' name='interrogation_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Interrogation}} {{roll=[[floor(([[@{mod1_interrogation}]]+@{mod2_interrogation}+[[@{mod3_interrogation} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_interrogation_total' value='@{mod1_interrogation}+@{mod2_interrogation}+@{mod3_interrogation}-20' class='input_background' disabled /></button>
+          <button type='roll' name='interrogation_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Interrogation}} {{roll=[[floor(([[@{mod1_interrogation}]]+@{mod2_interrogation}+[[@{mod3_interrogation} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Intimidation</p>
@@ -613,7 +1254,7 @@
           <input name='attr_mod3_intimidation' type='checkbox' value='20' class='skills_item' />
           <input name='attr_mod3_intimidation' type='checkbox' value='30' class='skills_item' />
           <input name='attr_mod3_intimidation' type='checkbox' value='40' class='skills_item' />
-          <button type='roll' name='intimidation_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Intimidation}} {{roll=[[floor(([[@{mod1_intimidation}]]+@{mod2_intimidation}+[[@{mod3_intimidation} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_intimidation_total' value='@{mod1_intimidation}+@{mod2_intimidation}+@{mod3_intimidation}-20' class='input_background' disabled /></button>
+          <button type='roll' name='intimidation_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Intimidation}} {{roll=[[floor(([[@{mod1_intimidation}]]+@{mod2_intimidation}+[[@{mod3_intimidation} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Investigation</p>
@@ -634,7 +1275,7 @@
           <input name='attr_mod3_investigation' type='checkbox' value='20' class='skills_item' />
           <input name='attr_mod3_investigation' type='checkbox' value='30' class='skills_item' />
           <input name='attr_mod3_investigation' type='checkbox' value='40' class='skills_item' />
-          <button type='roll' name='investigation_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Investigation}} {{roll=[[floor(([[@{mod1_investigation}]]+@{mod2_investigation}+[[@{mod3_investigation} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_investigation_total' value='@{mod1_investigation}+@{mod2_investigation}+@{mod3_investigation}-20' class='input_background' disabled /></button>
+          <button type='roll' name='investigation_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Investigation}} {{roll=[[floor(([[@{mod1_investigation}]]+@{mod2_investigation}+[[@{mod3_investigation} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Medication</p>
@@ -655,7 +1296,7 @@
           <input name='attr_mod3_medication' type='checkbox' value='40' class='skills_item' />
           <input name='attr_mod3_medication' type='checkbox' value='50' class='skills_item' />
           <input name='attr_mod3_medication' type='checkbox' value='60' class='skills_item' />
-          <button type='roll' name='medication_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Medication}} {{roll=[[floor(([[@{mod1_medication}]]+@{mod2_medication}+[[@{mod3_medication} -40]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_medication_total' value='@{mod1_medication}+@{mod2_medication}+@{mod3_medication}-40' class='input_background' disabled /></button>
+          <button type='roll' name='medication_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Medication}} {{roll=[[floor(([[@{mod1_medication}]]+@{mod2_medication}+[[@{mod3_medication} -40]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Nav Air</p>
@@ -676,7 +1317,7 @@
           <input name='attr_mod3_nav_air' type='checkbox' value='20' class='skills_item' />
           <input name='attr_mod3_nav_air' type='checkbox' value='30' class='skills_item' />
           <input name='attr_mod3_nav_air' type='checkbox' value='40' class='skills_item' />
-          <button type='roll' name='nav_air_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=nav_air}} {{roll=[[floor(([[@{mod1_nav_air}]]+@{mod2_nav_air}+[[@{mod3_nav_air} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_nav_air_total' value='@{mod1_nav_air}+@{mod2_nav_air}+@{mod3_nav_air}-20' class='input_background' disabled /></button>
+          <button type='roll' name='nav_air_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=nav_air}} {{roll=[[floor(([[@{mod1_nav_air}]]+@{mod2_nav_air}+[[@{mod3_nav_air} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Nav Land</p>
@@ -697,7 +1338,7 @@
           <input name='attr_mod3_nav_land' type='checkbox' value='20' class='skills_item' />
           <input name='attr_mod3_nav_land' type='checkbox' value='30' class='skills_item' />
           <input name='attr_mod3_nav_land' type='checkbox' value='40' class='skills_item' />
-          <button type='roll' name='nav_land_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=nav_land}} {{roll=[[floor(([[@{mod1_nav_land}]]+@{mod2_nav_land}+[[@{mod3_nav_land} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_nav_land_total' value='@{mod1_nav_land}+@{mod2_nav_land}+@{mod3_nav_land}-20' class='input_background' disabled /></button>
+          <button type='roll' name='nav_land_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=nav_land}} {{roll=[[floor(([[@{mod1_nav_land}]]+@{mod2_nav_land}+[[@{mod3_nav_land} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Nav Space</p>
@@ -718,7 +1359,7 @@
           <input name='attr_mod3_nav_space' type='checkbox' value='20' class='skills_item' />
           <input name='attr_mod3_nav_space' type='checkbox' value='30' class='skills_item' />
           <input name='attr_mod3_nav_space' type='checkbox' value='40' class='skills_item' />
-          <button type='roll' name='nav_space_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=nav_space}} {{roll=[[floor(([[@{mod1_nav_space}]]+@{mod2_nav_space}+[[@{mod3_nav_space} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_nav_space_total' value='@{mod1_nav_space}+@{mod2_nav_space}+@{mod3_nav_space}-20' class='input_background' disabled /></button>
+          <button type='roll' name='nav_space_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=nav_space}} {{roll=[[floor(([[@{mod1_nav_space}]]+@{mod2_nav_space}+[[@{mod3_nav_space} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
 
         <div class='skill_grid'>
@@ -740,7 +1381,7 @@
           <input name='attr_mod3_negotiation' type='checkbox' value='20' class='skills_item' />
           <input name='attr_mod3_negotiation' type='checkbox' value='30' class='skills_item' />
           <input name='attr_mod3_negotiation' type='checkbox' value='40' class='skills_item' />
-          <button type='roll' name='negotiation_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Negotiation}} {{roll=[[floor(([[@{mod1_negotiation}]]+@{mod2_negotiation}+[[@{mod3_negotiation} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_negotiation_total' value='@{mod1_negotiation}+@{mod2_negotiation}+@{mod3_negotiation}-20' class='input_background' disabled /></button>
+          <button type='roll' name='negotiation_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Negotiation}} {{roll=[[floor(([[@{mod1_negotiation}]]+@{mod2_negotiation}+[[@{mod3_negotiation} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Pilot Air</p>
@@ -761,7 +1402,7 @@
           <input name='attr_mod3_pilot_air' type='checkbox' value='20' class='skills_item' />
           <input name='attr_mod3_pilot_air' type='checkbox' value='30' class='skills_item' />
           <input name='attr_mod3_pilot_air' type='checkbox' value='40' class='skills_item' />
-          <button type='roll' name='pilot_air_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=pilot_air}} {{roll=[[floor(([[@{mod1_pilot_air}]]+@{mod2_pilot_air}+[[@{mod3_pilot_air} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_pilot_air_total' value='@{mod1_pilot_air}+@{mod2_pilot_air}+@{mod3_pilot_air}-20' class='input_background' disabled /></button>
+          <button type='roll' name='pilot_air_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=pilot_air}} {{roll=[[floor(([[@{mod1_pilot_air}]]+@{mod2_pilot_air}+[[@{mod3_pilot_air} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Pilot Land</p>
@@ -782,7 +1423,7 @@
           <input name='attr_mod3_pilot_land' type='checkbox' value='20' class='skills_item' />
           <input name='attr_mod3_pilot_land' type='checkbox' value='30' class='skills_item' />
           <input name='attr_mod3_pilot_land' type='checkbox' value='40' class='skills_item' />
-          <button type='roll' name='pilot_land_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=pilot_land}} {{roll=[[floor(([[@{mod1_pilot_land}]]+@{mod2_pilot_land}+[[@{mod3_pilot_land} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_pilot_land_total' value='@{mod1_pilot_land}+@{mod2_pilot_land}+@{mod3_pilot_land}-20' class='input_background' disabled /></button>
+          <button type='roll' name='pilot_land_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=pilot_land}} {{roll=[[floor(([[@{mod1_pilot_land}]]+@{mod2_pilot_land}+[[@{mod3_pilot_land} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Pilot Space</p>
@@ -803,7 +1444,7 @@
           <input name='attr_mod3_pilot_space' type='checkbox' value='20' class='skills_item' />
           <input name='attr_mod3_pilot_space' type='checkbox' value='30' class='skills_item' />
           <input name='attr_mod3_pilot_space' type='checkbox' value='40' class='skills_item' />
-          <button type='roll' name='pilot_space_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=pilot_space}} {{roll=[[floor(([[@{mod1_pilot_space}]]+@{mod2_pilot_space}+[[@{mod3_pilot_space} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_pilot_space_total' value='@{mod1_pilot_space}+@{mod2_pilot_space}+@{mod3_pilot_space}-20' class='input_background' disabled /></button>
+          <button type='roll' name='pilot_space_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=pilot_space}} {{roll=[[floor(([[@{mod1_pilot_space}]]+@{mod2_pilot_space}+[[@{mod3_pilot_space} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Security</p>
@@ -824,7 +1465,7 @@
           <input name='attr_mod3_security' type='checkbox' value='40' class='skills_item' />
           <input name='attr_mod3_security' type='checkbox' value='50' class='skills_item' />
           <input name='attr_mod3_security' type='checkbox' value='60' class='skills_item' />
-          <button type='roll' name='security_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Security}} {{roll=[[floor(([[@{mod1_security}]]+@{mod2_security}+[[@{mod3_security} -40]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_security_total' value='@{mod1_security}+@{mod2_security}+@{mod3_security}-40' class='input_background' disabled /></button>
+          <button type='roll' name='security_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Security}} {{roll=[[floor(([[@{mod1_security}]]+@{mod2_security}+[[@{mod3_security} -40]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Stunting</p>
@@ -845,7 +1486,7 @@
           <input name='attr_mod3_stunting' type='checkbox' value='20' class='skills_item' />
           <input name='attr_mod3_stunting' type='checkbox' value='30' class='skills_item' />
           <input name='attr_mod3_stunting' type='checkbox' value='40' class='skills_item' />
-          <button type='roll' name='stunting_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Stunting}} {{roll=[[floor(([[@{mod1_stunting}]]+@{mod2_stunting}+[[@{mod3_stunting} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_stunting_total' value='@{mod1_stunting}+@{mod2_stunting}+@{mod3_stunting}-20' class='input_background' disabled /></button>
+          <button type='roll' name='stunting_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Stunting}} {{roll=[[floor(([[@{mod1_stunting}]]+@{mod2_stunting}+[[@{mod3_stunting} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Survival</p>
@@ -866,7 +1507,7 @@
           <input name='attr_mod3_survival' type='checkbox' value='20' class='skills_item' />
           <input name='attr_mod3_survival' type='checkbox' value='30' class='skills_item' />
           <input name='attr_mod3_survival' type='checkbox' value='40' class='skills_item' />
-          <button type='roll' name='survival_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Survival}} {{roll=[[floor(([[@{mod1_survival}]]+@{mod2_survival}+[[@{mod3_survival} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_survival_total' value='@{mod1_survival}+@{mod2_survival}+@{mod3_survival}-20' class='input_background' disabled /></button>
+          <button type='roll' name='survival_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Survival}} {{roll=[[floor(([[@{mod1_survival}]]+@{mod2_survival}+[[@{mod3_survival} -20]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <div class='skill_grid'>
           <p class='bold_text skills_text'>Technology</p>
@@ -887,7 +1528,7 @@
           <input name='attr_mod3_technology' type='checkbox' value='40' class='skills_item' />
           <input name='attr_mod3_technology' type='checkbox' value='50' class='skills_item' />
           <input name='attr_mod3_technology' type='checkbox' value='60' class='skills_item' />
-          <button type='roll' name='technology_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Technology}} {{roll=[[floor(([[@{mod1_technology}]]+@{mod2_technology}+[[@{mod3_technology} -40]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_technology_total' value='@{mod1_technology}+@{mod2_technology}+@{mod3_technology}-40' class='input_background' disabled /></button>
+          <button type='roll' name='technology_roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=Technology}} {{roll=[[floor(([[@{mod1_technology}]]+@{mod2_technology}+[[@{mod3_technology} -40]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
         </div>
         <fieldset name='skills' class='repeating_skills'>
           <div class='skill_grid'>
@@ -912,7 +1553,7 @@
             <input name='attr_skill_R_mod3' type='checkbox' value='20+@{skill_R_mod4}' class='skills_item' />
             <input name='attr_skill_R_mod3' type='checkbox' value='30+@{skill_R_mod4}' class='skills_item' />
             <input name='attr_skill_R_mod3' type='checkbox' value='40+@{skill_R_mod4}' class='skills_item' />
-            <button type='roll' name='skill_Roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=@{skill_R_name} }} {{roll=[[floor(([[@{skill_R_mod1}]]+@{skill_R_mod2}+[[@{skill_R_mod3}-(20+@{skill_R_mod4})]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'><input name='attr_skill_R_total' value='@{skill_R_mod1}]]+@{skill_R_mod2}+[[@{skill_R_mod3}-(20+@{skill_R_mod4})' class='input_background' disabled /></button>
+            <button type='roll' name='skill_Roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=@{skill_R_name} }} {{roll=[[floor(([[@{skill_R_mod1}]]+@{skill_R_mod2}+[[@{skill_R_mod3}-(20+@{skill_R_mod4})]]+@{inlinemod-toggle}-1d100)/10)]]}}' class='clear'></button>
           </div>
         </fieldset>
       </div>
@@ -945,8 +1586,7 @@
           <div class='education4'><input name='attr_education_mod3' type='checkbox' value='5' class='skills_item ' /></div>
           <div class='education5'><input name='attr_education_mod3' type='checkbox' value='10' class='skills_item' /></div>
           <button name='education_roll' type='roll' class='clear'
-          value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=@{education_name} }} {{roll=[[floor(([[@{education_mod1}]]+@{education_mod2}+@{education_mod3}+@{inlinemod-toggle}-1d100)/10)]]}}'>
-          <input name='attr_education_total' value='@{education_mod1}+@{education_mod2}+@{education_mod3}' class='input_background' disabled /></button>
+          value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=@{education_name} }} {{roll=[[floor(([[@{education_mod1}]]+@{education_mod2}+@{education_mod3}+@{inlinemod-toggle}-1d100)/10)]]}}'></button>
         </div>
         <fieldset name='education' class='repeating_education'>
           <div class='education_grid'>
@@ -967,8 +1607,7 @@
             <div class='education4'><input name='attr_education_r_mod3' type='checkbox' value='5' class='skills_item ' /></div>
             <div class='education5'><input name='attr_education_r_mod3' type='checkbox' value='10' class='skills_item' /></div>
             <button name='education_roll' type='roll' class='clear'
-            value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=@{education_name} }} {{roll=[[floor(([[@{education_r_mod1}]]+@{education_r_mod2}+@{education_r_mod3}+@{inlinemod-toggle}-1d100)/10)]]}}'>
-            <input name='attr_education_r_total' value='@{education_r_mod1}+@{education_r_mod2}+@{education_r_mod3}' class='input_background' disabled /></button>
+            value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{roll-name=@{education_name} }} {{roll=[[floor(([[@{education_r_mod1}]]+@{education_r_mod2}+@{education_r_mod3}+@{inlinemod-toggle}-1d100)/10)]]}}'></button>
           </div>
         </fieldset>
       </div>
@@ -1004,1248 +1643,1254 @@
     </div>
   </div>
 
+</div>
+
+<!-- ______________________________ start of tab Equipment ______________________________ -->
+
+<div class='equipment box radius_border_box ssc'>
+  <div class='equipment_divider'>
+    <div class='equipment_ranged_weapons ssc'>
+      <h3 class='radius_border_top'>Ranged Weapons</h3>
+      <fieldset name='rangedweapons' class='repeating_rangedweapons'>
+        <div class='equipment_ranged_weapons_rep'>
+          <div class='equipment_ranged_weapons_grid1'>
+            <div class='equipment_ranged_weapons_gs1'>Name</div>
+            <input class='equipment_ranged_weapons_gs2 full_width' type='text' name='attr_R_weapon_name' placeholder='Name' />
+            <div class='equipment_ranged_weapons_gs3'>Type</div>
+            <input class='equipment_ranged_weapons_gs4 full_width' type='text' name='attr_R_weapon_class' placeholder='Class of Weapon' />
+          </div>
+          <div class='equipment_ranged_weapons_grid2'>
+            <div class='equipment_ranged_weapons_gs5'>Range</div>
+            <input class='equipment_ranged_weapons_gs6 full_width' type='text' value='0' name='attr_R_weapon_range' />
+            <div class='equipment_ranged_weapons_gs7'>DMG Roll</div>
+            <input class='equipment_ranged_weapons_gs8 full_width' type='text' value='2d10' name='attr_R_weapon_dam-roll' />
+            <div class='equipment_ranged_weapons_gs9'>Base</div>
+            <input class='equipment_ranged_weapons_gs10 full_width' type='text' value='0' name='attr_R_weapon_base' />
+            <div class='equipment_ranged_weapons_gs11'>Pierce</div>
+            <input class='equipment_ranged_weapons_gs12 full_width' type='text' value='0' name='attr_R_weapon_pierce' />
+          </div>
+          <div class='equipment_ranged_weapons_grid3'>
+            <div class='equipment_ranged_weapons_gs13'>Hit Mod</div>
+            <input class='equipment_ranged_weapons_gs14 full_width' type='text' value='0' name='attr_R_weapon_mod1' />
+            <div class='equipment_ranged_weapons_gs15'>Magazine</div>
+            <input class='equipment_ranged_weapons_gs16 full_width' type='text' value='0' name='attr_R_weapon_mag' />
+            <div class='equipment_ranged_weapons_gs17'>/</div>
+            <input class='equipment_ranged_weapons_gs18 full_width' type='text' value='0' name='attr_R_weapon_mag_max' />
+            <button class='equipment_ranged_weapons_gs19 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }} {{weapon= @{R_weapon_name}}} {{roll=[[floor(([[@{WFR}+@{WFR_advancement}+@{fatigue_mod}]]+@{R_weapon_mod1}+@{inlinemod-toggle}-1d100)/10)]]}} @{settings_hitroll}"></button>' >Hit</button>
+            <button class='equipment_ranged_weapons_gs20 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{weapon= @{R_weapon_name}}} {{damage=[[@{R_weapon_dam-roll}+@{R_weapon_base}]] }} {{pierce=[[@{R_weapon_pierce}]] }} {{@{settings_weapondescription}=@{R_ability_r} }}' >DMG</button>
+          </div>
+          <div class='equipment_ranged_weapons_grid4'>
+            <div class='equipment_ranged_weapons_gs21'>RoF</div>
+            <input class='equipment_ranged_weapons_gs22 full_width' type='text' placeholder='Semi' name='attr_R_weapon_semi' />
+            <div class='equipment_ranged_weapons_gs23'>/</div>
+            <input class='equipment_ranged_weapons_gs24 full_width' type='text' placeholder='Burst' name='attr_R_weapon_burst' />
+            <div class='equipment_ranged_weapons_gs25'>/</div>
+            <input class='equipment_ranged_weapons_gs26 full_width' type='text' placeholder='Auto' name='attr_R_weapon_auto' />
+            <div class='equipment_ranged_weapons_gs27'>Reload</div>
+            <input class='equipment_ranged_weapons_gs28 full_width' type='text' value='2 half actions' name='attr_R_weapon_reload' />
+            <div class='equipment_ranged_weapons_gs29'>Weight</div>
+            <input class='equipment_ranged_weapons_gs30 full_width' type='text' value='0' name='attr_R_weapon_weight' />
+          </div>
+          <div>
+            <input name='attr_R_ability_r' type='text' placeholder='Description' class='full_width_49px border_none' />
+            <label class='margin_adjust_wep'><input type='checkbox' name='attr_collapse' value='3' class='collapsible_entity_switch select_button hidden' /><span class='select_text radius_border_right_wep'>▼</span></label>
+            <label class='margin_adjust_wep2'><button type='roll' value='@{to-gm}&{template:mythic} {{name=@{R_ability_r} }} {{description=@{R_ability_desc_r} }}' class='hidden'></button><span class='select_text'>❖</span></label>
+            <input name='attr_collapse' type='checkbox'  value='3' class='collapsible_entity_switch hidden' />
+            <textarea name='attr_R_ability_desc_r' class='collapsible_entity_block description_rounded_margin' placeholder='Weapon Attachment: Benefit, Type Mount, Restriction, etc.'></textarea>
+          </div>
+        </div>
+        <hr>
+      </fieldset>
+    </div>
+
+    <div class='equipment_melee_weapons ssc'>
+      <h3 class='radius_border_top'>Melee Weapons</h3>
+      <fieldset name='meleeweapons' class='repeating_meleeweapons'>
+        <div class='equipment_ranged_weapons_rep'>
+          <div class='equipment_ranged_weapons_grid1'>
+            <div class='equipment_ranged_weapons_gs1'>Name</div>
+            <input class='equipment_ranged_weapons_gs2 full_width' type='text' name='attr_M_weapon_name' placeholder='Name' />
+            <div class='equipment_ranged_weapons_gs3'>Type</div>
+            <input class='equipment_ranged_weapons_gs4 full_width' type='text' name='attr_M_weapon_class' placeholder='Class of Weapon' />
+          </div>
+          <div class='equipment_ranged_weapons_grid2'>
+            <div class='equipment_ranged_weapons_gs5'>Reach</div>
+            <input class='equipment_ranged_weapons_gs6 full_width' type='text' value='0' name='attr_M_weapon_range' />
+            <div class='equipment_ranged_weapons_gs7'>DMG Roll</div>
+            <input class='equipment_ranged_weapons_gs8 full_width' type='text' value='2d10' name='attr_M_weapon_dam-roll' />
+            <div class='equipment_ranged_weapons_gs9'>Base</div>
+            <input class='equipment_ranged_weapons_gs10 full_width' type='text' value='0' name='attr_M_weapon_base' />
+            <div class='equipment_ranged_weapons_gs11'>Pierce</div>
+            <input class='equipment_ranged_weapons_gs12 full_width' type='text' value='0' name='attr_M_weapon_pierce' />
+          </div>
+          <div class='equipment_melee_weapons_grid3'>
+            <div class='equipment_melee_weapons_gs1'>Hit Mod</div>
+            <input class='equipment_melee_weapons_gs2 full_width' type='text' value='0' name='attr_M_weapon_mod1' />
+            <div class='equipment_melee_weapons_gs3'>Weight</div>
+            <input class='equipment_melee_weapons_gs4 full_width' type='text' value='0' name='attr_M_weapon_weight' />
+            <div class='equipment_melee_weapons_gs5'>Br Pts</div>
+            <input class='equipment_melee_weapons_gs6 full_width' type='text' value='0' name='attr_M_weapon_breakpoints' />
+            <div class='equipment_melee_weapons_gs7'>/</div>
+            <input class='equipment_melee_weapons_gs8 full_width' type='text' value='0' name='attr_M_weapon_breakpoints_max' />
+            <button class='equipment_melee_weapons_gs9 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }}{{weapon= @{M_weapon_name}}} {{roll=[[floor(([[@{WFM}+@{WFM_advancement}+@{fatigue_mod}]]+@{M_weapon_mod1}+@{inlinemod-toggle}-1d100)/10)]]}} @{settings_hitroll}'' >Hit</button>
+            <button class='equipment_melee_weapons_gs10 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{weapon= @{M_weapon_name}}} {{damage=[[@{M_weapon_dam-roll}+@{M_weapon_base}+@{M_weapon_base-mod}]] }} {{pierce=[[@{M_weapon_pierce}+@{M_weapon_pierce-mod}]] }} {{@{settings_weapondescription}=@{M_ability_r} }}' >DMG</button>
+          </div>
+          <div class='equipment_melee_weapons_grid4'>
+            <div class='equipment_melee_weapons_gs11'>damage plus Strength</div>
+            <select class='equipment_melee_weapons_gs12 full_width' name='attr_M_weapon_base-mod'>
+              <option selected='selected' value='0'>None</option>
+              <option value='[[floor(((@{STR} + @{STR_advancement})/10 + @{str_mythic})/2)]]'>Half</option>
+              <option value='[[floor((@{STR} + @{STR_advancement})/10 + @{STR_mythic})]]'>Full</option>
+            </select>
+            <div class='equipment_melee_weapons_gs13'>pierce plus Strength</div>
+            <select class='equipment_melee_weapons_gs14 full_width' name='attr_M_weapon_pierce-mod'>
+              <option selected='selected' value='0'>None</option>
+              <option value='[[floor(((@{STR} + @{STR_advancement})/10 + @{str_mythic})/2)]]'>Half</option>
+              <option value='[[floor((@{STR} + @{STR_advancement})/10 + @{STR_mythic})]]'>Full</option>
+            </select>
+          </div>
+          <div>
+            <input name='attr_M_ability_r' type='text' placeholder='Description' class='full_width_49px border_none' />
+            <label class='margin_adjust_wep'><input type='checkbox' name='attr_collapse' value='3' class='collapsible_entity_switch select_button hidden' /><span class='select_text radius_border_right_wep'>▼</span></label>
+            <label class='margin_adjust_wep2'><button type='roll' value='@{to-gm}&{template:mythic} {{name=@{M_ability_r} }} {{description=@{M_ability_desc_r} }}' class='hidden'></button><span class='select_text'>❖</span></label>
+            <input name='attr_collapse' type='checkbox'  value='3' class='collapsible_entity_switch hidden' />
+            <textarea name='attr_M_ability_desc_r' class='collapsible_entity_block description_rounded_margin' placeholder='Weapon Modification e.g. Gravity Hammer Crushing thruster'></textarea>
+          </div>
+        </div>
+        <hr>
+      </fieldset>
+    </div>
+
+    <div class='equipment_numerics text_centered'>
+      cR Count: <input name='attr_credits' type='number' class='numerical_field' />
+      cR Calculation: <input name='attr_credit_total' type='number' class='numerical_field' readonly />
+      Weight Calculation: <input name='attr_weight_total' type='number' class='numerical_field end_field' readonly> kilograms</input>
+      <input type='number' name='attr_M_weapon_weight_T'  hidden>
+      <input type='number' name='attr_R_weapon_weight_T'  hidden>
+    </div>
+  </div>
+  <br>
+
+  <div class='equipment_gear equipment_header'>
+    <div class='equipment_gear_gs1'>Gear / Item Name</div>
+    <div class='equipment_gear_gs2'>Amount</div>
+    <div class='equipment_gear_gs3'>Value</div>
+    <div class='equipment_gear_gs4'>Weight</div>
+    <div class='equipment_gear_gs5'>B Pts</div>
+    <div class='equipment_gear_gs6'>Page #</div>
+  </div>
+  <div class='equipment_gear'>
+    <input name='attr_gear_name' type='text' placeholder='Gear / Item Name' class='equipment_gear_gs1' />
+    <input name='attr_gear_quantity' type='text' value='1' placeholder='Amount' class='equipment_gear_gs2' />
+    <input name='attr_gear_cost' type='text' value='0' class='equipment_gear_gs3' />
+    <input name='attr_gear_weight' type='text' value='0' class='equipment_gear_gs4' />
+    <input name='attr_gear_bp' type='text' placeholder='Break Points' class='equipment_gear_gs5' />
+    <input name='attr_gear_pg#' type='text' placeholder='Page #' class='equipment_gear_gs6' />
+    <label class='margin_adjust equipment_gear_gs7'><input type='checkbox' name='attr_collapse' value='7' class='collapsible_entity_switch select_button hidden'><span class='select_text'>▼</span></label>
+  </div>
+  <input name='attr_collapse' type='checkbox'  value='7' class='collapsible_entity_switch hidden' />
+  <textarea name='attr_gear_desc' placeholder='Different equipment will have special rules.' class='collapsible_entity_block auto_margin 90width'></textarea>
+  <fieldset name='gear' class='repeating_gear'>
+    <div class='equipment_gear'>
+      <input name='attr_gear_name_r' type='text' placeholder='Gear / Item Name' class='equipment_gear_gs1' />
+      <input name='attr_gear_quantity_r' type='text' value='1' placeholder='Amount' class='equipment_gear_gs2' />
+      <input name='attr_gear_cost_r' type='text' value='0' class='equipment_gear_gs3' />
+      <input name='attr_gear_weight_r' type='text' value='0' class='equipment_gear_gs4' />
+      <input name='attr_gear_bp_r' type='text' placeholder='Break Points' class='equipment_gear_gs5' />
+      <input name='attr_gear_pg#_r' type='text' placeholder='Page #' class='equipment_gear_gs6' />
+      <label class='margin_adjust equipment_gear_gs7'><input type='checkbox' name='attr_collapse_r' value='2' class='collapsible_entity_switch select_button hidden' /><span class='select_text'>▼</span></label>
+    </div>
+    <input name='attr_collapse_r' type='checkbox'  value='2' class='collapsible_entity_switch hidden' />
+    <textarea name='attr_ability_desc_r' class='collapsible_entity_block auto_margin 90width'></textarea>
+  </fieldset>
+  <br>
+
+  <div class='equipment_armor_grid'>
+    <div class='equipment_armor_gs1 radius_border'>
+      <h3 class='radius_border_top'>Armor Display</h3>
+      <img src='https://cdn.discordapp.com/attachments/676016722939084800/694958755967795381/Mark_IV_Schematic.png' width='100%' />
+    </div>
+    <div class='equipment_armor_gs2 radius_border'>
+      <h3 class='radius_border_top'>Armor</h3>
+      <div>
+        <br>
+        <h3 class='radius_border_top'>Head</h3>
+        <input class='equipment_armor_input' type='text' name='attr_armor_head' value='0'>
+      </div>
+      <div>
+        <br>
+        <h3 class='radius_border_top'>Arm L</h3>
+        <input class='equipment_armor_input' type='text' name='attr_armor_arm_left' value='0'>
+      </div>
+      <div>
+        <br>
+        <h3 class='radius_border_top'>Arm R</h3>
+        <input class='equipment_armor_input' type='text' name='attr_armor_arm_right' value='0'>
+      </div>
+      <div>
+        <br>
+        <h3 class='radius_border_top'>Chest</h3>
+        <input class='equipment_armor_input' type='text' name='attr_armor_chest' value='0'>
+      </div>
+      <div>
+        <br>
+        <h3 class='radius_border_top'>Leg L</h3>
+        <input class='equipment_armor_input' type='text' name='attr_armor_leg_left' value='0'>
+      </div>
+      <div>
+        <br>
+        <h3 class='radius_border_top'>Leg R</h3>
+        <input class='equipment_armor_input' type='text' name='attr_armor_leg_right' value='0'>
+      </div>
+    </div>
+
+    <div class='equipment_armor_gs3 radius_border'>
+      <h3 class='radius_border_top'>Armor Permutations</h3>
+      <div>
+        <div class="equipment_permutations_grid equipment_titles">
+          <p class='bold_text equipment_titles'>Name</p>
+          <p class='bold_text equipment_titles'>Location</p>
+          <p class='bold_text equipment_titles'>Hpts</p>
+          <p class='bold_text equipment_titles'>Pg#</p>
+        </div>
+        <div class='equipment_permutations_grid'>
+          <input class='full_width' type='text' name='attr_permutation_name' placeholder='Name'>
+          <input class='full_width' type='text' name='attr_permutation_location' placeholder='Location'>
+          <input class='full_width' type='text' name='attr_permutation_hardpoints' placeholder='Hpts'>
+          <input class='full_width' type='text' name='attr_permutation_page' placeholder='Pg#'>
+        </div>
+        <label class='margin_adjust'><input type='checkbox' name='attr_collapse3' value='2' class='collapsible_entity_switch select_button hidden' /><span class='select_text'>▼</span></label>
+        <label class='margin_adjust2'><button type='roll' value='@{to-gm}&{template:mythic} {{name=@{permutation_name} }} {{description=@{permutation_desc} }}' class='hidden'></button><span class='select_text'>❖</span></label>
+        <input name='attr_collapse3' type='checkbox'  value='2' class='collapsible_entity_switch hidden' />
+        <textarea name='attr_permutation_desc' placeholder='All Human BDUs and Armor are designed to take Permutations. Permutations are attachments that modify Armor and offer various forms of function. Each section of Armor can only fit so many Permutations, which are shown as Hardpoints.' class='collapsible_entity_block'></textarea>
+      </div>
+      <fieldset name='permutations' class='repeating_permutations'>
+        <div>
+          <div class='equipment_permutations_grid'>
+            <input class='full_width' type='text' name='attr_permutation_name_r' placeholder='Name'>
+            <input class='full_width' type='text' name='attr_permutation_location_r' placeholder='Location'>
+            <input class='full_width' type='text' name='attr_permutation_hardpoints_r' placeholder='Hpts'>
+            <input class='full_width' type='text' name='attr_permutation_page_r' placeholder='Pg#'>
+          </div>
+          <label class='margin_adjust'><input type='checkbox' name='attr_collapse' value='2' class='collapsible_entity_switch select_button hidden' /><span class='select_text'>▼</span></label>
+          <label class='margin_adjust2'><button type='roll' value='@{to-gm}&{template:mythic} {{name=@{permutation_name_r} }} {{description=@{permutation_desc_r} }}' class='hidden'></button><span class='select_text'>❖</span></label>
+          <input name='attr_collapse' type='checkbox'  value='2' class='collapsible_entity_switch hidden' />
+          <textarea name='attr_permutation_desc_r' class='collapsible_entity_block'></textarea>
+        </div>
+      </fieldset>
+
+      <br>
+
+      <h3 class='radius_border_top'>Armor Description</h3>
+      <textarea name='attr_armor_desc'></textarea>
+      <fieldset name='armors' class='repeating_armors'>
+        <input class='full_width_49px' type='text' name='attr_armor_name_r' placeholder='Name'>
+        <label class='margin_adjust'><input type='checkbox' name='attr_collapse' value='2' class='collapsible_entity_switch select_button hidden' /><span class='select_text'>▼</span></label>
+        <label class='margin_adjust2'><button type='roll' value='@{to-gm}&{template:mythic} {{name=@{armor_name_r} }} {{description=@{armor_desc_r} }}' class='hidden'></button><span class='select_text'>❖</span></label>
+        <input name='attr_collapse' type='checkbox'  value='2' class='collapsible_entity_switch hidden' />
+        <textarea name='attr_armor_desc_r' class='collapsible_entity_block'></textarea>
+      </fieldset>
+    </div>
+  </div>
+
+</div>
 
 
-  <!-- ______________________________ start of tab Equipment ______________________________ -->
 
-  <div class='equipment box radius_border_box ssc'>
-    <div class='equipment_divider'>
-      <div class='equipment_ranged_weapons ssc'>
-        <h3 class='radius_border_top'>Ranged Weapons</h3>
-        <fieldset name='rangedweapons' class='repeating_rangedweapons'>
+<!-- ______________________________ start of tab Medical ______________________________ -->
+
+<div class='medical box radius_border_box'>
+  <!-- Medical -->
+  <div class='medical-grid'>
+
+    <div class='medicalg1 medicalG'>
+      Finger / Toe
+      <select name='attr_medical_finger/toe' class='full_width'>
+        <option selected='selected' value='0'>Nominal</option>
+        <option value='1'>01-15</option>
+        <option value='2'>16-30</option>
+        <option value='3'>31-45</option>
+        <option value='4'>46+</option>
+      </select>
+      <div>
+        <input name='attr_medical_finger/toe' type='checkbox' value='0' class='hidden hider' checked />
+        <div>No Effect / Healthy</div>
+        <input name='attr_medical_finger/toe' type='checkbox' value='1' class='hidden hider' />
+        <div>-1 WFM + WFR to Finger,<br>-2 Agility to Toe</div>
+        <input name='attr_medical_finger/toe' type='checkbox' value='2' class='hidden hider' />
+        <div>-2 WFM + WFR to Finger,<br>-4 Agility to Toe</div>
+        <input name='attr_medical_finger/toe' type='checkbox' value='3' class='hidden hider' />
+        <div>Body Location damaged.<br>No longer usable. -3 Strength to Finger, -3 Agility to Toe</div>
+        <input name='attr_medical_finger/toe' type='checkbox' value='4' class='hidden hider' />
+        <div>Body Locaton destroyed,<br>-4 Strength to Finger, -4 Agility to Toe</div>
+      </div>
+    </div>
+
+    <div class='medicalg2 medicalG'>
+      Heart
+      <select name='attr_medical_heart' class='full_width'>
+        <option selected='selected' value='0'>Nominal</option>
+        <option value='1'>01-20</option>
+        <option value='2'>21-30</option>
+        <option value='3'>31-40</option>
+        <option value='4'>41-59</option>
+        <option value='5'>60+</option>
+      </select>
+      <div>
+        <input name='attr_medical_heart' type='checkbox' value='0' class='hidden hider' checked />
+        <div>No Effect / Healthy</div>
+        <input name='attr_medical_heart' type='checkbox' value='1' class='hidden hider' />
+        <div>-2 Strength + Toughness + Agility</div>
+        <input name='attr_medical_heart' type='checkbox' value='2' class='hidden hider' />
+        <div>-5 Strength + Toughness + Agility</div>
+        <input name='attr_medical_heart' type='checkbox' value='3' class='hidden hider' />
+        <div>-10 Strength + Toughness + Agility</div>
+        <input name='attr_medical_heart' type='checkbox' value='4' class='hidden hider' />
+        <div>Body Location damaged.<br>+10 Fatigue, -15 Strength + Toughness + Agility</div>
+        <input name='attr_medical_heart' type='checkbox' value='5' class='hidden hider' />
+        <div>Body Locaton destroyed,<br>instant death</div>
+      </div>
+    </div>
+
+    <div class='medicalg3 medicalG'>
+      Neck
+      <select name='attr_medical_neck' class='full_width'>
+        <option selected='selected' value='0'>Nominal</option>
+        <option value='1'>01-20</option>
+        <option value='2'>21-25</option>
+        <option value='3'>26-30</option>
+        <option value='4'>31-40</option>
+        <option value='5'>41-59</option>
+        <option value='6'>60+</option>
+      </select>
+      <div>
+        <input name='attr_medical_neck' type='checkbox' value='0' class='hidden hider' checked />
+        <div>No Effect / Healthy</div>
+        <input name='attr_medical_neck' type='checkbox' value='1' class='hidden hider' />
+        <div>-2 Toughness</div>
+        <input name='attr_medical_neck' type='checkbox' value='2' class='hidden hider' />
+        <div>-5 Toughness</div>
+        <input name='attr_medical_neck' type='checkbox' value='3' class='hidden hider' />
+        <div>-10 Toughness</div>
+        <input name='attr_medical_neck' type='checkbox' value='4' class='hidden hider' />
+        <div>+1 Fatigue, -10 Toughness</div>
+        <input name='attr_medical_neck' type='checkbox' value='5' class='hidden hider' />
+        <div>Body Location damaged.<br>-20 Toughness, Paralyzed and Helpless</div>
+        <input name='attr_medical_neck' type='checkbox' value='6' class='hidden hider' />
+        <div>Body Location destroyed,<br>instant death</div>
+      </div>
+    </div>
+
+    <div class='medicalg4 medicalG'>
+      Skull / Brain
+      <select name='attr_medical_skull/brain' class='full_width'>
+        <option selected='selected' value='0'>Nominal</option>
+        <option value='1'>01-20</option>
+        <option value='2'>21-30</option>
+        <option value='3'>31-40</option>
+        <option value='4'>41-59</option>
+        <option value='5'>60+</option>
+      </select>
+      <div>
+        <input name='attr_medical_skull/brain' type='checkbox' value='0' class='hidden hider' checked />
+        <div>No Effect / Healthy</div>
+        <input name='attr_medical_skull/brain' type='checkbox' value='1' class='hidden hider' />
+        <div>-2 Perception + Intellect + WFM + WFR</div>
+        <input name='attr_medical_skull/brain' type='checkbox' value='2' class='hidden hider' />
+        <div>-5 Perception + Intellect + WFM + WFR</div>
+        <input name='attr_medical_skull/brain' type='checkbox' value='3' class='hidden hider' />
+        <div>-10 Perception + Intellect + WFM + WFR</div>
+        <input name='attr_medical_skull/brain' type='checkbox' value='4' class='hidden hider' />
+        <div>Body Location damaged.<br>+10 Fatigue, -15 Perception + Intellect + WFM + WFR</div>
+        <input name='attr_medical_skull/brain' type='checkbox' value='5' class='hidden hider' />
+        <div>Body Location destroyed,<br>instant death</div>
+      </div>
+    </div>
+
+    <div class='medicalg5 medicalG'>
+      Nose / Ear
+      <select name='attr_medical_nose/ear' class='full_width'>
+        <option selected='selected' value='0'>Nominal</option>
+        <option value='1'>01-20</option>
+        <option value='2'>21-25</option>
+        <option value='3'>26-30</option>
+        <option value='4'>31-40</option>
+        <option value='5'>41-59</option>
+        <option value='6'>60+</option>
+      </select>
+      <div>
+        <input name='attr_medical_nose/ear' type='checkbox' value='0' class='hidden hider' checked />
+        <div>No Effect / Healthy</div>
+        <input name='attr_medical_nose/ear' type='checkbox' value='1' class='hidden hider' />
+        <div>-2 Perception to smelling or hearing Perception tests</div>
+        <input name='attr_medical_nose/ear' type='checkbox' value='2' class='hidden hider' />
+        <div>-5 Perception to smelling or hearing Perception tests</div>
+        <input name='attr_medical_nose/ear' type='checkbox' value='3' class='hidden hider' />
+        <div>-10 Perception to smelling or hearing Perception tests</div>
+        <input name='attr_medical_nose/ear' type='checkbox' value='4' class='hidden hider' />
+        <div>-15 Perception to smelling or hearing Perception tests</div>
+        <input name='attr_medical_nose/ear' type='checkbox' value='5' class='hidden hider' />
+        <div>Body Location broken.<br>-20 Perception to smelling or hearing Perception tests</div>
+        <input name='attr_medical_nose/ear' type='checkbox' value='6' class='hidden hider' />
+        <div>Body Location destroyed,<br>cannot make or halve Perception to smelling or hearing tests</div>
+      </div>
+    </div>
+
+    <div class='medicalg6 medicalG'>
+      Limb (Arm / Leg)
+      <select name='attr_medical_arm/leg' class='full_width'>
+        <option selected='selected' value='0'>Nominal</option>
+        <option value='1'>01-20</option>
+        <option value='2'>21-25</option>
+        <option value='3'>26-30</option>
+        <option value='4'>31-40</option>
+        <option value='5'>41-59</option>
+        <option value='6'>60+</option>
+      </select>
+      <div>
+        <input name='attr_medical_arm/leg' type='checkbox' value='0' class='hidden hider' checked />
+        <div>No Effect / Healthy</div>
+        <input name='attr_medical_arm/leg' type='checkbox' value='1' class='hidden hider' />
+        <div>-2 Strength to Arm or<br>-2 Agility to Leg</div>
+        <input name='attr_medical_arm/leg' type='checkbox' value='2' class='hidden hider' />
+        <div>-5 Strength to Arm, or<br>-5 Agility to Leg</div>
+        <input name='attr_medical_arm/leg' type='checkbox' value='3' class='hidden hider' />
+        <div>-10 Strength to Arm, or<br>-10 Agility to Leg</div>
+        <input name='attr_medical_arm/leg' type='checkbox' value='4' class='hidden hider' />
+        <div>-15 Strength to Arm, or<br>-15 Agility to Leg</div>
+        <input name='attr_medical_arm/leg' type='checkbox' value='5' class='hidden hider' />
+        <div>Body Location damaged. -15 Strength to Arm, or -15 Agility to Leg. -5 to limb's Actions</div>
+        <input name='attr_medical_arm/leg' type='checkbox' value='6' class='hidden hider' />
+        <div>Body Location destroyed,<br>limb cannot be used<br>+3 Fatigue</div>
+      </div>
+    </div>
+
+    <div class='medicalg7 medicalG'>
+      Small / Large Intestines
+      <select name='attr_medical_small/large_intestines' class='full_width'>
+        <option selected='selected' value='0'>Nominal</option>
+        <option value='1'>01-20</option>
+        <option value='2'>21-25</option>
+        <option value='3'>26-30</option>
+        <option value='4'>31-40</option>
+        <option value='5'>41-59</option>
+        <option value='6'>60+</option>
+      </select>
+      <div>
+        <input name='attr_medical_small/large_intestines' type='checkbox' value='0' class='hidden hider' checked >
+        <div>No Effect / Healthy</div>
+        <input name='attr_medical_small/large_intestines' type='checkbox' value='1' class='hidden hider' />
+        <div>-2 Toughness + Agility</div>
+        <input name='attr_medical_small/large_intestines' type='checkbox' value='2' class='hidden hider' />
+        <div>-4 Toughness + Agility</div>
+        <input name='attr_medical_small/large_intestines' type='checkbox' value='3' class='hidden hider' />
+        <div>-6 Toughness + Agility</div>
+        <input name='attr_medical_small/large_intestines' type='checkbox' value='4' class='hidden hider' />
+        <div>-10 Toughness + Agility</div>
+        <input name='attr_medical_small/large_intestines' type='checkbox' value='5' class='hidden hider' />
+        <div>Body Location damaged.<br>+2 Fatigue, -15 Toughness + Agility</div>
+        <input name='attr_medical_small/large_intestines' type='checkbox' value='6' class='hidden hider' />
+        <div>Body Location destroyed,<br>+5 Fatigue, -20 Toughness + Agility</div>
+      </div>
+    </div>
+
+    <div class='medicalg8 medicalG'>
+      Lungs
+      <select name='attr_medical_lung' class='full_width'>
+        <option selected='selected' value='0'>Nominal</option>
+        <option value='1'>01-20</option>
+        <option value='2'>21-25</option>
+        <option value='3'>26-30</option>
+        <option value='4'>31-40</option>
+        <option value='5'>41-59</option>
+        <option value='6'>60+</option>
+      </select>
+      <div>
+        <input name='attr_medical_lung' type='checkbox' value='0' class='hidden hider' checked />
+        <div>No Effect / Healthy</div>
+        <input name='attr_medical_lung' type='checkbox' value='1' class='hidden hider' />
+        <div>-2 Toughness, stunned for<br>(D5-Toughness Modifier) rounds</div>
+        <input name='attr_medical_lung' type='checkbox' value='2' class='hidden hider' />
+        <div>-5 Toughness, stunned for<br>(2D5-Toughness Modifier) rounds</div>
+        <input name='attr_medical_lung' type='checkbox' value='3' class='hidden hider' />
+        <div>-10 Toughness, stunned for<br>(3D5-Toughness Modifier) rounds</div>
+        <input name='attr_medical_lung' type='checkbox' value='4' class='hidden hider' />
+        <div>-15 Toughness, stunned for<br>(4D5-Toughness Modifier) rounds</div>
+        <input name='attr_medical_lung' type='checkbox' value='5' class='hidden hider' />
+        <div>Body Location damaged.<br>-20 Toughness, stunned for<br>(5D5-Toughness Modifier) rounds</div>
+        <input name='attr_medical_lung' type='checkbox' value='6' class='hidden hider' />
+        <div>Body Location destroyed,<br>-25 Toughness, stunned for<br>(6D5-Toughness Modifier) rounds.<br>Character will take 2 wounds whenever they take a Movement Action quicker than 2 Meters per Turn.</div>
+      </div>
+    </div>
+
+    <div class='medicalg9 medicalG'>
+      Kidney / Stomach / Liver / Spleen
+      <select name='attr_medical_kidney/stomach/liver/spleen' class='full_width'>
+        <option selected='selected' value='0'>Nominal</option>
+        <option value='1'>01-20</option>
+        <option value='2'>21-25</option>
+        <option value='3'>26-30</option>
+        <option value='4'>31-40</option>
+        <option value='5'>41-59</option>
+        <option value='6'>60+</option>
+      </select>
+      <div>
+        <input name='attr_medical_kidney/stomach/liver/spleen' type='checkbox' value='0' class='hidden hider' checked />
+        <div>No Effect / Healthy</div>
+        <input name='attr_medical_kidney/stomach/liver/spleen' type='checkbox' value='1' class='hidden hider' />
+        <div>-2 Toughness + Agility</div>
+        <input name='attr_medical_kidney/stomach/liver/spleen' type='checkbox' value='2' class='hidden hider' />
+        <div>-4 Toughness + Agility</div>
+        <input name='attr_medical_kidney/stomach/liver/spleen' type='checkbox' value='3' class='hidden hider' />
+        <div>-6 Toughness + Agility</div>
+        <input name='attr_medical_kidney/stomach/liver/spleen' type='checkbox' value='4' class='hidden hider' />
+        <div>-10 Toughness + Agility</div>
+        <input name='attr_medical_kidney/stomach/liver/spleen' type='checkbox' value='5' class='hidden hider' />
+        <div>Body Location damaged.<br>+1 Fatigue, -15 Toughness + Agility</div>
+        <input name='attr_medical_kidney/stomach/liver/spleen' type='checkbox' value='6' class='hidden hider' />
+        <div>Body Location destroyed,<br>+5 Fatigue, -20 Toughness + Agility</div>
+      </div>
+    </div>
+
+    <div class='medicalg10 medicalG'>
+      Knee / Ankle / Shoulder / Elbow
+      <select name='attr_medical_knee/ankle/shoulder/elbow' class='full_width'>
+        <option selected='selected' value='0'>Nominal</option>
+        <option value='1'>01-20</option>
+        <option value='2'>21-25</option>
+        <option value='3'>26-30</option>
+        <option value='4'>31-40</option>
+        <option value='5'>41-59</option>
+        <option value='6'>60+</option>
+      </select>
+      <div>
+        <input name='attr_medical_knee/ankle/shoulder/elbow' type='checkbox' value='0' class='hidden hider' checked />
+        <div>No Effect / Healthy</div>
+        <input name='attr_medical_knee/ankle/shoulder/elbow' type='checkbox' value='1' class='hidden hider' />
+        <div>-2 Strength + Agility</div>
+        <input name='attr_medical_knee/ankle/shoulder/elbow' type='checkbox' value='2' class='hidden hider' />
+        <div>-4 Strength + Agility</div>
+        <input name='attr_medical_knee/ankle/shoulder/elbow' type='checkbox' value='3' class='hidden hider' />
+        <div>-6 Strength + Agility</div>
+        <input name='attr_medical_knee/ankle/shoulder/elbow' type='checkbox' value='4' class='hidden hider' />
+        <div>-10 Strength + Agility</div>
+        <input name='attr_medical_knee/ankle/shoulder/elbow' type='checkbox' value='5' class='hidden hider' />
+        <div>Body Location damaged.<br>+1 Fatigue, -15 Strength + Agility</div>
+        <input name='attr_medical_knee/ankle/shoulder/elbow' type='checkbox' value='6' class='hidden hider' />
+        <div>Body Location destroyed,<br>+5 Fatigue, -20 Strength + Agility</div>
+      </div>
+    </div>
+
+    <div class='medicalg11 medicalG'>
+      Eye
+      <select name='attr_medical_eye' class='full_width'>
+        <option selected='selected' value='0'>Nominal</option>
+        <option value='1'>01-20</option>
+        <option value='2'>21-25</option>
+        <option value='3'>26-30</option>
+        <option value='4'>31-40</option>
+        <option value='5'>41-59+</option>
+        <option value='6'>60+</option>
+      </select>
+      <div>
+        <input name='attr_medical_eye' type='checkbox' value='0' class='hidden hider' checked />
+        <div>No Effect / Healthy</div>
+        <input name='attr_medical_eye' type='checkbox' value='1' class='hidden hider' />
+        <div>-2 Perception to seeing tests</div>
+        <input name='attr_medical_eye' type='checkbox' value='2' class='hidden hider' />
+        <div>-5 Perception to seeing tests</div>
+        <input name='attr_medical_eye' type='checkbox' value='3' class='hidden hider' />
+        <div>-10 Perception to seeing tests</div>
+        <input name='attr_medical_eye' type='checkbox' value='4' class='hidden hider' />
+        <div>-12 Perception to seeing tests</div>
+        <input name='attr_medical_eye' type='checkbox' value='5' class='hidden hider' />
+        <div>Body Location broken.<br>-15 Perception to seeing tests</div>
+        <input name='attr_medical_eye' type='checkbox' value='6' class='hidden hider' />
+        <div>Body Location destroyed,<br>Character blinded for D5 rounds. -20 Perception to seeing tests</div>
+      </div>
+    </div>
+
+    <div class='medicalg12 medicalG'>
+      Mouth
+      <select name='attr_medical_mouth' class='full_width'>
+        <option selected='selected' value='0'>Nominal</option>
+        <option value='1'>01-20</option>
+        <option value='2'>21-25</option>
+        <option value='3'>26-30</option>
+        <option value='4'>31-40</option>
+        <option value='5'>41-59+</option>
+        <option value='6'>60+</option>
+      </select>
+      <div>
+        <input name='attr_medical_mouth' type='checkbox' value='0' class='hidden hider' checked />
+        <div>No Effect / Healthy</div>
+        <input name='attr_medical_mouth' type='checkbox' value='1' class='hidden hider' />
+        <div>-1 Toughness, -5 to speaking tests</div>
+        <input name='attr_medical_mouth' type='checkbox' value='2' class='hidden hider' />
+        <div>-3 Toughness, -5 to speaking tests</div>
+        <input name='attr_medical_mouth' type='checkbox' value='3' class='hidden hider' />
+        <div>-5 Toughness, -10 to speaking tests</div>
+        <input name='attr_medical_mouth' type='checkbox' value='4' class='hidden hider' />
+        <div>-8 Toughness, -10 to speaking tests</div>
+        <input name='attr_medical_mouth' type='checkbox' value='5' class='hidden hider' />
+        <div>Body Location broken.<br>+1 Fatigue, -12 Toughness, -15 to speaking tests</div>
+        <input name='attr_medical_mouth' type='checkbox' value='6' class='hidden hider' />
+        <div>Body Location destroyed,<br>+2 Fatigue, -15 Toughness, -15 to speaking tests</div>
+      </div>
+    </div>
+
+    <div class='medicalg13 medicalG'>
+      Hand
+      <select name='attr_medical_hand' class='full_width'>
+        <option selected='selected' value='0'>Nominal</option>
+        <option value='1'>01-20</option>
+        <option value='2'>21-25</option>
+        <option value='3'>26-30</option>
+        <option value='4'>31-40</option>
+        <option value='5'>41-59+</option>
+        <option value='6'>60+</option>
+      </select>
+      <div>
+        <input name='attr_medical_hand' type='checkbox' value='0' class='hidden hider' checked />
+        <div>No Effect / Healthy</div>
+        <input name='attr_medical_hand' type='checkbox' value='1' class='hidden hider' />
+        <div>-3 to both Warfare stats if hand is used to Attack</div>
+        <input name='attr_medical_hand' type='checkbox' value='2' class='hidden hider' />
+        <div>-5 to both Warfare stats if hand is used to Attack</div>
+        <input name='attr_medical_hand' type='checkbox' value='3' class='hidden hider' />
+        <div>-10 to both Warfare stats if hand is used to Attack</div>
+        <input name='attr_medical_hand' type='checkbox' value='4' class='hidden hider' />
+        <div>-13 to both Warfare stats if hand is used to Attack</div>
+        <input name='attr_medical_hand' type='checkbox' value='5' class='hidden hider' />
+        <div>Body Location broken.<br>-15 to both Warfare stats if hand is used to Attack</div>
+        <input name='attr_medical_hand' type='checkbox' value='6' class='hidden hider' />
+        <div>Body Location destroyed,<br>Character cannot use the hand for any Actions</div>
+      </div>
+    </div>
+
+    <div class='medicalg14 medicalG'>
+      Chin / Jaw / Cheek
+      <select name='attr_medical_chin/jaw/cheek' class='full_width'>
+        <option selected='selected' value='0'>Nominal</option>
+        <option value='1'>01-20</option>
+        <option value='2'>21-25</option>
+        <option value='3'>26-30</option>
+        <option value='4'>31-40</option>
+        <option value='5'>41-59+</option>
+        <option value='6'>60+</option>
+      </select>
+      <div>
+        <input name='attr_medical_chin/jaw/cheek' type='checkbox' value='0' class='hidden hider' checked />
+        <div>No Effect / Healthy</div>
+        <input name='attr_medical_chin/jaw/cheek' type='checkbox' value='1' class='hidden hider' />
+        <div>-2 Toughness</div>
+        <input name='attr_medical_chin/jaw/cheek' type='checkbox' value='2' class='hidden hider' />
+        <div>-4 Toughness, -5 to speaking tests</div>
+        <input name='attr_medical_chin/jaw/cheek' type='checkbox' value='3' class='hidden hider' />
+        <div>-6 Toughness, -10 to speaking tests</div>
+        <input name='attr_medical_chin/jaw/cheek' type='checkbox' value='4' class='hidden hider' />
+        <div>+1 Fatigue, -10 Toughness, -10 to speaking tests</div>
+        <input name='attr_medical_chin/jaw/cheek' type='checkbox' value='5' class='hidden hider' />
+        <div>Body Location damaged.<br>+2 Fatigue, -15 Toughness, -15 to speaking tests</div>
+        <input name='attr_medical_chin/jaw/cheek' type='checkbox' value='6' class='hidden hider' />
+        <div>Body Location destroyed,<br>+3 Fatigue, -20 Toughness, -20 to speaking tests</div>
+      </div>
+    </div>
+
+    <div class='medicalg15 medicalG'>
+      Foot
+      <select name='attr_medical_foot' class='full_width'>
+        <option selected='selected' value='0'>Nominal</option>
+        <option value='1'>01-20</option>
+        <option value='2'>21-25</option>
+        <option value='3'>26-30</option>
+        <option value='4'>31-40</option>
+        <option value='5'>41-59+</option>
+        <option value='6'>60+</option>
+      </select>
+      <div>
+        <input name='attr_medical_foot' type='checkbox' value='0' class='hidden hider' checked />
+        <div>No Effect / Healthy</div>
+        <input name='attr_medical_foot' type='checkbox' value='1' class='hidden hider' />
+        <div>-5 to Agility when figuring Movement Speed</div>
+        <input name='attr_medical_foot' type='checkbox' value='2' class='hidden hider' />
+        <div>-10 to Agility when figuring Movement Speed</div>
+        <input name='attr_medical_foot' type='checkbox' value='3' class='hidden hider' />
+        <div>-15 to Agility when figuring Movement Speed</div>
+        <input name='attr_medical_foot' type='checkbox' value='4' class='hidden hider' />
+        <div>-20 to Agility when figuring Movement Speed</div>
+        <input name='attr_medical_foot' type='checkbox' value='5' class='hidden hider' />
+        <div>Body Location broken.<br>-25 to Agility when figuring Movement Speed</div>
+        <input name='attr_medical_foot' type='checkbox' value='6' class='hidden hider' />
+        <div>Body Location destroyed,<br>Character cannot use the Foot for any Actions. Half Move reduced to 1 Meter, Full Move reduced to 2 Meters, Charge and Run are impossible.</div>
+      </div>
+    </div>
+
+    <div class='medicalg16 medicalG'>
+      Pelvis
+      <select name='attr_medical_pelvis' class='full_width'>
+        <option selected='selected' value='0'>Nominal</option>
+        <option value='1'>01-20</option>
+        <option value='2'>21-25</option>
+        <option value='3'>26-30</option>
+        <option value='4'>31-40</option>
+        <option value='5'>41-59+</option>
+        <option value='6'>60+</option>
+      </select>
+      <div>
+        <input name='attr_medical_pelvis' type='checkbox' value='0' class='hidden hider' checked />
+        <div>No Effect / Healthy</div>
+        <input name='attr_medical_pelvis' type='checkbox' value='1' class='hidden hider' />
+        <div>-1 Toughness, -4 Agility</div>
+        <input name='attr_medical_pelvis' type='checkbox' value='2' class='hidden hider' />
+        <div>-3 Toughness, -6 Agility</div>
+        <input name='attr_medical_pelvis' type='checkbox' value='3' class='hidden hider' />
+        <div>-6 Toughness, -8 Agility</div>
+        <input name='attr_medical_pelvis' type='checkbox' value='4' class='hidden hider' />
+        <div>-8 Toughness, -12 Agility</div>
+        <input name='attr_medical_pelvis' type='checkbox' value='5' class='hidden hider' />
+        <div>Body Location damaged.<br>-20 Toughness + Agility</div>
+        <input name='attr_medical_pelvis' type='checkbox' value='6' class='hidden hider' />
+        <div>Body Location destroyed,<br>-30 Toughness + Agility</div>
+      </div>
+    </div>
+
+    <div class='medicalg17 medicalG'>
+      Chest
+      <select name='attr_medical_chest' class='full_width'>
+        <option selected='selected' value='0'>Nominal</option>
+        <option value='1'>01-20</option>
+        <option value='2'>21-25</option>
+        <option value='3'>26-30</option>
+        <option value='4'>31-40</option>
+        <option value='5'>41-59+</option>
+        <option value='6'>60+</option>
+      </select>
+      <div>
+        <input name='attr_medical_chest' type='checkbox' value='0' class='hidden hider' checked />
+        <div>No Effect / Healthy</div>
+        <input name='attr_medical_chest' type='checkbox' value='1' class='hidden hider' />
+        <div>-2 Toughness</div>
+        <input name='attr_medical_chest' type='checkbox' value='2' class='hidden hider' />
+        <div>-4 Toughness</div>
+        <input name='attr_medical_chest' type='checkbox' value='3' class='hidden hider' />
+        <div>-8 Toughness, stunned for 1D5 rounds</div>
+        <input name='attr_medical_chest' type='checkbox' value='4' class='hidden hider' />
+        <div>-10 Toughness, stunned for 2D5 rounds</div>
+        <input name='attr_medical_chest' type='checkbox' value='5' class='hidden hider' />
+        <div>Body Location broken.<br>-15 Toughness, stunned for 3D5 rounds</div>
+        <input name='attr_medical_chest' type='checkbox' value='6' class='hidden hider' />
+        <div>Body Location destroyed,<br>instant death</div>
+      </div>
+    </div>
+
+    <div class='medicalgT'>
+      <div class='medical_background'>
+        <label class='medical_initial_label'><h2 class='medical_h2 medical_h2_rollable radius_border_top'>Hit Location</h2> <button type='roll' name='button' value='@{to-gm}&{template:mythic} {{loc=[[1d100]]}}' class='hidden'></button></label>
+        <h3> 01-10 HEAD</h3>
+        <div class='medical_table'> 01 Neck</div>
+        <div class='medical_table'> 02 Chin</div>
+        <div class='medical_table'> 03 Mouth</div>
+        <div class='medical_table'> 04-05 Nose</div>
+        <div class='medical_table'> 06-07 Cheeks</div>
+        <div class='medical_table'> 08 Eyes</div>
+        <div class='medical_table'> 09 Forehead</div>
+        <div class='medical_table'> 10 Ear</div>
+        <h3>11-20 LEFT ARM</h3>
+        <div class='medical_table'>11 Fingers</div>
+        <div class='medical_table'>12 Hands</div>
+        <div class='medical_table'>13-15 Forearm</div>
+        <div class='medical_table'>16 Elbow</div>
+        <div class='medical_table'>17-19 Bicep</div>
+        <div class='medical_table'>20 Shoulder</div>
+        <h3>21-30 RIGHT ARM</h3>
+        <div class='medical_table'>21 Fingers</div>
+        <div class='medical_table'>22 Hands</div>
+        <div class='medical_table'>23-25 Forearm</div>
+        <div class='medical_table'>26 Elbow</div>
+        <div class='medical_table'>27-29 Bicep</div>
+        <div class='medical_table'>30 Shoulder</div>
+        <h3>31-45 LEFT LEG</h3>
+        <div class='medical_table'>31 Toes</div>
+        <div class='medical_table'>32 Foot</div>
+        <div class='medical_table'>33 Ankle</div>
+        <div class='medical_table'>34-37 Shin</div>
+        <div class='medical_table'>38 Knee</div>
+        <div class='medical_table'>39-43 Thigh</div>
+        <div class='medical_table'>44-45 Pelvis</div>
+        <h3>46-61 RIGHT LEG</h3>
+        <div class='medical_table'>46 Toes</div>
+        <div class='medical_table'>47 Foot</div>
+        <div class='medical_table'>48 Ankle</div>
+        <div class='medical_table'>49-53 Shin</div>
+        <div class='medical_table'>54 Knee</div>
+        <div class='medical_table'>55-58 Thigh</div>
+        <div class='medical_table'>59-60 Pelvis</div>
+        <h3>62-100 CHEST</h3>
+        <div class='medical_table'>61-66 Small Intestines</div>
+        <div class='medical_table'>67-72 Large Intestines</div>
+        <div class='medical_table'>73-78 Kidney</div>
+        <div class='medical_table'>79-84 Stomach / Liver</div>
+        <div class='medical_table'>85-89 Heart</div>
+        <div class='medical_table'>90-96 Lungs</div>
+        <div class='medical_table radius_border_bottom'>97-100 No Organ Hit</div>
+      </div>
+      <div class='medical_background'>
+        <h3 class='radius_border_top'>ROLL LOCATION (optional)</h3>
+        <div class='medical_table'>1-3 Left</div>
+        <div class='medical_table'>  4-7 Center</div>
+        <div class='medical_table radius_border_bottom'>8-10 Right</div>
+      </div>
+      <div class='medical_background'>
+        <h3 class='radius_border_top'>IF Fingers / Toes 1D10</h3>
+        <div class='medical_table'>1-2 Pinky Finger / Toe</div>
+        <div class='medical_table'>3-4 Ring Finger / Toe</div>
+        <div class='medical_table'>5-6 Middle Finger / Toe</div>
+        <div class='medical_table'>7-8 Index Finger / Toe</div>
+        <div class='medical_table radius_border_bottom'>  9-10 Thumb Finger / Toe</div>
+      </div>
+    </div>
+
+    <div class='medicalgR ssc'>
+      <div class='medical_h2_background'>
+        <h2 class='medical_h2 radius_border_top'>Medical Information</h2>
+      </div>
+      <!-- Every textarea element requires a closing tag; cannot be a void element. -->
+      <textarea name='attr_medical_textfield' class='radius_border_bottom' placeholder='Not all injuries in 100DOS are lethal. Exhaustion, combat trauma, or exchanging blows with bare fists can all leave a character tattered, but intact. Fatigue measures the amount of non-lethal injury a character can take. For every level of Fatigue a Character has, they take a -5 Penalty to all Tests made.&#10;&#10;Once a Character surpasses their Toughness Modifier, multiplied by 2, in Fatigue, they fall into a coma. The Character’s coma will last one hour for every level of Fatigue the Character has. Every hour that passes, the level of Fatigue is reduced by one. The Character may wake up once their level of Fatigue is their Toughness Modifier or lower.'></textarea>
+      <fieldset class='repeating_medical'>
+        <textarea name='attr_medical_textfield' class='radius_border_bottom'></textarea>
+      </fieldset>
+    </div>
+
+  </div>
+</div>
+
+
+
+<!-- ______________________________ start of tab Advancements ______________________________ -->
+
+<div class='advancements box radius_border_box ssc'>
+
+  <h2>Experience Summary</h2>
+  <div class='text_centered'>
+    Unspent XP: <input name='attr_xp_current' type='number' value='@{xp_total}-@{xp_spent}' class='numerical_field' readonly />
+    Spent XP: <input name='attr_xp_spent' type='number' value='@{xp_total}-(@{advancement_costL}+@{advancement_costR})' class='numerical_field' readonly />
+    XP Total: <input name='attr_xp_total' type='number' class='numerical_field end_field' />
+  </div>
+  <br>
+  <div class='advancements_grid equipment_header'>
+    <div class='advancements_grid_gs1'>Name</div>
+    <div class='advancements_grid_gs2'>XP Cost</div>
+    <div class='advancements_grid_gs3'>Page #</div>
+    <div class='advancements_grid_gs4'>Name</div>
+    <div class='advancements_grid_gs5'>XP Cost</div>
+    <div class='advancements_grid_gs6'>Page #</div>
+  </div>
+  <div class='advancements_grid'>
+    <input class='advancements_grid_gs1' name='attr_advancement_nameL' type='text' placeholder='Write XP-costing item name here' />
+    <input class='advancements_grid_gs2' name='attr_advancement_costL' type='number' placeholder='XP Cost' />
+    <input class='advancements_grid_gs3' name='attr_advancement_pg#L' type='number' placeholder='Page #'  />
+    <input class='advancements_grid_gs4' name='attr_advancement_nameR' type='text' placeholder='Write XP-costing item name here' />
+    <input class='advancements_grid_gs5' name='attr_advancement_costR' type='number' placeholder='XP Cost' />
+    <input class='advancements_grid_gs6' name='attr_advancement_pg#R' type='number' placeholder='Page #' />
+  </div>
+  <fieldset name='advancements' class='repeating_advancements'>
+    <div class='advancements_grid'>
+      <input class='advancements_grid_gs1' name='attr_advancement_nameL_r' type='text' placeholder='Write XP-costing item name here' />
+      <input class='advancements_grid_gs2' name='attr_advancement_costL_r' type='number' placeholder='XP Cost' />
+      <input class='advancements_grid_gs3' name='attr_advancement_pg#L_r' type='number' placeholder='Page #'  />
+      <input class='advancements_grid_gs4' name='attr_advancement_nameR_r' type='text' placeholder='Write XP-costing item name here' />
+      <input class='advancements_grid_gs5' name='attr_advancement_costR_r' type='number' placeholder='XP Cost' />
+      <input class='advancements_grid_gs6' name='attr_advancement_pg#R_r' type='number' placeholder='Page #' />
+    </div>
+  </fieldset>
+
+  <div class='training'>
+    <div class='faction_training ssc auto_margin 90width radius_border'>
+      <h3 class='radius_border_top'>Faction Training</h3>
+      <div class='faction_training_grid'>
+        <div class='faction_training_grid_g1'><input name='attr_faction_training_human' type='checkbox' value='1'>U.N.S.C.</div>
+        <div class='faction_training_grid_g2'><input name='attr_faction_training_forerunner' type='checkbox' value='1'>Forerunner</div>
+        <div class='faction_training_grid_g3'><input name='attr_faction_training_covenant' type='checkbox' value='1'>Covenant / Banished</div>
+      </div>
+    </div>
+    <div class='weapon_training ssc auto_margin 90width radius_border'>
+      <h3 class='radius_border_top'>Weapon Training</h3>
+      <div class='weapon_training_grid'>
+        <div><input name='attr_weapons_training_basic' type='checkbox' />Basic</div>
+        <div><input name='attr_weapons_training_infantry' type='checkbox' />Infantry</div>
+        <div><input name='attr_weapons_training_vehicle' type='checkbox' />Vehicle</div>
+        <div><input name='attr_weapons_training_melee' type='checkbox' />Melee</div>
+        <div><input name='attr_weapons_training_heavy' type='checkbox' />Heavy</div>
+        <div><input name='attr_weapons_training_special' type='checkbox' />Advanced</div>
+        <div><input name='attr_weapons_training_long-range' type='checkbox' />Long-Range</div>
+        <div><input name='attr_weapons_training_explosives' type='checkbox' />Explosives</div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+
+
+<!-- ______________________________ start of tab Journal ______________________________ -->
+
+<div class='journal box radius_border_box'>
+  <!-- Journal -->
+  <h2>Journal: Objectives</h2>
+  <div class='edge_padding ssc'>
+    <fieldset name='objectives' class='repeating_objectives'>
+      <input name='attr_objective' type='text' class='full_width_30px' />
+      <label class='margin_adjust'><input type='checkbox' name='attr_objective_completed' value='1' class='select_button hidden' /><span class='select_text '>✔</span></label>
+    </fieldset>
+  </div>
+  <h2>Journal: Notes</h2>
+  <div class='edge_padding ssc'>
+    <fieldset name='notes' class='repeating_notes'>
+      <!-- insert new line html entity [&#10;] inside of placeholder attribute -->
+      <textarea name='attr_notes'
+      placeholder='Enter information such as plot details, unresolved mission details such as escaped targets, character relationships, et cetera here.&#10;
+      &#10;Also feel free to write appearance details here or in Bio & Info for public viewing: age, height, weight, colors of eyes, hair, skin, more that come to mind.&#10;
+      &#10;See Medical tab to include any medical information such as character injuries.'></textarea>
+    </fieldset>
+  </div>
+</div>
+
+
+
+<!-- ______________________________ start of tab Vehicles ______________________________ -->
+
+<div class='vehicles box ssc radius_border_box'>
+  <!-- Vehicles -->
+  <div class='vehicles_divider'>
+    <fieldset name='vehicles-R' class='repeating_vehicles'>
+      <div class='vehicles_grid1'>
+        <input name='attr_vehicle-name' type='text' class='vehicles_Gn full_width' placeholder='Name' />
+
+        <select name='attr_vehicle-shield' class='vehicles_Gs full_width'>
+          <option value='0' selected='selected'>Unshielded</option>
+          <option value='1'>Shielded</option>
+        </select>
+
+        <select name='attr_vehicle-type' class='vehicles_Gt full_width'>
+          <option value='0' selected='selected'>Ground</option>
+          <option value='1'>Air</option>
+          <option value='2'>Walker</option>
+          <option value='3'>Stationary</option>
+        </select>
+        <div class='vehicles_G1'><h3>DIMENSIONS</h3></div>
+        <div class='vehicles_G2'>Length</div>
+        <div class='vehicles_G3'>Width</div>
+        <div class='vehicles_G4'>Height</div>
+        <div class='vehicles_G5'>Weight</div>
+        <input name='attr_vehicle-length' type='text' class='vehicles_G6 full_width' placeholder='# Meters' />
+        <input name='attr_vehicle-width' type='text' class='vehicles_G7 full_width' placeholder='# Meters' />
+        <input name='attr_vehicle-height' type='text' class='vehicles_G8 full_width' placeholder='# Meters' />
+        <input name='attr_vehicle-weight' type='text' class='vehicles_G9 full_width' placeholder='KG / Metric Tons' />
+
+        <input name='attr_vehicle-type' type='checkbox' value='0' class='hidden hider' checked />
+        <div class='vehicles_G10'><h3>SPEED AND MANEUVERABILITY</h3></div>
+        <input name='attr_vehicle-type' type='checkbox' value='1' class='hidden hider' />
+        <div class='vehicles_G10'><h3>SPEED AND MANEUVERABILITY</h3></div>
+        <input name='attr_vehicle-type' type='checkbox' value='2' class='hidden hider' />
+        <div class='vehicles_G10'><h3>CHARACTERISTICS</h3></div>
+
+        <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
+        <div class='vehicles_G11'>Accelerate</div>
+        <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
+        <div class='vehicles_G12'>Brake</div>
+        <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
+        <div class='vehicles_G13'>Top Speed</div>
+        <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
+        <div class='vehicles_G14'>Maneuver</div>
+        <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
+        <input name='attr_vehicle-accelerate' type='text' class='vehicles_G15 full_width' placeholder='Meters per Turn' />
+        <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
+        <input name='attr_vehicle-brake' type='text' class='vehicles_G16 full_width' placeholder='Meters per Turn' />
+        <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
+        <input name='attr_vehicle-top_speed' type='text' class='vehicles_G17 full_width' placeholder='MpT/(# km/h)' />
+        <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
+        <input name='attr_vehicle-maneuver' type='text' class='vehicles_G18 full_width' placeholder="Pilot's Evasion" />
+
+        <input name='attr_vehicle-type' type='checkbox' value='1' class='hidden hider' />
+        <div class='vehicles_G19'>Vertical</div>
+        <input name='attr_vehicle-type' type='checkbox' value='1' class='hidden hider' />
+        <div class='vehicles_G20'>Takeoff</div>
+        <input name='attr_vehicle-type' type='checkbox' value='1' class='hidden hider' />
+        <div class='vehicles_G21'>Target Range</div>
+        <input name='attr_vehicle-type' type='checkbox' value='1' class='hidden hider' />
+        <div class='vehicles_G22'>Targeting</div>
+        <input name='attr_vehicle-type' type='checkbox' value='1' class='hidden hider' />
+        <input name='attr_vehicle-vertical' type='text' class='vehicles_G23 full_width' placeholder='MpT' />
+        <input name='attr_vehicle-type' type='checkbox' value='1' class='hidden hider' />
+        <input name='attr_vehicle-takeoff' type='text' class='vehicles_G24 full_width' placeholder='Min Half-Actions' />
+        <input name='attr_vehicle-type' type='checkbox' value='1' class='hidden hider' />
+        <input name='attr_vehicle-target_range' type='text' class='vehicles_G25 full_width' placeholder='Meters' />
+        <input name='attr_vehicle-type' type='checkbox' value='1' class='hidden hider' />
+        <input name='attr_vehicle-targeting' type='text' class='vehicles_G26 full_width' placeholder='Min Half-Actions' />
+
+        <input name='attr_vehicle-type' type='checkbox' value='2' class='hidden hider' />
+        <div class='vehicles_G27'>Strength</div>
+        <input name='attr_vehicle-type' type='checkbox' value='2' class='hidden hider full_width' />
+        <div class='vehicles_G28'>Melee</div>
+        <input name='attr_vehicle-type' type='checkbox' value='2' class='hidden hider' />
+        <input type='text' name='attr_vehicle-strength' class='vehicles_G29 full_width'/>
+        <input name='attr_vehicle-type' type='checkbox' value='2' class='hidden hider' />
+        <input name='attr_vehicle-melee' type='text' class='vehicles_G30 full_width' />
+
+        <input name='attr_vehicle-type' type='checkbox' value='2' class='hidden hider' />
+        <input name='attr_vehicle-strength-mythic' class='vehicles_G31 full_width' type='text' />
+        <input name='attr_vehicle-type' type='checkbox' value='2' class='hidden hider' />
+        <div class='vehicles_G32'>Mythic</div>
+
+        <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
+        <div class='vehicles_G33'><h3>CREW AND COMPLEMENT</h3></div>
+        <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
+        <div class='vehicles_G34'>Crew</div>
+        <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
+        <div class='vehicles_G35'>Complement</div>
+        <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
+        <input name='attr_vehicle-crew' type='text' class='vehicles_G36 full_width' placeholder='Minimum Crew Prerequisite' />
+        <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
+        <input name='attr_vehicle-compliment' type='text' class='vehicles_G37 full_width' placeholder='Maximum Crew Space' />
+        <div class='vehicles_G38'><h3>HULL</h3></div>
+        <div class='vehicles_G39'>Hull Material</div>
+        <input name='attr_vehicle-hull' type='text' class='vehicles_G40 full_width' placeholder='Alloy Composition & Plating' />
+      </div>
+      <div class='vehicles_grid2'>
+        <div class='vehicles_G41'><h3>BREAKPOINTS</h3></div>
+        <div class='vehicles_G42'>1-20 Wep</div>
+        <div class='vehicles_G43'>21-40 Mob</div>
+        <div class='vehicles_G44'>41-60 Eng</div>
+        <div class='vehicles_G45'>61-80 Optic</div>
+        <div class='vehicles_G46'>81-100 Crew</div>
+        <input name='attr_vehicle-bp-wep' type='text' class='vehicles_G47 full_width' placeholder='Weapon' />
+        <input name='attr_vehicle-bp-mod' type='text' class='vehicles_G48 full_width' placeholder='Mobility' />
+        <input name='attr_vehicle-bp-eng'type='text' class='vehicles_G49 full_width' placeholder='Engine' />
+        <input name='attr_vehicle-bp-op'type='text' class='vehicles_G50 full_width' placeholder='Optic' />
+        <input name='attr_vehicle-bp-crew'type='text' class='vehicles_G51 full_width' placeholder='Compartment' />
+        <div class='vehicles_G52'><h3>Armor</h3></div>
+        <div class='vehicles_G53'>Front</div>
+        <div class='vehicles_G54'>Back</div>
+        <div class='vehicles_G55'>Side</div>
+        <div class='vehicles_G56'>Top</div>
+        <div class='vehicles_G57'>Bottom</div>
+        <input name='attr_vehicle-armor-front' type='text' class='vehicles_G58 full_width' />
+        <input name='attr_vehicle-armor-back' type='text' class='vehicles_G59 full_width' />
+        <input name='attr_vehicle-armor-side' type='text' class='vehicles_G60 full_width' />
+        <input name='attr_vehicle-armor-top' type='text' class='vehicles_G61 full_width' />
+        <input name='attr_vehicle-armor-bottom' type='text' class='vehicles_G62 full_width' />
+      </div>
+      <div class='vehicles_grid3'>
+        <div class='vehicles_G63'><h3>Miscellaneous</h3></div>
+        <div class='vehicles_G64'>Size Points</div>
+        <div class='vehicles_G65'>Weapon Points</div>
+        <input name='attr_vehicle-size-points' type='text' class='vehicles_G66 full_width' placeholder='Warthog = 2' />
+        <input name='attr_vehicle-weapon-points' type='text' class='vehicles_G67 full_width' placeholder='Warthog = 2' />
+
+        <input name='attr_vehicle-shield' type='checkbox' value='1' class='hidden hider' />
+        <div class='vehicles_G68'>Shield Rating</div>
+        <input name='attr_vehicle-shield' type='checkbox' value='1' class='hidden hider' />
+        <div class='vehicles_G69'>Shield Current</div>
+        <input name='attr_vehicle-shield' type='checkbox' value='1' class='hidden hider' />
+        <div class='vehicles_G70'>Recharge Delay</div>
+        <input name='attr_vehicle-shield' type='checkbox' value='1' class='hidden hider' />
+        <div class='vehicles_G71'>Recharge Rate</div>
+        <input name='attr_vehicle-shield' type='checkbox' value='1' class='hidden hider' />
+        <input name='attr_vehicle-shield-rating' type='text' class='vehicles_G72 full_width' />
+        <input name='attr_vehicle-shield' type='checkbox' value='1' class='hidden hider' />
+        <input name='attr_vehicle-shield-current' type='text' class='vehicles_G73 full_width' />
+        <input name='attr_vehicle-shield' type='checkbox' value='1' class='hidden hider' />
+        <input name='attr_vehicle-recharge-delay' type='text' class='vehicles_G74 full_width' />
+        <input name='attr_vehicle-shield' type='checkbox' value='1' class='hidden hider' />
+        <input name='attr_vehicle-recharge-rate' type='text' class='vehicles_G75 full_width' />
+
+        <div class='vehicles_G76 '>
+          <div>
+            <input name='attr_aditional_info' type='text' placeholder='Additional Info' class='full_width_49px' />
+            <label class='margin_adjust'><input type='checkbox' name='attr_collapse' value='5' class='collapsible_entity_switch select_button hidden' /><span class='select_text '>▼</span></label>
+            <label class='margin_adjust2'><button type='roll' value='@{to-gm}&{template:mythic} {{name=@{aditional_info} }} {{description=@{aditional_info_desc} }}' class='hidden'></button><span class='select_text'>❖</span></label>
+            <input name='attr_collapse' type='checkbox'  value='5' class='collapsible_entity_switch hidden' />
+            <textarea name='attr_aditional_info_desc' class='collapsible_entity_block' placeholder='Enter any vehicle-specific rules or other unique information here.'></textarea>
+          </div>
+          <div>
+            <input name='attr_modifications' type='text' placeholder='Modifications' class='full_width_49px vehicles_descriptor' />
+            <label class='margin_adjust'><input type='checkbox' name='attr_collapse2' value='6' class='collapsible_entity_switch select_button hidden' /><span class='select_text radius_border_right'>▼</span></label>
+            <label class='margin_adjust2'><button type='roll' value='@{to-gm}&{template:mythic} {{name=@{modifications} }} {{description=@{modifications_desc} }}' class='hidden'></button><span class='select_text'>❖</span></label>
+            <input name='attr_collapse2' type='checkbox'  value='6' class='collapsible_entity_switch hidden' />
+            <textarea name='attr_modifications_desc' class='collapsible_entity_block description_rounded_margin' placeholder='Vehicles in Halo Mythic can be modified in many ways.  These use a Vehicle’s Weapon Points and Size Points, which are specialized Hardpoints on a Vehicle.  Each Modification takes a specified amount of Weapon and Size Points.
+            &#10;Vehicle modifications are classified into five categories; Body, Propulsion, Electronic, Combat, and Miscellaneous.'></textarea>
+          </div>
+        </div>
+      </div>
+      <br>
+    </fieldset>
+
+    <div class='vehicle_weapons'>
+      <div class='equipment_ranged_weapons'>
+        <h3 class='radius_border_top'>Vehicle Ranged Weapons</h3>
+        <fieldset name='vehiclerangedweapons' class='repeating_vrangedweapons'>
           <div class='equipment_ranged_weapons_rep'>
             <div class='equipment_ranged_weapons_grid1'>
               <div class='equipment_ranged_weapons_gs1'>Name</div>
-              <input class='equipment_ranged_weapons_gs2 full_width' type='text' name='attr_R_weapon_name' placeholder='Name' />
+              <input class='equipment_ranged_weapons_gs2 full_width' type='text' name='attr_V_R_weapon_name' placeholder='Name' />
               <div class='equipment_ranged_weapons_gs3'>Type</div>
-              <input class='equipment_ranged_weapons_gs4 full_width' type='text' name='attr_R_weapon_class' placeholder='Class of Weapon' />
+              <input class='equipment_ranged_weapons_gs4 full_width' type='text' name='attr_V_R_weapon_class' placeholder='Class of Weapon' />
             </div>
             <div class='equipment_ranged_weapons_grid2'>
               <div class='equipment_ranged_weapons_gs5'>Range</div>
-              <input class='equipment_ranged_weapons_gs6 full_width' type='text' value='0' name='attr_R_weapon_range' />
+              <input class='equipment_ranged_weapons_gs6 full_width' type='text' value='0' name='attr_V_R_weapon_range' />
               <div class='equipment_ranged_weapons_gs7'>DMG Roll</div>
-              <input class='equipment_ranged_weapons_gs8 full_width' type='text' value='2d10' name='attr_R_weapon_dam-roll' />
+              <input class='equipment_ranged_weapons_gs8 full_width' type='text' value='0' name='attr_V_R_weapon_dam-roll' />
               <div class='equipment_ranged_weapons_gs9'>Base</div>
-              <input class='equipment_ranged_weapons_gs10 full_width' type='text' value='0' name='attr_R_weapon_base' />
+              <input class='equipment_ranged_weapons_gs10 full_width' type='text' value='0' name='attr_V_R_weapon_base' />
               <div class='equipment_ranged_weapons_gs11'>Pierce</div>
-              <input class='equipment_ranged_weapons_gs12 full_width' type='text' value='0' name='attr_R_weapon_pierce' />
+              <input class='equipment_ranged_weapons_gs12 full_width' type='text' value='0' name='attr_V_R_weapon_pierce' />
             </div>
             <div class='equipment_ranged_weapons_grid3'>
               <div class='equipment_ranged_weapons_gs13'>Hit Mod</div>
-              <input class='equipment_ranged_weapons_gs14 full_width' type='text' value='0' name='attr_R_weapon_mod1' />
+              <input class='equipment_ranged_weapons_gs14 full_width' type='text' value='0' name='attr_V_R_weapon_mod1' />
               <div class='equipment_ranged_weapons_gs15'>Magazine</div>
-              <input class='equipment_ranged_weapons_gs16 full_width' type='text' value='0' name='attr_R_weapon_mag' />
+              <input class='equipment_ranged_weapons_gs16 full_width' type='text' value='0' name='attr_V_R_weapon_mag' />
               <div class='equipment_ranged_weapons_gs17'>/</div>
-              <input class='equipment_ranged_weapons_gs18 full_width' type='text' value='0' name='attr_R_weapon_mag_max' />
-              <button class='equipment_ranged_weapons_gs19 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }} {{weapon= @{R_weapon_name}}} {{roll=[[floor(([[@{WFR}+@{WFR_advancement}+@{fatigue_mod}]]+@{R_weapon_mod1}+@{inlinemod-toggle}-1d100)/10)]]}} @{settings_hitroll}"></button>' >Hit</button>
-              <button class='equipment_ranged_weapons_gs20 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{weapon= @{R_weapon_name}}} {{damage=[[@{R_weapon_dam-roll}+@{R_weapon_base}]] }} {{pierce=[[@{R_weapon_pierce}]] }} {{@{settings_weapondescription}=@{R_ability_r} }}' >DMG</button>
+              <input class='equipment_ranged_weapons_gs18 full_width' type='text' value='0' name='attr_V_R_weapon_mag_max' />
+              <button class='equipment_ranged_weapons_gs19 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }} {{weapon= @{V_R_weapon_name}}} {{roll=[[floor(([[@{WFR}+@{WFR_advancement}+@{fatigue_mod}]]+@{V_R_weapon_mod1}+@{inlinemod-toggle}-1d100)/10)]]}} @{settings_hitroll}"></button>' >Hit</button>
+              <button class='equipment_ranged_weapons_gs20 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{weapon= @{V_R_weapon_name}}} {{damage=[[@{V_R_weapon_dam-roll}+@{V_R_weapon_base}]] }} {{pierce=[[@{V_R_weapon_pierce}]] }} {{@{settings_weapondescription}=@{V_R_ability_r} }}' >DMG</button>
             </div>
             <div class='equipment_ranged_weapons_grid4'>
               <div class='equipment_ranged_weapons_gs21'>RoF</div>
-              <input class='equipment_ranged_weapons_gs22 full_width' type='text' placeholder='Semi' name='attr_R_weapon_semi' />
+              <input class='equipment_ranged_weapons_gs22 full_width' type='text' placeholder='Semi' name='attr_V_R_weapon_semi' />
               <div class='equipment_ranged_weapons_gs23'>/</div>
-              <input class='equipment_ranged_weapons_gs24 full_width' type='text' placeholder='Burst' name='attr_R_weapon_burst' />
+              <input class='equipment_ranged_weapons_gs24 full_width' type='text' placeholder='Burst' name='attr_V_R_weapon_burst' />
               <div class='equipment_ranged_weapons_gs25'>/</div>
-              <input class='equipment_ranged_weapons_gs26 full_width' type='text' placeholder='Auto' name='attr_R_weapon_auto' />
+              <input class='equipment_ranged_weapons_gs26 full_width' type='text' placeholder='Auto' name='attr_V_R_weapon_auto' />
               <div class='equipment_ranged_weapons_gs27'>Reload</div>
-              <input class='equipment_ranged_weapons_gs28 full_width' type='text' value='2 half actions' name='attr_R_weapon_reload' />
+              <input class='equipment_ranged_weapons_gs28 full_width' type='text' name='attr_V_R_weapon_reload' />
               <div class='equipment_ranged_weapons_gs29'>Weight</div>
-              <input class='equipment_ranged_weapons_gs30 full_width' type='text' value='0' name='attr_R_weapon_weight' />
+              <input class='equipment_ranged_weapons_gs30 full_width' type='text' value='0' name='attr_V_R_weapon_weight' />
             </div>
             <div>
-              <input name='attr_R_ability_r' type='text' placeholder='Description' class='full_width_49px border_none' />
+              <input name='attr_V_R_ability_r' type='text' placeholder='Description' class='full_width_49px border_none' />
               <label class='margin_adjust_wep'><input type='checkbox' name='attr_collapse' value='3' class='collapsible_entity_switch select_button hidden' /><span class='select_text radius_border_right_wep'>▼</span></label>
-              <label class='margin_adjust_wep2'><button type='roll' value='@{to-gm}&{template:mythic} {{name=@{R_ability_r} }} {{description=@{R_ability_desc_r} }}' class='hidden'></button><span class='select_text'>❖</span></label>
+              <label class='margin_adjust_wep2'><button type='roll' value='@{to-gm}&{template:mythic} {{name=@{V_R_ability_r} }} {{description=@{V_R_ability_desc_r} }}' class='hidden'></button><span class='select_text'>❖</span></label>
               <input name='attr_collapse' type='checkbox'  value='3' class='collapsible_entity_switch hidden' />
-              <textarea name='attr_R_ability_desc_r' class='collapsible_entity_block description_rounded_margin' placeholder='Weapon Attachment: Benefit, Type Mount, Restriction, etc.'></textarea>
+              <textarea name='attr_V_R_ability_desc_r' class='collapsible_entity_block description_rounded_margin'></textarea>
             </div>
           </div>
-          <hr>
+          <br>
         </fieldset>
       </div>
 
-      <div class='equipment_melee_weapons ssc'>
-        <h3 class='radius_border_top'>Melee Weapons</h3>
-        <fieldset name='meleeweapons' class='repeating_meleeweapons'>
+      <div class='equipment_melee_weapons'>
+        <h3 class='radius_border_top'>Vehicle Melee Weaponry</h3>
+        <fieldset name='vehiclemeleeweapons' class='repeating_vmeleeweapons'>
           <div class='equipment_ranged_weapons_rep'>
             <div class='equipment_ranged_weapons_grid1'>
               <div class='equipment_ranged_weapons_gs1'>Name</div>
-              <input class='equipment_ranged_weapons_gs2 full_width' type='text' name='attr_M_weapon_name' placeholder='Name' />
+              <input class='equipment_ranged_weapons_gs2 full_width' type='text' name='attr_V_M_weapon_name' placeholder='Name' />
               <div class='equipment_ranged_weapons_gs3'>Type</div>
-              <input class='equipment_ranged_weapons_gs4 full_width' type='text' name='attr_M_weapon_class' placeholder='Class of Weapon' />
+              <input class='equipment_ranged_weapons_gs4 full_width' type='text' name='attr_V_M_weapon_class' placeholder='Class of Weapon' />
             </div>
             <div class='equipment_ranged_weapons_grid2'>
               <div class='equipment_ranged_weapons_gs5'>Reach</div>
-              <input class='equipment_ranged_weapons_gs6 full_width' type='text' value='0' name='attr_M_weapon_range' />
+              <input class='equipment_ranged_weapons_gs6 full_width' type='text' value='0' name='attr_V_M_weapon_range' />
               <div class='equipment_ranged_weapons_gs7'>DMG Roll</div>
-              <input class='equipment_ranged_weapons_gs8 full_width' type='text' value='2d10' name='attr_M_weapon_dam-roll' />
+              <input class='equipment_ranged_weapons_gs8 full_width' type='text' value='0' name='attr_V_M_weapon_dam-roll' />
               <div class='equipment_ranged_weapons_gs9'>Base</div>
-              <input class='equipment_ranged_weapons_gs10 full_width' type='text' value='0' name='attr_M_weapon_base' />
+              <input class='equipment_ranged_weapons_gs10 full_width' type='text' value='0' name='attr_V_M_weapon_base' />
               <div class='equipment_ranged_weapons_gs11'>Pierce</div>
-              <input class='equipment_ranged_weapons_gs12 full_width' type='text' value='0' name='attr_M_weapon_pierce' />
+              <input class='equipment_ranged_weapons_gs12 full_width' type='text' value='0' name='attr_V_M_weapon_pierce' />
             </div>
             <div class='equipment_melee_weapons_grid3'>
               <div class='equipment_melee_weapons_gs1'>Hit Mod</div>
-              <input class='equipment_melee_weapons_gs2 full_width' type='text' value='0' name='attr_M_weapon_mod1' />
+              <input class='equipment_melee_weapons_gs2 full_width' type='text' value='0' name='attr_V_M_weapon_mod1' />
               <div class='equipment_melee_weapons_gs3'>Weight</div>
-              <input class='equipment_melee_weapons_gs4 full_width' type='text' value='0' name='attr_M_weapon_weight' />
+              <input class='equipment_melee_weapons_gs4 full_width' type='text' value='0' name='attr_V_M_weapon_weight' />
               <div class='equipment_melee_weapons_gs5'>Br Pts</div>
-              <input class='equipment_melee_weapons_gs6 full_width' type='text' value='0' name='attr_M_weapon_breakpoints' />
+              <input class='equipment_melee_weapons_gs6 full_width' type='text' value='0' name='attr_V_M_weapon_breakpoints' />
               <div class='equipment_melee_weapons_gs7'>/</div>
-              <input class='equipment_melee_weapons_gs8 full_width' type='text' value='0' name='attr_M_weapon_breakpoints_max' />
-              <button class='equipment_melee_weapons_gs9 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }}{{weapon= @{M_weapon_name}}} {{roll=[[floor(([[@{WFM}+@{WFM_advancement}+@{fatigue_mod}]]+@{M_weapon_mod1}+@{inlinemod-toggle}-1d100)/10)]]}} @{settings_hitroll}'' >Hit</button>
-              <button class='equipment_melee_weapons_gs10 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{weapon= @{M_weapon_name}}} {{damage=[[@{M_weapon_dam-roll}+@{M_weapon_base}+@{M_weapon_base-mod}]] }} {{pierce=[[@{M_weapon_pierce}+@{M_weapon_pierce-mod}]] }} {{@{settings_weapondescription}=@{M_ability_r} }}' >DMG</button>
-            </div>
-            <div class='equipment_melee_weapons_grid4'>
-              <div class='equipment_melee_weapons_gs11'>damage plus Strength</div>
-              <select class='equipment_melee_weapons_gs12 full_width' name='attr_M_weapon_base-mod'>
-                <option selected='selected' value='0'>None</option>
-                <option value='[[floor(((@{STR} + @{STR_advancement})/10 + @{str_mythic})/2)]]'>Half</option>
-                <option value='[[floor((@{STR} + @{STR_advancement})/10 + @{STR_mythic})]]'>Full</option>
-              </select>
-              <div class='equipment_melee_weapons_gs13'>pierce plus Strength</div>
-              <select class='equipment_melee_weapons_gs14 full_width' name='attr_M_weapon_pierce-mod'>
-                <option selected='selected' value='0'>None</option>
-                <option value='[[floor(((@{STR} + @{STR_advancement})/10 + @{str_mythic})/2)]]'>Half</option>
-                <option value='[[floor((@{STR} + @{STR_advancement})/10 + @{STR_mythic})]]'>Full</option>
-              </select>
+              <input class='equipment_melee_weapons_gs8 full_width' type='text' value='0' name='attr_V_M_weapon_breakpoints_max' />
+              <button class='equipment_melee_weapons_gs9 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }} {{weapon= @{V_M_weapon_name}}} {{roll=[[floor(([[@{WFM}+@{WFM_advancement}+@{fatigue_mod}]]+@{V_M_weapon_mod1}+@{inlinemod-toggle}-1d100)/10)]]}} @{settings_hitroll}'' >Hit</button>
+              <button class='equipment_melee_weapons_gs10 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{weapon= @{V_M_weapon_name}}} {{damage=[[@{V_M_weapon_dam-roll}+@{V_M_weapon_base}]] }} {{pierce=[[@{V_M_weapon_pierce}]] }} {{@{settings_weapondescription}=@{V_M_ability_r} }}' >DMG</button>
             </div>
             <div>
-              <input name='attr_M_ability_r' type='text' placeholder='Description' class='full_width_49px border_none' />
+              <input name='attr_V_M_ability_r' type='text' placeholder='Description' class='full_width_49px border_none' />
               <label class='margin_adjust_wep'><input type='checkbox' name='attr_collapse' value='3' class='collapsible_entity_switch select_button hidden' /><span class='select_text radius_border_right_wep'>▼</span></label>
-              <label class='margin_adjust_wep2'><button type='roll' value='@{to-gm}&{template:mythic} {{name=@{M_ability_r} }} {{description=@{M_ability_desc_r} }}' class='hidden'></button><span class='select_text'>❖</span></label>
+              <label class='margin_adjust_wep2'><button type='roll' value='@{to-gm}&{template:mythic} {{name=@{V_M_ability_r} }} {{description=@{V_M_ability_desc_r} }}' class='hidden'></button><span class='select_text'>❖</span></label>
               <input name='attr_collapse' type='checkbox'  value='3' class='collapsible_entity_switch hidden' />
-              <textarea name='attr_M_ability_desc_r' class='collapsible_entity_block description_rounded_margin' placeholder='Weapon Modification e.g. Gravity Hammer Crushing thruster'></textarea>
+              <textarea name='attr_V_M_ability_desc_r' class='collapsible_entity_block description_rounded_margin'></textarea>
             </div>
           </div>
-          <hr>
-        </fieldset>
-      </div>
-
-      <div class='equipment_numerics text_centered'>
-        cR Count: <input name='attr_credits' type='number' class='numerical_field' />
-        cR Calculation: <input name='attr_credit_total' type='number' class='numerical_field' readonly />
-        Weight Calculation: <input name='attr_weight_total' type='number' class='numerical_field end_field' readonly> kilograms</input>
-        <input type='number' name='attr_M_weapon_weight_T'  hidden>
-        <input type='number' name='attr_R_weapon_weight_T'  hidden>
-      </div>
-    </div>
-    <br>
-
-    <div class='equipment_gear equipment_header'>
-      <div class='equipment_gear_gs1'>Gear / Item Name</div>
-      <div class='equipment_gear_gs2'>Amount</div>
-      <div class='equipment_gear_gs3'>Value</div>
-      <div class='equipment_gear_gs4'>Weight</div>
-      <div class='equipment_gear_gs5'>B Pts</div>
-      <div class='equipment_gear_gs6'>Page #</div>
-    </div>
-    <div class='equipment_gear'>
-      <input name='attr_gear_name' type='text' placeholder='Gear / Item Name' class='equipment_gear_gs1' />
-      <input name='attr_gear_quantity' type='text' value='1' placeholder='Amount' class='equipment_gear_gs2' />
-      <input name='attr_gear_cost' type='text' value='0' class='equipment_gear_gs3' />
-      <input name='attr_gear_weight' type='text' value='0' class='equipment_gear_gs4' />
-      <input name='attr_gear_bp' type='text' placeholder='Break Points' class='equipment_gear_gs5' />
-      <input name='attr_gear_pg#' type='text' placeholder='Page #' class='equipment_gear_gs6' />
-      <label class='margin_adjust equipment_gear_gs7'><input type='checkbox' name='attr_collapse' value='7' class='collapsible_entity_switch select_button hidden'><span class='select_text'>▼</span></label>
-    </div>
-    <input name='attr_collapse' type='checkbox'  value='7' class='collapsible_entity_switch hidden' />
-    <textarea name='attr_gear_desc' placeholder='Different equipment will have special rules.' class='collapsible_entity_block auto_margin 90width'></textarea>
-    <fieldset name='gear' class='repeating_gear'>
-      <div class='equipment_gear'>
-        <input name='attr_gear_name_r' type='text' placeholder='Gear / Item Name' class='equipment_gear_gs1' />
-        <input name='attr_gear_quantity_r' type='text' value='1' placeholder='Amount' class='equipment_gear_gs2' />
-        <input name='attr_gear_cost_r' type='text' value='0' class='equipment_gear_gs3' />
-        <input name='attr_gear_weight_r' type='text' value='0' class='equipment_gear_gs4' />
-        <input name='attr_gear_bp_r' type='text' placeholder='Break Points' class='equipment_gear_gs5' />
-        <input name='attr_gear_pg#_r' type='text' placeholder='Page #' class='equipment_gear_gs6' />
-        <label class='margin_adjust equipment_gear_gs7'><input type='checkbox' name='attr_collapse_r' value='2' class='collapsible_entity_switch select_button hidden' /><span class='select_text'>▼</span></label>
-      </div>
-      <input name='attr_collapse_r' type='checkbox'  value='2' class='collapsible_entity_switch hidden' />
-      <textarea name='attr_ability_desc_r' class='collapsible_entity_block auto_margin 90width'></textarea>
-    </fieldset>
-    <br>
-
-    <div class='equipment_armor_grid'>
-      <div class='equipment_armor_gs1 radius_border'>
-        <h3 class='radius_border_top'>Armor Display</h3>
-        <img src='https://cdn.discordapp.com/attachments/676016722939084800/694958755967795381/Mark_IV_Schematic.png' width='100%' />
-      </div>
-      <div class='equipment_armor_gs2 radius_border'>
-        <h3 class='radius_border_top'>Armor</h3>
-        <div>
           <br>
-          <h3 class='radius_border_top'>Head</h3>
-          <input class='equipment_armor_input' type='text' name='attr_armor_head' value='0'>
-        </div>
-        <div>
-          <br>
-          <h3 class='radius_border_top'>Arm L</h3>
-          <input class='equipment_armor_input' type='text' name='attr_armor_arm_left' value='0'>
-        </div>
-        <div>
-          <br>
-          <h3 class='radius_border_top'>Arm R</h3>
-          <input class='equipment_armor_input' type='text' name='attr_armor_arm_right' value='0'>
-        </div>
-        <div>
-          <br>
-          <h3 class='radius_border_top'>Chest</h3>
-          <input class='equipment_armor_input' type='text' name='attr_armor_chest' value='0'>
-        </div>
-        <div>
-          <br>
-          <h3 class='radius_border_top'>Leg L</h3>
-          <input class='equipment_armor_input' type='text' name='attr_armor_leg_left' value='0'>
-        </div>
-        <div>
-          <br>
-          <h3 class='radius_border_top'>Leg R</h3>
-          <input class='equipment_armor_input' type='text' name='attr_armor_leg_right' value='0'>
-        </div>
-      </div>
-
-      <div class='equipment_armor_gs3 radius_border'>
-        <h3 class='radius_border_top'>Armor Permutations</h3>
-        <div>
-          <div class="equipment_permutations_grid equipment_titles">
-            <p class='bold_text equipment_titles'>Name</p>
-            <p class='bold_text equipment_titles'>Location</p>
-            <p class='bold_text equipment_titles'>Hpts</p>
-            <p class='bold_text equipment_titles'>Pg#</p>
-          </div>
-          <div class='equipment_permutations_grid'>
-            <input class='full_width' type='text' name='attr_permutation_name' placeholder='Name'>
-            <input class='full_width' type='text' name='attr_permutation_location' placeholder='Location'>
-            <input class='full_width' type='text' name='attr_permutation_hardpoints' placeholder='Hpts'>
-            <input class='full_width' type='text' name='attr_permutation_page' placeholder='Pg#'>
-          </div>
-          <label class='margin_adjust'><input type='checkbox' name='attr_collapse3' value='2' class='collapsible_entity_switch select_button hidden' /><span class='select_text'>▼</span></label>
-          <label class='margin_adjust2'><button type='roll' value='@{to-gm}&{template:mythic} {{name=@{permutation_name} }} {{description=@{permutation_desc} }}' class='hidden'></button><span class='select_text'>❖</span></label>
-          <input name='attr_collapse3' type='checkbox'  value='2' class='collapsible_entity_switch hidden' />
-          <textarea name='attr_permutation_desc' placeholder='All Human BDUs and Armor are designed to take Permutations. Permutations are attachments that modify Armor and offer various forms of function. Each section of Armor can only fit so many Permutations, which are shown as Hardpoints.' class='collapsible_entity_block'></textarea>
-        </div>
-        <fieldset name='permutations' class='repeating_permutations'>
-          <div>
-            <div class='equipment_permutations_grid'>
-              <input class='full_width' type='text' name='attr_permutation_name_r' placeholder='Name'>
-              <input class='full_width' type='text' name='attr_permutation_location_r' placeholder='Location'>
-              <input class='full_width' type='text' name='attr_permutation_hardpoints_r' placeholder='Hpts'>
-              <input class='full_width' type='text' name='attr_permutation_page_r' placeholder='Pg#'>
-            </div>
-            <label class='margin_adjust'><input type='checkbox' name='attr_collapse' value='2' class='collapsible_entity_switch select_button hidden' /><span class='select_text'>▼</span></label>
-            <label class='margin_adjust2'><button type='roll' value='@{to-gm}&{template:mythic} {{name=@{permutation_name_r} }} {{description=@{permutation_desc_r} }}' class='hidden'></button><span class='select_text'>❖</span></label>
-            <input name='attr_collapse' type='checkbox'  value='2' class='collapsible_entity_switch hidden' />
-            <textarea name='attr_permutation_desc_r' class='collapsible_entity_block'></textarea>
-          </div>
-        </fieldset>
-
-        <br>
-
-        <h3 class='radius_border_top'>Armor Description</h3>
-        <textarea name='attr_armor_desc'></textarea>
-        <fieldset name='armors' class='repeating_armors'>
-          <input class='full_width_49px' type='text' name='attr_armor_name_r' placeholder='Name'>
-          <label class='margin_adjust'><input type='checkbox' name='attr_collapse' value='2' class='collapsible_entity_switch select_button hidden' /><span class='select_text'>▼</span></label>
-          <label class='margin_adjust2'><button type='roll' value='@{to-gm}&{template:mythic} {{name=@{armor_name_r} }} {{description=@{armor_desc_r} }}' class='hidden'></button><span class='select_text'>❖</span></label>
-          <input name='attr_collapse' type='checkbox'  value='2' class='collapsible_entity_switch hidden' />
-          <textarea name='attr_armor_desc_r' class='collapsible_entity_block'></textarea>
         </fieldset>
       </div>
     </div>
-
   </div>
 
-
-
-  <!-- ______________________________ start of tab Medical ______________________________ -->
-
-  <div class='medical box radius_border_box'>
-    <!-- Medical -->
-    <div class='medical-grid'>
-
-      <div class='medicalg1 medicalG'>
-        Finger / Toe
-        <select name='attr_medical_finger/toe' class='full_width'>
-          <option selected='selected' value='0'>Nominal</option>
-          <option value='1'>01-15</option>
-          <option value='2'>16-30</option>
-          <option value='3'>31-45</option>
-          <option value='4'>46+</option>
-        </select>
-        <div>
-          <input name='attr_medical_finger/toe' type='checkbox' value='0' class='hidden hider' checked />
-          <div>No Effect / Healthy</div>
-          <input name='attr_medical_finger/toe' type='checkbox' value='1' class='hidden hider' />
-          <div>-1 WFM + WFR to Finger,<br>-2 Agility to Toe</div>
-          <input name='attr_medical_finger/toe' type='checkbox' value='2' class='hidden hider' />
-          <div>-2 WFM + WFR to Finger,<br>-4 Agility to Toe</div>
-          <input name='attr_medical_finger/toe' type='checkbox' value='3' class='hidden hider' />
-          <div>Body Location damaged.<br>No longer usable. -3 Strength to Finger, -3 Agility to Toe</div>
-          <input name='attr_medical_finger/toe' type='checkbox' value='4' class='hidden hider' />
-          <div>Body Locaton destroyed,<br>-4 Strength to Finger, -4 Agility to Toe</div>
-        </div>
-      </div>
-
-      <div class='medicalg2 medicalG'>
-        Heart
-        <select name='attr_medical_heart' class='full_width'>
-          <option selected='selected' value='0'>Nominal</option>
-          <option value='1'>01-20</option>
-          <option value='2'>21-30</option>
-          <option value='3'>31-40</option>
-          <option value='4'>41-59</option>
-          <option value='5'>60+</option>
-        </select>
-        <div>
-          <input name='attr_medical_heart' type='checkbox' value='0' class='hidden hider' checked />
-          <div>No Effect / Healthy</div>
-          <input name='attr_medical_heart' type='checkbox' value='1' class='hidden hider' />
-          <div>-2 Strength + Toughness + Agility</div>
-          <input name='attr_medical_heart' type='checkbox' value='2' class='hidden hider' />
-          <div>-5 Strength + Toughness + Agility</div>
-          <input name='attr_medical_heart' type='checkbox' value='3' class='hidden hider' />
-          <div>-10 Strength + Toughness + Agility</div>
-          <input name='attr_medical_heart' type='checkbox' value='4' class='hidden hider' />
-          <div>Body Location damaged.<br>+10 Fatigue, -15 Strength + Toughness + Agility</div>
-          <input name='attr_medical_heart' type='checkbox' value='5' class='hidden hider' />
-          <div>Body Locaton destroyed,<br>instant death</div>
-        </div>
-      </div>
-
-      <div class='medicalg3 medicalG'>
-        Neck
-        <select name='attr_medical_neck' class='full_width'>
-          <option selected='selected' value='0'>Nominal</option>
-          <option value='1'>01-20</option>
-          <option value='2'>21-25</option>
-          <option value='3'>26-30</option>
-          <option value='4'>31-40</option>
-          <option value='5'>41-59</option>
-          <option value='6'>60+</option>
-        </select>
-        <div>
-          <input name='attr_medical_neck' type='checkbox' value='0' class='hidden hider' checked />
-          <div>No Effect / Healthy</div>
-          <input name='attr_medical_neck' type='checkbox' value='1' class='hidden hider' />
-          <div>-2 Toughness</div>
-          <input name='attr_medical_neck' type='checkbox' value='2' class='hidden hider' />
-          <div>-5 Toughness</div>
-          <input name='attr_medical_neck' type='checkbox' value='3' class='hidden hider' />
-          <div>-10 Toughness</div>
-          <input name='attr_medical_neck' type='checkbox' value='4' class='hidden hider' />
-          <div>+1 Fatigue, -10 Toughness</div>
-          <input name='attr_medical_neck' type='checkbox' value='5' class='hidden hider' />
-          <div>Body Location damaged.<br>-20 Toughness, Paralyzed and Helpless</div>
-          <input name='attr_medical_neck' type='checkbox' value='6' class='hidden hider' />
-          <div>Body Location destroyed,<br>instant death</div>
-        </div>
-      </div>
-
-      <div class='medicalg4 medicalG'>
-        Skull / Brain
-        <select name='attr_medical_skull/brain' class='full_width'>
-          <option selected='selected' value='0'>Nominal</option>
-          <option value='1'>01-20</option>
-          <option value='2'>21-30</option>
-          <option value='3'>31-40</option>
-          <option value='4'>41-59</option>
-          <option value='5'>60+</option>
-        </select>
-        <div>
-          <input name='attr_medical_skull/brain' type='checkbox' value='0' class='hidden hider' checked />
-          <div>No Effect / Healthy</div>
-          <input name='attr_medical_skull/brain' type='checkbox' value='1' class='hidden hider' />
-          <div>-2 Perception + Intellect + WFM + WFR</div>
-          <input name='attr_medical_skull/brain' type='checkbox' value='2' class='hidden hider' />
-          <div>-5 Perception + Intellect + WFM + WFR</div>
-          <input name='attr_medical_skull/brain' type='checkbox' value='3' class='hidden hider' />
-          <div>-10 Perception + Intellect + WFM + WFR</div>
-          <input name='attr_medical_skull/brain' type='checkbox' value='4' class='hidden hider' />
-          <div>Body Location damaged.<br>+10 Fatigue, -15 Perception + Intellect + WFM + WFR</div>
-          <input name='attr_medical_skull/brain' type='checkbox' value='5' class='hidden hider' />
-          <div>Body Location destroyed,<br>instant death</div>
-        </div>
-      </div>
-
-      <div class='medicalg5 medicalG'>
-        Nose / Ear
-        <select name='attr_medical_nose/ear' class='full_width'>
-          <option selected='selected' value='0'>Nominal</option>
-          <option value='1'>01-20</option>
-          <option value='2'>21-25</option>
-          <option value='3'>26-30</option>
-          <option value='4'>31-40</option>
-          <option value='5'>41-59</option>
-          <option value='6'>60+</option>
-        </select>
-        <div>
-          <input name='attr_medical_nose/ear' type='checkbox' value='0' class='hidden hider' checked />
-          <div>No Effect / Healthy</div>
-          <input name='attr_medical_nose/ear' type='checkbox' value='1' class='hidden hider' />
-          <div>-2 Perception to smelling or hearing Perception tests</div>
-          <input name='attr_medical_nose/ear' type='checkbox' value='2' class='hidden hider' />
-          <div>-5 Perception to smelling or hearing Perception tests</div>
-          <input name='attr_medical_nose/ear' type='checkbox' value='3' class='hidden hider' />
-          <div>-10 Perception to smelling or hearing Perception tests</div>
-          <input name='attr_medical_nose/ear' type='checkbox' value='4' class='hidden hider' />
-          <div>-15 Perception to smelling or hearing Perception tests</div>
-          <input name='attr_medical_nose/ear' type='checkbox' value='5' class='hidden hider' />
-          <div>Body Location broken.<br>-20 Perception to smelling or hearing Perception tests</div>
-          <input name='attr_medical_nose/ear' type='checkbox' value='6' class='hidden hider' />
-          <div>Body Location destroyed,<br>cannot make or halve Perception to smelling or hearing tests</div>
-        </div>
-      </div>
-
-      <div class='medicalg6 medicalG'>
-        Limb (Arm / Leg)
-        <select name='attr_medical_arm/leg' class='full_width'>
-          <option selected='selected' value='0'>Nominal</option>
-          <option value='1'>01-20</option>
-          <option value='2'>21-25</option>
-          <option value='3'>26-30</option>
-          <option value='4'>31-40</option>
-          <option value='5'>41-59</option>
-          <option value='6'>60+</option>
-        </select>
-        <div>
-          <input name='attr_medical_arm/leg' type='checkbox' value='0' class='hidden hider' checked />
-          <div>No Effect / Healthy</div>
-          <input name='attr_medical_arm/leg' type='checkbox' value='1' class='hidden hider' />
-          <div>-2 Strength to Arm or<br>-2 Agility to Leg</div>
-          <input name='attr_medical_arm/leg' type='checkbox' value='2' class='hidden hider' />
-          <div>-5 Strength to Arm, or<br>-5 Agility to Leg</div>
-          <input name='attr_medical_arm/leg' type='checkbox' value='3' class='hidden hider' />
-          <div>-10 Strength to Arm, or<br>-10 Agility to Leg</div>
-          <input name='attr_medical_arm/leg' type='checkbox' value='4' class='hidden hider' />
-          <div>-15 Strength to Arm, or<br>-15 Agility to Leg</div>
-          <input name='attr_medical_arm/leg' type='checkbox' value='5' class='hidden hider' />
-          <div>Body Location damaged. -15 Strength to Arm, or -15 Agility to Leg. -5 to limb's Actions</div>
-          <input name='attr_medical_arm/leg' type='checkbox' value='6' class='hidden hider' />
-          <div>Body Location destroyed,<br>limb cannot be used<br>+3 Fatigue</div>
-        </div>
-      </div>
-
-      <div class='medicalg7 medicalG'>
-        Small / Large Intestines
-        <select name='attr_medical_small/large_intestines' class='full_width'>
-          <option selected='selected' value='0'>Nominal</option>
-          <option value='1'>01-20</option>
-          <option value='2'>21-25</option>
-          <option value='3'>26-30</option>
-          <option value='4'>31-40</option>
-          <option value='5'>41-59</option>
-          <option value='6'>60+</option>
-        </select>
-        <div>
-          <input name='attr_medical_small/large_intestines' type='checkbox' value='0' class='hidden hider' checked >
-          <div>No Effect / Healthy</div>
-          <input name='attr_medical_small/large_intestines' type='checkbox' value='1' class='hidden hider' />
-          <div>-2 Toughness + Agility</div>
-          <input name='attr_medical_small/large_intestines' type='checkbox' value='2' class='hidden hider' />
-          <div>-4 Toughness + Agility</div>
-          <input name='attr_medical_small/large_intestines' type='checkbox' value='3' class='hidden hider' />
-          <div>-6 Toughness + Agility</div>
-          <input name='attr_medical_small/large_intestines' type='checkbox' value='4' class='hidden hider' />
-          <div>-10 Toughness + Agility</div>
-          <input name='attr_medical_small/large_intestines' type='checkbox' value='5' class='hidden hider' />
-          <div>Body Location damaged.<br>+2 Fatigue, -15 Toughness + Agility</div>
-          <input name='attr_medical_small/large_intestines' type='checkbox' value='6' class='hidden hider' />
-          <div>Body Location destroyed,<br>+5 Fatigue, -20 Toughness + Agility</div>
-        </div>
-      </div>
-
-      <div class='medicalg8 medicalG'>
-        Lungs
-        <select name='attr_medical_lung' class='full_width'>
-          <option selected='selected' value='0'>Nominal</option>
-          <option value='1'>01-20</option>
-          <option value='2'>21-25</option>
-          <option value='3'>26-30</option>
-          <option value='4'>31-40</option>
-          <option value='5'>41-59</option>
-          <option value='6'>60+</option>
-        </select>
-        <div>
-          <input name='attr_medical_lung' type='checkbox' value='0' class='hidden hider' checked />
-          <div>No Effect / Healthy</div>
-          <input name='attr_medical_lung' type='checkbox' value='1' class='hidden hider' />
-          <div>-2 Toughness, stunned for<br>(D5-Toughness Modifier) rounds</div>
-          <input name='attr_medical_lung' type='checkbox' value='2' class='hidden hider' />
-          <div>-5 Toughness, stunned for<br>(2D5-Toughness Modifier) rounds</div>
-          <input name='attr_medical_lung' type='checkbox' value='3' class='hidden hider' />
-          <div>-10 Toughness, stunned for<br>(3D5-Toughness Modifier) rounds</div>
-          <input name='attr_medical_lung' type='checkbox' value='4' class='hidden hider' />
-          <div>-15 Toughness, stunned for<br>(4D5-Toughness Modifier) rounds</div>
-          <input name='attr_medical_lung' type='checkbox' value='5' class='hidden hider' />
-          <div>Body Location damaged.<br>-20 Toughness, stunned for<br>(5D5-Toughness Modifier) rounds</div>
-          <input name='attr_medical_lung' type='checkbox' value='6' class='hidden hider' />
-          <div>Body Location destroyed,<br>-25 Toughness, stunned for<br>(6D5-Toughness Modifier) rounds.<br>Character will take 2 wounds whenever they take a Movement Action quicker than 2 Meters per Turn.</div>
-        </div>
-      </div>
-
-      <div class='medicalg9 medicalG'>
-        Kidney / Stomach / Liver / Spleen
-        <select name='attr_medical_kidney/stomach/liver/spleen' class='full_width'>
-          <option selected='selected' value='0'>Nominal</option>
-          <option value='1'>01-20</option>
-          <option value='2'>21-25</option>
-          <option value='3'>26-30</option>
-          <option value='4'>31-40</option>
-          <option value='5'>41-59</option>
-          <option value='6'>60+</option>
-        </select>
-        <div>
-          <input name='attr_medical_kidney/stomach/liver/spleen' type='checkbox' value='0' class='hidden hider' checked />
-          <div>No Effect / Healthy</div>
-          <input name='attr_medical_kidney/stomach/liver/spleen' type='checkbox' value='1' class='hidden hider' />
-          <div>-2 Toughness + Agility</div>
-          <input name='attr_medical_kidney/stomach/liver/spleen' type='checkbox' value='2' class='hidden hider' />
-          <div>-4 Toughness + Agility</div>
-          <input name='attr_medical_kidney/stomach/liver/spleen' type='checkbox' value='3' class='hidden hider' />
-          <div>-6 Toughness + Agility</div>
-          <input name='attr_medical_kidney/stomach/liver/spleen' type='checkbox' value='4' class='hidden hider' />
-          <div>-10 Toughness + Agility</div>
-          <input name='attr_medical_kidney/stomach/liver/spleen' type='checkbox' value='5' class='hidden hider' />
-          <div>Body Location damaged.<br>+1 Fatigue, -15 Toughness + Agility</div>
-          <input name='attr_medical_kidney/stomach/liver/spleen' type='checkbox' value='6' class='hidden hider' />
-          <div>Body Location destroyed,<br>+5 Fatigue, -20 Toughness + Agility</div>
-        </div>
-      </div>
-
-      <div class='medicalg10 medicalG'>
-        Knee / Ankle / Shoulder / Elbow
-        <select name='attr_medical_knee/ankle/shoulder/elbow' class='full_width'>
-          <option selected='selected' value='0'>Nominal</option>
-          <option value='1'>01-20</option>
-          <option value='2'>21-25</option>
-          <option value='3'>26-30</option>
-          <option value='4'>31-40</option>
-          <option value='5'>41-59</option>
-          <option value='6'>60+</option>
-        </select>
-        <div>
-          <input name='attr_medical_knee/ankle/shoulder/elbow' type='checkbox' value='0' class='hidden hider' checked />
-          <div>No Effect / Healthy</div>
-          <input name='attr_medical_knee/ankle/shoulder/elbow' type='checkbox' value='1' class='hidden hider' />
-          <div>-2 Strength + Agility</div>
-          <input name='attr_medical_knee/ankle/shoulder/elbow' type='checkbox' value='2' class='hidden hider' />
-          <div>-4 Strength + Agility</div>
-          <input name='attr_medical_knee/ankle/shoulder/elbow' type='checkbox' value='3' class='hidden hider' />
-          <div>-6 Strength + Agility</div>
-          <input name='attr_medical_knee/ankle/shoulder/elbow' type='checkbox' value='4' class='hidden hider' />
-          <div>-10 Strength + Agility</div>
-          <input name='attr_medical_knee/ankle/shoulder/elbow' type='checkbox' value='5' class='hidden hider' />
-          <div>Body Location damaged.<br>+1 Fatigue, -15 Strength + Agility</div>
-          <input name='attr_medical_knee/ankle/shoulder/elbow' type='checkbox' value='6' class='hidden hider' />
-          <div>Body Location destroyed,<br>+5 Fatigue, -20 Strength + Agility</div>
-        </div>
-      </div>
-
-      <div class='medicalg11 medicalG'>
-        Eye
-        <select name='attr_medical_eye' class='full_width'>
-          <option selected='selected' value='0'>Nominal</option>
-          <option value='1'>01-20</option>
-          <option value='2'>21-25</option>
-          <option value='3'>26-30</option>
-          <option value='4'>31-40</option>
-          <option value='5'>41-59+</option>
-          <option value='6'>60+</option>
-        </select>
-        <div>
-          <input name='attr_medical_eye' type='checkbox' value='0' class='hidden hider' checked />
-          <div>No Effect / Healthy</div>
-          <input name='attr_medical_eye' type='checkbox' value='1' class='hidden hider' />
-          <div>-2 Perception to seeing tests</div>
-          <input name='attr_medical_eye' type='checkbox' value='2' class='hidden hider' />
-          <div>-5 Perception to seeing tests</div>
-          <input name='attr_medical_eye' type='checkbox' value='3' class='hidden hider' />
-          <div>-10 Perception to seeing tests</div>
-          <input name='attr_medical_eye' type='checkbox' value='4' class='hidden hider' />
-          <div>-12 Perception to seeing tests</div>
-          <input name='attr_medical_eye' type='checkbox' value='5' class='hidden hider' />
-          <div>Body Location broken.<br>-15 Perception to seeing tests</div>
-          <input name='attr_medical_eye' type='checkbox' value='6' class='hidden hider' />
-          <div>Body Location destroyed,<br>Character blinded for D5 rounds. -20 Perception to seeing tests</div>
-        </div>
-      </div>
-
-      <div class='medicalg12 medicalG'>
-        Mouth
-        <select name='attr_medical_mouth' class='full_width'>
-          <option selected='selected' value='0'>Nominal</option>
-          <option value='1'>01-20</option>
-          <option value='2'>21-25</option>
-          <option value='3'>26-30</option>
-          <option value='4'>31-40</option>
-          <option value='5'>41-59+</option>
-          <option value='6'>60+</option>
-        </select>
-        <div>
-          <input name='attr_medical_mouth' type='checkbox' value='0' class='hidden hider' checked />
-          <div>No Effect / Healthy</div>
-          <input name='attr_medical_mouth' type='checkbox' value='1' class='hidden hider' />
-          <div>-1 Toughness, -5 to speaking tests</div>
-          <input name='attr_medical_mouth' type='checkbox' value='2' class='hidden hider' />
-          <div>-3 Toughness, -5 to speaking tests</div>
-          <input name='attr_medical_mouth' type='checkbox' value='3' class='hidden hider' />
-          <div>-5 Toughness, -10 to speaking tests</div>
-          <input name='attr_medical_mouth' type='checkbox' value='4' class='hidden hider' />
-          <div>-8 Toughness, -10 to speaking tests</div>
-          <input name='attr_medical_mouth' type='checkbox' value='5' class='hidden hider' />
-          <div>Body Location broken.<br>+1 Fatigue, -12 Toughness, -15 to speaking tests</div>
-          <input name='attr_medical_mouth' type='checkbox' value='6' class='hidden hider' />
-          <div>Body Location destroyed,<br>+2 Fatigue, -15 Toughness, -15 to speaking tests</div>
-        </div>
-      </div>
-
-      <div class='medicalg13 medicalG'>
-        Hand
-        <select name='attr_medical_hand' class='full_width'>
-          <option selected='selected' value='0'>Nominal</option>
-          <option value='1'>01-20</option>
-          <option value='2'>21-25</option>
-          <option value='3'>26-30</option>
-          <option value='4'>31-40</option>
-          <option value='5'>41-59+</option>
-          <option value='6'>60+</option>
-        </select>
-        <div>
-          <input name='attr_medical_hand' type='checkbox' value='0' class='hidden hider' checked />
-          <div>No Effect / Healthy</div>
-          <input name='attr_medical_hand' type='checkbox' value='1' class='hidden hider' />
-          <div>-3 to both Warfare stats if hand is used to Attack</div>
-          <input name='attr_medical_hand' type='checkbox' value='2' class='hidden hider' />
-          <div>-5 to both Warfare stats if hand is used to Attack</div>
-          <input name='attr_medical_hand' type='checkbox' value='3' class='hidden hider' />
-          <div>-10 to both Warfare stats if hand is used to Attack</div>
-          <input name='attr_medical_hand' type='checkbox' value='4' class='hidden hider' />
-          <div>-13 to both Warfare stats if hand is used to Attack</div>
-          <input name='attr_medical_hand' type='checkbox' value='5' class='hidden hider' />
-          <div>Body Location broken.<br>-15 to both Warfare stats if hand is used to Attack</div>
-          <input name='attr_medical_hand' type='checkbox' value='6' class='hidden hider' />
-          <div>Body Location destroyed,<br>Character cannot use the hand for any Actions</div>
-        </div>
-      </div>
-
-      <div class='medicalg14 medicalG'>
-        Chin / Jaw / Cheek
-        <select name='attr_medical_chin/jaw/cheek' class='full_width'>
-          <option selected='selected' value='0'>Nominal</option>
-          <option value='1'>01-20</option>
-          <option value='2'>21-25</option>
-          <option value='3'>26-30</option>
-          <option value='4'>31-40</option>
-          <option value='5'>41-59+</option>
-          <option value='6'>60+</option>
-        </select>
-        <div>
-          <input name='attr_medical_chin/jaw/cheek' type='checkbox' value='0' class='hidden hider' checked />
-          <div>No Effect / Healthy</div>
-          <input name='attr_medical_chin/jaw/cheek' type='checkbox' value='1' class='hidden hider' />
-          <div>-2 Toughness</div>
-          <input name='attr_medical_chin/jaw/cheek' type='checkbox' value='2' class='hidden hider' />
-          <div>-4 Toughness, -5 to speaking tests</div>
-          <input name='attr_medical_chin/jaw/cheek' type='checkbox' value='3' class='hidden hider' />
-          <div>-6 Toughness, -10 to speaking tests</div>
-          <input name='attr_medical_chin/jaw/cheek' type='checkbox' value='4' class='hidden hider' />
-          <div>+1 Fatigue, -10 Toughness, -10 to speaking tests</div>
-          <input name='attr_medical_chin/jaw/cheek' type='checkbox' value='5' class='hidden hider' />
-          <div>Body Location damaged.<br>+2 Fatigue, -15 Toughness, -15 to speaking tests</div>
-          <input name='attr_medical_chin/jaw/cheek' type='checkbox' value='6' class='hidden hider' />
-          <div>Body Location destroyed,<br>+3 Fatigue, -20 Toughness, -20 to speaking tests</div>
-        </div>
-      </div>
-
-      <div class='medicalg15 medicalG'>
-        Foot
-        <select name='attr_medical_foot' class='full_width'>
-          <option selected='selected' value='0'>Nominal</option>
-          <option value='1'>01-20</option>
-          <option value='2'>21-25</option>
-          <option value='3'>26-30</option>
-          <option value='4'>31-40</option>
-          <option value='5'>41-59+</option>
-          <option value='6'>60+</option>
-        </select>
-        <div>
-          <input name='attr_medical_foot' type='checkbox' value='0' class='hidden hider' checked />
-          <div>No Effect / Healthy</div>
-          <input name='attr_medical_foot' type='checkbox' value='1' class='hidden hider' />
-          <div>-5 to Agility when figuring Movement Speed</div>
-          <input name='attr_medical_foot' type='checkbox' value='2' class='hidden hider' />
-          <div>-10 to Agility when figuring Movement Speed</div>
-          <input name='attr_medical_foot' type='checkbox' value='3' class='hidden hider' />
-          <div>-15 to Agility when figuring Movement Speed</div>
-          <input name='attr_medical_foot' type='checkbox' value='4' class='hidden hider' />
-          <div>-20 to Agility when figuring Movement Speed</div>
-          <input name='attr_medical_foot' type='checkbox' value='5' class='hidden hider' />
-          <div>Body Location broken.<br>-25 to Agility when figuring Movement Speed</div>
-          <input name='attr_medical_foot' type='checkbox' value='6' class='hidden hider' />
-          <div>Body Location destroyed,<br>Character cannot use the Foot for any Actions. Half Move reduced to 1 Meter, Full Move reduced to 2 Meters, Charge and Run are impossible.</div>
-        </div>
-      </div>
-
-      <div class='medicalg16 medicalG'>
-        Pelvis
-        <select name='attr_medical_pelvis' class='full_width'>
-          <option selected='selected' value='0'>Nominal</option>
-          <option value='1'>01-20</option>
-          <option value='2'>21-25</option>
-          <option value='3'>26-30</option>
-          <option value='4'>31-40</option>
-          <option value='5'>41-59+</option>
-          <option value='6'>60+</option>
-        </select>
-        <div>
-          <input name='attr_medical_pelvis' type='checkbox' value='0' class='hidden hider' checked />
-          <div>No Effect / Healthy</div>
-          <input name='attr_medical_pelvis' type='checkbox' value='1' class='hidden hider' />
-          <div>-1 Toughness, -4 Agility</div>
-          <input name='attr_medical_pelvis' type='checkbox' value='2' class='hidden hider' />
-          <div>-3 Toughness, -6 Agility</div>
-          <input name='attr_medical_pelvis' type='checkbox' value='3' class='hidden hider' />
-          <div>-6 Toughness, -8 Agility</div>
-          <input name='attr_medical_pelvis' type='checkbox' value='4' class='hidden hider' />
-          <div>-8 Toughness, -12 Agility</div>
-          <input name='attr_medical_pelvis' type='checkbox' value='5' class='hidden hider' />
-          <div>Body Location damaged.<br>-20 Toughness + Agility</div>
-          <input name='attr_medical_pelvis' type='checkbox' value='6' class='hidden hider' />
-          <div>Body Location destroyed,<br>-30 Toughness + Agility</div>
-        </div>
-      </div>
-
-      <div class='medicalg17 medicalG'>
-        Chest
-        <select name='attr_medical_chest' class='full_width'>
-          <option selected='selected' value='0'>Nominal</option>
-          <option value='1'>01-20</option>
-          <option value='2'>21-25</option>
-          <option value='3'>26-30</option>
-          <option value='4'>31-40</option>
-          <option value='5'>41-59+</option>
-          <option value='6'>60+</option>
-        </select>
-        <div>
-          <input name='attr_medical_chest' type='checkbox' value='0' class='hidden hider' checked />
-          <div>No Effect / Healthy</div>
-          <input name='attr_medical_chest' type='checkbox' value='1' class='hidden hider' />
-          <div>-2 Toughness</div>
-          <input name='attr_medical_chest' type='checkbox' value='2' class='hidden hider' />
-          <div>-4 Toughness</div>
-          <input name='attr_medical_chest' type='checkbox' value='3' class='hidden hider' />
-          <div>-8 Toughness, stunned for 1D5 rounds</div>
-          <input name='attr_medical_chest' type='checkbox' value='4' class='hidden hider' />
-          <div>-10 Toughness, stunned for 2D5 rounds</div>
-          <input name='attr_medical_chest' type='checkbox' value='5' class='hidden hider' />
-          <div>Body Location broken.<br>-15 Toughness, stunned for 3D5 rounds</div>
-          <input name='attr_medical_chest' type='checkbox' value='6' class='hidden hider' />
-          <div>Body Location destroyed,<br>instant death</div>
-        </div>
-      </div>
-
-      <div class='medicalgT'>
-        <div class='medical_background'>
-          <label class='medical_initial_label'><h2 class='medical_h2 medical_h2_rollable radius_border_top'>Hit Location</h2> <button type='roll' name='button' value='@{to-gm}&{template:mythic} {{loc=[[1d100]]}}' class='hidden'></button></label>
-          <h3> 01-10 HEAD</h3>
-          <div class='medical_table'> 01 Neck</div>
-          <div class='medical_table'> 02 Chin</div>
-          <div class='medical_table'> 03 Mouth</div>
-          <div class='medical_table'> 04-05 Nose</div>
-          <div class='medical_table'> 06-07 Cheeks</div>
-          <div class='medical_table'> 08 Eyes</div>
-          <div class='medical_table'> 09 Forehead</div>
-          <div class='medical_table'> 10 Ear</div>
-          <h3>11-20 LEFT ARM</h3>
-          <div class='medical_table'>11 Fingers</div>
-          <div class='medical_table'>12 Hands</div>
-          <div class='medical_table'>13-15 Forearm</div>
-          <div class='medical_table'>16 Elbow</div>
-          <div class='medical_table'>17-19 Bicep</div>
-          <div class='medical_table'>20 Shoulder</div>
-          <h3>21-30 RIGHT ARM</h3>
-          <div class='medical_table'>21 Fingers</div>
-          <div class='medical_table'>22 Hands</div>
-          <div class='medical_table'>23-25 Forearm</div>
-          <div class='medical_table'>26 Elbow</div>
-          <div class='medical_table'>27-29 Bicep</div>
-          <div class='medical_table'>30 Shoulder</div>
-          <h3>31-45 LEFT LEG</h3>
-          <div class='medical_table'>31 Toes</div>
-          <div class='medical_table'>32 Foot</div>
-          <div class='medical_table'>33 Ankle</div>
-          <div class='medical_table'>34-37 Shin</div>
-          <div class='medical_table'>38 Knee</div>
-          <div class='medical_table'>39-43 Thigh</div>
-          <div class='medical_table'>44-45 Pelvis</div>
-          <h3>46-61 RIGHT LEG</h3>
-          <div class='medical_table'>46 Toes</div>
-          <div class='medical_table'>47 Foot</div>
-          <div class='medical_table'>48 Ankle</div>
-          <div class='medical_table'>49-53 Shin</div>
-          <div class='medical_table'>54 Knee</div>
-          <div class='medical_table'>55-58 Thigh</div>
-          <div class='medical_table'>59-60 Pelvis</div>
-          <h3>62-100 CHEST</h3>
-          <div class='medical_table'>61-66 Small Intestines</div>
-          <div class='medical_table'>67-72 Large Intestines</div>
-          <div class='medical_table'>73-78 Kidney</div>
-          <div class='medical_table'>79-84 Stomach / Liver</div>
-          <div class='medical_table'>85-89 Heart</div>
-          <div class='medical_table'>90-96 Lungs</div>
-          <div class='medical_table radius_border_bottom'>97-100 No Organ Hit</div>
-        </div>
-        <div class='medical_background'>
-          <h3 class='radius_border_top'>ROLL LOCATION (optional)</h3>
-          <div class='medical_table'>1-3 Left</div>
-          <div class='medical_table'>  4-7 Center</div>
-          <div class='medical_table radius_border_bottom'>8-10 Right</div>
-        </div>
-        <div class='medical_background'>
-          <h3 class='radius_border_top'>IF Fingers / Toes 1D10</h3>
-          <div class='medical_table'>1-2 Pinky Finger / Toe</div>
-          <div class='medical_table'>3-4 Ring Finger / Toe</div>
-          <div class='medical_table'>5-6 Middle Finger / Toe</div>
-          <div class='medical_table'>7-8 Index Finger / Toe</div>
-          <div class='medical_table radius_border_bottom'>  9-10 Thumb Finger / Toe</div>
-        </div>
-      </div>
-
-      <div class='medicalgR ssc'>
-        <div class='medical_h2_background'>
-          <h2 class='medical_h2 radius_border_top'>Medical Information</h2>
-        </div>
-        <!-- Every textarea element requires a closing tag; cannot be a void element. -->
-        <textarea name='attr_medical_textfield' class='radius_border_bottom' placeholder='Not all injuries in 100DOS are lethal. Exhaustion, combat trauma, or exchanging blows with bare fists can all leave a character tattered, but intact. Fatigue measures the amount of non-lethal injury a character can take. For every level of Fatigue a Character has, they take a -5 Penalty to all Tests made.&#10;&#10;Once a Character surpasses their Toughness Modifier, multiplied by 2, in Fatigue, they fall into a coma. The Character’s coma will last one hour for every level of Fatigue the Character has. Every hour that passes, the level of Fatigue is reduced by one. The Character may wake up once their level of Fatigue is their Toughness Modifier or lower.'></textarea>
-        <fieldset class='repeating_medical'>
-          <textarea name='attr_medical_textfield' class='radius_border_bottom'></textarea>
-        </fieldset>
-      </div>
-
-    </div>
-  </div>
+</div>
 
 
 
-  <!-- ______________________________ start of tab Advancements ______________________________ -->
+<!-- ______________________________ start of tab Settings ______________________________ -->
 
-  <div class='advancements box radius_border_box ssc'>
+<div class='settings box radius_border_box'>
+  <!-- Settings -->
+  <h2>Settings</h2>
+  <h3>Species Overrides</h3>
+  <select name='attr_settings_race' class='full_width edge_padding'>
+    <option selected='selected' value='0'>Racial Features: N/A </option>
+    <option value='1'>Spartan 2 / Spartan 3 / Spartan 4 </option>
+    <option value='2'>Sangheili / Elite </option>
+    <option value='1'>Jiralhanae / Brutes </option>
+    <option value='3'>Kig-yar Ruutian / Halo Trilogy Jackals </option>
+    <option value='4'>Kig-yar T'vaoan / Halo Reach Jackals / Skirmishers </option>
+    <option value='3'>Kig-yar Ibie'shan / Halo 4/5 Jackals </option>
+    <option value='5'>Mgalekgolo / Hunters </option>
+    <option value='1'>Promethean Knight </option>
+    <option value='6'>Dont Auto Calculate Speed And Weight</option>
+  </select>
+  <br>
 
-    <h2>Experience Summary</h2>
-    <div class='text_centered'>
-      Unspent XP: <input name='attr_xp_current' type='number' value='@{xp_total}-@{xp_spent}' class='numerical_field' readonly />
-      Spent XP: <input name='attr_xp_spent' type='number' value='@{xp_total}-(@{advancement_costL}+@{advancement_costR})' class='numerical_field' readonly />
-      XP Total: <input name='attr_xp_total' type='number' class='numerical_field end_field' />
-    </div>
-    <br>
-    <div class='advancements_grid equipment_header'>
-      <div class='advancements_grid_gs1'>Name</div>
-      <div class='advancements_grid_gs2'>XP Cost</div>
-      <div class='advancements_grid_gs3'>Page #</div>
-      <div class='advancements_grid_gs4'>Name</div>
-      <div class='advancements_grid_gs5'>XP Cost</div>
-      <div class='advancements_grid_gs6'>Page #</div>
-    </div>
-    <div class='advancements_grid'>
-      <input class='advancements_grid_gs1' name='attr_advancement_nameL' type='text' placeholder='Write XP-costing item name here' />
-      <input class='advancements_grid_gs2' name='attr_advancement_costL' type='number' placeholder='XP Cost' />
-      <input class='advancements_grid_gs3' name='attr_advancement_pg#L' type='number' placeholder='Page #'  />
-      <input class='advancements_grid_gs4' name='attr_advancement_nameR' type='text' placeholder='Write XP-costing item name here' />
-      <input class='advancements_grid_gs5' name='attr_advancement_costR' type='number' placeholder='XP Cost' />
-      <input class='advancements_grid_gs6' name='attr_advancement_pg#R' type='number' placeholder='Page #' />
-    </div>
-    <fieldset name='advancements' class='repeating_advancements'>
-      <div class='advancements_grid'>
-        <input class='advancements_grid_gs1' name='attr_advancement_nameL_r' type='text' placeholder='Write XP-costing item name here' />
-        <input class='advancements_grid_gs2' name='attr_advancement_costL_r' type='number' placeholder='XP Cost' />
-        <input class='advancements_grid_gs3' name='attr_advancement_pg#L_r' type='number' placeholder='Page #'  />
-        <input class='advancements_grid_gs4' name='attr_advancement_nameR_r' type='text' placeholder='Write XP-costing item name here' />
-        <input class='advancements_grid_gs5' name='attr_advancement_costR_r' type='number' placeholder='XP Cost' />
-        <input class='advancements_grid_gs6' name='attr_advancement_pg#R_r' type='number' placeholder='Page #' />
-      </div>
-    </fieldset>
+  <h3>Initiative Overrides</h3>
+  <select name='attr_initmod0' class='full_width edge_padding'>
+    <option selected='selected' value='[[floor'>No tiebreaker</option>
+    <option value='[['>Decimal tiebreaker</option>
+    <option value='tiebreaker [[@{AGI_total}]] roll [[floor'>AGI tiebreaker</option>
+  </select>
+  <br>
 
-    <div class='training'>
-      <div class='faction_training ssc auto_margin 90width radius_border'>
-        <h3 class='radius_border_top'>Faction Training</h3>
-        <div class='faction_training_grid'>
-          <div class='faction_training_grid_g1'><input name='attr_faction_training_human' type='checkbox' value='1'>U.N.S.C.</div>
-          <div class='faction_training_grid_g2'><input name='attr_faction_training_forerunner' type='checkbox' value='1'>Forerunner</div>
-          <div class='faction_training_grid_g3'><input name='attr_faction_training_covenant' type='checkbox' value='1'>Covenant / Banished</div>
-        </div>
-      </div>
-      <div class='weapon_training ssc auto_margin 90width radius_border'>
-        <h3 class='radius_border_top'>Weapon Training</h3>
-        <div class='weapon_training_grid'>
-          <div><input name='attr_weapons_training_basic' type='checkbox' />Basic</div>
-          <div><input name='attr_weapons_training_infantry' type='checkbox' />Infantry</div>
-          <div><input name='attr_weapons_training_vehicle' type='checkbox' />Vehicle</div>
-          <div><input name='attr_weapons_training_melee' type='checkbox' />Melee</div>
-          <div><input name='attr_weapons_training_heavy' type='checkbox' />Heavy</div>
-          <div><input name='attr_weapons_training_special' type='checkbox' />Advanced</div>
-          <div><input name='attr_weapons_training_long-range' type='checkbox' />Long-Range</div>
-          <div><input name='attr_weapons_training_explosives' type='checkbox' />Explosives</div>
-        </div>
-      </div>
-    </div>
+  <h3>Auto Roll Hit Locations</h3>
+  <select name='attr_settings_hitroll' class='full_width edge_padding'>
+    <option value='{{loc=[[1d100]]}}'selected='selected'>Automatically roll hit locations</option>
+    <option value=' '>Don't automatically roll hit locations</option>
+  </select>
+  <br>
 
-  </div>
+  <h3>Weapon Description in Damage Roll</h3>
+  <select name='attr_settings_weapondescription' class='full_width edge_padding'>
+    <option value='description'>Include weapon description</option>
+    <option value=' 'selected='selected'>Exclude weapon description</option>
+  </select>
+  <br>
 
+  <h3>Calculate The Negative Impact Of Fatigue Automatically</h3>
+  <select name='attr_settings_fatigue' class='full_width edge_padding'>
+    <option value='0'selected='selected'>Auto calculate Fatigue</option>
+    <option value='1'>Dont auto calculate Fatigue</option>
+  </select>
+  <br>
 
-
-  <!-- ______________________________ start of tab Journal ______________________________ -->
-
-  <div class='journal box radius_border_box'>
-    <!-- Journal -->
-    <h2>Journal: Objectives</h2>
-    <div class='edge_padding ssc'>
-      <fieldset name='objectives' class='repeating_objectives'>
-        <input name='attr_objective' type='text' class='full_width_30px' />
-        <label class='margin_adjust'><input type='checkbox' name='attr_objective_completed' value='1' class='select_button hidden' /><span class='select_text '>✔</span></label>
-      </fieldset>
-    </div>
-    <h2>Journal: Notes</h2>
-    <div class='edge_padding ssc'>
-      <fieldset name='notes' class='repeating_notes'>
-        <!-- insert new line html entity [&#10;] inside of placeholder attribute -->
-        <textarea name='attr_notes'
-        placeholder='Enter information such as plot details, unresolved mission details such as escaped targets, character relationships, et cetera here.&#10;
-        &#10;Also feel free to write appearance details here or in Bio & Info for public viewing: age, height, weight, colors of eyes, hair, skin, more that come to mind.&#10;
-        &#10;See Medical tab to include any medical information such as character injuries.'></textarea>
-      </fieldset>
-    </div>
-  </div>
-
-
-
-  <!-- ______________________________ start of tab Vehicles ______________________________ -->
-
-  <div class='vehicles box ssc radius_border_box'>
-    <!-- Vehicles -->
-    <div class='vehicles_divider'>
-      <fieldset name='vehicles-R' class='repeating_vehicles'>
-        <div class='vehicles_grid1'>
-          <input name='attr_vehicle-name' type='text' class='vehicles_Gn full_width' placeholder='Name' />
-
-          <select name='attr_vehicle-shield' class='vehicles_Gs full_width'>
-            <option value='0' selected='selected'>Unshielded</option>
-            <option value='1'>Shielded</option>
-          </select>
-
-          <select name='attr_vehicle-type' class='vehicles_Gt full_width'>
-            <option value='0' selected='selected'>Ground</option>
-            <option value='1'>Air</option>
-            <option value='2'>Walker</option>
-            <option value='3'>Stationary</option>
-          </select>
-          <div class='vehicles_G1'><h3>DIMENSIONS</h3></div>
-          <div class='vehicles_G2'>Length</div>
-          <div class='vehicles_G3'>Width</div>
-          <div class='vehicles_G4'>Height</div>
-          <div class='vehicles_G5'>Weight</div>
-          <input name='attr_vehicle-length' type='text' class='vehicles_G6 full_width' placeholder='# Meters' />
-          <input name='attr_vehicle-width' type='text' class='vehicles_G7 full_width' placeholder='# Meters' />
-          <input name='attr_vehicle-height' type='text' class='vehicles_G8 full_width' placeholder='# Meters' />
-          <input name='attr_vehicle-weight' type='text' class='vehicles_G9 full_width' placeholder='KG / Metric Tons' />
-
-          <input name='attr_vehicle-type' type='checkbox' value='0' class='hidden hider' checked />
-          <div class='vehicles_G10'><h3>SPEED AND MANEUVERABILITY</h3></div>
-          <input name='attr_vehicle-type' type='checkbox' value='1' class='hidden hider' />
-          <div class='vehicles_G10'><h3>SPEED AND MANEUVERABILITY</h3></div>
-          <input name='attr_vehicle-type' type='checkbox' value='2' class='hidden hider' />
-          <div class='vehicles_G10'><h3>CHARACTERISTICS</h3></div>
-
-          <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
-          <div class='vehicles_G11'>Accelerate</div>
-          <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
-          <div class='vehicles_G12'>Brake</div>
-          <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
-          <div class='vehicles_G13'>Top Speed</div>
-          <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
-          <div class='vehicles_G14'>Maneuver</div>
-          <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
-          <input name='attr_vehicle-accelerate' type='text' class='vehicles_G15 full_width' placeholder='Meters per Turn' />
-          <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
-          <input name='attr_vehicle-brake' type='text' class='vehicles_G16 full_width' placeholder='Meters per Turn' />
-          <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
-          <input name='attr_vehicle-top_speed' type='text' class='vehicles_G17 full_width' placeholder='MpT/(# km/h)' />
-          <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
-          <input name='attr_vehicle-maneuver' type='text' class='vehicles_G18 full_width' placeholder="Pilot's Evasion" />
-
-          <input name='attr_vehicle-type' type='checkbox' value='1' class='hidden hider' />
-          <div class='vehicles_G19'>Vertical</div>
-          <input name='attr_vehicle-type' type='checkbox' value='1' class='hidden hider' />
-          <div class='vehicles_G20'>Takeoff</div>
-          <input name='attr_vehicle-type' type='checkbox' value='1' class='hidden hider' />
-          <div class='vehicles_G21'>Target Range</div>
-          <input name='attr_vehicle-type' type='checkbox' value='1' class='hidden hider' />
-          <div class='vehicles_G22'>Targeting</div>
-          <input name='attr_vehicle-type' type='checkbox' value='1' class='hidden hider' />
-          <input name='attr_vehicle-vertical' type='text' class='vehicles_G23 full_width' placeholder='MpT' />
-          <input name='attr_vehicle-type' type='checkbox' value='1' class='hidden hider' />
-          <input name='attr_vehicle-takeoff' type='text' class='vehicles_G24 full_width' placeholder='Min Half-Actions' />
-          <input name='attr_vehicle-type' type='checkbox' value='1' class='hidden hider' />
-          <input name='attr_vehicle-target_range' type='text' class='vehicles_G25 full_width' placeholder='Meters' />
-          <input name='attr_vehicle-type' type='checkbox' value='1' class='hidden hider' />
-          <input name='attr_vehicle-targeting' type='text' class='vehicles_G26 full_width' placeholder='Min Half-Actions' />
-
-          <input name='attr_vehicle-type' type='checkbox' value='2' class='hidden hider' />
-          <div class='vehicles_G27'>Strength</div>
-          <input name='attr_vehicle-type' type='checkbox' value='2' class='hidden hider full_width' />
-          <div class='vehicles_G28'>Melee</div>
-          <input name='attr_vehicle-type' type='checkbox' value='2' class='hidden hider' />
-          <input type='text' name='attr_vehicle-strength' class='vehicles_G29 full_width'/>
-          <input name='attr_vehicle-type' type='checkbox' value='2' class='hidden hider' />
-          <input name='attr_vehicle-melee' type='text' class='vehicles_G30 full_width' />
-
-          <input name='attr_vehicle-type' type='checkbox' value='2' class='hidden hider' />
-          <input name='attr_vehicle-strength-mythic' class='vehicles_G31 full_width' type='text' />
-          <input name='attr_vehicle-type' type='checkbox' value='2' class='hidden hider' />
-          <div class='vehicles_G32'>Mythic</div>
-
-          <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
-          <div class='vehicles_G33'><h3>CREW AND COMPLEMENT</h3></div>
-          <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
-          <div class='vehicles_G34'>Crew</div>
-          <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
-          <div class='vehicles_G35'>Complement</div>
-          <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
-          <input name='attr_vehicle-crew' type='text' class='vehicles_G36 full_width' placeholder='Minimum Crew Prerequisite' />
-          <input name='attr_vehicle-type' type='checkbox' value='3' class='hidden hidernot' />
-          <input name='attr_vehicle-compliment' type='text' class='vehicles_G37 full_width' placeholder='Maximum Crew Space' />
-          <div class='vehicles_G38'><h3>HULL</h3></div>
-          <div class='vehicles_G39'>Hull Material</div>
-          <input name='attr_vehicle-hull' type='text' class='vehicles_G40 full_width' placeholder='Alloy Composition & Plating' />
-        </div>
-        <div class='vehicles_grid2'>
-          <div class='vehicles_G41'><h3>BREAKPOINTS</h3></div>
-          <div class='vehicles_G42'>1-20 Wep</div>
-          <div class='vehicles_G43'>21-40 Mob</div>
-          <div class='vehicles_G44'>41-60 Eng</div>
-          <div class='vehicles_G45'>61-80 Optic</div>
-          <div class='vehicles_G46'>81-100 Crew</div>
-          <input name='attr_vehicle-bp-wep' type='text' class='vehicles_G47 full_width' placeholder='Weapon' />
-          <input name='attr_vehicle-bp-mod' type='text' class='vehicles_G48 full_width' placeholder='Mobility' />
-          <input name='attr_vehicle-bp-eng'type='text' class='vehicles_G49 full_width' placeholder='Engine' />
-          <input name='attr_vehicle-bp-op'type='text' class='vehicles_G50 full_width' placeholder='Optic' />
-          <input name='attr_vehicle-bp-crew'type='text' class='vehicles_G51 full_width' placeholder='Compartment' />
-          <div class='vehicles_G52'><h3>Armor</h3></div>
-          <div class='vehicles_G53'>Front</div>
-          <div class='vehicles_G54'>Back</div>
-          <div class='vehicles_G55'>Side</div>
-          <div class='vehicles_G56'>Top</div>
-          <div class='vehicles_G57'>Bottom</div>
-          <input name='attr_vehicle-armor-front' type='text' class='vehicles_G58 full_width' />
-          <input name='attr_vehicle-armor-back' type='text' class='vehicles_G59 full_width' />
-          <input name='attr_vehicle-armor-side' type='text' class='vehicles_G60 full_width' />
-          <input name='attr_vehicle-armor-top' type='text' class='vehicles_G61 full_width' />
-          <input name='attr_vehicle-armor-bottom' type='text' class='vehicles_G62 full_width' />
-        </div>
-        <div class='vehicles_grid3'>
-          <div class='vehicles_G63'><h3>Miscellaneous</h3></div>
-          <div class='vehicles_G64'>Size Points</div>
-          <div class='vehicles_G65'>Weapon Points</div>
-          <input name='attr_vehicle-size-points' type='text' class='vehicles_G66 full_width' placeholder='Warthog = 2' />
-          <input name='attr_vehicle-weapon-points' type='text' class='vehicles_G67 full_width' placeholder='Warthog = 2' />
-
-          <input name='attr_vehicle-shield' type='checkbox' value='1' class='hidden hider' />
-          <div class='vehicles_G68'>Shield Rating</div>
-          <input name='attr_vehicle-shield' type='checkbox' value='1' class='hidden hider' />
-          <div class='vehicles_G69'>Shield Current</div>
-          <input name='attr_vehicle-shield' type='checkbox' value='1' class='hidden hider' />
-          <div class='vehicles_G70'>Recharge Delay</div>
-          <input name='attr_vehicle-shield' type='checkbox' value='1' class='hidden hider' />
-          <div class='vehicles_G71'>Recharge Rate</div>
-          <input name='attr_vehicle-shield' type='checkbox' value='1' class='hidden hider' />
-          <input name='attr_vehicle-shield-rating' type='text' class='vehicles_G72 full_width' />
-          <input name='attr_vehicle-shield' type='checkbox' value='1' class='hidden hider' />
-          <input name='attr_vehicle-shield-current' type='text' class='vehicles_G73 full_width' />
-          <input name='attr_vehicle-shield' type='checkbox' value='1' class='hidden hider' />
-          <input name='attr_vehicle-recharge-delay' type='text' class='vehicles_G74 full_width' />
-          <input name='attr_vehicle-shield' type='checkbox' value='1' class='hidden hider' />
-          <input name='attr_vehicle-recharge-rate' type='text' class='vehicles_G75 full_width' />
-
-          <div class='vehicles_G76 '>
-            <div>
-              <input name='attr_aditional_info' type='text' placeholder='Additional Info' class='full_width_49px' />
-              <label class='margin_adjust'><input type='checkbox' name='attr_collapse' value='5' class='collapsible_entity_switch select_button hidden' /><span class='select_text '>▼</span></label>
-              <label class='margin_adjust2'><button type='roll' value='@{to-gm}&{template:mythic} {{name=@{aditional_info} }} {{description=@{aditional_info_desc} }}' class='hidden'></button><span class='select_text'>❖</span></label>
-              <input name='attr_collapse' type='checkbox'  value='5' class='collapsible_entity_switch hidden' />
-              <textarea name='attr_aditional_info_desc' class='collapsible_entity_block' placeholder='Enter any vehicle-specific rules or other unique information here.'></textarea>
-            </div>
-            <div>
-              <input name='attr_modifications' type='text' placeholder='Modifications' class='full_width_49px vehicles_descriptor' />
-              <label class='margin_adjust'><input type='checkbox' name='attr_collapse2' value='6' class='collapsible_entity_switch select_button hidden' /><span class='select_text radius_border_right'>▼</span></label>
-              <label class='margin_adjust2'><button type='roll' value='@{to-gm}&{template:mythic} {{name=@{modifications} }} {{description=@{modifications_desc} }}' class='hidden'></button><span class='select_text'>❖</span></label>
-              <input name='attr_collapse2' type='checkbox'  value='6' class='collapsible_entity_switch hidden' />
-              <textarea name='attr_modifications_desc' class='collapsible_entity_block description_rounded_margin' placeholder='Vehicles in Halo Mythic can be modified in many ways.  These use a Vehicle’s Weapon Points and Size Points, which are specialized Hardpoints on a Vehicle.  Each Modification takes a specified amount of Weapon and Size Points.
-              &#10;Vehicle modifications are classified into five categories; Body, Propulsion, Electronic, Combat, and Miscellaneous.'></textarea>
-            </div>
-          </div>
-        </div>
-        <br>
-      </fieldset>
-
-      <div class='vehicle_weapons'>
-        <div class='equipment_ranged_weapons'>
-          <h3 class='radius_border_top'>Vehicle Ranged Weapons</h3>
-          <fieldset name='vehiclerangedweapons' class='repeating_vrangedweapons'>
-            <div class='equipment_ranged_weapons_rep'>
-              <div class='equipment_ranged_weapons_grid1'>
-                <div class='equipment_ranged_weapons_gs1'>Name</div>
-                <input class='equipment_ranged_weapons_gs2 full_width' type='text' name='attr_V_R_weapon_name' placeholder='Name' />
-                <div class='equipment_ranged_weapons_gs3'>Type</div>
-                <input class='equipment_ranged_weapons_gs4 full_width' type='text' name='attr_V_R_weapon_class' placeholder='Class of Weapon' />
-              </div>
-              <div class='equipment_ranged_weapons_grid2'>
-                <div class='equipment_ranged_weapons_gs5'>Range</div>
-                <input class='equipment_ranged_weapons_gs6 full_width' type='text' value='0' name='attr_V_R_weapon_range' />
-                <div class='equipment_ranged_weapons_gs7'>DMG Roll</div>
-                <input class='equipment_ranged_weapons_gs8 full_width' type='text' value='0' name='attr_V_R_weapon_dam-roll' />
-                <div class='equipment_ranged_weapons_gs9'>Base</div>
-                <input class='equipment_ranged_weapons_gs10 full_width' type='text' value='0' name='attr_V_R_weapon_base' />
-                <div class='equipment_ranged_weapons_gs11'>Pierce</div>
-                <input class='equipment_ranged_weapons_gs12 full_width' type='text' value='0' name='attr_V_R_weapon_pierce' />
-              </div>
-              <div class='equipment_ranged_weapons_grid3'>
-                <div class='equipment_ranged_weapons_gs13'>Hit Mod</div>
-                <input class='equipment_ranged_weapons_gs14 full_width' type='text' value='0' name='attr_V_R_weapon_mod1' />
-                <div class='equipment_ranged_weapons_gs15'>Magazine</div>
-                <input class='equipment_ranged_weapons_gs16 full_width' type='text' value='0' name='attr_V_R_weapon_mag' />
-                <div class='equipment_ranged_weapons_gs17'>/</div>
-                <input class='equipment_ranged_weapons_gs18 full_width' type='text' value='0' name='attr_V_R_weapon_mag_max' />
-                <button class='equipment_ranged_weapons_gs19 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }} {{weapon= @{V_R_weapon_name}}} {{roll=[[floor(([[@{WFR}+@{WFR_advancement}+@{fatigue_mod}]]+@{V_R_weapon_mod1}+@{inlinemod-toggle}-1d100)/10)]]}} @{settings_hitroll}"></button>' >Hit</button>
-                <button class='equipment_ranged_weapons_gs20 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{weapon= @{V_R_weapon_name}}} {{damage=[[@{V_R_weapon_dam-roll}+@{V_R_weapon_base}]] }} {{pierce=[[@{V_R_weapon_pierce}]] }} {{@{settings_weapondescription}=@{V_R_ability_r} }}' >DMG</button>
-              </div>
-              <div class='equipment_ranged_weapons_grid4'>
-                <div class='equipment_ranged_weapons_gs21'>RoF</div>
-                <input class='equipment_ranged_weapons_gs22 full_width' type='text' placeholder='Semi' name='attr_V_R_weapon_semi' />
-                <div class='equipment_ranged_weapons_gs23'>/</div>
-                <input class='equipment_ranged_weapons_gs24 full_width' type='text' placeholder='Burst' name='attr_V_R_weapon_burst' />
-                <div class='equipment_ranged_weapons_gs25'>/</div>
-                <input class='equipment_ranged_weapons_gs26 full_width' type='text' placeholder='Auto' name='attr_V_R_weapon_auto' />
-                <div class='equipment_ranged_weapons_gs27'>Reload</div>
-                <input class='equipment_ranged_weapons_gs28 full_width' type='text' name='attr_V_R_weapon_reload' />
-                <div class='equipment_ranged_weapons_gs29'>Weight</div>
-                <input class='equipment_ranged_weapons_gs30 full_width' type='text' value='0' name='attr_V_R_weapon_weight' />
-              </div>
-              <div>
-                <input name='attr_V_R_ability_r' type='text' placeholder='Description' class='full_width_49px border_none' />
-                <label class='margin_adjust_wep'><input type='checkbox' name='attr_collapse' value='3' class='collapsible_entity_switch select_button hidden' /><span class='select_text radius_border_right_wep'>▼</span></label>
-                <label class='margin_adjust_wep2'><button type='roll' value='@{to-gm}&{template:mythic} {{name=@{V_R_ability_r} }} {{description=@{V_R_ability_desc_r} }}' class='hidden'></button><span class='select_text'>❖</span></label>
-                <input name='attr_collapse' type='checkbox'  value='3' class='collapsible_entity_switch hidden' />
-                <textarea name='attr_V_R_ability_desc_r' class='collapsible_entity_block description_rounded_margin'></textarea>
-              </div>
-            </div>
-            <br>
-          </fieldset>
-        </div>
-
-        <div class='equipment_melee_weapons'>
-          <h3 class='radius_border_top'>Vehicle Melee Weaponry</h3>
-          <fieldset name='vehiclemeleeweapons' class='repeating_vmeleeweapons'>
-            <div class='equipment_ranged_weapons_rep'>
-              <div class='equipment_ranged_weapons_grid1'>
-                <div class='equipment_ranged_weapons_gs1'>Name</div>
-                <input class='equipment_ranged_weapons_gs2 full_width' type='text' name='attr_V_M_weapon_name' placeholder='Name' />
-                <div class='equipment_ranged_weapons_gs3'>Type</div>
-                <input class='equipment_ranged_weapons_gs4 full_width' type='text' name='attr_V_M_weapon_class' placeholder='Class of Weapon' />
-              </div>
-              <div class='equipment_ranged_weapons_grid2'>
-                <div class='equipment_ranged_weapons_gs5'>Reach</div>
-                <input class='equipment_ranged_weapons_gs6 full_width' type='text' value='0' name='attr_V_M_weapon_range' />
-                <div class='equipment_ranged_weapons_gs7'>DMG Roll</div>
-                <input class='equipment_ranged_weapons_gs8 full_width' type='text' value='0' name='attr_V_M_weapon_dam-roll' />
-                <div class='equipment_ranged_weapons_gs9'>Base</div>
-                <input class='equipment_ranged_weapons_gs10 full_width' type='text' value='0' name='attr_V_M_weapon_base' />
-                <div class='equipment_ranged_weapons_gs11'>Pierce</div>
-                <input class='equipment_ranged_weapons_gs12 full_width' type='text' value='0' name='attr_V_M_weapon_pierce' />
-              </div>
-              <div class='equipment_melee_weapons_grid3'>
-                <div class='equipment_melee_weapons_gs1'>Hit Mod</div>
-                <input class='equipment_melee_weapons_gs2 full_width' type='text' value='0' name='attr_V_M_weapon_mod1' />
-                <div class='equipment_melee_weapons_gs3'>Weight</div>
-                <input class='equipment_melee_weapons_gs4 full_width' type='text' value='0' name='attr_V_M_weapon_weight' />
-                <div class='equipment_melee_weapons_gs5'>Br Pts</div>
-                <input class='equipment_melee_weapons_gs6 full_width' type='text' value='0' name='attr_V_M_weapon_breakpoints' />
-                <div class='equipment_melee_weapons_gs7'>/</div>
-                <input class='equipment_melee_weapons_gs8 full_width' type='text' value='0' name='attr_V_M_weapon_breakpoints_max' />
-                <button class='equipment_melee_weapons_gs9 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }} {{weapon= @{V_M_weapon_name}}} {{roll=[[floor(([[@{WFM}+@{WFM_advancement}+@{fatigue_mod}]]+@{V_M_weapon_mod1}+@{inlinemod-toggle}-1d100)/10)]]}} @{settings_hitroll}'' >Hit</button>
-                <button class='equipment_melee_weapons_gs10 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{weapon= @{V_M_weapon_name}}} {{damage=[[@{V_M_weapon_dam-roll}+@{V_M_weapon_base}]] }} {{pierce=[[@{V_M_weapon_pierce}]] }} {{@{settings_weapondescription}=@{V_M_ability_r} }}' >DMG</button>
-              </div>
-              <div>
-                <input name='attr_V_M_ability_r' type='text' placeholder='Description' class='full_width_49px border_none' />
-                <label class='margin_adjust_wep'><input type='checkbox' name='attr_collapse' value='3' class='collapsible_entity_switch select_button hidden' /><span class='select_text radius_border_right_wep'>▼</span></label>
-                <label class='margin_adjust_wep2'><button type='roll' value='@{to-gm}&{template:mythic} {{name=@{V_M_ability_r} }} {{description=@{V_M_ability_desc_r} }}' class='hidden'></button><span class='select_text'>❖</span></label>
-                <input name='attr_collapse' type='checkbox'  value='3' class='collapsible_entity_switch hidden' />
-                <textarea name='attr_V_M_ability_desc_r' class='collapsible_entity_block description_rounded_margin'></textarea>
-              </div>
-            </div>
-            <br>
-          </fieldset>
-        </div>
-      </div>
-    </div>
-
-  </div>
-
-
-
-  <!-- ______________________________ start of tab Settings ______________________________ -->
-
-  <div class='settings box radius_border_box'>
-    <!-- Settings -->
-    <h2>Settings</h2>
-    <h3>Species Overrides</h3>
-    <select name='attr_settings_race' class='full_width edge_padding'>
-      <option selected='selected' value='0'>Racial Features: N/A </option>
-      <option value='1'>Spartan 2 / Spartan 3 / Spartan 4 </option>
-      <option value='2'>Sangheili / Elite </option>
-      <option value='1'>Jiralhanae / Brutes </option>
-      <option value='3'>Kig-yar Ruutian / Halo Trilogy Jackals </option>
-      <option value='4'>Kig-yar T'vaoan / Halo Reach Jackals / Skirmishers </option>
-      <option value='3'>Kig-yar Ibie'shan / Halo 4/5 Jackals </option>
-      <option value='5'>Mgalekgolo / Hunters </option>
-      <option value='1'>Promethean Knight </option>
-      <option value='6'>Dont Auto Calculate Speed And Weight</option>
-    </select>
+  <h3>Firefox Compatibility Mode Enable</h3>
+  <select name='attr_firefox' class='full_width edge_padding'>
+    <option value="1"selected='selected'>Disabled</option>
+    <option value="0">Enabled</option>
+  </select>
     <br>
 
-    <h3>Initiative Overrides</h3>
-    <select name='attr_initmod0' class='full_width edge_padding'>
-      <option selected='selected' value='[[floor'>No tiebreaker</option>
-      <option value='[['>Decimal tiebreaker</option>
-      <option value='tiebreaker [[@{AGI_total}]] roll [[floor'>AGI tiebreaker</option>
-    </select>
-    <br>
-
-    <h3>Auto Roll Hit Locations</h3>
-    <select name='attr_settings_hitroll' class='full_width edge_padding'>
-      <option value='{{loc=[[1d100]]}}'selected='selected'>Automatically roll hit locations</option>
-      <option value=' '>Don't automatically roll hit locations</option>
-    </select>
-    <br>
-
-    <h3>Weapon Description in Damage Roll</h3>
-    <select name='attr_settings_weapondescription' class='full_width edge_padding'>
-      <option value='description'>Include weapon description</option>
-      <option value=' 'selected='selected'>Exclude weapon description</option>
-    </select>
-    <br>
-
-    <h3>Calculate The Negative Impact Of Fatigue Automatically</h3>
-    <select name='attr_settings_fatigue' class='full_width edge_padding'>
-      <option value='0'selected='selected'>Auto calculate Fatigue</option>
-      <option value='1'>Dont auto calculate Fatigue</option>
-    </select>
-    <br>
-
-
-    <h3>NPC Sheet</h3>
-    <label class='text_centered bttn_top_padding'><input type='checkbox' name='attr_npc_sheet' class='collapsible_entity_switch select_button hidden' /><span class='select_text'>NPC Sheet</span></label>
-    <br>
-  </div>
+  <h3>NPC Sheet</h3>
+  <label class='text_centered bttn_top_padding'><input type='checkbox' name='attr_npc_sheet' class='collapsible_entity_switch select_button hidden' /><span class='select_text'>NPC Sheet</span></label>
+  <br>
+</div>
 
 </div>
 
@@ -2615,26 +3260,26 @@
 
       // normal no modifiers ___________________________________________________
       if(settings_race != 6) {
-      setAttrs({
-        half_move: (move_mod),
-        full_move: (move_mod * 2),
-        charge_move: (move_mod * 3),
-        run_move: (move_mod * 6),
-        sprint_move: (move_mod * 8),
-        jump_move:(str_mod / 4),
-        leap_move:(agi_mod / 2),
-        carry: (weight_mod),
-        lift: (weight_mod * 2),
-        push: (weight_mod * 4),
-        fatigue_max: (tou_mod * 2)
-      });
-
-      if (str_mod >= agi_mod) {
         setAttrs({
-          leap_move:(str_mod / 2)
+          half_move: (move_mod),
+          full_move: (move_mod * 2),
+          charge_move: (move_mod * 3),
+          run_move: (move_mod * 6),
+          sprint_move: (move_mod * 8),
+          jump_move:(str_mod / 4),
+          leap_move:(agi_mod / 2),
+          carry: (weight_mod),
+          lift: (weight_mod * 2),
+          push: (weight_mod * 4),
+          fatigue_max: (tou_mod * 2)
         });
+
+        if (str_mod >= agi_mod) {
+          setAttrs({
+            leap_move:(str_mod / 2)
+          });
+        }
       }
-    }
 
       // Spartan + Jiralhanae + Promethean Knight (carry weight * 2) ___________
       if(settings_race == 1) {
@@ -2967,7 +3612,7 @@
           {{#rollBetween() loc 39 43}}  39-43 Thigh	 {{/rollBetween() loc 39 43}}
           {{#rollBetween() loc 44 45}}  44-45 Pelvis	{{/rollBetween() loc 44 45}}
 
-          {{#rollBetween() loc 46 61}}  RIGHT LEG:	  {{/rollBetween() loc 46 61}}
+          {{#rollBetween() loc 46 60}}  RIGHT LEG:	  {{/rollBetween() loc 46 60}}
           {{#rollBetween() loc 46 46}}  46 Toes		 {{/rollBetween() loc 46 46}}
           {{#rollBetween() loc 47 47}}  47 Foot		 {{/rollBetween() loc 47 47}}
           {{#rollBetween() loc 48 48}}  48 Ankle		{{/rollBetween() loc 48 48}}
@@ -2976,7 +3621,7 @@
           {{#rollBetween() loc 55 58}}  55-58 Thigh	 {{/rollBetween() loc 55 58}}
           {{#rollBetween() loc 59 60}}  59-60 Pelvis	{{/rollBetween() loc 59 60}}
 
-          {{#rollBetween() loc 62 100}} CHEST:				  {{/rollBetween() loc 62 100}}
+          {{#rollBetween() loc 61 100}} CHEST:				  {{/rollBetween() loc 61 100}}
           {{#rollBetween() loc 61 66}}  61-66 Small Intestines  {{/rollBetween() loc 61 66}}
           {{#rollBetween() loc 67 72}}  67-72 Large Intestines  {{/rollBetween() loc 67 72}}
           {{#rollBetween() loc 73 78}}  73-78 Kidney			{{/rollBetween() loc 73 78}}


### PR DESCRIPTION
## Changes / Comments
:green_square: 1 Fix text expand in the Weapons section overlapping with buggy to chat button
:green_square: 2 Skills do not work on firefox(added firefox compatibility mode)
:green_square: 3 The hit table is mislabeled  (46-60)

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [Y] Does the pull request title have the sheet name(s)? Include each sheet name.
- [Y] Is this a bug fix?
- [Y] Does this add functional enhancements (new features or extending existing features) ?
- [N] Does this add or change functional aesthetics (such as layout or color scheme) ? 
(https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
