### PR TITLE
Adding new roll buttons

### DIFF
--- a/UltimaTorcia/CS_LUltimaTorcia.html
+++ b/UltimaTorcia/CS_LUltimaTorcia.html
@@ -424,7 +424,25 @@
                                 <button type=roll
                                     value="&{template:default} {{name=Pozione di Mana}} {{Roll:= [[D6]] }}"></button>
                             </div>
-                        </div>                    
+                        </div>  
+                        <div class='2colrow ' style='margin-bottom: 10px;'>
+                            <div class='col'>
+                                <b class='b'>Riposo Ristoratore Salute</b>
+                            </div>
+                            <div class='col'>
+                                <button type=roll
+                                    value="&{template:default} {{name=Riposo Ristoratore Salute}} {{Roll:= [[D4]] }}"></button>
+                            </div>
+                        </div>
+                        <div class='2colrow' style='margin-bottom: 10px;'>
+                            <div class='col'>
+                                <b class='b'>Riposo Ristoratore Mana</b>
+                            </div>
+                            <div class='col'>
+                                <button type=roll
+                                    value="&{template:default} {{name=Riposo Ristoratore Mana}} {{Roll:= [[D4]] }}"></button>
+                            </div>
+                        </div>  
                     </div>
                 </div>
             </div>
@@ -591,6 +609,34 @@
                     <div class='col' style='width: 10%;'>
                         <button type=roll
                             value="&{template:default} {{name=Iniziativa}} {{Roll= [[@{iniziative}@{iniziativeExtra}kh1 @{iniziative_mod} &{tracker} ]] }}"></button>
+                    </div>
+                    	<br>
+				<br>
+				    <div class='col' style='width: 10%;'>
+                        <b class='b' style=' width: 100%;'>Ricarica Arma</b><br>
+                    </div>
+                    <div class='col' style='width: 10%;'>
+                        <input type=text name=attr_ricaricaarma style='width: 100%;'>
+                    </div>
+                    <div class='col' style='width: 10%;'>
+                        <input type=text name=attr_ricaricaarma_mod style='width: 100%;'>
+                    </div>
+                    <div class='col' style='width: 10%;'>
+                        <input type=text name=attr_ricaricaarmaExtra style='width: 100%;'>
+                    </div>
+                    <div class='col' style='width: 10%;'>
+                        <button type=roll
+                            value="&{template:default} {{name=Ricarica Arma}} {{Roll= [[@{ricaricaarma}@{ricaricaarmaExtra}kh1 @{ricaricaarma_mod} ]] }}"></button>
+                    </div>
+				<br>
+					<div class='2colrow ' style='margin-top: 15px; margin-bottom: 10px;'>
+                            <div class='col'>
+                                <b class='b'>Rottura Arma</b>
+                            </div>
+                            <div class='col'>
+                                <button type=roll
+                                    value="&{template:default} {{name=Rottura Arma}} {{Roll:= [[D6]] }}"></button>
+                            </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Adding new roll buttons in Character(Personaggio) and Weapons(Armi) sheets:
- Health and Mana recovery after a refreshing rest
- Charge weapon roll and Weapon Breakage roll

## Changes / Comments






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
