### PR TITLE
[Ironsworn] Discover A Site and minor fixes

### DIFF
--- a/Ironsworn/Ironsworn.css
+++ b/Ironsworn/Ironsworn.css
@@ -1139,15 +1139,15 @@ input.sheet-table-btn:checked ~ div.sheet-move-nav-content {
   height: 50em;
 }
 .sheet-move-container {
-  display: flex;
   flex-wrap: wrap;
   flex-direction: column;
   justify-content: space-between;
-  height: 36em;
+  height: 45em;
   margin-top: 1em;
   display: flex;
   font-size: 1em;
   font-weight: normal;
+  align-content: space-between;
 }
 .sheet-move-container .sheet-move-scroll-list {
   overflow: auto;
@@ -1167,20 +1167,32 @@ input.sheet-table-btn:checked ~ div.sheet-move-nav-content {
 .sheet-move-group-title h3 {
   color: #fff;
 }
+.sheet-move-name {
+  width: 100%;
+  border: 2px solid #4c4d4f;
+}
 .sheet-move-highlight:checked ~ .sheet-move-name {
   background: #fd0;
   outline-offset: 0;
   box-shadow: inset 0 0 0 2px;
 }
+.sheet-roll-show {
+  padding: 0 !important;
+  font-size: 20px !important;
+  margin: 0 !important;
+}
+.sheet-roll-show:hover {
+  color: #fff;
+}
 .sheet-move-list {
   padding: 0;
+  display: flex;
 }
 .sheet-move-list label {
   cursor: pointer;
 }
 .sheet-move-list div {
   font-weight: 600;
-  width: 100%;
   font-size: 14px;
   text-align: center;
   margin: 0 0 0px;
@@ -2261,6 +2273,7 @@ span.sheet-oracle-result {
 }
 .sheet-flex-container {
   display: flex;
+  align-items: flex-start;
 }
 .sheet-flex-wrapper {
   display: flex;
@@ -2482,6 +2495,7 @@ input.sheet-border-bottom {
 }
 .sheet-rolltemplate-ironsworn_oracles .sheet-result-row,
 .sheet-rolltemplate-moves_oracles .sheet-result-row,
+.sheet-rolltemplate-ironsworn_moves .sheet-result-row,
 .sheet-rolltemplate-delve_oracles .sheet-result-row {
   padding: 0.5em;
 }

--- a/Ironsworn/Ironsworn.html
+++ b/Ironsworn/Ironsworn.html
@@ -4757,6 +4757,9 @@
                 <h3>FATE MOVES</h3>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Pay the Price Move" name="rollpayThePrice" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Pay the Price}} {{action=[[d6+undefined+(?{Modifier|0})]]}} {{negate1=[[1+undefined+(?{Modifier|0})]]}} {{negate2=[[2+undefined+(?{Modifier|0})]]}} {{negate3=[[3+undefined+(?{Modifier|0})]]}} {{negate4=[[4+undefined+(?{Modifier|0})]]}} {{negate5=[[5+undefined+(?{Modifier|0})]]}} {{negate6=[[6+undefined+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[undefined+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[undefined]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="pay_the_price"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_pay_the_price_highlight"/>
@@ -4764,6 +4767,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Ask the Oracle Move" name="rollaskTheOracle" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Ask the Oracle}} {{action=[[d6+undefined+(?{Modifier|0})]]}} {{negate1=[[1+undefined+(?{Modifier|0})]]}} {{negate2=[[2+undefined+(?{Modifier|0})]]}} {{negate3=[[3+undefined+(?{Modifier|0})]]}} {{negate4=[[4+undefined+(?{Modifier|0})]]}} {{negate5=[[5+undefined+(?{Modifier|0})]]}} {{negate6=[[6+undefined+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[undefined+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[undefined]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="ask_the_oracle"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_ask_the_oracle_highlight"/>
@@ -4776,6 +4782,9 @@
                 <h3>COMBAT MOVES</h3>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Enter the Fray Move" name="rollenterTheFray" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Enter the Fray}} {{action=[[d6+?{Stat|Heart, @{heart}|Shadow, @{shadow}|Wits, @{wits}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="enter_the_fray"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_enter_the_fray_highlight"/>
@@ -4783,6 +4792,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Strike Move" name="rollstrike" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Strike}} {{action=[[d6+?{Stat|Edge&#44;@{edge}|Iron&#44;@{iron}|Light - Lightbearer&#44;?{Light&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="strike"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_strike_highlight"/>
@@ -4790,6 +4802,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Clash Move" name="rollclash" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Clash}} {{action=[[d6+?{Stat|Edge&#44;@{edge}|Iron&#44;@{iron}|Light - Lightbearer&#44;?{Light&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="clash"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_clash_highlight"/>
@@ -4797,6 +4812,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Turn the Tide Move" name="rollturnTheTide" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Turn the Tide}} {{action=[[d6+undefined+(?{Modifier|0})]]}} {{negate1=[[1+undefined+(?{Modifier|0})]]}} {{negate2=[[2+undefined+(?{Modifier|0})]]}} {{negate3=[[3+undefined+(?{Modifier|0})]]}} {{negate4=[[4+undefined+(?{Modifier|0})]]}} {{negate5=[[5+undefined+(?{Modifier|0})]]}} {{negate6=[[6+undefined+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[undefined+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[undefined]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="turn_the_tide"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_turn_the_tide_highlight"/>
@@ -4804,6 +4822,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="End the Fight" name="rollendTheFight" value="&amp;{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=End the Fight}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="end_the_fight"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_end_the_fight_highlight"/>
@@ -4811,6 +4832,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Battle Move" name="rollBattle" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Battle}} {{action=[[d6+?{Stat|Edge, @{edge}|Iron, @{iron}|Heart, @{heart}|Shadow, @{shadow}|Wits, @{wits}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="battle"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_battle_highlight"/>
@@ -4824,6 +4848,9 @@
                 <h3>DELVE MOVES</h3>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Discover a Site" name="rolldiscoverASite" value="&amp;{template:ironsworn_moves} {{header=Discover a Site}} {{discoverASite=[[2d10kl1]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="discover_a_site"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_discover_a_site_highlight"/>
@@ -4831,6 +4858,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Delve the Depths Move" name="rolldelveTheDepths" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Delve the Depths}} {{action=[[d6+?{Stat|Edge,@{edge}|Shadow,@{shadow}|Wits,@{wits}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="delve_the_depths"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_delve_the_depths_highlight"/>
@@ -4838,6 +4868,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Find an Opportunity Move" name="rollfindAnOpportunity" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Find an Opportunity}} {{action=[[d6+undefined+(?{Modifier|0})]]}} {{negate1=[[1+undefined+(?{Modifier|0})]]}} {{negate2=[[2+undefined+(?{Modifier|0})]]}} {{negate3=[[3+undefined+(?{Modifier|0})]]}} {{negate4=[[4+undefined+(?{Modifier|0})]]}} {{negate5=[[5+undefined+(?{Modifier|0})]]}} {{negate6=[[6+undefined+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[undefined+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[undefined]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="find_an_opportunity"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_find_an_opportunity_highlight"/>
@@ -4845,6 +4878,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Reveal a Danger Move" name="rollrevealADanger" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Reveal a Danger}} {{action=[[d6+undefined+(?{Modifier|0})]]}} {{negate1=[[1+undefined+(?{Modifier|0})]]}} {{negate2=[[2+undefined+(?{Modifier|0})]]}} {{negate3=[[3+undefined+(?{Modifier|0})]]}} {{negate4=[[4+undefined+(?{Modifier|0})]]}} {{negate5=[[5+undefined+(?{Modifier|0})]]}} {{negate6=[[6+undefined+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[undefined+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[undefined]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="reveal_a_danger"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_reveal_a_danger_highlight"/>
@@ -4852,6 +4888,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Check Your Gear Move" name="rollcheckYourGear" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Check Your Gear}} {{action=[[d6+?{Stat|Supply,@{supply}|Wits - Improviser,@{wits}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="check_your_gear"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_check_your_gear_highlight"/>
@@ -4859,6 +4898,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Locate Your Objective" name="rolllocateYourObjective" value="&amp;{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=Locate Your Objective}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="locate_your_objective"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_locate_your_objective_highlight"/>
@@ -4866,6 +4908,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Escape the Depths Move" name="rollescapeTheDepths" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Escape the Depths}} {{action=[[d6+?{Stat|Edge,@{edge}|Heart,@{heart}|Iron,@{iron}|Wits,@{wits}|Shadow,@{shadow}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="escape_the_depths"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_escape_the_depths_highlight"/>
@@ -4873,6 +4918,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Reveal a Danger - Alt Move" name="rollrevealADangerAlt" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Reveal a Danger - Alt}} {{action=[[d6+undefined+(?{Modifier|0})]]}} {{negate1=[[1+undefined+(?{Modifier|0})]]}} {{negate2=[[2+undefined+(?{Modifier|0})]]}} {{negate3=[[3+undefined+(?{Modifier|0})]]}} {{negate4=[[4+undefined+(?{Modifier|0})]]}} {{negate5=[[5+undefined+(?{Modifier|0})]]}} {{negate6=[[6+undefined+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[undefined+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[undefined]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="reveal_a_danger_alt"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_reveal_a_danger_alt_highlight"/>
@@ -4885,6 +4933,9 @@
                 <h3>ADVENTURE MOVES</h3>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Face Danger Move" name="rollfaceDanger" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Face Danger}} {{action=[[d6+?{Stat|Edge&#44;@{edge}|Iron&#44;@{iron}|Heart&#44;@{heart}|Shadow&#44;@{shadow}|Wits&#44;@{wits}|Essence - Invoke&#44;?{Essence&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="face_danger"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_face_danger_highlight"/>
@@ -4892,6 +4943,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Secure an Advantage Move" name="rollsecureAnAdvantage" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Secure an Advantage}} {{action=[[d6+?{Stat|Edge&#44;@{edge}|Iron&#44;@{iron}|Heart&#44;@{heart}|Shadow&#44;@{shadow}|Wits&#44;@{wits}|God's Stat - Devotant&#44;?{God's Stat&amp;#124;0&amp;#125;|Essence - Invoke&#44;?{Essence&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="secure_an_advantage"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_secure_an_advantage_highlight"/>
@@ -4899,6 +4953,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Gather Information Move" name="rollgatherInformation" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Gather Information}} {{action=[[d6+?{Stat|Wits,@{wits}|Shadow - Infiltrator/Trickster/Scry,@{shadow}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="gather_information"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_gather_information_highlight"/>
@@ -4906,6 +4963,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Heal Move" name="rollheal" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Heal}} {{action=[[d6+?{Stat|Wits,@{wits}|Iron,@{iron}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="heal"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_heal_highlight"/>
@@ -4913,6 +4973,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Resupply Move" name="rollresupply" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Resupply}} {{action=[[d6+?{Stat|Wits,@{wits}|Edge - Cave Lion,@{edge}|Shadow - Infiltrator,@{shadow}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="resupply"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_resupply_highlight"/>
@@ -4920,6 +4983,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Make Camp Move" name="rollmakeCamp" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Make Camp}} {{action=[[d6+?{Stat|Supply&#44;@{supply}|Wits - Wildblood&#44;@{wits}|Health - Mammoth&#44;?{Mammoth's Health&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="make_camp"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_make_camp_highlight"/>
@@ -4927,6 +4993,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Undertake a Journey Move" name="rollundertakeAJourney" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Undertake a Journey}} {{action=[[d6+?{Stat|Wits,@{wits}|Shadow - Shadow-walk,@{shadow}|Spirit or Heart - Tether&#44;?{Tether Stat&amp;#124;Spirit&amp;#44;@{spirit}&amp;#124;Heart&amp;#44;@{heart}&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="undertake_a_journey"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_undertake_a_journey_highlight"/>
@@ -4934,6 +5003,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Reach Your Destination" name="rollreachYourDestination" value="&amp;{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=Reach Your Destination}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="reach_your_destination"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_reach_your_destination_highlight"/>
@@ -4946,6 +5018,9 @@
                 <h3>RELATIONSHIP MOVES</h3>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Compel Move" name="rollcompel" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Compel}} {{action=[[d6+?{Stat|Iron&#44;@{iron}|Heart&#44;@{heart}|Shadow&#44;@{shadow}|Essence - Invoke&#44;?{Essence&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="compel"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_compel_highlight"/>
@@ -4953,6 +5028,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Sojourn Move" name="rollsojourn" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Sojourn}} {{action=[[d6+?{Stat|Heart&#44;@{heart}|Shadow - Pretender&#44;@{shadow}|God's Stat - Devotant&#44;?{God's Stat&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="sojourn"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_sojourn_highlight"/>
@@ -4960,6 +5038,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Draw the Circle Move" name="rolldrawTheCircle" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Draw the Circle}} {{action=[[d6+@{heart}+(?{Modifier|0})]]}} {{negate1=[[1+@{heart}+(?{Modifier|0})]]}} {{negate2=[[2+@{heart}+(?{Modifier|0})]]}} {{negate3=[[3+@{heart}+(?{Modifier|0})]]}} {{negate4=[[4+@{heart}+(?{Modifier|0})]]}} {{negate5=[[5+@{heart}+(?{Modifier|0})]]}} {{negate6=[[6+@{heart}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[@{heart}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[@{heart}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="draw_the_circle"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_draw_the_circle_highlight"/>
@@ -4967,6 +5048,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Forge a Bond Move" name="rollforgeABond" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Forge a Bond}} {{action=[[d6+?{Stat|Heart,@{heart}|Shadow - Trickster,@{shadow}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="forge_a_bond"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_forge_a_bond_highlight"/>
@@ -4974,6 +5058,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Test Your Bond Move" name="rolltestYourBond" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Test Your Bond}} {{action=[[d6+@{heart}+(?{Modifier|0})]]}} {{negate1=[[1+@{heart}+(?{Modifier|0})]]}} {{negate2=[[2+@{heart}+(?{Modifier|0})]]}} {{negate3=[[3+@{heart}+(?{Modifier|0})]]}} {{negate4=[[4+@{heart}+(?{Modifier|0})]]}} {{negate5=[[5+@{heart}+(?{Modifier|0})]]}} {{negate6=[[6+@{heart}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[@{heart}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[@{heart}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="test_your_bond"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_test_your_bond_highlight"/>
@@ -4981,6 +5068,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Aid Your Ally Move" name="rollaidYourAlly" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Aid Your Ally}} {{action=[[d6+?{Stat|Edge, @{edge}|Iron, @{iron}|Heart, @{heart}|Shadow, @{shadow}|Wits, @{wits}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="aid_your_ally"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_aid_your_ally_highlight"/>
@@ -4988,6 +5078,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Write Your Epilogue" name="rollwriteYourEpilogue" value="&amp;{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=Write Your Epilogue}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="write_your_epilogue"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_write_your_epilogue_highlight"/>
@@ -5001,6 +5094,9 @@
                 <h3>FAILURE MOVES</h3>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Mark Your Failure Move" name="rollmarkYourFailure" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Mark Your Failure}} {{action=[[d6+undefined+(?{Modifier|0})]]}} {{negate1=[[1+undefined+(?{Modifier|0})]]}} {{negate2=[[2+undefined+(?{Modifier|0})]]}} {{negate3=[[3+undefined+(?{Modifier|0})]]}} {{negate4=[[4+undefined+(?{Modifier|0})]]}} {{negate5=[[5+undefined+(?{Modifier|0})]]}} {{negate6=[[6+undefined+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[undefined+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[undefined]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="mark_your_failure"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_mark_your_failure_highlight"/>
@@ -5008,6 +5104,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Learn From Your Failures" name="rolllearnFromYourFailures" value="&amp;{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=Learn From Your Failures}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="learn_from_your_failures"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_learn_from_your_failures_highlight"/>
@@ -5020,6 +5119,9 @@
                 <h3>QUEST MOVES</h3>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Swear an Iron Vow Move" name="rollswearAnIronVow" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Swear an Iron Vow}} {{action=[[d6+?{Stat|Heart&#44;@{heart}|God's Stat - Devotant&#44;?{God's Stat&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="swear_an_iron_vow"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_swear_an_iron_vow_highlight"/>
@@ -5027,6 +5129,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Reach a Milestone Move" name="rollreachAMilestone" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Reach a Milestone}} {{action=[[d6+undefined+(?{Modifier|0})]]}} {{negate1=[[1+undefined+(?{Modifier|0})]]}} {{negate2=[[2+undefined+(?{Modifier|0})]]}} {{negate3=[[3+undefined+(?{Modifier|0})]]}} {{negate4=[[4+undefined+(?{Modifier|0})]]}} {{negate5=[[5+undefined+(?{Modifier|0})]]}} {{negate6=[[6+undefined+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[undefined+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[undefined]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="reach_a_milestone"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_reach_a_milestone_highlight"/>
@@ -5034,6 +5139,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Fulfill Your Vow" name="rollfulfillYourVow" value="&amp;{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=Fulfill Your Vow}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="fulfill_your_vow"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_fulfill_your_vow_highlight"/>
@@ -5041,6 +5149,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Forsake Your Vow Move" name="rollforsakeYourVow" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Forsake Your Vow}} {{action=[[d6+undefined+(?{Modifier|0})]]}} {{negate1=[[1+undefined+(?{Modifier|0})]]}} {{negate2=[[2+undefined+(?{Modifier|0})]]}} {{negate3=[[3+undefined+(?{Modifier|0})]]}} {{negate4=[[4+undefined+(?{Modifier|0})]]}} {{negate5=[[5+undefined+(?{Modifier|0})]]}} {{negate6=[[6+undefined+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[undefined+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[undefined]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="forsake_your_vow"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_forsake_your_vow_highlight"/>
@@ -5048,6 +5159,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Advance Move" name="rolladvance" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Advance}} {{action=[[d6+undefined+(?{Modifier|0})]]}} {{negate1=[[1+undefined+(?{Modifier|0})]]}} {{negate2=[[2+undefined+(?{Modifier|0})]]}} {{negate3=[[3+undefined+(?{Modifier|0})]]}} {{negate4=[[4+undefined+(?{Modifier|0})]]}} {{negate5=[[5+undefined+(?{Modifier|0})]]}} {{negate6=[[6+undefined+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[undefined+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[undefined]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="advance"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_advance_highlight"/>
@@ -5060,6 +5174,9 @@
                 <h3>SUFFER MOVES</h3>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Endure Harm Move" name="rollendureHarm" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Endure Harm}} {{action=[[d6+?{Stat|Health,@{health}|Iron,@{iron}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="endure_harm"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_endure_harm_highlight"/>
@@ -5067,6 +5184,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Endure Stress Move" name="rollendureStress" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Endure Stress}} {{action=[[d6+?{Stat|Spirit,@{spirit}|Heart,@{heart}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="endure_stress"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_endure_stress_highlight"/>
@@ -5074,6 +5194,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Companion Endure Harm Move" name="rollcompanionEndureHarm" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Companion Endure Harm}} {{action=[[d6+?{Stat|Heart&#44;@{heart}|Companion's Health&#44;?{Health&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="companion_endure_harm"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_companion_endure_harm_highlight"/>
@@ -5081,6 +5204,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Face Death Move" name="rollfaceDeath" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Face Death}} {{action=[[d6+?{Stat|Heart,@{heart}|Shadow - Shadow-kin,@{shadow}}+(?{Modifier|0})]]}} {{owl=[[?{Owl Companion|No&#44;0|Yes&#44;?{Owl's Health&amp;#124;0&amp;#125;&#125;]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}+(?{Owl Companion})]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="face_death"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_face_death_highlight"/>
@@ -5088,6 +5214,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Face Desolation Move" name="rollfaceDesolation" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Face Desolation}} {{action=[[d6+@{heart}+(?{Modifier|0})]]}} {{negate1=[[1+@{heart}+(?{Modifier|0})]]}} {{negate2=[[2+@{heart}+(?{Modifier|0})]]}} {{negate3=[[3+@{heart}+(?{Modifier|0})]]}} {{negate4=[[4+@{heart}+(?{Modifier|0})]]}} {{negate5=[[5+@{heart}+(?{Modifier|0})]]}} {{negate6=[[6+@{heart}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[@{heart}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[@{heart}]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="face_desolation"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_face_desolation_highlight"/>
@@ -5095,6 +5224,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Out of Supply Move" name="rolloutOfSupply" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Out of Supply}} {{action=[[d6+undefined+(?{Modifier|0})]]}} {{negate1=[[1+undefined+(?{Modifier|0})]]}} {{negate2=[[2+undefined+(?{Modifier|0})]]}} {{negate3=[[3+undefined+(?{Modifier|0})]]}} {{negate4=[[4+undefined+(?{Modifier|0})]]}} {{negate5=[[5+undefined+(?{Modifier|0})]]}} {{negate6=[[6+undefined+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[undefined+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[undefined]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="out_of_supply"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_out_of_supply_highlight"/>
@@ -5102,6 +5234,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Face a Setback Move" name="rollfaceASetback" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Face a Setback}} {{action=[[d6+undefined+(?{Modifier|0})]]}} {{negate1=[[1+undefined+(?{Modifier|0})]]}} {{negate2=[[2+undefined+(?{Modifier|0})]]}} {{negate3=[[3+undefined+(?{Modifier|0})]]}} {{negate4=[[4+undefined+(?{Modifier|0})]]}} {{negate5=[[5+undefined+(?{Modifier|0})]]}} {{negate6=[[6+undefined+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[undefined+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[undefined]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="face_a_setback"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_face_a_setback_highlight"/>
@@ -5115,6 +5250,9 @@
                 <h3>RARITY MOVES</h3>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Wield A Rarity Move" name="rollwieldARairty" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Wield A Rarity}} {{rarityAction=[[d6+?{Stat|Edge,@{edge}|Iron,@{iron}|Heart,@{heart}|Shadow,@{shadow}|Wits,@{wits}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}} {{rarityDie6=[[6+?{Stat}+(?{Modifier|0})]]}} {{rarityDie5=[[5+?{Stat}+(?{Modifier|0})]]}} {{rarityDie1=[[1+?{Stat}+(?{Modifier|0})]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="wield_a_rarity"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_wield_a_rarity_highlight"/>
@@ -5128,6 +5266,9 @@
                 <h3>THREAT MOVES</h3>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Advance A Threat Move" name="rolladvanceAThreat" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Advance A Threat}} {{action=[[d6+undefined+(?{Modifier|0})]]}} {{negate1=[[1+undefined+(?{Modifier|0})]]}} {{negate2=[[2+undefined+(?{Modifier|0})]]}} {{negate3=[[3+undefined+(?{Modifier|0})]]}} {{negate4=[[4+undefined+(?{Modifier|0})]]}} {{negate5=[[5+undefined+(?{Modifier|0})]]}} {{negate6=[[6+undefined+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[undefined+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[undefined]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="advance_a_threat"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_advance_a_threat_highlight"/>
@@ -5135,6 +5276,9 @@
                 </label>
               </div>
               <div class="move-list">
+                      <div class="button-container">
+                              <button class="roll-show" type="roll" title="Take a Hiatus Move" name="rolltakeAHiatus" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Take a Hiatus}} {{action=[[d6+undefined+(?{Modifier|0})]]}} {{negate1=[[1+undefined+(?{Modifier|0})]]}} {{negate2=[[2+undefined+(?{Modifier|0})]]}} {{negate3=[[3+undefined+(?{Modifier|0})]]}} {{negate4=[[4+undefined+(?{Modifier|0})]]}} {{negate5=[[5+undefined+(?{Modifier|0})]]}} {{negate6=[[6+undefined+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[undefined+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[undefined]]}}"></button>
+                      </div>
                 <label class="move">
                   <input class="hide selected-move" type="radio" name="attr_selected_move" value="take_a_hiatus"/>
                   <input class="hide move-highlight" type="checkbox" name="attr_take_a_hiatus_highlight"/>
@@ -5177,114 +5321,6 @@
                     <input class="hide" type="radio" name="attr_selected_move" value="ask_the_oracle"/>
                     <input class="hide move-highlight" type="checkbox" name="attr_ask_the_oracle_highlight"/>
                     <div class="move-name">Ask the Oracle</div>
-                  </label>
-                </div>
-              </div>
-              <div class="move-group-scroll">
-                <div class="move-group-title">
-                  <h3>COMBAT MOVES</h3>
-                </div>
-                <div class="move-list">
-                  <label class="move">
-                    <input class="hide" type="radio" name="attr_selected_move" value="enter_the_fray"/>
-                    <input class="hide move-highlight" type="checkbox" name="attr_enter_the_fray_highlight"/>
-                    <div class="move-name">Enter the Fray</div>
-                  </label>
-                </div>
-                <div class="move-list">
-                  <label class="move">
-                    <input class="hide" type="radio" name="attr_selected_move" value="strike"/>
-                    <input class="hide move-highlight" type="checkbox" name="attr_strike_highlight"/>
-                    <div class="move-name">Strike</div>
-                  </label>
-                </div>
-                <div class="move-list">
-                  <label class="move">
-                    <input class="hide" type="radio" name="attr_selected_move" value="clash"/>
-                    <input class="hide move-highlight" type="checkbox" name="attr_clash_highlight"/>
-                    <div class="move-name">Clash</div>
-                  </label>
-                </div>
-                <div class="move-list">
-                  <label class="move">
-                    <input class="hide" type="radio" name="attr_selected_move" value="turn_the_tide"/>
-                    <input class="hide move-highlight" type="checkbox" name="attr_turn_the_tide_highlight"/>
-                    <div class="move-name">Turn the Tide</div>
-                  </label>
-                </div>
-                <div class="move-list">
-                  <label class="move">
-                    <input class="hide" type="radio" name="attr_selected_move" value="end_the_fight"/>
-                    <input class="hide move-highlight" type="checkbox" name="attr_end_the_fight_highlight"/>
-                    <div class="move-name">End the Fight</div>
-                  </label>
-                </div>
-                <div class="move-list">
-                  <label class="move">
-                    <input class="hide" type="radio" name="attr_selected_move" value="battle"/>
-                    <input class="hide move-highlight" type="checkbox" name="attr_battle_highlight"/>
-                    <div class="move-name">Battle</div>
-                  </label>
-                </div>
-              </div>
-              <div class="move-group-scroll">
-                <div class="move-group-title">
-                  <h3>DELVE MOVES</h3>
-                </div>
-                <div class="move-list">
-                  <label class="move">
-                    <input class="hide" type="radio" name="attr_selected_move" value="discover_a_site"/>
-                    <input class="hide move-highlight" type="checkbox" name="attr_discover_a_site_highlight"/>
-                    <div class="move-name">Discover a Site</div>
-                  </label>
-                </div>
-                <div class="move-list">
-                  <label class="move">
-                    <input class="hide" type="radio" name="attr_selected_move" value="delve_the_depths"/>
-                    <input class="hide move-highlight" type="checkbox" name="attr_delve_the_depths_highlight"/>
-                    <div class="move-name">Delve the Depths</div>
-                  </label>
-                </div>
-                <div class="move-list">
-                  <label class="move">
-                    <input class="hide" type="radio" name="attr_selected_move" value="find_an_opportunity"/>
-                    <input class="hide move-highlight" type="checkbox" name="attr_find_an_opportunity_highlight"/>
-                    <div class="move-name">Find an Opportunity</div>
-                  </label>
-                </div>
-                <div class="move-list">
-                  <label class="move">
-                    <input class="hide" type="radio" name="attr_selected_move" value="reveal_a_danger"/>
-                    <input class="hide move-highlight" type="checkbox" name="attr_reveal_a_danger_highlight"/>
-                    <div class="move-name">Reveal a Danger</div>
-                  </label>
-                </div>
-                <div class="move-list">
-                  <label class="move">
-                    <input class="hide" type="radio" name="attr_selected_move" value="check_your_gear"/>
-                    <input class="hide move-highlight" type="checkbox" name="attr_check_your_gear_highlight"/>
-                    <div class="move-name">Check Your Gear</div>
-                  </label>
-                </div>
-                <div class="move-list">
-                  <label class="move">
-                    <input class="hide" type="radio" name="attr_selected_move" value="locate_your_objective"/>
-                    <input class="hide move-highlight" type="checkbox" name="attr_locate_your_objective_highlight"/>
-                    <div class="move-name">Locate Your Objective</div>
-                  </label>
-                </div>
-                <div class="move-list">
-                  <label class="move">
-                    <input class="hide" type="radio" name="attr_selected_move" value="escape_the_depths"/>
-                    <input class="hide move-highlight" type="checkbox" name="attr_escape_the_depths_highlight"/>
-                    <div class="move-name">Escape the Depths</div>
-                  </label>
-                </div>
-                <div class="move-list">
-                  <label class="move">
-                    <input class="hide" type="radio" name="attr_selected_move" value="reveal_a_danger_alt"/>
-                    <input class="hide move-highlight" type="checkbox" name="attr_reveal_a_danger_alt_highlight"/>
-                    <div class="move-name">Reveal a Danger - Alt</div>
                   </label>
                 </div>
               </div>
@@ -5405,25 +5441,6 @@
               </div>
               <div class="move-group-scroll">
                 <div class="move-group-title">
-                  <h3>FAILURE MOVES</h3>
-                </div>
-                <div class="move-list">
-                  <label class="move">
-                    <input class="hide" type="radio" name="attr_selected_move" value="mark_your_failure"/>
-                    <input class="hide move-highlight" type="checkbox" name="attr_mark_your_failure_highlight"/>
-                    <div class="move-name">Mark Your Failure</div>
-                  </label>
-                </div>
-                <div class="move-list">
-                  <label class="move">
-                    <input class="hide" type="radio" name="attr_selected_move" value="learn_from_your_failures"/>
-                    <input class="hide move-highlight" type="checkbox" name="attr_learn_from_your_failures_highlight"/>
-                    <div class="move-name">Learn From Your Failures</div>
-                  </label>
-                </div>
-              </div>
-              <div class="move-group-scroll">
-                <div class="move-group-title">
                   <h3>QUEST MOVES</h3>
                 </div>
                 <div class="move-list">
@@ -5459,6 +5476,53 @@
                     <input class="hide" type="radio" name="attr_selected_move" value="advance"/>
                     <input class="hide move-highlight" type="checkbox" name="attr_advance_highlight"/>
                     <div class="move-name">Advance</div>
+                  </label>
+                </div>
+              </div>
+              <div class="move-group-scroll">
+                <div class="move-group-title">
+                  <h3>COMBAT MOVES</h3>
+                </div>
+                <div class="move-list">
+                  <label class="move">
+                    <input class="hide" type="radio" name="attr_selected_move" value="enter_the_fray"/>
+                    <input class="hide move-highlight" type="checkbox" name="attr_enter_the_fray_highlight"/>
+                    <div class="move-name">Enter the Fray</div>
+                  </label>
+                </div>
+                <div class="move-list">
+                  <label class="move">
+                    <input class="hide" type="radio" name="attr_selected_move" value="strike"/>
+                    <input class="hide move-highlight" type="checkbox" name="attr_strike_highlight"/>
+                    <div class="move-name">Strike</div>
+                  </label>
+                </div>
+                <div class="move-list">
+                  <label class="move">
+                    <input class="hide" type="radio" name="attr_selected_move" value="clash"/>
+                    <input class="hide move-highlight" type="checkbox" name="attr_clash_highlight"/>
+                    <div class="move-name">Clash</div>
+                  </label>
+                </div>
+                <div class="move-list">
+                  <label class="move">
+                    <input class="hide" type="radio" name="attr_selected_move" value="turn_the_tide"/>
+                    <input class="hide move-highlight" type="checkbox" name="attr_turn_the_tide_highlight"/>
+                    <div class="move-name">Turn the Tide</div>
+                  </label>
+                </div>
+                <div class="move-list">
+                  <label class="move">
+                    <input class="hide" type="radio" name="attr_selected_move" value="end_the_fight"/>
+                    <input class="hide move-highlight" type="checkbox" name="attr_end_the_fight_highlight"/>
+                    <div class="move-name">End the Fight</div>
+                  </label>
+                </div>
+                <div class="move-list">
+                  <label class="move">
+                    <input class="hide" type="radio" name="attr_selected_move" value="battle"/>
+                    <input class="hide move-highlight" type="checkbox" name="attr_battle_highlight"/>
+                    <div class="move-name">Battle</div>
                   </label>
                 </div>
               </div>
@@ -5513,6 +5577,86 @@
                     <input class="hide" type="radio" name="attr_selected_move" value="face_a_setback"/>
                     <input class="hide move-highlight" type="checkbox" name="attr_face_a_setback_highlight"/>
                     <div class="move-name">Face a Setback</div>
+                  </label>
+                </div>
+              </div>
+              <div class="move-group-scroll">
+                <div class="move-group-title">
+                  <h3>DELVE MOVES</h3>
+                </div>
+                <div class="move-list">
+                  <label class="move">
+                    <input class="hide" type="radio" name="attr_selected_move" value="discover_a_site"/>
+                    <input class="hide move-highlight" type="checkbox" name="attr_discover_a_site_highlight"/>
+                    <div class="move-name">Discover a Site</div>
+                  </label>
+                </div>
+                <div class="move-list">
+                  <label class="move">
+                    <input class="hide" type="radio" name="attr_selected_move" value="delve_the_depths"/>
+                    <input class="hide move-highlight" type="checkbox" name="attr_delve_the_depths_highlight"/>
+                    <div class="move-name">Delve the Depths</div>
+                  </label>
+                </div>
+                <div class="move-list">
+                  <label class="move">
+                    <input class="hide" type="radio" name="attr_selected_move" value="find_an_opportunity"/>
+                    <input class="hide move-highlight" type="checkbox" name="attr_find_an_opportunity_highlight"/>
+                    <div class="move-name">Find an Opportunity</div>
+                  </label>
+                </div>
+                <div class="move-list">
+                  <label class="move">
+                    <input class="hide" type="radio" name="attr_selected_move" value="reveal_a_danger"/>
+                    <input class="hide move-highlight" type="checkbox" name="attr_reveal_a_danger_highlight"/>
+                    <div class="move-name">Reveal a Danger</div>
+                  </label>
+                </div>
+                <div class="move-list">
+                  <label class="move">
+                    <input class="hide" type="radio" name="attr_selected_move" value="check_your_gear"/>
+                    <input class="hide move-highlight" type="checkbox" name="attr_check_your_gear_highlight"/>
+                    <div class="move-name">Check Your Gear</div>
+                  </label>
+                </div>
+                <div class="move-list">
+                  <label class="move">
+                    <input class="hide" type="radio" name="attr_selected_move" value="locate_your_objective"/>
+                    <input class="hide move-highlight" type="checkbox" name="attr_locate_your_objective_highlight"/>
+                    <div class="move-name">Locate Your Objective</div>
+                  </label>
+                </div>
+                <div class="move-list">
+                  <label class="move">
+                    <input class="hide" type="radio" name="attr_selected_move" value="escape_the_depths"/>
+                    <input class="hide move-highlight" type="checkbox" name="attr_escape_the_depths_highlight"/>
+                    <div class="move-name">Escape the Depths</div>
+                  </label>
+                </div>
+                <div class="move-list">
+                  <label class="move">
+                    <input class="hide" type="radio" name="attr_selected_move" value="reveal_a_danger_alt"/>
+                    <input class="hide move-highlight" type="checkbox" name="attr_reveal_a_danger_alt_highlight"/>
+                    <div class="move-name">Reveal a Danger - Alt</div>
+                  </label>
+                </div>
+              </div>
+              <div class="move-group-scroll">
+                <div class="move-group-title">
+                  <h3>FAILURE MOVES</h3>
+                </div>
+                <div class="move-list">
+                  <label class="move">
+                    <input class="hide" type="radio" name="attr_selected_move" value="mark_your_failure"/>
+                    <input class="hide move-highlight" type="checkbox" name="attr_mark_your_failure_highlight"/>
+                    <div class="move-name">Mark Your Failure</div>
+                  </label>
+                </div>
+                <div class="move-list">
+                  <label class="move">
+                    <input class="hide" type="radio" name="attr_selected_move" value="learn_from_your_failures"/>
+                    <input class="hide move-highlight" type="checkbox" name="attr_learn_from_your_failures_highlight"/>
+                    <div class="move-name">Learn From Your Failures</div>
                   </label>
                 </div>
               </div>
@@ -5635,9 +5779,9 @@
                           <div class="battle showhide">
                             <div class="move-title move-preview">Battle</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Battle Move" name="rollBattle" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Battle}} {{action=[[d6+?{Stat|Edge, @{edge}|Iron, @{iron}|Heart, @{heart}|Shadow, @{shadow}|Wits, @{wits}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Battle Move" name="rollBattle" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Battle}} {{action=[[d6+?{Stat|Edge, @{edge}|Iron, @{iron}|Heart, @{heart}|Shadow, @{shadow}|Wits, @{wits}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you fight a battle,</strong> and it happens in a blur, envision your objective and roll. If you primarily...</p>
@@ -5669,9 +5813,9 @@
                           <div class="clash showhide">
                             <div class="move-title move-preview">Clash</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Clash Move" name="rollclash" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Clash}} {{action=[[d6+?{Stat|Edge&#44;@{edge}|Iron&#44;@{iron}|Light - Lightbearer&#44;?{Light&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Clash Move" name="rollclash" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Clash}} {{action=[[d6+?{Stat|Edge&#44;@{edge}|Iron&#44;@{iron}|Light - Lightbearer&#44;?{Light&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When </strong>your foe has initiative and you fight with them in close quarters,</strong> roll +iron. When you exchange a volley at range, or shoot at an advancing foe, roll +edge.</p>
@@ -5689,9 +5833,9 @@
                           <div class="companion-endure-harm showhide">
                             <div class="move-title move-preview">Companion Endure Harm</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Companion Endure Harm Move" name="rollcompanionEndureHarm" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Companion Endure Harm}} {{action=[[d6+?{Stat|Heart&#44;@{heart}|Companion's Health&#44;?{Health&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Companion Endure Harm Move" name="rollcompanionEndureHarm" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Companion Endure Harm}} {{action=[[d6+?{Stat|Heart&#44;@{heart}|Companion's Health&#44;?{Health&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>your companion faces physical damage,</strong> they suffer -health equal to the amount of harm inflicted. If your companion’s health is 0, exchange any leftover -health for -momentum.</p>
@@ -5707,9 +5851,9 @@
                           <div class="compel showhide">
                             <div class="move-title move-preview">Compel</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Compel Move" name="rollcompel" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Compel}} {{action=[[d6+?{Stat|Iron&#44;@{iron}|Heart&#44;@{heart}|Shadow&#44;@{shadow}|Essence - Invoke&#44;?{Essence&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Compel Move" name="rollcompel" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Compel}} {{action=[[d6+?{Stat|Iron&#44;@{iron}|Heart&#44;@{heart}|Shadow&#44;@{shadow}|Essence - Invoke&#44;?{Essence&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you attempt to persuade someone to do something,</strong> envision your approach and roll. If you...</p>
@@ -5728,9 +5872,9 @@
                           <div class="delve-the-depths showhide">
                             <div class="move-title move-preview">Delve the Depths</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Delve the Depths Move" name="rolldelveTheDepths" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Delve the Depths}} {{action=[[d6+?{Stat|Edge,@{edge}|Shadow,@{shadow}|Wits,@{wits}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Delve the Depths Move" name="rolldelveTheDepths" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Delve the Depths}} {{action=[[d6+?{Stat|Edge,@{edge}|Shadow,@{shadow}|Wits,@{wits}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you traverse an area within a perilous site,</strong> envision your surroundings (<em>Ask the Oracle</em> if unsure). Then, consider your approach. If you navigate this area…</p>
@@ -5787,9 +5931,9 @@
                           <div class="discover-a-site showhide">
                             <div class="move-title move-preview">Discover a Site</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Discover a Site Move" name="rolldiscoverASite" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Discover a Site}} {{action=[[d6+undefined+(?{Modifier|0})]]}} {{negate1=[[1+undefined+(?{Modifier|0})]]}} {{negate2=[[2+undefined+(?{Modifier|0})]]}} {{negate3=[[3+undefined+(?{Modifier|0})]]}} {{negate4=[[4+undefined+(?{Modifier|0})]]}} {{negate5=[[5+undefined+(?{Modifier|0})]]}} {{negate6=[[6+undefined+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[undefined+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[undefined]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Discover a Site" name="rolldiscoverASite" value="&amp;{template:ironsworn_moves} {{header=Discover a Site}} {{discoverASite=[[2d10kl1]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you resolve to enter a perilous site in pursuit of an objective,</strong> choose the theme and domain which best represent its nature (<em>Ask the Oracle</em> if unsure), and give it a rank.</p>
@@ -5808,9 +5952,9 @@
                           <div class="draw-the-circle showhide">
                             <div class="move-title move-preview">Draw the Circle</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Draw the Circle Move" name="rolldrawTheCircle" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Draw the Circle}} {{action=[[d6+@{heart}+(?{Modifier|0})]]}} {{negate1=[[1+@{heart}+(?{Modifier|0})]]}} {{negate2=[[2+@{heart}+(?{Modifier|0})]]}} {{negate3=[[3+@{heart}+(?{Modifier|0})]]}} {{negate4=[[4+@{heart}+(?{Modifier|0})]]}} {{negate5=[[5+@{heart}+(?{Modifier|0})]]}} {{negate6=[[6+@{heart}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[@{heart}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[@{heart}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Draw the Circle Move" name="rolldrawTheCircle" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Draw the Circle}} {{action=[[d6+@{heart}+(?{Modifier|0})]]}} {{negate1=[[1+@{heart}+(?{Modifier|0})]]}} {{negate2=[[2+@{heart}+(?{Modifier|0})]]}} {{negate3=[[3+@{heart}+(?{Modifier|0})]]}} {{negate4=[[4+@{heart}+(?{Modifier|0})]]}} {{negate5=[[5+@{heart}+(?{Modifier|0})]]}} {{negate6=[[6+@{heart}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[@{heart}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[@{heart}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you challenge someone to a formal duel, or accept a challenge,</strong> roll +heart. If you share a bond with this community, add +1.</p>
@@ -5832,9 +5976,9 @@
                           <div class="end-the-fight showhide">
                             <div class="move-title move-preview">End the Fight</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll Progress
-                                <button class="hide" type="roll" title="End the Fight" name="rollendTheFight" value="&amp;{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=End the Fight}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="End the Fight" name="rollendTheFight" value="&amp;{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=End the Fight}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p><strong><em>Progress Move</em></strong></p>
@@ -5857,9 +6001,9 @@
                           <div class="endure-harm showhide">
                             <div class="move-title move-preview">Endure Harm</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Endure Harm Move" name="rollendureHarm" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Endure Harm}} {{action=[[d6+@{iron}+(?{Modifier|0})]]}} {{negate1=[[1+@{iron}+(?{Modifier|0})]]}} {{negate2=[[2+@{iron}+(?{Modifier|0})]]}} {{negate3=[[3+@{iron}+(?{Modifier|0})]]}} {{negate4=[[4+@{iron}+(?{Modifier|0})]]}} {{negate5=[[5+@{iron}+(?{Modifier|0})]]}} {{negate6=[[6+@{iron}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[@{iron}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[@{iron}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Endure Harm Move" name="rollendureHarm" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Endure Harm}} {{action=[[d6+?{Stat|Health,@{health}|Iron,@{iron}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you face physical damage,</strong> suffer -health equal to your foe’s rank or as appropriate to the situation. If your health is 0, suffer -momentum equal to any remaining -health.</p>
@@ -5890,9 +6034,9 @@
                           <div class="endure-stress showhide">
                             <div class="move-title move-preview">Endure Stress</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Endure Stress Move" name="rollendureStress" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Endure Stress}} {{action=[[d6+?{Stat|Spirit,@{spirit}|Heart,@{heart}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Endure Stress Move" name="rollendureStress" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Endure Stress}} {{action=[[d6+?{Stat|Spirit,@{spirit}|Heart,@{heart}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you face mental shock or despair,</strong> suffer -spirit equal to your foe’s rank or as appropriate to the situation. If your spirit is 0, suffer -momentum equal to any remaining -spirit.</p>
@@ -5921,9 +6065,9 @@
                           <div class="enter-the-fray showhide">
                             <div class="move-title move-preview">Enter the Fray</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Enter the Fray Move" name="rollenterTheFray" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Enter the Fray}} {{action=[[d6+?{Stat|Heart, @{heart}|Shadow, @{shadow}|Wits, @{wits}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Enter the Fray Move" name="rollenterTheFray" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Enter the Fray}} {{action=[[d6+?{Stat|Heart, @{heart}|Shadow, @{shadow}|Wits, @{wits}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you enter into combat,</strong> set the rank of each of your foes.</p>
@@ -5954,9 +6098,9 @@
                           <div class="escape-the-depths showhide">
                             <div class="move-title move-preview">Escape the Depths</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Escape the Depths Move" name="rollescapeTheDepths" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Escape the Depths}} {{action=[[d6+?{Stat|Edge,@{edge}|Heart,@{heart}|Iron,@{iron}|Wits,@{wits}|Shadow,@{shadow}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Escape the Depths Move" name="rollescapeTheDepths" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Escape the Depths}} {{action=[[d6+?{Stat|Edge,@{edge}|Heart,@{heart}|Iron,@{iron}|Wits,@{wits}|Shadow,@{shadow}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you flee or withdraw from a site,</strong> consider the situation and your approach. If you...</p>
@@ -5997,9 +6141,9 @@
                           <div class="face-danger showhide">
                             <div class="move-title move-preview">Face Danger</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Face Danger Move" name="rollfaceDanger" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Face Danger}} {{action=[[d6+?{Stat|Edge&#44;@{edge}|Iron&#44;@{iron}|Heart&#44;@{heart}|Shadow&#44;@{shadow}|Wits&#44;@{wits}|Essence - Invoke&#44;?{Essence&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Face Danger Move" name="rollfaceDanger" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Face Danger}} {{action=[[d6+?{Stat|Edge&#44;@{edge}|Iron&#44;@{iron}|Heart&#44;@{heart}|Shadow&#44;@{shadow}|Wits&#44;@{wits}|Essence - Invoke&#44;?{Essence&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you attempt something risky or react to an imminent threat,</strong> envision your action and roll. If you act...</p>
@@ -6026,9 +6170,9 @@
                           <div class="face-death showhide">
                             <div class="move-title move-preview">Face Death</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Face Death Move" name="rollfaceDeath" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Face Death}} {{action=[[d6+?{Stat|Heart,@{heart}|Shadow - Shadow-kin,@{shadow}}+(?{Modifier|0})]]}} {{owl=[[?{Owl Companion|No&#44;0|Yes&#44;?{Owl's Health&amp;#124;0&amp;#125;&#125;]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}+(?{Owl Companion})]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Face Death Move" name="rollfaceDeath" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Face Death}} {{action=[[d6+?{Stat|Heart,@{heart}|Shadow - Shadow-kin,@{shadow}}+(?{Modifier|0})]]}} {{owl=[[?{Owl Companion|No&#44;0|Yes&#44;?{Owl's Health&amp;#124;0&amp;#125;&#125;]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}+(?{Owl Companion})]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you are brought to the brink of death,</strong> and glimpse the world beyond, roll +heart.</p>
@@ -6046,9 +6190,9 @@
                           <div class="face-desolation showhide">
                             <div class="move-title move-preview">Face Desolation</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Face Desolation Move" name="rollfaceDesolation" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Face Desolation}} {{action=[[d6+@{heart}+(?{Modifier|0})]]}} {{negate1=[[1+@{heart}+(?{Modifier|0})]]}} {{negate2=[[2+@{heart}+(?{Modifier|0})]]}} {{negate3=[[3+@{heart}+(?{Modifier|0})]]}} {{negate4=[[4+@{heart}+(?{Modifier|0})]]}} {{negate5=[[5+@{heart}+(?{Modifier|0})]]}} {{negate6=[[6+@{heart}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[@{heart}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[@{heart}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Face Desolation Move" name="rollfaceDesolation" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Face Desolation}} {{action=[[d6+@{heart}+(?{Modifier|0})]]}} {{negate1=[[1+@{heart}+(?{Modifier|0})]]}} {{negate2=[[2+@{heart}+(?{Modifier|0})]]}} {{negate3=[[3+@{heart}+(?{Modifier|0})]]}} {{negate4=[[4+@{heart}+(?{Modifier|0})]]}} {{negate5=[[5+@{heart}+(?{Modifier|0})]]}} {{negate6=[[6+@{heart}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[@{heart}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[@{heart}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you are brought to the brink of desolation,</strong> roll +heart.</p>
@@ -6096,9 +6240,9 @@
                           <div class="forge-a-bond showhide">
                             <div class="move-title move-preview">Forge a Bond</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Forge a Bond Move" name="rollforgeABond" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Forge a Bond}} {{action=[[d6+?{Stat|Heart,@{heart}|Shadow - Trickster,@{shadow}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Forge a Bond Move" name="rollforgeABond" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Forge a Bond}} {{action=[[d6+?{Stat|Heart,@{heart}|Shadow - Trickster,@{shadow}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you spend significant time with a person or community, stand together to face hardships, or make sacrifices for their cause,</strong> you can attempt to create a bond. When you do, roll +heart. If you make this move after you successfully <em>Fulfill Your Vow</em> to their benefit, you may reroll any dice.</p>
@@ -6124,9 +6268,9 @@
                           <div class="fulfill-your-vow showhide">
                             <div class="move-title move-preview">Fulfill Your Vow</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll Progress
-                                <button class="hide" type="roll" title="Fulfill Your Vow" name="rollfulfillYourVow" value="&amp;{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=Fulfill Your Vow}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Fulfill Your Vow" name="rollfulfillYourVow" value="&amp;{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=Fulfill Your Vow}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p><strong><em>Progress Move</em></strong></p>
@@ -6145,9 +6289,9 @@
                           <div class="gather-information showhide">
                             <div class="move-title move-preview">Gather Information</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Gather Information Move" name="rollgatherInformation" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Gather Information}} {{action=[[d6+?{Stat|Wits,@{wits}|Shadow - Infiltrator/Trickster/Scry,@{shadow}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Gather Information Move" name="rollgatherInformation" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Gather Information}} {{action=[[d6+?{Stat|Wits,@{wits}|Shadow - Infiltrator/Trickster/Scry,@{shadow}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you search an area, ask questions, conduct an investigation, or follow a track,</strong> roll +wits. If you act within a community or ask questions of a person with whom you share a bond, add +1.</p>
@@ -6161,9 +6305,9 @@
                           <div class="heal showhide">
                             <div class="move-title move-preview">Heal</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Heal Move" name="rollheal" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Heal}} {{action=[[d6+?{Stat|Wits,@{wits}|Iron,@{iron}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Heal Move" name="rollheal" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Heal}} {{action=[[d6+?{Stat|Wits,@{wits}|Iron,@{iron}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you treat an injury or ailment,</strong> roll +wits. If you are mending your own wounds, roll +wits or +iron, whichever is lower.</p>
@@ -6177,9 +6321,9 @@
                           <div class="learn-from-your-failures showhide">
                             <div class="move-title move-preview">Learn From Your Failures</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll Progress
-                                <button class="hide" type="roll" title="Learn From Your Failures" name="rolllearnFromYourFailures" value="&amp;{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=Learn From Your Failures}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Learn From Your Failures" name="rolllearnFromYourFailures" value="&amp;{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=Learn From Your Failures}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p><strong><em>Progress Move</em></strong></p>
@@ -6199,9 +6343,9 @@
                           <div class="locate-your-objective showhide">
                             <div class="move-title move-preview">Locate Your Objective</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll Progress
-                                <button class="hide" type="roll" title="Locate Your Objective" name="rolllocateYourObjective" value="&amp;{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=Locate Your Objective}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Locate Your Objective" name="rolllocateYourObjective" value="&amp;{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=Locate Your Objective}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p><strong><em>Progress Move</em></strong></p>
@@ -6220,9 +6364,9 @@
                           <div class="make-camp showhide">
                             <div class="move-title move-preview">Make Camp</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Make Camp Move" name="rollmakeCamp" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Make Camp}} {{action=[[d6+?{Stat|Supply&#44;@{supply}|Wits - Wildblood&#44;@{wits}|Health - Mammoth&#44;?{Mammoth's Health&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Make Camp Move" name="rollmakeCamp" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Make Camp}} {{action=[[d6+?{Stat|Supply&#44;@{supply}|Wits - Wildblood&#44;@{wits}|Health - Mammoth&#44;?{Mammoth's Health&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you rest and recover for several hours in the wild,</strong> roll +supply.</p>
@@ -6310,9 +6454,9 @@
                           <div class="reach-your-destination showhide">
                             <div class="move-title move-preview">Reach Your Destination</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll Progress
-                                <button class="hide" type="roll" title="Reach Your Destination" name="rollreachYourDestination" value="&amp;{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=Reach Your Destination}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Reach Your Destination" name="rollreachYourDestination" value="&amp;{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=Reach Your Destination}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p><strong><em>Progress Move</em></strong></p>
@@ -6331,9 +6475,9 @@
                           <div class="resupply showhide">
                             <div class="move-title move-preview">Resupply</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Resupply Move" name="rollresupply" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Resupply}} {{action=[[d6+?{Stat|Wits,@{wits}|Edge - Cave Lion,@{edge}|Shadow - Infiltrator,@{shadow}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Resupply Move" name="rollresupply" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Resupply}} {{action=[[d6+?{Stat|Wits,@{wits}|Edge - Cave Lion,@{edge}|Shadow - Infiltrator,@{shadow}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you hunt, forage, or scavenge,</strong> roll +wits.</p>
@@ -6399,9 +6543,9 @@
                           <div class="secure-an-advantage showhide">
                             <div class="move-title move-preview">Secure an Advantage</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Secure an Advantage Move" name="rollsecureAnAdvantage" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Secure an Advantage}} {{action=[[d6+?{Stat|Edge&#44;@{edge}|Iron&#44;@{iron}|Heart&#44;@{heart}|Shadow&#44;@{shadow}|Wits&#44;@{wits}|God's Stat - Devotant&#44;?{God's Stat&amp;#124;0&amp;#125;|Essence - Invoke&#44;?{Essence&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Secure an Advantage Move" name="rollsecureAnAdvantage" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Secure an Advantage}} {{action=[[d6+?{Stat|Edge&#44;@{edge}|Iron&#44;@{iron}|Heart&#44;@{heart}|Shadow&#44;@{shadow}|Wits&#44;@{wits}|God's Stat - Devotant&#44;?{God's Stat&amp;#124;0&amp;#125;|Essence - Invoke&#44;?{Essence&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you assess a situation, make preparations, or attempt to gain leverage,</strong> envision your action and roll. If you act...</p>
@@ -6426,9 +6570,9 @@
                           <div class="sojourn showhide">
                             <div class="move-title move-preview">Sojourn</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Sojourn Move" name="rollsojourn" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Sojourn}} {{action=[[d6+?{Stat|Heart&#44;@{heart}|Shadow - Pretender&#44;@{shadow}|God's Stat - Devotant&#44;?{God's Stat&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Sojourn Move" name="rollsojourn" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Sojourn}} {{action=[[d6+?{Stat|Heart&#44;@{heart}|Shadow - Pretender&#44;@{shadow}|God's Stat - Devotant&#44;?{God's Stat&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you spend time in a community seeking assistance,</strong> roll +heart. If you share a bond, add +1.</p>
@@ -6459,9 +6603,9 @@
                           <div class="strike showhide">
                             <div class="move-title move-preview">Strike</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Strike Move" name="rollstrike" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Strike}} {{action=[[d6+?{Stat|Edge&#44;@{edge}|Iron&#44;@{iron}|Light - Lightbearer&#44;?{Light&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Strike Move" name="rollstrike" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Strike}} {{action=[[d6+?{Stat|Edge&#44;@{edge}|Iron&#44;@{iron}|Light - Lightbearer&#44;?{Light&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you have initiative and attack in close quarters,</strong> roll +iron. When you have initiative and attack at range, roll +edge.</p>
@@ -6475,9 +6619,9 @@
                           <div class="swear-an-iron-vow showhide">
                             <div class="move-title move-preview">Swear an Iron Vow</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Swear an Iron Vow Move" name="rollswearAnIronVow" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Swear an Iron Vow}} {{action=[[d6+?{Stat|Heart&#44;@{heart}|God's Stat - Devotant&#44;?{God's Stat&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Swear an Iron Vow Move" name="rollswearAnIronVow" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Swear an Iron Vow}} {{action=[[d6+?{Stat|Heart&#44;@{heart}|God's Stat - Devotant&#44;?{God's Stat&amp;#124;0&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you swear upon iron to complete a quest,</strong> write your vow and give the quest a rank. Then, roll +heart. If you make this vow to a person or community with whom you share a bond, add +1.</p>
@@ -6509,9 +6653,9 @@
                           <div class="test-your-bond showhide">
                             <div class="move-title move-preview">Test Your Bond</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Test Your Bond Move" name="rolltestYourBond" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Test Your Bond}} {{action=[[d6+@{heart}+(?{Modifier|0})]]}} {{negate1=[[1+@{heart}+(?{Modifier|0})]]}} {{negate2=[[2+@{heart}+(?{Modifier|0})]]}} {{negate3=[[3+@{heart}+(?{Modifier|0})]]}} {{negate4=[[4+@{heart}+(?{Modifier|0})]]}} {{negate5=[[5+@{heart}+(?{Modifier|0})]]}} {{negate6=[[6+@{heart}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[@{heart}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[@{heart}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Test Your Bond Move" name="rolltestYourBond" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Test Your Bond}} {{action=[[d6+@{heart}+(?{Modifier|0})]]}} {{negate1=[[1+@{heart}+(?{Modifier|0})]]}} {{negate2=[[2+@{heart}+(?{Modifier|0})]]}} {{negate3=[[3+@{heart}+(?{Modifier|0})]]}} {{negate4=[[4+@{heart}+(?{Modifier|0})]]}} {{negate5=[[5+@{heart}+(?{Modifier|0})]]}} {{negate6=[[6+@{heart}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[@{heart}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[@{heart}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>your bond is tested through conflict, betrayal, or circumstance,</strong> roll +heart.</p>
@@ -6538,9 +6682,9 @@
                           <div class="undertake-a-journey showhide">
                             <div class="move-title move-preview">Undertake a Journey</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Undertake a Journey Move" name="rollundertakeAJourney" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Undertake a Journey}} {{action=[[d6+?{Stat|Wits,@{wits}|Shadow - Shadow-walk,@{shadow}|Spirit or Heart - Tether&#44;?{Tether Stat&amp;#124;Spirit&amp;#44;@{spirit}&amp;#124;Heart&amp;#44;@{heart}&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Undertake a Journey Move" name="rollundertakeAJourney" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Undertake a Journey}} {{action=[[d6+?{Stat|Wits,@{wits}|Shadow - Shadow-walk,@{shadow}|Spirit or Heart - Tether&#44;?{Tether Stat&amp;#124;Spirit&amp;#44;@{spirit}&amp;#124;Heart&amp;#44;@{heart}&amp;#125;&#125;+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you travel across hazardous or unfamiliar lands,</strong> set the rank of your journey.</p>
@@ -6566,9 +6710,9 @@
                           <div class="wield-a-rarity showhide">
                             <div class="move-title move-preview">Wield A Rarity</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll
-                                <button class="hide" type="roll" title="Wield A Rarity Move" name="rollwieldARairty" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Wield A Rarity}} {{rarityAction=[[d6+?{Stat|Edge,@{edge}|Iron,@{iron}|Heart,@{heart}|Shadow,@{shadow}|Wits,@{wits}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}} {{rarityDie6=[[6+?{Stat}+(?{Modifier|0})]]}} {{rarityDie5=[[5+?{Stat}+(?{Modifier|0})]]}} {{rarityDie1=[[1+?{Stat}+(?{Modifier|0})]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Wield A Rarity Move" name="rollwieldARairty" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=Wield A Rarity}} {{rarityAction=[[d6+?{Stat|Edge,@{edge}|Iron,@{iron}|Heart,@{heart}|Shadow,@{shadow}|Wits,@{wits}}+(?{Modifier|0})]]}} {{negate1=[[1+?{Stat}+(?{Modifier|0})]]}} {{negate2=[[2+?{Stat}+(?{Modifier|0})]]}} {{negate3=[[3+?{Stat}+(?{Modifier|0})]]}} {{negate4=[[4+?{Stat}+(?{Modifier|0})]]}} {{negate5=[[5+?{Stat}+(?{Modifier|0})]]}} {{negate6=[[6+?{Stat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[?{Stat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[?{Stat}]]}} {{rarityDie6=[[6+?{Stat}+(?{Modifier|0})]]}} {{rarityDie5=[[5+?{Stat}+(?{Modifier|0})]]}} {{rarityDie1=[[1+?{Stat}+(?{Modifier|0})]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p>When <strong>you make a move aided by an augmented asset,</strong> roll your rarity die in place of your action die.</p>
@@ -6582,9 +6726,9 @@
                           <div class="write-your-epilogue showhide">
                             <div class="move-title move-preview">Write Your Epilogue</div>
                             <div class="roll-viewer">
-                              <label class="roll-label">Roll Progress
-                                <button class="hide" type="roll" title="Write Your Epilogue" name="rollwriteYourEpilogue" value="&amp;{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=Write Your Epilogue}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
-                              </label>
+                                    <label class="roll-label">Roll
+                                            <button class="hide" type="roll" title="Write Your Epilogue" name="rollwriteYourEpilogue" value="&amp;{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=Write Your Epilogue}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                                    </label>
                             </div>
                             <div class="move-description">
                               <p><strong><em>Progress Move</em></strong></p>
@@ -18954,6 +19098,11 @@
     {{/^rollGreater() rarityAction challenge1}}
     {{/^rollTotal() rarityDie6 rarityAction}}{{/^rollLess() momentum 0}}
     {{/rarityAction}}
+    {{#discoverASite}}
+    <div class="sheet-subheader">{{header}}</div>
+    <div class="sheet-result-row">
+      <div class="sheet-oracle-table-text">Clear {{discoverASite}} Progress</div>
+    </div>{{/discoverASite}}
     {{#custom}}
     {{#header}}
     <div class="sheet-result-body sheet-result-row">
@@ -19487,22 +19636,7 @@ on('change:repeating_sites:domain_select', function(eventinfo) {
   setAttrs({
     repeating_sites_domain: eventinfo.newValue,
   });
-});//Reset Health if set above Max
-on('change:health', function(healthChange) {
-  getAttrs(["max_health"], function(values) {
-    if (parseInt(healthChange.newValue) > parseInt(values.max_health)) {
-      setAttrs({health: values.max_health});
-    }
-  });
-});
-
-on('change:health_reset', function() {
-  getAttrs(["max_health"], function(values) {
-      setAttrs({health: values.max_health});
-  });
-});
-
-//Cannot increase Health while Wounded
+});//Cannot increase Health while Wounded
 //Health reaching 0 marks Wounded
 on('change:health', function(eventinfo) {
     getAttrs(["debilWounded"], function(values) {
@@ -19529,53 +19663,16 @@ on('change:spirit', function(eventinfo) {
 //Cannot increase Supply while Unprepared
 //Supply reaching 0 marks Unprepared
 on('change:supply', function(eventinfo) {
-    getAttrs(["unprepared"], function(values) {
+    getAttrs(["debilUnprepared"], function(values) {
         if(values.unprepared == "on") {
             if (parseInt(eventinfo.newValue) > parseInt(eventinfo.previousValue)) {
                 setAttrs({supply: eventinfo.previousValue});
             }
         }
     });
-    if (parseInt(eventinfo.newValue) === 0) setAttrs({unprepared_button: "on"});
+    if (parseInt(eventinfo.newValue) === 0) setAttrs({debilUnprepared: "on"});
 });
-
-// Edge sets Speed value
-on('change:edge', function(eventinfo) {
-  setAttrs({speed: speedValues[eventinfo.newValue].full});
-});
-
-const speedValues = {
-  '8': { full: '40ft/20ft. 12m/6m. 8/4', imperial: '40ft/20ft', metric: '12 m/6 m. ', units: '8/4' },
-  '7': { full: '40ft/20ft. 12m/6m. 8/4', imperial: '40ft/20ft',metric: '12m/6m. ', units: '8/4' },
-  '6': { full: '35ft/15ft. 10.5m/4.5m. 7/3', imperial: '35ft/15ft',metric: '10.5m/4.5m.', units: '7/3' },
-  '5': { full: '35ft/15ft. 10.5m/4.5m. 7/3', imperial: '35ft/15ft',metric: '10.5m/4.5m.', units: '7/3' },
-  '4': { full: '30ft/15ft. 9m/4.5m. 6/3', imperial: '30ft/15ft',metric: '9m/4.5m.', units: '6/3' },
-  '3': { full: '30ft/15ft. 9m/4.5m. 6/3', imperial: '30ft/15ft',metric: '9m/4.5m.', units: '6/3' },
-  '2': { full: '25ft/10ft. 7.5m/3m. 5/2', imperial: '25ft/10ft',metric: '7.5m/3m.', units: '5/2' },
-  '1': { full: '25ft/10ft. 7.5m/3m. 5/2', imperial: '25ft/10ft',metric: '7.5m/3m.', units: '5/2' },
-  '0': { full: '25ft/10ft. 7.5m/3m. 5/2', imperial: '25ft/10ft',metric: '7.5m/3m.', units: '5/2' }
-}
-
-// Heart sets Resilience value
-on('change:heart', function(eventinfo) {
-  let resValue = parseInt(eventinfo.newValue) + 1
-  setAttrs({resilience: resValue});
-});
-
-// Iron sets Max Load value
-on('change:iron', function(eventinfo) {
-  let loadValue = parseInt(eventinfo.newValue) + 4
-  setAttrs({max_load: loadValue});
-});
-
-// Setting Encumbered if load is over max
-on('change:load', function(eventinfo) {
-  getAttrs(['max_load'], function(values) {
-    if (parseInt(eventinfo.newValue) > parseInt(values.max_load)) {
-      setAttrs({encumbered: 'on'});
-    }
-  });
-});on('remove:repeating_vow remove:repeating_bonds remove:repeating_progress remove:repeating_sites remove:repeating_assets', function() { 
+  on('remove:repeating_vow remove:repeating_bonds remove:repeating_progress remove:repeating_sites remove:repeating_assets', function() { 
   const timestamp = Number(new Date())
   setAttrs({ repeat_delete: timestamp });
 });

--- a/Ironsworn/src/Ironsworn.styl
+++ b/Ironsworn/src/Ironsworn.styl
@@ -242,7 +242,8 @@ button.btn.repcontrol_add
   flex-flow: row wrap
 
 .sheet-flex-container
-  display: flex
+  display flex
+  align-items flex-start
 
 .sheet-flex-wrapper
   display flex

--- a/Ironsworn/src/components/moves/mixins/container.pug
+++ b/Ironsworn/src/components/moves/mixins/container.pug
@@ -1,3 +1,56 @@
+mixin progressRoll(opts)
+  button(
+    type="roll"
+    title=opts.title
+    name=`roll${opts.name}`
+    class='hide'
+    value=`&{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=${opts.title}}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}`
+  )
+
+mixin oracleRoll(opts)
+  button(
+    type="roll"
+    title=opts.title
+    name=`roll${opts.name}`
+    class='hide'
+    value=`&{template:${opts.type}} {{header=${opts.title}}} {{${opts.name}=[[d100]]}}`
+  )
+
+mixin rarityRoll(opts)
+  button(
+    type="roll"
+    title=`${opts.title} Move`
+    class='hide'
+    name=`roll${opts.name}`
+    value!=`&{template:ironsworn_moves} {{header=@{character_name}}} {{name=${opts.title}}} {{rarityAction=[[d6+${opts.stat}+(?{Modifier|0})]]}} {{negate1=[[1+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate2=[[2+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate3=[[3+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate4=[[4+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate5=[[5+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate6=[[6+${opts.stat_repeat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[${opts.stat_repeat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[${opts.stat_repeat}]]}} {{rarityDie6=[[6+${opts.stat_repeat}+(?{Modifier|0})]]}} {{rarityDie5=[[5+${opts.stat_repeat}+(?{Modifier|0})]]}} {{rarityDie1=[[1+${opts.stat_repeat}+(?{Modifier|0})]]}}`
+  )
+
+mixin owlRoll(opts)
+  button(
+    type="roll"
+    title=`${opts.title} Move`
+    class='hide'
+    name=`roll${opts.name}`
+    value!=`&{template:ironsworn_moves} {{header=@{character_name}}} {{name=${opts.title}}} {{action=[[d6+${opts.stat}+(?{Modifier|0})]]}} {{owl=[[?{Owl Companion|No&#44;0|Yes&#44;?{Owl's Health&amp;#124;0&amp;#125;&#125;]]}} {{negate1=[[1+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate2=[[2+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate3=[[3+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate4=[[4+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate5=[[5+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate6=[[6+${opts.stat_repeat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}+(?{Owl Companion})]]}} {{modifiers=[[${opts.stat_repeat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[${opts.stat_repeat}]]}}`
+  )
+
+mixin movesRoll(opts)
+  button(
+    type="roll"
+    title=`${opts.title} Move`
+    class='hide'
+    name=`roll${opts.name}`
+    value!=`&{template:ironsworn_moves} {{header=@{character_name}}} {{name=${opts.title}}} {{action=[[d6+${opts.stat}+(?{Modifier|0})]]}} {{negate1=[[1+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate2=[[2+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate3=[[3+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate4=[[4+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate5=[[5+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate6=[[6+${opts.stat_repeat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[${opts.stat_repeat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[${opts.stat_repeat}]]}}`
+  )
+
+mixin rollLabel
+  label.roll-label Roll
+    block
+
+mixin rollListLabel
+  label.roll-list-label Roll
+    block
+
 mixin container(opts)
   input(type='radio' name='attr_move_preview' class=`${opts.class} hide` value=opts.radio)
   div(class=`${opts.class} showhide`)
@@ -5,50 +58,37 @@ mixin container(opts)
     if opts.roll
       div.roll-viewer
         if opts.progress
-          label.roll-label Roll Progress
-            button(
-              type="roll"
-              title=opts.title
-              name=`roll${opts.name}`
-              class='hide'
-              value=`&{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=${opts.title}}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}`
-            )
+          +rollLabel
+            +progressRoll(opts)
         else if opts.oracle
-          label.roll-label Roll Oracle
-            button(
-              type="roll"
-              title=opts.title
-              name=`roll${opts.name}`
-              class='hide'
-              value=`&{template:${opts.type}} {{header=${opts.title}}} {{${opts.name}=[[d100]]}}`
-            )
+          +rollLabel
+            +oracleRoll(opts)
         else if opts.rarity
-          label.roll-label Roll
-            button(
-              type="roll"
-              title=`${opts.title} Move`
-              class='hide'
-              name=`roll${opts.name}`
-              value!=`&{template:ironsworn_moves} {{header=@{character_name}}} {{name=${opts.title}}} {{rarityAction=[[d6+${opts.stat}+(?{Modifier|0})]]}} {{negate1=[[1+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate2=[[2+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate3=[[3+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate4=[[4+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate5=[[5+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate6=[[6+${opts.stat_repeat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[${opts.stat_repeat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[${opts.stat_repeat}]]}} {{rarityDie6=[[6+${opts.stat_repeat}+(?{Modifier|0})]]}} {{rarityDie5=[[5+${opts.stat_repeat}+(?{Modifier|0})]]}} {{rarityDie1=[[1+${opts.stat_repeat}+(?{Modifier|0})]]}}`
-            )
+          +rollLabel
+            +rarityRoll(opts)
         else if opts.owl
-          label.roll-label Roll
-            button(
-              type="roll"
-              title=`${opts.title} Move`
-              class='hide'
-              name=`roll${opts.name}`
-              value!=`&{template:ironsworn_moves} {{header=@{character_name}}} {{name=${opts.title}}} {{action=[[d6+${opts.stat}+(?{Modifier|0})]]}} {{owl=[[?{Owl Companion|No&#44;0|Yes&#44;?{Owl's Health&amp;#124;0&amp;#125;&#125;]]}} {{negate1=[[1+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate2=[[2+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate3=[[3+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate4=[[4+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate5=[[5+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate6=[[6+${opts.stat_repeat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}+(?{Owl Companion})]]}} {{modifiers=[[${opts.stat_repeat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[${opts.stat_repeat}]]}}`
-            )
+          +rollLabel
+            +owlRoll(opts)
         else
-          label.roll-label Roll
-            button(
-              type="roll"
-              title=`${opts.title} Move`
-              class='hide'
-              name=`roll${opts.name}`
-              value!=`&{template:ironsworn_moves} {{header=@{character_name}}} {{name=${opts.title}}} {{action=[[d6+${opts.stat}+(?{Modifier|0})]]}} {{negate1=[[1+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate2=[[2+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate3=[[3+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate4=[[4+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate5=[[5+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate6=[[6+${opts.stat_repeat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[${opts.stat_repeat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[${opts.stat_repeat}]]}}`
-            )
+          +rollLabel
+            +movesRoll(opts)
     div.move-description
       block
     div.oracle-footer.move-page-footer=opts.page
+
+mixin listButton(opts)
+  if opts.progress
+    +rollListLabel
+      +progressRoll(opts)
+  else if opts.oracle
+    +rollListLabel
+      +oracleRoll(opts)
+  else if opts.rarity
+    +rollListLabel
+      +rarityRoll(opts)
+  else if opts.owl
+    +rollListLabel
+      +owlRoll(opts)
+  else
+    +rollListLabel
+      +movesRoll(opts)

--- a/Ironsworn/src/components/moves/mixins/container.pug
+++ b/Ironsworn/src/components/moves/mixins/container.pug
@@ -1,44 +1,53 @@
-mixin progressRoll(opts)
+mixin progressRoll(opts, visibility)
   button(
     type="roll"
     title=opts.title
     name=`roll${opts.name}`
-    class='hide'
+    class=visibility
     value=`&{template:ironsworn_progress} {{header=@{character_name}}} {{progress_name=${opts.title}}} {{progress=[[?{Filled Progress|0}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}`
   )
 
-mixin oracleRoll(opts)
+mixin oracleRoll(opts, visibility)
   button(
     type="roll"
     title=opts.title
     name=`roll${opts.name}`
-    class='hide'
+    class=visibility
     value=`&{template:${opts.type}} {{header=${opts.title}}} {{${opts.name}=[[d100]]}}`
   )
 
-mixin rarityRoll(opts)
+mixin discoverASiteRoll(opts, visibility)
+  button(
+    type="roll"
+    title=opts.title
+    name=`roll${opts.name}`
+    class=visibility
+    value=`&{template:ironsworn_moves} {{header=${opts.title}}} {{${opts.name}=[[2d10kl1]]}}`
+  )
+
+mixin rarityRoll(opts, visibility)
   button(
     type="roll"
     title=`${opts.title} Move`
-    class='hide'
+    class=visibility
     name=`roll${opts.name}`
     value!=`&{template:ironsworn_moves} {{header=@{character_name}}} {{name=${opts.title}}} {{rarityAction=[[d6+${opts.stat}+(?{Modifier|0})]]}} {{negate1=[[1+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate2=[[2+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate3=[[3+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate4=[[4+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate5=[[5+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate6=[[6+${opts.stat_repeat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[${opts.stat_repeat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[${opts.stat_repeat}]]}} {{rarityDie6=[[6+${opts.stat_repeat}+(?{Modifier|0})]]}} {{rarityDie5=[[5+${opts.stat_repeat}+(?{Modifier|0})]]}} {{rarityDie1=[[1+${opts.stat_repeat}+(?{Modifier|0})]]}}`
   )
 
-mixin owlRoll(opts)
+mixin owlRoll(opts, visibility)
   button(
     type="roll"
     title=`${opts.title} Move`
-    class='hide'
+    class=visibility
     name=`roll${opts.name}`
     value!=`&{template:ironsworn_moves} {{header=@{character_name}}} {{name=${opts.title}}} {{action=[[d6+${opts.stat}+(?{Modifier|0})]]}} {{owl=[[?{Owl Companion|No&#44;0|Yes&#44;?{Owl's Health&amp;#124;0&amp;#125;&#125;]]}} {{negate1=[[1+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate2=[[2+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate3=[[3+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate4=[[4+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate5=[[5+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate6=[[6+${opts.stat_repeat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}+(?{Owl Companion})]]}} {{modifiers=[[${opts.stat_repeat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[${opts.stat_repeat}]]}}`
   )
 
-mixin movesRoll(opts)
+mixin movesRoll(opts, visibility)
   button(
     type="roll"
     title=`${opts.title} Move`
-    class='hide'
+    class=visibility
     name=`roll${opts.name}`
     value!=`&{template:ironsworn_moves} {{header=@{character_name}}} {{name=${opts.title}}} {{action=[[d6+${opts.stat}+(?{Modifier|0})]]}} {{negate1=[[1+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate2=[[2+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate3=[[3+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate4=[[4+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate5=[[5+${opts.stat_repeat}+(?{Modifier|0})]]}} {{negate6=[[6+${opts.stat_repeat}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[${opts.stat_repeat}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[${opts.stat_repeat}]]}}`
   )
@@ -59,36 +68,37 @@ mixin container(opts)
       div.roll-viewer
         if opts.progress
           +rollLabel
-            +progressRoll(opts)
+            +progressRoll(opts, 'hide')
         else if opts.oracle
           +rollLabel
-            +oracleRoll(opts)
+            +oracleRoll(opts, 'hide')
         else if opts.rarity
           +rollLabel
-            +rarityRoll(opts)
+            +rarityRoll(opts, 'hide')
         else if opts.owl
           +rollLabel
-            +owlRoll(opts)
+            +owlRoll(opts, 'hide')
+        else if opts.discover_a_site
+          +rollLabel
+            +discoverASiteRoll(opts, 'hide')
         else
           +rollLabel
-            +movesRoll(opts)
+            +movesRoll(opts, 'hide')
     div.move-description
       block
     div.oracle-footer.move-page-footer=opts.page
 
 mixin listButton(opts)
-  if opts.progress
-    +rollListLabel
-      +progressRoll(opts)
-  else if opts.oracle
-    +rollListLabel
-      +oracleRoll(opts)
-  else if opts.rarity
-    +rollListLabel
-      +rarityRoll(opts)
-  else if opts.owl
-    +rollListLabel
-      +owlRoll(opts)
-  else
-    +rollListLabel
-      +movesRoll(opts)
+  .button-container
+    if opts.progress
+      +progressRoll(opts, 'roll-show')
+    else if opts.oracle
+      +oracleRoll(opts, 'roll-show')
+    else if opts.rarity
+      +rarityRoll(opts, 'roll-show')
+    else if opts.owl
+      +owlRoll(opts, 'roll-show')
+    else if opts.discover_a_site
+      +discoverASiteRoll(opts, 'roll-show')
+    else
+      +movesRoll(opts, 'roll-show')

--- a/Ironsworn/src/components/moves/mixins/move-builder.pug
+++ b/Ironsworn/src/components/moves/mixins/move-builder.pug
@@ -4,8 +4,6 @@ include ./oracle-table
 include ./standalone-tables
 include ../../../data/oracles
 
-//- TODO: Discover a site roll
-
 mixin moveBuilder(opts)
   +container(opts)
     each row in opts.content

--- a/Ironsworn/src/components/moves/moves.pug
+++ b/Ironsworn/src/components/moves/moves.pug
@@ -23,6 +23,7 @@ input(type='radio' class='hide full-move-list' name='attr_move_view' value='1' c
             h3=group.title
           each move in group.moves
             .move-list
+              +listButton(moveList[move.value])
               label.move
                 input(type='radio' class='hide selected-move' name='attr_selected_move' value=move.value)
                 input(type='checkbox' class='hide move-highlight' name=`attr_${move.value}_highlight`)

--- a/Ironsworn/src/components/moves/moves.pug
+++ b/Ironsworn/src/components/moves/moves.pug
@@ -1,6 +1,8 @@
 include ../../data/group-list
+include ../../data/scroll-list
 include ../../data/move-list
 include ./mixins/move-builder
+
 
 //- Search Bar
 input(type='radio' class='hide full-move-list' name='attr_move_view' value='1' checked)
@@ -49,7 +51,7 @@ input(type='radio' class='hide move-preview' name='attr_move_view' value='2')
         input(type='checkbox' class='hide' name='attr_close_move_preview')
   .preview-container
     .move-scroll-list
-      each group in moveGroups
+      each group in moveGroupsScroll
         .move-group-scroll
           .move-group-title
             h3=group.title

--- a/Ironsworn/src/components/moves/moves.pug
+++ b/Ironsworn/src/components/moves/moves.pug
@@ -33,6 +33,7 @@ input(type='radio' class='hide full-move-list' name='attr_move_view' value='1' c
             h3=group.title
           each move in group.moves
             .move-list
+              +listButton(moveList[move.value])
               label.move
                 input(type='radio' class='hide selected-move' name='attr_selected_move' value=move.value)
                 input(type='checkbox' class='hide move-highlight' name=`attr_${move.value}_highlight`)

--- a/Ironsworn/src/components/moves/moves.styl
+++ b/Ironsworn/src/components/moves/moves.styl
@@ -19,7 +19,7 @@ div
 input
   &.sheet-search-preview-bar
     width 17.6em
-    border 2px solid #4C4D4F
+    borderCommon()
     border-radius 0
     &:focus
       outline 3px solid #fd0
@@ -27,7 +27,7 @@ input
       box-shadow inset 0 0 0 2px
   &.sheet-search-bar
     width 50%
-    border 2px solid #4C4D4F
+    borderCommon()
     &:focus
       outline 3px solid #fd0
       outline-offset 0
@@ -51,23 +51,23 @@ input
   .sheet-move-scroll-list
     width 21.9em
     overflow auto
-    border 2px solid #4C4D4F
+    borderCommon()
     padding 0
     height 50em
 
 .sheet-move-container
-  display flex
   flex-wrap wrap
   flex-direction column
   justify-content space-between
-  height 36em
+  height 45em
   margin-top 1em
   display flex
   font-size 1em
   font-weight normal
+  align-content space-between
   .sheet-move-scroll-list
     overflow auto
-    border 2px solid #4C4D4F
+    borderCommon()
     padding 1em
     width max-content
 
@@ -82,6 +82,10 @@ input
   h3
     color #fff
 
+.sheet-move-name
+  width 100%
+  borderCommon()
+
 .sheet-move-highlight
   &:checked
     & ~ .sheet-move-name
@@ -89,13 +93,20 @@ input
       outline-offset 0
       box-shadow inset 0 0 0 2px
 
+.sheet-roll-show
+  padding 0 !important
+  font-size 20px !important
+  margin 0 !important
+  &:hover
+    color white
+
 .sheet-move-list
   padding 0
+  display flex
   label
     cursor pointer
   div
     font-weight 600
-    width 100%
     font-size 14px
     text-align center
     margin 0 0 0px
@@ -122,7 +133,7 @@ span
     margin-left 1em
 
 .sheet-move-group
-  border 2px solid #4C4D4F
+  borderCommon()
   box-sizing border-box
   width 30%
   margin 0.3em
@@ -130,7 +141,7 @@ span
   height -moz-fit-content
 
 .sheet-move-group-scroll
-  border 2px solid #4C4D4F
+  borderCommon()
   box-sizing border-box
   height fit-content
   height -moz-fit-content
@@ -188,7 +199,7 @@ span
 .sheet-move-description
   std-font('Crimson Text')
   padding 1em
-  border 2px solid #4C4D4F
+  borderCommon()
   p
     margin-bottom 0.3em
 

--- a/Ironsworn/src/components/oracles/oracles.styl
+++ b/Ironsworn/src/components/oracles/oracles.styl
@@ -117,7 +117,7 @@ span.sheet-oracle-result
   width 80%
 
 .sheet-oracle-box
-  border: 2px solid #4C4D4F
+  borderCommon()
   box-sizing: border-box
   width: 100%
 

--- a/Ironsworn/src/data/move-list.pug
+++ b/Ironsworn/src/data/move-list.pug
@@ -286,7 +286,7 @@
           p: `If you are returning to a previously explored site, roll both challenge dice, take the lowest value, and clear that number of progress boxes. Then, <em>Delve the Depths</em> to explore this place.`
         }
       ],      
-      discover: true
+      discover_a_site: true
     },
     draw_the_circle: {
       title: 'Draw the Circle',
@@ -368,8 +368,8 @@
       class: 'endure-harm',
       page: 'Ironsworn - page 91',
       radio: 'endure_harm',
-      stat: `@{iron}`,
-      stat_repeat: '@{iron}',
+      stat: `?{Stat|Health,@{health}|Iron,@{iron}}`,
+      stat_repeat: '?{Stat}',
       system: 'ironsworn',
       content: [
         {

--- a/Ironsworn/src/data/scroll-list.pug
+++ b/Ironsworn/src/data/scroll-list.pug
@@ -1,0 +1,106 @@
+- 
+  var 
+    moveGroupsScroll = [
+      { 
+        title: 'FATE MOVES',
+        moves: [
+          { name: 'Pay the Price', value: 'pay_the_price' },
+          { name: 'Ask the Oracle', value: 'ask_the_oracle' }
+        ]
+      },
+      { 
+        title: 'ADVENTURE MOVES',
+        moves: [
+          { name: 'Face Danger', value: 'face_danger' },
+          { name: 'Secure an Advantage', value: 'secure_an_advantage' },
+          { name: 'Gather Information', value: 'gather_information' },
+          { name: 'Heal', value: 'heal' },
+          { name: 'Resupply', value: 'resupply' },
+          { name: 'Make Camp', value: 'make_camp' },
+          { name: 'Undertake a Journey', value: 'undertake_a_journey' },
+          { name: 'Reach Your Destination', value: 'reach_your_destination' }
+        ]
+      },
+      { 
+        title: 'RELATIONSHIP MOVES',
+        moves: [
+          { name: 'Compel', value: 'compel' },
+          { name: 'Sojourn', value: 'sojourn' },
+          { name: 'Draw the Circle', value: 'draw_the_circle' },
+          { name: 'Forge a Bond', value: 'forge_a_bond' },
+          { name: 'Test Your Bond', value: 'test_your_bond' },
+          { name: 'Aid Your Ally', value: 'aid_your_ally' },
+          { name: 'Write Your Epilogue', value: 'write_your_epilogue' }
+        ]
+      },
+      { 
+        title: 'QUEST MOVES',
+        moves: [
+          { name: 'Swear An Iron Vow', value: 'swear_an_iron_vow' },
+          { name: 'Reach a Milestone', value: 'reach_a_milestone' },
+          { name: 'Fulfill Your Vow', value: 'fulfill_your_vow' },
+          { name: 'Forsake Your Vow', value: 'forsake_your_vow' },
+          { name: 'Advance', value: 'advance' }
+        ]
+      },
+      { 
+        title: 'COMBAT MOVES',
+        moves: [
+          { name: 'Enter the Fray', value: 'enter_the_fray' },
+          { name: 'Strike', value: 'strike' },
+          { name: 'Clash', value: 'clash' },
+          { name: 'Turn the Tide', value: 'turn_the_tide' },
+          { name: 'End the Fight', value: 'end_the_fight' },
+          { name: 'Battle', value: 'battle' }
+        ]
+      },
+      { 
+        title: 'SUFFER MOVES',
+        moves: [
+          { name: 'Endure Harm', value: 'endure_harm' },
+          { name: 'Endure Stress', value: 'endure_stress' },
+          { name: 'Companion Endure Harm', value: 'companion_endure_harm' },
+          { name: 'Face Death', value: 'face_death' },
+          { name: 'Face Desolation', value: 'face_desolation' },
+          { name: 'Out of Supply', value: 'out_of_supply' },
+          { name: 'Face a Setback', value: 'face_a_setback' },
+        ]
+      },
+      { 
+        title: 'DELVE MOVES',
+        optional: 'sites',
+        moves: [
+          { name: 'Discover a Site', value: 'discover_a_site' },
+          { name: 'Delve the Depths', value: 'delve_the_depths' },
+          { name: 'Find an Opportunity', value: 'find_an_opportunity' },
+          { name: 'Reveal a Danger', value: 'reveal_a_danger' },
+          { name: 'Check Your Gear', value: 'check_your_gear' },
+          { name: 'Locate Your Objective', value: 'locate_your_objective' },
+          { name: 'Escape the Depths', value: 'escape_the_depths' },
+          { name: 'Reveal a Danger - Alt', value: 'reveal_a_danger_alt' }
+        ]
+      },
+      { 
+        title: 'FAILURE MOVES',
+        optional: 'failures',
+        moves: [
+          { name: 'Mark Your Failure', value: 'mark_your_failure' },
+          { name: 'Learn From Your Failures', value: 'learn_from_your_failures' }
+        ]
+      },
+      { 
+        title: 'RARITY MOVES',
+        optional: 'rarity',
+        moves: [
+          { name: 'Wield A Rarity', value: 'wield_a_rarity' }
+        ]
+      },
+      { 
+        title: 'THREAT MOVES',
+        optional: 'threat',
+        moves: [
+          { name: 'Advance a Threat', value: 'advance_a_threat' },
+          { name: 'Take a Hiatus', value: 'take_a_hiatus' }
+        ]
+      },
+    ]

--- a/Ironsworn/src/package-lock.json
+++ b/Ironsworn/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Ironsworn/src/roll-templates/moves/moves.pug
+++ b/Ironsworn/src/roll-templates/moves/moves.pug
@@ -14,7 +14,7 @@ include ../mixins/actions
   ]
 
 rolltemplate.sheet-rolltemplate-ironsworn_moves 
-  div.sheet-roll-container
+  .sheet-roll-container
     | {{#action}}
     +actionHeader
     | {{#rollLess() momentum 0}}
@@ -41,19 +41,19 @@ rolltemplate.sheet-rolltemplate-ironsworn_moves
 
     | {{#discoverASite}}
     .sheet-subheader {{header}}
-    .sheet-result-row
+    .sheet-result-row.sheet-discover-a-site-row
       .sheet-oracle-table-text Clear {{discoverASite}} Progress
     | {{/discoverASite}}
 
     | {{#custom}}
     | {{#header}}
-    div.sheet-result-body.sheet-result-row
-      div.sheet-subheader {{header}}
+    .sheet-result-body.sheet-result-row
+      .sheet-subheader {{header}}
     | {{/header}}
-    div.sheet-result-body.sheet-result-row
+    .sheet-result-body.sheet-result-row
       div {{name}}  
     | {{#allprops() custom name header}}
-    div.sheet-result-body.sheet-result-row
+    .sheet-result-body.sheet-result-row
       div {{key}}
       div {{value}}
     | {{/allprops() custom name header}}

--- a/Ironsworn/src/roll-templates/moves/moves.pug
+++ b/Ironsworn/src/roll-templates/moves/moves.pug
@@ -39,6 +39,12 @@ rolltemplate.sheet-rolltemplate-ironsworn_moves
     | {{/^rollLess() momentum 0}}
     | {{/rarityAction}}
 
+    | {{#discoverASite}}
+    .sheet-subheader {{header}}
+    .sheet-result-row
+      .sheet-oracle-table-text Clear {{discoverASite}} Progress
+    | {{/discoverASite}}
+
     | {{#custom}}
     | {{#header}}
     div.sheet-result-body.sheet-result-row

--- a/Ironsworn/src/roll-templates/oracles/oracles.styl
+++ b/Ironsworn/src/roll-templates/oracles/oracles.styl
@@ -1,6 +1,6 @@
 .sheet-rolltemplate-ironsworn_oracles .sheet-result-row,
 .sheet-rolltemplate-moves_oracles .sheet-result-row,
-.sheet-rolltemplate-ironsworn_moves .sheet-result-row,
+.sheet-rolltemplate-ironsworn_moves .sheet-discover-a-site-row,
 .sheet-rolltemplate-delve_oracles .sheet-result-row
   padding 0.5em
 

--- a/Ironsworn/src/roll-templates/oracles/oracles.styl
+++ b/Ironsworn/src/roll-templates/oracles/oracles.styl
@@ -1,5 +1,6 @@
 .sheet-rolltemplate-ironsworn_oracles .sheet-result-row,
 .sheet-rolltemplate-moves_oracles .sheet-result-row,
+.sheet-rolltemplate-ironsworn_moves .sheet-result-row,
 .sheet-rolltemplate-delve_oracles .sheet-result-row
   padding 0.5em
 

--- a/Ironsworn/src/workers/scripts/stats.js
+++ b/Ironsworn/src/workers/scripts/stats.js
@@ -1,18 +1,3 @@
-//Reset Health if set above Max
-on('change:health', function(healthChange) {
-  getAttrs(["max_health"], function(values) {
-    if (parseInt(healthChange.newValue) > parseInt(values.max_health)) {
-      setAttrs({health: values.max_health});
-    }
-  });
-});
-
-on('change:health_reset', function() {
-  getAttrs(["max_health"], function(values) {
-      setAttrs({health: values.max_health});
-  });
-});
-
 //Cannot increase Health while Wounded
 //Health reaching 0 marks Wounded
 on('change:health', function(eventinfo) {
@@ -40,50 +25,12 @@ on('change:spirit', function(eventinfo) {
 //Cannot increase Supply while Unprepared
 //Supply reaching 0 marks Unprepared
 on('change:supply', function(eventinfo) {
-    getAttrs(["unprepared"], function(values) {
+    getAttrs(["debilUnprepared"], function(values) {
         if(values.unprepared == "on") {
             if (parseInt(eventinfo.newValue) > parseInt(eventinfo.previousValue)) {
                 setAttrs({supply: eventinfo.previousValue});
             }
         }
     });
-    if (parseInt(eventinfo.newValue) === 0) setAttrs({unprepared_button: "on"});
-});
-
-// Edge sets Speed value
-on('change:edge', function(eventinfo) {
-  setAttrs({speed: speedValues[eventinfo.newValue].full});
-});
-
-const speedValues = {
-  '8': { full: '40ft/20ft. 12m/6m. 8/4', imperial: '40ft/20ft', metric: '12 m/6 m. ', units: '8/4' },
-  '7': { full: '40ft/20ft. 12m/6m. 8/4', imperial: '40ft/20ft',metric: '12m/6m. ', units: '8/4' },
-  '6': { full: '35ft/15ft. 10.5m/4.5m. 7/3', imperial: '35ft/15ft',metric: '10.5m/4.5m.', units: '7/3' },
-  '5': { full: '35ft/15ft. 10.5m/4.5m. 7/3', imperial: '35ft/15ft',metric: '10.5m/4.5m.', units: '7/3' },
-  '4': { full: '30ft/15ft. 9m/4.5m. 6/3', imperial: '30ft/15ft',metric: '9m/4.5m.', units: '6/3' },
-  '3': { full: '30ft/15ft. 9m/4.5m. 6/3', imperial: '30ft/15ft',metric: '9m/4.5m.', units: '6/3' },
-  '2': { full: '25ft/10ft. 7.5m/3m. 5/2', imperial: '25ft/10ft',metric: '7.5m/3m.', units: '5/2' },
-  '1': { full: '25ft/10ft. 7.5m/3m. 5/2', imperial: '25ft/10ft',metric: '7.5m/3m.', units: '5/2' },
-  '0': { full: '25ft/10ft. 7.5m/3m. 5/2', imperial: '25ft/10ft',metric: '7.5m/3m.', units: '5/2' }
-}
-
-// Heart sets Resilience value
-on('change:heart', function(eventinfo) {
-  let resValue = parseInt(eventinfo.newValue) + 1
-  setAttrs({resilience: resValue});
-});
-
-// Iron sets Max Load value
-on('change:iron', function(eventinfo) {
-  let loadValue = parseInt(eventinfo.newValue) + 4
-  setAttrs({max_load: loadValue});
-});
-
-// Setting Encumbered if load is over max
-on('change:load', function(eventinfo) {
-  getAttrs(['max_load'], function(values) {
-    if (parseInt(eventinfo.newValue) > parseInt(values.max_load)) {
-      setAttrs({encumbered: 'on'});
-    }
-  });
+    if (parseInt(eventinfo.newValue) === 0) setAttrs({debilUnprepared: "on"});
 });


### PR DESCRIPTION
## Summary
The Discover a Site move had not been re-implemented when migrating to pugjs. There were also some other issues that cropped up as part of this release, outlined below.

## Discover A Site Move
![image](https://user-images.githubusercontent.com/19798820/86497284-f9080900-bd78-11ea-958b-608bd87a14e0.png)
Resolves #6884 

## Quick Roll Buttons on the Move Overview Page
![image](https://user-images.githubusercontent.com/19798820/86497240-c4944d00-bd78-11ea-972d-59169f1b2cfb.png)

## Minor Fixes
- It was only using the iron stat for endure harm. Resolves #6897 
- Reordering Scrolling move list, as the most used moves where in the centre of the list.
- Unprepared Debility was not being set when supply reached zero. This was because of the wrong attribute been looked for.
- Removed some dead Ironcrunch code.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
