### PR TITLE
PokeroleV2 CSS correction

### DIFF
--- a/Pokerole_v2/Pokerole.css
+++ b/Pokerole_v2/Pokerole.css
@@ -188,7 +188,7 @@ div.sheet-section{
 }
 
 .sheet-type-toggle[value="trainer"] ~   div.sheet-section{ background-color:var(--section);}
-.sheet-type-toggle[value="trainer"] ~   div.sheet-section strong{ color:var(--border) !important; text-shadow: 0px 0px 3px var(--background) !important;}
+.sheet-type-toggle[value="trainer"] ~   .sheet-character-header strong{ color:var(--border) !important; text-shadow: 0px 0px 3px var(--background) !important;}
 .sheet-type-toggle[value="normal"] ~    div.sheet-section{ background-color:var(--normal);}
 .sheet-type-toggle[value="bug"] ~       div.sheet-section{ background-color:var(--bug);}
 .sheet-type-toggle[value="dark"] ~      div.sheet-section{ background-color:var(--dark);}


### PR DESCRIPTION
There was an aesthetic bug in the CSS code that passed notice. It didn't harm any data, but it forced the strong tags in other areas to display incorrectly.

## Changes / Comments
- Bug fix.
- No enhancements.
- Aesthetics correction.
- No attributes changes.
- Not a new sheet.