### PR TITLE
changing visibility of drain attribute

### DIFF
--- a/Shadowrun6th-German/sheet.html
+++ b/Shadowrun6th-German/sheet.html
@@ -2087,7 +2087,7 @@
             <h6>Malus (Dauer: A)</h6>
             <input class="smallinput" type="number" name="attr_sustain_malus" value="0" placeholder="0" title="sustain_malus" max="0"/>
         </div>
-        <input class="toggle-hide" name="attr_drain_hide" type="checkbox" value="1"/>
+        <input class="toggle-hide" name="attr_drain_hide" type="checkbox" value="0"/>
         <div class="inline magicsection">
             <h6>Entzug:</h6>
             <select class="attributedropdown" name="attr_magic_drain_attribute" value="int" title="magic_drain_attribute"> 


### PR DESCRIPTION
toggle-hide in front of the drain dropdown deactivated
no other changes ... just a bugfix according to https://app.roll20.net/forum/post/8786790/shadowrun-6-sheet-german-work-in-progress-translation-en-later/?pageforid=8939316#post-8939316
