### PR TITLE
[Fate] Sheet Updates week of July 14th 2020

### DIFF
--- a/Fate/FateOmni.css
+++ b/Fate/FateOmni.css
@@ -725,11 +725,13 @@ input[value="list"] ~ .sheet-SkillList {
 
 .sheet-ExtraDisplay button[type="roll"].sheet-roll::before,
 .sheet-StuntDisplay button[type="roll"].sheet-roll::before,
+.sheet-SkillDisplay button[type="action"]::before,
 .sheet-SkillDisplay button[type="roll"]::before {
 	content: "";
 }
 
 .sheet-StuntDisplay button[type="roll"].sheet-roll,
+.sheet-SkillDisplay button[type="action"],
 .sheet-SkillDisplay button[type="roll"] {
 	text-align: left;
 	padding-left: 6px;
@@ -780,6 +782,7 @@ input[value="list"] ~ .sheet-SkillList {
 
 .sheet-ExtraDisplay button[type="roll"].sheet-roll:active,
 .sheet-StuntDisplay button[type="roll"].sheet-roll:active,
+.sheet-SkillDisplay button[type="action"]:active,
 .sheet-SkillDisplay button[type="roll"]:active {
 	color: white;
 	text-shadow: 0 0 2px white;
@@ -787,6 +790,7 @@ input[value="list"] ~ .sheet-SkillList {
 
 .sheet-ExtraDisplay button[type="roll"].sheet-roll:hover,
 .sheet-StuntDisplay button[type="roll"].sheet-roll:hover,
+.sheet-SkillDisplay button[type="action"]:hover,
 .sheet-SkillDisplay button[type="roll"]:hover {
 	color: white;
 	text-shadow: 0 0 2px black;
@@ -794,10 +798,12 @@ input[value="list"] ~ .sheet-SkillList {
 
 .sheet-ExtraDisplay button[type="roll"].sheet-roll,
 .sheet-StuntDisplay button[type="roll"].sheet-roll,
+.sheet-SkillDisplay button[type="action"],
 .sheet-SkillDisplay button[type="roll"] {
 	font-size: 14px;
 }
 
+.sheet-SkillDisplay .sheet-SkillList button[type="action"],
 .sheet-SkillDisplay .sheet-SkillList button[type="roll"] {
 	min-width: 225px;
 }
@@ -1394,9 +1400,11 @@ input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
 
 input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:active,
 input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:active,
+input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:active,
 input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:active,
 input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:hover,
 input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:hover,
+input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:hover,
 input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:hover {
 	background: #1b75bb;
 }
@@ -1430,6 +1438,7 @@ input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
 
 input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll,
 input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll,
+input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"],
 input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"] {
 	border: 1px solid #eef8ff;
 }
@@ -1526,9 +1535,11 @@ input[value="green"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
 
 input[value="green"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:active,
 input[value="green"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:active,
+input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:active,
 input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:active,
 input[value="green"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:hover,
 input[value="green"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:hover,
+input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:hover,
 input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:hover {
 	background: #356e45;
 }
@@ -1562,6 +1573,7 @@ input[value="green"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
 
 input[value="green"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll,
 input[value="green"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll,
+input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"],
 input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"] {
 	border: 1px solid #eeffe5;
 }
@@ -1658,9 +1670,11 @@ input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
 
 input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:active,
 input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:active,
+input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:active,
 input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:active,
 input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:hover,
 input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:hover,
+input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:hover,
 input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:hover {
 	background: #3c1e5f;
 }
@@ -1694,6 +1708,7 @@ input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
 
 input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll,
 input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll,
+input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"],
 input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"] {
 	border: 1px solid #f8eeff;
 }
@@ -1790,9 +1805,11 @@ input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
 
 input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:active,
 input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:active,
+input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:active,
 input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:active,
 input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:hover,
 input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:hover,
+input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:hover,
 input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:hover {
 	background: #3a5224;
 }
@@ -1826,6 +1843,7 @@ input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
 
 input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll,
 input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll,
+input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"],
 input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"] {
 	border: 1px solid #d9e0d3;
 }
@@ -1926,9 +1944,11 @@ input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
 
 input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:active,
 input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:active,
+input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:active,
 input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:active,
 input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:hover,
 input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:hover,
+input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:hover,
 input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:hover {
 	background: #990000;
 }
@@ -1962,6 +1982,7 @@ input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
 
 input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll,
 input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll,
+input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"],
 input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"] {
 	border: 1px solid #eeeeee;
 }
@@ -2058,9 +2079,11 @@ input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
 
 input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:active,
 input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:active,
+input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:active,
 input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:active,
 input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:hover,
 input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:hover,
+input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:hover,
 input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:hover {
 	background: #000000;
 }
@@ -2094,6 +2117,7 @@ input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
 
 input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll,
 input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll,
+input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"],
 input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"] {
 	border: 1px solid #eeeeee;
 }
@@ -2192,9 +2216,11 @@ input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
 
 input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:active,
 input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:active,
+input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:active,
 input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:active,
 input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:hover,
 input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:hover,
+input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:hover,
 input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:hover {
 	background: #007da4;
 }
@@ -2228,6 +2254,7 @@ input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
 
 input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll,
 input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll,
+input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"],
 input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"] {
 	border: 1px solid #eef8ff;
 }
@@ -2324,9 +2351,11 @@ input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
 
 input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:active,
 input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:active,
+input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:active,
 input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:active,
 input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:hover,
 input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:hover,
+input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:hover,
 input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:hover {
 	background: #e3ac24;
 }
@@ -2360,6 +2389,7 @@ input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
 
 input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll,
 input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll,
+input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"],
 input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"] {
 	border: 1px solid #fff8ee;
 }

--- a/Fate/FateOmni.css
+++ b/Fate/FateOmni.css
@@ -43,6 +43,14 @@
 	margin-left: 0px;
 }
 
+
+.sheet-pronouns {
+	border: 0px;
+	font-size: 18px;
+	padding: 0px;
+	margin-left: 0px;
+}
+
 .sheet-floatright {
 	float: right;
 }
@@ -567,26 +575,36 @@ input.sheet-icon[value="blank"] + span.sheet-icon::before {
 	margin-left: 20px;
 }
 
+.sheet-pronounbox div,
 .sheet-fpbox div {
 	text-align: center;
-	vertical-align: middle;
+	vertical-align: bottom;
 	white-space: nowrap;
 	margin-left: 10px;
 }
+
+.sheet-pronounbox > div > div,
 .sheet-fpbox > div > div {
 	display: block;
 }
+
+.sheet-pronounbox > div > div + div,
 .sheet-fpbox > div > div + div {
 	font-weight: bold;
 	font-size: 90%;
 	text-transform: uppercase;
 }
+
 .sheet-fpbox input[type=number] {
 	border: 0px;
 	font-size: 30px;
 	font-weight: bold;
 	width: 2em;
 	margin-left: 0.5em;
+	text-align: center;
+}
+
+.sheet-pronounbox input {
 	text-align: center;
 }
 
@@ -1323,6 +1341,7 @@ input[value="blue"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-ch
 input[value="blue"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox + span.sheet-checkmark::before,
 input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader,
 input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-Bar,
+input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-pronounbox,
 input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-fpbox,
 input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-fpbox input[type=number],
 input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-optwrap,
@@ -1454,6 +1473,7 @@ input[value="green"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-c
 input[value="green"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox + span.sheet-checkmark::before,
 input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader,
 input[value="green"].sheet-theme + .sheet-Wrapper .sheet-Bar,
+input[value="green"].sheet-theme + .sheet-Wrapper .sheet-pronounbox,
 input[value="green"].sheet-theme + .sheet-Wrapper .sheet-fpbox,
 input[value="green"].sheet-theme + .sheet-Wrapper .sheet-fpbox input[type=number],
 input[value="green"].sheet-theme + .sheet-Wrapper .sheet-optwrap,
@@ -1585,6 +1605,7 @@ input[value="purple"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-
 input[value="purple"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox + span.sheet-checkmark::before,
 input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader,
 input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-Bar,
+input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-pronounbox,
 input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-fpbox,
 input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-fpbox input[type=number],
 input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-optwrap,
@@ -1716,6 +1737,7 @@ input[value="cthulhu"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet
 input[value="cthulhu"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox + span.sheet-checkmark::before,
 input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader,
 input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-Bar,
+input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-pronounbox,
 input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-fpbox,
 input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-fpbox input[type=number],
 input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-optwrap,
@@ -1847,6 +1869,7 @@ input[value="evilhat"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet
 input[value="evilhat"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox + span.sheet-checkmark::before,
 input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader,
 input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-Bar,
+input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-pronounbox,
 input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-fpbox,
 input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-fpbox input[type=number],
 input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-optwrap,
@@ -1982,6 +2005,7 @@ input[value="gray"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-ch
 input[value="gray"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox + span.sheet-checkmark::before,
 input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader,
 input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-Bar,
+input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-pronounbox,
 input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-fpbox,
 input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-fpbox input[type=number],
 input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-optwrap,
@@ -2115,6 +2139,7 @@ input[value="shotc"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-c
 input[value="shotc"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox + span.sheet-checkmark::before,
 input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader,
 input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-Bar,
+input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-pronounbox,
 input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-fpbox,
 input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-fpbox input[type=number],
 input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-optwrap,
@@ -2246,6 +2271,7 @@ input[value="orange"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-
 input[value="orange"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox + span.sheet-checkmark::before,
 input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader,
 input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-Bar,
+input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-pronounbox,
 input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-fpbox,
 input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-fpbox input[type=number],
 input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-optwrap,

--- a/Fate/FateOmni.html
+++ b/Fate/FateOmni.html
@@ -273,7 +273,7 @@
 			<input type="checkbox" class="triggerbox" name="attr_Show-Skillswaps" value="1">
 			<div class="SkillCell">
 				<div class="SectionHeader">
-					<span><span data-i18n="swap-skills">Swappable Skillsets</span> <span name="attr_lastswapped"></span> <span class="boxcorner"><input type="checkbox" class="checkbox" name="attr_EditSwaps" value="1" checked><span class="pencilbox"/></span>
+					<span><span data-i18n="swap-skills">Swappable Skillsets</span> <span name="attr_lastswapped"></span> <span class="boxcorner"><input type="checkbox" class="checkbox" name="attr_EditSwaps" value="1" checked><span class="pencilbox"/></span></span>
 				</div>
 				<div class="SkillFrame">
 					<input type="checkbox" class="triggerbox" name="attr_EditSwaps" value="1" checked>
@@ -906,8 +906,28 @@
 									<select class="compact" name="attr_icon">
 										<option value="" data-i18n="none"></option>
 										<option value="plus" data-i18n="plusdie"></option>
-										<option value="minus" data-i18n="blankdie"></option>
-										<option value="blank" data-i18n="minusdie"></option>
+										<option value="blank" data-i18n="blankdie"></option>
+										<option value="minus" data-i18n="minusdie"></option>
+									</select>
+								</div>
+									<input type="hidden" class="hideIfNull" name="attr_icon" value="">
+								<div>
+									<b style="font-size: 80%;"><span data-i18n="label-icon"></span> 2:</b>
+									<select class="compact" name="attr_icon2">
+										<option value="" data-i18n="none"></option>
+										<option value="plus" data-i18n="plusdie"></option>
+										<option value="blank" data-i18n="blankdie"></option>
+										<option value="minus" data-i18n="minusdie"></option>
+									</select>
+								</div>
+									<input type="hidden" class="hideIfNull" name="attr_icon2" value="">
+								<div>
+									<b style="font-size: 80%;"><span data-i18n="label-icon"></span> 3:</b>
+									<select class="compact" name="attr_icon3">
+										<option value="" data-i18n="none"></option>
+										<option value="plus" data-i18n="plusdie"></option>
+										<option value="blank" data-i18n="blankdie"></option>
+										<option value="minus" data-i18n="minusdie"></option>
 									</select>
 								</div>
 							</div>
@@ -1063,6 +1083,8 @@
 							<div class="track space-below clear-all">
 								<input type="hidden" class="hideIfNull" name="attr_label" value=""><div class="fieldlabel">
 									<input type="hidden" class="hideIfNull icon" name="attr_icon" value=""><span class="icon"></span>
+									<input type="hidden" class="hideIfNull icon" name="attr_icon2" value=""><span class="icon"></span>
+									<input type="hidden" class="hideIfNull icon" name="attr_icon3" value=""><span class="icon"></span>
 									<b><span name="attr_label"></span></b>
 								</div>
 								<div class="indented">

--- a/Fate/FateOmni.html
+++ b/Fate/FateOmni.html
@@ -108,6 +108,16 @@
 				</div>
 			</div>
 		</div>
+		<div class="pronounbox">
+			<div>
+				<div>
+					<input name="attr_pronouns" type="text" class="compact pronouns">
+				</div>
+				<div data-i18n="pronouns">
+					Pronouns
+				</div>
+			</div>
+		</div>
 		<div>
 			<div class="optwrap">
 				<input type="checkbox" class="checkbox" name="attr_SheetOptions" value="1"><span class="optionsbox"></span>

--- a/Fate/FateOmni.html
+++ b/Fate/FateOmni.html
@@ -2794,6 +2794,7 @@ var loadSkills = function(caller) {
 						value = Number(value) + bonus;
 						gridrow = "row" + value;
 						skillRatingByNameID[skillid] = value;
+						attrs["Skill"+skillNameByID[skillid]] = value; // Externalize the skill rating in an attribute that can be addressed by macros
 						skillRatingByName[skillNameByID[skillid]] = value;
 						var wordid = id + "-word";
 						attrs[wordid] = "";

--- a/Fate/FateOmni.html
+++ b/Fate/FateOmni.html
@@ -2816,7 +2816,7 @@ var loadSkills = function(caller) {
 						value = Number(value) + bonus;
 						gridrow = "row" + value;
 						skillRatingByNameID[skillid] = value;
-						attrs["Skill"+skillNameByID[skillid]] = value; // Externalize the skill rating in an attribute that can be addressed by macros
+						attrs["Skill-"+skillNameByID[skillid]] = value; // Externalize the skill rating in an attribute that can be addressed by macros
 						skillRatingByName[skillNameByID[skillid]] = value;
 						var wordid = id + "-word";
 						attrs[wordid] = "";
@@ -3418,6 +3418,7 @@ on("change:repeating_modes remove:repeating_modes sheet:opened", function() {
 
 on("sheet:opened change:repeating_aspects remove:repeating_aspects", function() {
 	getSectionIDs("aspects", function(list) {
+		log("Parsing aspect list");
 		var gets = [];
 		for( var i = 0; i < list.length; i++ ) {
 			gets[i*4] = "repeating_aspects_" + list[i] + "_aspect";
@@ -3427,7 +3428,10 @@ on("sheet:opened change:repeating_aspects remove:repeating_aspects", function() 
 		}
 		getAttrs(gets, function(a) {
 			var atext = "";
+			var lcount = {};
+			var attrs = {}
 			for( var i = 0; i < list.length; i++ ) {
+				var lmod = "Unlabeled";
 				var aspect = a["repeating_aspects_" + list[i] + "_aspect"];
 				var label = a["repeating_aspects_" + list[i] + "_label"];
 				var flags = a["repeating_aspects_" + list[i] + "_flags"];
@@ -3441,13 +3445,26 @@ on("sheet:opened change:repeating_aspects remove:repeating_aspects", function() 
 						atext = atext + " (" + flags + ")";
 					}
 					atext = atext + ":**\n";
+					lmod = label.replace(/\s+/g,"");
 				}
 				atext = atext + "***" + aspect + "***";
 				if ( typeof notes !== "undefined" && notes !== "" ) {
 					atext = atext + "\n"+ notes ;
 				}
+				if ( typeof lcount[lmod] === "undefined" ) {
+					lcount[lmod] = 0;
+				}
+				lcount[lmod]++;
+				var lkey = lmod + lcount[lmod];
+				if ( lcount[lmod] == 1 ) {
+					lkey = lmod;
+				}
+				lkey = "Aspect-" + lkey;
+				attrs[lkey] = aspect;
 			}
-			setAttrs({ "aspectlist": atext });
+			attrs["aspectlist"] = atext;
+			log("Done parsing aspect list"); log(attrs);
+			setAttrs(attrs);
 		});
 	});
 });
@@ -3459,11 +3476,191 @@ on("change:repeating_skills:skill change:repeating_skills:rating change:repeatin
 on("sheet:opened change:repeating_stunts remove:repeating_stunts", function() {
 	log("Event: Stunts change");
 	getSectionIDs("stunts", function(list) {
-		setAttrs({
-			stuntcount: list.length
+		log("parsing stunt list");
+		var attrs = { stuntcount: list.length };
+		var slist = [];
+		for ( var i = 0; i < list.length; i++ ) {
+			slist[i*2] = "repeating_stunts_" + list[i] + "_name";
+			slist[i*2+1] = "repeating_stunts_" + list[i] + "_desc";
+		}
+		getAttrs(slist,function(stunts) {
+			for ( var i = 0; i < list.length; i++ ) {
+				var stuntkey = "repeating_stunts_" + list[i] + "_name";
+				var desckey = "repeating_stunts_" + list[i] + "_desc";
+				var snum = i + 1;
+				var atstunt = "Stunt-Name-" + snum;
+				var atstuntd = "Stunt-Desc-" + snum;
+				var atstuntf = "Stunt-" + snum;
+				attrs[atstunt] = stunts[stuntkey];
+				attrs[atstuntd] = stunts[desckey];
+				attrs[atstuntf] = stunts[stuntkey] + ": " + stunts[desckey];
+			}			
+			setAttrs(attrs);
+			log("stunt list parsed"); log(attrs);
 		});
 	});
 });
+
+on("sheet:opened change:repeating_consequences remove:repeating_consequences", function() {
+	log("Event: Consequences change");
+	getSectionIDs("consequences", function(list) {
+		log("parsing consequence list");
+		var attrs = {};
+		var slist = [];
+		for ( var i = 0; i < list.length; i++ ) {
+			slist[i*4] = "repeating_consequences_" + list[i] + "_label";
+			slist[i*4+1] = "repeating_consequences_" + list[i] + "_track";
+			slist[i*4+2] = "repeating_consequences_" + list[i] + "_trackcheck";
+			slist[i*4+3] = "repeating_consequences_" + list[i] + "_aspect";
+		}
+		getAttrs(slist,function(c) {
+			var lcheck = {};
+			for ( var i = 0; i < list.length; i++ ) {
+				var ckey = "repeating_consequences_" + list[i] + "_label";
+				var tkey = "repeating_consequences_" + list[i] + "_track";
+				var akey = "repeating_consequences_" + list[i] + "_aspect";
+				var tckey = "repeating_consequences_" + list[i] + "_trackcheck";
+				var checked = false;
+				if ( c[tckey] == "1" ) {
+					checked = true;
+				}
+				var aspect = c[akey];
+				var value = Number(c[tkey]);
+				var remaining = value;
+				if ( checked ) { remaining = 0; }
+				var label = c[ckey];
+				label = label.replace(/[^A-Za-z0-9]/g,"");
+				if ( typeof lcheck[label] === "undefined" ) {
+					lcheck[label] = 0;
+				}
+				lcheck[label]++;
+				if ( lcheck[label] > 1 ) {
+					label = label + lcheck[label];
+				}
+				label = "Consequence-" + label;
+				attrs[label] = aspect;
+				attrs[label+"-Total"] = value;
+				attrs[label+"-Remaining"] = remaining;
+				attrs[label+"-Marked"] = checked;
+			}
+			setAttrs(attrs);
+			log("consequence list parsed"); log(attrs);
+		});
+	});
+});
+
+on("sheet:opened change:repeating_stress remove:repeating_stress", function() {
+	log("Event: Stress change");
+	getSectionIDs("stress", function(list) {
+		log("parsing stress list");
+		var attrs = {};
+		var slist = [];
+		for ( var i = 0; i < list.length; i++ ) {
+			slist[i*20] = "repeating_stress_" + list[i] + "_label";
+			slist[i*20+1] = "repeating_stress_" + list[i] + "_track";
+			for ( var j = 1; j < 10; j++ ) {
+				slist[i*20+j*2] = "repeating_stress_" + list[i] + "_track" + j;
+				slist[i*20+j*2+1] = "repeating_stress_" + list[i] + "_check" + j;
+			}
+		}
+		getAttrs(slist,function(c) {
+			var lcheck = {};
+			for ( var i = 0; i < list.length; i++ ) {
+				var lkey = "repeating_stress_" + list[i] + "_label";
+				var tkey = "repeating_stress_" + list[i] + "_track";
+				var tally = 0; var remaining = 0;
+				for ( var j = 1; j <= Number(c[tkey]); j++ ) {
+					var vakey = "repeating_stress_" + list[i] + "_track" + j;
+					var chkey = "repeating_stress_" + list[i] + "_check" + j;
+					var value = Number(c[vakey]);
+					if ( isNaN(value) || value == 0 ) {
+						value = 1;
+					}
+					var count = 1;
+					if ( c[chkey] == "1" ) {
+						count = 0;
+					}
+					tally += value;
+					remaining += value*count;
+				}
+				var label = c[lkey];
+				label = label.replace(/[^A-Za-z0-9]/g,"");
+				if ( label == "" ) { label = "Track"; }
+				if ( typeof lcheck[label] === "undefined" ) {
+					lcheck[label] = 0;
+				}
+				lcheck[label]++;
+				if ( lcheck[label] > 1 ) {
+					label = label + lcheck[label];
+				}
+				label = "Stress-" + label;
+				attrs[label+"-Total"] = tally;
+				attrs[label+"-Remaining"] = remaining;
+				attrs[label+"-Used"] = tally - remaining;
+				attrs[label+"-Length"] = c[tkey];
+			}
+			setAttrs(attrs);
+			log("stress list parsed"); log(attrs);
+		});
+	});
+});
+
+on("sheet:opened change:repeating_conditions remove:repeating_conditions", function() {
+	log("Event: Condition change");
+	getSectionIDs("conditions", function(list) {
+		log("parsing conditions list");
+		var attrs = {};
+		var slist = [];
+		for ( var i = 0; i < list.length; i++ ) {
+			slist[i*20] = "repeating_conditions_" + list[i] + "_label";
+			slist[i*20+1] = "repeating_conditions_" + list[i] + "_track";
+			for ( var j = 1; j < 10; j++ ) {
+				slist[i*20+j*2] = "repeating_conditions_" + list[i] + "_track" + j;
+				slist[i*20+j*2+1] = "repeating_conditions_" + list[i] + "_check" + j;
+			}
+		}
+		getAttrs(slist,function(c) {
+			var lcheck = {};
+			for ( var i = 0; i < list.length; i++ ) {
+				var lkey = "repeating_conditions_" + list[i] + "_label";
+				var tkey = "repeating_conditions_" + list[i] + "_track";
+				var tally = 0; var remaining = 0;
+				for ( var j = 1; j <= Number(c[tkey]); j++ ) {
+					var vakey = "repeating_conditions_" + list[i] + "_track" + j;
+					var chkey = "repeating_conditions_" + list[i] + "_check" + j;
+					var value = Number(c[vakey]);
+					if ( isNaN(value) || value == 0 ) {
+						value = 1;
+					}
+					var count = 1;
+					if ( c[chkey] == "1" ) {
+						count = 0;
+					}
+					tally += value;
+					remaining += value*count;
+				}
+				var label = c[lkey];
+				label = label.replace(/[^A-Za-z0-9]/g,"");
+				if ( label == "" ) { label = "Track"; }
+				if ( typeof lcheck[label] === "undefined" ) {
+					lcheck[label] = 0;
+				}
+				lcheck[label]++;
+				if ( lcheck[label] > 1 ) {
+					label = label + lcheck[label];
+				}
+				label = "Condition-" + label;
+				attrs[label+"-Total"] = tally;
+				attrs[label+"-Remaining"] = remaining;
+				attrs[label+"-Used"] = tally - remaining;
+				attrs[label+"-Length"] = c[tkey];
+			}
+			setAttrs(attrs);
+			log("conditions list parsed"); log(attrs);
+		});
+	});
+});
+
 
 on("change:addskills", function() {
 	log("Event: addskills change");
@@ -3650,8 +3847,8 @@ on("change:repeating_swaps:skills", function(e) {
 	const skillsid = e.sourceAttribute;
 	getAttrs([skillsid], function(s) {
 		var stext = s[skillsid];
-		stext = stext.replace(/\n/," ");
-		stext = stext.replace(/  */," ");
+		stext = stext.replace(/\n/g," ");
+		stext = stext.replace(/  */g," ");
 		stext = stext.replace(/^  */,"");
 		stext = stext.replace(/  *$/,"");
 		var attrs = {};
@@ -3663,18 +3860,13 @@ on("change:repeating_swaps:skills", function(e) {
 on("clicked:repeating_swaps:loadswap", function(e) {
 	const rowprefix = (e.sourceAttribute).slice(0,-8); // Strips off the loadswap
 	const skillsid = rowprefix + "skills";
-
 	getAttrs([skillsid], function(l) {
-
 		var list = l[skillsid].toString().split(/\s*,\s*/);
-
 		var rates = {};
 		for(var i = 0; i < list.length; i++) {
 			var parts = list[i].toString().split(/\s*:\s*/);
 			rates[parts[0]] = Number(parts[1]);
 		}
-		log(rates);
-
 		getSectionIDs("skills", function(s) {
 			const lid = rowprefix + "label";
 			var fields = [ lid ];
@@ -3700,10 +3892,7 @@ on("clicked:repeating_swaps:loadswap", function(e) {
 				setAttrs(attrs,{silent:true},function() { loadSkills("clicked:repeating_swaps:loadswap") });
 			});
 		});
-
 	});
-
-
 });
 
 </script>

--- a/Fate/FateOmni.html
+++ b/Fate/FateOmni.html
@@ -20,6 +20,7 @@
 					<option value="dfa" data-i18n="dfa"></option>
 					<option value="foc" data-i18n="foc"></option>
 					<option value="kaijuinc" data-i18n="kaijuinc"></option>
+					<option value="ngen" data-i18n="ngen"></option>
 					<option value="cats" data-i18n="cats"></option>
 					<option value="shotc" data-i18n="shotc"></option>
 					<option value="tachyon" data-i18n="tachyon-squadron"></option>
@@ -72,6 +73,7 @@
 		<span><input type="checkbox" class="checkbox" name="attr_Show-Skills" value="1" checked><span class="checker" data-i18n="skills">Skills</span> </span>
 		<span><input type="checkbox" class="checkbox" name="attr_Show-Stress" value="1" checked><span class="checker" data-i18n="stress">Stress</span> </span>
 		<span><input type="checkbox" class="checkbox" name="attr_Show-Stunts" value="1" checked><span class="checker" data-i18n="stunts">Stunts</span> </span>
+		<span><input type="checkbox" class="checkbox" name="attr_Show-Skillswaps" value="1"><span class="checker" data-i18n="swap-skills">Swappable Skillsets</span> </span>
 		<span><input type="checkbox" class="checkbox" name="attr_Show-TempAspects" value="1" checked><span class="checker" data-i18n="situation-aspects">Situation Aspects</span> </span>
 		<span>
 			<select name="attr_theme" class="compact">
@@ -266,6 +268,44 @@
 				</div>
 			</div> <!-- End Roles -->
 
+			<!-- Swappable Skillsets -->
+			<input type="hidden" name="attr_lastswapped" value="">
+			<input type="checkbox" class="triggerbox" name="attr_Show-Skillswaps" value="1">
+			<div class="SkillCell">
+				<div class="SectionHeader">
+					<span><span data-i18n="swap-skills">Swappable Skillsets</span> <span name="attr_lastswapped"></span> <span class="boxcorner"><input type="checkbox" class="checkbox" name="attr_EditSwaps" value="1" checked><span class="pencilbox"/></span>
+				</div>
+				<div class="SkillFrame">
+					<input type="checkbox" class="triggerbox" name="attr_EditSwaps" value="1" checked>
+					<div class="SkillEdit">
+						<div class="EditTitleBar">
+							<span><span data-i18n="edit">Edit</span> <span data-i18n="swap-skills">Swappable Skillsets</span></span>
+							<span><input type="checkbox" class="checkbox" name="attr_EditSwaps" value="1" checked><span class="pencilbox"/></span>
+						</div>
+						<fieldset class="repeating_swaps">
+							<div>
+								<div class="fieldlabel" data-i18n="label">Label</div>
+							</div>
+							<input type="text" name="attr_label" value="">
+							<div>
+								<div class="fieldlabel" data-i18n="skills">Skills</div>
+							</div>
+							<div data-i18n="swap-skills-instruct"></div>
+							<textarea name="attr_skills"></textarea>
+							<button type="action" name="act_importswap"><span data-i18n="grab-current-skills"></span></button>
+						</fieldset>
+					</div>
+					<div class="SkillDisplay">
+						<input type="hidden" value="list">
+						<div class="SkillList">
+							<fieldset class="repeating_swaps">
+								<button type="action" name="act_loadswap"><span data-i18n="load-skillset"></span>: <b><span name="attr_label"></span></b></button>
+							</fieldset>
+						</div>
+					</div>
+				</div>
+			</div>
+			<!-- / Swappable Skillsets -->
 
 			<!-- Skills -->
 
@@ -1696,6 +1736,7 @@
 // These skills, aspect labels, and stress labels are translation keys, but if no translation is found it'll default to the key-as-given for the name.
 
 var skillsets = {
+	ngen: [ "Athletics", "Contacts", "Deceive", "Empathy", "Fight", "Heart", "Humanity", "Investigate", "Kindness", "Notice", "Provoke", "Resources", "Shapeshift", "Stealth", "Strength", "Thieving", "Will", "Wisdom" ],
 	tachyon: [ "Athletics", "Discipline", "Empathy", "Fight", "Gunnery", "Investigate", "Notice", "Pilot", "Provoke", "Rapport", "Shoot", "Sneak", "Tactics", "Technology" ],
 	kaijuinc: [ "Ambition", "Combat", "Empathy", "Fitness", "Kaiju Studies", "Networking", "Operate", "Provoke", "Rapport", "Spin", "Technology", "Tradecraft" ], 
 	robo: [ "Athletics", "Burglary", "Combat", "Contacts", "Deceive", "Empathy", "Notice", "Physique", "Provoke", "Rapport", "Stealth", "Vehicles", "Will" ],
@@ -1724,6 +1765,31 @@ var gamesets = {
 		conditions: [],
 		skills: [],
 		settings: {}
+	},
+	ngen: {
+		addskills: "ngen",
+		addstress: "esc", 
+		stresskeys: ["physical","mental"], 
+		stresslength: 2,
+		addconsequence: "all",
+		addswaps: [ "Immaterial", "Animal", "Plant", "Human" ],
+		aspects: [ "High Concept", "Weakness", "Immaterial Form", "Plant Form", "Animal Form", "Human Form", "Bond", "Free Aspect" ],
+		settings: {
+			"SkillStyle": "pyramid",
+			"Show-Aspects": 1,
+			"Show-Conditions": 0,
+			"Show-Consequences": 1,
+			"Show-Corruption": 0,
+			"Show-FP": 1,
+			"Show-Notes": 1,
+			"Show-Powers": 0,
+			"Show-Refresh": 1,
+			"Show-Skills": 1,
+			"Show-Skillswaps": 1,
+			"Show-Stress": 1,
+			"Show-Stunts": 1,
+			"Show-TempAspects": 1
+		}
 	},
 	fcore: { 
 		addskills: "fcore",
@@ -2678,10 +2744,23 @@ var loadGameProcess  = function(set) {
 	if ( typeof set.aspects !== "undefined" ) {
 		addAspect(set);
 	}
+	if ( typeof set.addswaps !== "undefined" ) {
+		var attrs = {};
+		for ( var i = 0; i < set.addswaps.length; i++ ) {
+			var newid = generateActuallyUniqueRowID();
+			var lid = "repeating_swaps_" + newid + "_label";
+			var ltext = getTranslationByKey(set.addswaps[i]);
+			if ( ltext === false ) {
+				ltext = set.addswaps[i];
+ 			}
+			attrs[lid] = ltext;
+		}
+		setAttrs(attrs);
+	}
 };
 
-var loadSkills = function() {
-	log("ENTER loadSkills() called");
+var loadSkills = function(caller) {
+	log("ENTER loadSkills() called by " + caller);
 	getSectionIDs("skills", function(list) {
 		// log("ENTER loadSkills() getSectionIDs()");
 		var fieldlist = [];
@@ -2742,7 +2821,7 @@ var loadSkills = function() {
 					attrs[attrnamelist] = listform;
 				}
 				// log(attrs);
-				setAttrs(attrs);
+				setAttrs(attrs,{silent:true}); // We don't need to trigger any cascades here, this contains modifications of some fields in repeating_skills but we're already processing the whole thing in here
 				// log("EXIT loadSkills() getAttrs");
 
 				// As a coda to this, we go and make sure that stunts with incorporated skills are recorded properly.
@@ -2935,7 +3014,7 @@ var addSkills = function(values) {
 						log("NOT INSERTED: I believe that " + skillname + " is already in the skill list, so, nope.");
 					}
 				}
-				setAttrs(attrs,"silent",function() { log("addSkills callback to loadSkills"); loadSkills(); }); // doing loadSkills() as a callback so it'll happen after all the attrs are set
+				setAttrs(attrs,{silent:true},function() { log("addSkills callback to loadSkills"); loadSkills("addSkills"); }); // doing loadSkills() as a callback so it'll happen after all the attrs are set
 
 			}
 		);
@@ -3173,7 +3252,7 @@ var addConsequence = function(values) {
 
 on("sheet:opened", function() {
 	log("Event: Sheet Opened");
-	loadSkills();
+	loadSkills("sheet:opened");
 });
 
 on("change:addextra", function() {
@@ -3229,7 +3308,7 @@ on("change:repeating_roles remove:repeating_roles sheet:opened", function() {
 							}
 							log("Attrs ready to set:");
 							log(attrs);
-							setAttrs(attrs,"quiet",function() { loadSkills(); });
+							setAttrs(attrs,{silent:true},function() { loadSkills("change:repeating_roles remove:repeating_roles sheet:opened"); });
 						});
 					});
 				});
@@ -3305,7 +3384,7 @@ on("change:repeating_modes remove:repeating_modes sheet:opened", function() {
 							}
 							log("Attrs ready to set:");
 							log(attrs);
-							setAttrs(attrs,"quiet",function() { loadSkills(); });
+							setAttrs(attrs,{silent:true},function() { loadSkills("change:repeating_modes remove:repeating_modes sheet:opened"); });
 						});
 					});
 				});
@@ -3350,8 +3429,8 @@ on("sheet:opened change:repeating_aspects remove:repeating_aspects", function() 
 	});
 });
 
-on("change:repeating_skills remove:repeating_skills change:skillstyle  change:repeating_stunts:skill change:repeating_extras:skill change:rolltally", function() {
-	loadSkills();
+on("change:repeating_skills:skill change:repeating_skills:rating change:repeating_skills:bonus remove:repeating_skills change:skillstyle change:repeating_stunts:skill change:repeating_extras:skill change:rolltally", function() {
+	loadSkills("change:repeating_skills:skill change:repeating_skills:rating change:repeating_skills:bonus remove:repeating_skills change:skillstyle change:repeating_stunts:skill change:repeating_extras:skill change:rolltally");
 });
 
 on("sheet:opened change:repeating_stunts remove:repeating_stunts", function() {
@@ -3462,7 +3541,7 @@ on("change:repeating_powers:sfxmenu", function(e) {
 				}
 				newtext = newtext + text + " ";
 				attrs[fxid] = newtext;
-				setAttrs(attrs,"silent"); // Silent because we don't need to trigger a second run through this same handler
+				setAttrs(attrs,{silent:true}); // Silent because we don't need to trigger a second run through this same handler
 			});
 		}
 	}
@@ -3515,6 +3594,93 @@ on("change:repeating_aspects:rollthis", function(e) {
 			setAttrs(attrs);
 		});
 	});
+});
+
+on("clicked:repeating_swaps:importswap", function(e) {
+	const rowprefix = (e.sourceAttribute).slice(0,-10); // Strips off the importswap
+	const skillsid = rowprefix + "skills";
+	getSectionIDs("skills", function(s) {
+		var fields = [];
+		for(var i=0; i < s.length; i++) {
+			fields[i*2] = "repeating_skills_" + s[i] + "_skill";
+			fields[i*2+1] = "repeating_skills_" + s[i] + "_rating";
+		}
+		getAttrs(fields, function(v) {
+			var attrs = {};
+			attrs[skillsid] = "";
+			for(var i=0; i < s.length; i++) {
+				const sid = "repeating_skills_" + s[i] + "_skill";
+				const rid = "repeating_skills_" + s[i] + "_rating";
+				if ( i > 0 ) {
+					attrs[skillsid] += ", ";
+				}
+				attrs[skillsid] += v[sid] + ":" + v[rid];
+			}
+			setAttrs(attrs);
+		});
+	});
+});
+
+on("change:repeating_swaps:skills", function(e) {
+	log("change:repeating_swaps:skills");
+	log(e);
+	const skillsid = e.sourceAttribute;
+	getAttrs([skillsid], function(s) {
+		var stext = s[skillsid];
+		stext = stext.replace(/\n/," ");
+		stext = stext.replace(/  */," ");
+		stext = stext.replace(/^  */,"");
+		stext = stext.replace(/  *$/,"");
+		var attrs = {};
+		attrs[skillsid] = stext;
+		setAttrs(attrs,{silent:true});
+	});
+})
+
+on("clicked:repeating_swaps:loadswap", function(e) {
+	const rowprefix = (e.sourceAttribute).slice(0,-8); // Strips off the loadswap
+	const skillsid = rowprefix + "skills";
+
+	getAttrs([skillsid], function(l) {
+
+		var list = l[skillsid].toString().split(/\s*,\s*/);
+
+		var rates = {};
+		for(var i = 0; i < list.length; i++) {
+			var parts = list[i].toString().split(/\s*:\s*/);
+			rates[parts[0]] = Number(parts[1]);
+		}
+		log(rates);
+
+		getSectionIDs("skills", function(s) {
+			const lid = rowprefix + "label";
+			var fields = [ lid ];
+			for(var i=0; i < s.length; i++) {
+				fields[1+i*2] = "repeating_skills_" + s[i] + "_skill";
+				fields[1+i*2+1] = "repeating_skills_" + s[i] + "_rating";
+			}
+			getAttrs(fields, function(v) {
+				var attrs = { "lastswapped": "(" + v[lid] + ")" };
+				for(var i=0; i < s.length; i++) {
+					const sid = "repeating_skills_" + s[i] + "_skill";
+					const rid = "repeating_skills_" + s[i] + "_rating";
+					const skill = v[sid];
+					const rating = Number(v[rid]);
+					if ( typeof rates[skill] !== "undefined") {
+						// Then we have a skill that matches one of the loadable's skills
+						if ( rating != rates[skill] ) {
+							attrs[rid] = rates[skill];
+							log("Changing "+skill+" rating to "+rates[skill]);
+						}
+					}
+				}
+				setAttrs(attrs,{silent:true},function() { loadSkills("clicked:repeating_swaps:loadswap") });
+			});
+		});
+
+	});
+
+
 });
 
 </script>

--- a/Fate/sheet.json
+++ b/Fate/sheet.json
@@ -22,12 +22,13 @@
 				"Dresden Files Accelerated|dfa",
 				"Fate of Cthulhu|foc",
 				"Kaiju Incorporated|kaijuinc",
+				"Ngen Mapu|ngen",
 				"Secrets of Cats|cats",
 				"Shadow of the Century|shotc",
 				"Tachyon Squadron|tachyon",
 				"Venture City|venture"
 			],
-			"optiontranslationkeys": [ "noset","custom-build","fcore","fcon","fae","threerocketeers","robo","dfa","foc","kaijuinc","cats","shotc","tachyon","venture"
+			"optiontranslationkeys": [ "noset","custom-build","fcore","fcon","fae","threerocketeers","robo","dfa","foc","kaijuinc","ngen","cats","shotc","tachyon","venture"
 			],
 			"value": "none",
 			"description": "Choose a prebuilt set of options. Other than the first two, your choice will override the settings seen below.",
@@ -188,13 +189,22 @@
 			"default": "1"
 		},
 		{
-			"attribute": "Show-TempAspects",
-			"displayname": "Situation Aspects",
-			"displaytranslationkey": "situation-aspects",
+			"attribute": "Show-Stunts",
+			"displayname": "Stunts",
+			"displaytranslationkey": "stunts",
 			"type": "select",
 			"options": [ "Show|1", "Hide|0" ],
 			"optiontranslationkeys": [ "show", "hide" ],
 			"default": "1"
+		},
+		{
+			"attribute": "Show-Skillswaps",
+			"displayname": "Swappable Skillsets",
+			"displaytranslationkey": "swap-skills",
+			"type": "select",
+			"options": [ "Show|1", "Hide|0" ],
+			"optiontranslationkeys": [ "show", "hide" ],
+			"default": "0"
 		},
 		{
 			"attribute": "custom-aspects",

--- a/Fate/translation.json
+++ b/Fate/translation.json
@@ -297,5 +297,16 @@
 	"roll": "Roll",
 	"tachyon-squadron": "Tachyon Squadron",
 	"pronouns": "Pronouns",
+	"swap-skills": "Swappable Skillsets",
+	"swap-skills-instruct": "Enter a list separated by commas, with each entry in this format (not including the quotes): \"Skill Name:Value\", e.g., \"Athletics:2, Investigation:1\". Unlisted skills will not be altered. All skills listed here must already exist in the sheet's skills.",
+	"load-skillset": "Load Skillset",
+	"grab-current-skills": "Import Current Skillset",
+	"ngen": "Ngen Mapu",
+	"Heart": "Heart",
+	"Humanity": "Humanity",
+	"Kindness": "Kindness",
+	"Shapeshift": "Shapeshift",
+	"Thieving": "Thieving",
+	"Wisdom": "Wisdom",
 	"zzzz-end-of-json": "<!-- End of JSON File -->"
 }

--- a/Fate/translation.json
+++ b/Fate/translation.json
@@ -296,5 +296,6 @@
 	"bonus": "Bonus",
 	"roll": "Roll",
 	"tachyon-squadron": "Tachyon Squadron",
+	"pronouns": "Pronouns",
 	"zzzz-end-of-json": "<!-- End of JSON File -->"
 }


### PR DESCRIPTION
## Changes / Comments

Character sheet now has a space for pronouns.

Support for swappable skillsets (useful for various shapeshifting implementations).

Support for Ngen Mapu gameset.

Extras Icon bug fixed (minus/blank swapped), added option to display a 2nd and 3rd icon. Closed a missing span tag.

Skills are "externalized" from their fieldsets as named attributes in the format Skill-[Name], e.g., Skill-Athletics attribute stores the numeric value of the Athletics skill and can be addressed in macros via @{selected|Skill-Athletics}.

Aspects are externalized as Aspect-[Label] attributes with the name of the aspect as the value. If multiple aspects with the same-named label are encountered, subsequent instances are given a number, so you might have Aspect-OtherAspect and Aspect-OtherAspect2 if you had two aspects labeled as "Other Aspect".

Stunts are externalized numbered, e.g., Stunt-1, with three attributes; Stunt-1 contains the full name and text of the stunt, Stunt-Name-1 contains just the name of the stunt, Stunt-Desc-1 contains the text of the stunt without the name.

Consequences are externalized as Consequence-[Label], e.g., Consequence-Mild, with the value containing the name of the aspect in that consequence slot. Additional attributes exist for total value of the consequence (Consequence-Mild-Total), remaining value (zero if marked, total value if not) (Consequence-Mild-Remaining), and boolean Marked status (Consequence-Mild-Marked). 

Stress tracks are externalized in summary form. The attribute prefix is Stress-[Label], e.g., Stress-PhysicalStress. Summary suffixes include -Length, indicating the number of boxes, -Total, indicating the total capacity of the track, -Remaining, indicating the capacity of the unmarked boxes on the track, and -Used, indicating the capacity of the marked boxes on the track. If you wanted to indicate a "health bar" on a token, you would reference (for example) Stress-PhysicalStress-Total for the maximum value and Stress-PhysicalStress-Remaining for the current "health" value.

Conditions are handled the same as Stress, with an attribute prefix of Condition-[Label], e.g., Condition-Indebted.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
