### PR TITLE
[Legend of the Elements] Fix bug when selecting the Watershaper

### DIFF
--- a/Legend-of-the-Elements/LOTE.css
+++ b/Legend-of-the-Elements/LOTE.css
@@ -24,8 +24,7 @@ input[type="radio"][value="7"]:checked ~ div.sheet-Peasant,
 input[type="radio"][value="8"]:checked ~ div.sheet-Scholar,
 input[type="radio"][value="9"]:checked ~ div.sheet-Spiritshaper,
 input[type="radio"][value="10"]:checked ~ div.sheet-Warrior,
-input[type="radio"][value="11"]:checked ~ div.sheet-Wate
-rshaper,
+input[type="radio"][value="11"]:checked ~ div.sheet-Watershaper,
 input[type="radio"][value="99"]:checked ~ div.sheet-Custom
 {
     display: block;


### PR DESCRIPTION
## Changes / Comments
A line break in the Legend-of-the-Elements/LOTE.css was preventing the Watershaper sheet from being correctly loaded. This fixes it.





## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
