### PR TITLE
[Chronicles of Darkness] Fix category

### DIFF
--- a/approved.yaml
+++ b/approved.yaml
@@ -3140,11 +3140,6 @@ adventureww:
   - "Adventure!"
   - "Storyteller System"
 
-chroniclesofdarkness:
-  - "Chronicles of Darkness"
-  - "Chronicles of Darkness"
-  - "Storyteller System"
-
 cwod:
   - CWorldofDarkness
   - Classic World of Darkness
@@ -3226,6 +3221,12 @@ godmachine:
   - "Storyteller System"
 
 #STORYTELLING SYSTEM
+
+chroniclesofdarkness:
+  - "Chronicles of Darkness"
+  - "Chronicles of Darkness"
+  - "Storytelling System"
+  
 nwodchangeling:
   - "NWOD-Changeling"
   - "Changeling: The Lost"


### PR DESCRIPTION
## Changes / Comments

I understand we're generally not meant to update the `approved.yaml` file. This is just putting the Chronicles of Darkness sheet into the correct category - "Storytelling System", *not* "Storyteller System".

![image](https://user-images.githubusercontent.com/4495480/87860152-bc074f00-c900-11ea-9eae-a76ad57dfdb9.png)

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
