### PR TITLE
[AW2E Burned Over] Fixed harm roll

### DIFF
--- a/AW2E-Burned-Over/apocalypse-world-burned-over.html
+++ b/AW2E-Burned-Over/apocalypse-world-burned-over.html
@@ -414,7 +414,7 @@
                 <label class="sheet-harm sheet-section-title"><span data-i18n="harm">Harm</span>:</label>
                 <div class="sheet-roll-box sheet-cf">
                     <label class="sheet-buttonLbl"><span data-i18n="suffer-harm">suffer harm</span>:</label>
-                    <button type='roll' value='&{template:aw} {{name=@{character_name}}} {{roll_name=^{harm}}} {{result=[[2d6 + ?{Harm |0|1|2|3|4|5}]]}}' name='roll_harm'></button>
+                    <button type='roll' value='&{template:aw} {{name=@{character_name}}} {{roll_name=^{harm}}} {{result=[[2d6 - ?{Harm |0|1|2|3|4|5}]]}}' name='roll_harm'></button>
                 </div>
 
                 <div class="sheet-harm-section">


### PR DESCRIPTION
## Changes / Comments

#6922 It was pointed out that the dice roll button for Harm used the stat incorrectly, so I changed the equation.




## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
