### PR TITLE
Mork Borg - Add missing attributes for items carried and current omens.

### DIFF
--- a/Mork Borg/morkborgsheet.html
+++ b/Mork Borg/morkborgsheet.html
@@ -161,7 +161,7 @@
           <label class="inline">
             <span class="unifraktur" data-i18n="omens-u">Omens</span>
           </label>
-          <input type="number" class="short" value="0" />
+          <input name="attr_omens_curr" type="number" class="short" value="0" />
           <select name="attr_omens" class="short">
             <option value="2" selected="selected">d2</option>
             <option value="3">d3</option>
@@ -274,7 +274,7 @@
           <label class="inline">
             <span class="note">Items carried</span>
           </label>
-          <input type="number" value="0" />
+          <input name="attr_items_carried" type="number" value="0" />
           <br />
           <div class="2colrow">
             <div class="col">


### PR DESCRIPTION
## Changes / Comments

A couple fields on the Mork Borg character sheet were missing an attribute name, so they weren't getting persisted.  This change just adds the attribute names so that the values aren't lost whenever the sheet refreshes.




## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ x ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ x ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
