### PR TITLE
[Chronicles of Darkness] FIX Click through Attributes sheet-border

### DIFF
--- a/Chronicles of Darkness/CofD.css
+++ b/Chronicles of Darkness/CofD.css
@@ -854,6 +854,7 @@ input.sheet-game-line[value="hunter"] ~ * input.sheet-rolltype-select[value="rot
 
 .sheet-attributes > .sheet-border {
     border: 1px solid black;
+    pointer-events: none;
 }
 
 .sheet-attributes > .sheet-power {


### PR DESCRIPTION
Currently it is impossible to click on the Attributes or Attribute dots, because sheet-border div element somehow ends on top of them.

The issue is present in Firefox 78.0.2. Other browsers not tested.

## Changes / Comments

Added CSS property for "sheet-border" to ignore mouse events completely.
This is just an element for a nice border around attributes, so it doesn't need mouse events anyway.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
