### PR TITLE
[Chronicles of Darkness] FIX Attribute Grid Order

### DIFF
--- a/Chronicles of Darkness/CofD.html
+++ b/Chronicles of Darkness/CofD.html
@@ -322,6 +322,7 @@
                 <div class="attributes-category power">Power</div>
                 <div class="attributes-category finesse">Finesse</div>
                 <div class="attributes-category resistance">Resistance</div>
+                <div class="mental border"></div>
                 <div class="power mental label">
                     <input type="hidden" class="flag" name="attr_intelligence_flag" value="0" />
                     <button type="action" class="toggle" name="act_intelligence" data-i18n="intelligence">Intelligence</button>
@@ -361,7 +362,7 @@
                     <button type="action" class="dot ne-1 ne-2 ne-3" name="act_resolve_4"></button>
                     <button type="action" class="dot ne-1 ne-2 ne-3 ne-4" name="act_resolve_5"></button>
                 </div>
-                <div class="mental border"></div>
+                <div class="physical border"></div>
                 <div class="power physical label">
                     <input type="hidden" class="flag" name="attr_strength_flag" value="0" />
                     <button type="action" class="toggle" name="act_strength" data-i18n="strength">Strength</button>
@@ -401,7 +402,7 @@
                     <button type="action" class="dot ne-1 ne-2 ne-3" name="act_stamina_4"></button>
                     <button type="action" class="dot ne-1 ne-2 ne-3 ne-4" name="act_stamina_5"></button>
                 </div>
-                <div class="physical border"></div>
+                <div class="social border"></div>
                 <div class="power social label">
                     <input type="hidden" class="flag" name="attr_presence_flag" value="0" />
                     <button type="action" class="toggle" name="act_presence" data-i18n="presence">Presence</button>
@@ -441,7 +442,6 @@
                     <button type="action" class="dot ne-1 ne-2 ne-3" name="act_composure_4"></button>
                     <button type="action" class="dot ne-1 ne-2 ne-3 ne-4" name="act_composure_5"></button>
                 </div>
-                <div class="social border"></div>
             </div>
         </div>
     


### PR DESCRIPTION
## Changes / Comments

Move border divs to be underneath clickable divs in the CSS Grid for Attributes.

This issue occurs in Firefox, but not in Chromium (Chrome, Edge, Brave).

This is an alternative fix to #7039

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
