### PR TITLE
[Tormenta20] little fix on custom template roll

### DIFF
--- a/Tormenta20/tormenta20.html
+++ b/Tormenta20/tormenta20.html
@@ -1786,9 +1786,9 @@
 
             {{/^rollWasCrit() theroll}}
             <div class="props">
-                {{#allprops() name criticalname ifcritical ifcriticalerror description notcritical theroll rollname}}
+                {{#allprops() name criticalname ifcritical ifcriticalerror description notcritical theroll rollname secondname}}
                    <div class="content"><b>{{key}}</b> {{value}}</div>
-                {{/allprops() name criticalname ifcritical ifcriticalerror description notcritical theroll rollname}}
+                {{/allprops() name criticalname ifcritical ifcriticalerror description notcritical theroll rollname secondname}}
             </div>
             {{#description}}
                 <div class="descricao">


### PR DESCRIPTION
## Changes / Comments

A subtitle property was appearing twice on a specific template roll.




## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
