### PR TITLE
[D20 Modern] Adding missing armor penalties

### DIFF
--- a/d20 Modern/d20 Modern.html
+++ b/d20 Modern/d20 Modern.html
@@ -332,7 +332,7 @@
                 <tr>
                     <td><input type="checkbox" class="sheet-bigcheck" name="attr_Balance-CrossClass" value="2"/><span></span></td>
                     <td><button type="roll" class="sheet-btn" name="roll_Balance" value="/e rolls Balance [[1d20+@{Balance}]]" >Balance</button></td>
-                    <td><input type="number" class="sheet-ability" name="attr_Balance" value="[[@{Balance-ability}+@{Balance-Ranks}+@{Balance-Misc}]]" disabled="true"/></td>
+                    <td><input type="number" class="sheet-ability" name="attr_Balance" value="[[@{Balance-ability}+@{Balance-Ranks}+@{Balance-Misc}+@{Armor-Penalty}]]" disabled="true"/></td>
                     <td>
                         <select class="sheet-number" name="attr_Balance-ability" style="width:40px;">
                             <option value="@{Strength-mod}">Str</option>
@@ -366,7 +366,7 @@
                 <tr>
                     <td><input type="checkbox" class="sheet-bigcheck" name="attr_Climb-CrossClass" value="2"/><span></span></td>
                     <td><button type="roll" class="sheet-btn" name="roll_Climb" value="/e rolls Climb [[1d20+@{Climb}]]" >Climb</button></td>
-                    <td><input type="number" class="sheet-ability" name="attr_Climb" value="[[@{Climb-ability}+@{Climb-Ranks}+@{Climb-Misc}]]" disabled="true"/></td>
+                    <td><input type="number" class="sheet-ability" name="attr_Climb" value="[[@{Climb-ability}+@{Climb-Ranks}+@{Climb-Misc}+@{Armor-Penalty}]]" disabled="true"/></td>
                     <td>
                         <select class="sheet-number" name="attr_Climb-ability" style="width:40px;">
                             <option value="@{Strength-mod}" selected>Str</option>
@@ -585,7 +585,7 @@
                 <tr>
                     <td><input type="checkbox" class="sheet-bigcheck" name="attr_Escape_Artist-CrossClass" value="2"/><span></span></td>
                     <td><button type="roll" class="sheet-btn" name="roll_Escape_Artist" value="/e rolls Escape Artist [[1d20+@{Escape_Artist}]]" ><div class="sheet-smaller">Escape Artist</div></button></td>
-                    <td><input type="number" class="sheet-ability" name="attr_Escape_Artist" value="[[@{Escape_Artist-ability}+@{Escape_Artist-Ranks}+@{Escape_Artist-Misc}]]" disabled="true"/></td>
+                    <td><input type="number" class="sheet-ability" name="attr_Escape_Artist" value="[[@{Escape_Artist-ability}+@{Escape_Artist-Ranks}+@{Escape_Artist-Misc}+@{Armor-Penalty}]]" disabled="true"/></td>
                     <td>
                         <select class="sheet-number" name="attr_Escape_Artist-ability" style="width:40px;">
                             <option value="@{Strength-mod}">Str</option>
@@ -670,7 +670,7 @@
                 <tr>
                     <td><input type="checkbox" class="sheet-bigcheck" name="attr_Hide-CrossClass" value="2"/><span></span></td>
                     <td><button type="roll" class="sheet-btn" name="roll_Hide" value="/e rolls Hide [[1d20+@{Hide}]]" >Hide</button></td>
-                    <td><input type="number" class="sheet-ability" name="attr_Hide" value="[[@{Hide-ability}+@{Hide-Ranks}+@{Hide-Misc}]]" disabled="true"/></td>
+                    <td><input type="number" class="sheet-ability" name="attr_Hide" value="[[@{Hide-ability}+@{Hide-Ranks}+@{Hide-Misc}+@{Armor-Penalty}]]" disabled="true"/></td>
                     <td>
                         <select class="sheet-number" name="attr_Hide-ability" style="width:40px;">
                             <option value="@{Strength-mod}">Str</option>
@@ -1091,7 +1091,7 @@
                 <tr>
                     <td><input type="checkbox" class="sheet-bigcheck" name="attr_Sleight_of_Hand-CrossClass" value="2"/><span></span></td>
                     <td><button type="roll" class="sheet-btn" name="roll_Sleight_of_Hand" value="/e rolls Sleight of Hand [[1d20+@{Sleight_of_Hand}]]" ><div class="sheet-smaller">Sleight of Hand*</div></button></td>
-                    <td><input type="number" class="sheet-ability" name="attr_Sleight_of_Hand" value="[[@{Sleight_of_Hand-ability} + @{Sleight_of_Hand-Ranks} + @{Sleight_of_Hand-Misc} ]]" disabled="true"/></td>
+                    <td><input type="number" class="sheet-ability" name="attr_Sleight_of_Hand" value="[[@{Sleight_of_Hand-ability} + @{Sleight_of_Hand-Ranks} + @{Sleight_of_Hand-Misc} + @{Armor-Penalty}]]" disabled="true"/></td>
                     <td>
                         <select class="sheet-number" name="attr_Sleight_of_Hand-ability" style="width:40px;">
                             <option value="@{Strength-mod}">Str</option>


### PR DESCRIPTION
## Changes / Comments

The D20 Modern SRD lists several skills as having armor penalties.  These penalties appeared to be missing from a few skills.



## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
