### PR TITLE
Update Palladium Fantasy 1E

### DIFF
--- a/Palladium Fantasy 1E/palladium_fantasy_1e.html
+++ b/Palladium Fantasy 1E/palladium_fantasy_1e.html
@@ -150,7 +150,11 @@
                 <input class='roll-field' type="text" value="0" name="attr_invoke_trust" readonly>
                 <button class='rolldice' type="roll" title='Charm or Impress' name='roll_charm_impress' value="@{whispertoggle}&{template:custom} {{color=black}} {{title=**@{character_name}**}} {{subtitle=Charm or Impress Attempt}} {{Skill Check=[[1d100]]}} {{Chance of Success=@{charm_impress}}}" >Charm</button>                
                 <input class='roll-field' type="text" value="0" name="attr_charm_impress" readonly>
-                <button class='rolldice' type="roll" title='Perception based on IQ and ME' name='roll_perception' value="@{whispertoggle}&{template:custom} {{color=yellow}} {{title=**@{character_name}**}} {{subtitle=Perception}} {{Perception=[[d20cs<1cf>20+@{perception}]]}} {{desc=Target equal or below=[[floor((@{iq}+@{me})/2)]]}}" >Percep.</button>                
+                <button class='rolldice' type="roll" title='Perception from Rifts' name='roll_perception' value="@{whispertoggle}&{template:custom} {{color=yellow}} {{title=**@{character_name}'s**}} {{subtitle=Perception Roll}} {{Perception=[[d20+@{perception}]]}} {{desc=The number to beat is based on difficulty as determined by the GM
+            **4** Easy
+            **8** Moderate
+            **14** Challenging
+            **17** Difficult}}" >Percep.</button>
                 <input class='roll-field' type='text' title='Perception Bonus' value="0" name="attr_perception" />
                 <button class='rolldice' type="roll" title='Initiative (d20+80)' name='roll_initiative' value="@{whispertoggle}&{template:custom} {{color=black}} {{title=**@{character_name}**}} {{subtitle=Initiative}} {{Initiative=[[d20+80+@{initiative_mod}&{tracker}]]}}" >Init.</button>                
                 <input class='roll-field' type='text' title='Initiative Bonus' value="0" name="attr_initiative_mod" />


### PR DESCRIPTION
Changed the output of the perception roll button.  Perception doesn't actually exist in this old ruleset, and so I had inserted my homebrew version of it.  It has been changed to use the version of perception from the Rifts game system (also produced by Palladium Books).  I only learned of that rule while writing the Heroes Unlimited 2E sheet, so thought I should probably bring that rule here also.  

## Changes / Comments
This changes no attributes, just the output of one roll button to a more "official" version.
## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
