### PR TITLE
(Coriolis Alternative) Fixed wrong attribute on talents

### DIFF
--- a/Coriolis Alternative/CoriolisAlternative.html
+++ b/Coriolis Alternative/CoriolisAlternative.html
@@ -343,7 +343,7 @@
             <div class="coriolis-grid-generic coriolis-grid-panel">
                 <span class="panel-header" data-i18n="label-talents">Talents</span>
             </div>
-            <fieldset class="repeating_critical-injuries">
+            <fieldset class="repeating_talent">
                 <div class="coriolis-grid-generic coriolis-grid-row">
                 <input name="attr_talent" type="text" data-i18n-placeholder="placeholder-talent" placeholder="Talent"/>
                 </div>


### PR DESCRIPTION
## Changes / Comments

- The repeating field for **talents** was using the same attribute as **critical damage**. Changed the talent attribute to the correct attribute.
- This will unfortunately result in some data loss for players


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
