### PR TITLE
Chroniques Oubliees: improvements for the import of statblocks

### DIFF
--- a/ChroniquesOubliees/co.css
+++ b/ChroniquesOubliees/co.css
@@ -52,7 +52,6 @@ table.sheet-tabsep{
     text-align: center;
     font-style: normal;
     font-weight: bold;
-    text-transform: capitalize;
     color: white;
     border:none;
     white-space: nowrap;

--- a/ChroniquesOubliees/co.html
+++ b/ChroniquesOubliees/co.html
@@ -362,10 +362,10 @@
                           </tr>
                           <td class="boxtitre-chance">PC</td>
                           <td class="boxinputlight-chance"><span class="input" class="chance" name="attr_pc_base" /></td>
-                            <td class="boxinputlight-chance"><input type="number" class="chance" name="attr_pc_bonus" value="0" /></td>
-                            <td class="boxinput-chance"><input type="number" class="chance" name="attr_pc" value="3" min="0" /> <span class="input">/</span> <span class="input" name="attr_pc_max" /></td>
-                              <tr>
-                              </tr>
+                          <td class="boxinputlight-chance"><input type="number" class="chance" name="attr_pc_bonus" value="0" /></td>
+                          <td class="boxinput-chance"><input type="number" class="chance" name="attr_pc" value="3" min="0" /> <span class="input">/</span> <span class="input" name="attr_pc_max" /></td>
+                          <tr>
+                          </tr>
                         </table>
                       </div>
                     </div><!-- fin des points de chance -->
@@ -423,105 +423,105 @@
         <fieldset class="repeating_armes">
           <div class="attack">
             <input class="options-flag" name="attr_armeoptflag" type="checkbox"
-            title="Montrer/cacher les options"><span>y</span>
-            <div>
-          <table  class="tabsep">
-            <tr>
-        <input type='hidden' name='attr_armebonusoption' value='0' />
-        <input type='hidden' name='attr_armedmtemp' value='' />
-        <input type='hidden' name='attr_armedegats' value='{{degats=[[(@{armedmnbde}d@{armedmde}@{armedmrollmod}+[[@{armedmcar}]]+@{armedmdiv})@{division_attaque_assuree}]]}}' />
-        <input type='hidden' name='attr_armepoudre' value='{{poudre=}}' />
-        <input type='hidden' name='attr_armereussiteauto' value='{{attaqueautomatique=}}' />
-        <input type='hidden' name='attr_armedmrollmod' value='' />
-        <input type='hidden' name='attr_armeattrollmod' value='' />
-        <input type='hidden' name='attr_armeattnbde' value='1' />
-        <input type='hidden' name='attr_armeattde' value='@{ETATDE}' />
-              <td>
-                <button type="roll" class="atk" name="roll_Arme" value="@{jets_caches}&{template:co1} {{perso=@{character_name}}} {{name=@{armenom}}} {{subtags=Attaque}} {{attaque=[[ @{armeattnbde}d@{armeattde}@{armeattrollmod}cs>@{armecrit}cf1 + [[@{armeatk}]] + @{armeatkdiv} +@{bonus_attaque_option} +@{armebonusoption}]]}} @{armereussiteauto} @{armepoudre} @{armedegats} {{special=@{armespec}}} {{degats2=@{bonus_dm_option}}} {{dmtemp=@{armedmtemp}}}" />
-              </td>
-              <td class="boxinputleft-atk" style="min-width:130px;">
-                <input type="text" class="atk" style="width:11px; text-align:right; font-size:10px" name="attr_armelabel" value=0>
-                <input type="text" class="atk" name="attr_armenom" style="font-weight: bold;width:94%;margin-left:-5px" placeholder="Arme/attaque"/>
-              </td>
-              <td class="boxinputleft-atk">
-                <select class="carac-atk" style="width: 87px;" name="attr_armeatk" size="1">
-                  <option value="@{ATKCAC}" selected>CONTACT</option>
-                  <option value="@{ATKTIR}">DISTANCE</option>
-                  <option value="@{ATKMAG}">MAGIE</option>
-                </select>+<input type="number" class="atk" style="width:32px;" name="attr_armeatkdiv" value="0" title="Bonus d'attaque divers" />
-              </td>
-              <td class="boxinputleft-atk" style="text-align: right;">
-                <input type="number" class="atk" name="attr_armecrit" style="width:32px;" min="2" max="20" value="20" title="Seuil de Critique (par défaut 20)" />
-              </td>
-              <td class="boxinputleft-atk">
-                <input type="number" class="atk" style="width:32px;" name="attr_armedmnbde" value="1" title="Nombre de dés de dommage" />
-                <select class="carac-atk"  style="width:47px;" name="attr_armedmde" size="1" title="Dé de dommage">
-                  <option value="3">d3</option>
-                  <option value="4" selected>d4</option>
-                  <option value="6">d6</option>
-                  <option value="8">d8</option>
-                  <option value="10">d10</option>
-                  <option value="12">d12</option>
-                </select>+<select class="carac-atk" style="width:52px;" name="attr_armedmcar" size="1" title="Modificateur aux dommages">
-                  <option value="0">-</option>
-                  <option value="@{FOR}" selected>FOR</option>
-                  <option value="@{DEX}">DEX</option>
-                  <option value="@{CON}">CON</option>
-                  <option value="@{INT}">INT</option>
-                  <option value="@{SAG}">SAG</option>
-                  <option value="@{CHA}">CHA</option>
-                </select>+<input type="number" class="atk" style="width:32px;" name="attr_armedmdiv" value="0" title="Bonus de dommage divers" />
-              </td>
-              <td class="boxinputleft-atk" style="min-width:50px;">
-                <input type="text" class="atk" name="attr_armeportee" placeholder="Portée" title="Portée" />
-              </td>
-              <td class="boxinputleft-atk" style="width:100%;">
-                <textarea name="attr_armespec" class="atk" placeholder="Notes, capacités spéciales, effet ..." spellcheck="false" title="Notes, capacités spéciales, effet ..."></textarea>
-              </td>
-            </tr>
-          </table>
-            </div>
-            <div class="options">
-              <table class="tabsep">
-                <tr>
-                  <td style="width:18px; text-align:center;">
-                    <input type="checkbox" name="attr_armeactionvisible" title="Attaque visible dans les actions" value="1" checked>
-                  </td>
-                  <td class="boxinputleft-atk">
-                    <select class="carac-atk" style="width: 122px;" name="attr_armetypeattaque" title="Type d'attaque">
-                      <option>Naturel</option>
-                      <option>Arme 1 main</option>
-                      <option>Arme 2 mains</option>
-                      <option>Sortilege</option>
-                      <option>Arme gauche</option>
-                      <option>Arme de jet</option>
-                    </select>
-                  </td>
-                  <td class="boxinputleft-atk" style="min-width: 180px;">
-                <textarea name="attr_armemodificateurs" class="atk" placeholder="Liste de modificateurs" spellcheck="false" title="Modificateurs d'attaque, séparés par des virgules&#10; avantage: garde le meilleur de 2 dés&#10; avecd12: utilise le d12 en attaque&#10; auto: réussite automatique&#10; choc: peut faire des attaques non léthales sans malus&#10; désavantage: garde le moins bon de 2 dés&#10; explodeMax: dés de dégâts explosifs&#10; pasDeDmg: l'attaque ne fait pas de dégât&#10; poudre: arme à poudre&#10; reroll1: relance les 1 des dé de DM&#10; tempDmg: fait toujours des attaques non léthales"></textarea>
-                  </td>
-                  <td class="boxinputleft-atk">
-                    <select class="carac-atk" style="width: 87px;" name="attr_armetypedegats" title="Type des dégâts">
-                      <option>tranchant</option>
-                      <option>contondant</option>
-                      <option>percant</option>
-                      <option>mental</option>
-                      <option>feu</option>
-                      <option>acide</option>
-                      <option value="electrique">électrique</option>
-                      <option>froid</option>
-                      <option>sonique</option>
-                      <option>poison</option>
-                      <option>maladie</option>
-                      <option>magique</option>
-                    </select>
-                  </td>
-              <td class="boxinputleft-atk" style="width:100%;">
-                <textarea name="attr_armeoptions" class="atk" placeholder="Options d'attaque avec argument" spellcheck="false" title="Options d'attaque"></textarea>
-              </td>
-                </tr>
-              </table>
-            </div>
+                                                                title="Montrer/cacher les options"><span>y</span>
+                                                                <div>
+                                                                  <table  class="tabsep">
+                                                                    <tr>
+                                                                      <input type='hidden' name='attr_armebonusoption' value='0' />
+                                                                      <input type='hidden' name='attr_armedmtemp' value='' />
+                                                                      <input type='hidden' name='attr_armedegats' value='{{degats=[[(@{armedmnbde}d@{armedmde}@{armedmrollmod}+[[@{armedmcar}]]+@{armedmdiv})@{division_attaque_assuree}]]}}' />
+                                                                      <input type='hidden' name='attr_armepoudre' value='{{poudre=}}' />
+                                                                      <input type='hidden' name='attr_armereussiteauto' value='{{attaqueautomatique=}}' />
+                                                                      <input type='hidden' name='attr_armedmrollmod' value='' />
+                                                                      <input type='hidden' name='attr_armeattrollmod' value='' />
+                                                                      <input type='hidden' name='attr_armeattnbde' value='1' />
+                                                                      <input type='hidden' name='attr_armeattde' value='@{ETATDE}' />
+                                                                      <td>
+                                                                        <button type="roll" class="atk" name="roll_Arme" value="@{jets_caches}&{template:co1} {{perso=@{character_name}}} {{name=@{armenom}}} {{subtags=Attaque}} {{attaque=[[ @{armeattnbde}d@{armeattde}@{armeattrollmod}cs>@{armecrit}cf1 + [[@{armeatk}]] + @{armeatkdiv} +@{bonus_attaque_option} +@{armebonusoption}]]}} @{armereussiteauto} @{armepoudre} @{armedegats} {{special=@{armespec}}} {{degats2=@{bonus_dm_option}}} {{dmtemp=@{armedmtemp}}}" />
+                                                                      </td>
+                                                                      <td class="boxinputleft-atk" style="min-width:130px;">
+                                                                        <input type="text" class="atk" style="width:11px; text-align:right; font-size:10px" name="attr_armelabel" value=0>
+                                                                        <input type="text" class="atk" name="attr_armenom" style="font-weight: bold;width:94%;margin-left:-5px" placeholder="Arme/attaque"/>
+                                                                      </td>
+                                                                      <td class="boxinputleft-atk">
+                                                                        <select class="carac-atk" style="width: 87px;" name="attr_armeatk" size="1">
+                                                                          <option value="@{ATKCAC}" selected>CONTACT</option>
+                                                                          <option value="@{ATKTIR}">DISTANCE</option>
+                                                                          <option value="@{ATKMAG}">MAGIE</option>
+                                                                        </select>+<input type="number" class="atk" style="width:32px;" name="attr_armeatkdiv" value="0" title="Bonus d'attaque divers" />
+                                                                      </td>
+                                                                      <td class="boxinputleft-atk" style="text-align: right;">
+                                                                        <input type="number" class="atk" name="attr_armecrit" style="width:32px;" min="2" max="20" value="20" title="Seuil de Critique (par défaut 20)" />
+                                                                      </td>
+                                                                      <td class="boxinputleft-atk">
+                                                                        <input type="number" class="atk" style="width:32px;" name="attr_armedmnbde" value="1" title="Nombre de dés de dommage" />
+                                                                        <select class="carac-atk"  style="width:47px;" name="attr_armedmde" size="1" title="Dé de dommage">
+                                                                          <option value="3">d3</option>
+                                                                          <option value="4" selected>d4</option>
+                                                                          <option value="6">d6</option>
+                                                                          <option value="8">d8</option>
+                                                                          <option value="10">d10</option>
+                                                                          <option value="12">d12</option>
+                                                                        </select>+<select class="carac-atk" style="width:52px;" name="attr_armedmcar" size="1" title="Modificateur aux dommages">
+                                                                          <option value="0">-</option>
+                                                                          <option value="@{FOR}" selected>FOR</option>
+                                                                          <option value="@{DEX}">DEX</option>
+                                                                          <option value="@{CON}">CON</option>
+                                                                          <option value="@{INT}">INT</option>
+                                                                          <option value="@{SAG}">SAG</option>
+                                                                          <option value="@{CHA}">CHA</option>
+                                                                        </select>+<input type="number" class="atk" style="width:32px;" name="attr_armedmdiv" value="0" title="Bonus de dommage divers" />
+                                                                      </td>
+                                                                      <td class="boxinputleft-atk" style="min-width:50px;">
+                                                                        <input type="text" class="atk" name="attr_armeportee" placeholder="Portée" title="Portée" />
+                                                                      </td>
+                                                                      <td class="boxinputleft-atk" style="width:100%;">
+                                                                        <textarea name="attr_armespec" class="atk" placeholder="Notes, capacités spéciales, effet ..." spellcheck="false" title="Notes, capacités spéciales, effet ..."></textarea>
+                                                                      </td>
+                                                                    </tr>
+                                                                  </table>
+                                                                </div>
+                                                                <div class="options">
+                                                                  <table class="tabsep">
+                                                                    <tr>
+                                                                      <td style="width:18px; text-align:center;">
+                                                                        <input type="checkbox" name="attr_armeactionvisible" title="Attaque visible dans les actions" value="1" checked>
+                                                                      </td>
+                                                                      <td class="boxinputleft-atk">
+                                                                        <select class="carac-atk" style="width: 122px;" name="attr_armetypeattaque" title="Type d'attaque">
+                                                                          <option>Naturel</option>
+                                                                          <option>Arme 1 main</option>
+                                                                          <option>Arme 2 mains</option>
+                                                                          <option>Sortilege</option>
+                                                                          <option>Arme gauche</option>
+                                                                          <option>Arme de jet</option>
+                                                                        </select>
+                                                                      </td>
+                                                                      <td class="boxinputleft-atk" style="min-width: 180px;">
+                                                                        <textarea name="attr_armemodificateurs" class="atk" placeholder="Liste de modificateurs" spellcheck="false" title="Modificateurs d'attaque, séparés par des virgules&#10; avantage: garde le meilleur de 2 dés&#10; avecd12: utilise le d12 en attaque&#10; auto: réussite automatique&#10; choc: peut faire des attaques non léthales sans malus&#10; désavantage: garde le moins bon de 2 dés&#10; explodeMax: dés de dégâts explosifs&#10; pasDeDmg: l'attaque ne fait pas de dégât&#10; poudre: arme à poudre&#10; reroll1: relance les 1 des dé de DM&#10; tempDmg: fait toujours des attaques non léthales"></textarea>
+                                                                      </td>
+                                                                      <td class="boxinputleft-atk">
+                                                                        <select class="carac-atk" style="width: 87px;" name="attr_armetypedegats" title="Type des dégâts">
+                                                                          <option>tranchant</option>
+                                                                          <option>contondant</option>
+                                                                          <option>percant</option>
+                                                                          <option>mental</option>
+                                                                          <option>feu</option>
+                                                                          <option>acide</option>
+                                                                          <option value="electrique">électrique</option>
+                                                                          <option>froid</option>
+                                                                          <option>sonique</option>
+                                                                          <option>poison</option>
+                                                                          <option>maladie</option>
+                                                                          <option>magique</option>
+                                                                        </select>
+                                                                      </td>
+                                                                      <td class="boxinputleft-atk" style="width:100%;">
+                                                                        <textarea name="attr_armeoptions" class="atk" placeholder="Options d'attaque avec argument" spellcheck="false" title="Options d'attaque"></textarea>
+                                                                      </td>
+                                                                    </tr>
+                                                                  </table>
+                                                                </div>
           </div>
         </fieldset>
       </div>
@@ -533,78 +533,78 @@
         <table>
           <tr>
             <td style="text-align:center;">
-                    <input type="checkbox" name="attr_attaque_en_puissance_check" title="Attaque en puissance utilisée" value="1" unchecked>
-                  </td>
-                  <td>
-                  Attaque en puissance
-                  </td>
-                  <td>
-                  <input type='hidden' name='attr_malus_attaque_en_puissance' value='-5' />
-                  <span name="attr_malus_attaque_en_puissance"></span> en attaque et +
-                <input type="number" class="atk" style="width:32px;" name="attr_attaque_en_puissance" value="1" min="1" title="Nombre de dés de dommage ajoutés" />
+              <input type="checkbox" name="attr_attaque_en_puissance_check" title="Attaque en puissance utilisée" value="1" unchecked>
+            </td>
+            <td>
+              Attaque en puissance
+            </td>
+            <td>
+              <input type='hidden' name='attr_malus_attaque_en_puissance' value='-5' />
+              <span name="attr_malus_attaque_en_puissance"></span> en attaque et +
+              <input type="number" class="atk" style="width:32px;" name="attr_attaque_en_puissance" value="1" min="1" title="Nombre de dés de dommage ajoutés" />
 
-                                    d6 DM
-                  </td
-              </tr>
-              <tr>
-                  <td style="text-align:center;">
-                    <input type="checkbox" name="attr_attaque_assuree_check" title="Attaque assurée" value="1" unchecked>
-                  <input type='hidden' name='attr_division_attaque_assuree' value='' />
-                  </td>
-                  <td>
-                  Attaque assurée
-                  </td>
-                  <td>
-                    +5 en attaque et DM divisés par 2
-                  </td>
-              </tr>
-              <tr>
-                  <td style="text-align:center;">
-                    <input type="checkbox" name="attr_attaque_risquee_check" title="Attaque risquée" value="1" unchecked>
-                  </td>
-                  <td>
-                  Attaque risquée
-                  </td>
-                  <td>
-                    +2 en attaque au contact et -4 en DEF
-                  </td>
-              </tr>
-              <tr>
-                  <td style="text-align:center;">
-                    <input type="checkbox" name="attr_attaque_dm_temp_check" title="Assomer" value="1" unchecked>
-                  </td>
-                  <td>
-                  Attaque non léthale
-                  </td>
-                  <td>
-                    -2 en attaque si arme non adaptée
-                  </td>
-              </tr>
-            </table>
+              d6 DM
+            </td
+          </tr>
+          <tr>
+            <td style="text-align:center;">
+              <input type="checkbox" name="attr_attaque_assuree_check" title="Attaque assurée" value="1" unchecked>
+              <input type='hidden' name='attr_division_attaque_assuree' value='' />
+            </td>
+            <td>
+              Attaque assurée
+            </td>
+            <td>
+              +5 en attaque et DM divisés par 2
+            </td>
+          </tr>
+          <tr>
+            <td style="text-align:center;">
+              <input type="checkbox" name="attr_attaque_risquee_check" title="Attaque risquée" value="1" unchecked>
+            </td>
+            <td>
+              Attaque risquée
+            </td>
+            <td>
+              +2 en attaque au contact et -4 en DEF
+            </td>
+          </tr>
+          <tr>
+            <td style="text-align:center;">
+              <input type="checkbox" name="attr_attaque_dm_temp_check" title="Assomer" value="1" unchecked>
+            </td>
+            <td>
+              Attaque non léthale
+            </td>
+            <td>
+              -2 en attaque si arme non adaptée
+            </td>
+          </tr>
+        </table>
       </div>
     </div>
     <div class="tab-content tab2">
       <div> <!-- Voies -->
-          <tr><!-- Capa Race -->
-            <td COLSPAN="2" style="vertical-align:top;">
-              <table class="tabsep">
-                <tr>
-                  <td class="boxinputleft">
-                    <span class="textbasesmall">Capacité raciale</span><br/>
-                    <textarea name="attr_CAPA_RACE" spellcheck="false" style="height:3em;"></textarea>
-                  </td>
-                  <td class="boxinputleft">
-                    <span class="textbasesmall">Langues Connues</span><br/>
-                    <textarea name="attr_LANGUES" spellcheck="false" style="height:3em;"></textarea>
-                  </td>
-                  <td class="boxinputleft">
-                    <span class="textbasesmall">Autres capacités</span><br/>
-                    <textarea name="attr_DIVERS" spellcheck="false" style="height:3em;"></textarea>
-                  </td>
-                </tr>
-              </table>
-            </td>
-          </tr><!-- FIN Capa Race -->
+        <tr><!-- Capa Race -->
+          <td COLSPAN="2" style="vertical-align:top;">
+            <table class="tabsep">
+              <tr>
+                <td class="boxinputleft">
+                  <span class="textbasesmall">Capacité raciale</span><br/>
+                  <textarea name="attr_CAPA_RACE" spellcheck="false" style="height:3em;"></textarea>
+                </td>
+                <td class="boxinputleft">
+                  <span class="textbasesmall">Langues Connues</span><br/>
+                  <textarea name="attr_LANGUES" spellcheck="false" style="height:3em;"></textarea>
+                </td>
+                <td class="boxinputleft">
+                  <span class="textbasesmall">Autres capacités</span><br/>
+                  <textarea name="attr_DIVERS" spellcheck="false" style="height:3em;"></textarea>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr><!-- FIN Capa Race -->
         <table>
           <tr><td class="textfatleft" COLSPAN="5">CAPACITÉS DU PERSONNAGE</td></tr>
           <tr>
@@ -760,7 +760,7 @@
                 <input type="text" name="attr_jetcapanom" style="font-weight: bold;" placeholder="Nom du Jet de capacité" />
               </td>
               <td class="textbase"  style="text-align: right;">
-              Jet
+                                  Jet
               </td>
               <td class="boxinputleft">
                 <input type="number" style="width:32px;" name="attr_jetcapanbde" value="1" title="Nombre de dés" />
@@ -828,7 +828,7 @@
               <tr><td class="boxtitre">ÉQUIPEMENT : Divers</td></tr>
               <tr><td class="boxinputleft"><textarea name="attr_equip-div" spellcheck="false" style="height:6em;" title="ÉQUIPEMENT DIVERS"></textarea></td></tr>
             </table>
-        </div>
+          </div>
           <div class="col">
             <table>
               <tr><td class="boxtitre">Notes</td></tr>
@@ -850,10 +850,10 @@
           <li>Magie :
             <ul>
               <li>Points de mana :
-            <input type="checkbox" name="attr_option_pm" value="1" title="@{option_pr}" checked />
+                <input type="checkbox" name="attr_option_pm" value="1" title="@{option_pr}" checked />
               </li>
               <li> Épuisement magique :
-            <input type="checkbox" name="attr_option_epuisement" value="1" title="@{option_pr}" />
+                <input type="checkbox" name="attr_option_epuisement" value="1" title="@{option_pr}" />
               </li>
             </ul>
           </li>
@@ -861,302 +861,307 @@
       </div> <!-- FIN Options -->
       <div>
         <span class="textbase">Jets</span>&nbsp;
-          <select class="sheet-carac" style="width: 75px;" name="attr_jets_caches" title="@{jets_caches}" size="1">
-            <option value="" selected>Normaux</option>
-            <option value="/w gm ">Cachés</option>
-          </select>
+        <select class="sheet-carac" style="width: 75px;" name="attr_jets_caches" title="@{jets_caches}" size="1">
+          <option value="" selected>Normaux</option>
+          <option value="/w gm ">Cachés</option>
+        </select>
       </div>
     </div>
   </div> <!-- FIN fiche type PJ -->
   <div class="tab-content fp2"> <!-- fiche type PNJ -->
-    <img class="imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesOubliees/co_hr.png" />
-    <div class="container">
-      <div style="width:375px;">
-        <table class="tabsep">
-          <tr>
-            <td class="boxtitre-car">
-              <button class="boxtitre-car" type="roll" name="roll_pnj_FOR" title="Jet de Force" value="@{jets_caches}&{template:co1} {{perso=@{character_name}}} {{name=Force}} {{subtags=Caractéristique}} {{carac=[[ @{FOR_SUP}[Dé] + [[@{pnj_for}]][Bonus] ]] }}">FOR</button>
-              <input type="checkbox" class="car" name="attr_pnj_for_sup" title="@{pnj_for_sup}"><span></span>
-            </td>
-            <td class="boxinput">
-              <input type="number" class="car" name="attr_pnj_for" title="Force" value="0" />
-            </td>
-            <td class="boxtitre-car">
-              <button class="boxtitre-car" type="roll" name="roll_pnj_DEX" title="Jet de Dextérité" value="@{jets_caches}&{template:co1} {{perso=@{character_name}}} {{name=Dextérité}} {{subtags=Caractéristique}} {{carac=[[ @{DEX_SUP}[Dé] + [[@{pnj_dex}]][Bonus] ]] }}">DEX</button>
-              <input type="checkbox" class="car" name="attr_pnj_dex_sup" title="@{pnj_dex_sup}"><span></span>
-            </td>
-            <td class="boxinput-car">
-              <input type="number" class="car" name="attr_pnj_dex" title="Dextérité" value="0" />
-            </td>
-            <td class="boxtitre-car">
-              <button class="boxtitre-car" type="roll" name="roll_pnj_CON" title="Jet de Constitution" value="@{jets_caches}&{template:co1} {{perso=@{character_name}}} {{name=Constitution}} {{subtags=Caractéristique}} {{carac=[[ @{CON_SUP}[Dé] + [[@{pnj_con}]][Bonus] ]] }}">CON</button>
-              <input type="checkbox" class="car" name="attr_pnj_con_sup" title="@{pnj_con_sup}"><span></span>
-            </td>
-            <td class="boxinput-car">
-              <input type="number" class="car" name="attr_pnj_con" title="Constitution" value="0" />
-            </td>
-          </tr>
-          <tr>
-            <td class="boxtitre-car">
-              <button class="boxtitre-car" type="roll" name="roll_pnj_INT" title="Jet d'Intelligence" value="@{jets_caches}&{template:co1} {{perso=@{character_name}}} {{name=Intelligence}} {{subtags=Caractéristique}} {{carac=[[ @{INT_SUP}[Dé] + [[@{pnj_int}]][Bonus] ]] }}">INT</button>
-              <input type="checkbox" class="car" name="attr_pnj_int_sup" title="@{pnj_int_sup}"><span></span>
-            </td>
-            <td class="boxinput-car">
-              <input type="number" class="car" name="attr_pnj_int" title="Intelligence" value="0" />
-            </td>
-            <td class="boxtitre-car">
-              <button class="boxtitre-car" type="roll" name="roll_pnj_SAG" title="Jet de Sagesse" value="@{jets_caches}&{template:co1} {{perso=@{character_name}}} {{name=Sagesse}} {{subtags=Caractéristique}} {{carac=[[ @{SAG_SUP}[Dé] + [[@{pnj_sag}]][Bonus] ]] }}">SAG</button>
-              <input type="checkbox" class="car" name="attr_pnj_sag_sup" title="@{pnj_sag_sup}"><span></span>
-            </td>
-            <td class="boxinput-car">
-              <input type="number" class="car" name="attr_pnj_sag" title="Sagesse" value="0" />
-            </td>
-            <td class="boxtitre-car">
-              <button class="boxtitre-car" type="roll" name="roll_pnj_CHA" title="Jet de Charisme" value="@{jets_caches}&{template:co1} {{perso=@{character_name}}} {{name=Charisme}} {{subtags=Caractéristique}} {{carac=[[ @{CHA_SUP}[Dé] + [[@{pnj_cha}]][Bonus] ]] }}">CHA</button>
-              <input type="checkbox" class="car" name="attr_pnj_cha_sup" title="@{pnj_cha_sup}"><span></span>
-            </td>
-            <td class="boxinput-car">
-              <input type="number" class="car" name="attr_pnj_cha" title="Charisme" value="0" />
-            </td>
-          </tr>
-        </table>
-        <table class="tabsep">
-          <tr>
-            <td class="boxtitre-def" style="width:21%">DEF</td>
-            <td class="boxinput-def">
-              <input type="number" class="def" name="attr_pnj_def" title="Défense" value="10" min="0"/>
-            </td>
-            <td class="boxtitre-pv" style="width:21%">PV</td>
-            <td class="boxinput-pv">
-              <input type="number" class="pv" name="attr_pnj_pv_max" title="PVs max" value="0" min="0"/>
-            </td>
-            <td class="boxtitre-init">
-              <button class="boxtitre-init" type="roll" name="roll_pnj__INIT" title="Initiative" value="@{jets_caches}&{template:co1} {{perso=@{character_name}}} {{name=Initiative}} {{subtags=Combat}} {{carac=[[@{pnj_init} &{tracker}]]}}"> INIT</button>
-            </td>
-            <td class="boxinput-init">
-              <input type="number" class="init" name="attr_pnj_init" title="Initiative" value="10" min="1"/>
-          </tr>
-        </table>
-        <div class=container>
-        <table class="tabsep" style="width:20%;">
-          <tr><td class="boxtitre-def">RD</td></tr>
-          <tr><td class="boxinputleft-def">
-              <textarea class="def" name="attr_pnj_rd" spellcheck="false" title="@{pnj_rd}"></textarea></td></tr>
-        </table>
-        <table style="width:51px">
-          <tr><td>
-        <input type="checkbox" name="attr_pnj_armure" title="@{pnj_armure}" style="width:9px"><span class="def" style="font-size:9px">Armure</span>
-            </td></tr>
-          <tr><td>
-              <input type="checkbox" name="attr_pnj_bouclier" title="@{pnj_bouclier}" style="width:9px"><span class="def" style="font-size:9px">Bouclier</span>
-            </td></tr>
-        </table>
-        <table class="tabsep" style="width:18%;">
-          <tr>
-            <td  class="boxinput-pv">
-              <span class="textbase-pv">PV restants</span>&nbsp;
-              <input type="number" class="pv" name="attr_pnj_pv" title="Points de Vie restants" value="0" />
-            </td>
-          </tr>
-          <tr>
-            <td  class="boxinput-pv">
-              <span class="textbase-pv">DM temp.</span>&nbsp;
-              <input type="number" class="pv" name="attr_pnj_dmtemp" title="Dommages Temporaires"  value="0" />
-            </td>
-          </tr>
-        </table>
-        &nbsp;&nbsp;
-        <span class="textbase">Jets</span>&nbsp;
-          <select class="sheet-carac" style="width: 75px;" name="attr_pnj_jets_caches" title="@{jets_caches}" size="1">
-            <option value="" selected>Normaux</option>
-            <option value="/w gm ">Cachés</option>
-          </select>
-        </div>
-      </div>
-      <div style="width:100%;">
-      <table>
-        <tr><td class="boxtitre">Capacités</td></tr>
-        <tr><td class="boxinputleft"><textarea name="attr_capacites_pnj" style="height:5em;" spellcheck="false" title="@{capacites_pnj}"></textarea></td></tr>
-      </table>
-      <br/>
-      <input type="checkbox" class="block-switch-arrow"><span>Importer statblock</span><br/>
-      <div class="block-hidden-arrow"></div>
-      <div class="block-show-arrow">
-        <textarea name="attr_statblock" style="height: 10em;" placeholder="Coller ici un statblock copié depuis le PDF"></textarea>
-        &nbsp;
-        <textarea name="attr_sbresult" style="height: 5em;"></textarea>
-      </div>
-      </div>
-    </div>
-    <img class="imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesOubliees/co_hr.png" />
-    <div> <!-- Attaques -->
-      <table class="tabsep">
-        <tr>
-          <td class="textfatleft-atk" style="width:148px;">Attaques</td>
-          <td class="textbase-atk" style="width:50px;">Toucher</td>
-          <td class="textbase-atk" style="width:32px;">Crit.</td>
-          <td class="textbase-atk" style="width:125px;">DM</td>
-          <td class="textbase-atk" style="width:50px;">Portée</td>
-          <td class="textbase-atk">Spécial</td>
-        </tr>
-      </table>
-      <fieldset class="repeating_pnjatk">
-          <div class="attack">
-            <input class="options-flag" name="attr_armeoptflag" type="checkbox"
-            title="Montrer/cacher les options"><span>y</span>
-            <div>
-        <table  class="tabsep">
-          <tr>
-        <input type='hidden' name='attr_armebonusoption' value='0' />
-        <input type='hidden' name='attr_armedmtemp' value='' />
-        <input type='hidden' name='attr_armedegats' value='{{degats=[[(@{armedmnbde}d@{armedmde}@{armedmrollmod}+@{armedm})@{division_attaque_assuree}]]}}' />
-        <input type='hidden' name='attr_armepoudre' value='{{poudre=}}' />
-        <input type='hidden' name='attr_armereussiteauto' value='{{attaqueautomatique=}}' />
-        <input type='hidden' name='attr_armedmrollmod' value='' />
-        <input type='hidden' name='attr_armeattrollmod' value='' />
-        <input type='hidden' name='attr_armeattnbde' value='1' />
-        <input type='hidden' name='attr_armeattde' value='@{ETATDE}' />
-            <td>
-              <button type="roll" class="atk" name="roll_pnj_Arme" value="@{jets_caches}&{template:co1} {{perso=@{character_name}}} {{name=@{armenom}}} {{subtags=Attaque}} {{attaque=[[ @{armeattnbde}d@{armeattde}@{armeattrollmod}cs>@{armecrit}cf1 + @{armeatk} +@{bonus_attaque_option} +@{armebonusoption}]]}} @{armereussiteauto} @{armedegats} @{armepoudre} {{special=@{armespec}}} {{degats2=@{bonus_dm_option}}} {{dmtemp=@{armedmtemp}}}" />
-            </td>
-            <td class="boxinputleft-atk" style="min-width:130px;">
-               <input type="text" class="atk" style="width:11px; text-align:right; font-size:10px" name="attr_armelabel" value=0>
-              <input type="text" class="atk" name="attr_armenom" style="font-weight: bold;width:94%;margin-left:-5px" placeholder="Arme/attaque"/>
-            </td>
-            <td class="boxinputleft-atk">
-            +<input type="number" class="atk" style="width:32px;" name="attr_armeatk" value="0" title="Bonus d'attaque" />
-            </td>
-            <td class="boxinputleft-atk" style="text-align: right;">
-              <input type="number" class="atk" name="attr_armecrit" style="width:32px;" min="2" max="20" value="20" title="Seuil de Critique (par défaut 20)" />
-            </td>
-            <td class="boxinputleft-atk">
-              <input type="number" class="atk" style="width:32px;" name="attr_armedmnbde" value="1" title="Nombre de dés de dommage" />
-              <select class="carac-atk"  style="width:47px;" name="attr_armedmde" size="1" title="Dé de dommage">
-                <option value="3">d3</option>
-                <option value="4" selected>d4</option>
-                <option value="6">d6</option>
-                <option value="8">d8</option>
-                <option value="10">d10</option>
-                <option value="12">d12</option>
-              </select>
-                +<input type="number" class="atk" style="width:32px;" name="attr_armedm" value="0" title="Bonus de dommage" />
-            </td>
-            <td class="boxinputleft-atk" style="min-width:50px;">
-              <input type="text" class="atk" name="attr_armeportee" placeholder="Portée" title="Portée" />
-            </td>
-            <td class="boxinputleft-atk" style="width:100%;">
-              <textarea class="atk" name="attr_armespec" spellcheck="false" placeholder="Notes, capacités spéciales, effet ..." title="Notes, capacités spéciales, effet ..."></textarea>
-            </td>
-          </tr>
-        </table>
-    </div>
-            <div class="options">
-              <table class="tabsep">
-                <tr>
-                  <td style="width:18px; text-align:center;">
-                    <input type="checkbox" name="attr_armeactionvisible" title="Attaque visible dans les actions" value="1" checked>
-                  </td>
-                  <td class="boxinputleft-atk">
-                    <select class="carac-atk" style="width: 131px;" name="attr_armetypeattaque" title="Type d'attaque">
-                      <option>Naturel</option>
-                      <option>Arme 1 main</option>
-                      <option>Arme 2 mains</option>
-                      <option>Sortilege</option>
-                      <option>Arme gauche</option>
-                      <option>Arme de jet</option>
-                    </select>
-                  </td>
-                  <td class="boxinputleft-atk" style="min-width: 180px;">
-                <textarea name="attr_armemodificateurs" class="atk" placeholder="Liste de modificateurs" spellcheck="false" title="Modificateurs d'attaque, séparés par des virgules&#10; avantage: garde le meilleur de 2 dés&#10; avecd12: utilise le d12 en attaque&#10; auto: réussite automatique&#10; choc: peut faire des attaques non léthales sans malus&#10; désavantage: garde le moins bon de 2 dés&#10; explodeMax: dé de dégâts explosifs&#10; pasDeDmg: l'attaque ne fait pas de dégâts&#10; poudre: arme à poudre&#10; reroll1: relance les 1 des dés de DM&#10; tempDmg: fait toujours des attaques non léthales"></textarea>
-                  </td>
-                  <td class="boxinputleft-atk">
-                    <select class="carac-atk" style="width: 87px;" name="attr_armetypedegats" title="Type des dégâts">
-                      <option>tranchant</option>
-                      <option>contondant</option>
-                      <option>percant</option>
-                      <option>mental</option>
-                      <option>feu</option>
-                      <option>acide</option>
-                      <option value="electrique">électrique</option>
-                      <option>froid</option>
-                      <option>sonique</option>
-                      <option>poison</option>
-                      <option>maladie</option>
-                      <option>magique</option>
-                    </select>
-                  </td>
-              <td class="boxinputleft-atk" style="width:100%;">
-                <textarea name="attr_armeoptions" class="atk" placeholder="Options d'attaque avec argument" spellcheck="false" title="Options d'attaque"></textarea>
-              </td>
-                </tr>
-              </table>
-            </div>
-          </div>
-      </fieldset>
-    </div>
-      <input type="checkbox" class="block-switch-arrow"><span class="textfatleft-atk">Options d'attaque</span><br/>
-      <div class="block-hidden-arrow"></div>
-      <div class="block-show-arrow"> <!-- Options d'attaque -->
-        <table>
-          <tr>
-                <td colspan='2'>
-                Attaque de groupe :
+    <input type="radio" name="attr_tab" class="tab tab1" value="carac. pnj"><span title="Caractéristiques"></span>
+    <input type="radio" name="attr_tab" class="tab tab2" value="statblock"><span title="Statblock"></span>
+    <!--  <input type="radio" name="attr_tab" class="tab tab3" value="Equipement"><span title="Équipement"></span>
+      <input type="radio" name="attr_tab" class="tab tab4" value="Options"><span title="Options"></span> -->
+      <div class="tab-content tab1">
+        <img class="imghr-up" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesOubliees/co_hr.png" />
+        <div class="container">
+          <div style="width:375px;">
+            <table class="tabsep">
+              <tr>
+                <td class="boxtitre-car">
+                  <button class="boxtitre-car" type="roll" name="roll_pnj_FOR" title="Jet de Force" value="@{jets_caches}&{template:co1} {{perso=@{character_name}}} {{name=Force}} {{subtags=Caractéristique}} {{carac=[[ @{FOR_SUP}[Dé] + [[@{pnj_for}]][Bonus] ]] }}">FOR</button>
+                  <input type="checkbox" class="car" name="attr_pnj_for_sup" title="@{pnj_for_sup}"><span></span>
                 </td>
-                <td>
-                  <input type='hidden' name='attr_message_attaque_de_groupe' value="attaquant par jet" />
-                  <input type='number' class='atk' style="width:24px;" name="attr_attaque_de_groupe" value="1" min="1" title="Nombre d'attaques de pnj résolues en un jet" /> <span name='attr_message_attaque_de_groupe'></span>
+                <td class="boxinput">
+                  <input type="number" class="car" name="attr_pnj_for" title="Force" value="0" />
                 </td>
-          </tr>
-          <tr>
-            <td style="text-align:center;">
-                    <input type="checkbox" name="attr_attaque_en_puissance_check" title="Attaque en puissance utilisée" value="1" unchecked>
-                  </td>
-                  <td>
-                  Attaque en puissance
-                  </td>
-                  <td>
-                  <span name="attr_malus_attaque_en_puissance"></span> en attaque et +
-                <input type="number" class="atk" style="width:24px;" name="attr_attaque_en_puissance" value="1" min="1" title="Nombre de dés de dommage ajoutés" />
-
-                                    d6 DM
-                  </td
+                <td class="boxtitre-car">
+                  <button class="boxtitre-car" type="roll" name="roll_pnj_DEX" title="Jet de Dextérité" value="@{jets_caches}&{template:co1} {{perso=@{character_name}}} {{name=Dextérité}} {{subtags=Caractéristique}} {{carac=[[ @{DEX_SUP}[Dé] + [[@{pnj_dex}]][Bonus] ]] }}">DEX</button>
+                  <input type="checkbox" class="car" name="attr_pnj_dex_sup" title="@{pnj_dex_sup}"><span></span>
+                </td>
+                <td class="boxinput-car">
+                  <input type="number" class="car" name="attr_pnj_dex" title="Dextérité" value="0" />
+                </td>
+                <td class="boxtitre-car">
+                  <button class="boxtitre-car" type="roll" name="roll_pnj_CON" title="Jet de Constitution" value="@{jets_caches}&{template:co1} {{perso=@{character_name}}} {{name=Constitution}} {{subtags=Caractéristique}} {{carac=[[ @{CON_SUP}[Dé] + [[@{pnj_con}]][Bonus] ]] }}">CON</button>
+                  <input type="checkbox" class="car" name="attr_pnj_con_sup" title="@{pnj_con_sup}"><span></span>
+                </td>
+                <td class="boxinput-car">
+                  <input type="number" class="car" name="attr_pnj_con" title="Constitution" value="0" />
+                </td>
               </tr>
               <tr>
-                  <td style="text-align:center;">
-                    <input type="checkbox" name="attr_attaque_assuree_check" title="Attaque assurée" value="1" unchecked>
-                  </td>
-                  <td>
-                  Attaque assurée
-                  </td>
-                  <td>
-                    +5 en attaque et DM divisés par 2
-                  </td>
-              </tr>
-              <tr>
-                  <td style="text-align:center;">
-                    <input type='hidden' name='attr_defense_si_attaque_risquee' value='6'/>
-                    <input type="checkbox" name="attr_attaque_risquee_check" title="Attaque risquée" value="1" unchecked />
-                  </td>
-                  <td>
-                  Attaque risquée
-                  </td>
-                  <td>
-                  +2 en attaque au contact mais la DEF passe de <span name='attr_pnj_def'></span> à <span name='attr_defense_si_attaque_risquee'></span> pour 1 tour
-                  </td>
-              </tr>
-              <tr>
-                  <td style="text-align:center;">
-                    <input type="checkbox" name="attr_attaque_dm_temp_check" title="Assomer" value="1" unchecked>
-                  </td>
-                  <td>
-                  Attaque non léthale
-                  </td>
-                  <td>
-                    -2 en attaque si arme non adaptée
-                  </td>
+                <td class="boxtitre-car">
+                  <button class="boxtitre-car" type="roll" name="roll_pnj_INT" title="Jet d'Intelligence" value="@{jets_caches}&{template:co1} {{perso=@{character_name}}} {{name=Intelligence}} {{subtags=Caractéristique}} {{carac=[[ @{INT_SUP}[Dé] + [[@{pnj_int}]][Bonus] ]] }}">INT</button>
+                  <input type="checkbox" class="car" name="attr_pnj_int_sup" title="@{pnj_int_sup}"><span></span>
+                </td>
+                <td class="boxinput-car">
+                  <input type="number" class="car" name="attr_pnj_int" title="Intelligence" value="0" />
+                </td>
+                <td class="boxtitre-car">
+                  <button class="boxtitre-car" type="roll" name="roll_pnj_SAG" title="Jet de Sagesse" value="@{jets_caches}&{template:co1} {{perso=@{character_name}}} {{name=Sagesse}} {{subtags=Caractéristique}} {{carac=[[ @{SAG_SUP}[Dé] + [[@{pnj_sag}]][Bonus] ]] }}">SAG</button>
+                  <input type="checkbox" class="car" name="attr_pnj_sag_sup" title="@{pnj_sag_sup}"><span></span>
+                </td>
+                <td class="boxinput-car">
+                  <input type="number" class="car" name="attr_pnj_sag" title="Sagesse" value="0" />
+                </td>
+                <td class="boxtitre-car">
+                  <button class="boxtitre-car" type="roll" name="roll_pnj_CHA" title="Jet de Charisme" value="@{jets_caches}&{template:co1} {{perso=@{character_name}}} {{name=Charisme}} {{subtags=Caractéristique}} {{carac=[[ @{CHA_SUP}[Dé] + [[@{pnj_cha}]][Bonus] ]] }}">CHA</button>
+                  <input type="checkbox" class="car" name="attr_pnj_cha_sup" title="@{pnj_cha_sup}"><span></span>
+                </td>
+                <td class="boxinput-car">
+                  <input type="number" class="car" name="attr_pnj_cha" title="Charisme" value="0" />
+                </td>
               </tr>
             </table>
-      </div>
+            <table class="tabsep">
+              <tr>
+                <td class="boxtitre-def" style="width:21%">DEF</td>
+                <td class="boxinput-def">
+                  <input type="number" class="def" name="attr_pnj_def" title="Défense" value="10" min="0"/>
+                </td>
+                <td class="boxtitre-pv" style="width:21%">PV</td>
+                <td class="boxinput-pv">
+                  <input type="number" class="pv" name="attr_pnj_pv_max" title="PVs max" value="0" min="0"/>
+                </td>
+                <td class="boxtitre-init">
+                  <button class="boxtitre-init" type="roll" name="roll_pnj__INIT" title="Initiative" value="@{jets_caches}&{template:co1} {{perso=@{character_name}}} {{name=Initiative}} {{subtags=Combat}} {{carac=[[@{pnj_init} &{tracker}]]}}"> INIT</button>
+                </td>
+                <td class="boxinput-init">
+                  <input type="number" class="init" name="attr_pnj_init" title="Initiative" value="10" min="1"/>
+              </tr>
+            </table>
+            <div class=container>
+              <table class="tabsep" style="width:20%;">
+                <tr><td class="boxtitre-def">RD</td></tr>
+                <tr><td class="boxinputleft-def">
+                    <textarea class="def" name="attr_pnj_rd" spellcheck="false" title="@{pnj_rd}"></textarea></td></tr>
+              </table>
+              <table style="width:51px">
+                <tr><td>
+                    <input type="checkbox" name="attr_pnj_armure" title="@{pnj_armure}" style="width:9px"><span class="def" style="font-size:9px">Armure</span>
+                  </td></tr>
+                  <tr><td>
+                      <input type="checkbox" name="attr_pnj_bouclier" title="@{pnj_bouclier}" style="width:9px"><span class="def" style="font-size:9px">Bouclier</span>
+                    </td></tr>
+              </table>
+              <table class="tabsep" style="width:18%;">
+                <tr>
+                  <td  class="boxinput-pv">
+                    <span class="textbase-pv">PV restants</span>&nbsp;
+                    <input type="number" class="pv" name="attr_pnj_pv" title="Points de Vie restants" value="0" />
+                  </td>
+                </tr>
+                <tr>
+                  <td  class="boxinput-pv">
+                    <span class="textbase-pv">DM temp.</span>&nbsp;
+                    <input type="number" class="pv" name="attr_pnj_dmtemp" title="Dommages Temporaires"  value="0" />
+                  </td>
+                </tr>
+              </table>
+              &nbsp;&nbsp;
+              <span class="textbase">Jets</span>&nbsp;
+              <select class="sheet-carac" style="width: 75px;" name="attr_pnj_jets_caches" title="@{jets_caches}" size="1">
+                <option value="" selected>Normaux</option>
+                <option value="/w gm ">Cachés</option>
+              </select>
+            </div>
+          </div>
+          <div style="width:100%;">
+            <table>
+              <tr><td class="boxtitre">Capacités</td></tr>
+              <tr><td class="boxinputleft"><textarea name="attr_capacites_pnj" style="height:8em;" spellcheck="false" title="@{capacites_pnj}"></textarea></td></tr>
+            </table>
+          </div>
+        </div>
+        <img class="imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesOubliees/co_hr.png" />
+        <div> <!-- Attaques -->
+          <table class="tabsep">
+            <tr>
+              <td class="textfatleft-atk" style="width:148px;">Attaques</td>
+              <td class="textbase-atk" style="width:50px;">Toucher</td>
+              <td class="textbase-atk" style="width:32px;">Crit.</td>
+              <td class="textbase-atk" style="width:125px;">DM</td>
+              <td class="textbase-atk" style="width:50px;">Portée</td>
+              <td class="textbase-atk">Spécial</td>
+            </tr>
+          </table>
+          <fieldset class="repeating_pnjatk">
+            <div class="attack">
+              <input class="options-flag" name="attr_armeoptflag" type="checkbox"
+                                                                  title="Montrer/cacher les options"><span>y</span>
+                                                                  <div>
+                                                                    <table  class="tabsep">
+                                                                      <tr>
+                                                                        <input type='hidden' name='attr_armebonusoption' value='0' />
+                                                                        <input type='hidden' name='attr_armedmtemp' value='' />
+                                                                        <input type='hidden' name='attr_armedegats' value='{{degats=[[(@{armedmnbde}d@{armedmde}@{armedmrollmod}+@{armedm})@{division_attaque_assuree}]]}}' />
+                                                                        <input type='hidden' name='attr_armepoudre' value='{{poudre=}}' />
+                                                                        <input type='hidden' name='attr_armereussiteauto' value='{{attaqueautomatique=}}' />
+                                                                        <input type='hidden' name='attr_armedmrollmod' value='' />
+                                                                        <input type='hidden' name='attr_armeattrollmod' value='' />
+                                                                        <input type='hidden' name='attr_armeattnbde' value='1' />
+                                                                        <input type='hidden' name='attr_armeattde' value='@{ETATDE}' />
+                                                                        <td>
+                                                                          <button type="roll" class="atk" name="roll_pnj_Arme" value="@{jets_caches}&{template:co1} {{perso=@{character_name}}} {{name=@{armenom}}} {{subtags=Attaque}} {{attaque=[[ @{armeattnbde}d@{armeattde}@{armeattrollmod}cs>@{armecrit}cf1 + @{armeatk} +@{bonus_attaque_option} +@{armebonusoption}]]}} @{armereussiteauto} @{armedegats} @{armepoudre} {{special=@{armespec}}} {{degats2=@{bonus_dm_option}}} {{dmtemp=@{armedmtemp}}}" />
+                                                                        </td>
+                                                                        <td class="boxinputleft-atk" style="min-width:130px;">
+                                                                          <input type="text" class="atk" style="width:11px; text-align:right; font-size:10px" name="attr_armelabel" value=0>
+                                                                          <input type="text" class="atk" name="attr_armenom" style="font-weight: bold;width:94%;margin-left:-5px" placeholder="Arme/attaque"/>
+                                                                        </td>
+                                                                        <td class="boxinputleft-atk">
+                                                                                                    +<input type="number" class="atk" style="width:32px;" name="attr_armeatk" value="0" title="Bonus d'attaque" />
+                                                                        </td>
+                                                                        <td class="boxinputleft-atk" style="text-align: right;">
+                                                                          <input type="number" class="atk" name="attr_armecrit" style="width:32px;" min="2" max="20" value="20" title="Seuil de Critique (par défaut 20)" />
+                                                                        </td>
+                                                                        <td class="boxinputleft-atk">
+                                                                          <input type="number" class="atk" style="width:32px;" name="attr_armedmnbde" value="1" title="Nombre de dés de dommage" />
+                                                                          <select class="carac-atk"  style="width:47px;" name="attr_armedmde" size="1" title="Dé de dommage">
+                                                                            <option value="3">d3</option>
+                                                                            <option value="4" selected>d4</option>
+                                                                            <option value="6">d6</option>
+                                                                            <option value="8">d8</option>
+                                                                            <option value="10">d10</option>
+                                                                            <option value="12">d12</option>
+                                                                          </select>
+                                                                          +<input type="number" class="atk" style="width:32px;" name="attr_armedm" value="0" title="Bonus de dommage" />
+                                                                        </td>
+                                                                        <td class="boxinputleft-atk" style="min-width:50px;">
+                                                                          <input type="text" class="atk" name="attr_armeportee" placeholder="Portée" title="Portée" />
+                                                                        </td>
+                                                                        <td class="boxinputleft-atk" style="width:100%;">
+                                                                          <textarea class="atk" name="attr_armespec" spellcheck="false" placeholder="Notes, capacités spéciales, effet ..." title="Notes, capacités spéciales, effet ..."></textarea>
+                                                                        </td>
+                                                                      </tr>
+                                                                    </table>
+                                                                  </div>
+                                                                  <div class="options">
+                                                                    <table class="tabsep">
+                                                                      <tr>
+                                                                        <td style="width:18px; text-align:center;">
+                                                                          <input type="checkbox" name="attr_armeactionvisible" title="Attaque visible dans les actions" value="1" checked>
+                                                                        </td>
+                                                                        <td class="boxinputleft-atk">
+                                                                          <select class="carac-atk" style="width: 131px;" name="attr_armetypeattaque" title="Type d'attaque">
+                                                                            <option>Naturel</option>
+                                                                            <option>Arme 1 main</option>
+                                                                            <option>Arme 2 mains</option>
+                                                                            <option>Sortilege</option>
+                                                                            <option>Arme gauche</option>
+                                                                            <option>Arme de jet</option>
+                                                                          </select>
+                                                                        </td>
+                                                                        <td class="boxinputleft-atk" style="min-width: 180px;">
+                                                                          <textarea name="attr_armemodificateurs" class="atk" placeholder="Liste de modificateurs" spellcheck="false" title="Modificateurs d'attaque, séparés par des virgules&#10; avantage: garde le meilleur de 2 dés&#10; avecd12: utilise le d12 en attaque&#10; auto: réussite automatique&#10; choc: peut faire des attaques non léthales sans malus&#10; désavantage: garde le moins bon de 2 dés&#10; explodeMax: dé de dégâts explosifs&#10; pasDeDmg: l'attaque ne fait pas de dégâts&#10; poudre: arme à poudre&#10; reroll1: relance les 1 des dés de DM&#10; tempDmg: fait toujours des attaques non léthales"></textarea>
+                                                                        </td>
+                                                                        <td class="boxinputleft-atk">
+                                                                          <select class="carac-atk" style="width: 87px;" name="attr_armetypedegats" title="Type des dégâts">
+                                                                            <option>tranchant</option>
+                                                                            <option>contondant</option>
+                                                                            <option>percant</option>
+                                                                            <option>mental</option>
+                                                                            <option>feu</option>
+                                                                            <option>acide</option>
+                                                                            <option value="electrique">électrique</option>
+                                                                            <option>froid</option>
+                                                                            <option>sonique</option>
+                                                                            <option>poison</option>
+                                                                            <option>maladie</option>
+                                                                            <option>magique</option>
+                                                                          </select>
+                                                                        </td>
+                                                                        <td class="boxinputleft-atk" style="width:100%;">
+                                                                          <textarea name="attr_armeoptions" class="atk" placeholder="Options d'attaque avec argument" spellcheck="false" title="Options d'attaque"></textarea>
+                                                                        </td>
+                                                                      </tr>
+                                                                    </table>
+                                                                  </div>
+            </div>
+          </fieldset>
+        </div>
+        <input type="checkbox" class="block-switch-arrow"><span class="textfatleft-atk">Options d'attaque</span><br/>
+        <div class="block-hidden-arrow"></div>
+        <div class="block-show-arrow"> <!-- Options d'attaque -->
+          <table>
+            <tr>
+              <td colspan='2'>
+                Attaque de groupe :
+              </td>
+              <td>
+                <input type='hidden' name='attr_message_attaque_de_groupe' value="attaquant par jet" />
+                <input type='number' class='atk' style="width:24px;" name="attr_attaque_de_groupe" value="1" min="1" title="Nombre d'attaques de pnj résolues en un jet" /> <span name='attr_message_attaque_de_groupe'></span>
+              </td>
+            </tr>
+            <tr>
+              <td style="text-align:center;">
+                <input type="checkbox" name="attr_attaque_en_puissance_check" title="Attaque en puissance utilisée" value="1" unchecked>
+              </td>
+              <td>
+                Attaque en puissance
+              </td>
+              <td>
+                <span name="attr_malus_attaque_en_puissance"></span> en attaque et +
+                <input type="number" class="atk" style="width:24px;" name="attr_attaque_en_puissance" value="1" min="1" title="Nombre de dés de dommage ajoutés" />
+
+                d6 DM
+              </td
+            </tr>
+            <tr>
+              <td style="text-align:center;">
+                <input type="checkbox" name="attr_attaque_assuree_check" title="Attaque assurée" value="1" unchecked>
+              </td>
+              <td>
+                Attaque assurée
+              </td>
+              <td>
+                +5 en attaque et DM divisés par 2
+              </td>
+            </tr>
+            <tr>
+              <td style="text-align:center;">
+                <input type='hidden' name='attr_defense_si_attaque_risquee' value='6'/>
+                <input type="checkbox" name="attr_attaque_risquee_check" title="Attaque risquée" value="1" unchecked />
+              </td>
+              <td>
+                Attaque risquée
+              </td>
+              <td>
+                +2 en attaque au contact mais la DEF passe de <span name='attr_pnj_def'></span> à <span name='attr_defense_si_attaque_risquee'></span> pour 1 tour
+              </td>
+            </tr>
+            <tr>
+              <td style="text-align:center;">
+                <input type="checkbox" name="attr_attaque_dm_temp_check" title="Assomer" value="1" unchecked>
+              </td>
+              <td>
+                Attaque non léthale
+              </td>
+              <td>
+                -2 en attaque si arme non adaptée
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div><!-- fin des caracs de PNJs -->
+      <div class="tab-content tab2">
+        <img class="imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesOubliees/co_hr.png" />
+            <table>
+              <tr><td class="boxtitre">Importer un block de statistiques</td></tr>
+              <tr><td class="boxinputleft"><textarea name="attr_statblock" style="height:20em;" spellcheck="false" placeholder="Coller ici un statblock copié depuis le PDF" ></textarea></td></tr>
+            </table>
+      </div><!-- fin import statblocks -->
   </div> <!-- FIN fiche type PNJ -->
 </div> <!-- FIN FDP -->
 <!-- TEMPLATES -->
@@ -1563,7 +1568,9 @@
           "jets_caches", "pnj_default_jets_caches",
         ],
         function(values) {
-          var attrs = {};
+          var attrs = {
+            tab: "carac. pnj"
+          };
           attrs.pnj_for = Math.floor((parseInt(values.FORCE) - 10) / 2);
           if (isNaN(attrs.pnj_for)) attrs.pnj_for = 0;
           var bonus = parseInt(values.FOR_BONUS);
@@ -1719,6 +1726,10 @@
             });
           });
         });
+      });
+    } else {
+      setAttrs({
+        tab: 'caracteristiques'
       });
     }
   });
@@ -2168,7 +2179,16 @@
             currentRow = currentRow.substring(1).trim();
           }
           var index = currentRow.search(/\bDM\b/i);
-          var specAtt = currentRow.substring(0, index);
+          var specAtt = currentRow.substring(0, index).trim();
+          if (!portee) {
+            //parfois la portée n'est pas placée juste après le nom de l'attaque et se retrouve dans le champ spécial
+            portee = /\(\d+\s*m\)/i.exec(specAtt);
+            if (portee) {
+              specAtt = specAtt.substring(0, portee.index).trim();
+              portee = parseInt(portee[0].substring(1));
+              if (isNaN(portee)) portee = 0;
+            }
+          }
           currentRow = currentRow.substring(index + 3).trim();
           index = currentRow.search(/\s/);
           if (index < 0) {
@@ -2272,6 +2292,12 @@
             var valAttr = row.substring(l.match.index + lstat.length, l.end).trim();
             valAttr = valAttr.replace(/\)$/, '');
             if (lattr.search(/(for|dex|con|sag|int|cha)/) > 0) {
+              //Cas ou on rajoute une autre valeur pour la caractéristique
+              //par exemple pour le centaure
+              var caracParen = valAttr.search(/\([+-]\d/);
+              if (caracParen > 0) {
+                valAttr = valAttr.substring(0, caracParen - 1).trim();
+              }
               if (valAttr.endsWith('*')) {
                 valAttr = valAttr.substr(0, valAttr.length - 1);
                 newAttrs[lattr + '_sup'] = 'on';
@@ -2307,12 +2333,19 @@
             } else if (lattr == 'pnj_pv_max') {
               //On met aussi les pv courants à jour
               var pvMax = parseInt(valAttr);
-              //Cas où on note entre parenhèse les PV courants
-              var caracParen = valAttr.indexOf('(');
-              if (caracParen > 0) {
-                var pvCourant = parseInt(valAttr.substring(caracParen + 1));
-                newAttrs.pnj_pv = pvCourant;
-                valAttr = valAttr.substring(0, caracParen).trim();
+              //Cas où on note entre parenhèse les PV courants ou la RD
+              var pvParen = valAttr.indexOf('(');
+              if (pvParen > 0) {
+                var pvSuite = valAttr.substring(pvParen + 1);
+                valAttr = valAttr.substring(0, pvParen).trim();
+                pvMax = parseInt(valAttr);
+                if (pvSuite.startsWith('RD')) {
+                  newAttrs.pnj_rd = parseInt(pvSuite.substring(2));
+                  newAttrs.pnj_pv = pvMax;
+                } else {
+                  var pvCourant = parseInt(pvSuite);
+                  newAttrs.pnj_pv = pvCourant;
+                }
               } else newAttrs.pnj_pv = pvMax;
             }
             newAttrs[lattr] = valAttr;

--- a/ChroniquesOubliees/co.html
+++ b/ChroniquesOubliees/co.html
@@ -1,5 +1,5 @@
 <div class="mainBg"> <!-- FDP -->
-  <input type="hidden" name="attr_version" value="3.4" />
+  <input type="hidden" name="attr_version" value="3.5" />
   <input type="hidden" name="attr_pnj_default_jets_caches" value="false" />
   <!-- INPUT HIDDEN TYPE DE JETS -->
   <input type="hidden" name="attr_jetnormal" value="1d@{ETATDE}" />
@@ -1406,8 +1406,17 @@
           });
         });
       }
+      if (verfdp < 3.5) {
+        getAttrs(['type_personnage'], function(values) {
+          if (values.type_personnage == 'PNJ') {
+            setAttrs({
+              tab: "carac. pnj"
+            });
+          }
+        });
+      }
       setAttrs({
-        version: 3.4
+        version: 3.5
       });
     });
   });


### PR DESCRIPTION
## Changes / Comments
Can parse more statblocks that led to errors.
The text area for statblocks is now in a dedicated tab, so that the user is forced to click outside to see the result.




## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
