### PR TITLE
[Only War (Enhanced)] update 08/16/20

### DIFF
--- a/Only-War-Enhanced/OnlyWarEnhanced.css
+++ b/Only-War-Enhanced/OnlyWarEnhanced.css
@@ -462,7 +462,7 @@ ______________________________ start of minimisable infographic ________________
 .sheet-minimisable_infographic_toggles { /* This is the spacing of the whisper buttons, scatter button, etc */
 	display: grid;
 	grid-column-gap: 10px;
-	grid-template-columns: 100px 60px 100px 70px 100px 80px 80px auto;
+	grid-template-columns: 100px 60px 100px 70px 100px 80px 80px 150px auto;
 }
 
 .sheet-minimisable_infographic_grid {
@@ -587,84 +587,97 @@ ______________________________ start of equipment tab __________________________
 .sheet-equipment_numerics { grid-area: e3; margin-top: 10px; }
 .sheet-equipment_ranged_weapons_rep, .sheet-equipment_melee_weapons_rep { background:#6E8B3D; border:1px solid white; border-radius: 10px; padding: 2px; }
 
-.sheet-equipment_ranged_weapons_gs1 { grid-area: rw1;		color: white; font-size: 12px; padding: 0px 2px; }
-.sheet-equipment_ranged_weapons_gs2 { grid-area: rw2;		color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
-.sheet-equipment_ranged_weapons_gs3 { grid-area: rw3;		color: white; font-size: 12px; padding: 0px 2px; }
-.sheet-equipment_ranged_weapons_gs4 { grid-area: rw4;		color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
-.sheet-equipment_ranged_weapons_gs5 { grid-area: rw5;		color: white; font-size: 12px; padding: 0px 2px; }
-.sheet-equipment_ranged_weapons_gs6 { grid-area: rw6;		color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; border-top-right-radius: 10px; }
+.sheet-equipment_ranged_weapons_gs1 { grid-area: rw1;	color: white; font-size: 12px; padding: 0px 2px; }
+.sheet-equipment_ranged_weapons_gs2 { grid-area: rw2;	color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
+.sheet-equipment_ranged_weapons_gs3 { grid-area: rw3;	color: white; font-size: 12px; padding: 0px 2px; }
+.sheet-equipment_ranged_weapons_gs4 { grid-area: rw4;	color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
 
-.sheet-equipment_ranged_weapons_gs7 { grid-area: rw7;		color: white; font-size: 12px; padding: 0px 2px; }
-.sheet-equipment_ranged_weapons_gs8 { grid-area: rw8;		color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
-.sheet-equipment_ranged_weapons_gs9 { grid-area: rw9;		color: white; font-size: 30px; margin-top: -27px; text-align: center; height: 15px; }
-.sheet-equipment_ranged_weapons_gs10 { grid-area: rw10; 	color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
-.sheet-equipment_ranged_weapons_gs11 { grid-area: rw11; 	color: white; font-size: 30px; margin-top: -27px; text-align: center; height: 15px; }
-.sheet-equipment_ranged_weapons_gs12 { grid-area: rw12; 	color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
-.sheet-equipment_ranged_weapons_gs13 { grid-area: rw13; 	color: white; font-size: 12px; padding: 0px 2px; }
-.sheet-equipment_ranged_weapons_gs14 { grid-area: rw14; 	color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
-.sheet-equipment_ranged_weapons_gs15 { grid-area: rw15; 	color: white; font-size: 12px; padding: 0px 2px; }
-.sheet-equipment_ranged_weapons_gs16 { grid-area: rw16; 	color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
-.sheet-equipment_ranged_weapons_gs17 { grid-area: rw17; 	color: white; font-size: 12px; padding: 0px 2px; }
-.sheet-equipment_ranged_weapons_gs18 { grid-area: rw18; 	color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
+.sheet-equipment_ranged_weapons_gs5 { grid-area: rw5;	color: white; font-size: 12px; padding: 0px 2px; }
+.sheet-equipment_ranged_weapons_gs6 { grid-area: rw6;	color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; border-top-right-radius: 10px; }
+.sheet-equipment_ranged_weapons_gs7 { grid-area: rw7; color: white; font-size: 12px; padding: 0px 2px; }
+.sheet-equipment_ranged_weapons_gs8 { grid-area: rw8; color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
+.sheet-equipment_ranged_weapons_gs9 { grid-area: rw9; color: white; font-size: 12px; padding: 0px 2px; }
+.sheet-equipment_ranged_weapons_gs10 { grid-area: rw10; color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
+.sheet-equipment_ranged_weapons_gs11 { grid-area: rw11; color: white; font-size: 12px; padding: 0px 2px; }
+.sheet-equipment_ranged_weapons_gs12 { grid-area: rw12; color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
 
-.sheet-equipment_ranged_weapons_gs19 { grid-area: rw19; 	color: white; font-size: 12px; padding: 0px 2px; }
-.sheet-equipment_ranged_weapons_gs20 { grid-area: rw20; 	color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
-.sheet-equipment_ranged_weapons_gs21 { grid-area: rw21; 	color: white; font-size: 30px; margin-top: -27px; text-align: center; height: 15px; }
-.sheet-equipment_ranged_weapons_gs22 { grid-area: rw22; 	color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
-.sheet-equipment_ranged_weapons_gs23 { grid-area: rw23; 	color: white; font-size: 12px; padding: 0px 2px; }
-.sheet-equipment_ranged_weapons_gs24 { grid-area: rw24; 	color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
-.sheet-equipment_ranged_weapons_gs25 { grid-area: rw25; 	color: white; font-size: 12px; width: 50px!important;}
-.sheet-equipment_ranged_weapons_gs26 { grid-area: rw26; 	color: white; font-size: 12px; width: 50px!important;}
+.sheet-equipment_ranged_weapons_gs13 { grid-area: rw13;	color: white; font-size: 12px; padding: 0px 2px; }
+.sheet-equipment_ranged_weapons_gs14 { grid-area: rw14;	color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
+.sheet-equipment_ranged_weapons_gs15 { grid-area: rw15;	color: white; font-size: 30px; margin-top: -27px; text-align: center; height: 15px; }
+.sheet-equipment_ranged_weapons_gs16 { grid-area: rw16; color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
+.sheet-equipment_ranged_weapons_gs17 { grid-area: rw17; color: white; font-size: 30px; margin-top: -27px; text-align: center; height: 15px; }
+.sheet-equipment_ranged_weapons_gs18 { grid-area: rw18; color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
+.sheet-equipment_ranged_weapons_gs19 { grid-area: rw19; color: white; font-size: 12px; padding: 0px 2px; }
+.sheet-equipment_ranged_weapons_gs20 { grid-area: rw20; color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
+.sheet-equipment_ranged_weapons_gs21 { grid-area: rw21; color: white; font-size: 30px; margin-top: -27px; text-align: center; height: 15px; }
+.sheet-equipment_ranged_weapons_gs22 { grid-area: rw22; color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
+.sheet-equipment_ranged_weapons_gs23 { grid-area: rw23; color: white; font-size: 12px; width: 50px!important;}
+.sheet-equipment_ranged_weapons_gs24 { grid-area: rw24; color: white; font-size: 12px; width: 50px!important;}
 
-.sheet-equipment_ranged_weapons_gs27 { grid-area: rw27; 	color: white; font-size: 12px; padding: 0px 2px; }
-.sheet-equipment_ranged_weapons_gs28 { grid-area: rw28; 	color: white; font-size: 12px; padding: 0px 2px; }
-.sheet-equipment_ranged_weapons_gs29 { grid-area: rw29; 	color: white; font-size: 12px; padding: 0px 2px; }
-.sheet-equipment_ranged_weapons_gs30 { grid-area: rw30; 	color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
-.sheet-equipment_ranged_weapons_gs31 { grid-area: rw31; 	color: white; font-size: 12px; padding: 0px 2px; }
-.sheet-equipment_ranged_weapons_gs32 { grid-area: rw32; 	color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
-.sheet-equipment_ranged_weapons_gs33 { grid-area: rw33; 	color: white; font-size: 12px; padding: 0px 2px; }
-.sheet-equipment_ranged_weapons_gs34 { grid-area: rw34; 	color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
+.sheet-equipment_ranged_weapons_gs25 { grid-area: rw25; color: white; font-size: 12px; padding: 0px 2px; }
+.sheet-equipment_ranged_weapons_gs26 { grid-area: rw26; color: white; font-size: 12px; padding: 0px 2px; }
+.sheet-equipment_ranged_weapons_gs27 { grid-area: rw27; color: white; font-size: 12px; padding: 0px 2px; }
+.sheet-equipment_ranged_weapons_gs28 { grid-area: rw28; color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
+.sheet-equipment_ranged_weapons_gs29 { grid-area: rw29; color: white; font-size: 12px; padding: 0px 2px; }
+.sheet-equipment_ranged_weapons_gs30 { grid-area: rw30; color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
+.sheet-equipment_ranged_weapons_gs31 { grid-area: rw31; color: white; font-size: 12px; padding: 0px 2px; }
+.sheet-equipment_ranged_weapons_gs32 { grid-area: rw32; color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
 
-.sheet-equipment_ranged_weapons_grid1 { /* gs1-6, Name, Class, Range */
+.sheet-equipment_ranged_weapons_gs33 { grid-area: rw33; color: white; font-size: 12px; padding: 0px 2px; }
+.sheet-equipment_ranged_weapons_gs34 { grid-area: rw34; color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
+.sheet-equipment_ranged_weapons_gs35 { grid-area: rw35; color: white; font-size: 12px; padding: 0px 2px; }
+.sheet-equipment_ranged_weapons_gs36 { grid-area: rw36; color: white; font-size: 12px; padding: 0px 2px; }
+.sheet-equipment_ranged_weapons_gs37 { grid-area: rw37; color: white; font-size: 12px; padding: 0px 2px; }
+.sheet-equipment_ranged_weapons_gs38 { grid-area: rw38; color: white; font-size: 12px; padding: 0px 2px; }
+
+.sheet-equipment_ranged_weapons_grid1 { /* gs1-4, Name, Class */
 	align-items: center;
 	display: grid;
 	grid-template-columns: auto auto auto auto auto auto auto auto auto auto;
 	grid-template-areas:
-	'rw1 rw2 rw2 rw2 rw3 rw4 rw4 rw5 rw6 rw6';
+	'rw1 rw2 rw2 rw2 rw2 rw2 rw3 rw4 rw4 rw4';
 }
 
-.sheet-equipment_ranged_weapons_grid2 { /* gs7-18, RoF, Dmg, Type, Pen */
+.sheet-equipment_ranged_weapons_grid2 { /* gs5-12, Range, Dmg, Pen, Type */
 	align-items: center;
 	display: grid;
-	grid-template-columns: auto 8% 4% 8% 4% 8% auto auto auto auto;
+	grid-template-columns: auto auto auto auto auto auto auto auto auto auto;
 	grid-template-areas:
-	'rw7 rw8 rw9 rw10 rw11 rw12 rw13 rw14 rw15 rw16 rw17 rw18';
+	'rw5 rw6 rw7 rw8 rw8 rw9 rw10 rw11 rw12 rw12';
 }
 
-.sheet-equipment_ranged_weapons_grid3 { /* gs19-26 Magazine, Hit/Dmg buttons */
+.sheet-equipment_ranged_weapons_grid3 { /* gs13-24 RoF, Magazine, Hit/Dmg buttons */
 	align-items: center;
 	display: grid;
-	grid-template-columns: auto auto auto auto auto auto auto auto 61px 61px;
+	grid-template-columns: auto 8% 4% 8% 4% 8% auto 8% 4% 8% 61px 61px; /* 12 columns, nonstandard */
 	grid-template-areas:
-	'rw19 rw20 rw21 rw22 rw23 rw24 rw24 rw24 rw25 rw26';
+	'rw13 rw14 rw15 rw16 rw17 rw18 rw19 rw20 rw21 rw22 rw23 rw24';
 }
 
 
-.sheet-equipment_ranged_weapons_grid4 { /* gs27-34 Trained?, HitMod, Reload, Weight */
+.sheet-equipment_ranged_weapons_grid4 { /* gs25-32 Trained?, HitMod, Reload, Weight */
 	align-items: center;
 	display: grid;
-	grid-template-columns: auto 20px auto auto auto auto auto auto auto auto;
+	grid-template-columns: auto 20px auto auto auto auto auto auto auto; /* 9 columns, nonstandard */
 	grid-template-areas:
-	'rw27 rw28 rw29 rw30 rw31 rw31 rw32 rw32 rw33 rw34';
+	'rw25 rw26 rw27 rw28 rw29 rw30 rw30 rw31 rw32';
+}
+
+.sheet-equipment_ranged_weapons_grid5 { /* gs33-38 Domain, Mishap chance, Spray */
+	align-items: center;
+	display: grid;
+	grid-template-columns: auto auto auto auto auto auto auto auto auto 20px;
+	grid-template-areas:
+	'rw33 rw34 rw34 rw35 rw35 rw36 rw36 rw36 rw37 rw38';
 }
 
 .sheet-equipment_melee_weapons_gs1 { grid-area: mw1;	color: white; font-size: 12px; padding: 0px 2px; }
 .sheet-equipment_melee_weapons_gs2 { grid-area: mw2;	color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
 .sheet-equipment_melee_weapons_gs3 { grid-area: mw3;	color: white; font-size: 12px; padding: 0px 2px; }
 .sheet-equipment_melee_weapons_gs4 { grid-area: mw4;	color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
+
 .sheet-equipment_melee_weapons_gs5 { grid-area: mw5;	color: white; font-size: 12px; padding: 0px 2px; }
 .sheet-equipment_melee_weapons_gs6 { grid-area: mw6;	color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
-
 .sheet-equipment_melee_weapons_gs7 { grid-area: mw7;	color: white; font-size: 12px; padding: 0px 2px; }
 .sheet-equipment_melee_weapons_gs8 { grid-area: mw8;	color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
 .sheet-equipment_melee_weapons_gs9 { grid-area: mw9;	color: white; font-size: 12px; padding: 0px 2px; }
@@ -681,20 +694,20 @@ ______________________________ start of equipment tab __________________________
 .sheet-equipment_melee_weapons_gs19 { grid-area: mw19; color: white; font-size: 12px; width: 50px!important; }
 .sheet-equipment_melee_weapons_gs20 { grid-area: mw20; color: white; font-size: 12px; width: 50px!important; }
 
-.sheet-equipment_melee_weapons_grid1 { /* gs1-6 name, domain, reach */
+.sheet-equipment_melee_weapons_grid1 { /* gs1-4 name, domain */
 	align-items: center;
 	display: grid;
 	grid-template-columns: auto auto auto auto auto auto auto auto auto auto;
 	grid-template-areas:
-	'mw1 mw2 mw2 mw2 mw3 mw4 mw4 mw5 mw6 mw6';
+	'mw1 mw2 mw2 mw2 mw2 mw2 mw2 mw3 mw4 mw4';
 }
 
-.sheet-equipment_melee_weapons_grid2 { /* gs7-12 damage, type, pen */
+.sheet-equipment_melee_weapons_grid2 { /* gs5-12 reach, damage, pen, type */
 	align-items: center;
 	display: grid;
 	grid-template-columns: auto auto auto auto auto auto auto auto auto auto;
 	grid-template-areas:
-	'mw7 mw8 mw8 mw8 mw9 mw10 mw10 mw11 mw12 mw12';
+	'mw5 mw6 mw7 mw8 mw8 mw9 mw10 mw11 mw12 mw12';
 }
 
 .sheet-equipment_melee_weapons_grid3 { /* gs13-20 trained?, hitmod, weight, buttons */
@@ -1001,14 +1014,14 @@ ______________________________ start of Psykana tab ____________________________
 .sheet-psykana_ability_gs12 { grid-area: pa12; color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
 
 .sheet-psykana_ability_gs13 { grid-area: pa13; color: white; font-size: 12px; padding: 0px 2px; }
-.sheet-psykana_ability_gs14 { grid-area: pa14; color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
+.sheet-psykana_ability_gs14 { grid-area: pa14; color: white; font-size: 12px; padding: 0px 2px; }
 .sheet-psykana_ability_gs15 { grid-area: pa15; color: white; font-size: 12px; padding: 0px 2px; }
 .sheet-psykana_ability_gs16 { grid-area: pa16; color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
 .sheet-psykana_ability_gs17 { grid-area: pa17; color: white; font-size: 12px; width: 50px!important;}
 .sheet-psykana_ability_gs18 { grid-area: pa18; color: white; font-size: 12px; width: 50px!important;}
 
-.sheet-psykana_ability_gs19 { grid-area: pa19; color: white; font-size: 12px; padding: 0px 5px; }
-.sheet-psykana_ability_gs20 { grid-area: pa20; color: white; font-size: 12px; padding: 0px 5px; }
+.sheet-psykana_ability_gs19 { grid-area: pa19; color: white; font-size: 12px; padding: 0px 2px; }
+.sheet-psykana_ability_gs20 { grid-area: pa20; color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
 .sheet-psykana_ability_gs21 { grid-area: pa21; color: white; font-size: 12px; padding: 0px 2px; }
 .sheet-psykana_ability_gs22 { grid-area: pa22; color: white; font-size: 12px; border: none; border-bottom: 1px dotted white; }
 
@@ -1023,25 +1036,25 @@ ______________________________ start of Psykana tab ____________________________
 .sheet-psykana_ability_grid2 { /* gs5-12, Range, Dmg, Type, Pen */
 	align-items: center;
 	display: grid;
-	grid-template-columns: auto auto auto auto auto auto auto auto auto auto;
+	grid-template-columns: auto auto auto auto auto auto auto auto auto auto auto auto;
 	grid-template-areas:
-	'pa5 pa6 pa6 pa6 pa7 pa8 pa8 pa9 pa10 pa10 pa11 pa12';
+	'pa5 pa6 pa6 pa7 pa8 pa8 pa9 pa10 pa10 pa10 pa11 pa12';
 }
 
-.sheet-psykana_ability_grid3 { /* gs13-18 Action, Sustain, Hit/Dmg buttons */
+.sheet-psykana_ability_grid3 { /* gs13-18 Focus Power, Hit Mod, Hit/Dmg buttons */
 	align-items: center;
 	display: grid;
 	grid-template-columns: auto auto auto auto auto auto auto auto 61px 61px;
 	grid-template-areas:
-	'pa13 pa14 pa14 pa14 pa15 pa16 pa16 pa16 pa17 pa18';
+	'pa13 pa14 pa14 pa14 pa14 pa15 pa16 pa16 pa17 pa18';
 }
 
-.sheet-psykana_ability_grid4 { /* gs19-22 Focus Power, HitMod, extra space */
+.sheet-psykana_ability_grid4 { /* gs19-22 Actions to cast, Actions to sustain */
 	align-items: center;
 	display: grid;
 	grid-template-columns: auto auto auto auto auto auto auto auto auto auto;
 	grid-template-areas:
-	'pa19 pa19 pa20 pa20 pa20 pa21 pa22 . . . ';
+	'pa19 pa19 pa20 pa20 pa20 pa21 pa22 pa22 pa22 .';
 }
 
 

--- a/Only-War-Enhanced/OnlyWarEnhanced.html
+++ b/Only-War-Enhanced/OnlyWarEnhanced.html
@@ -267,7 +267,8 @@
 		<p></p>
 		<button class='clear minimisable_infographic_override' type='roll' name='scatter' value="@{to-gm}&{template:mythic} {{character= @{character_name}}} {{scatter-range= [[(?{Degrees of Failiure|1})+?{Modifier|0}]]}} {{scatter-direction=[[1d10]]}}">Scatter</button>
 		<button class='clear minimisable_infographic_override' type='roll' name='shock' value="@{to-gm}&{template:mythic} {{character= @{character_name}}} {{shock= [[(?{Fear DoF|1})*10 + 1d100]]}}">Shock</button>
-		<button class='clear minimisable_infographic_override' type='roll' name='d100' value="@{to-gm}&{template:mythic} [[ ([[?{Target Number|50}]] - [[1d100]])/10]] {{character= @{character_name}}} {{target= $[[0]]}} {{roll=$[[1]]}} {{difference=$[[2]]}}">1d100</button>
+		<button class='clear minimisable_infographic_override' type='roll' name='d100' value="@{to-gm}&{template:mythic} [[ ([[?{Target Number|50}]] - [[1d100]])/10]] {{d100= }} {{character= @{character_name}}} {{target= $[[0]]}} {{roll=$[[1]]}} {{difference=$[[2]]}}">1d100</button>
+		<button class='clear minimisable_infographic_override' type='roll' name='righteousfury' value="@{to-gm}&{template:mythic} {{character= @{character_name}}} {{righteousfury= }} {{@{settings_crunchsummary}= }} {{target=  [[?{Target|Person, 0|Vehicle, 1}]] }} {{location= [[?{Location|Arm/Weapon, 0|Body/Propulsion, 1|Head/Turret, 2|Leg/Hull, 3}]]}} {{type= [[?{Damage Type|Energy, 0|Explosive, 1|Impact, 2|Rending, 3}]] }} {{roll=[[ ceil(?{Dice Roll|1d5, 1d5|1d10, 1d10} / ?{Mitigation|None, 1| True Grit, 2}) ]] }} ">Righteous Fury</button>
 	  </div>
 	  <input type='checkbox' name='attr_infographic' class='collapsible_entity_switch hidden' />
 	  <div class='collapsible_entity_block'>
@@ -998,42 +999,56 @@
 			  <input class='equipment_ranged_weapons_gs2 full_width' type='text' name='attr_R_weapon_name' />
 			  <div class='equipment_ranged_weapons_gs3'>Class</div>
 			  <input class='equipment_ranged_weapons_gs4 full_width' type='text' name='attr_R_weapon_class' />
-			  <div class='equipment_ranged_weapons_gs5'>Range</div>
-			  <input class='equipment_ranged_weapons_gs6 full_width' type='text' value='0' name='attr_R_weapon_range' />
 			</div>
 			<div class='equipment_ranged_weapons_grid2'>
-			  <div class='equipment_ranged_weapons_gs7'>RoF</div>
-			  <input class='equipment_ranged_weapons_gs8 full_width' type='text' placeholder='Std' name='attr_R_weapon_standard' />
-			  <div class='equipment_ranged_weapons_gs9'>/</div>
-			  <input class='equipment_ranged_weapons_gs10 full_width' type='text' placeholder='Bst' name='attr_R_weapon_burst' />
-			  <div class='equipment_ranged_weapons_gs11'>/</div>
-			  <input class='equipment_ranged_weapons_gs12 full_width' type='text' placeholder='Auto' name='attr_R_weapon_auto' />
-			  <div class='equipment_ranged_weapons_gs13'>Damage</div>
-			  <input class='equipment_ranged_weapons_gs14 full_width' type='text' value='0' name='attr_R_weapon_dam-roll' />
-			  <div class='equipment_ranged_weapons_gs15'>Type</div>
-			  <input class='equipment_ranged_weapons_gs16 full_width' type='text' name='attr_R_weapon_type' />
-			  <div class='equipment_ranged_weapons_gs17'>Pen</div>
-			  <input class='equipment_ranged_weapons_gs18 full_width' type='text' value='0' name='attr_R_weapon_pen' />
+			  <div class='equipment_ranged_weapons_gs5'>Range</div>
+			  <input class='equipment_ranged_weapons_gs6 full_width' type='text' value='0' name='attr_R_weapon_range' />
+			  <div class='equipment_ranged_weapons_gs7'>Damage</div>
+			  <input class='equipment_ranged_weapons_gs8 full_width' type='text' value='0' name='attr_R_weapon_dam-roll' />
+			  <div class='equipment_ranged_weapons_gs9'>Pen</div>
+			  <input class='equipment_ranged_weapons_gs10 full_width' type='text' value='0' name='attr_R_weapon_pen' />
+			  <div class='equipment_ranged_weapons_gs11'>Type</div>
+			  <input class='equipment_ranged_weapons_gs12 full_width' type='text' name='attr_R_weapon_type' />
 			</div>
 			<div class='equipment_ranged_weapons_grid3'>
+			  <div class='equipment_ranged_weapons_gs13'>RoF</div>
+			  <input class='equipment_ranged_weapons_gs14 full_width' type='text' placeholder='Std' name='attr_R_weapon_standard' />
+			  <div class='equipment_ranged_weapons_gs15'>/</div>
+			  <input class='equipment_ranged_weapons_gs16 full_width' type='text' placeholder='Bst' name='attr_R_weapon_burst' />
+			  <div class='equipment_ranged_weapons_gs17'>/</div>
+			  <input class='equipment_ranged_weapons_gs18 full_width' type='text' placeholder='Auto' name='attr_R_weapon_auto' />
 			  <div class='equipment_ranged_weapons_gs19'>Magazine</div>
 			  <input class='equipment_ranged_weapons_gs20 full_width' type='text' value='0' name='attr_R_weapon_mag' />
 			  <div class='equipment_ranged_weapons_gs21'>/</div>
 			  <input class='equipment_ranged_weapons_gs22 full_width' type='text' value='0' name='attr_R_weapon_mag_max' />
-			  <div class='equipment_ranged_weapons_gs23'>Domain</div>
-			  <input class='equipment_ranged_weapons_gs24 full_width' type='text' name='attr_R_weapon_domain' />
-			  <button class='equipment_ranged_weapons_gs25 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }} {{weapon= @{R_weapon_name}}} {{roll=[[floor(( [[@{BS} + @{BS_advancement} + @{R_weapon_trained} - 20 + @{R_weapon_mod1}]] + [[?{Attack Type|Standard (+10),+10 | Burst (+0),+0 | Auto (-10),-10 | Called Shot (-20),-20 | Suppressing Fire (-20),-20} + ?{Aim | No aim (+0),+0 | Half aim (+10),+10| Full aim (+20),+20} + ?{Range | Point Blank (+30),+30 | Short Range (+10),+10 | Standard range (+0),+0 | Long Range (-10),-10 | Extreme Range (-30),-30} + @{inlinemod-toggle} ]] - 1d100)/10)]]}} @{settings_hitroll}' >Hit</button>
-			  <button class='equipment_ranged_weapons_gs26 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{type= @{R_weapon_type}}} {{weapon= @{R_weapon_name}}} {{damage=[[@{R_weapon_dam-roll}]] }} {{pen=[[@{R_weapon_pen}]] }} {{@{settings_weapondescription}=@{R_ability_r} }}' >DMG</button>
+			  <button class='equipment_ranged_weapons_gs23 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }} {{weapon= @{R_weapon_name}}} {{roll=[[floor(( [[@{BS} + @{BS_advancement} + @{R_weapon_trained} - 20 + @{R_weapon_mod1}]] + [[?{Attack Type|Standard (+10),+10 | Burst (+0),+0 | Auto (-10),-10 | Called Shot (-20),-20 | Suppressing Fire (-20),-20} + ?{Aim | No aim (+0),+0 | Half aim (+10),+10| Full aim (+20),+20} + ?{Range | Point Blank (+30),+30 | Short Range (+10),+10 | Standard range (+0),+0 | Long Range (-10),-10 | Extreme Range (-30),-30} + @{inlinemod-toggle} ]] - 1d100@{R_weapon_mishap_chance})/10)]]}} @{settings_hitroll}' >Hit</button>
+			  <button class='equipment_ranged_weapons_gs24 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{type= @{R_weapon_type}}} {{weapon= @{R_weapon_name}}} {{damage=[[@{R_weapon_dam-roll}@{R_weapon_spray}]] }} {{pen=[[@{R_weapon_pen}]] }}  {{@{settings_weapondescription}=@{R_ability_r} }}' >DMG</button>
 			</div>
 			<div class='equipment_ranged_weapons_grid4'>
-			  <div class='equipment_ranged_weapons_gs27'>Trained?</div>
-			  <input class='equipment_ranged_weapons_gs28' type='checkbox' value='20' name='attr_R_weapon_trained' checked />
-			  <div class='equipment_ranged_weapons_gs29'>Hit Mod</div>
-			  <input class='equipment_ranged_weapons_gs30 full_width' type='text' value='0' name='attr_R_weapon_mod1' />
-			  <div class='equipment_ranged_weapons_gs31'>Reload</div>
-			  <input class='equipment_ranged_weapons_gs32 full_width' type='text' value='0' name='attr_R_weapon_reload' />
-			  <div class='equipment_ranged_weapons_gs33'>Weight</div>
-			  <input class='equipment_ranged_weapons_gs34 full_width' type='text' value='0' name='attr_R_weapon_weight' />
+			  <div class='equipment_ranged_weapons_gs25'>Trained?</div>
+			  <input class='equipment_ranged_weapons_gs26' type='checkbox' value='20' name='attr_R_weapon_trained' checked />
+			  <div class='equipment_ranged_weapons_gs27'>Hit Mod</div>
+			  <input class='equipment_ranged_weapons_gs28 full_width' type='text' value='0' name='attr_R_weapon_mod1' />
+			  <div class='equipment_ranged_weapons_gs29'>Reload</div>
+			  <input class='equipment_ranged_weapons_gs30 full_width' type='text' value='0' name='attr_R_weapon_reload' />
+			  <div class='equipment_ranged_weapons_gs31'>Weight</div>
+			  <input class='equipment_ranged_weapons_gs32 full_width' type='text' value='0' name='attr_R_weapon_weight' />
+			</div>
+			<div class='equipment_ranged_weapons_grid5'>
+			  <div class='equipment_ranged_weapons_gs33'>Domain</div>
+			  <input class='equipment_ranged_weapons_gs34 full_width' type='text' name='attr_R_weapon_domain' />
+			  <div class='equipment_ranged_weapons_gs35'>Mishap Chance</div>
+			  <!-- TODO: shift this dropdown down a couple of px -->
+			  <select name='attr_R_weapon_mishap_chance' class='equipment_ranged_weapons_gs36 full_width'>
+				<option value='cs>90' >Unreliable (91)</option>
+				<option value='cs>93' >Burst/Auto (94)</option>
+				<option value='cs>95' selected='selected'>Standard (96)</option>
+				<option value='cs>99' >Reliable (100)</option>
+				<option value='cs11cs22cs33cs44cs55cs66cs77cs88cs99cs100' >Doubles</option>
+				<option value='cs>?{Mishap chance|96}' >Custom</option>
+			  </select>
+			  <div class='equipment_ranged_weapons_gs37'>Spray?</div>
+			  <input class='equipment_ranged_weapons_gs38' type='checkbox' value='cf9' name='attr_R_weapon_spray' />
 			</div>
 			<div>
 			  <input name='attr_R_ability_r' type='text' placeholder='Special' class='full_width_49px border_none' />
@@ -1056,16 +1071,16 @@
 			  <input class='equipment_melee_weapons_gs2 full_width' type='text' name='attr_M_weapon_name' />
 			  <div class='equipment_melee_weapons_gs3'>Domain</div>
 			  <input class='equipment_melee_weapons_gs4 full_width' type='text' name='attr_M_weapon_domain' />
-			  <div class='equipment_melee_weapons_gs5'>Reach</div>
-			  <input class='equipment_melee_weapons_gs6 full_width' type='text' name='attr_M_weapon_reach' />
 			</div>
 			<div class='equipment_melee_weapons_grid2'>
+			  <div class='equipment_melee_weapons_gs5'>Reach</div>
+			  <input class='equipment_melee_weapons_gs6 full_width' type='text' name='attr_M_weapon_reach' />
 			  <div class='equipment_melee_weapons_gs7'>Damage</div>
 			  <input class='equipment_melee_weapons_gs8 full_width' type='text' value='0' name='attr_M_weapon_dam-roll' />
-			  <div class='equipment_melee_weapons_gs9'>Type</div>
-			  <input class='equipment_melee_weapons_gs10 full_width' type='text' value='0' name='attr_M_weapon_type' />
-			  <div class='equipment_melee_weapons_gs11'>Pen</div>
-			  <input class='equipment_melee_weapons_gs12 full_width' type='text' value='0' name='attr_M_weapon_pen' />
+			  <div class='equipment_melee_weapons_gs9'>Pen</div>
+			  <input class='equipment_melee_weapons_gs10 full_width' type='text' value='0' name='attr_M_weapon_pen' />
+			  <div class='equipment_melee_weapons_gs11'>Type</div>
+			  <input class='equipment_melee_weapons_gs12 full_width' type='text' name='attr_M_weapon_type' />
 			</div>
 			<div class='equipment_melee_weapons_grid3'>
 			  <div class='equipment_melee_weapons_gs13'>Trained?</div>
@@ -1483,23 +1498,23 @@
 			  <input class='psykana_ability_gs12 full_width' type='text' value='0' name='attr_P_pen' />
 			</div>
 			<div class='psykana_ability_grid3'>
-			  <div class='psykana_ability_gs13'>Action</div>
-			  <input class='psykana_ability_gs14 full_width' type='text' name='attr_P_action' />
-			  <div class='psykana_ability_gs15'>Sustained</div>
-			  <input class='psykana_ability_gs16 full_width' type='text' name='attr_P_sustained' />
-			  <button class='psykana_ability_gs17 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }} {{weapon= @{P_name}}} {{roll=[[floor(( [[@{P_focus} + @{P_mod1} ]] + [[5 * @{effective_psy_rating}]] + @{inlinemod-toggle} - 1d100@{psy_roll})/10)]]}} @{settings_hitroll}' >Cast</button>
-			  <button class='psykana_ability_gs18 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{type= @{P_type}}} {{weapon= @{P_name}}} {{damage=[[@{P_dam-roll}]] }} {{pen=[[@{P_pen}]] }} {{@{settings_weapondescription}=@{P_ability_r} }}' >DMG</button>
-			</div>
-			<div class='psykana_ability_grid4'>
-			  <div class='psykana_ability_gs19'>Focus Power</div>
+			  <div class='psykana_ability_gs13'>Focus Power</div>
 			  <!-- TODO: shift this dropdown down a couple of px -->
-			  <select name='attr_P_focus' class='psykana_info_gs20 full_width'>
+			  <select name='attr_P_focus' class='psykana_ability_gs14 full_width'>
 				<option value='[[@{WP} + @{WP_advancement} ]]' selected='selected'>Willpower</option>
 				<option value='[[@{PER} + @{PER_advancement} ]]'>Perception</option>
 				<option value='[[@{mod1_psyniscience} + @{mod2_psyniscience} + @{mod3_psyniscience} - 20 ]]'>Psyniscience</option>
 			  </select>
-			  <div class='psykana_ability_gs21'>Power Mod</div>
-			  <input class='psykana_ability_gs22 full_width' type='text' value='0' name='attr_P_mod1' />
+			  <div class='psykana_ability_gs15'>Power Mod</div>
+			  <input class='psykana_ability_gs16 full_width' type='text' value='0' name='attr_P_mod1' />
+			  <button class='psykana_ability_gs17 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{psy= }} {{attack= }} {{weapon= @{P_name}}} {{roll=[[floor(( [[@{P_focus} + @{P_mod1} ]] + [[5 * @{effective_psy_rating}]] + @{inlinemod-toggle} - 1d100cs>90@{psy_roll})/10)]]}} @{settings_hitroll}' >Cast</button>
+			  <button class='psykana_ability_gs18 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{type= @{P_type}}} {{weapon= @{P_name}}} {{damage=[[@{P_dam-roll}]] }} {{pen=[[@{P_pen}]] }} {{@{settings_weapondescription}=@{P_ability_r} }}' >DMG</button>
+			</div>
+			<div class='psykana_ability_grid4'>
+			  <div class='psykana_ability_gs19'>Action</div>
+			  <input class='psykana_ability_gs20 full_width' type='text' name='attr_P_action' />
+			  <div class='psykana_ability_gs21'>Sustained</div>
+			  <input class='psykana_ability_gs22 full_width' type='text' name='attr_P_sustained' />
 			</div>
 			<div>
 			  <input name='attr_P_ability_r' type='text' placeholder='Disclaimer: 5 * Effective PR not yet counted in casting test' class='full_width_49px border_none' />
@@ -1533,7 +1548,7 @@
 
 	<h3>Auto Roll Hit Locations</h3>
 	<select name='attr_settings_hitroll' class='full_width edge_padding'>
-	  <option value='{{loc=[[1d100]]}}'selected='selected'>Automatically roll hit locations</option>
+	  <option value='{{loc=[[1d100]]}}' selected='selected'>Automatically roll hit locations</option>
 	  <option value=' '>Don't automatically roll hit locations</option>
 	</select>
 	<br>
@@ -1541,7 +1556,14 @@
 	<h3>Weapon Special in Damage Roll</h3>
     <select name='attr_settings_weapondescription' class='full_width edge_padding'>
       <option value='description'>Include weapon Special</option>
-      <option value=' 'selected='selected'>Exclude weapon Special</option>
+      <option value=' ' selected='selected'>Exclude weapon Special</option>
+    </select>
+    <br>
+	
+	<h3>Crunch Summary in Righteous Fury</h3>
+    <select name='attr_settings_crunchsummary' class='full_width edge_padding'>
+      <option value='crunch'>Include Crunch Summary</option>
+      <option value=' ' selected='selected'>Exclude Crunch Summary</option>
     </select>
     <br>
 
@@ -1572,9 +1594,11 @@
   <div class='minimisable_infographic_toggles'>
 	<p></p>
 	<label><input type='checkbox' name='attr_to-gm' value='/w gm' class='select_button hidden' /><span class='select_text'>To GM</span></label>
-	<label><input type='checkbox' name='attr_inlinemod-toggle' value='?{Modifier|0}' class='select_button hidden' checked/><span class='select_text'>Inline Mod</span></label>
+	<label><input type='checkbox' name='attr_inlinemod-toggle' value='?{Modifier|0}' class='select_button hidden' checked='checked'><span class='select_text'>Inline Mod</span></label>
 	<label><input type='checkbox' name='attr_vehicle_sheet' class='auto_margin collapsible_entity_switch select_button hidden' /><span class='select_text'>Vehicle</span></label>
-	<button class='clear minimisable_infographic_override' type='roll' name='scatter' value="@{to-gm}&{template:mythic} {{character= @{character_name}}} {{scatter-range= [[(?{Degrees of Failiure|1})+?{Modifier|0}]]}} {{scatter-direction=[[1d10]]}}">Scatter</button>
+	<button class='clear minimisable_infographic_override' type='roll' name='scatter' value="@{to-gm}&{template:mythic} {{character= @{character_name}}} {{scatter-range= [[(?{Degrees of Failiure|1})+?{Distance Mod|0}]]}} {{scatter-direction=[[1d10]]}}">Scatter</button>
+	<button class='clear minimisable_infographic_override' type='roll' name='d100' value="@{to-gm}&{template:mythic} [[ ([[?{Target Number|50}]] - [[1d100]])/10]] {{d100= }} {{character= @{character_name}}} {{target= $[[0]]}} {{roll=$[[1]]}} {{difference=$[[2]]}}">1d100</button>
+	<button class='clear minimisable_infographic_override' type='roll' name='righteousfury' value="@{to-gm}&{template:mythic} {{character= @{character_name}}} {{righteousfury= }} {{@{settings_crunchsummary}= }} {{target=  [[?{Target|Person, 0|Vehicle, 1}]] }} {{location= [[?{Location|Arm/Weapon, 0|Body/Propulsion, 1|Head/Turret, 2|Leg/Hull, 3}]]}} {{type= [[?{Damage Type|Energy, 0|Explosive, 1|Impact, 2|Rending, 3}]] }} {{roll=[[ ceil(?{Dice Roll|1d5, 1d5|1d10, 1d10} / ?{Mitigation|None, 1| True Grit, 2}) ]] }}">Fury</button>
   </div>
 
   	<!-- Vehicles -->
@@ -1685,49 +1709,63 @@
 	  <div class='vehicle_weapons'>
 		<div class='equipment_ranged_weapons'>
 		  <h3 class='radius_border_top'>Vehicle Ranged Weapons</h3>
-		  <fieldset name='vehiclerangedweapons' class='repeating_vrangedweapons'>
+		  <fieldset name='vehiclerangedweapons' class='repeating_vehiclerangedweapons'>
 		  <div class='equipment_ranged_weapons_rep'>
 			<div class='equipment_ranged_weapons_grid1'>
 			  <div class='equipment_ranged_weapons_gs1'>Name</div>
 			  <input class='equipment_ranged_weapons_gs2 full_width' type='text' name='attr_V_R_weapon_name' />
 			  <div class='equipment_ranged_weapons_gs3'>Class</div>
 			  <input class='equipment_ranged_weapons_gs4 full_width' type='text' name='attr_V_R_weapon_class' />
-			  <div class='equipment_ranged_weapons_gs5'>Range</div>
-			  <input class='equipment_ranged_weapons_gs6 full_width' type='text' value='0' name='attr_V_R_weapon_range' />
 			</div>
 			<div class='equipment_ranged_weapons_grid2'>
-			  <div class='equipment_ranged_weapons_gs7'>RoF</div>
-			  <input class='equipment_ranged_weapons_gs8 full_width' type='text' placeholder='Std' name='attr_V_R_weapon_standard' />
-			  <div class='equipment_ranged_weapons_gs9'>/</div>
-			  <input class='equipment_ranged_weapons_gs10 full_width' type='text' placeholder='Bst' name='attr_V_R_weapon_burst' />
-			  <div class='equipment_ranged_weapons_gs11'>/</div>
-			  <input class='equipment_ranged_weapons_gs12 full_width' type='text' placeholder='Auto' name='attr_V_R_weapon_auto' />
-			  <div class='equipment_ranged_weapons_gs13'>Damage</div>
-			  <input class='equipment_ranged_weapons_gs14 full_width' type='text' value='0' name='attr_V_R_weapon_dam-roll' />
-			  <div class='equipment_ranged_weapons_gs15'>Type</div>
-			  <input class='equipment_ranged_weapons_gs16 full_width' type='text' name='attr_V_R_weapon_type' />
-			  <div class='equipment_ranged_weapons_gs17'>Pen</div>
-			  <input class='equipment_ranged_weapons_gs18 full_width' type='text' value='0' name='attr_V_R_weapon_pen' />
+			  <div class='equipment_ranged_weapons_gs5'>Range</div>
+			  <input class='equipment_ranged_weapons_gs6 full_width' type='text' value='0' name='attr_V_R_weapon_range' />
+			  <div class='equipment_ranged_weapons_gs7'>Damage</div>
+			  <input class='equipment_ranged_weapons_gs8 full_width' type='text' value='0' name='attr_V_R_weapon_dam-roll' />
+			  <div class='equipment_ranged_weapons_gs9'>Pen</div>
+			  <input class='equipment_ranged_weapons_gs10 full_width' type='text' value='0' name='attr_V_R_weapon_pen' />
+			  <div class='equipment_ranged_weapons_gs11'>Type</div>
+			  <input class='equipment_ranged_weapons_gs12 full_width' type='text' name='attr_V_R_weapon_type' />
 			</div>
 			<div class='equipment_ranged_weapons_grid3'>
+			  <div class='equipment_ranged_weapons_gs13'>RoF</div>
+			  <input class='equipment_ranged_weapons_gs14 full_width' type='text' placeholder='Std' name='attr_V_R_weapon_standard' />
+			  <div class='equipment_ranged_weapons_gs15'>/</div>
+			  <input class='equipment_ranged_weapons_gs16 full_width' type='text' placeholder='Bst' name='attr_V_R_weapon_burst' />
+			  <div class='equipment_ranged_weapons_gs17'>/</div>
+			  <input class='equipment_ranged_weapons_gs18 full_width' type='text' placeholder='Auto' name='attr_V_R_weapon_auto' />
 			  <div class='equipment_ranged_weapons_gs19'>Magazine</div>
 			  <input class='equipment_ranged_weapons_gs20 full_width' type='text' value='0' name='attr_V_R_weapon_mag' />
 			  <div class='equipment_ranged_weapons_gs21'>/</div>
 			  <input class='equipment_ranged_weapons_gs22 full_width' type='text' value='0' name='attr_V_R_weapon_mag_max' />
-			  <div class='equipment_ranged_weapons_gs23'>Domain</div>
-			  <input class='equipment_ranged_weapons_gs24 full_width' type='text' name='attr_V_R_weapon_domain' />
-			  <button class='equipment_ranged_weapons_gs25 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }} {{weapon= @{V_R_weapon_name}}} {{roll=[[floor(( [[@{BS} + @{BS_advancement} + @{V_R_weapon_trained} - 20 + @{V_R_weapon_mod1}]] + [[?{Attack Type|Standard (+10),+10 | Burst (+0),+0 | Auto (-10),-10 | Called Shot (-20),-20 | Suppressing Fire (-20),-20} + ?{Aim | No aim (+0),+0 | Half aim (+10),+10| Full aim (+20),+20} + ?{Range | Point Blank (+30),+30 | Short Range (+10),+10 | Standard range (+0),+0 | Long Range (-10),-10 | Extreme Range (-30),-30} + @{inlinemod-toggle} ]] - 1d100)/10)]]}} @{settings_hitroll}'>Hit</button>
-			  <button class='equipment_ranged_weapons_gs26 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{type= @{V_R_weapon_type}}} {{weapon= @{V_R_weapon_name}}} {{damage=[[@{V_R_weapon_dam-roll}]] }} {{pen=[[@{V_R_weapon_pen}]] }} {{@{settings_weapondescription}=@{V_R_ability_r} }}' >DMG</button>
+			  <button class='equipment_ranged_weapons_gs23 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }} {{weapon= @{V_R_weapon_name}}} {{roll=[[floor(( [[@{BS} + @{BS_advancement} + @{V_R_weapon_trained} - 20 + @{V_R_weapon_mod1}]] + [[?{Attack Type|Standard (+10),+10 | Burst (+0),+0 | Auto (-10),-10 | Called Shot (-20),-20 | Suppressing Fire (-20),-20} + ?{Aim | No aim (+0),+0 | Half aim (+10),+10| Full aim (+20),+20} + ?{Range | Point Blank (+30),+30 | Short Range (+10),+10 | Standard range (+0),+0 | Long Range (-10),-10 | Extreme Range (-30),-30} + @{inlinemod-toggle} ]] - 1d100@{V_R_weapon_mishap_chance})/10)]]}} @{settings_hitroll}' >Hit</button>
+			  <button class='equipment_ranged_weapons_gs24 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{type= @{V_R_weapon_type}}} {{weapon= @{V_R_weapon_name}}} {{damage=[[@{V_R_weapon_dam-roll}@{V_R_weapon_spray}]] }} {{pen=[[@{V_R_weapon_pen}]] }}  {{@{settings_weapondescription}=@{V_R_ability_r} }}' >DMG</button>
 			</div>
 			<div class='equipment_ranged_weapons_grid4'>
-			  <div class='equipment_ranged_weapons_gs27'>Trained?</div>
-			  <input class='equipment_ranged_weapons_gs28' type='checkbox' value='20' name='attr_V_R_weapon_trained' checked />
-			  <div class='equipment_ranged_weapons_gs29'>Hit Mod</div>
-			  <input class='equipment_ranged_weapons_gs30 full_width' type='text' value='0' name='attr_V_R_weapon_mod1' />
-			  <div class='equipment_ranged_weapons_gs31'>Reload</div>
-			  <input class='equipment_ranged_weapons_gs32 full_width' type='text' value='0' name='attr_V_R_weapon_reload' />
-			  <div class='equipment_ranged_weapons_gs33'>Weight</div>
-			  <input class='equipment_ranged_weapons_gs34 full_width' type='text' value='0' name='attr_V_R_weapon_weight' />
+			  <div class='equipment_ranged_weapons_gs25'>Trained?</div>
+			  <input class='equipment_ranged_weapons_gs26' type='checkbox' value='20' name='attr_V_R_weapon_trained' checked />
+			  <div class='equipment_ranged_weapons_gs27'>Hit Mod</div>
+			  <input class='equipment_ranged_weapons_gs28 full_width' type='text' value='0' name='attr_V_R_weapon_mod1' />
+			  <div class='equipment_ranged_weapons_gs29'>Reload</div>
+			  <input class='equipment_ranged_weapons_gs30 full_width' type='text' value='0' name='attr_V_R_weapon_reload' />
+			  <div class='equipment_ranged_weapons_gs31'>Weight</div>
+			  <input class='equipment_ranged_weapons_gs32 full_width' type='text' value='0' name='attr_V_R_weapon_weight' />
+			</div>
+			<div class='equipment_ranged_weapons_grid5'>
+			  <div class='equipment_ranged_weapons_gs33'>Domain</div>
+			  <input class='equipment_ranged_weapons_gs34 full_width' type='text' name='attr_V_R_weapon_domain' />
+			  <div class='equipment_ranged_weapons_gs35'>Mishap Chance</div>
+			  <!-- TODO: shift this dropdown down a couple of px -->
+			  <select name='attr_V_R_weapon_mishap_chance' class='equipment_ranged_weapons_gs36 full_width'>
+				<option value='cs>90' >Unreliable (91)</option>
+				<option value='cs>93' >Burst/Auto (94)</option>
+				<option value='cs>95' selected='selected'>Standard (96)</option>
+				<option value='cs>99' >Reliable (100)</option>
+				<option value='cs11cs22cs33cs44cs55cs66cs77cs88cs99cs100' >Doubles</option>
+				<option value='cs>?{Mishap chance|96}' >Custom</option>
+			  </select>
+			  <div class='equipment_ranged_weapons_gs37'>Spray?</div>
+			  <input class='equipment_ranged_weapons_gs38' type='checkbox' value='cf9' name='attr_V_R_weapon_spray' />
 			</div>
 			<div>
 			  <input name='attr_V_R_ability_r' type='text' placeholder='Special' class='full_width_49px border_none' />
@@ -1738,28 +1776,28 @@
 			</div>
 		  </div>
 		  <br />
-		  </fieldset>
+		</fieldset>
 		</div>
 
 		<div class='equipment_melee_weapons'>
 		  <h3 class='radius_border_top'>Vehicle Melee Weaponry</h3>
-		  <fieldset name='vehiclemeleeweapons' class='repeating_vmeleeweapons'>
+		  <fieldset name='vehiclemeleeweapons' class='repeating_vehiclemeleeweapons'>
 		  <div class='equipment_melee_weapons_rep'>
 			<div class='equipment_melee_weapons_grid1'>
 			  <div class='equipment_melee_weapons_gs1'>Name</div>
 			  <input class='equipment_melee_weapons_gs2 full_width' type='text' name='attr_V_M_weapon_name' />
 			  <div class='equipment_melee_weapons_gs3'>Domain</div>
 			  <input class='equipment_melee_weapons_gs4 full_width' type='text' name='attr_V_M_weapon_domain' />
-			  <div class='equipment_melee_weapons_gs5'>Reach</div>
-			  <input class='equipment_melee_weapons_gs6 full_width' type='text' name='attr_V_M_weapon_reach' />
 			</div>
 			<div class='equipment_melee_weapons_grid2'>
+			  <div class='equipment_melee_weapons_gs5'>Reach</div>
+			  <input class='equipment_melee_weapons_gs6 full_width' type='text' name='attr_V_M_weapon_reach' />
 			  <div class='equipment_melee_weapons_gs7'>Damage</div>
 			  <input class='equipment_melee_weapons_gs8 full_width' type='text' value='0' name='attr_V_M_weapon_dam-roll' />
-			  <div class='equipment_melee_weapons_gs9'>Type</div>
-			  <input class='equipment_melee_weapons_gs10 full_width' type='text' value='0' name='attr_V_M_weapon_type' />
-			  <div class='equipment_melee_weapons_gs11'>Pen</div>
-			  <input class='equipment_melee_weapons_gs12 full_width' type='text' value='0' name='attr_V_M_weapon_pen' />
+			  <div class='equipment_melee_weapons_gs9'>Pen</div>
+			  <input class='equipment_melee_weapons_gs10 full_width' type='text' value='0' name='attr_V_M_weapon_pen' />
+			  <div class='equipment_melee_weapons_gs11'>Type</div>
+			  <input class='equipment_melee_weapons_gs12 full_width' type='text' name='attr_V_M_weapon_type' />
 			</div>
 			<div class='equipment_melee_weapons_grid3'>
 			  <div class='equipment_melee_weapons_gs13'>Trained?</div>
@@ -1768,9 +1806,7 @@
 			  <input class='equipment_melee_weapons_gs16 full_width' type='text' value='0' name='attr_V_M_weapon_mod1' />
 			  <div class='equipment_melee_weapons_gs17'>Weight</div>
 			  <input class='equipment_melee_weapons_gs18 full_width' type='text' value='0' name='attr_V_M_weapon_weight' />
-
 			  <button class='equipment_melee_weapons_gs19 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }}{{weapon= @{V_M_weapon_name}}} {{roll=[[floor(([[@{WS}+@{WS_advancement} + @{V_M_weapon_trained} - 20 + @{V_M_weapon_mod1}]] + [[?{Attack Type | Standard (+10),+10 | Swift Attack (+0),+0 | Lighting (-10),-10 | Charge (+20),+20 | All-out (+30),+30} + ?{Aim | No aim (+0),+0 | Half aim (+10),+10 | Full aim (+20),+20} + @{inlinemod-toggle} ]]-1d100)/10)]]}} @{settings_hitroll}' >Hit</button>
-			  
 			  <button class='equipment_melee_weapons_gs20 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{weapon= @{V_M_weapon_name}}} {{type= @{V_M_weapon_type}}} {{damage=[[@{V_M_weapon_dam-roll}+[[floor((@{STR} + @{STR_advancement})/10) + @{str_unnat}]]]] }} {{pen= [[@{V_M_weapon_pen}]] }} {{@{settings_weapondescription}=@{V_M_ability_r} }}' >DMG</button>
 			</div>
 			<div>
@@ -1782,7 +1818,7 @@
 			</div>
 		  </div>
 		  <br />
-		  </fieldset>
+		</fieldset>
 		</div>
 	  </div>
 	</div>
@@ -2060,14 +2096,14 @@
 		case 1:
 		  psykana_limit_factor = 1;
 		  setAttrs({
-			psy_roll: ('cs11cs22cs33cs44cs55cs66cs77cs88cs99cs100')
+			psy_roll: ('cf11cf22cf33cf44cf55cf66cf77cf88cf99cf100')
 		  });
 		  break;
 		case 2:
 		  psykana_limit_factor = 1;
 		  push_addend_epr = psy_push;
 		  setAttrs({
-			psy_roll: ('cs>0cf0')
+			psy_roll: ('cf>0')
 		  });
 		  break;
 	  }
@@ -2217,13 +2253,13 @@
   
   
   
-  {{#target}}
+  {{#d100}}
   <div class="sheet-template-header">{{character}} just rolls a d100 </div>
   <div class="sheet-template-content">
     <div class="sheet-template-row template-center">Target: {{target}} Roll: {{roll}} </div>
 	<div class="sheet-template-row template-center">Difference: {{difference}}</div>
   </div>
-  {{/target}}
+  {{/d100}}
   
   
   
@@ -2267,15 +2303,22 @@
         {{#rollLess() roll 0 }}<div style="float: right">Additional DoF</div>{{/rollLess() roll 0 }}
       </div>
 
-      {{#rollWasCrit() roll }}<div class="sheet-template-row template-center">That's not good...</div>{{/rollWasCrit() roll }}
-      {{#rollWasFumble() roll }}<div class="sheet-template-row template-center">How about that?</div>{{/rollWasFumble() roll }}
+      {{#rollWasCrit() roll }}
+		{{#psy}}<div class="sheet-template-row template-center">Failed to Cast</div>{{/psy}}
+		{{^psy}}<div class="sheet-template-row template-center">That's not good...</div>{{/psy}}
+	  {{/rollWasCrit() roll }}
+      {{#rollWasFumble() roll }}
+		{{#psy}}<div class="sheet-template-row template-center">Psychic Phenomena</div>{{/psy}}
+		{{^psy}}<div class="sheet-template-row template-center">How about that?</div>{{/psy}}
+		
+	  {{/rollWasFumble() roll }}
     </div>
     {{/attack}}
 
 
 
     {{#loc}}
-    {{^attack}}<div class="sheet-template-content sheet-template-round">{{/attack}}
+      {{^attack}}<div class="sheet-template-content sheet-template-round">{{/attack}}
       {{#attack}} <div class="sheet-template-content">{{/attack}}
         <div class="sheet-template-row sheet-template-center sheet-template-break">Hit Location {{loc}}</div>
         <div class="sheet-template-row sheet-template-center">
@@ -2298,7 +2341,7 @@
 
       {{#damage}}
       <div class="sheet-template-header">{{character}} rolls for damage with {{weapon}} </div>
-      {{#description}}<div class="sheet-template-content template-content_top">{{/description}}
+        {{#description}}<div class="sheet-template-content template-content_top">{{/description}}
         {{^description}}<div class="sheet-template-content">  {{/description}}
           <div class="sheet-template-2x2">
 
@@ -2317,13 +2360,780 @@
           </div>
 
         </div>
-        {{/damage}}
-        {{#description}}
+      {{/damage}}
+      {{#description}}
         {{#name}}<div class="sheet-template-header">{{name}}</div>{{/name}}
         <div class="sheet-template-content">
           <div class="sheet-template-row ">{{description}}</div>
         </div>
-        {{/description}}
+      {{/description}}
+		
+		
+		
+		{{#righteousfury}}
+		<div class="sheet-template-header">{{character}} attacks with Righteous Fury (p258/p276)</div>
+        <div class="sheet-template-content">
+		  <!-- target is person -->
+		  {{#rollTotal() target 0}}
+			<!-- target is person's Arm -->
+			{{#rollTotal() location 0}} 
+			  <!-- target is person's Arm, Energy damage -->
+			  {{#rollTotal() type 0}}
+				<div class="sheet-template-row template-center">Energy critcal to Arm.</div>
+				<div class="sheet-template-row template-center">Severity: {{roll}}</div>
+				  {{#crunch}}
+					{{#rollTotal() roll 1}}
+					  <div class="sheet-template-row template-center">All Tests involving the arm take a -30 for 1d5 Rounds.</div>
+					{{/rollTotal() roll 1}}
+					{{#rollTotal() roll 2}}
+					  <div class="sheet-template-row template-center">Arm is useless for 1d5 Rounds. Target takes 1 Fatigue.</div>
+					{{/rollTotal() roll 2}}
+					{{#rollTotal() roll 3}}
+					  <div class="sheet-template-row template-center">Target may only take a Half Action in the next Round, takes 1d5 Fatigue.</div>
+					{{/rollTotal() roll 3}}
+					{{#rollTotal() roll 4}}
+					  <div class="sheet-template-row template-center">Target is Stunned for 1 Round, knocked Prone. Arm is useless for 1d10 Rounds.</div>
+					{{/rollTotal() roll 4}}
+					{{#rollTotal() roll 5}}
+					  <div class="sheet-template-row template-center">Target is Stunned for 1 Round, arm is useless until target receives medical treatment.</div>
+					{{/rollTotal() roll 5}}
+					{{#rollTotal() roll 6}}
+					  <div class="sheet-template-row template-center">Target takes 1d5 WS and BS damage, 1d5 Fatigue. +0 TOU Test or permanently lose use of the hand.</div>
+					{{/rollTotal() roll 6}}
+					{{#rollTotal() roll 7}}
+					  <div class="sheet-template-row template-center">Until arm is repaired, target counts as having only one arm. Target is Stunned for 1 Round, takes 1d5 Fatigue.</div>
+					{{/rollTotal() roll 7}}
+					{{#rollTotal() roll 8}}
+					  <div class="sheet-template-row template-center">+0 TOU Test or be Stunned for 1d5 Rounds. Target takes 1d10 Fatigue, loses arm.</div>
+					{{/rollTotal() roll 8}}
+					{{#rollTotal() roll 9}}
+					  <div class="sheet-template-row template-center">+0 TOU Test or die of shock. On survival, target takes 1d10 Fatigue and is Stunned for 1 Round, loses arm.</div>
+					{{/rollTotal() roll 9}}
+					{{#rollGreater() roll 9}}
+					  <div class="sheet-template-row template-center">Arm is burned to a stump, target dies.</div>
+					{{/rollGreater() roll 9}}
+				  {{/crunch}}
+			  {{/rollTotal() type 0}}
+			  <!-- target is person's Arm, Explosive damage -->
+			  {{#rollTotal() type 1}}
+				<div class="sheet-template-row template-center">Explosive critcal to Arm.</div>
+				<div class="sheet-template-row template-center">Severity: {{roll}}</div>
+				  {{#crunch}}
+					{{#rollTotal() roll 1}}
+					  <div class="sheet-template-row template-center">Target takes 1 Fatigue.</div>
+					{{/rollTotal() roll 1}}
+					{{#rollTotal() roll 2}}
+					  <div class="sheet-template-row template-center">Target drops anything held in that hand, +0 TOU Test or be Stunned for 1 Round.</div>
+					{{/rollTotal() roll 2}}
+					{{#rollTotal() roll 3}}
+					  <div class="sheet-template-row template-center">Target loses 1 finger (and up to 1d5 other fingertips), takes 1d10 WS and BS damage, destroys anything carried in the hand. If it is an explosive, kill target instantly.</div>
+					{{/rollTotal() roll 3}}
+					{{#rollTotal() roll 4}}
+					  <div class="sheet-template-row template-center">Target is Stunned for 1 Round, arm is useless until medical treatment is received. +0 TOU check or suffer Blood Loss.</div>
+					{{/rollTotal() roll 4}}
+					{{#rollTotal() roll 5}}
+					  <div class="sheet-template-row template-center">+10 TOU check or lose the hand. On success, 1 permanent WS and BS damage.</div>
+					{{/rollTotal() roll 5}}
+					{{#rollTotal() roll 6}}
+					  <div class="sheet-template-row template-center">Target takes 1d5 Fatigue. Until medical attention is received, target counts as only having one arm. Target gains Blood Loss.</div>
+					{{/rollTotal() roll 6}}
+					{{#rollTotal() roll 7}}
+					  <div class="sheet-template-row template-center">+0 TOU Test or die of shock. On success, target is Stunned for 1d10 Rounds, takes 1d10 Fatigue, gains Blood Loss, loses arm.</div>
+					{{/rollTotal() roll 7}}
+					{{#rollTotal() roll 8}}
+					  <div class="sheet-template-row template-center">Target dies.</div>
+					{{/rollTotal() roll 8}}
+					{{#rollTotal() roll 9}}
+					  <div class="sheet-template-row template-center">Arm explodes, target dies. If carrying a weapon with a power source, that explodes, dealing 1d10+5 Impact damage to anyone within 2 meters.</div>
+					{{/rollTotal() roll 9}}
+					{{#rollGreater() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies. If carrying a weapon with a power source, that explodes, dealing 1d10+5 Impact damage to anyone within 2 meters. If carrying ammunition, it cooks off, dealing 1d10+5 Impact damage to anyone within 1d10 meters. If target is carrying other explosives, they detonate centered on the target.</div>
+					{{/rollGreater() roll 9}}
+				  {{/crunch}}
+			  {{/rollTotal() type 1}}
+			  <!-- target is person's Arm, Impact damage -->
+			  {{#rollTotal() type 2}}
+				<div class="sheet-template-row template-center">Impact critcal to Arm.</div>
+				<div class="sheet-template-row template-center">Severity: {{roll}}</div>
+				  {{#crunch}}
+					{{#rollTotal() roll 1}}
+					  <div class="sheet-template-row template-center">Target drops anything held in that hand.</div>
+					{{/rollTotal() roll 1}}
+					{{#rollTotal() roll 2}}
+					  <div class="sheet-template-row template-center">Target takes 1 Fatigue.</div>
+					{{/rollTotal() roll 2}}
+					{{#rollTotal() roll 3}}
+					  <div class="sheet-template-row template-center">Target is Stunned for 1 Round, drops anything held in that hand. 10% chance that the thing dropped is unusable until repaired.</div>
+					{{/rollTotal() roll 3}}
+					{{#rollTotal() roll 4}}
+					  <div class="sheet-template-row template-center">Target drops anything held in that hand. +0 TOU Test or take 1d10 WS and BS damage.</div>
+					{{/rollTotal() roll 4}}
+					{{#rollTotal() roll 5}}
+					  <div class="sheet-template-row template-center">Target's limb is useless until target receives medical treatment.</div>
+					{{/rollTotal() roll 5}}
+					{{#rollTotal() roll 6}}
+					  <div class="sheet-template-row template-center">Target crushes 1d5 fingers, takes 1 Fatigue, +0 TOU Test or take 2 permanent WS and BS damage.</div>
+					{{/rollTotal() roll 6}}
+					{{#rollTotal() roll 7}}
+					  <div class="sheet-template-row template-center">Target's arm is broken; until repaired, target counts as not having the arm. Target suffers Blood Loss.</div>
+					{{/rollTotal() roll 7}}
+					{{#rollTotal() roll 8}}
+					  <div class="sheet-template-row template-center">+0 TOU Test or die of shock. On success, Stunned for 1d10 Rounds, takes 1d5 Fatigue, suffers Blood Loss, loses the arm.</div>
+					{{/rollTotal() roll 8}}
+					{{#rollTotal() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies.</div>
+					{{/rollTotal() roll 9}}
+					{{#rollGreater() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies, anyone within 2 meters of the target suffers 1d5-3 Impact damage to a random body part.</div>
+					{{/rollGreater() roll 9}}
+				  {{/crunch}}
+			  {{/rollTotal() type 2}}
+			  <!-- target is person's Arm, Rending damage -->
+			  {{#rollTotal() type 3}}
+				<div class="sheet-template-row template-center">Rending critcal to Arm.</div>
+				<div class="sheet-template-row template-center">Severity: {{roll}}</div>
+				  {{#crunch}}
+					{{#rollTotal() roll 1}}
+					  <div class="sheet-template-row template-center">Target drops anything held in that arm.</div>
+					{{/rollTotal() roll 1}}
+					{{#rollTotal() roll 2}}
+					  <div class="sheet-template-row template-center">Target drops anything held in that arm, takes 1 Fatigue.</div>
+					{{/rollTotal() roll 2}}
+					{{#rollTotal() roll 3}}
+					  <div class="sheet-template-row template-center">Target drops anything held in that arm, +0 TOU Test or suffer Blood Loss.</div>
+					{{/rollTotal() roll 3}}
+					{{#rollTotal() roll 4}}
+					  <div class="sheet-template-row template-center">Target falls Prone, takes 2 Fatigue. Limb is useless for 1d10 Rounds.</div>
+					{{/rollTotal() roll 4}}
+					{{#rollTotal() roll 5}}
+					  <div class="sheet-template-row template-center">Target suffers Blood Loss. Limb is useless without medical treatment.</div>
+					{{/rollTotal() roll 5}}
+					{{#rollTotal() roll 6}}
+					  <div class="sheet-template-row template-center">Target loses 1d5 fingers, Stunned for 1 Round, +0 TOU Test or lose the whole hand.</div>
+					{{/rollTotal() roll 6}}
+					{{#rollTotal() roll 7}}
+					  <div class="sheet-template-row template-center">Target takes 1d10 STR damage. Target only counts as having one arm until receiving medical treatment. Suffers Blood Loss.</div>
+					{{/rollTotal() roll 7}}
+					{{#rollTotal() roll 8}}
+					  <div class="sheet-template-row template-center">Target loses the arm, +0 TOU or die of shock. On success, Stunned for 1d10 Rounds and suffers Blood Loss.</div>
+					{{/rollTotal() roll 8}}
+					{{#rollTotal() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies.</div>
+					{{/rollTotal() roll 9}}
+					{{#rollGreater() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies. If carrying a ranged weapon, 5% chance to hit a single random target within 2d10 meters. Treated as a single shot from the weapon.</div>
+					{{/rollGreater() roll 9}}
+				  {{/crunch}}
+			  {{/rollTotal() type 3}}
+			{{/rollTotal() location 0}}
+			
+			<!-- target is person's Body -->
+			{{#rollTotal() location 1}}
+			  <!-- target is person's Body, Energy damage -->
+			  {{#rollTotal() type 0}}
+				<div class="sheet-template-row template-center">Energy critcal to Body.</div>
+				<div class="sheet-template-row template-center">Severity: {{roll}}</div>
+				  {{#crunch}}
+					{{#rollTotal() roll 1}}
+					  <div class="sheet-template-row template-center">Target can only take a Half Action next Turn.</div>
+					{{/rollTotal() roll 1}}
+					{{#rollTotal() roll 2}}
+					  <div class="sheet-template-row template-center">+0 TOU Test or be knocked Prone.</div>
+					{{/rollTotal() roll 2}}
+					{{#rollTotal() roll 3}}
+					  <div class="sheet-template-row template-center">Target takes 2 Fatigue and 1d5 TOU damage.</div>
+					{{/rollTotal() roll 3}}
+					{{#rollTotal() roll 4}}
+					  <div class="sheet-template-row template-center">Target takes 1d10 Fatigue, can only take a Half Action on next Round.</div>
+					{{/rollTotal() roll 4}}
+					{{#rollTotal() roll 5}}
+					  <div class="sheet-template-row template-center">Target knocked Prone, +0 AGI Test or catch fire (p266), and +0 TOU Test or be Stunned for 1 Round.</div>
+					{{/rollTotal() roll 5}}
+					{{#rollTotal() roll 6}}
+					  <div class="sheet-template-row template-center">Target knocked Prone, Stunned for 1d10 Rounds, takes 1d5 Fatigue. +0 AGI Test or catch fire (p266)</div>
+					{{/rollTotal() roll 6}}
+					{{#rollTotal() roll 7}}
+					  <div class="sheet-template-row template-center">Target is Stunned for 2d10 Rounds, takes 1d10 permanent TOU damage.</div>
+					{{/rollTotal() roll 7}}
+					{{#rollTotal() roll 8}}
+					  <div class="sheet-template-row template-center">Target is Stunned for 2d10 Rounds. STR, TOU, AGI are halved until target can get medical treatment. 2d5 permanent FEL damage.</div>
+					{{/rollTotal() roll 8}}
+					{{#rollTotal() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies in a fire.</div>
+					{{/rollTotal() roll 9}}
+					{{#rollGreater() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies in a fire, carried ammo has a 50% chance to cook off. All creatures within 1d5 meters must pass an Evasion Test or take 1d10+5 X damage. Carried grenades or missiles will explode one Round later, centered on the Target.</div>
+					{{/rollGreater() roll 9}}
+				  {{/crunch}}
+			  {{/rollTotal() type 0}}
+			  <!-- target is person's Body, Explosive damage -->
+			  {{#rollTotal() type 1}}
+				<div class="sheet-template-row template-center">Explosive critcal to Body.</div>
+				<div class="sheet-template-row template-center">Severity: {{roll}}</div>
+				  {{#crunch}}
+					{{#rollTotal() roll 1}}
+					  <div class="sheet-template-row template-center">Target knocked backwards 1d5 meters, knocked Prone.</div>
+					{{/rollTotal() roll 1}}
+					{{#rollTotal() roll 2}}
+					  <div class="sheet-template-row template-center">Target knocked backwards 1d5 meters (gaining 1 Fatigue per meter), knocked Prone.</div>
+					{{/rollTotal() roll 2}}
+					{{#rollTotal() roll 3}}
+					  <div class="sheet-template-row template-center">Target knocked backwards 1d5 meters, Stunned for 1 Round, knocked Prone.</div>
+					{{/rollTotal() roll 3}}
+					{{#rollTotal() roll 4}}
+					  <div class="sheet-template-row template-center">+0 TOU Test or suffer Blood Loss and be Stunned for 1 Round.</div>
+					{{/rollTotal() roll 4}}
+					{{#rollTotal() roll 5}}
+					  <div class="sheet-template-row template-center">+0 TOU Test or suffer Blood Loss and 1 permanent TOU damage. Target gains 1d5 Fatigue, knocked Prone.</div>
+					{{/rollTotal() roll 5}}
+					{{#rollTotal() roll 6}}
+					  <div class="sheet-template-row template-center">Target is Stunned for 1 Round, may only take a Half Action next Round, and is knocked Prone.</div>
+					{{/rollTotal() roll 6}}
+					{{#rollTotal() roll 7}}
+					  <div class="sheet-template-row template-center">Target suffers Blood Loss, is knocked Prone, is Stunned for 1d10 Rounds, +0 TOU Test or fall unconscious</div>
+					{{/rollTotal() roll 7}}
+					{{#rollTotal() roll 8}}
+					  <div class="sheet-template-row template-center">Target dies.</div>
+					{{/rollTotal() roll 8}}
+					{{#rollTotal() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies. Any carried ammunition cooks off, dealing 1d10+5 Impact damage to anyone within 1d10 meters. Any other explosives immediately detonate as well.</div>
+					{{/rollTotal() roll 9}}
+					{{#rollGreater() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies. Any carried ammunition cooks off, dealing 1d10+5 Impact damage to anyone within 1d10 meters. Any other explosives immediately detonate as well. Anyone within 1d10 meters of the target must make a +0 AGI Test or take -10 to all WS and BS Tests for 1 Round.</div>
+					{{/rollGreater() roll 9}}
+				  {{/crunch}}
+			  {{/rollTotal() type 1}}
+			  <!-- target is person's Body, Impact damage -->
+			  {{#rollTotal() type 2}}
+				<div class="sheet-template-row template-center">Impact critcal to Body.</div>
+				<div class="sheet-template-row template-center">Severity: {{roll}}</div>
+				  {{#crunch}}
+					{{#rollTotal() roll 1}}
+					  <div class="sheet-template-row template-center">Target can only take a Half Action next Turn.</div>
+					{{/rollTotal() roll 1}}
+					{{#rollTotal() roll 2}}
+					  <div class="sheet-template-row template-center">Target takes 1 Fatigue, knocked Prone.</div>
+					{{/rollTotal() roll 2}}
+					{{#rollTotal() roll 3}}
+					  <div class="sheet-template-row template-center">Target breaks a rib, knocked Prone, Stunned for 1 Round.</div>
+					{{/rollTotal() roll 3}}
+					{{#rollTotal() roll 4}}
+					  <div class="sheet-template-row template-center">Target takes 1d10 Toughness damage, +0 AGI Test or be knocked Prone.</div>
+					{{/rollTotal() roll 4}}
+					{{#rollTotal() roll 5}}
+					  <div class="sheet-template-row template-center">Target is Stunned for 2 Rounds, +0 TOU Test or take 1d5 Fatigue.</div>
+					{{/rollTotal() roll 5}}
+					{{#rollTotal() roll 6}}
+					  <div class="sheet-template-row template-center">Target is flung out 1d5 meters and falls Prone (unless hitting a solid object), takes 1d5 Fatigue, Stunned for 2 Rounds.</div>
+					{{/rollTotal() roll 6}}
+					{{#rollTotal() roll 7}}
+					  <div class="sheet-template-row template-center">Target breaks 1d5 ribs. 1d5 permanent TOU damage. Target can either await medical attention (+0 Medicae Test to set ribs) or continue (20% chance each Round to die instantly).</div>
+					{{/rollTotal() roll 7}}
+					{{#rollTotal() roll 8}}
+					  <div class="sheet-template-row template-center">Target suffers Blood Loss, 1d10 permanent TOU damage.</div>
+					{{/rollTotal() roll 8}}
+					{{#rollTotal() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies.</div>
+					{{/rollTotal() roll 9}}
+					{{#rollGreater() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies, is flung 1d10 meters. Anyone in the path must make a +0 AGI Test or be knocked Prone.</div>
+					{{/rollGreater() roll 9}}
+				  {{/crunch}}
+			  {{/rollTotal() type 2}}
+			  <!-- target is person's Body, Rending damage -->
+			  {{#rollTotal() type 3}}
+				<div class="sheet-template-row template-center">Rending critcal to Body.</div>
+				<div class="sheet-template-row template-center">Severity: {{roll}}</div>
+				  {{#crunch}}
+					{{#rollTotal() roll 1}}
+					  <div class="sheet-template-row template-center">Target takes 1 Fatigue if not wearing armor.</div>
+					{{/rollTotal() roll 1}}
+					{{#rollTotal() roll 2}}
+					  <div class="sheet-template-row template-center">Target gains 1 Fatigue, +0 TOU Test or be Stunned for 1 Round.</div>
+					{{/rollTotal() roll 2}}
+					{{#rollTotal() roll 3}}
+					  <div class="sheet-template-row template-center">Target is Stunned for 1 Round, +0 TOU Test or gain Blood Loss.</div>
+					{{/rollTotal() roll 3}}
+					{{#rollTotal() roll 4}}
+					  <div class="sheet-template-row template-center">Target suffers Blood Loss, Stunned for 1 Round.</div>
+					{{/rollTotal() roll 4}}
+					{{#rollTotal() roll 5}}
+					  <div class="sheet-template-row template-center">Target suffers 1d10 TOU damage and Blood Loss, drops a puddle of blood on the floor. Anyone crossing this puddle must make a +0 AGI Test or fall Prone.</div>
+					{{/rollTotal() roll 5}}
+					{{#rollTotal() roll 6}}
+					  <div class="sheet-template-row template-center">Target is knocked Prone, takes 1d10 TOU damage, Blood Loss.</div>
+					{{/rollTotal() roll 6}}
+					{{#rollTotal() roll 7}}
+					  <div class="sheet-template-row template-center">Target takes 1d5 permanent TOU damage, Blood Loss. Option to hold guts in with one arm (+0 Medicae Test to bind them in) or continue (%20 chance each round to spill guts for 2d10 damage).</div>
+					{{/rollTotal() roll 7}}
+					{{#rollTotal() roll 8}}
+					  <div class="sheet-template-row template-center">+0 TOU test or die. On success, target takes 1d10 permanent TOU damage, is Stunned for 1 Round, and suffers Blood Loss.</div>
+					{{/rollTotal() roll 8}}
+					{{#rollTotal() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies.</div>
+					{{/rollTotal() roll 9}}
+					{{#rollGreater() roll 9}}
+					  <div class="sheet-template-row template-center">Target drops a 4 meter radius puddle of blood and dies. For the rest of the encounter, anyone moving through this puddle must make a +0 AGI Test or fall Prone.</div>
+					{{/rollGreater() roll 9}}
+				  {{/crunch}}
+			  {{/rollTotal() type 3}}
+			{{/rollTotal() location 1}}
+			<!-- target is person's Head -->
+			{{#rollTotal() location 2}}
+			  <!-- target is person's Head, Energy damage -->
+			  {{#rollTotal() type 0}}
+				<div class="sheet-template-row template-center">Energy critcal to Head.</div>
+				<div class="sheet-template-row template-center">Severity: {{roll}}</div>
+				  {{#crunch}}
+					{{#rollTotal() roll 1}}
+					  <div class="sheet-template-row template-center">Target takes -10 to all Tests except TOU for 1 Round.</div>
+					{{/rollTotal() roll 1}}
+					{{#rollTotal() roll 2}}
+					  <div class="sheet-template-row template-center">Target is Blinded for 1 Round.</div>
+					{{/rollTotal() roll 2}}
+					{{#rollTotal() roll 3}}
+					  <div class="sheet-template-row template-center">Target is deafened for 1d5 hours or until receiving first aid.</div>
+					{{/rollTotal() roll 3}}
+					{{#rollTotal() roll 4}}
+					  <div class="sheet-template-row template-center">Target loses hair, takes 2 Fatigue and is Blinded for 1d5 Rounds.</div>
+					{{/rollTotal() roll 4}}
+					{{#rollTotal() roll 5}}
+					  <div class="sheet-template-row template-center">Target loses hair, is Blinded for 1d10 Rounds, Stunned for 1 Round, takes 1 permanent FEL damage.</div>
+					{{/rollTotal() roll 5}}
+					{{#rollTotal() roll 6}}
+					  <div class="sheet-template-row template-center">Target is Blinded for 1d10 hours, takes 1d5 Fatigue, 1d5 permanent FEL and PER damage.</div>
+					{{/rollTotal() roll 6}}
+					{{#rollTotal() roll 7}}
+					  <div class="sheet-template-row template-center">Target is Blinded permanently, takes 1d10 Fatigue. Reroll 1d10 as new FEL, unless FEL is already 10 or less.</div>
+					{{/rollTotal() roll 7}}
+					{{#rollTotal() roll 8}}
+					  <div class="sheet-template-row template-center">Target dies.</div>
+					{{/rollTotal() roll 8}}
+					{{#rollTotal() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies.</div>
+					{{/rollTotal() roll 9}}
+					{{#rollGreater() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies, catches fire, runs headless 2d10 meters in a random direction. Anyone or anything flammable it passes makes a +0 AGI Test or catches fire.</div>
+					{{/rollGreater() roll 9}}
+				  {{/crunch}}
+			  {{/rollTotal() type 0}}
+			  <!-- target is person's Head, Explosive damage -->
+			  {{#rollTotal() type 1}}
+				<div class="sheet-template-row template-center">Explosive critcal to Head.</div>
+				<div class="sheet-template-row template-center">Severity: {{roll}}</div>
+				  {{#crunch}}
+					{{#rollTotal() roll 1}}
+					  <div class="sheet-template-row template-center">Target can only take a Half Action next Turn.</div>
+					{{/rollTotal() roll 1}}
+					{{#rollTotal() roll 2}}
+					  <div class="sheet-template-row template-center">Target is Blinded and Deafened for 1 Round.</div>
+					{{/rollTotal() roll 2}}
+					{{#rollTotal() roll 3}}
+					  <div class="sheet-template-row template-center">Target takes 2 Fatigue, +0 TOU Test or take 1d10 PER and FEL damage.</div>
+					{{/rollTotal() roll 3}}
+					{{#rollTotal() roll 4}}
+					  <div class="sheet-template-row template-center">Target takes 1d10 INT damage, is knocked Prone. +0 TOU Test or take 1 permanent INT damage and be Stunned for 2 Rounds.</div>
+					{{/rollTotal() roll 4}}
+					{{#rollTotal() roll 5}}
+					  <div class="sheet-template-row template-center">Target is Stunned for 1d10 Rounds, permanently Deafened, takes 1d5 permanent FEL damage.</div>
+					{{/rollTotal() roll 5}}
+					{{#rollTotal() roll 6}}
+					  <div class="sheet-template-row template-center">Target dies.</div>
+					{{/rollTotal() roll 6}}
+					{{#rollTotal() roll 7}}
+					  <div class="sheet-template-row template-center">Target dies. Any carried ammunition cooks off, dealing 1d10+5 Impact damage to anyone within 1d10 meters. Any other explosives immediately detonate as well.</div>
+					{{/rollTotal() roll 7}}
+					{{#rollTotal() roll 8}}
+					  <div class="sheet-template-row template-center">Target dies, leaving a gore puddle. Anyone passing over this spot takes a +0 AGI Test or falls Prone.</div>
+					{{/rollTotal() roll 8}}
+					{{#rollTotal() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies.</div>
+					{{/rollTotal() roll 9}}
+					{{#rollGreater() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies, any allies within 2 meters take a +0 Fear Test or take the next Turn fleeing from the attacker.</div>
+					{{/rollGreater() roll 9}}
+				  {{/crunch}}
+			  {{/rollTotal() type 1}}
+			  <!-- target is person's Head, Impact damage -->
+			  {{#rollTotal() type 2}}
+				<div class="sheet-template-row template-center">Impact critcal to Head.</div>
+				<div class="sheet-template-row template-center">Severity: {{roll}}</div>
+				  {{#crunch}}
+					{{#rollTotal() roll 1}}
+					  <div class="sheet-template-row template-center">Target passes +0 TOU Test or takes 1 Fatigue.</div>
+					{{/rollTotal() roll 1}}
+					{{#rollTotal() roll 2}}
+					  <div class="sheet-template-row template-center">Target takes a -10 to PER and INT Tests for 1d5 Rounds.</div>
+					{{/rollTotal() roll 2}}
+					{{#rollTotal() roll 3}}
+					  <div class="sheet-template-row template-center">Target is Blinded for 1 Round, +0 TOU Test or be Stunned for 1 Round.</div>
+					{{/rollTotal() roll 3}}
+					{{#rollTotal() roll 4}}
+					  <div class="sheet-template-row template-center">Target passes +0 TOU Test or be Stunned for 1 Round and knocked Prone.</div>
+					{{/rollTotal() roll 4}}
+					{{#rollTotal() roll 5}}
+					  <div class="sheet-template-row template-center">Target is Stunned for 1 Round, gains 1 Fatigue, staggers back 1d5 meters, takes 1 permanent INT damage.</div>
+					{{/rollTotal() roll 5}}
+					{{#rollTotal() roll 6}}
+					  <div class="sheet-template-row template-center">Target is Stunned for 1d5 Rounds, knocked backwards 1d5 meters, +0 AGI Test or fall Prone.</div>
+					{{/rollTotal() roll 6}}
+					{{#rollTotal() roll 7}}
+					  <div class="sheet-template-row template-center">Target is Stunned for 1d10 Rounds, halves all movement for 1d10 hours.</div>
+					{{/rollTotal() roll 7}}
+					{{#rollTotal() roll 8}}
+					  <div class="sheet-template-row template-center">Target dies.</div>
+					{{/rollTotal() roll 8}}
+					{{#rollTotal() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies, anyone within 4 meters of target takes a +0 AGI Test or takes a -10 to WS and BS Tests on the next Turn.</div>
+					{{/rollTotal() roll 9}}
+					{{#rollGreater() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies, anyone within 4 meters of target takes a +0 AGI Test or takes a -10 to WS and BS Tests on the next Turn. If hit was from a melee weapon, attacker can immediately make an attack (same weapon) against any other target that can be reached without moving. If ranged, attacker can immediately make an attack (same weapon) against any target standing directly behind the original and still within range.</div>
+					{{/rollGreater() roll 9}}
+				  {{/crunch}}
+			  {{/rollTotal() type 2}}
+			  <!-- target is person's Head, Rending damage -->
+			  {{#rollTotal() type 3}}
+				<div class="sheet-template-row template-center">Rending critcal to Head.</div>
+				<div class="sheet-template-row template-center">Severity: {{roll}}</div>
+				  {{#crunch}}
+					{{#rollTotal() roll 1}}
+					  <div class="sheet-template-row template-center">Target takes 1 Fatigue, unless wearing helmet.</div>
+					{{/rollTotal() roll 1}}
+					{{#rollTotal() roll 2}}
+					  <div class="sheet-template-row template-center">Target takes a +10 to all WS and BS Tests for 1d10 Rounds. +0 TOU Test or suffer Blood Loss.</div>
+					{{/rollTotal() roll 2}}
+					{{#rollTotal() roll 3}}
+					  <div class="sheet-template-row template-center">Target is Stunned for 1d5 Rounds, drops helmet if worn, suffers Blood Loss.</div>
+					{{/rollTotal() roll 3}}
+					{{#rollTotal() roll 4}}
+					  <div class="sheet-template-row template-center">Target takes 1d10 PER damage, +20 TOU Test or lose an eye. (p266)</div>
+					{{/rollTotal() roll 4}}
+					{{#rollTotal() roll 5}}
+					  <div class="sheet-template-row template-center">Target is sTunned for 1d5 Rounds, drops helmet if worn. If no helmet, loses an ear (Deafened) until receiving medical treatment, +0 TOU Test or suffer 1 permanent FEL damage.</div>
+					{{/rollTotal() roll 5}}
+					{{#rollTotal() roll 6}}
+					  <div class="sheet-template-row template-center">Roll 1d10. 1-3: Target loses an eye. (p266) 4-7: nose. (1d10 permanent FEL damage) 8-10: ear (Deafened until receiving medical treatment). Target suffers Blood Loss, is Stunned for 1 Round.</div>
+					{{/rollTotal() roll 6}}
+					{{#rollTotal() roll 7}}
+					  <div class="sheet-template-row template-center">Target rerolls FEL as 1d10, is permanently Blinded, suffers Blood Loss, Stunned for 1 Round.</div>
+					{{/rollTotal() roll 7}}
+					{{#rollTotal() roll 8}}
+					  <div class="sheet-template-row template-center">Target dies.</div>
+					{{/rollTotal() roll 8}}
+					{{#rollTotal() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies, head lands 2d10 meters away.</div>
+					{{/rollTotal() roll 9}}
+					{{#rollGreater() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies, head lands 2d10 meters away. Anyone nearby makes a +0 AGI Test or takes -10 to all WS and BS for 1 Round.</div>
+					{{/rollGreater() roll 9}}
+				  {{/crunch}}
+			  {{/rollTotal() type 3}}
+			{{/rollTotal() location 2}}
+			<!-- target is person's Leg -->
+			{{#rollTotal() location 3}}
+			  <!-- target is person's Leg, Energy damage -->
+			  {{#rollTotal() type 0}}
+				<div class="sheet-template-row template-center">Energy critcal to Leg.</div>
+				<div class="sheet-template-row template-center">Severity: {{roll}}</div>
+				  {{#crunch}}
+					{{#rollTotal() roll 1}}
+					  <div class="sheet-template-row template-center">Target cannot Run or Charge for 2 Rounds.</div>
+					{{/rollTotal() roll 1}}
+					{{#rollTotal() roll 2}}
+					  <div class="sheet-template-row template-center">Target must pass +0 TOU Test or takes 1 Fatigue.</div>
+					{{/rollTotal() roll 2}}
+					{{#rollTotal() roll 3}}
+					  <div class="sheet-template-row template-center">Target takes 1 Fatigue, is knocked Prone, and reduces movement by half for 1d10 Rounds.</div>
+					{{/rollTotal() roll 3}}
+					{{#rollTotal() roll 4}}
+					  <div class="sheet-template-row template-center">Target reduces movement by half, may not Run or Charge until receiving medical treatment.</div>
+					{{/rollTotal() roll 4}}
+					{{#rollTotal() roll 5}}
+					  <div class="sheet-template-row template-center">Target takes 1 Fatigue, knocked Prone, reduces movement by half for 2d10 Rounds.</div>
+					{{/rollTotal() roll 5}}
+					{{#rollTotal() roll 6}}
+					  <div class="sheet-template-row template-center">Target takes 2 Fatigue, makes a +0 TOU Test or loses the foot. On success, target reduces movement by half until receiving medical treatment.</div>
+					{{/rollTotal() roll 6}}
+					{{#rollTotal() roll 7}}
+					  <div class="sheet-template-row template-center">Targettakes 1d5 Fatigue. +0 TOU Test or be Stunned for 1 Round. Target considered to only have one leg until receiving medical treatment.</div>
+					{{/rollTotal() roll 7}}
+					{{#rollTotal() roll 8}}
+					  <div class="sheet-template-row template-center">Target takes 1d10 Fatigue, suffers Blood Loss, loses the leg, +0 TOU Test or be Stunned for 1 Round.</div>
+					{{/rollTotal() roll 8}}
+					{{#rollTotal() roll 9}}
+					  <div class="sheet-template-row template-center">Target passes a +0 TOU Test or dies.</div>
+					{{/rollTotal() roll 9}}
+					{{#rollGreater() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies.</div>
+					{{/rollGreater() roll 9}}
+				  {{/crunch}}
+			  {{/rollTotal() type 0}}
+			  <!-- target is person's Leg, Explosive damage -->
+			  {{#rollTotal() type 1}}
+				<div class="sheet-template-row template-center">Explosive critcal to Leg.</div>
+				<div class="sheet-template-row template-center">Severity: {{roll}}</div>
+				  {{#crunch}}
+					{{#rollTotal() roll 1}}
+					  <div class="sheet-template-row template-center">Target sent back 1 meter, +0 TOU Test or be knocked Prone.</div>
+					{{/rollTotal() roll 1}}
+					{{#rollTotal() roll 2}}
+					  <div class="sheet-template-row template-center">Target knocked Prone, may only take Half Moves for movement actions for 1d5 Rounds.</div>
+					{{/rollTotal() roll 2}}
+					{{#rollTotal() roll 3}}
+					  <div class="sheet-template-row template-center">Target takes 2d10 AGI damage.</div>
+					{{/rollTotal() roll 3}}
+					{{#rollTotal() roll 4}}
+					  <div class="sheet-template-row template-center">Target flung 1d5 meters away from explosion, knocked prone. Needs a Full Action to stand back up, movement reduced by half for 1d10 Rounds.</div>
+					{{/rollTotal() roll 4}}
+					{{#rollTotal() roll 5}}
+					  <div class="sheet-template-row template-center">Target takes 1d5 permanent AGI damage, -10 TOU Test or take 1d5 Fatigue.</div>
+					{{/rollTotal() roll 5}}
+					{{#rollTotal() roll 6}}
+					  <div class="sheet-template-row template-center">Target takes 1d10 Fatigue, counts as only having one leg until receiving medical treatment. +0 TOU Test or lose the foot.</div>
+					{{/rollTotal() roll 6}}
+					{{#rollTotal() roll 7}}
+					  <div class="sheet-template-row template-center">Target takes a +0 TOU Test or dies. On success, Stunned for 1d10 Rounds, takes 1d10 Fatigue, suffers Blood Loss, loses the leg.</div>
+					{{/rollTotal() roll 7}}
+					{{#rollTotal() roll 8}}
+					  <div class="sheet-template-row template-center">Target dies.</div>
+					{{/rollTotal() roll 8}}
+					{{#rollTotal() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies, anyone within 2 meters takes 1d10+2 Impact damage.</div>
+					{{/rollTotal() roll 9}}
+					{{#rollGreater() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies, anyone within 2 meters takes 1d10+2 Impact damage, (if ammunition carried) anyone within 1d10 meters also takes 1d10+5 Impact damage, any other carried explosives detonate.</div>
+					{{/rollGreater() roll 9}}
+				  {{/crunch}}
+			  {{/rollTotal() type 1}}
+			  <!-- target is person's Leg, Impact damage -->
+			  {{#rollTotal() type 2}}
+				<div class="sheet-template-row template-center">Impact critcal to Leg.</div>
+				<div class="sheet-template-row template-center">Severity: {{roll}}</div>
+				  {{#crunch}}
+					{{#rollTotal() roll 1}}
+					  <div class="sheet-template-row template-center">Target takes 1 Fatigue.</div>
+					{{/rollTotal() roll 1}}
+					{{#rollTotal() roll 2}}
+					  <div class="sheet-template-row template-center">Target's movement reduced by half for 1 Round, +0 TOU Test or be Stunned for 1 Round and fall Prone.</div>
+					{{/rollTotal() roll 2}}
+					{{#rollTotal() roll 3}}
+					  <div class="sheet-template-row template-center">Target takes 1d10 AGI damage and is knocked Prone.</div>
+					{{/rollTotal() roll 3}}
+					{{#rollTotal() roll 4}}
+					  <div class="sheet-template-row template-center">Target takes 2d10 AGI damage and is knocked Prone.</div>
+					{{/rollTotal() roll 4}}
+					{{#rollTotal() roll 5}}
+					  <div class="sheet-template-row template-center">Target is Stunned for 1 Round, knocked Prone, movement reduced to 1 Meter until receiving medical treatment.</div>
+					{{/rollTotal() roll 5}}
+					{{#rollTotal() roll 6}}
+					  <div class="sheet-template-row template-center">Target's movment reduced by half until receiving medical treatment. Target takes 2 Fatigue, +0 TOU Test or lose the foot.</div>
+					{{/rollTotal() roll 6}}
+					{{#rollTotal() roll 7}}
+					  <div class="sheet-template-row template-center">Target is Stunned for 2 Rounds, knocked Prone, counts as not having the leg until receiving medical treatment.</div>
+					{{/rollTotal() roll 7}}
+					{{#rollTotal() roll 8}}
+					  <div class="sheet-template-row template-center">Target suffers Blood Loss, 1d5 permanent AGI damage, loses the leg, +0 TOU Test or die.</div>
+					{{/rollTotal() roll 8}}
+					{{#rollTotal() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies.</div>
+					{{/rollTotal() roll 9}}
+					{{#rollGreater() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies, drowning out conversation within 2d10 meters for the rest of the Round.</div>
+					{{/rollGreater() roll 9}}
+				  {{/crunch}}
+			  {{/rollTotal() type 2}}
+			  <!-- target is person's Leg, Rending damage -->
+			  {{#rollTotal() type 3}}
+				<div class="sheet-template-row template-center">Rending critcal to Leg.</div>
+				<div class="sheet-template-row template-center">Severity: {{roll}}</div>
+				  {{#crunch}}
+					{{#rollTotal() roll 1}}
+					  <div class="sheet-template-row template-center">Target takes 1 Fatigue.</div>
+					{{/rollTotal() roll 1}}
+					{{#rollTotal() roll 2}}
+					  <div class="sheet-template-row template-center">Target takes a +0 AGI Test or falls Prone and gains Blood Loss.</div>
+					{{/rollTotal() roll 2}}
+					{{#rollTotal() roll 3}}
+					  <div class="sheet-template-row template-center">Target takes 1d5 AGI damage, gains Blood Loss.</div>
+					{{/rollTotal() roll 3}}
+					{{#rollTotal() roll 4}}
+					  <div class="sheet-template-row template-center">Target knocked Prone, takes 1d10 AGI damage, movement reduced by half until receiving medical treatment.</div>
+					{{/rollTotal() roll 4}}
+					{{#rollTotal() roll 5}}
+					  <div class="sheet-template-row template-center">Target gains Blood Loss, +0 TOU Test or take 1 permanent AGI damage.</div>
+					{{/rollTotal() roll 5}}
+					{{#rollTotal() roll 6}}
+					  <div class="sheet-template-row template-center">Target gains Blood Loss, +0 TOU Test or lose the foot. On success, movement reduced by half until receiving medical treatment.</div>
+					{{/rollTotal() roll 6}}
+					{{#rollTotal() roll 7}}
+					  <div class="sheet-template-row template-center">Target gains Blood Loss, is Stunned for 1 Round, knocked Prone, counts as not having the leg until receiving medical treatment.</div>
+					{{/rollTotal() roll 7}}
+					{{#rollTotal() roll 8}}
+					  <div class="sheet-template-row template-center">Target loses the leg. +0 TOU Test or die. On success, target is Stunned for 1d10 Rounds and gains Blood Loss.</div>
+					{{/rollTotal() roll 8}}
+					{{#rollTotal() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies.</div>
+					{{/rollTotal() roll 9}}
+					{{#rollGreater() roll 9}}
+					  <div class="sheet-template-row template-center">Target dies. Anyone making a Run or Charge within 6 meters of the target makes a +0 AGI Test or falls Prone.</div>
+					{{/rollGreater() roll 9}}
+				  {{/crunch}}
+			  {{/rollTotal() type 3}}
+			{{/rollTotal() location 3}}
+		  {{/rollTotal() target 0}}
+		  <!-- target is vehicle -->
+		  {{#rollTotal() target 1}}
+			<!-- target is vehicle's Weapon -->
+			{{#rollTotal() location 0}}
+			  <div class="sheet-template-row template-center">Weapon critical.</div>
+				<div class="sheet-template-row template-center">Severity: {{roll}}</div>
+				  {{#crunch}}
+					{{#rollTotal() roll 1}}
+					  <div class="sheet-template-row template-center">Gunner is Stunned for 1 Round.</div>
+					{{/rollTotal() roll 1}}
+					{{#rollTotal() roll 2}}
+					  <div class="sheet-template-row template-center">Weapon jams, jam can be cleared conventionally.</div>
+					{{/rollTotal() roll 2}}
+					{{#rollTotal() roll 3}}
+					  <div class="sheet-template-row template-center">Shots made on this weapon take a -10 for 1d5 Rounds.</div>
+					{{/rollTotal() roll 3}}
+					{{#rollTotal() roll 4}}
+					  <div class="sheet-template-row template-center">Weapon Locked (p286). Weapon can only fire in whatever direction it was used last. If Fixed Weapon, Weapon Disabled (p286) until repaired.</div>
+					{{/rollTotal() roll 4}}
+					{{#rollTotal() roll 5}}
+					  <div class="sheet-template-row template-center">Weapon Disabled (p286) until repaired.</div>
+					{{/rollTotal() roll 5}}
+					{{#rollTotal() roll 6}}
+					  <div class="sheet-template-row template-center">Weapon Targeting Systems Destroyed (p285).</div>
+					{{/rollTotal() roll 6}}
+					{{#rollTotal() roll 7}}
+					  <div class="sheet-template-row template-center">Using the weapon now carries a 30% chance to cook off all ammunition. In this event, roll half the weapon damage against vehicle and gunners, Weapon Destroyed (p286).</div>
+					{{/rollTotal() roll 7}}
+					{{#rollTotal() roll 8}}
+					  <div class="sheet-template-row template-center">Weapon removed from housing. Gunner has a 20% chance of taking 1/4 the damage of the shot that caused this RF.</div>
+					{{/rollTotal() roll 8}}
+					{{#rollTotal() roll 9}}
+					  <div class="sheet-template-row template-center">All crew takes 1d10+6 Explosive damage to Body, take 1 Fatigue, +0 AGI Test or catch fire (p284). Victims can attempt to put out the fire (p266).</div>
+					{{/rollTotal() roll 9}}
+					{{#rollGreater() roll 9}}
+					  <div class="sheet-template-row template-center">That's too much text, go to p276.</div>
+					{{/rollGreater() roll 9}}
+				  {{/crunch}}
+			{{/rollTotal() location 0}}
+			<!-- target is vehicle's Motive Systems -->
+			{{#rollTotal() location 1}}
+			  <div class="sheet-template-row template-center">Motive Systems critical.</div>
+				<div class="sheet-template-row template-center">Severity: {{roll}}</div>
+				  {{#crunch}}
+					{{#rollTotal() roll 1}}
+					  <div class="sheet-template-row template-center">Driver takes +0 Operate Test. On fail, roll Scatter to change vehicle facing, driver takes 1 Fatigue.</div>
+					{{/rollTotal() roll 1}}
+					{{#rollTotal() roll 2}}
+					  <div class="sheet-template-row template-center">Vehicle may only move up to Tactical Speed next Turn.</div>
+					{{/rollTotal() roll 2}}
+					{{#rollTotal() roll 3}}
+					  <div class="sheet-template-row template-center">Motive Systems Impaired (p284).</div>
+					{{/rollTotal() roll 3}}
+					{{#rollTotal() roll 4}}
+					  <div class="sheet-template-row template-center">-10 Operate Test to move the vehicle faster than Tactical Speed. On fail, no movement. Skimmers would crash.</div>
+					{{/rollTotal() roll 4}}
+					{{#rollTotal() roll 5}}
+					  <div class="sheet-template-row template-center">That's too much text, go to p277.</div>
+					{{/rollTotal() roll 5}}
+					{{#rollTotal() roll 6}}
+					  <div class="sheet-template-row template-center">That's too much text, go to p277.</div>
+					{{/rollTotal() roll 6}}
+					{{#rollTotal() roll 7}}
+					  <div class="sheet-template-row template-center">That's too much text, go to p277.</div>
+					{{/rollTotal() roll 7}}
+					{{#rollTotal() roll 8}}
+					  <div class="sheet-template-row template-center">Motive Systems Destroyed (p285). Skimmers crash.</div>
+					{{/rollTotal() roll 8}}
+					{{#rollTotal() roll 9}}
+					  <div class="sheet-template-row template-center">Motive Systems Destroyed (p285), Skimmers crash, vehicle catches fire (p284).</div>
+					{{/rollTotal() roll 9}}
+					{{#rollGreater() roll 9}}
+					  <div class="sheet-template-row template-center">That's too much text, go to p277.</div>
+					{{/rollGreater() roll 9}}
+				  {{/crunch}}
+			{{/rollTotal() location 1}}
+			<!-- target is vehicle's Turret -->
+			{{#rollTotal() location 2}}
+			  <div class="sheet-template-row template-center">Turret critical.</div>
+				<div class="sheet-template-row template-center">Severity: {{roll}}</div>
+				  {{#crunch}}
+					{{#rollTotal() roll 1}}
+					  <div class="sheet-template-row template-center">Anyone in the Turret is Stunned for 1 Round.</div>
+					{{/rollTotal() roll 1}}
+					{{#rollTotal() roll 2}}
+					  <div class="sheet-template-row template-center">Turret weapon jammed.</div>
+					{{/rollTotal() roll 2}}
+					{{#rollTotal() roll 3}}
+					  <div class="sheet-template-row template-center">Shots from the turret weapon take a -10 for 1d5 Rounds.</div>
+					{{/rollTotal() roll 3}}
+					{{#rollTotal() roll 4}}
+					  <div class="sheet-template-row template-center">Turret Locked (p286). Gun can only fire in the direction it fired last. Pintles OK.</div>
+					{{/rollTotal() roll 4}}
+					{{#rollTotal() roll 5}}
+					  <div class="sheet-template-row template-center">That's too much text, go to p278.</div>
+					{{/rollTotal() roll 5}}
+					{{#rollTotal() roll 6}}
+					  <div class="sheet-template-row template-center">All weapons within the turret gain Targeting Systems Destroyed (p285).</div>
+					{{/rollTotal() roll 6}}
+					{{#rollTotal() roll 7}}
+					  <div class="sheet-template-row template-center">That's too much text, go to p278.</div>
+					{{/rollTotal() roll 7}}
+					{{#rollTotal() roll 8}}
+					  <div class="sheet-template-row template-center">All weapons on the turret gains Weapon Destroyed (p286). Turret Locked. Turret catches fire (p284).</div>
+					{{/rollTotal() roll 8}}
+					{{#rollTotal() roll 9}}
+					  <div class="sheet-template-row template-center">All weapons on the turret gains Weapon Destroyed (p286). Turret Locked. Turret catches fire (p284). All Crew +0 AGI Test or catch fire. Victims can put themselves out (p266).</div>
+					{{/rollTotal() roll 9}}
+					{{#rollGreater() roll 9}}
+					  <div class="sheet-template-row template-center">That's too much text, go to p278.</div>
+					{{/rollGreater() roll 9}}
+				  {{/crunch}}
+			{{/rollTotal() location 2}}
+			<!-- target is vehicle's Hull -->
+			{{#rollTotal() location 3}}
+			  <div class="sheet-template-row template-center">Hull critical.</div>
+				<div class="sheet-template-row template-center">Severity: {{roll}}</div>
+				  {{#crunch}}
+					{{#rollTotal() roll 1}}
+					  <div class="sheet-template-row template-center">Unbuckled crew take a +10 TOU Test or be Stunned for 1 Round.</div>
+					{{/rollTotal() roll 1}}
+					{{#rollTotal() roll 2}}
+					  <div class="sheet-template-row template-center">All crew takes -20 to do anything until someone takes a Full Action to close a gas leak.</div>
+					{{/rollTotal() roll 2}}
+					{{#rollTotal() roll 3}}
+					  <div class="sheet-template-row template-center">Unbuckled crew take a +10 TOU Test or be Stunned for 1 Round. All shooting from the vehicle takes a -10 for 1 Round.</div>
+					{{/rollTotal() roll 3}}
+					{{#rollTotal() roll 4}}
+					  <div class="sheet-template-row template-center">Random crewmember takes 1d10+6 Impact damage to Body, takes 1 Fatigue.</div>
+					{{/rollTotal() roll 4}}
+					{{#rollTotal() roll 5}}
+					  <div class="sheet-template-row template-center">Hit vehicle facing reduces AP by 1d10.</div>
+					{{/rollTotal() roll 5}}
+					{{#rollTotal() roll 6}}
+					  <div class="sheet-template-row template-center">That's too much text, go to p279.</div>
+					{{/rollTotal() roll 6}}
+					{{#rollTotal() roll 7}}
+					  <div class="sheet-template-row template-center">Hit vehicle facing reduces AP by half. If it was a ranged hit, each crewmember has a 20% chance to take 1/4 the damage, vehicle now Open Topped.</div>
+					{{/rollTotal() roll 7}}
+					{{#rollTotal() roll 8}}
+					  <div class="sheet-template-row template-center">Hit vehicle facing reduces AP by half. If it was a ranged hit, each crewmember has a 20% chance to take 1/4 the damage, vehicle now Open Topped. Vehicle catches fire (p284).</div>
+					{{/rollTotal() roll 8}}
+					{{#rollTotal() roll 9}}
+					  <div class="sheet-template-row template-center">Vehicle Destroyed (p285). Each weapon has 50% chance for Weapon Destroyed. Everyone takes 1d10+6 Explosive damage, -10 TOU Test or be Stunned for 1d10 Rounds. Skimmers crash.</div>
+					{{/rollTotal() roll 9}}
+					{{#rollGreater() roll 9}}
+					  <div class="sheet-template-row template-center">That's too much text, go to p279.</div>
+					{{/rollGreater() roll 9}}
+				  {{/crunch}}
+			{{/rollTotal() location 3}}
+		  {{/rollTotal() target 1}}
+        </div>
+		{{/righteousfury}}
 
 
 
@@ -2346,7 +3156,7 @@
 		
 		
 		{{#shock}}
-        <div class="sheet-template-header">{{character}} experiences Shock</div>
+        <div class="sheet-template-header">{{character}} experiences Shock (p304)</div>
         <div class="sheet-template-content">
           <div class="sheet-template-row template-center">Severity: {{shock}}</div>
           {{#rollBetween() shock 1 20}}

--- a/Only-War-Enhanced/sheet.json
+++ b/Only-War-Enhanced/sheet.json
@@ -30,6 +30,17 @@
 			"description": "Select the Auto Hit Location setting to use on the character sheet."
 		},
 		{
+			"attribute": "settings_crunchsummary",
+			"displayname": "Crunch Summary in Righteous Fury",
+			"type": "select",
+			"options": [
+				"Include Crunch Summary|crunch",
+				"Exclude Crunch Summary| "
+			],
+			"default": " ",
+			"description": "Includes a summary of the gameplay-related information for Righteous Fury rolls."
+		},
+		{
 			"attribute": "settings_weapondescription",
 			"displayname": "Weapon Special in Damage Roll",
 			"type": "select",


### PR DESCRIPTION
## Changes / Comments

Added Righteous Fury roller, tables.
added an option to toggle a crunch summary for Righteous Fury rolls
Edited Crit and Fumble thresholds to show when Psychic Power rolls fail or cause Psychic Phenomena
Re-ordered the Psychic Abilities block to look better
Re-ordered the Melee Weapon block to look better
Re-ordered the Ranged Weapons block to streamline function, make room for new Mishap Chance
Added dropdown for Mishap Chance for ranged weapons. Added "spray?" checkbox to add a Fumble on a "9" when rolling damage.



## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
No, this is a feature update.
- [x] Does this add functional enhancements (new features or extending existing features) ?
Added Righteous Fury roller, added Mishap Chance dropdown menu for ranged weapons. 
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
Updates to the statisic blocks for Ranged Weapons, Melee Weapons, and Psychic Focus Power Tests
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
No changes or deletions for attr_ names here
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
