### PR TITLE
[D6 Adventure] Updated Toggle Labels, tweaked dice mod toggle option

### DIFF
--- a/D6_Adventure/D6AdventureSheet.html
+++ b/D6_Adventure/D6AdventureSheet.html
@@ -27,15 +27,15 @@
           <input type="hidden" class="toggleflag" name="attr_wtype"><label>Announce Rolls To</label>
           
           <div class="advantagetoggle whispertoggle">
-              <input type="radio" class="toggle-left" name="attr_whispertoggle" value="" checked="checked"><span data-i18n="Publique">PUBLIC</span>
-              <input type="radio" class="toggle-right" name="attr_whispertoggle" value="/w gm "><span data-i18n="GM seulement">TO <span class="togm">GM</span></span>
+              <input type="radio" class="toggle-left" name="attr_whispertoggle" value="" checked="checked"><span data-i18n="Public">PUBLIC</span>
+              <input type="radio" class="toggle-right" name="attr_whispertoggle" value="/w gm "><span data-i18n="GM Only">GM ONLY<span class="togm"></span></span>
           </div>
           </td>
           <td>
           <div class="advantagetoggle modstoggle">
               <label>Dice Mods</label>
           <input type="radio" class="toggle-left" name="attr_modstoggle" value="+ ?{Dice mods|0}d6 + ?{Other Mods(pip)|0}" checked="checked"><span data-i18n="Yes">YES</span>
-              <input type="radio" class="toggle-right" name="attr_modstoggle" value=""><span data-i18n="No"><span class="No">NO</span></span>
+              <input type="radio" class="toggle-right" name="attr_modstoggle" value="+ 0"><span data-i18n="No"><span class="No">NO</span></span>
           </div>
           </td></tr>
          </tbody>


### PR DESCRIPTION
## Changes / Comments
Updated the labels on the radio button toggles for ease of reading.
Modified the dice mod toggle to have a better off usage.





## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [X ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
