### PR TITLE
[Pathfinder Community] [Pathfinder 2 Playtest by Roll20] Revert "Strike Rank" to "SR"

### DIFF
--- a/Pathfinder 2 Playtest by Roll20/translations/af.json
+++ b/Pathfinder 2 Playtest by Roll20/translations/af.json
@@ -266,7 +266,7 @@
 	"defensive-abilities": "DEFENSIVE ABILITIES",
 	"dr": "DR",
 	"immunities": "IMMUNITIES",
-	"sr": "Strike Rank",
+	"sr": "SR",
 	"resistances": "RESISTANCES",
 	"weaknesses": "WEAKNESSES",
 	"offense": "OFFENSE",

--- a/Pathfinder 2 Playtest by Roll20/translations/cs.json
+++ b/Pathfinder 2 Playtest by Roll20/translations/cs.json
@@ -266,7 +266,7 @@
 	"defensive-abilities": "DEFENSIVE ABILITIES",
 	"dr": "DR",
 	"immunities": "IMMUNITIES",
-	"sr": "Strike Rank",
+	"sr": "SR",
 	"resistances": "RESISTANCES",
 	"weaknesses": "WEAKNESSES",
 	"offense": "OFFENSE",

--- a/Pathfinder 2 Playtest by Roll20/translations/da.json
+++ b/Pathfinder 2 Playtest by Roll20/translations/da.json
@@ -266,7 +266,7 @@
 	"defensive-abilities": "DEFENSIVE ABILITIES",
 	"dr": "DR",
 	"immunities": "IMMUNITIES",
-	"sr": "Strike Rank",
+	"sr": "SR",
 	"resistances": "RESISTANCES",
 	"weaknesses": "WEAKNESSES",
 	"offense": "OFFENSE",

--- a/Pathfinder 2 Playtest by Roll20/translations/el.json
+++ b/Pathfinder 2 Playtest by Roll20/translations/el.json
@@ -266,7 +266,7 @@
 	"defensive-abilities": "DEFENSIVE ABILITIES",
 	"dr": "DR",
 	"immunities": "IMMUNITIES",
-	"sr": "Strike Rank",
+	"sr": "SR",
 	"resistances": "RESISTANCES",
 	"weaknesses": "WEAKNESSES",
 	"offense": "OFFENSE",

--- a/Pathfinder 2 Playtest by Roll20/translations/en.json
+++ b/Pathfinder 2 Playtest by Roll20/translations/en.json
@@ -266,7 +266,7 @@
 	"defensive-abilities": "DEFENSIVE ABILITIES",
 	"dr": "DR",
 	"immunities": "IMMUNITIES",
-	"sr": "Strike Rank",
+	"sr": "SR",
 	"resistances": "RESISTANCES",
 	"weaknesses": "WEAKNESSES",
 	"offense": "OFFENSE",

--- a/Pathfinder 2 Playtest by Roll20/translations/es.json
+++ b/Pathfinder 2 Playtest by Roll20/translations/es.json
@@ -266,7 +266,7 @@
 	"defensive-abilities": "DEFENSIVE ABILITIES",
 	"dr": "RE",
 	"immunities": "IMMUNITIES",
-	"sr": "Strike Rank",
+	"sr": "SR",
 	"resistances": "RESISTANCES",
 	"weaknesses": "WEAKNESSES",
 	"offense": "OFFENSE",

--- a/Pathfinder 2 Playtest by Roll20/translations/he.json
+++ b/Pathfinder 2 Playtest by Roll20/translations/he.json
@@ -266,7 +266,7 @@
 	"defensive-abilities": "DEFENSIVE ABILITIES",
 	"dr": "DR",
 	"immunities": "IMMUNITIES",
-	"sr": "Strike Rank",
+	"sr": "SR",
 	"resistances": "RESISTANCES",
 	"weaknesses": "WEAKNESSES",
 	"offense": "OFFENSE",

--- a/Pathfinder 2 Playtest by Roll20/translations/it.json
+++ b/Pathfinder 2 Playtest by Roll20/translations/it.json
@@ -266,7 +266,7 @@
 	"defensive-abilities": "DEFENSIVE ABILITIES",
 	"dr": "DR",
 	"immunities": "IMMUNITIES",
-	"sr": "Strike Rank",
+	"sr": "SR",
 	"resistances": "RESISTANCES",
 	"weaknesses": "WEAKNESSES",
 	"offense": "OFFENSE",

--- a/Pathfinder 2 Playtest by Roll20/translations/ja.json
+++ b/Pathfinder 2 Playtest by Roll20/translations/ja.json
@@ -266,7 +266,7 @@
 	"defensive-abilities": "DEFENSIVE ABILITIES",
 	"dr": "DR",
 	"immunities": "IMMUNITIES",
-	"sr": "Strike Rank",
+	"sr": "SR",
 	"resistances": "RESISTANCES",
 	"weaknesses": "WEAKNESSES",
 	"offense": "OFFENSE",

--- a/Pathfinder 2 Playtest by Roll20/translations/ko.json
+++ b/Pathfinder 2 Playtest by Roll20/translations/ko.json
@@ -266,7 +266,7 @@
 	"defensive-abilities": "DEFENSIVE ABILITIES",
 	"dr": "DR",
 	"immunities": "IMMUNITIES",
-	"sr": "Strike Rank",
+	"sr": "SR",
 	"resistances": "RESISTANCES",
 	"weaknesses": "WEAKNESSES",
 	"offense": "OFFENSE",

--- a/Pathfinder 2 Playtest by Roll20/translations/nl.json
+++ b/Pathfinder 2 Playtest by Roll20/translations/nl.json
@@ -266,7 +266,7 @@
 	"defensive-abilities": "DEFENSIVE ABILITIES",
 	"dr": "DR",
 	"immunities": "IMMUNITIES",
-	"sr": "Strike Rank",
+	"sr": "SR",
 	"resistances": "RESISTANCES",
 	"weaknesses": "WEAKNESSES",
 	"offense": "OFFENSE",

--- a/Pathfinder 2 Playtest by Roll20/translations/pt.json
+++ b/Pathfinder 2 Playtest by Roll20/translations/pt.json
@@ -266,7 +266,7 @@
 	"defensive-abilities": "DEFENSIVE ABILITIES",
 	"dr": "RD",
 	"immunities": "IMMUNITIES",
-	"sr": "Strike Rank",
+	"sr": "SR",
 	"resistances": "RESISTANCES",
 	"weaknesses": "WEAKNESSES",
 	"offense": "OFFENSE",

--- a/Pathfinder 2 Playtest by Roll20/translations/ru.json
+++ b/Pathfinder 2 Playtest by Roll20/translations/ru.json
@@ -266,7 +266,7 @@
 	"defensive-abilities": "DEFENSIVE ABILITIES",
 	"dr": "DR",
 	"immunities": "IMMUNITIES",
-	"sr": "Strike Rank",
+	"sr": "SR",
 	"resistances": "RESISTANCES",
 	"weaknesses": "WEAKNESSES",
 	"offense": "OFFENSE",

--- a/Pathfinder 2 Playtest by Roll20/translations/sv.json
+++ b/Pathfinder 2 Playtest by Roll20/translations/sv.json
@@ -266,7 +266,7 @@
 	"defensive-abilities": "DEFENSIVE ABILITIES",
 	"dr": "DR",
 	"immunities": "IMMUNITIES",
-	"sr": "Strike Rank",
+	"sr": "SR",
 	"resistances": "RESISTANCES",
 	"weaknesses": "WEAKNESSES",
 	"offense": "OFFENSE",

--- a/Pathfinder 2 Playtest by Roll20/translations/tr.json
+++ b/Pathfinder 2 Playtest by Roll20/translations/tr.json
@@ -266,7 +266,7 @@
 	"defensive-abilities": "DEFENSIVE ABILITIES",
 	"dr": "DR",
 	"immunities": "IMMUNITIES",
-	"sr": "Strike Rank",
+	"sr": "SR",
 	"resistances": "RESISTANCES",
 	"weaknesses": "WEAKNESSES",
 	"offense": "OFFENSE",

--- a/Pathfinder 2 Playtest by Roll20/translations/zh.json
+++ b/Pathfinder 2 Playtest by Roll20/translations/zh.json
@@ -266,7 +266,7 @@
 	"defensive-abilities": "防禦能力",
 	"dr": "DR",
 	"immunities": "免疫",
-	"sr": "Strike Rank",
+	"sr": "SR",
 	"resistances": "抗力",
 	"weaknesses": "弱點",
 	"offense": "攻擊",

--- a/Pathfinder Community/translations/af.json
+++ b/Pathfinder Community/translations/af.json
@@ -1870,7 +1870,7 @@
 	"spell-range": "Range",
 	"spell-resist-bonus-abbrv": "SR Bonus",
 	"spell-resistance": "Spell Resistance",
-	"spell-resistance-abbrv": "Strike Rank",
+	"spell-resistance-abbrv": "SR",
 	"spell-resistance-abbrv2": "Spell Resist",
 	"spell-resistance-title": "Spell Resistance: Avoids the effects of spells and spell-like abilities that directly affect it. Caster Level check vs SR to negate resistance.",
 	"spell-roll-options": "Spell Roll Options",

--- a/Pathfinder Community/translations/cs.json
+++ b/Pathfinder Community/translations/cs.json
@@ -1870,7 +1870,7 @@
 	"spell-range": "Range",
 	"spell-resist-bonus-abbrv": "SR Bonus",
 	"spell-resistance": "Spell Resistance",
-	"spell-resistance-abbrv": "Strike Rank",
+	"spell-resistance-abbrv": "SR",
 	"spell-resistance-abbrv2": "Spell Resist",
 	"spell-resistance-title": "Spell Resistance: Avoids the effects of spells and spell-like abilities that directly affect it. Caster Level check vs SR to negate resistance.",
 	"spell-roll-options": "Spell Roll Options",

--- a/Pathfinder Community/translations/da.json
+++ b/Pathfinder Community/translations/da.json
@@ -1870,7 +1870,7 @@
 	"spell-range": "Range",
 	"spell-resist-bonus-abbrv": "SR Bonus",
 	"spell-resistance": "Spell Resistance",
-	"spell-resistance-abbrv": "Strike Rank",
+	"spell-resistance-abbrv": "SR",
 	"spell-resistance-abbrv2": "Spell Resist",
 	"spell-resistance-title": "Spell Resistance: Avoids the effects of spells and spell-like abilities that directly affect it. Caster Level check vs SR to negate resistance.",
 	"spell-roll-options": "Spell Roll Options",

--- a/Pathfinder Community/translations/de.json
+++ b/Pathfinder Community/translations/de.json
@@ -1870,7 +1870,7 @@
 	"spell-range": "Range",
 	"spell-resist-bonus-abbrv": "SR Bonus",
 	"spell-resistance": "Zauberresistenz",
-	"spell-resistance-abbrv": "Strike Rank",
+	"spell-resistance-abbrv": "SR",
 	"spell-resistance-abbrv2": "Spell Resist",
 	"spell-resistance-title": "Spell Resistance: Avoids the effects of spells and spell-like abilities that directly affect it. Caster Level check vs SR to negate resistance.",
 	"spell-roll-options": "Spell Roll Options",

--- a/Pathfinder Community/translations/el.json
+++ b/Pathfinder Community/translations/el.json
@@ -1870,7 +1870,7 @@
 	"spell-range": "Range",
 	"spell-resist-bonus-abbrv": "SR Bonus",
 	"spell-resistance": "Spell Resistance",
-	"spell-resistance-abbrv": "Strike Rank",
+	"spell-resistance-abbrv": "SR",
 	"spell-resistance-abbrv2": "Spell Resist",
 	"spell-resistance-title": "Spell Resistance: Avoids the effects of spells and spell-like abilities that directly affect it. Caster Level check vs SR to negate resistance.",
 	"spell-roll-options": "Spell Roll Options",

--- a/Pathfinder Community/translations/en.json
+++ b/Pathfinder Community/translations/en.json
@@ -1870,7 +1870,7 @@
 	"spell-range": "Range",
 	"spell-resist-bonus-abbrv": "SR Bonus",
 	"spell-resistance": "Spell Resistance",
-	"spell-resistance-abbrv": "Strike Rank",
+	"spell-resistance-abbrv": "SR",
 	"spell-resistance-abbrv2": "Spell Resist",
 	"spell-resistance-title": "Spell Resistance: Avoids the effects of spells and spell-like abilities that directly affect it. Caster Level check vs SR to negate resistance.",
 	"spell-roll-options": "Spell Roll Options",

--- a/Pathfinder Community/translations/es.json
+++ b/Pathfinder Community/translations/es.json
@@ -1870,7 +1870,7 @@
 	"spell-range": "Range",
 	"spell-resist-bonus-abbrv": "SR Bonus",
 	"spell-resistance": "Spell Resistance",
-	"spell-resistance-abbrv": "Strike Rank",
+	"spell-resistance-abbrv": "SR",
 	"spell-resistance-abbrv2": "Resistencia a conjuros",
 	"spell-resistance-title": "Spell Resistance: Avoids the effects of spells and spell-like abilities that directly affect it. Caster Level check vs SR to negate resistance.",
 	"spell-roll-options": "Spell Roll Options",

--- a/Pathfinder Community/translations/he.json
+++ b/Pathfinder Community/translations/he.json
@@ -1870,7 +1870,7 @@
 	"spell-range": "Range",
 	"spell-resist-bonus-abbrv": "SR Bonus",
 	"spell-resistance": "Spell Resistance",
-	"spell-resistance-abbrv": "Strike Rank",
+	"spell-resistance-abbrv": "SR",
 	"spell-resistance-abbrv2": "Spell Resist",
 	"spell-resistance-title": "Spell Resistance: Avoids the effects of spells and spell-like abilities that directly affect it. Caster Level check vs SR to negate resistance.",
 	"spell-roll-options": "Spell Roll Options",

--- a/Pathfinder Community/translations/ja.json
+++ b/Pathfinder Community/translations/ja.json
@@ -1870,7 +1870,7 @@
 	"spell-range": "Range",
 	"spell-resist-bonus-abbrv": "SR Bonus",
 	"spell-resistance": "Spell Resistance",
-	"spell-resistance-abbrv": "Strike Rank",
+	"spell-resistance-abbrv": "SR",
 	"spell-resistance-abbrv2": "Spell Resist",
 	"spell-resistance-title": "Spell Resistance: Avoids the effects of spells and spell-like abilities that directly affect it. Caster Level check vs SR to negate resistance.",
 	"spell-roll-options": "Spell Roll Options",

--- a/Pathfinder Community/translations/ko.json
+++ b/Pathfinder Community/translations/ko.json
@@ -1870,7 +1870,7 @@
 	"spell-range": "Range",
 	"spell-resist-bonus-abbrv": "SR Bonus",
 	"spell-resistance": "Spell Resistance",
-	"spell-resistance-abbrv": "Strike Rank",
+	"spell-resistance-abbrv": "SR",
 	"spell-resistance-abbrv2": "Spell Resist",
 	"spell-resistance-title": "Spell Resistance: Avoids the effects of spells and spell-like abilities that directly affect it. Caster Level check vs SR to negate resistance.",
 	"spell-roll-options": "Spell Roll Options",

--- a/Pathfinder Community/translations/nl.json
+++ b/Pathfinder Community/translations/nl.json
@@ -1870,7 +1870,7 @@
 	"spell-range": "Range",
 	"spell-resist-bonus-abbrv": "SR Bonus",
 	"spell-resistance": "Spell Resistance",
-	"spell-resistance-abbrv": "Strike Rank",
+	"spell-resistance-abbrv": "SR",
 	"spell-resistance-abbrv2": "Spell Resist",
 	"spell-resistance-title": "Spell Resistance: Avoids the effects of spells and spell-like abilities that directly affect it. Caster Level check vs SR to negate resistance.",
 	"spell-roll-options": "Spell Roll Options",

--- a/Pathfinder Community/translations/pt.json
+++ b/Pathfinder Community/translations/pt.json
@@ -1870,7 +1870,7 @@
 	"spell-range": "Range",
 	"spell-resist-bonus-abbrv": "SR Bonus",
 	"spell-resistance": "Resistência a Magia",
-	"spell-resistance-abbrv": "Strike Rank",
+	"spell-resistance-abbrv": "SR",
 	"spell-resistance-abbrv2": "Resistência a Magia",
 	"spell-resistance-title": "Spell Resistance: Avoids the effects of spells and spell-like abilities that directly affect it. Caster Level check vs SR to negate resistance.",
 	"spell-roll-options": "Spell Roll Options",

--- a/Pathfinder Community/translations/ru.json
+++ b/Pathfinder Community/translations/ru.json
@@ -1870,7 +1870,7 @@
 	"spell-range": "Range",
 	"spell-resist-bonus-abbrv": "SR Bonus",
 	"spell-resistance": "Spell Resistance",
-	"spell-resistance-abbrv": "Strike Rank",
+	"spell-resistance-abbrv": "SR",
 	"spell-resistance-abbrv2": "Spell Resist",
 	"spell-resistance-title": "Spell Resistance: Avoids the effects of spells and spell-like abilities that directly affect it. Caster Level check vs SR to negate resistance.",
 	"spell-roll-options": "Spell Roll Options",

--- a/Pathfinder Community/translations/sv.json
+++ b/Pathfinder Community/translations/sv.json
@@ -1870,7 +1870,7 @@
 	"spell-range": "Range",
 	"spell-resist-bonus-abbrv": "SR Bonus",
 	"spell-resistance": "Spell Resistance",
-	"spell-resistance-abbrv": "Strike Rank",
+	"spell-resistance-abbrv": "SR",
 	"spell-resistance-abbrv2": "Spell Resist",
 	"spell-resistance-title": "Spell Resistance: Avoids the effects of spells and spell-like abilities that directly affect it. Caster Level check vs SR to negate resistance.",
 	"spell-roll-options": "Spell Roll Options",

--- a/Pathfinder Community/translations/tr.json
+++ b/Pathfinder Community/translations/tr.json
@@ -1870,7 +1870,7 @@
 	"spell-range": "Range",
 	"spell-resist-bonus-abbrv": "SR Bonus",
 	"spell-resistance": "Spell Resistance",
-	"spell-resistance-abbrv": "Strike Rank",
+	"spell-resistance-abbrv": "SR",
 	"spell-resistance-abbrv2": "Spell Resist",
 	"spell-resistance-title": "Spell Resistance: Avoids the effects of spells and spell-like abilities that directly affect it. Caster Level check vs SR to negate resistance.",
 	"spell-roll-options": "Spell Roll Options",


### PR DESCRIPTION
# Changes / Comments

Several instances of "SR" were incorrectly replaced with "Strike Rank." This is especially bad in Pathfinder first edition, which doesn't even have the concept of a "strike rank," which has led to [some confusion](https://app.roll20.net/forum/post/9015166/pathfinder-1e-sheet-spell-resistance-now-reading-as-strike-rank).

Some instances of "Strike Rank" are correct, and I've left those alone.

Specifically: 
- For the Pathfinder Community sheet, I reverted to "SR" because the field is intended to be an abbreviation.
- For the Pathfinder 2 Playtest sheet, I reverted to "SR" to match the length and style of similar fields.