### PR TITLE
[Twilight 2000 2.2] css tweak and sheet improvments

### DIFF
--- a/Twilight-2000-v2.2/Twilight2000.css
+++ b/Twilight-2000-v2.2/Twilight2000.css
@@ -5,7 +5,10 @@ text
 	color: #222222;
 }
 
-
+.sheet-hc{
+	width:51px;
+	text-align:center
+}
 
 .sheet-weapon_name{
 	width: 100px;
@@ -669,9 +672,11 @@ button[type="roll"].sheet-plain::before
     border-top: none;
     border-right: none;
 	border-left: none;
-	border-bottom: dotted 1px black;
+	border-bottom: solid 1px black;
     color: black;
+	border-radius: 0;
 }
+
 
 
 

--- a/Twilight-2000-v2.2/Twilight2000.html
+++ b/Twilight-2000-v2.2/Twilight2000.html
@@ -354,7 +354,7 @@
 		<thead>
 			<tr>
 				<th colspan="8"></th>
-				<th style="border-bottom: 1px solid black" colspan="3">Mag.</th>
+				<th style="border-bottom: 1px solid black" colspan="4">Mag.</th>
 				<th style="border-bottom: 1px solid black"  colspan="2">Recoil</th>
 				<th></th>
 				<th></th>

--- a/Twilight-2000-v2.2/Twilight2000.html
+++ b/Twilight-2000-v2.2/Twilight2000.html
@@ -1,30 +1,31 @@
 <p>
+	<input value="0" name="attr_fix1Done" type="hidden">
 	<div style="width: 100%">
 		<h3 style="margin-bottom: 10px;text-align:center;font-size: 3em">Character Record Sheet</h3>		
 	</div>
 	<div class='sheet-3colrow'>
 		<div style="margin-right:15px" class='sheet-col sheet-details'>
 			<table style="width: 100%">
-				<tr><td><p>Player</p></td><td><input type="text" name="attr_Player"/></td></tr>
-				<tr><td><p>Character</p></td><td><input type="text" name="attr_Name"/></td></tr>
-				<tr><td><p>Nationality</p></td><td><input type="text" name="attr_Nationality"/></td></tr>
-				<tr><td><p>Gender</p></td><td><input type="text" name="attr_Gender"/></td></tr>
+				<tr><td><p>Player</p></td><td><input type="text" class="standard" name="attr_Player"/></td></tr>
+				<tr><td><p>Character</p></td><td><input  class="standard" type="text" name="attr_Name"/></td></tr>
+				<tr><td><p>Nationality</p></td><td><input  class="standard" type="text" name="attr_Nationality"/></td></tr>
+				<tr><td><p>Gender</p></td><td><input type="text" class="standard"  name="attr_Gender"/></td></tr>
 			</table>
 		</div>
 		<div class='sheet-col sheet-details'>
 			<table style="width: 100%">
-				<tr><td><p>Age</p></td><td><input style="text-align: center" type="text" name="attr_Age"/></td></tr>
-				<tr><td><p>Service Branch</p></td><td><div><input style="text-align: center" type="text" name="attr_Service_Branch"/></td></tr>
-				<tr><td><p>Weight</p></td><td><input style="text-align: center" type="text" name="attr_Weight"/></td></tr>
-				<tr><td><p>Throw Range</p></td><td><input style="text-align: center" READONLY type="text" name="attr_Throw_Range"/></td></tr>
+				<tr><td><p>Age</p></td><td><input  class="standard"  style="text-align: center" type="text" name="attr_Age"/></td></tr>
+				<tr><td><p>Service Branch</p></td><td><div><input  class="standard" style="text-align: center" type="text" name="attr_Service_Branch"/></td></tr>
+				<tr><td><p>Weight</p></td><td><input  class="standard" style="text-align: center" type="text" name="attr_Weight"/></td></tr>
+				<tr><td><p>Throw Range</p></td><td><input  class="standard" style="text-align: center" READONLY type="text" name="attr_Throw_Range"/></td></tr>
 			</table>
 		</div>
 		<div class='sheet-col sheet-details'>
 			<table style="width: 100%">
 				<tr><td><p>Initiative</p></td><td><input style="text-align: center" type="text" name="attr_Initiative"/></td></tr>
-				<tr><td><p>Rank</p></td><td><input style="text-align: center" type="text" name="attr_Rank"/></td></tr>
-				<tr><td><p>Rads</p></td><td><input style="text-align: center" type="text" name="attr_Rads"/></td></tr>			
-				<tr><td><p>Load</p></td><td><input READONLY style="text-align: center" type="text" name="attr_Load"/></td></tr>						
+				<tr><td><p>Rank</p></td><td><input  class="standard" style="text-align: center" type="text" name="attr_Rank"/></td></tr>
+				<tr><td><p>Rads</p></td><td><input  class="standard" style="text-align: center" type="text" name="attr_Rads"/></td></tr>			
+				<tr><td><p>Load</p></td><td><input  class="standard" READONLY style="text-align: center" type="text" name="attr_Load"/></td></tr>						
 			</table>
 		</div>
 	</div>
@@ -200,7 +201,7 @@
 					<table style="width: 100%">
 						<tr>
 							<td>Initative</rd>
-							<td colspan="3"><input READONLY style="width: 55px" type="text" name="attr_Initiative" /><button type="roll" value="&{template:default} {{name=Initiatve}} {{roll=[[@{Initiative}]]}}" /></td>	
+							<td colspan="3"><input READONLY style="width: 55px" type="text" name="attr_Initiative" /><button type="roll" value="&{template:default} {{name=Initiatve}} {{roll=[[@{Initiative} &{tracker}]]}}" /></td>	
 						</tr>					
 						<tr>
 							<td></td><td></td>
@@ -221,12 +222,12 @@
 				</div>
 			</div>
 			<div style="margin-top: 5px">
-				<img src="https://i.imgur.com/AIV1SQ4.png" />
+				<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Twilight-2000-v2.2/twlogo.png" />
 			</div>
 
 		</div><!--Col1-->
 		<div style="padding: 5px; width:29%" class='sheet-col'>
-			<h3 style="text-align: center">Hit Capacity<button type="roll" value="value='&{template:Hit-Location} {{roll=[[1d10]]}}" /></h3>
+			<h3 style="text-align: center">Hit Capacity<button type="roll" name="roll_hitloc" value="value='&{template:Hit-Location} {{roll=[[1d10]]}}" /></h3>
 			<br />
 			<table style="width: 100%">
 				<thead>
@@ -248,10 +249,10 @@
 					</tr>
 					<tr>
 						<td><input type="number"  value="0" name="attr_head_curr" /></td>
-						<td><input READONLY type="number" name="attr_head_scratch" /></td>												
-						<td><input READONLY type="number" name="attr_head_slight" /></td>												
-						<td><input READONLY type="number" name="attr_head_serious" /></td>						
-						<td><input  READONLY type="number" name="attr_head_critical" /></td>
+						<td><input READONLY type="text" class="hc"  name="attr_head_scratch" /></td>												
+						<td><input READONLY type="text" class="hc" name="attr_head_slight" /></td>												
+						<td><input READONLY type="text" class="hc" name="attr_head_serious" /></td>						
+						<td><input  READONLY type="text" class="hc" name="attr_head_critical" /></td>
 					</tr>
 					<tr><td>Chest</td>
 						<td style="text-align: center"><input type="checkbox" name="attr__chest_scratch_chk"></td>
@@ -261,10 +262,10 @@
 					</tr>
 					<tr>
 						<td><input type="number"  value="0" name="attr_chest_curr" /></td>
-						<td><input READONLY type="number" name="attr_chest_scratch" /></td>												
-						<td><input  READONLY type="number" name="attr_chest_slight" /></td>												
-						<td><input READONLY type="number" name="attr_chest_serious" /></td>						
-						<td><input READONLY type="number" name="attr_chest_critical" /></td>
+						<td><input READONLY type="text" class="hc" name="attr_chest_scratch" /></td>												
+						<td><input  READONLY type="text" class="hc"  name="attr_chest_slight" /></td>												
+						<td><input READONLY type="text"  class="hc"  name="attr_chest_serious" /></td>						
+						<td><input READONLY type="text" class="hc"  name="attr_chest_critical" /></td>
 					</tr>					
 					<tr><td >Abdomen</td>
 						<td style="text-align: center"><input type="checkbox" name="attr__Abdomen_scratch_chk"></td>
@@ -274,11 +275,11 @@
 					</tr>					
 					</tr>
 					<tr>
-						<td><input READONLY type="number" name="attr_Abdomen_curr" /></td>
-						<td><input READONLY type="number" name="attr_other_scratch" /></td>												
-						<td><input READONLY type="number" name="attr_other_slight" /></td>												
-						<td><input READONLY type="number" name="attr_other_serious" /></td>						
-						<td><input READONLY type="number" name="attr_other_critical" /></td>
+						<td><input  type="number" name="attr_Abdomen_curr" /></td>
+						<td><input READONLY type="text" class="hc" name="attr_other_scratch" /></td>												
+						<td><input READONLY type="text" class="hc" name="attr_other_slight" /></td>												
+						<td><input READONLY type="text" class="hc" name="attr_other_serious" /></td>						
+						<td><input READONLY type="text" class="hc" name="attr_other_critical" /></td>
 					</tr>										
 					<tr><td >Right Arm</td>
 						<td style="text-align: center"><input type="checkbox" name="attr__right_arm_scratch_chk"></td>
@@ -289,10 +290,10 @@
 					
 					<tr>
 						<td><input  type="number" name="attr_right_arm_curr" /></td>
-						<td><input READONLY type="number" name="attr_other_scratch" /></td>												
-						<td><input READONLY type="number" name="attr_other_slight" /></td>												
-						<td><input  READONLY type="number" name="attr_other_serious" /></td>						
-						<td><input READONLY type="number" name="attr_other_critical" /></td>
+						<td><input READONLY type="text" class="hc"name="attr_other_scratch" /></td>												
+						<td><input READONLY type="text" class="hc"name="attr_other_slight" /></td>												
+						<td><input  READONLY type="text" class="hc"name="attr_other_serious" /></td>						
+						<td><input READONLY type="text" class="hc"name="attr_other_critical" /></td>
 					</tr>										
 					<tr><td >Left Arm</td>
 						<td style="text-align: center"><input type="checkbox" name="attr__left_arm_scratch_chk"></td>
@@ -302,10 +303,10 @@
 					</tr>
 					<tr>
 						<td><input  type="number" name="attr_left_arm_curr" /></td>
-						<td><input READONLY type="number" name="attr_other_scratch" /></td>												
-						<td><input READONLY type="number" name="attr_other_slight" /></td>												
-						<td><input READONLY type="number" name="attr_other_serious" /></td>						
-						<td><input READONLY type="number" name="attr_other_critical" /></td>
+						<td><input READONLY type="text" class="hc"name="attr_other_scratch" /></td>												
+						<td><input READONLY type="text" class="hc"name="attr_other_slight" /></td>												
+						<td><input READONLY type="text" class="hc" name="attr_other_serious" /></td>						
+						<td><input READONLY type="text" class="hc" name="attr_other_critical" /></td>
 					</tr>			
 					<tr><td >Right Leg</td>
 						<td style="text-align: center"><input type="checkbox" name="attr_right_leg_scratch_chk"></td>
@@ -315,10 +316,10 @@
 					</tr>
 					<tr>
 						<td><input type="number"  value="0" name="attr_right_leg_curr" /></td>
-						<td><input READONLY type="number" name="attr_other_scratch" /></td>												
-						<td><input READONLY type="number" name="attr_other_slight" /></td>												
-						<td><input READONLY type="number" name="attr_other_serious" /></td>						
-						<td><input READONLY type="number" name="attr_other_critical" /></td>
+						<td><input READONLY type="text" class="hc"name="attr_other_scratch" /></td>												
+						<td><input READONLY type="text" class="hc" name="attr_other_slight" /></td>												
+						<td><input READONLY type="text" class="hc" name="attr_other_serious" /></td>						
+						<td><input READONLY type="text" class="hc" name="attr_other_critical" /></td>
 					</tr>	
 					<tr><td >Left Leg</td>
 						<td style="text-align: center"><input type="checkbox" name="attr_left_leg_scratch_chk"></td>
@@ -328,10 +329,10 @@
 					</tr>
 					<tr>
 						<td><input type="number"  value="0" name="attr_left_leg_curr" /></td>
-						<td><input READONLY type="number" name="attr_other_scratch" /></td>												
-						<td><input READONLY type="number" name="attr_other_slight" /></td>												
-						<td><input READONLY type="number" name="attr_other_serious" /></td>						
-						<td><input READONLY type="number" name="attr_other_critical" /></td>
+						<td><input READONLY type="text" class="hc"name="attr_other_scratch" /></td>												
+						<td><input READONLY type="text" class="hc" name="attr_other_slight" /></td>												
+						<td><input READONLY type="text" class="hc"name="attr_other_serious" /></td>						
+						<td><input READONLY type="text" class="hc" name="attr_other_critical" /></td>
 					</tr>
 
 				</tbody>
@@ -384,7 +385,7 @@
 			<td><input type="number"  value="0" name="attr_weapon_hit_mod_1"></td>
 			<td><input style="width: 55px;" type="text" name="attr_weapon_rof_1"></td>
 			<td><input type="number"  value="0" name="attr_weapon_damage_1"></td>			
-			<td><button type="roll"  value="&{template:missile-damage} {{weapon=@{weapon_name_1}}}  {{base=[[@{weapon_damage_1}]]}} {{damage1=[[(@{weapon_damage_1}-?{mods|0})d6]]}}  {{damage2=[[1d6-1]]}}"/></td>			
+			<td><button type="roll"  value="@{missdam1}"/></td>			
 			<td><input class="sheet-weapon_pen" type="text" name="attr_weapon_PEN_1"></td>			
 			<td><input type="number"  value="0" name="attr_weapon_bulk_1"></td>			
 			<td><input type="number"  value="0" name="attr_weapon_mag_full_1"></td>			
@@ -401,7 +402,7 @@
 			<td><input type="number"  value="0" name="attr_weapon_hit_mod_2"></td>
 			<td><input style="width: 55px;"  type="text" name="attr_weapon_rof_2"></td>
 			<td><input type="number"  value="0" name="attr_weapon_damage_2"></td>			
-			<td><button type="roll"  value="&{template:missile-damage} {{weapon=@{weapon_name_2}}}  {{base=[[@{weapon_damage_2}]]}} {{damage1=[[(@{weapon_damage_2}-?{mods|0})d6]]}}  {{damage2=[[1d6-1]]}}"/></td>			
+			<td><button type="roll"  value="@{missdam2}"/></td>			
 			<td><input class="sheet-weapon_pen" type="text" name="attr_weapon_PEN_2"></td>			
 			<td><input type="number"  value="0" name="attr_weapon_bulk_2"></td>			
 			<td><input type="number"  value="0" name="attr_weapon_mag_full_2"></td>			
@@ -418,7 +419,7 @@
 			<td><input type="number"  value="0" name="attr_weapon_hit_mod_3"></td>
 			<td><input style="width: 55px;" type="text" name="attr_weapon_rof_3"></td>
 			<td><input type="number"  value="0" name="attr_weapon_damage_3"></td>			
-			<td><button type="roll"  value="&{template:missile-damage} {{weapon=@{weapon_name_3}}}  {{base=[[@{weapon_damage_3}]]}} {{damage1=[[(@{weapon_damage_3}-?{mods|0})d6]]}}  {{damage2=[[1d6-1]]}}"/></td>			
+			<td><button type="roll"  value="@{missdam3}"/></td>			
 			<td><input class="sheet-weapon_pen" type="text" name="attr_weapon_PEN_3"></td>			
 			<td><input type="number"  value="0" name="attr_weapon_bulk_3"></td>			
 			<td><input type="number"  value="0" name="attr_weapon_mag_full_3"></td>			
@@ -435,7 +436,7 @@
 			<td><input type="number"  value="0" name="attr_weapon_hit_mod_4"></td>
 			<td><input style="width: 55px;" type="text" name="attr_weapon_rof_4"></td>
 			<td><input type="number"  value="0" name="attr_weapon_damage_4"></td>			
-			<td><button type="roll"  value="&{template:missile-damage} {{weapon=@{weapon_name_4}}}  {{base=[[@{weapon_damage_4}]]}} {{damage1=[[(@{weapon_damage_4}-?{mods|0})d6]]}}  {{damage2=[[1d6-1]]}}"/></td>			
+			<td><button type="roll"  value="@{missdam4}"/></td>			
 			<td><input class="sheet-weapon_pen" type="text" name="attr_weapon_PEN_4"></td>			
 			<td><input type="number"  value="0" name="attr_weapon_bulk_4"></td>			
 			<td><input type="number"  value="0" name="attr_weapon_mag_full_4"></td>			
@@ -452,7 +453,7 @@
 			<td><input type="number"  value="0" name="attr_weapon_hit_mod_5"></td>
 			<td><input style="width: 55px;" type="text" name="attr_weapon_rof_5"></td>
 			<td><input type="number"  value="0" name="attr_weapon_damage_5"></td>			
-			<td><button type="roll"  value="&{template:missile-damage} {{weapon=@{weapon_name_5}}}  {{base=[[@{weapon_damage_5}]]}} {{damage1=[[(@{weapon_damage_5}-?{mods|0})d6]]}}  {{damage2=[[1d6-1]]}}"/></td>			
+			<td><button type="roll"  value="@{missdam5}"/></td>			
 			<td><input class="sheet-weapon_pen" type="text" name="attr_weapon_PEN_5"></td>			
 			<td><input type="number"  value="0" name="attr_weapon_bulk_5"></td>			
 			<td><input type="number"  value="0" name="attr_weapon_mag_full_5"></td>			
@@ -461,11 +462,32 @@
 			<td><input type="number"  value="0" name="attr_weapon_recoil_ss_5"></td>
 			<td><input type="number"  value="0" name="attr_weapon_recoil_burst_5"></td>			
 			<td><input class="sheet-weapon_range" type="number" name="attr_weapon_range_5"></td>
-		</tr>		
-
+		</tr>	
 
 		</tbody>
 		</table>
+
+			<textarea name="attr_missdam1" style="display:none">&{template:missile-damage} {{weapon=@{weapon_name_1}}}  {{base=[[@{weapon_damage_1}]]}} {{damage1=[[(@{weapon_damage_1}-?{mods|0})d6]]}}  {{damage2=[[1d6-1]]}}
+
+value='&{template:Hit-Location} {{roll=[[1d10]]}}</textarea>
+
+			<textarea name="attr_missdam2" style="display:none">&{template:missile-damage} {{weapon=@{weapon_name_2}}}  {{base=[[@{weapon_damage_2}]]}} {{damage1=[[(@{weapon_damage_2}-?{mods|0})d6]]}}  {{damage2=[[1d6-1]]}}
+
+value='&{template:Hit-Location} {{roll=[[1d10]]}}</textarea>
+
+			<textarea name="attr_missdam3" style="display:none">&{template:missile-damage} {{weapon=@{weapon_name_3}}}  {{base=[[@{weapon_damage_3}]]}} {{damage1=[[(@{weapon_damage_3}-?{mods|0})d6]]}}  {{damage2=[[1d6-1]]}}
+
+value='&{template:Hit-Location} {{roll=[[1d10]]}}</textarea>
+
+			<textarea name="attr_missdam4" style="display:none">&{template:missile-damage} {{weapon=@{weapon_name_4}}}  {{base=[[@{weapon_damage_4}]]}} {{damage1=[[(@{weapon_damage_4}-?{mods|0})d6]]}}  {{damage2=[[1d6-1]]}}
+
+value='&{template:Hit-Location} {{roll=[[1d10]]}}</textarea>
+
+
+			<textarea name="attr_missdam5" style="display:none">&{template:missile-damage} {{weapon=@{weapon_name_5}}}  {{base=[[@{weapon_damage_5}]]}} {{damage1=[[(@{weapon_damage_5}-?{mods|0})d6]]}}  {{damage2=[[1d6-1]]}}
+
+value='&{template:Hit-Location} {{roll=[[1d10]]}}</textarea>
+
 	</div>
 	
 
@@ -541,7 +563,7 @@
 						</td>			
 						<td><input type="number"  value="0" name="attr_melee_weapon_hit_mod_1"></td>
 						<td><input style="width: 55px" type="text" name="attr_melee_weapon_damage_1"></td>			
-						<td><button type="roll"  value="&{template:melee-damage} {{weapon=@{melee_weapon_name_1}}}  {{damage=[[@{melee_weapon_damage_1}+@{damage_bonus_1}]]}}    "/></td>			
+						<td><button type="roll"  value="@{mldam1}"/></td>			
 						<td><input type="number"  value="0" name="attr_melee_weapon_wt_1"></td>			
 					</tr>
 					<tr>
@@ -556,7 +578,7 @@
 						</td>			
 						<td><input type="number"  value="0" name="attr_melee_weapon_hit_mod_2"></td>
 						<td><input style="width: 55px" type="text" name="attr_melee_weapon_damage_2"></td>			
-						<td><button type="roll"  value="&{template:melee-damage} {{weapon=@{melee_weapon_name_2}}}  {{damage=[[@{melee_weapon_damage_2}+@{damage_bonus_2}]]}}    "/></td>			
+						<td><button type="roll"  value="@{mldam2}"/></td>			
 						<td><input type="number"  value="0" name="attr_melee_weapon_wt_2"></td>			
 					</tr>	
 					<tr>
@@ -571,11 +593,27 @@
 						</td>			
 						<td><input type="number"  value="0" name="attr_melee_weapon_hit_mod_3"></td>
 						<td><input style="width: 55px" type="text" name="attr_melee_weapon_damage_3"></td>			
-						<td><button type="roll"  value="&{template:melee-damage} {{weapon=@{melee_weapon_name_3}}}  {{damage=[[@{melee_weapon_damage_3}+@{damage_bonus_3}]]}}    "/></td>			
+						<td><button type="roll"  value="@{mldam3}"/></td>			
 						<td><input type="number"  value="0" name="attr_melee_weapon_wt_3"></td>			
 					</tr>					
 					</tbody>					
 			</table>
+
+			<textarea name="attr_mldam1" style="display:none">&{template:melee-damage} {{weapon=@{melee_weapon_name_1}}}  {{damage=[[@{melee_weapon_damage_1}+@{damage_bonus_1}]]}}    
+
+value='&{template:Hit-Location} {{roll=[[1d10]]}}</textarea>
+
+			<textarea name="attr_mldam2" style="display:none">&{template:melee-damage} {{weapon=@{melee_weapon_name_2}}}  {{damage=[[@{melee_weapon_damage_2}+@{damage_bonus_2}]]}}    
+
+value='&{template:Hit-Location} {{roll=[[1d10]]}}</textarea>
+
+			<textarea name="attr_mldam3" style="display:none">&{template:melee-damage} {{weapon=@{melee_weapon_name_3}}}  {{damage=[[@{melee_weapon_damage_3}+@{damage_bonus_3}]]}}    
+
+value='&{template:Hit-Location} {{roll=[[1d10]]}}</textarea>
+
+
+
+
 		</div>
 	
 	</div>	
@@ -630,13 +668,13 @@
 	<table class="skillRoll" style="border 1px black">
 		<tr><th colspan="1">Hit location roll</th></tr>
 		<tr>
-			{{#rollTotal() roll 1}}<td style="text-align: center">Hit on the Head</td>{{/rollTotal() roll 1}}
-			{{#rollTotal() roll 2}}<td style="text-align: center">Hit on the Right Arm</td>{{/rollTotal() roll 2}}		
-			{{#rollTotal() roll 3}}<td style="text-align: center">Hit on the Left Arm</td>{{/rollTotal() roll 3}}
-			{{#rollTotal() roll 4}}<td style="text-align: center">Hit on the Chest</td>{{/rollTotal() roll 4}}
-			{{#rollBetween() roll 5 6}}<td style="text-align: center">Hit on the Abdomen</td>{{/rollBetween() roll 5 6}}
-			{{#rollBetween() roll 7 8}}<td style="text-align: center">Hit on the Right Leg</td>{{/rollBetween() roll 7 8}}
-			{{#rollBetween() roll 9 10}}<td style="text-align: center">Hit on the Right Leg</td>{{/rollBetween() roll 9 10}}				
+			{{#rollTotal() roll 1}}<td style="text-align: center">{{roll}} Hit on the Head</td>{{/rollTotal() roll 1}}
+			{{#rollTotal() roll 2}}<td style="text-align: center">{{roll}} Hit on the Right Arm</td>{{/rollTotal() roll 2}}		
+			{{#rollTotal() roll 3}}<td style="text-align: center">{{roll}} Hit on the Left Arm</td>{{/rollTotal() roll 3}}
+			{{#rollTotal() roll 4}}<td style="text-align: center">{{roll}} Hit on the Chest</td>{{/rollTotal() roll 4}}
+			{{#rollBetween() roll 5 6}}<td style="text-align: center">{{roll}} Hit on the Abdomen</td>{{/rollBetween() roll 5 6}}
+			{{#rollBetween() roll 7 8}}<td style="text-align: center">{{roll}} Hit on the Right Leg</td>{{/rollBetween() roll 7 8}}
+			{{#rollBetween() roll 9 10}}<td style="text-align: center">{{roll}} Hit on the Right Leg</td>{{/rollBetween() roll 9 10}}				
 		</tr>
 	</table>
 </rolltemplate>
@@ -718,6 +756,41 @@
 	
 <!-- workers -->
 <script type="text/worker">
+
+on('sheet:opened',function(){
+		
+	getAttrs(["fix1Done","strength", "constitution"], function(pvalue) {		
+		
+		
+		let fix1Done=parseInt(pvalue.fix1Done);
+		console.log("fix1Done: "+fix1Done );
+		
+		if (fix1Done==0){
+	
+			console.log("************ start capacities caclulation ************");
+		str = JSON.stringify(pvalue, null, 4); // (Optional) beautiful indented output.
+console.log("pvalue");
+console.log(str);
+			var constitution =  parseInt(pvalue.constitution);
+			console.log("constitution:"+constitution);
+			var strength =  parseInt(pvalue.strength);
+			console.log("strength: "+strength);
+			var head_hc =constitution*2;
+
+			var chest_hc=(constitution+strength)*3;
+			var other_hc = (constitution+strength)*2;
+
+			setAttrs({head_scratch: "1-"+Math.floor(head_hc*0.5),head_slight: ""+(Math.floor(head_hc*0.5)+1)+"- "+head_hc,head_serious: ""+(head_hc+1)+" - "+(head_hc*2),head_critical: ""+(head_hc*2+1)+"+"});
+			setAttrs({chest_scratch: "1-"+Math.floor(chest_hc*0.5),chest_slight: ""+(Math.floor(chest_hc*0.5)+1)+"- "+chest_hc,chest_serious: ""+(chest_hc+1)+" - "+(chest_hc*2),chest_critical: ""+(chest_hc*2+1)+"+"});  
+			setAttrs({other_scratch: "1-"+Math.floor(other_hc*0.5),other_slight: ""+(Math.floor(other_hc*0.5)+1)+"- "+other_hc,other_serious: ""+(other_hc+1)+" - "+(other_hc*2),other_critical: ""+(other_hc*2+1)+"+"});
+			setAttrs({fix1Done:1});
+		}
+		
+	});		
+})
+
+
+
 //unarmed combat damage
     on("change:strength change:unarmed_martial_arts", function() {
 	    getAttrs(["strength","unarmed_martial_arts" ,"unarmed_damage"
@@ -755,13 +828,14 @@
 			console.log("************ start capacities caclulation ************");
 			var constitution =  parseInt(pvalue.constitution);
 			var strength =  parseInt(pvalue.strength);
-			var head_hc =constitution;
+			var head_hc =constitution*2;
+
 			var chest_hc=(constitution+strength)*3;
 			var other_hc = (constitution+strength)*2;
-			setAttrs({head_scratch: head_hc,head_slight: head_hc*2,head_serious: head_hc*4,head_critical: head_hc*8});
-			setAttrs({chest_scratch: Math.floor(chest_hc*0.5),chest_slight: chest_hc,chest_serious: chest_hc*2,chest_critical: chest_hc*4});  
-			setAttrs({other_scratch: Math.floor(other_hc*0.5),other_slight: other_hc,other_serious: other_hc*2,other_critical: other_hc*4});			
-			setAttrs({load: chest_hc,throw_range:strength*4});
+
+			setAttrs({head_scratch: "1-"+Math.floor(head_hc*0.5),head_slight: ""+(Math.floor(head_hc*0.5)+1)+"- "+head_hc,head_serious: ""+(head_hc+1)+" - "+(head_hc*2),head_critical: ""+(head_hc*2+1)+"+"});
+			setAttrs({chest_scratch: "1-"+Math.floor(chest_hc*0.5),chest_slight: ""+(Math.floor(chest_hc*0.5)+1)+"- "+chest_hc,chest_serious: ""+(chest_hc+1)+" - "+(chest_hc*2),chest_critical: ""+(chest_hc*2+1)+"+"});  
+			setAttrs({other_scratch: "1-"+Math.floor(other_hc*0.5),other_slight: ""+(Math.floor(other_hc*0.5)+1)+"- "+other_hc,other_serious: ""+(other_hc+1)+" - "+(other_hc*2),other_critical: ""+(other_hc*2+1)+"+"}); 
 	    });
     });
 


### PR DESCRIPTION
## Changes / Comments
Minor css change to remove the radii  from text inputs
adjusted Mag header on missile weapons
Automatic hit location roll with damage
Added rolled number to hit location to use with 4 legged hit location
Clarified hit location hit capacities
Added missing logo
The initiative button will now add a token to the turn order if a token is selected when it is clicked.





## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [x ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
