### PR TITLE
ChroniquesOublieesContemporain Version 3.6

### DIFF
--- a/ChroniquesOublieesContemporain/README.md
+++ b/ChroniquesOublieesContemporain/README.md
@@ -10,9 +10,19 @@ Le jeu complet est disponible sur le site de l'éditeur [Black Book Editions](ht
 
 # Version courante
 
-3.5 [Screenshot](coc_v2.png)
+3.6 [Screenshot](coc_v2.png)
 
 # Notes de version
+
+## v3.6 (2020-09-04)
+
+- Case à cocher sur l'onglet Capacités de la fiche de PJ permettant de basculer entre :
+  - le mode Affichage, avec nom et description textuelle complète des capacités
+  - le mode Edition, où l'utilisateur peut entrer le texte des capacités (la première ligne de texte est toujours considérée comme étant le nom de la capacité).
+- Possibilité d'importer la liste des voies et des capacités du profil du personnage. Consulter la [documentation](https://stephaned68.github.io/ChroniquesContemporaines/import-abilities) pour plus de détails.
+- Possibilité de lier un jet de capacité avec l'une des capacités de la grille, en indiquant le numéro de voie et le rang correspondant. Cette information est principalement utilisée par le script API COlib.
+
+Le script API compagnon [COlib](https://github.com/stephaned68/COlib) permet un import des données, non seulement dans la fiche de personnage mais aussi dans le journal Roll20. Consulter la [documentation](https://stephaned68.github.io/COlib/commands) pour plus de détails.
 
 ## v3.5 (2020-08-22)
 

--- a/ChroniquesOublieesContemporain/coc.css
+++ b/ChroniquesOublieesContemporain/coc.css
@@ -128,8 +128,24 @@ table.sheet-tabsep {
   white-space: nowrap;
 }
 
+.sheet-boxtext {
+  width: 266px;
+  padding: 2px;
+}
+
 textarea.sheet-boxability {
   width: 92%;
+}
+
+span.sheet-boxability,
+div.sheet-boxability {
+  white-space: pre-wrap;
+  font-size: x-small;
+  user-select: text;
+}
+
+div.sheet-boxability {
+  padding: 5px;
 }
 
 .sheet-textfat {
@@ -502,7 +518,7 @@ input[type='checkbox'].sheet-block-switch:checked + span::before {
   display: block;
 }
 
-.sheet-attack:hover .sheet-options-flag + span {
+.sheet-options-block:hover .sheet-options-flag + span {
   display: block;
 }
 
@@ -512,6 +528,10 @@ input[type='checkbox'].sheet-block-switch:checked + span::before {
 
 .sheet-options-flag:checked ~ .sheet-options {
   display: block;
+}
+
+.sheet-setup-abilities {
+  float: right;
 }
 
 /* TEMPLATES */

--- a/ChroniquesOublieesContemporain/coc.html
+++ b/ChroniquesOublieesContemporain/coc.html
@@ -1,8 +1,8 @@
 <div class="sheet-mainBg">
   <!-- FDP -->
   <!-- INPUT HIDDEN Version FdP -->
-  <input type="hidden" name="attr_VERFDP" value="3.5.0" />
-  <input type="hidden" name="attr_VERSION" value="3.5.0" />
+  <input type="hidden" name="attr_VERFDP" value="3.6.0" />
+  <input type="hidden" name="attr_VERSION" value="3.6.0" />
   <!-- INPUT HIDDEN Univers (COF, CG, COC) -->
   <input type="hidden" name="attr_UNIVERS" value="COC" />
   <input type="hidden" name="attr_coc_setting_bitume" value="0" />
@@ -66,20 +66,20 @@
   <input type="hidden" name="attr_QRYUD" value="" />
   <!-- Fin INPUT HIDDEN -->
   <div class="sheet-container">
-    <!-- Identité -->    
+    <!-- Identité -->
     <input type="checkbox" class="block-switch" style="display: none;" name="attr_coc_setting_bitume" value="1">
     <div class="block-hidden">
       <div style="vertical-align: middle; text-align: center;">
-        <img style="width:70%; height:90%" title="Version 3.5 - 22/08/2020"
+        <img style="width:70%; height:90%" title="Version 3.6 - 04/09/2020"
           src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesOublieesContemporain/coc_logo.png" />
       </div>
     </div>
     <div class="block-show">
       <div style="vertical-align: middle; text-align: center;">
-        <img style="width:70%; height:90%" title="Version 3.5 - 22/08/2020"
+        <img style="width:70%; height:90%" title="Version 3.6 - 04/09/2020"
           src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesOublieesContemporain/coc_bitume.jpg" />
       </div>
-    </div>  
+    </div>
     <div style="width:250px;">
       <table>
         <tr>
@@ -382,7 +382,8 @@
                       <img class="sheet-iconimg"
                         src="https://raw.githubusercontent.com/stephaned68/ChroniquesContemporaines/master/cond_etourdi.png" />
                     </button>
-                    <button type="action" class="sheet-flatbtn sheet-iconbtn" name="act_cond_immobilise" title="Immobilisé">
+                    <button type="action" class="sheet-flatbtn sheet-iconbtn" name="act_cond_immobilise"
+                      title="Immobilisé">
                       <img class="sheet-iconimg"
                         src="https://raw.githubusercontent.com/stephaned68/ChroniquesContemporaines/master/cond_immobilise.png" />
                     </button>
@@ -883,7 +884,7 @@
           </tr>
         </table>
         <fieldset class="repeating_armes">
-          <div class="attack">
+          <div class="options-block">
             <input class="options-flag" name="attr_armeoptflag" type="checkbox"
               title="Montrer/cacher les options"><span>y</span>
             <div>
@@ -1101,307 +1102,626 @@
     </div>
     <div class="sheet-tab-content sheet-tab2">
       <div>
-        <!-- Voies -->
-        <table>
-          <tr>
-            <td class="sheet-textfatleft" colspan="5">CAPACITÉS DU PERSONNAGE</td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
-            <td class="sheet-boxtitresmall">Voie 1</td>
-            <td class="sheet-boxtitresmall">Voie 2</td>
-            <td class="sheet-boxtitresmall">Voie 3</td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">R</td>
-            <td class="sheet-boxinputleft">
-              <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie1nom" title="@{voie1nom}"
-                placeholder="Nom de la Voie n°1" />
-            </td>
-            <td class="sheet-boxinput">
-              <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie2nom" title="@{voie2nom}"
-                placeholder="Nom de la Voie n°2" />
-            </td>
-            <td class="sheet-boxinput">
-              <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie3nom" title="@{voie3nom}"
-                placeholder="Nom de la Voie n°3" />
-            </td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">1</td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v1r1" value="1" />
-              <textarea name="attr_voie1-1" class="sheet-boxability" title="@{voie1-1}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v2r1" value="1" />
-              <textarea name="attr_voie2-1" class="sheet-boxability" title="@{voie2-1}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v3r1" value="1" />
-              <textarea name="attr_voie3-1" class="sheet-boxability" title="@{voie3-1}"></textarea>
-            </td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">2</td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v1r2" value="1" />
-              <textarea name="attr_voie1-2" class="sheet-boxability" title="@{voie1-2}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v2r2" value="1" />
-              <textarea name="attr_voie2-2" class="sheet-boxability" title="@{voie2-2}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v3r2" value="1" />
-              <textarea name="attr_voie3-2" class="sheet-boxability" title="@{voie3-2}"></textarea>
-            </td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">3</td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v1r3" value="1" />
-              <textarea name="attr_voie1-3" class="sheet-boxability" title="@{voie1-3}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v2r3" value="1" />
-              <textarea name="attr_voie2-3" class="sheet-boxability" title="@{voie2-3}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v3r3" value="1" />
-              <textarea name="attr_voie3-3" class="sheet-boxability" title="@{voie3-3}"></textarea>
-            </td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">4</td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v1r4" value="1" />
-              <textarea name="attr_voie1-4" class="sheet-boxability" title="@{voie1-4}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v2r4" value="1" />
-              <textarea name="attr_voie2-4" class="sheet-boxability" title="@{voie2-4}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v3r4" value="1" />
-              <textarea name="attr_voie3-4" class="sheet-boxability" title="@{voie3-4}"></textarea>
-            </td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">5</td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v1r5" value="1" />
-              <textarea name="attr_voie1-5" class="sheet-boxability" title="@{voie1-5}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v2r5" value="1" />
-              <textarea name="attr_voie2-5" class="sheet-boxability" title="@{voie2-5}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v3r5" value="1" />
-              <textarea name="attr_voie3-5" class="sheet-boxability" title="@{voie3-5}"></textarea>
-            </td>
-          </tr>
-        </table>
-        <table>
-          <tr>
-            <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
-            <td class="sheet-boxtitresmall">Voie 4</td>
-            <td class="sheet-boxtitresmall">Voie 5</td>
-            <td class="sheet-boxtitresmall">Voie 6</td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">R</td>
-            <td class="sheet-boxinputleft">
-              <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie4nom" title="@{voie4nom}"
-                placeholder="Nom de la Voie n°4" />
-            </td>
-            <td class="sheet-boxinput">
-              <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie5nom" title="@{voie5nom}"
-                placeholder="Nom de la Voie n°5" />
-            </td>
-            <td class="sheet-boxinput">
-              <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie6nom" title="@{voie6nom}"
-                placeholder="Nom de la Voie n°6" />
-            </td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">1</td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v4r1" value="1" />
-              <textarea name="attr_voie4-1" class="sheet-boxability" title="@{voie4-1}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v5r1" value="1" />
-              <textarea name="attr_voie5-1" class="sheet-boxability" title="@{voie5-1}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v6r1" value="1" />
-              <textarea name="attr_voie6-1" class="sheet-boxability" title="@{voie6-1}"></textarea>
-            </td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">2</td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v4r2" value="1" />
-              <textarea name="attr_voie4-2" class="sheet-boxability" title="@{voie4-2}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v5r2" value="1" />
-              <textarea name="attr_voie5-2" class="sheet-boxability" title="@{voie5-2}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v6r2" value="1" />
-              <textarea name="attr_voie6-2" class="sheet-boxability" title="@{voie6-2}"></textarea>
-            </td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">3</td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v4r3" value="1" />
-              <textarea name="attr_voie4-3" class="sheet-boxability" title="@{voie4-3}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v5r3" value="1" />
-              <textarea name="attr_voie5-3" class="sheet-boxability" title="@{voie5-3}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v6r3" value="1" />
-              <textarea name="attr_voie6-3" class="sheet-boxability" title="@{voie6-3}"></textarea>
-            </td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">4</td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v4r4" value="1" />
-              <textarea name="attr_voie4-4" class="sheet-boxability" title="@{voie4-4}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v5r4" value="1" />
-              <textarea name="attr_voie5-4" class="sheet-boxability" title="@{voie5-4}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v6r4" value="1" />
-              <textarea name="attr_voie6-4" class="sheet-boxability" title="@{voie6-4}"></textarea>
-            </td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">5</td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v4r5" value="1" />
-              <textarea name="attr_voie4-5" class="sheet-boxability" title="@{voie4-5}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v5r5" value="1" />
-              <textarea name="attr_voie5-5" class="sheet-boxability" title="@{voie5-5}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v6r5" value="1" />
-              <textarea name="attr_voie6-5" class="sheet-boxability" title="@{voie6-5}"></textarea>
-            </td>
-          </tr>
-        </table>
-        <div>
-          <input type="checkbox" class="sheet-block-switch" name="attr_voies789"><span>Plus de voies</span>
-          <div class="sheet-block-hidden"></div>
-          <div class="sheet-block-show">
-            <table>
-              <tr>
-                <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
-                <td class="sheet-boxtitresmall">Voie 7</td>
-                <td class="sheet-boxtitresmall">Voie 8</td>
-                <td class="sheet-boxtitresmall">Voie 9</td>
-              </tr>
-              <tr>
-                <td class="sheet-boxtitresmall">R</td>
-                <td class="sheet-boxinputleft">
-                  <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie7nom" title="@{voie7nom}" placeholder="Nom de la Voie n°7" />
-                </td>
-                <td class="sheet-boxinput">
-                  <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie8nom" title="@{voie8nom}" placeholder="Nom de la Voie n°8" />
-                </td>
-                <td class="sheet-boxinput">
-                  <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie9nom" title="@{voie9nom}" placeholder="Nom de la Voie n°9" />
-                </td>
-              </tr>
-              <tr>
-                <td class="sheet-boxtitresmall">1</td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v7r1" value="1" />
-                  <textarea name="attr_voie7-1" class="sheet-boxability" title="@{voie7-1}"></textarea>
-                </td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v8r1" value="1" />
-                  <textarea name="attr_voie8-1" class="sheet-boxability" title="@{voie8-1"></textarea>
-                </td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v9r1" value="1" />
-                  <textarea name="attr_voie9-1" class="sheet-boxability" title="@{voie9-1}"></textarea>
-                </td>
-              </tr>
-              <tr>
-                <td class="sheet-boxtitresmall">2</td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v7r2" value="1" />
-                  <textarea name="attr_voie7-2" class="sheet-boxability" title="@{voie7-2}"></textarea>
-                </td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v8r2" value="1" />
-                  <textarea name="attr_voie8-2" class="sheet-boxability" title="@{voie8-2}"></textarea>
-                </td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v9r2" value="1" />
-                  <textarea name="attr_voie9-2" class="sheet-boxability" title="@{voie9-2}"></textarea>
-                </td>
-              </tr>
-              <tr>
-                <td class="sheet-boxtitresmall">3</td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v7r3" value="1" />
-                  <textarea name="attr_voie7-3" class="sheet-boxability" title="@{voie7-3}"></textarea>
-                </td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v8r3" value="1" />
-                  <textarea name="attr_voie8-3" class="sheet-boxability" title="@{voie8-3}"></textarea>
-                </td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v9r3" value="1" />
-                  <textarea name="attr_voie9-3" class="sheet-boxability" title="@{voie9-3}"></textarea>
-                </td>
-              </tr>
-              <tr>
-                <td class="sheet-boxtitresmall">4</td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v7r4" value="1" />
-                  <textarea name="attr_voie7-4" class="sheet-boxability" title="@{voie7-4}"></textarea>
-                </td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v8r4" value="1" />
-                  <textarea name="attr_voie8-4" class="sheet-boxability" title="@{voie8-4}"></textarea>
-                </td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v9r4" value="1" />
-                  <textarea name="attr_voie9-4" class="sheet-boxability" title="@{voie9-4}"></textarea>
-                </td>
-              </tr>
-              <tr>
-                <td class="sheet-boxtitresmall">5</td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v7r5" value="1" />
-                  <textarea name="attr_voie7-5" class="sheet-boxability" title="@{voie7-5}"></textarea>
-                </td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v8r5" value="1" />
-                  <textarea name="attr_voie8-5" class="sheet-boxability" title="@{voie8-5}"></textarea>
-                </td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v9r5" value="1" />
-                  <textarea name="attr_voie9-5" class="sheet-boxability" title="@{voie9-5}"></textarea>
-                </td>
-              </tr>
-            </table>
+        <input class="block-switch" name="attr_setup_abilities" type="checkbox">
+        <div class="block-hidden">
+          <table>
+            <tr>
+              <td class="sheet-textfatleft" colspan="5">
+                CAPACITÉS DU PERSONNAGE
+                <input type="checkbox" class="sheet-setup-abilities" name="attr_setup_abilities"
+                  title="Editer les capacités">
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
+              <td class="sheet-boxtitresmall">Voie 1</td>
+              <td class="sheet-boxtitresmall">Voie 2</td>
+              <td class="sheet-boxtitresmall">Voie 3</td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">R</td>
+              <td class="sheet-boxinputleft">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie1nom"
+                  title="@{voie1nom}" placeholder="Nom de la Voie n°1" />
+              </td>
+              <td class="sheet-boxinput">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie2nom"
+                  title="@{voie2nom}" placeholder="Nom de la Voie n°2" />
+              </td>
+              <td class="sheet-boxinput">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie3nom"
+                  title="@{voie3nom}" placeholder="Nom de la Voie n°3" />
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">1</td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v1r1" value="1" />
+                <span name="attr_voie1-1" class="sheet-boxability" title="@{voie1-1}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v2r1" value="1" />
+                <span name="attr_voie2-1" class="sheet-boxability" title="@{voie2-1}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v3r1" value="1" />
+                <span name="attr_voie3-1" class="sheet-boxability" title="@{voie3-1}"></span>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">2</td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v1r2" value="1" />
+                <span name="attr_voie1-2" class="sheet-boxability" title="@{voie1-2}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v2r2" value="1" />
+                <span name="attr_voie2-2" class="sheet-boxability" title="@{voie2-2}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v3r2" value="1" />
+                <span name="attr_voie3-2" class="sheet-boxability" title="@{voie3-2}"></span>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">3</td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v1r3" value="1" />
+                <span name="attr_voie1-3" class="sheet-boxability" title="@{voie1-3}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v2r3" value="1" />
+                <span name="attr_voie2-3" class="sheet-boxability" title="@{voie2-3}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v3r3" value="1" />
+                <span name="attr_voie3-3" class="sheet-boxability" title="@{voie3-3}"></span>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">4</td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v1r4" value="1" />
+                <span name="attr_voie1-4" class="sheet-boxability" title="@{voie1-4}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v2r4" value="1" />
+                <span name="attr_voie2-4" class="sheet-boxability" title="@{voie2-4}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v3r4" value="1" />
+                <span name="attr_voie3-4" class="sheet-boxability" title="@{voie3-4}"></span>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">5</td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v1r5" value="1" />
+                <span name="attr_voie1-5" class="sheet-boxability" title="@{voie1-5}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v2r5" value="1" />
+                <span name="attr_voie2-5" class="sheet-boxability" title="@{voie2-5}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v3r5" value="1" />
+                <span name="attr_voie3-5" class="sheet-boxability" title="@{voie3-5}"></span>
+              </td>
+            </tr>
+          </table>
+          <table>
+            <tr>
+              <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
+              <td class="sheet-boxtitresmall">Voie 4</td>
+              <td class="sheet-boxtitresmall">Voie 5</td>
+              <td class="sheet-boxtitresmall">Voie 6</td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">R</td>
+              <td class="sheet-boxinputleft">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie4nom"
+                  title="@{voie4nom}" placeholder="Nom de la Voie n°4" />
+              </td>
+              <td class="sheet-boxinput">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie5nom"
+                  title="@{voie5nom}" placeholder="Nom de la Voie n°5" />
+              </td>
+              <td class="sheet-boxinput">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie6nom"
+                  title="@{voie6nom}" placeholder="Nom de la Voie n°6" />
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">1</td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v4r1" value="1" />
+                <span name="attr_voie4-1" class="sheet-boxability" title="@{voie4-1}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v5r1" value="1" />
+                <span name="attr_voie5-1" class="sheet-boxability" title="@{voie5-1}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v6r1" value="1" />
+                <span name="attr_voie6-1" class="sheet-boxability" title="@{voie6-1}"></span>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">2</td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v4r2" value="1" />
+                <span name="attr_voie4-2" class="sheet-boxability" title="@{voie4-2}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v5r2" value="1" />
+                <span name="attr_voie5-2" class="sheet-boxability" title="@{voie5-2}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v6r2" value="1" />
+                <span name="attr_voie6-2" class="sheet-boxability" title="@{voie6-2}"></span>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">3</td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v4r3" value="1" />
+                <span name="attr_voie4-3" class="sheet-boxability" title="@{voie4-3}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v5r3" value="1" />
+                <span name="attr_voie5-3" class="sheet-boxability" title="@{voie5-3}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v6r3" value="1" />
+                <span name="attr_voie6-3" class="sheet-boxability" title="@{voie6-3}"></span>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">4</td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v4r4" value="1" />
+                <span name="attr_voie4-4" class="sheet-boxability" title="@{voie4-4}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v5r4" value="1" />
+                <span name="attr_voie5-4" class="sheet-boxability" title="@{voie5-4}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v6r4" value="1" />
+                <span name="attr_voie6-4" class="sheet-boxability" title="@{voie6-4}"></span>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">5</td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v4r5" value="1" />
+                <span name="attr_voie4-5" class="sheet-boxability" title="@{voie4-5}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v5r5" value="1" />
+                <span name="attr_voie5-5" class="sheet-boxability" title="@{voie5-5}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v6r5" value="1" />
+                <span name="attr_voie6-5" class="sheet-boxability" title="@{voie6-5}"></span>
+              </td>
+            </tr>
+          </table>
+          <div>
+            <input type="checkbox" class="sheet-block-switch" name="attr_voies789"><span>Plus de voies</span>
+            <div class="sheet-block-hidden"></div>
+            <div class="sheet-block-show">
+              <table>
+                <tr>
+                  <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
+                  <td class="sheet-boxtitresmall">Voie 7</td>
+                  <td class="sheet-boxtitresmall">Voie 8</td>
+                  <td class="sheet-boxtitresmall">Voie 9</td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">R</td>
+                  <td class="sheet-boxinputleft">
+                    <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie7nom"
+                      title="@{voie7nom}" placeholder="Nom de la Voie n°7" />
+                  </td>
+                  <td class="sheet-boxinput">
+                    <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie8nom"
+                      title="@{voie8nom}" placeholder="Nom de la Voie n°8" />
+                  </td>
+                  <td class="sheet-boxinput">
+                    <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie9nom"
+                      title="@{voie9nom}" placeholder="Nom de la Voie n°9" />
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">1</td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v7r1" value="1" />
+                    <span name="attr_voie7-1" class="sheet-boxability" title="@{voie7-1}"></span>
+                  </td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v8r1" value="1" />
+                    <span name="attr_voie8-1" class="sheet-boxability" title="@{voie8-1"></span>
+                  </td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v9r1" value="1" />
+                    <span name="attr_voie9-1" class="sheet-boxability" title="@{voie9-1}"></span>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">2</td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v7r2" value="1" />
+                    <span name="attr_voie7-2" class="sheet-boxability" title="@{voie7-2}"></span>
+                  </td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v8r2" value="1" />
+                    <span name="attr_voie8-2" class="sheet-boxability" title="@{voie8-2}"></span>
+                  </td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v9r2" value="1" />
+                    <span name="attr_voie9-2" class="sheet-boxability" title="@{voie9-2}"></span>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">3</td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v7r3" value="1" />
+                    <span name="attr_voie7-3" class="sheet-boxability" title="@{voie7-3}"></span>
+                  </td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v8r3" value="1" />
+                    <span name="attr_voie8-3" class="sheet-boxability" title="@{voie8-3}"></span>
+                  </td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v9r3" value="1" />
+                    <span name="attr_voie9-3" class="sheet-boxability" title="@{voie9-3}"></span>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">4</td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v7r4" value="1" />
+                    <span name="attr_voie7-4" class="sheet-boxability" title="@{voie7-4}"></span>
+                  </td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v8r4" value="1" />
+                    <span name="attr_voie8-4" class="sheet-boxability" title="@{voie8-4}"></span>
+                  </td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v9r4" value="1" />
+                    <span name="attr_voie9-4" class="sheet-boxability" title="@{voie9-4}"></span>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">5</td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v7r5" value="1" />
+                    <span name="attr_voie7-5" class="sheet-boxability" title="@{voie7-5}"></span>
+                  </td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v8r5" value="1" />
+                    <span name="attr_voie8-5" class="sheet-boxability" title="@{voie8-5}"></span>
+                  </td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v9r5" value="1" />
+                    <span name="attr_voie9-5" class="sheet-boxability" title="@{voie9-5}"></span>
+                  </td>
+                </tr>
+              </table>
+            </div>
           </div>
         </div>
+        <div class="block-show">
+          <table>
+            <tr>
+              <td class="sheet-textfatleft" colspan="5">
+                CAPACITÉS DU PERSONNAGE
+                <input type="checkbox" class="sheet-setup-abilities" name="attr_setup_abilities"
+                  title="Editer les capacités">
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
+              <td class="sheet-boxtitresmall">Voie 1</td>
+              <td class="sheet-boxtitresmall">Voie 2</td>
+              <td class="sheet-boxtitresmall">Voie 3</td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">R</td>
+              <td class="sheet-boxinputleft">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie1nom"
+                  title="@{voie1nom}" placeholder="Nom de la Voie n°1" />
+              </td>
+              <td class="sheet-boxinput">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie2nom"
+                  title="@{voie2nom}" placeholder="Nom de la Voie n°2" />
+              </td>
+              <td class="sheet-boxinput">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie3nom"
+                  title="@{voie3nom}" placeholder="Nom de la Voie n°3" />
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">1</td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v1r1" value="1" />
+                <textarea name="attr_voie1-1" class="sheet-boxability" title="@{voie1-1}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v2r1" value="1" />
+                <textarea name="attr_voie2-1" class="sheet-boxability" title="@{voie2-1}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v3r1" value="1" />
+                <textarea name="attr_voie3-1" class="sheet-boxability" title="@{voie3-1}"></textarea>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">2</td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v1r2" value="1" />
+                <textarea name="attr_voie1-2" class="sheet-boxability" title="@{voie1-2}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v2r2" value="1" />
+                <textarea name="attr_voie2-2" class="sheet-boxability" title="@{voie2-2}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v3r2" value="1" />
+                <textarea name="attr_voie3-2" class="sheet-boxability" title="@{voie3-2}"></textarea>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">3</td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v1r3" value="1" />
+                <textarea name="attr_voie1-3" class="sheet-boxability" title="@{voie1-3}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v2r3" value="1" />
+                <textarea name="attr_voie2-3" class="sheet-boxability" title="@{voie2-3}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v3r3" value="1" />
+                <textarea name="attr_voie3-3" class="sheet-boxability" title="@{voie3-3}"></textarea>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">4</td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v1r4" value="1" />
+                <textarea name="attr_voie1-4" class="sheet-boxability" title="@{voie1-4}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v2r4" value="1" />
+                <textarea name="attr_voie2-4" class="sheet-boxability" title="@{voie2-4}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v3r4" value="1" />
+                <textarea name="attr_voie3-4" class="sheet-boxability" title="@{voie3-4}"></textarea>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">5</td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v1r5" value="1" />
+                <textarea name="attr_voie1-5" class="sheet-boxability" title="@{voie1-5}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v2r5" value="1" />
+                <textarea name="attr_voie2-5" class="sheet-boxability" title="@{voie2-5}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v3r5" value="1" />
+                <textarea name="attr_voie3-5" class="sheet-boxability" title="@{voie3-5}"></textarea>
+              </td>
+            </tr>
+          </table>
+          <table>
+            <tr>
+              <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
+              <td class="sheet-boxtitresmall">Voie 4</td>
+              <td class="sheet-boxtitresmall">Voie 5</td>
+              <td class="sheet-boxtitresmall">Voie 6</td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">R</td>
+              <td class="sheet-boxinputleft">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie4nom"
+                  title="@{voie4nom}" placeholder="Nom de la Voie n°4" />
+              </td>
+              <td class="sheet-boxinput">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie5nom"
+                  title="@{voie5nom}" placeholder="Nom de la Voie n°5" />
+              </td>
+              <td class="sheet-boxinput">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie6nom"
+                  title="@{voie6nom}" placeholder="Nom de la Voie n°6" />
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">1</td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v4r1" value="1" />
+                <textarea name="attr_voie4-1" class="sheet-boxability" title="@{voie4-1}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v5r1" value="1" />
+                <textarea name="attr_voie5-1" class="sheet-boxability" title="@{voie5-1}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v6r1" value="1" />
+                <textarea name="attr_voie6-1" class="sheet-boxability" title="@{voie6-1}"></textarea>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">2</td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v4r2" value="1" />
+                <textarea name="attr_voie4-2" class="sheet-boxability" title="@{voie4-2}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v5r2" value="1" />
+                <textarea name="attr_voie5-2" class="sheet-boxability" title="@{voie5-2}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v6r2" value="1" />
+                <textarea name="attr_voie6-2" class="sheet-boxability" title="@{voie6-2}"></textarea>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">3</td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v4r3" value="1" />
+                <textarea name="attr_voie4-3" class="sheet-boxability" title="@{voie4-3}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v5r3" value="1" />
+                <textarea name="attr_voie5-3" class="sheet-boxability" title="@{voie5-3}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v6r3" value="1" />
+                <textarea name="attr_voie6-3" class="sheet-boxability" title="@{voie6-3}"></textarea>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">4</td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v4r4" value="1" />
+                <textarea name="attr_voie4-4" class="sheet-boxability" title="@{voie4-4}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v5r4" value="1" />
+                <textarea name="attr_voie5-4" class="sheet-boxability" title="@{voie5-4}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v6r4" value="1" />
+                <textarea name="attr_voie6-4" class="sheet-boxability" title="@{voie6-4}"></textarea>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">5</td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v4r5" value="1" />
+                <textarea name="attr_voie4-5" class="sheet-boxability" title="@{voie4-5}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v5r5" value="1" />
+                <textarea name="attr_voie5-5" class="sheet-boxability" title="@{voie5-5}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v6r5" value="1" />
+                <textarea name="attr_voie6-5" class="sheet-boxability" title="@{voie6-5}"></textarea>
+              </td>
+            </tr>
+          </table>
+          <div>
+            <input type="checkbox" class="sheet-block-switch" name="attr_voies789"><span>Plus de voies</span>
+            <div class="sheet-block-hidden"></div>
+            <div class="sheet-block-show">
+              <table>
+                <tr>
+                  <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
+                  <td class="sheet-boxtitresmall">Voie 7</td>
+                  <td class="sheet-boxtitresmall">Voie 8</td>
+                  <td class="sheet-boxtitresmall">Voie 9</td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">R</td>
+                  <td class="sheet-boxinputleft">
+                    <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie7nom"
+                      title="@{voie7nom}" placeholder="Nom de la Voie n°7" />
+                  </td>
+                  <td class="sheet-boxinput">
+                    <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie8nom"
+                      title="@{voie8nom}" placeholder="Nom de la Voie n°8" />
+                  </td>
+                  <td class="sheet-boxinput">
+                    <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie9nom"
+                      title="@{voie9nom}" placeholder="Nom de la Voie n°9" />
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">1</td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v7r1" value="1" />
+                    <textarea name="attr_voie7-1" class="sheet-boxability" title="@{voie7-1}"></textarea>
+                  </td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v8r1" value="1" />
+                    <textarea name="attr_voie8-1" class="sheet-boxability" title="@{voie8-1"></textarea>
+                  </td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v9r1" value="1" />
+                    <textarea name="attr_voie9-1" class="sheet-boxability" title="@{voie9-1}"></textarea>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">2</td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v7r2" value="1" />
+                    <textarea name="attr_voie7-2" class="sheet-boxability" title="@{voie7-2}"></textarea>
+                  </td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v8r2" value="1" />
+                    <textarea name="attr_voie8-2" class="sheet-boxability" title="@{voie8-2}"></textarea>
+                  </td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v9r2" value="1" />
+                    <textarea name="attr_voie9-2" class="sheet-boxability" title="@{voie9-2}"></textarea>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">3</td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v7r3" value="1" />
+                    <textarea name="attr_voie7-3" class="sheet-boxability" title="@{voie7-3}"></textarea>
+                  </td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v8r3" value="1" />
+                    <textarea name="attr_voie8-3" class="sheet-boxability" title="@{voie8-3}"></textarea>
+                  </td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v9r3" value="1" />
+                    <textarea name="attr_voie9-3" class="sheet-boxability" title="@{voie9-3}"></textarea>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">4</td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v7r4" value="1" />
+                    <textarea name="attr_voie7-4" class="sheet-boxability" title="@{voie7-4}"></textarea>
+                  </td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v8r4" value="1" />
+                    <textarea name="attr_voie8-4" class="sheet-boxability" title="@{voie8-4}"></textarea>
+                  </td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v9r4" value="1" />
+                    <textarea name="attr_voie9-4" class="sheet-boxability" title="@{voie9-4}"></textarea>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">5</td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v7r5" value="1" />
+                    <textarea name="attr_voie7-5" class="sheet-boxability" title="@{voie7-5}"></textarea>
+                  </td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v8r5" value="1" />
+                    <textarea name="attr_voie8-5" class="sheet-boxability" title="@{voie8-5}"></textarea>
+                  </td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v9r5" value="1" />
+                    <textarea name="attr_voie9-5" class="sheet-boxability" title="@{voie9-5}"></textarea>
+                  </td>
+                </tr>
+              </table>
+            </div>
+          </div>
+        </div>
+        <!-- Voies -->
         <img class="sheet-imghr"
           src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesOublieesContemporain/coc_hr.jpg" />
         <table class="sheet-tabsep" title="repeating_jetcapas">
@@ -1469,6 +1789,7 @@
                     <option value="@{ATKTIR}">ATD</option>
                     <option value="@{ATKMEN}">MEN</option>
                     <option value="@{ATKMAG}">MAG</option>
+                    <option value="@{ATKPIL}">PIL</option>
                   </optgroup>
                 </select>+&nbsp;(
                 <select class="sheet-carac" style="width:40px;" name="attr_jetcapacoeff" size="1"
@@ -1495,15 +1816,36 @@
                   title="@{jetcapadiv} Bonus divers" />
               </td>
               <td class="sheet-boxinputleft" style="width: 25%;">
-                <input type="text" name="attr_jetcapatitre" style="width:100%;" placeholder="Compétence (CARAC)"
-                  title="@{jetcapatitre}" />
+                &nbsp;Voie :&nbsp;
+                <select class="sheet-selectmin" name="attr_jetcapavoieno" title="@{jetcapavoieno}">
+                  <option value="">-</option>
+                  <option value="v1">1</option>
+                  <option value="v2">2</option>
+                  <option value="v3">3</option>
+                  <option value="v4">4</option>
+                  <option value="v5">5</option>
+                  <option value="v6">6</option>
+                  <option value="v7">7</option>
+                  <option value="v8">8</option>
+                  <option value="v9">9</option>
+                </select>
+                &nbsp;Rang :&nbsp;
+                <select class="sheet-selectmin" name="attr_jetcapavoierang" title="@{jetcapavoierang}">
+                  <option value="">-</option>
+                  <option value="r1">1</option>
+                  <option value="r2">2</option>
+                  <option value="r3">3</option>
+                  <option value="r4">4</option>
+                  <option value="r5">5</option>
+                </select>
+                <input type="hidden" name="attr_jetcapavr" value="" />
               </td>
             </tr>
             <tr>
               <td>&nbsp;</td>
               <td class="sheet-boxinputleft" style="width: 25%;">
-                <input type="text" name="attr_jetcapavoie" style="width:100%;" placeholder="Voie, rang"
-                  title="@{jetcapavoie}" />
+                <input type="text" name="attr_jetcapatitre" style="width:100%;" placeholder="Compétence (CARAC)"
+                  title="@{jetcapatitre}" />
               </td>
               <td class="sheet-boxinputleft" colspan="3">
                 <textarea name="attr_jetcapadesc" placeholder="Description" title="@{jetcapadesc}"></textarea>
@@ -1747,10 +2089,13 @@
               </div>
             </fieldset>
             <div>
-              <input type="checkbox" class="optional-block-switch" name="attr_coc_setting_bitume" value="1"><span></span>
+              <input type="checkbox" class="optional-block-switch" name="attr_coc_setting_bitume"
+                value="1"><span></span>
               <div class="optional-block">
                 <div class="sheet-boxtitre" style="margin: 5px 5px 5px 0; width: 100px;">
-                  <button type="roll" class="sheet-boxtitre" name="roll_ud" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Usure}} {{subtags=Test}} {{carac=[[@{QRYUD}cf<3]] }}">Usure (Ud)</button>
+                  <button type="roll" class="sheet-boxtitre" name="roll_ud"
+                    value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Usure}} {{subtags=Test}} {{carac=[[@{QRYUD}cf<3]] }}">Usure
+                    (Ud)</button>
                 </div>
               </div>
             </div>
@@ -1897,6 +2242,21 @@
       <!-- FIN Config -->
       <img class="sheet-imghr"
         src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesOublieesContemporain/coc_hr.jpg" />
+      <div class="sheet-row">
+          <input type="checkbox" class="sheet-block-switch"><span>Importer profil</span>
+          <div class="sheet-block-hidden"></div>
+          <div class="sheet-block-show">
+            <div class="sheet-2colrow">
+              <div class="sheet-col">
+                <textarea class="sheet-boxinputleft" name="attr_json_profile" style="height: 10em; white-space: pre-wrap;"></textarea>
+              </div>
+              <div class="sheet-col">
+                <button type="action" name="act_json_import" class="sheet-flatbtn sheet-iconbtn"
+                  title="Importer le profil">W</button>
+              </div>
+            </div>
+          </div>
+        </div>
     </div>
   </div>
   <div class="sheet-tab-content sheet-fp2">
@@ -2020,7 +2380,8 @@
                     <option value="@{AGI}">AGI</option>
                   </select>
                   +
-                  <input type="number" style="width:32px;" name="attr_jetvdiv" value="0" title="@{jetvdiv} Bonus divers" />
+                  <input type="number" style="width:32px;" name="attr_jetvdiv" value="0"
+                    title="@{jetvdiv} Bonus divers" />
                   <input type="hidden" name="attr_jetvcaracp" value="" />
                 </td>
                 <td class="sheet-boxinputleft" style="width:100%;">
@@ -2031,7 +2392,7 @@
           </fieldset>
           <img class="sheet-imghr"
             src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesOublieesContemporain/coc_hr.jpg" />
-        </div>        
+        </div>
       </div>
       <div class="block-show">
         <div>
@@ -2046,15 +2407,14 @@
                 </tr>
                 <tr>
                   <td class="sheet-textfatleft" colspan="4">Description :<br>
-                    <textarea type="text" class="sheet-nobox" style="border: 1px solid; height: 5em;" name="attr_VEHICULE_DESC"
-                      title="@{VEHICULE_DESC}">
+                    <textarea type="text" class="sheet-nobox" style="border: 1px solid; height: 5em;"
+                      name="attr_VEHICULE_DESC" title="@{VEHICULE_DESC}">
                     </textarea>
                   </td>
                 </tr>
                 <tr>
                   <td class="sheet-textfatleft" colspan="4">Pilote :
-                    <input type="text" class="sheet-nobox" name="attr_PILOTE"
-                      title="@{PILOTE} Nom du pilote" />
+                    <input type="text" class="sheet-nobox" name="attr_PILOTE" title="@{PILOTE} Nom du pilote" />
                   </td>
                   <td colspan="3">&nbsp;</td>
                 </tr>
@@ -2073,10 +2433,12 @@
                   <input type="number" name="attr_vbmod-res" style="width: 30px;" value="0"
                     title="@{vbmod-res} Coût (R)" />
                   <br>
-                  <textarea name="attr_vbmod-effet" placeholder="Effet de la modification" title="@{vbmod-effet} Effet"></textarea>
+                  <textarea name="attr_vbmod-effet" placeholder="Effet de la modification"
+                    title="@{vbmod-effet} Effet"></textarea>
                   <br>
-                  <input type="text" style="width: 95%;" name="attr_vbmod-buffs" placeholder="Ex : RAP : +1" value="" title="@{vbmod-buffs}" />
-                  <input type="checkbox" name="attr_vbmod-on" value="1" title="@{vbmod-on} Active ?" />  
+                  <input type="text" style="width: 95%;" name="attr_vbmod-buffs" placeholder="Ex : RAP : +1" value=""
+                    title="@{vbmod-buffs}" />
+                  <input type="checkbox" name="attr_vbmod-on" value="1" title="@{vbmod-on} Active ?" />
                 </div>
               </fieldset>
             </div>
@@ -2090,7 +2452,8 @@
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre" style="width: 25%;" title="Rapidité">RAP</td>
-                  <td class="sheet-boxinput" style="width: 25%;"><input type="number" name="attr_vbrap_base" value="0" /></td>
+                  <td class="sheet-boxinput" style="width: 25%;"><input type="number" name="attr_vbrap_base"
+                      value="0" /></td>
                   <td class="sheet-boxinputlight" style="width: 25%;">
                     <input type="hidden" name="attr_vbrap_div" value="0" />
                     <span name="attr_vbrap_div"></span>
@@ -2102,7 +2465,8 @@
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre" style="width: 25%;" title="Maniabilité">MAN</td>
-                  <td class="sheet-boxinput" style="width: 25%;"><input type="number" name="attr_vbman_base" value="0" /></td>
+                  <td class="sheet-boxinput" style="width: 25%;"><input type="number" name="attr_vbman_base"
+                      value="0" /></td>
                   <td class="sheet-boxinputlight" style="width: 25%;">
                     <input type="hidden" name="attr_vbman_div" value="0" />
                     <span name="attr_vbman_div"></span>
@@ -2114,7 +2478,8 @@
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre" style="width: 25%;" title="Impact">IMP</td>
-                  <td class="sheet-boxinput" style="width: 25%;"><input type="number" name="attr_vbimp_base" value="0" /></td>
+                  <td class="sheet-boxinput" style="width: 25%;"><input type="number" name="attr_vbimp_base"
+                      value="0" /></td>
                   <td class="sheet-boxinputlight" style="width: 25%;">
                     <input type="hidden" name="attr_vbimp_div" value="0" />
                     <span name="attr_vbimp_div"></span>
@@ -2126,7 +2491,8 @@
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre" style="width: 25%;" title="Emplacements">EMP</td>
-                  <td class="sheet-boxinput" style="width: 25%;"><input type="number" name="attr_vbemp_base" value="0" /></td>
+                  <td class="sheet-boxinput" style="width: 25%;"><input type="number" name="attr_vbemp_base"
+                      value="0" /></td>
                   <td class="sheet-boxinputlight" style="width: 25%;">
                     <input type="hidden" name="attr_vbemp_div" value="0" />
                     <span name="attr_vbemp_div"></span>
@@ -2143,7 +2509,8 @@
                   <td class="sheet-boxinputlight" style="width: 10%;">10+</td>
                   <td class="sheet-boxinputlight" style="width: 15%;"><span name="attr_vbimp"></span></td>
                   <td class="sheet-boxinputlight" style="width: 15%;"><span name="attr_vbman"></span></td>
-                  <td class="sheet-boxinput" style="width: 20%;"><input type="number" name="attr_vbdef_div" value="0" /></td>
+                  <td class="sheet-boxinput" style="width: 20%;"><input type="number" name="attr_vbdef_div" value="0" />
+                  </td>
                   <td class="sheet-boxinputlight" style="width: 15%;">
                     <input type="hidden" name="attr_vbdef" value="0" />
                     <span name="attr_vbdef"></span>
@@ -2154,7 +2521,8 @@
               <table class="sheet-tabsep">
                 <tr>
                   <td class="sheet-boxtitre">
-                    <button type="roll" class="sheet-nod20 sheet-boxtitre" name="roll_vbud" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Usure}} {{subtags=Test}} {{carac=[[d@{vbud}cf<3]] }}">&nbsp;UD&nbsp;</button>
+                    <button type="roll" class="sheet-nod20 sheet-boxtitre" name="roll_vbud"
+                      value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Usure}} {{subtags=Test}} {{carac=[[d@{vbud}cf<3]] }}">&nbsp;UD&nbsp;</button>
                   </td>
                   <td class="sheet-textfatleft">Dés d'Usure</td>
                   <td>
@@ -2169,7 +2537,9 @@
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre">
-                    <button type="roll" class="sheet-roll-d12 sheet-boxtitre" name="roll_vbud12" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Usure}} {{subtags=Test}} {{carac=[[d12cf<3]] }}"> Ud12</button>
+                    <button type="roll" class="sheet-roll-d12 sheet-boxtitre" name="roll_vbud12"
+                      value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Usure}} {{subtags=Test}} {{carac=[[d12cf<3]] }}">
+                      Ud12</button>
                   </td>
                   <td class="sheet-textfatleft">
                     <input type="checkbox" name="attr_vbud12_1" value="1">
@@ -2191,19 +2561,21 @@
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre">
-                    <button type="roll" class="sheet-roll-d10 sheet-boxtitre" name="roll_vbud10" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Usure}} {{subtags=Test}} {{carac=[[d10cf<3]] }}"> Ud10</button>
+                    <button type="roll" class="sheet-roll-d10 sheet-boxtitre" name="roll_vbud10"
+                      value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Usure}} {{subtags=Test}} {{carac=[[d10cf<3]] }}">
+                      Ud10</button>
                   </td>
                   <td class="sheet-textfatleft">
-                    <input type="checkbox" name="attr_vbud10_1 value="1">
-                    <input type="checkbox" name="attr_vbud10_2 value="1">
-                    <input type="checkbox" name="attr_vbud10_3 value="1">
-                    <input type="checkbox" name="attr_vbud10_4 value="1">|
-                    <input type="checkbox" name="attr_vbud10_5 value="1">
-                    <input type="checkbox" name="attr_vbud10_6 value="1">
-                    <input type="checkbox" name="attr_vbud10_7 value="1">
-                    <input type="checkbox" name="attr_vbud10_8 value="1">|
-                    <input type="checkbox" name="attr_vbud10_9 value="1">
-                    <input type="checkbox" name="attr_vbud10_10 value="1">
+                    <input type="checkbox" name="attr_vbud10_1 value=" 1">
+                    <input type="checkbox" name="attr_vbud10_2 value=" 1">
+                    <input type="checkbox" name="attr_vbud10_3 value=" 1">
+                    <input type="checkbox" name="attr_vbud10_4 value=" 1">|
+                    <input type="checkbox" name="attr_vbud10_5 value=" 1">
+                    <input type="checkbox" name="attr_vbud10_6 value=" 1">
+                    <input type="checkbox" name="attr_vbud10_7 value=" 1">
+                    <input type="checkbox" name="attr_vbud10_8 value=" 1">|
+                    <input type="checkbox" name="attr_vbud10_9 value=" 1">
+                    <input type="checkbox" name="attr_vbud10_10 value=" 1">
                   </td>
                   <td>
                     <input type="radio" name="attr_vbud" value="10" />
@@ -2211,7 +2583,9 @@
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre">
-                    <button type="roll" class="sheet-roll-d8 sheet-boxtitre" name="roll_vbud8" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Usure}} {{subtags=Test}} {{carac=[[d8cf<3]] }}"> Ud8</button>
+                    <button type="roll" class="sheet-roll-d8 sheet-boxtitre" name="roll_vbud8"
+                      value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Usure}} {{subtags=Test}} {{carac=[[d8cf<3]] }}">
+                      Ud8</button>
                   </td>
                   <td class="sheet-textfatleft">
                     <input type="checkbox" name="attr_vbud8_1" value="1">
@@ -2224,12 +2598,14 @@
                     <input type="checkbox" name="attr_vbud8_8" value="1">
                   </td>
                   <td>
-                    <input type="radio" name="attr_vbud" value="8" selected/>
+                    <input type="radio" name="attr_vbud" value="8" selected />
                   </td>
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre">
-                    <button type="roll" class="sheet-roll-d6 sheet-boxtitre" name="roll_vbud6" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Usure}} {{subtags=Test}} {{carac=[[d6cf<3]] }}"> Ud6</button>
+                    <button type="roll" class="sheet-roll-d6 sheet-boxtitre" name="roll_vbud6"
+                      value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Usure}} {{subtags=Test}} {{carac=[[d6cf<3]] }}">
+                      Ud6</button>
                   </td>
                   <td class="sheet-textfatleft">
                     <input type="checkbox" name="attr_vbud6_1" value="1">
@@ -2245,13 +2621,15 @@
                 </tr>
                 <tr>
                   <td class="sheet-boxtitre">
-                    <button type="roll" class="sheet-roll-d4 sheet-boxtitre" name="roll_vbud4" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Usure}} {{subtags=Test}} {{carac=[[d4cf<3]] }}"> Ud4</button>
+                    <button type="roll" class="sheet-roll-d4 sheet-boxtitre" name="roll_vbud4"
+                      value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Usure}} {{subtags=Test}} {{carac=[[d4cf<3]] }}">
+                      Ud4</button>
                   </td>
                   <td class="sheet-textfatleft">
                     <input type="checkbox" name="attr_vbud4_1" value="1">
                     <input type="checkbox" name="attr_vbud4_2" value="1">
                     <input type="checkbox" name="attr_vbud4_3" value="1">
-                    <input type="checkbox" name="attr_vbud4_4" value="1"> 
+                    <input type="checkbox" name="attr_vbud4_4" value="1">
                   </td>
                   <td>
                     <input type="radio" name="attr_vbud" value="4" />
@@ -2338,7 +2716,8 @@
                     <option value="@{vbimp}">IMP</option>
                   </select>
                   +
-                  <input type="number" style="width:32px;" name="attr_jetvdiv" value="0" title="@{jetvdiv} Bonus divers" />
+                  <input type="number" style="width:32px;" name="attr_jetvdiv" value="0"
+                    title="@{jetvdiv} Bonus divers" />
                   <input type="hidden" name="attr_jetvcaracp" value="" />
                 </td>
                 <td class="sheet-boxinputleft" style="width:100%;">
@@ -2349,7 +2728,7 @@
           </fieldset>
         </div>
         <img class="sheet-imghr"
-            src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesOublieesContemporain/coc_hr.jpg" />
+          src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesOublieesContemporain/coc_hr.jpg" />
       </div>
       <div class="sheet-textfatleft">PARAMETRES</div>
       <ul>
@@ -2625,9 +3004,10 @@
                   placeholder="Coller ici un statblock copié depuis le PDF"></textarea>
               </div>
               <div class="sheet-col">
-                <button type="action" name="act_sb_import" class="sheet-flatbtn sheet-iconbtn" title="Importer le stat-block">W</button>
+                <button type="action" name="act_sb_import" class="sheet-flatbtn sheet-iconbtn"
+                  title="Importer le stat-block">W</button>
                 <!-- <button type="roll" name="roll_sb_import_help" class="sheet-neutre sheet-nod20 sheet-flatbtn" value="[Import de stat-block](https://stephaned68.github.io/ChroniquesContemporaines/import-statblock)">Aide</button> -->
-                <textarea class="sheet-boxinputleft"  name="attr_sbresult" style="height: 5em;"></textarea>
+                <textarea class="sheet-boxinputleft" name="attr_sbresult" style="height: 5em;"></textarea>
               </div>
             </div>
           </div>
@@ -2867,16 +3247,18 @@ function removeRepeating(sectionName) {
 }
 
 /**
- * Add a trait/ability to an NPC object
+ * Add a trait/ability or extra to an NPC object
  * @param {object} npcObj
  * @param {object} traitObj
  */
 function addTrait(npcObj, traitObj) {
   if (traitObj['nom'] !== '' && traitObj['desc'] !== '') {
     npcObj['Capas'].push(`${traitObj['nom']}~${traitObj['desc']}`);
-    traitObj['nom'] = '';
-    traitObj['desc'] = '';
+  } else if (traitObj['desc'] !== '') {
+    npcObj['Extras'].push(traitObj['desc'].trim());
   }
+  traitObj['nom'] = '';
+  traitObj['desc'] = '';
 }
 
 /**
@@ -2902,6 +3284,9 @@ function importStatblock(text) {
     PV: 0,
     RD: 0,
     DEF: 0,
+    ATC: '',
+    ATD: '',
+    PIL: '',
     Atks: [],
     Capas: [],
     Extras: [],
@@ -2912,7 +3297,7 @@ function importStatblock(text) {
   console.log('** CO sheetworker : parsing text <<<');
   rows.forEach(function (row, rownr) {
     let dataRow = row.trim();
-    console.log(dataRow);
+    console.log(rownr, dataRow);
     if (rownr === 0 && dataRow.toUpperCase().indexOf('NC') === -1) {
       // assume first line is name
       npc['character_name'] = dataRow;
@@ -2931,6 +3316,7 @@ function importStatblock(text) {
     }
     // reading paths & ranks
     if (dataRow.toUpperCase().startsWith('VOIE ')) {
+      if (capacites) addTrait(npc, capacite);
       npc['Extras'].push(dataRow);
       return;
     }
@@ -3030,10 +3416,10 @@ function processBaseAttributes(universe, pnjObj) {
   var jnor = '1d20';
   var jsup = '2d20kh1';
   var pnjAttrs = {};
-  if (pnjObj.character_name !== '') {
+  if (pnjObj.hasOwnProperty('character_name')) {
     pnjAttrs['character_name'] = pnjObj.character_name;
+    delete pnjObj['character_name'];
   }
-  delete pnjObj['character_name'];
   pnjAttrs['NIVEAU'] = parseInt(pnjObj.NC) || 0;
   delete pnjObj['NC'];
   pnjAttrs['TAILLE'] = pnjObj.TAILLE || '';
@@ -3137,13 +3523,19 @@ function processAttacks(universe, pnjObj) {
     }
     consoleLog(atkNom + ' ' + atkBonus + ' ' + atkDM + ' ' + atkSpec);
     if (atkBonus === -1) {
-      atkAtt = '0'; // No attack bonus found, damage only
+      if (atkNom.endsWith(' /') && pnjObj.hasOwnProperty('ATD')) {
+        atkBonus = parseInt(pnjObj.ATD.replace('+', '')) || 0;
+        atkNom = atkNom.replace(' /', '');
+      } else {
+        atkAtt = '0'; // No attack bonus found, damage only
+      }
     }
     let atkDmg = atkDM !== '' ? 'degats=' : '0';
     let atkNbDe = 0;
     let atkDe = '';
     let atkBonusDM = 0;
     if (atkDM !== '') {
+      atkDM = atkDM.toLowerCase();
       atkDM = atkDM.replace('d', '|');
       atkDM = atkDM.replace('+', '|+');
       atkDM = atkDM.replace('-', '|-');
@@ -4160,10 +4552,10 @@ on('clicked:sb_import', function () {
         divers = pnjObj['Extras'].join('\n');
       }
       delete pnjObj['Extras'];
-      let otherAttrs = Object.keys(pnjObj);
+      const otherAttrs = Object.keys(pnjObj);
       consoleLog(otherAttrs, 'additional data');
-      for (const other in otherAttrs) {
-        divers += other + ' ' + pnjObj[other] + '\n';
+      for (const other of otherAttrs) {
+        divers += '\n' + other + ' ' + pnjObj[other];
       }
       setAttrs({
         pnj_divers: divers,
@@ -4668,6 +5060,40 @@ on(
         }
         setAttrs({
           repeating_jetcapas_jetcapaskill: skill,
+        });
+      }
+    );
+  }
+);
+
+/**
+ * On changing path & rank number attributes
+ * - Set the path & rank identifier (v?r?)
+ */
+on(
+  [
+    'change:repeating_jetcapas:jetcapavoieno',
+    'change:repeating_jetcapas:jetcapavoierang',
+  ].join(' '),
+  function () {
+    getAttrs(
+      [
+        'repeating_jetcapas_jetcapavoieno',
+        'repeating_jetcapas_jetcapavoierang',
+      ],
+      function (values) {
+        const vr = `${values.repeating_jetcapas_jetcapavoieno}${values.repeating_jetcapas_jetcapavoierang}`;
+        if (vr.length !== 4) return;
+        getAttrs([vr.replace('v', 'voie').replace('r', '-')], function (value) {
+          const rankData = value[Object.keys(value)[0]].split('\n');
+          const rankName = rankData.shift();
+          const rankDesc = rankData.length > 0 ? rankData.join('\n') : '';
+          const updated = {
+            repeating_jetcapas_jetcapanom: rankName,
+            repeating_jetcapas_jetcapadesc: rankDesc,
+            repeating_jetcapas_jetcapavr: vr,
+          };
+          setAttrs(updated);
         });
       }
     );
@@ -5604,6 +6030,7 @@ on(['change:coc_setting', 'change:coc_surh'].join(' '), function () {
   getAttrs(['coc_setting', 'coc_surh'], function (values) {
     defaultConfig = {
       cthulhu: {
+        coc_surh: '',
         INIT_JET: '@{INIT}',
         option_atkmen: '0',
         option_atkpsi: '0',
@@ -5619,6 +6046,7 @@ on(['change:coc_setting', 'change:coc_surh'].join(' '), function () {
         coc_setting_bitume: '0',
       },
       pulp: {
+        coc_surh: '',
         INIT_JET: '@{INIT}',
         option_atkmen: '0',
         option_atkpsi: '0',
@@ -5634,6 +6062,7 @@ on(['change:coc_setting', 'change:coc_surh'].join(' '), function () {
         coc_setting_bitume: '0',
       },
       postapo: {
+        coc_surh: '',
         INIT_JET: '@{INIT}',
         option_atkmen: '0',
         option_atkpsi: '0',
@@ -5664,6 +6093,7 @@ on(['change:coc_setting', 'change:coc_surh'].join(' '), function () {
         coc_setting_bitume: '0',
       },
       cyberpunk: {
+        coc_surh: '',
         INIT_JET: '{[[@{INIT}]]+1d6!, ([[@{INIT}]]*2)+0d6}kl1',
         option_atkmen: '1',
         option_atkpsi: '0',
@@ -5679,6 +6109,7 @@ on(['change:coc_setting', 'change:coc_surh'].join(' '), function () {
         coc_setting_bitume: '0',
       },
       shadowrun: {
+        coc_surh: '',
         INIT_JET: '{[[@{INIT}]]+1d6!, ([[@{INIT}]]*2)+0d6}kl1',
         option_atkmen: '1',
         option_atkpsi: '0',
@@ -5694,6 +6125,7 @@ on(['change:coc_setting', 'change:coc_surh'].join(' '), function () {
         coc_setting_bitume: '0',
       },
       menacex: {
+        coc_surh: '',
         INIT_JET: '@{INIT}',
         option_atkmen: '0',
         option_atkpsi: '1',
@@ -5709,6 +6141,7 @@ on(['change:coc_setting', 'change:coc_surh'].join(' '), function () {
         coc_setting_bitume: '0',
       },
       bitume: {
+        coc_surh: '',
         INIT_JET: '{[[@{INIT}]]+1d6!, ([[@{INIT}]]*2)+0d6}kl1',
         option_atkmen: '0',
         option_atkpsi: '0',
@@ -5832,6 +6265,35 @@ on(['change:coc_setting', 'change:coc_surh'].join(' '), function () {
         }
       }
     }
+    setAttrs(attrs);
+  });
+});
+
+/**
+ * On clicking JSON profile import button
+ * - parse and update profile's path & abilities
+ */
+on('clicked:json_import', function () {
+  getAttrs(['json_profile'], function (value) {
+    if (value.json_profile.trim() === '') return;
+    const jsonData = JSON.parse(value.json_profile);
+    const attrs = {
+      json_profile: '',
+      PROFIL: jsonData.profile,
+      FAMILLE: jsonData.family,
+    };
+    jsonData.paths.forEach((path, ix) => {
+      attrs[`voie${ix + 1}nom`] = path.name;
+      path.abilities.forEach((ability, rank) => {
+        const abilityAttr = `voie${ix + 1}-${rank + 1}`;
+        if (typeof ability === 'string') {
+          attrs[abilityAttr] = ability;
+        } else {
+          attrs[abilityAttr] = ability.name + '\n' + ability.description;
+        }
+      });
+    });
+    consoleLog(attrs);
     setAttrs(attrs);
   });
 });

--- a/ChroniquesOublieesContemporain/sheet.json
+++ b/ChroniquesOublieesContemporain/sheet.json
@@ -1,10 +1,10 @@
 {
-	"html": "coc.html",
-	"css": "coc.css",
-	"authors": "Ulti, Stéphane D, and Natha",
-	"roll20userid": ["1794854","75857","84776"],
-	"preview": "coc_v2.png",
-	"instructions": "Feuille de Personnage pour [Chroniques Oubliées Contemporain](http://www.black-book-editions.fr/produit.php?id=4349). Chroniques Oubliées Contemporain est le dérivé de Chroniques Oubliées Fantasy adapté pour jouer dans la période 1900-2100. Il permet de jouer des aventures du genre espionnage, commando militaire, enquêtes policières occultes, vampires contre garous, mutants, super-héros, épouvante, pulp, apocalypse zombie, cyberpunk, et plus.",
+  "html": "coc.html",
+  "css": "coc.css",
+  "authors": "Ulti, Stéphane D, and Natha",
+  "roll20userid": ["1794854", "75857", "84776"],
+  "preview": "coc_v2.png",
+  "instructions": "Feuille de Personnage pour [Chroniques Oubliées Contemporain](http://www.black-book-editions.fr/produit.php?id=4349). Chroniques Oubliées Contemporain est le dérivé de Chroniques Oubliées Fantasy adapté pour jouer dans la période 1900-2100. Il permet de jouer des aventures du genre espionnage, commando militaire, enquêtes policières occultes, vampires contre garous, mutants, super-héros, épouvante, pulp, apocalypse zombie, cyberpunk, et plus. Version 3.6 (04/09/2020). [Lisez-moi](https://github.com/Roll20/roll20-character-sheets/blob/master/ChroniquesOublieesContemporain/README.md).",
   "useroptions": [
     {
       "attribute": "coc_setting",
@@ -13,6 +13,8 @@
       "options": [
         "Cthulhu/Epouvante|cthulhu",
         "Pulp|pulp",
+        "Post-Apocalypse|postapo",
+        "Surhumains|surhumain",
         "Cyberpunk|cyberpunk",
         "Cyber+Fantasy|shadowrun",
         "Menace-X|menacex",
@@ -20,6 +22,28 @@
       ],
       "default": "",
       "description": "Choix des options de jeux"
+    },
+    {
+      "attribute": "coc_surh",
+      "displayname": "Surhumains ?",
+      "type": "select",
+      "options": [
+        "Ange|ange",
+        "Démon|demon",
+        "Loup-garou|garou",
+        "Vampire|vampire",
+        "Dragon (Fée)|fee-dragon",
+        "Dryade (Fée)|fee-dryade",
+        "Dwergar (Fée)|fee-dwergar",
+        "Gobelin (Fée)|fee-gobelin",
+        "Lutin (Fée)|fee-lutin",
+        "Ogre (Fée)|fee-ogre",
+        "Mutant Endo|mutant-endo",
+        "Mutant Exo|mutant-exo",
+        "Mutant Psy|mutant-psycho"
+      ],
+      "default": "",
+      "description": "Choix du type de surhumains"
     }
   ]
 }


### PR DESCRIPTION
## Changes / Comments
- New checkbox on the ability tab of the PC character sheet that toggles between :
  - Display mode, with the name and full textual description of the ability
  - Edit mode, where the user can enter the abilities in text areas (the first line of the text area is always assumed to be the name of the ability).
- The list of paths and abilities for the character profile can now be imported using JSON data copied from a public API and pasted into the sheet.
- It is now possible to link an ability roll with one of the abilities in the grid, by specifying the corresponding path and rank numbers. This information is mainly used by the API script COlib. This companion script also allows JSON data import, not only in the character sheet but also in the Roll20 journal.


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
