### PR TITLE
[Soulbound] NPC sheet

### DIFF
--- a/Age-of-Sigmar-Soulbound/README.MD
+++ b/Age-of-Sigmar-Soulbound/README.MD
@@ -2,14 +2,22 @@
 This is the Warhammer Age of Sigmar: Soulbound Character Sheet readme
 
 ## Version info
-### V1.0.0 - initial submission to roll20
+### V1.0 - initial submission to roll20
 
 all rolls using standard roll20 api
 
 player sheet only
 
+### V2.0 - NPC sheet
+
+added new options menu (Accessible by the cog symbol)
+
+added npc sheet (toggle between player and npc switch in options menu)
+
+fixed issue with wounds, sheetworker will update existing sheets
+
 ## Contributing/Issues
 For issues or contributions consider raising an issue on the [development repo](https://github.com/CloverFox/roll20-soulbound-sheet)
 
 ## Special Thanks
-ej93 for group-init compatibility
+ej93 for group-init compatibility, as well as the lions share of the NPC sheet

--- a/Age-of-Sigmar-Soulbound/soulbound.css
+++ b/Age-of-Sigmar-Soulbound/soulbound.css
@@ -8,6 +8,87 @@
     display: none;
 }
 
+/*Configure the tab buttons*/
+.sheet-player,
+.sheet-party,
+.sheet-npc {
+    display: none;
+}
+
+/* show the selected tab */
+.sheet-tabs-toggle[value="player"] ~ div.sheet-player,
+.sheet-tabs-toggle[value="party"] ~ div.sheet-party,
+.sheet-tabs-toggle[value="npc"] ~ div.sheet-npc {
+    display: block;
+}
+
+.sheet-content,
+.sheet-options-button:checked ~ .sheet-options {
+    display: block;
+}
+
+.sheet-options,
+.sheet-options-button:checked ~ .sheet-content {
+    display: none;
+}
+
+.sheet-section-options {
+    display: flex;
+}
+
+.sheet-section-options .sheet-options-check {
+    margin-left: auto;
+}
+
+.sheet-options-check-center {
+    display: flex;
+    justify-content: center;
+}
+
+.sheet-option-entry {
+    display: flex;
+}
+
+.sheet-option-entry div {
+    margin-right: 20px;
+}
+
+.sheet-option-entry select {
+    width: 100px;
+}
+
+.sheet-stack {
+    display: grid;
+}
+
+.sheet-stack > * {
+    grid-row: 1;
+    grid-column: 1;
+}
+
+.sheet-options-check {
+    text-align: center;
+}
+
+.sheet-options-check input[type="checkbox"] {
+    opacity: 0;
+    cursor: pointer;
+    z-index: 1;
+}
+
+.sheet-options-check input[type="checkbox"] + span::before {
+    font-family: Pictos, serif;
+    line-height: 14px;
+    text-align: center;
+    content: "y";
+    font-size: 20px;
+}
+
+.sheet-options-check input[type="checkbox"]:checked + span::before {
+    background: grey;
+    color: white;
+}
+
 .sheet-talents-container input[type="checkbox"] {
     opacity: 0;
     width: 16px;
@@ -166,6 +247,7 @@ button[type="roll"].sheet-text-big {
 .sheet-talents-check2 {
     grid-column: col 3;
 }
+
 .sheet-talents-button {
     grid-column: col 4;
 }
@@ -189,6 +271,7 @@ button[type="roll"].sheet-text-big {
 .sheet-talents-container button[type="roll"]::before {
     content: "";
 }
+
 .sheet-talents-container textarea {
     height: 60px;
     width: 380px;
@@ -235,7 +318,7 @@ button[type="roll"].sheet-text-big {
     text-align: center;
 }
 
-.sheet-wounds-tracker *{
+.sheet-wounds-tracker * {
     width: 90px;
 }
 
@@ -246,6 +329,10 @@ button[type="roll"].sheet-text-big {
 
 .sheet-wounds-counter div {
     margin-bottom: 5px;
+}
+
+.sheet-wounds-counter input:read-only {
+    cursor: default;
 }
 
 .sheet-death-saves {
@@ -376,6 +463,10 @@ button[type="roll"].sheet-text-big {
     grid-template-columns: 250px 40px 70px 70px 70px auto;
 }
 
+.sheet-weapon-traits {
+    width: auto;
+}
+
 .sheet-weapon-focus .sheet-cover {
     width: 70px;
     height: 40px;
@@ -490,4 +581,117 @@ input[type="number"].sheet-small-digit {
 
 .sheet-text-area {
     padding: 0;
+}
+
+/*npc tab*/
+.sheet-npc-name {
+    display: flex;
+    width: 100%;
+    text-align: center;
+}
+
+.sheet-npc-attacks {
+    display: grid;
+    grid-template-columns: 140px 43px 80px 73px 50px 50px 50px 80px auto;
+    grid-template-rows: 28px;
+}
+
+.sheet-npc-attack-name {
+    width: 140px;
+}
+
+.sheet-npc-attack-prof {
+    width: 78px;
+}
+
+.sheet-npc-attack-prof-val {
+    width: 68px;
+}
+
+.sheet-npc-attack-range {
+    width: 78px;
+}
+
+.sheet-npc-attack-traits {
+    width: 100%;
+}
+
+.sheet-npc-details {
+    justify-content: space-between;
+    display: flex;
+}
+
+.sheet-npc-details > div {
+    display: flex;
+}
+
+.sheet-npc-details input[type="text"] {
+    width: 100px;
+}
+
+.sheet-section-npc-skills-traits {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+}
+
+.sheet-npc-skills {
+    display: grid;
+    grid-template-columns: 210px 40px 60px 50px auto;
+    grid-template-rows: 28px;
+}
+
+.sheet-npc-base-stats {
+    display: flex;
+    justify-content: space-evenly;
+    text-align: center;
+}
+
+.sheet-npc-base-stats input[type="number"] {
+    font-size: 25px;
+    width: 1.75em;
+    border: 0;
+}
+
+.sheet-npc-base-stats button[type="roll"] {
+    text-align: center;
+    font-size: 25px;
+    margin: 10px 0;
+}
+
+.sheet-npc-combat-abilities {
+    display: flex;
+    justify-content: space-between;
+}
+
+.sheet-npc-combat-stats {
+    display: flex;
+    margin: 5px 0;
+}
+
+.sheet-npc-combat-stats * {
+    flex: 1;
+    text-align: center;
+}
+
+.sheet-npc-info {
+    display: flex;
+    margin: 0 0 5px 0;
+}
+
+.sheet-npc-info * {
+    text-align: center;
+    width: 100%;
+}
+
+.sheet-npc-mel-select {
+    width: auto;
+}
+
+.sheet-npc-acc-select {
+    width: auto;
+}
+
+.sheet-npc-def-select {
+    width: auto;
 }

--- a/Age-of-Sigmar-Soulbound/soulbound.html
+++ b/Age-of-Sigmar-Soulbound/soulbound.html
@@ -5,1098 +5,1377 @@
 <input type="hidden" name="attr_defence" value="ceil((@{body}+@{reflexes_1}+@{reflexes_2}+@{reflexes_3})/2)"
        disabled="true">
 
-<div class="section-character">
-    <div class="img-name">
-        <img src="https://i.imgur.com/NMAlvGL.jpg" class="soulbound-img"/>
-        <div>
-            <input type="text" name="attr_character_name">
-            <span>Character Name</span>
+<input type="checkbox" class="options-button" hidden="true" name="attr_options" value="1"/>
+<div class="options">
+    <div class="options-check-center">
+        <div class="options-check stack">
+            <input type="checkbox" class="options-button" name="attr_options" value="1"/>
+            <span></span>
         </div>
     </div>
-    <div class="info">
-        <div class="archetype">
-            <input type="text" name="attr_archetype">
-            <span>Archetype</span>
-        </div>
-        <div class="species">
-            <input type="text" name="attr_species">
-            <span>Species</span>
-        </div>
-        <div class="age">
-            <input type="text" name="attr_age">
-            <span>Age</span>
-        </div>
-        <div class="eyes">
-            <input type="text" name="attr_eyes">
-            <span>Eyes</span>
-        </div>
-        <div class="hair">
-            <input type="text" name="attr_hair">
-            <span>Hair</span>
-        </div>
-        <div class="height">
-            <input type="text" name="attr_height">
-            <span>Height</span>
-        </div>
-        <div class="weight">
-            <input type="text" name="attr_weight">
-            <span>Weight</span>
-        </div>
-        <div class="dist-features">
-            <input type="text" name="attr_dist_features">
-            <span>Distinguishing Features</span>
-        </div>
-        <div class="xp">
-            <input type="text" name="attr_xp">
-            <span>xp</span>
-        </div>
+    <div class="option-entry">
+        <div>Sheet Type:</div>
+        <select name="attr_sheet_tab">
+            <option value="player" selected="selected">player</option>
+            <option value="npc">npc</option>
+        </select>
+    </div>
+    <div>Sheet version:
+        <input type="text" name="attr_version" value="2.0" disabled="true" hidden="true">
+        <span name="attr_version"></span>
     </div>
 </div>
-<div class="section-attributes-and-skills">
-    <div class="attributes-container">
-        <div class="header">Attributes</div>
-        <div class="line"></div>
+<div class="content">
+    <input type='hidden' class='sheet-tabs-toggle' name='attr_sheet_tab' value='player'/>
 
-        <div class="attributes">
+    <div class="sheet-player">
+        <div class="section-character">
+            <div class="img-name">
+                <img src="https://i.imgur.com/NMAlvGL.jpg" class="soulbound-img"/>
+                <div>
+                    <input type="text" name="attr_character_name">
+                    <span>Character Name</span>
+                </div>
+            </div>
+            <div class="info">
+                <div class="archetype">
+                    <input type="text" name="attr_archetype">
+                    <span>Archetype</span>
+                </div>
+                <div class="species">
+                    <input type="text" name="attr_species">
+                    <span>Species</span>
+                </div>
+                <div class="age">
+                    <input type="text" name="attr_age">
+                    <span>Age</span>
+                </div>
+                <div class="eyes">
+                    <input type="text" name="attr_eyes">
+                    <span>Eyes</span>
+                </div>
+                <div class="hair">
+                    <input type="text" name="attr_hair">
+                    <span>Hair</span>
+                </div>
+                <div class="height">
+                    <input type="text" name="attr_height">
+                    <span>Height</span>
+                </div>
+                <div class="weight">
+                    <input type="text" name="attr_weight">
+                    <span>Weight</span>
+                </div>
+                <div class="dist-features">
+                    <input type="text" name="attr_dist_features">
+                    <span>Distinguishing Features</span>
+                </div>
+                <div class="xp">
+                    <input type="text" name="attr_xp">
+                    <span>xp</span>
+                </div>
+            </div>
+        </div>
+        <div class="section-options">
+            <div class="options-check stack">
+                <input type="checkbox" class="options-button" name="attr_options" value="1"/>
+                <span></span>
+            </div>
+        </div>
+
+        <div class="section-attributes-and-skills">
+            <div class="attributes-container">
+                <div class="header">Attributes</div>
+                <div class="line"></div>
+
+                <div class="attributes">
+                    <div>
+                        <input type="number" name="attr_body" value="1">
+                        <button type="roll" class="text-button text-big"
+                                value="&{template:default} {{name=Body}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[@{body}d6s>?{Target DN? |2|3|4|5|6}]] successes}}"
+                                name="roll_might">Body
+                        </button>
+                    </div>
+                    <div>
+                        <input type="number" name="attr_mind" value="1">
+                        <button type="roll" class="text-button text-big"
+                                value="&{template:default} {{name=Mind}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[@{mind}d6s>?{Target DN? |2|3|4|5|6}]] successes}}"
+                                name="roll_might">Mind
+                        </button>
+                    </div>
+                    <div>
+                        <input type="number" name="attr_soul" value="1">
+                        <button type="roll" class="text-button text-big"
+                                value="&{template:default} {{name=Soul}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[@{soul}d6s>?{Target DN? |2|3|4|5|6}]] successes}}"
+                                name="roll_might">Soul
+                        </button>
+                    </div>
+                </div>
+            </div>
             <div>
-                <input type="number" name="attr_body" value="1">
-                <button type="roll" class="text-button text-big"
-                        value="&{template:default} {{name=Body}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[@{body}d6s>?{Target DN? |2|3|4|5|6}]] successes}}"
-                        name="roll_might">Body
-                </button>
+                <div class="header">Skills</div>
+                <div class="line"></div>
+                <div class="skills-list">
+                    <div class="skills">
+                        <div></div>
+                        <div>Training</div>
+                        <div>Focus</div>
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Arcana}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{arcana_attribute}+@{arcana_1}+@{arcana_2}+@{arcana_3}+?{Arcana bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{arcana_focus_1} + @{arcana_focus_2} + @{arcana_focus_3}]] focus points}}"
+                                    name="roll_arcana">Arcana
+                            </button>
+                            <select class="attribute-select" name="attr_arcana_attribute">
+                                <option value="@{body}">body</option>
+                                <option value="@{mind}">mind</option>
+                                <option value="@{soul}" selected="selected">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_arcana_1" value="1">
+                            <input type="checkbox" name="attr_arcana_2" value="1">
+                            <input type="checkbox" name="attr_arcana_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_arcana_focus_1" value="1">
+                            <input type="checkbox" name="attr_arcana_focus_2" value="1">
+                            <input type="checkbox" name="attr_arcana_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Athletics}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{athletics_attribute}+@{athletics_1}+@{athletics_2}+@{athletics_3}+?{Athletics bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{athletics_focus_1} + @{athletics_focus_2} + @{athletics_focus_3}]] focus points}}"
+                                    name="roll_athletics">Athletics
+                            </button>
+                            <select class="attribute-select" name="attr_athletics_attribute">
+                                <option value="@{body}" selected="selected">body</option>
+                                <option value="@{mind}">mind</option>
+                                <option value="@{soul}">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_athletics_1" value="1">
+                            <input type="checkbox" name="attr_athletics_2" value="1">
+                            <input type="checkbox" name="attr_athletics_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_athletics_focus_1" value="1">
+                            <input type="checkbox" name="attr_athletics_focus_2" value="1">
+                            <input type="checkbox" name="attr_athletics_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Awareness}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{awareness_attribute}+@{awareness_1}+@{awareness_2}+@{awareness_3}+?{Awareness bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{awareness_focus_1} + @{awareness_focus_2} + @{awareness_focus_3}]] focus points}}"
+                                    name="roll_awareness">Awareness
+                            </button>
+                            <select class="attribute-select" name="attr_awareness_attribute">
+                                <option value="@{body}">body</option>
+                                <option value="@{mind}" selected="selected">mind</option>
+                                <option value="@{soul}">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_awareness_1" value="1">
+                            <input type="checkbox" name="attr_awareness_2" value="1">
+                            <input type="checkbox" name="attr_awareness_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_awareness_focus_1" value="1">
+                            <input type="checkbox" name="attr_awareness_focus_2" value="1">
+                            <input type="checkbox" name="attr_awareness_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Ballistic skill}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{ballistic_skill_attribute}+@{ballistic_skill_1}+@{ballistic_skill_2}+@{ballistic_skill_3}+?{Ballistic skill bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{ballistic_skill_focus_1} + @{ballistic_skill_focus_2} + @{ballistic_skill_focus_3}]] focus points}}"
+                                    name="roll_ballistic_skill">Ballistic skill
+                            </button>
+                            <select class="attribute-select" name="attr_ballistic_skill_attribute">
+                                <option value="@{body}" selected="selected">body</option>
+                                <option value="@{mind}">mind</option>
+                                <option value="@{soul}">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_ballistic_skill_1" value="1">
+                            <input type="checkbox" name="attr_ballistic_skill_2" value="1">
+                            <input type="checkbox" name="attr_ballistic_skill_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_ballistic_skill_focus_1" value="1">
+                            <input type="checkbox" name="attr_ballistic_skill_focus_2" value="1">
+                            <input type="checkbox" name="attr_ballistic_skill_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Beast Handling}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{beast_handling_attribute}+@{beast_handling_1}+@{beast_handling_2}+@{beast_handling_3}+?{Beast Handling bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{beast_handling_focus_1} + @{beast_handling_focus_2} + @{beast_handling_focus_3}]] focus points}}"
+                                    name="roll_beast_handling">Beast Handling
+                            </button>
+                            <select class="attribute-select" name="attr_beast_handling_attribute">
+                                <option value="@{body}">body</option>
+                                <option value="@{mind}">mind</option>
+                                <option value="@{soul}" selected="selected">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_beast_handling_1" value="1">
+                            <input type="checkbox" name="attr_beast_handling_2" value="1">
+                            <input type="checkbox" name="attr_beast_handling_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_beast_handling_focus_1" value="1">
+                            <input type="checkbox" name="attr_beast_handling_focus_2" value="1">
+                            <input type="checkbox" name="attr_beast_handling_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Channelling}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{channelling_attribute}+@{channelling_1}+@{channelling_2}+@{channelling_3}+?{Channelling bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{channelling_focus_1} + @{channelling_focus_2} + @{channelling_focus_3}]] focus points}}"
+                                    name="roll_channelling">Channelling
+                            </button>
+                            <select class="attribute-select" name="attr_channelling_attribute">
+                                <option value="@{body}">body</option>
+                                <option value="@{mind}" selected="selected">mind</option>
+                                <option value="@{soul}">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_channelling_1" value="1">
+                            <input type="checkbox" name="attr_channelling_2" value="1">
+                            <input type="checkbox" name="attr_channelling_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_channelling_focus_1" value="1">
+                            <input type="checkbox" name="attr_channelling_focus_2" value="1">
+                            <input type="checkbox" name="attr_channelling_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Crafting}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{crafting_attribute}+@{crafting_1}+@{crafting_2}+@{crafting_3}+?{Crafting bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{crafting_focus_1} + @{crafting_focus_2} + @{crafting_focus_3}]] focus points}}"
+                                    name="roll_crafting">Crafting
+                            </button>
+                            <select class="attribute-select" name="attr_crafting_attribute">
+                                <option value="@{body}">body</option>
+                                <option value="@{mind}" selected="selected">mind</option>
+                                <option value="@{soul}">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_crafting_1" value="1">
+                            <input type="checkbox" name="attr_crafting_2" value="1">
+                            <input type="checkbox" name="attr_crafting_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_crafting_focus_1" value="1">
+                            <input type="checkbox" name="attr_crafting_focus_2" value="1">
+                            <input type="checkbox" name="attr_crafting_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Determination}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{determination_attribute}+@{determination_1}+@{determination_2}+@{determination_3}+?{Determination bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{determination_focus_1} + @{determination_focus_2} + @{determination_focus_3}]] focus points}}"
+                                    name="roll_determination">Determination
+                            </button>
+                            <select class="attribute-select" name="attr_determination_attribute">
+                                <option value="@{body}">body</option>
+                                <option value="@{mind}">mind</option>
+                                <option value="@{soul}" selected="selected">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_determination_1" value="1">
+                            <input type="checkbox" name="attr_determination_2" value="1">
+                            <input type="checkbox" name="attr_determination_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_determination_focus_1" value="1">
+                            <input type="checkbox" name="attr_determination_focus_2" value="1">
+                            <input type="checkbox" name="attr_determination_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Devotion}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{devotion_attribute}+@{devotion_1}+@{devotion_2}+@{devotion_3}+?{Devotion bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{devotion_focus_1} + @{devotion_focus_2} + @{devotion_focus_3}]] focus points}}"
+                                    name="roll_devotion">Devotion
+                            </button>
+                            <select class="attribute-select" name="attr_devotion_attribute">
+                                <option value="@{body}">body</option>
+                                <option value="@{mind}">mind</option>
+                                <option value="@{soul}" selected="selected">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_devotion_1" value="1">
+                            <input type="checkbox" name="attr_devotion_2" value="1">
+                            <input type="checkbox" name="attr_devotion_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_devotion_focus_1" value="1">
+                            <input type="checkbox" name="attr_devotion_focus_2" value="1">
+                            <input type="checkbox" name="attr_devotion_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Dexterity}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{dexterity_attribute}+@{dexterity_1}+@{dexterity_2}+@{dexterity_3}+?{Dexterity bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{dexterity_focus_1} + @{dexterity_focus_2} + @{dexterity_focus_3}]] focus points}}"
+                                    name="roll_dexterity">Dexterity
+                            </button>
+                            <select class="attribute-select" name="attr_dexterity_attribute">
+                                <option value="@{body}" selected="selected">body</option>
+                                <option value="@{mind}">mind</option>
+                                <option value="@{soul}">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_dexterity_1" value="1">
+                            <input type="checkbox" name="attr_dexterity_2" value="1">
+                            <input type="checkbox" name="attr_dexterity_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_dexterity_focus_1" value="1">
+                            <input type="checkbox" name="attr_dexterity_focus_2" value="1">
+                            <input type="checkbox" name="attr_dexterity_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Entertain}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{entertain_attribute}+@{entertain_1}+@{entertain_2}+@{entertain_3}+?{Entertain bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{entertain_focus_1} + @{entertain_focus_2} + @{entertain_focus_3}]] focus points}}"
+                                    name="roll_entertain">Entertain
+                            </button>
+                            <select class="attribute-select" name="attr_entertain_attribute">
+                                <option value="@{body}">body</option>
+                                <option value="@{mind}">mind</option>
+                                <option value="@{soul}" selected="selected">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_entertain_1" value="1">
+                            <input type="checkbox" name="attr_entertain_2" value="1">
+                            <input type="checkbox" name="attr_entertain_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_entertain_focus_1" value="1">
+                            <input type="checkbox" name="attr_entertain_focus_2" value="1">
+                            <input type="checkbox" name="attr_entertain_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Fortitude}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{fortitude_attribute}+@{fortitude_1}+@{fortitude_2}+@{fortitude_3}+?{Fortitude bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{fortitude_focus_1} + @{fortitude_focus_2} + @{fortitude_focus_3}]] focus points}}"
+                                    name="roll_fortitude">Fortitude
+                            </button>
+                            <select class="attribute-select" name="attr_fortitude_attribute">
+                                <option value="@{body}" selected="selected">body</option>
+                                <option value="@{mind}">mind</option>
+                                <option value="@{soul}">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_fortitude_1" value="1">
+                            <input type="checkbox" name="attr_fortitude_2" value="1">
+                            <input type="checkbox" name="attr_fortitude_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_fortitude_focus_1" value="1">
+                            <input type="checkbox" name="attr_fortitude_focus_2" value="1">
+                            <input type="checkbox" name="attr_fortitude_focus_3" value="1">
+                        </div>
+
+                    </div>
+                    <div class="skills">
+                        <div></div>
+                        <div>Training</div>
+                        <div>Focus</div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Guile}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{guile_attribute}+@{guile_1}+@{guile_2}+@{guile_3}+?{Guile bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{guile_focus_1} + @{guile_focus_2} + @{guile_focus_3}]] focus points}}"
+                                    name="roll_guile">Guile
+                            </button>
+                            <select class="attribute-select" name="attr_guile_attribute">
+                                <option value="@{body}">body</option>
+                                <option value="@{mind}" selected="selected">mind</option>
+                                <option value="@{soul}">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_guile_1" value="1">
+                            <input type="checkbox" name="attr_guile_2" value="1">
+                            <input type="checkbox" name="attr_guile_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_guile_focus_1" value="1">
+                            <input type="checkbox" name="attr_guile_focus_2" value="1">
+                            <input type="checkbox" name="attr_guile_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Intimidation}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{intimidation_attribute}+@{intimidation_1}+@{intimidation_2}+@{intimidation_3}+?{Intimidation bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{intimidation_focus_1} + @{intimidation_focus_2} + @{intimidation_focus_3}]] focus points}}"
+                                    name="roll_intimidation">Intimidation
+                            </button>
+                            <select class="attribute-select" name="attr_intimidation_attribute">
+                                <option value="@{body}">body</option>
+                                <option value="@{mind}">mind</option>
+                                <option value="@{soul}" selected="selected">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_intimidation_1" value="1">
+                            <input type="checkbox" name="attr_intimidation_2" value="1">
+                            <input type="checkbox" name="attr_intimidation_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_intimidation_focus_1" value="1">
+                            <input type="checkbox" name="attr_intimidation_focus_2" value="1">
+                            <input type="checkbox" name="attr_intimidation_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Intuition}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{intuition_attribute}+@{intuition_1}+@{intuition_2}+@{intuition_3}+?{Intuition bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{intuition_focus_1} + @{intuition_focus_2} + @{intuition_focus_3}]] focus points}}"
+                                    name="roll_intuition">Intuition
+                            </button>
+                            <select class="attribute-select" name="attr_intuition_attribute">
+                                <option value="@{body}">body</option>
+                                <option value="@{mind}" selected="selected">mind</option>
+                                <option value="@{soul}">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_intuition_1" value="1">
+                            <input type="checkbox" name="attr_intuition_2" value="1">
+                            <input type="checkbox" name="attr_intuition_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_intuition_focus_1" value="1">
+                            <input type="checkbox" name="attr_intuition_focus_2" value="1">
+                            <input type="checkbox" name="attr_intuition_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Lore}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{lore_attribute}+@{lore_1}+@{lore_2}+@{lore_3}+?{Lore bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{lore_focus_1} + @{lore_focus_2} + @{lore_focus_3}]] focus points}}"
+                                    name="roll_lore">Lore
+                            </button>
+                            <select class="attribute-select" name="attr_lore_attribute">
+                                <option value="@{body}">body</option>
+                                <option value="@{mind}" selected="selected">mind</option>
+                                <option value="@{soul}">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_lore_1" value="1">
+                            <input type="checkbox" name="attr_lore_2" value="1">
+                            <input type="checkbox" name="attr_lore_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_lore_focus_1" value="1">
+                            <input type="checkbox" name="attr_lore_focus_2" value="1">
+                            <input type="checkbox" name="attr_lore_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Medicine}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{medicine_attribute}+@{medicine_1}+@{medicine_2}+@{medicine_3}+?{Medicine bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{medicine_focus_1} + @{medicine_focus_2} + @{medicine_focus_3}]] focus points}}"
+                                    name="roll_medicine">Medicine
+                            </button>
+                            <select class="attribute-select" name="attr_medicine_attribute">
+                                <option value="@{body}">body</option>
+                                <option value="@{mind}" selected="selected">mind</option>
+                                <option value="@{soul}">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_medicine_1" value="1">
+                            <input type="checkbox" name="attr_medicine_2" value="1">
+                            <input type="checkbox" name="attr_medicine_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_medicine_focus_1" value="1">
+                            <input type="checkbox" name="attr_medicine_focus_2" value="1">
+                            <input type="checkbox" name="attr_medicine_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Might}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{might_attribute}+@{might_1}+@{might_2}+@{might_3}+?{Might bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{might_focus_1} + @{might_focus_2} + @{might_focus_3}]] focus points}}"
+                                    name="roll_might">Might
+                            </button>
+                            <select class="attribute-select" name="attr_might_attribute">
+                                <option value="@{body}" selected="selected">body</option>
+                                <option value="@{mind}">mind</option>
+                                <option value="@{soul}">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_might_1" value="1">
+                            <input type="checkbox" name="attr_might_2" value="1">
+                            <input type="checkbox" name="attr_might_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_might_focus_1" value="1">
+                            <input type="checkbox" name="attr_might_focus_2" value="1">
+                            <input type="checkbox" name="attr_might_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Nature}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{nature_attribute}+@{nature_1}+@{nature_2}+@{nature_3}+?{Nature bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{nature_focus_1} + @{nature_focus_2} + @{nature_focus_3}]] focus points}}"
+                                    name="roll_nature">Nature
+                            </button>
+                            <select class="attribute-select" name="attr_nature_attribute">
+                                <option value="@{body}">body</option>
+                                <option value="@{mind}" selected="selected">mind</option>
+                                <option value="@{soul}">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_nature_1" value="1">
+                            <input type="checkbox" name="attr_nature_2" value="1">
+                            <input type="checkbox" name="attr_nature_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_nature_focus_1" value="1">
+                            <input type="checkbox" name="attr_nature_focus_2" value="1">
+                            <input type="checkbox" name="attr_nature_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Reflexes}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{reflexes_attribute}+@{reflexes_1}+@{reflexes_2}+@{reflexes_3}+?{Reflexes bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{reflexes_focus_1} + @{reflexes_focus_2} + @{reflexes_focus_3}]] focus points}}"
+                                    name="roll_reflexes">Reflexes
+                            </button>
+                            <select class="attribute-select" name="attr_reflexes_attribute">
+                                <option value="@{body}" selected="selected">body</option>
+                                <option value="@{mind}">mind</option>
+                                <option value="@{soul}">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_reflexes_1" value="1">
+                            <input type="checkbox" name="attr_reflexes_2" value="1">
+                            <input type="checkbox" name="attr_reflexes_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_reflexes_focus_1" value="1">
+                            <input type="checkbox" name="attr_reflexes_focus_2" value="1">
+                            <input type="checkbox" name="attr_reflexes_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Stealth}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{stealth_attribute}+@{stealth_1}+@{stealth_2}+@{stealth_3}+?{Stealth bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{stealth_focus_1} + @{stealth_focus_2} + @{stealth_focus_3}]] focus points}}"
+                                    name="roll_stealth">Stealth
+                            </button>
+                            <select class="attribute-select" name="attr_stealth_attribute">
+                                <option value="@{body}" selected="selected">body</option>
+                                <option value="@{mind}">mind</option>
+                                <option value="@{soul}">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_stealth_1" value="1">
+                            <input type="checkbox" name="attr_stealth_2" value="1">
+                            <input type="checkbox" name="attr_stealth_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_stealth_focus_1" value="1">
+                            <input type="checkbox" name="attr_stealth_focus_2" value="1">
+                            <input type="checkbox" name="attr_stealth_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Survival}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{survival_attribute}+@{survival_1}+@{survival_2}+@{survival_3}+?{Survival bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{survival_focus_1} + @{survival_focus_2} + @{survival_focus_3}]] focus points}}"
+                                    name="roll_survival">Survival
+                            </button>
+                            <select class="attribute-select" name="attr_survival_attribute">
+                                <option value="@{body}">body</option>
+                                <option value="@{mind}" selected="selected">mind</option>
+                                <option value="@{soul}">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_survival_1" value="1">
+                            <input type="checkbox" name="attr_survival_2" value="1">
+                            <input type="checkbox" name="attr_survival_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_survival_focus_1" value="1">
+                            <input type="checkbox" name="attr_survival_focus_2" value="1">
+                            <input type="checkbox" name="attr_survival_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Theology}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{theology_attribute}+@{theology_1}+@{theology_2}+@{theology_3}+?{Theology bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{theology_focus_1} + @{theology_focus_2} + @{theology_focus_3}]] focus points}}"
+                                    name="roll_theology">Theology
+                            </button>
+                            <select class="attribute-select" name="attr_theology_attribute">
+                                <option value="@{body}">body</option>
+                                <option value="@{mind}" selected="selected">mind</option>
+                                <option value="@{soul}">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_theology_1" value="1">
+                            <input type="checkbox" name="attr_theology_2" value="1">
+                            <input type="checkbox" name="attr_theology_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_theology_focus_1" value="1">
+                            <input type="checkbox" name="attr_theology_focus_2" value="1">
+                            <input type="checkbox" name="attr_theology_focus_3" value="1">
+                        </div>
+
+                        <div class="desc">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Weapon Skill}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{weapon_skill_attribute}+@{weapon_skill_1}+@{weapon_skill_2}+@{weapon_skill_3}+?{Weapon Skill bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{weapon_skill_focus_1} + @{weapon_skill_focus_2} + @{weapon_skill_focus_3}]] focus points}}"
+                                    name="roll_weapon_skill">Weapon Skill
+                            </button>
+                            <select class="attribute-select" name="attr_weapon_skill_attribute">
+                                <option value="@{body}" selected="selected">body</option>
+                                <option value="@{mind}">mind</option>
+                                <option value="@{soul}">soul</option>
+                            </select>
+                        </div>
+                        <div class="training">
+                            <input type="checkbox" name="attr_weapon_skill_1" value="1">
+                            <input type="checkbox" name="attr_weapon_skill_2" value="1">
+                            <input type="checkbox" name="attr_weapon_skill_3" value="1">
+                        </div>
+                        <div class="focus">
+                            <input type="checkbox" name="attr_weapon_skill_focus_1" value="1">
+                            <input type="checkbox" name="attr_weapon_skill_focus_2" value="1">
+                            <input type="checkbox" name="attr_weapon_skill_focus_3" value="1">
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+        <div class="natural-awareness">
+            <span>Natural Awareness</span>
+            <input type="number" disabled="true" name="attr_nat_awareness"
+                   value="ceil((@{mind} + @{awareness_1} + @{awareness_2} + @{awareness_3})/2) + @{natural_awareness_bonus}">
+        </div>
+        <div class="section-abilities">
+            <div>
+                <div class="header">Combat Abilities</div>
+                <div class="line"></div>
+                <div class="combat-abilities">
+                    <div class="combat-mel-acc-def">
+                        <div></div>
+                        <div>mel</div>
+                        <div>acc</div>
+                        <div>def</div>
+
+                        <span>extraordinary</span>
+                        <input type="checkbox" name="attr_mel_extraordinary" value="1">
+                        <input type="checkbox" name="attr_acc_extraordinary" value="1">
+                        <input type="checkbox" name="attr_def_extraordinary" value="1">
+
+                        <span>superb</span>
+                        <input type="checkbox" name="attr_mel_superb" value="1">
+                        <input type="checkbox" name="attr_acc_superb" value="1">
+                        <input type="checkbox" name="attr_def_superb" value="1">
+
+                        <span>great</span>
+                        <input type="checkbox" name="attr_mel_great" value="1">
+                        <input type="checkbox" name="attr_acc_great" value="1">
+                        <input type="checkbox" name="attr_def_great" value="1">
+
+                        <span>good</span>
+                        <input type="checkbox" name="attr_mel_good" value="1">
+                        <input type="checkbox" name="attr_acc_good" value="1">
+                        <input type="checkbox" name="attr_def_good" value="1">
+
+                        <span>average</span>
+                        <input type="checkbox" name="attr_mel_average" value="1">
+                        <input type="checkbox" name="attr_acc_average" value="1">
+                        <input type="checkbox" name="attr_def_average" value="1">
+
+                        <span>poor</span>
+                        <input type="checkbox" name="attr_mel_poor" value="1">
+                        <input type="checkbox" name="attr_acc_poor" value="1">
+                        <input type="checkbox" name="attr_def_poor" value="1">
+                    </div>
+                    <div class="combat-misc">
+                        <div class="combat-ability-entry">
+                            <button type="roll" class="sheet-text-button"
+                                    value="&{template:default} {{name=Initiative}} {{Result=[[@{initiative} &{tracker}]]}}">
+                                Initiative
+                            </button>
+                            <div>
+                                <input type="number" disabled="true" name="attr_initiative_display"
+                                       value="@{initiative}">
+                            </div>
+                        </div>
+                        <div class="combat-ability-entry">
+                            <span>Mettle</span>
+                            <div>
+                                <input type="number" name="attr_mettle" value="">/
+                                <input type="number" disabled="true" name="attr_mettle_max"
+                                       value="ceil(@{soul}/2)+@{mettle_max_bonus}">
+                            </div>
+                        </div>
+                        <div class="combat-ability-entry">
+                            <span>Armour</span>
+                            <div>
+                                <input type="number" name="attr_armour">
+                            </div>
+                        </div>
+                        <div class="combat-ability-entry">
+                            <span>Toughness</span>
+                            <div>
+                                <input type="number" name="attr_toughness">/
+                                <input type="number" disabled="true" name="attr_toughness_max"
+                                       value="@{body} + @{mind} + @{soul} + @{toughness_bonus}">
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
             <div>
-                <input type="number" name="attr_mind" value="1">
-                <button type="roll" class="text-button text-big"
-                        value="&{template:default} {{name=Mind}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[@{mind}d6s>?{Target DN? |2|3|4|5|6}]] successes}}"
-                        name="roll_might">Mind
-                </button>
-            </div>
-            <div>
-                <input type="number" name="attr_soul" value="1">
-                <button type="roll" class="text-button text-big"
-                        value="&{template:default} {{name=Soul}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[@{soul}d6s>?{Target DN? |2|3|4|5|6}]] successes}}"
-                        name="roll_might">Soul
-                </button>
-            </div>
-        </div>
-    </div>
-    <div>
-        <div class="header">Skills</div>
-        <div class="line"></div>
-        <div class="skills-list">
-            <div class="skills">
-                <div></div>
-                <div>Training</div>
-                <div>Focus</div>
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Arcana}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{arcana_attribute}+@{arcana_1}+@{arcana_2}+@{arcana_3}+?{Arcana bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{arcana_focus_1} + @{arcana_focus_2} + @{arcana_focus_3}]] focus points}}"
-                            name="roll_arcana">Arcana
-                    </button>
-                    <select class="attribute-select" name="attr_arcana_attribute">
-                        <option value="@{body}">body</option>
-                        <option value="@{mind}">mind</option>
-                        <option value="@{soul}" selected="selected">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_arcana_1" value="1">
-                    <input type="checkbox" name="attr_arcana_2" value="1">
-                    <input type="checkbox" name="attr_arcana_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_arcana_focus_1" value="1">
-                    <input type="checkbox" name="attr_arcana_focus_2" value="1">
-                    <input type="checkbox" name="attr_arcana_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Athletics}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{athletics_attribute}+@{athletics_1}+@{athletics_2}+@{athletics_3}+?{Athletics bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{athletics_focus_1} + @{athletics_focus_2} + @{athletics_focus_3}]] focus points}}"
-                            name="roll_athletics">Athletics
-                    </button>
-                    <select class="attribute-select" name="attr_athletics_attribute">
-                        <option value="@{body}" selected="selected">body</option>
-                        <option value="@{mind}">mind</option>
-                        <option value="@{soul}">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_athletics_1" value="1">
-                    <input type="checkbox" name="attr_athletics_2" value="1">
-                    <input type="checkbox" name="attr_athletics_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_athletics_focus_1" value="1">
-                    <input type="checkbox" name="attr_athletics_focus_2" value="1">
-                    <input type="checkbox" name="attr_athletics_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Awareness}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{awareness_attribute}+@{awareness_1}+@{awareness_2}+@{awareness_3}+?{Awareness bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{awareness_focus_1} + @{awareness_focus_2} + @{awareness_focus_3}]] focus points}}"
-                            name="roll_awareness">Awareness
-                    </button>
-                    <select class="attribute-select" name="attr_awareness_attribute">
-                        <option value="@{body}">body</option>
-                        <option value="@{mind}" selected="selected">mind</option>
-                        <option value="@{soul}">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_awareness_1" value="1">
-                    <input type="checkbox" name="attr_awareness_2" value="1">
-                    <input type="checkbox" name="attr_awareness_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_awareness_focus_1" value="1">
-                    <input type="checkbox" name="attr_awareness_focus_2" value="1">
-                    <input type="checkbox" name="attr_awareness_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Ballistic skill}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{ballistic_skill_attribute}+@{ballistic_skill_1}+@{ballistic_skill_2}+@{ballistic_skill_3}+?{Ballistic skill bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{ballistic_skill_focus_1} + @{ballistic_skill_focus_2} + @{ballistic_skill_focus_3}]] focus points}}"
-                            name="roll_ballistic_skill">Ballistic skill
-                    </button>
-                    <select class="attribute-select" name="attr_ballistic_skill_attribute">
-                        <option value="@{body}" selected="selected">body</option>
-                        <option value="@{mind}">mind</option>
-                        <option value="@{soul}">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_ballistic_skill_1" value="1">
-                    <input type="checkbox" name="attr_ballistic_skill_2" value="1">
-                    <input type="checkbox" name="attr_ballistic_skill_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_ballistic_skill_focus_1" value="1">
-                    <input type="checkbox" name="attr_ballistic_skill_focus_2" value="1">
-                    <input type="checkbox" name="attr_ballistic_skill_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Beast Handling}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{beast_handling_attribute}+@{beast_handling_1}+@{beast_handling_2}+@{beast_handling_3}+?{Beast Handling bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{beast_handling_focus_1} + @{beast_handling_focus_2} + @{beast_handling_focus_3}]] focus points}}"
-                            name="roll_beast_handling">Beast Handling
-                    </button>
-                    <select class="attribute-select" name="attr_beast_handling_attribute">
-                        <option value="@{body}">body</option>
-                        <option value="@{mind}">mind</option>
-                        <option value="@{soul}" selected="selected">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_beast_handling_1" value="1">
-                    <input type="checkbox" name="attr_beast_handling_2" value="1">
-                    <input type="checkbox" name="attr_beast_handling_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_beast_handling_focus_1" value="1">
-                    <input type="checkbox" name="attr_beast_handling_focus_2" value="1">
-                    <input type="checkbox" name="attr_beast_handling_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Channelling}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{channelling_attribute}+@{channelling_1}+@{channelling_2}+@{channelling_3}+?{Channelling bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{channelling_focus_1} + @{channelling_focus_2} + @{channelling_focus_3}]] focus points}}"
-                            name="roll_channelling">Channelling
-                    </button>
-                    <select class="attribute-select" name="attr_channelling_attribute">
-                        <option value="@{body}">body</option>
-                        <option value="@{mind}" selected="selected">mind</option>
-                        <option value="@{soul}">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_channelling_1" value="1">
-                    <input type="checkbox" name="attr_channelling_2" value="1">
-                    <input type="checkbox" name="attr_channelling_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_channelling_focus_1" value="1">
-                    <input type="checkbox" name="attr_channelling_focus_2" value="1">
-                    <input type="checkbox" name="attr_channelling_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Crafting}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{crafting_attribute}+@{crafting_1}+@{crafting_2}+@{crafting_3}+?{Crafting bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{crafting_focus_1} + @{crafting_focus_2} + @{crafting_focus_3}]] focus points}}"
-                            name="roll_crafting">Crafting
-                    </button>
-                    <select class="attribute-select" name="attr_crafting_attribute">
-                        <option value="@{body}">body</option>
-                        <option value="@{mind}" selected="selected">mind</option>
-                        <option value="@{soul}">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_crafting_1" value="1">
-                    <input type="checkbox" name="attr_crafting_2" value="1">
-                    <input type="checkbox" name="attr_crafting_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_crafting_focus_1" value="1">
-                    <input type="checkbox" name="attr_crafting_focus_2" value="1">
-                    <input type="checkbox" name="attr_crafting_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Determination}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{determination_attribute}+@{determination_1}+@{determination_2}+@{determination_3}+?{Determination bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{determination_focus_1} + @{determination_focus_2} + @{determination_focus_3}]] focus points}}"
-                            name="roll_determination">Determination
-                    </button>
-                    <select class="attribute-select" name="attr_determination_attribute">
-                        <option value="@{body}">body</option>
-                        <option value="@{mind}">mind</option>
-                        <option value="@{soul}" selected="selected">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_determination_1" value="1">
-                    <input type="checkbox" name="attr_determination_2" value="1">
-                    <input type="checkbox" name="attr_determination_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_determination_focus_1" value="1">
-                    <input type="checkbox" name="attr_determination_focus_2" value="1">
-                    <input type="checkbox" name="attr_determination_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Devotion}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{devotion_attribute}+@{devotion_1}+@{devotion_2}+@{devotion_3}+?{Devotion bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{devotion_focus_1} + @{devotion_focus_2} + @{devotion_focus_3}]] focus points}}"
-                            name="roll_devotion">Devotion
-                    </button>
-                    <select class="attribute-select" name="attr_devotion_attribute">
-                        <option value="@{body}">body</option>
-                        <option value="@{mind}">mind</option>
-                        <option value="@{soul}" selected="selected">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_devotion_1" value="1">
-                    <input type="checkbox" name="attr_devotion_2" value="1">
-                    <input type="checkbox" name="attr_devotion_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_devotion_focus_1" value="1">
-                    <input type="checkbox" name="attr_devotion_focus_2" value="1">
-                    <input type="checkbox" name="attr_devotion_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Dexterity}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{dexterity_attribute}+@{dexterity_1}+@{dexterity_2}+@{dexterity_3}+?{Dexterity bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{dexterity_focus_1} + @{dexterity_focus_2} + @{dexterity_focus_3}]] focus points}}"
-                            name="roll_dexterity">Dexterity
-                    </button>
-                    <select class="attribute-select" name="attr_dexterity_attribute">
-                        <option value="@{body}" selected="selected">body</option>
-                        <option value="@{mind}">mind</option>
-                        <option value="@{soul}">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_dexterity_1" value="1">
-                    <input type="checkbox" name="attr_dexterity_2" value="1">
-                    <input type="checkbox" name="attr_dexterity_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_dexterity_focus_1" value="1">
-                    <input type="checkbox" name="attr_dexterity_focus_2" value="1">
-                    <input type="checkbox" name="attr_dexterity_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Entertain}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{entertain_attribute}+@{entertain_1}+@{entertain_2}+@{entertain_3}+?{Entertain bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{entertain_focus_1} + @{entertain_focus_2} + @{entertain_focus_3}]] focus points}}"
-                            name="roll_entertain">Entertain
-                    </button>
-                    <select class="attribute-select" name="attr_entertain_attribute">
-                        <option value="@{body}">body</option>
-                        <option value="@{mind}">mind</option>
-                        <option value="@{soul}" selected="selected">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_entertain_1" value="1">
-                    <input type="checkbox" name="attr_entertain_2" value="1">
-                    <input type="checkbox" name="attr_entertain_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_entertain_focus_1" value="1">
-                    <input type="checkbox" name="attr_entertain_focus_2" value="1">
-                    <input type="checkbox" name="attr_entertain_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Fortitude}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{fortitude_attribute}+@{fortitude_1}+@{fortitude_2}+@{fortitude_3}+?{Fortitude bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{fortitude_focus_1} + @{fortitude_focus_2} + @{fortitude_focus_3}]] focus points}}"
-                            name="roll_fortitude">Fortitude
-                    </button>
-                    <select class="attribute-select" name="attr_fortitude_attribute">
-                        <option value="@{body}" selected="selected">body</option>
-                        <option value="@{mind}">mind</option>
-                        <option value="@{soul}">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_fortitude_1" value="1">
-                    <input type="checkbox" name="attr_fortitude_2" value="1">
-                    <input type="checkbox" name="attr_fortitude_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_fortitude_focus_1" value="1">
-                    <input type="checkbox" name="attr_fortitude_focus_2" value="1">
-                    <input type="checkbox" name="attr_fortitude_focus_3" value="1">
-                </div>
-
-            </div>
-            <div class="skills">
-                <div></div>
-                <div>Training</div>
-                <div>Focus</div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Guile}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{guile_attribute}+@{guile_1}+@{guile_2}+@{guile_3}+?{Guile bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{guile_focus_1} + @{guile_focus_2} + @{guile_focus_3}]] focus points}}"
-                            name="roll_guile">Guile
-                    </button>
-                    <select class="attribute-select" name="attr_guile_attribute">
-                        <option value="@{body}">body</option>
-                        <option value="@{mind}" selected="selected">mind</option>
-                        <option value="@{soul}">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_guile_1" value="1">
-                    <input type="checkbox" name="attr_guile_2" value="1">
-                    <input type="checkbox" name="attr_guile_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_guile_focus_1" value="1">
-                    <input type="checkbox" name="attr_guile_focus_2" value="1">
-                    <input type="checkbox" name="attr_guile_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Intimidation}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{intimidation_attribute}+@{intimidation_1}+@{intimidation_2}+@{intimidation_3}+?{Intimidation bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{intimidation_focus_1} + @{intimidation_focus_2} + @{intimidation_focus_3}]] focus points}}"
-                            name="roll_intimidation">Intimidation
-                    </button>
-                    <select class="attribute-select" name="attr_intimidation_attribute">
-                        <option value="@{body}">body</option>
-                        <option value="@{mind}">mind</option>
-                        <option value="@{soul}" selected="selected">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_intimidation_1" value="1">
-                    <input type="checkbox" name="attr_intimidation_2" value="1">
-                    <input type="checkbox" name="attr_intimidation_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_intimidation_focus_1" value="1">
-                    <input type="checkbox" name="attr_intimidation_focus_2" value="1">
-                    <input type="checkbox" name="attr_intimidation_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Intuition}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{intuition_attribute}+@{intuition_1}+@{intuition_2}+@{intuition_3}+?{Intuition bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{intuition_focus_1} + @{intuition_focus_2} + @{intuition_focus_3}]] focus points}}"
-                            name="roll_intuition">Intuition
-                    </button>
-                    <select class="attribute-select" name="attr_intuition_attribute">
-                        <option value="@{body}">body</option>
-                        <option value="@{mind}" selected="selected">mind</option>
-                        <option value="@{soul}">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_intuition_1" value="1">
-                    <input type="checkbox" name="attr_intuition_2" value="1">
-                    <input type="checkbox" name="attr_intuition_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_intuition_focus_1" value="1">
-                    <input type="checkbox" name="attr_intuition_focus_2" value="1">
-                    <input type="checkbox" name="attr_intuition_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Lore}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{lore_attribute}+@{lore_1}+@{lore_2}+@{lore_3}+?{Lore bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{lore_focus_1} + @{lore_focus_2} + @{lore_focus_3}]] focus points}}"
-                            name="roll_lore">Lore
-                    </button>
-                    <select class="attribute-select" name="attr_lore_attribute">
-                        <option value="@{body}">body</option>
-                        <option value="@{mind}" selected="selected">mind</option>
-                        <option value="@{soul}">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_lore_1" value="1">
-                    <input type="checkbox" name="attr_lore_2" value="1">
-                    <input type="checkbox" name="attr_lore_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_lore_focus_1" value="1">
-                    <input type="checkbox" name="attr_lore_focus_2" value="1">
-                    <input type="checkbox" name="attr_lore_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Medicine}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{medicine_attribute}+@{medicine_1}+@{medicine_2}+@{medicine_3}+?{Medicine bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{medicine_focus_1} + @{medicine_focus_2} + @{medicine_focus_3}]] focus points}}"
-                            name="roll_medicine">Medicine
-                    </button>
-                    <select class="attribute-select" name="attr_medicine_attribute">
-                        <option value="@{body}">body</option>
-                        <option value="@{mind}" selected="selected">mind</option>
-                        <option value="@{soul}">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_medicine_1" value="1">
-                    <input type="checkbox" name="attr_medicine_2" value="1">
-                    <input type="checkbox" name="attr_medicine_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_medicine_focus_1" value="1">
-                    <input type="checkbox" name="attr_medicine_focus_2" value="1">
-                    <input type="checkbox" name="attr_medicine_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Might}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{might_attribute}+@{might_1}+@{might_2}+@{might_3}+?{Might bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{might_focus_1} + @{might_focus_2} + @{might_focus_3}]] focus points}}"
-                            name="roll_might">Might
-                    </button>
-                    <select class="attribute-select" name="attr_might_attribute">
-                        <option value="@{body}" selected="selected">body</option>
-                        <option value="@{mind}">mind</option>
-                        <option value="@{soul}">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_might_1" value="1">
-                    <input type="checkbox" name="attr_might_2" value="1">
-                    <input type="checkbox" name="attr_might_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_might_focus_1" value="1">
-                    <input type="checkbox" name="attr_might_focus_2" value="1">
-                    <input type="checkbox" name="attr_might_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Nature}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{nature_attribute}+@{nature_1}+@{nature_2}+@{nature_3}+?{Nature bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{nature_focus_1} + @{nature_focus_2} + @{nature_focus_3}]] focus points}}"
-                            name="roll_nature">Nature
-                    </button>
-                    <select class="attribute-select" name="attr_nature_attribute">
-                        <option value="@{body}">body</option>
-                        <option value="@{mind}" selected="selected">mind</option>
-                        <option value="@{soul}">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_nature_1" value="1">
-                    <input type="checkbox" name="attr_nature_2" value="1">
-                    <input type="checkbox" name="attr_nature_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_nature_focus_1" value="1">
-                    <input type="checkbox" name="attr_nature_focus_2" value="1">
-                    <input type="checkbox" name="attr_nature_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Reflexes}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{reflexes_attribute}+@{reflexes_1}+@{reflexes_2}+@{reflexes_3}+?{Reflexes bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{reflexes_focus_1} + @{reflexes_focus_2} + @{reflexes_focus_3}]] focus points}}"
-                            name="roll_reflexes">Reflexes
-                    </button>
-                    <select class="attribute-select" name="attr_reflexes_attribute">
-                        <option value="@{body}" selected="selected">body</option>
-                        <option value="@{mind}">mind</option>
-                        <option value="@{soul}">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_reflexes_1" value="1">
-                    <input type="checkbox" name="attr_reflexes_2" value="1">
-                    <input type="checkbox" name="attr_reflexes_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_reflexes_focus_1" value="1">
-                    <input type="checkbox" name="attr_reflexes_focus_2" value="1">
-                    <input type="checkbox" name="attr_reflexes_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Stealth}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{stealth_attribute}+@{stealth_1}+@{stealth_2}+@{stealth_3}+?{Stealth bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{stealth_focus_1} + @{stealth_focus_2} + @{stealth_focus_3}]] focus points}}"
-                            name="roll_stealth">Stealth
-                    </button>
-                    <select class="attribute-select" name="attr_stealth_attribute">
-                        <option value="@{body}" selected="selected">body</option>
-                        <option value="@{mind}">mind</option>
-                        <option value="@{soul}">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_stealth_1" value="1">
-                    <input type="checkbox" name="attr_stealth_2" value="1">
-                    <input type="checkbox" name="attr_stealth_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_stealth_focus_1" value="1">
-                    <input type="checkbox" name="attr_stealth_focus_2" value="1">
-                    <input type="checkbox" name="attr_stealth_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Survival}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{survival_attribute}+@{survival_1}+@{survival_2}+@{survival_3}+?{Survival bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{survival_focus_1} + @{survival_focus_2} + @{survival_focus_3}]] focus points}}"
-                            name="roll_survival">Survival
-                    </button>
-                    <select class="attribute-select" name="attr_survival_attribute">
-                        <option value="@{body}">body</option>
-                        <option value="@{mind}" selected="selected">mind</option>
-                        <option value="@{soul}">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_survival_1" value="1">
-                    <input type="checkbox" name="attr_survival_2" value="1">
-                    <input type="checkbox" name="attr_survival_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_survival_focus_1" value="1">
-                    <input type="checkbox" name="attr_survival_focus_2" value="1">
-                    <input type="checkbox" name="attr_survival_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Theology}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{theology_attribute}+@{theology_1}+@{theology_2}+@{theology_3}+?{Theology bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{theology_focus_1} + @{theology_focus_2} + @{theology_focus_3}]] focus points}}"
-                            name="roll_theology">Theology
-                    </button>
-                    <select class="attribute-select" name="attr_theology_attribute">
-                        <option value="@{body}">body</option>
-                        <option value="@{mind}" selected="selected">mind</option>
-                        <option value="@{soul}">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_theology_1" value="1">
-                    <input type="checkbox" name="attr_theology_2" value="1">
-                    <input type="checkbox" name="attr_theology_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_theology_focus_1" value="1">
-                    <input type="checkbox" name="attr_theology_focus_2" value="1">
-                    <input type="checkbox" name="attr_theology_focus_3" value="1">
-                </div>
-
-                <div class="desc">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Weapon Skill}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{weapon_skill_attribute}+@{weapon_skill_1}+@{weapon_skill_2}+@{weapon_skill_3}+?{Weapon Skill bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=[[@{weapon_skill_focus_1} + @{weapon_skill_focus_2} + @{weapon_skill_focus_3}]] focus points}}"
-                            name="roll_weapon_skill">Weapon Skill
-                    </button>
-                    <select class="attribute-select" name="attr_weapon_skill_attribute">
-                        <option value="@{body}" selected="selected">body</option>
-                        <option value="@{mind}">mind</option>
-                        <option value="@{soul}">soul</option>
-                    </select>
-                </div>
-                <div class="training">
-                    <input type="checkbox" name="attr_weapon_skill_1" value="1">
-                    <input type="checkbox" name="attr_weapon_skill_2" value="1">
-                    <input type="checkbox" name="attr_weapon_skill_3" value="1">
-                </div>
-                <div class="focus">
-                    <input type="checkbox" name="attr_weapon_skill_focus_1" value="1">
-                    <input type="checkbox" name="attr_weapon_skill_focus_2" value="1">
-                    <input type="checkbox" name="attr_weapon_skill_focus_3" value="1">
-                </div>
-            </div>
-        </div>
-    </div>
-
-</div>
-<div class="natural-awareness">
-    <span>Natural Awareness</span>
-    <input type="number" disabled="true" name="attr_nat_awareness"
-           value="ceil((@{mind} + @{awareness_1} + @{awareness_2} + @{awareness_3})/2) + @{natural_awareness_bonus}">
-</div>
-
-<div class="section-abilities">
-    <div>
-        <div class="header">Combat Abilities</div>
-        <div class="line"></div>
-        <div class="combat-abilities">
-            <div class="combat-mel-acc-def">
-                <div></div>
-                <div>mel</div>
-                <div>acc</div>
-                <div>def</div>
-
-                <span>extraordinary</span>
-                <input type="checkbox" name="attr_mel_extraordinary" value="1">
-                <input type="checkbox" name="attr_acc_extraordinary" value="1">
-                <input type="checkbox" name="attr_def_extraordinary" value="1">
-
-                <span>superb</span>
-                <input type="checkbox" name="attr_mel_superb" value="1">
-                <input type="checkbox" name="attr_acc_superb" value="1">
-                <input type="checkbox" name="attr_def_superb" value="1">
-
-                <span>great</span>
-                <input type="checkbox" name="attr_mel_great" value="1">
-                <input type="checkbox" name="attr_acc_great" value="1">
-                <input type="checkbox" name="attr_def_great" value="1">
-
-                <span>good</span>
-                <input type="checkbox" name="attr_mel_good" value="1">
-                <input type="checkbox" name="attr_acc_good" value="1">
-                <input type="checkbox" name="attr_def_good" value="1">
-
-                <span>average</span>
-                <input type="checkbox" name="attr_mel_average" value="1">
-                <input type="checkbox" name="attr_acc_average" value="1">
-                <input type="checkbox" name="attr_def_average" value="1">
-
-                <span>poor</span>
-                <input type="checkbox" name="attr_mel_poor" value="1">
-                <input type="checkbox" name="attr_acc_poor" value="1">
-                <input type="checkbox" name="attr_def_poor" value="1">
-            </div>
-            <div class="combat-misc">
-                <div class="combat-ability-entry">
-                    <button type="roll" class="sheet-text-button"
-                            value="&{template:default} {{name=Initiative}} {{Result=[[@{initiative} &{tracker}]]}}">
-                        Initiative
-                    </button>
-                    <div>
-                        <input type="number" disabled="true" name="attr_initiative_display"
-                               value="@{initiative}">
+                <div class="header">Bonuses</div>
+                <div class="line"></div>
+                <div class="combat-misc-bonus">
+                    <div class="combat-ability-entry">
+                        <span>Melee</span>
+                        <div>
+                            <input type="number" name="attr_melee_bonus"
+                                   value="0">
+                        </div>
                     </div>
-                </div>
-                <div class="combat-ability-entry">
-                    <span>Mettle</span>
-                    <div>
-                        <input type="number" name="attr_mettle" value="">/
-                        <input type="number" disabled="true" name="attr_mettle_max"
-                               value="ceil(@{soul}/2)+@{mettle_max_bonus}">
+                    <div class="combat-ability-entry">
+                        <span>Accuracy</span>
+                        <div>
+                            <input type="number" name="attr_accuracy_bonus"
+                                   value="0">
+                        </div>
                     </div>
-                </div>
-                <div class="combat-ability-entry">
-                    <span>Armour</span>
-                    <div>
-                        <input type="number" name="attr_armour">
+                    <div class="combat-ability-entry">
+                        <span>Defence</span>
+                        <div>
+                            <input type="number" name="attr_defence_bonus"
+                                   value="0">
+                        </div>
                     </div>
-                </div>
-                <div class="combat-ability-entry">
-                    <span>Toughness</span>
-                    <div>
-                        <input type="number" name="attr_toughness">/
-                        <input type="number" disabled="true" name="attr_toughness_max"
-                               value="@{body} + @{mind} + @{soul} + @{toughness_bonus}">
+                    <div class="combat-ability-entry">
+                        <span>Initiative</span>
+                        <div>
+                            <input type="number" name="attr_initiative_bonus"
+                                   value="0">
+                        </div>
+                    </div>
+                    <div class="combat-ability-entry">
+                        <span>Mettle</span>
+                        <div>
+                            <input type="number" name="attr_mettle_max_bonus"
+                                   value="0">
+                        </div>
+                    </div>
+                    <div class="combat-ability-entry">
+                        <span>Toughness</span>
+                        <div>
+                            <input type="number" name="attr_toughness_bonus"
+                                   value="0">
+                        </div>
+                    </div>
+                    <div class="combat-ability-entry">
+                        <span>Max Wounds</span>
+                        <div>
+                            <input type="number" name="attr_wounds_max_bonus"
+                                   value="0">
+                        </div>
+                    </div>
+                    <div class="combat-ability-entry">
+                        <span>Natural Awareness</span>
+                        <div>
+                            <input type="number" name="attr_natural_awareness_bonus"
+                                   value="0">
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
-    <div>
-        <div class="header">Bonuses</div>
-        <div class="line"></div>
-        <div class="combat-misc-bonus">
-            <div class="combat-ability-entry">
-                <span>Melee</span>
-                <div>
-                    <input type="number" name="attr_melee_bonus"
-                           value="0">
-                </div>
-            </div>
-            <div class="combat-ability-entry">
-                <span>Accuracy</span>
-                <div>
-                    <input type="number" name="attr_accuracy_bonus"
-                           value="0">
-                </div>
-            </div>
-            <div class="combat-ability-entry">
-                <span>Defence</span>
-                <div>
-                    <input type="number" name="attr_defence_bonus"
-                           value="0">
-                </div>
-            </div>
-            <div class="combat-ability-entry">
-                <span>Initiative</span>
-                <div>
-                    <input type="number" name="attr_initiative_bonus"
-                           value="0">
-                </div>
-            </div>
-            <div class="combat-ability-entry">
-                <span>Mettle</span>
-                <div>
-                    <input type="number" name="attr_mettle_max_bonus"
-                           value="0">
-                </div>
-            </div>
-            <div class="combat-ability-entry">
-                <span>Toughness</span>
-                <div>
-                    <input type="number" name="attr_toughness_bonus"
-                           value="0">
-                </div>
-            </div>
-            <div class="combat-ability-entry">
-                <span>Max Wounds</span>
-                <div>
-                    <input type="number" name="attr_wounds_max_bonus"
-                           value="0">
-                </div>
-            </div>
-            <div class="combat-ability-entry">
-                <span>Natural Awareness</span>
-                <div>
-                    <input type="number" name="attr_natural_awareness_bonus"
-                           value="0">
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
-<div class="section-talents-wounds">
-    <div class="talents">
-        <div class="header">Talents</div>
-        <div class="line"></div>
-        <fieldset class="repeating_talents">
-            <div class="talents-container">
-                <!--due to css funkyness this is reversed to allow the checkbox to be at the back-->
-                <button type="roll" name="talent-description" class="talents-button"
-                        value="&{template:default} {{name=@{talents}}} {{@{talents_description}}}">w
-                </button>
-                <input type="checkbox" class="sheet-block-switch talents-check" name="attr_block_switch" value="1"/>
-                <span class="talents-check2"></span>
-                <div class="sheet-block-a talents-block">
-                    <input type="text" name="attr_talents">
-                </div>
-                <div class="sheet-block-b talents-block">
-                    <input type="text" name="attr_talents">
-                    <textarea name="attr_talents_description"></textarea>
-                </div>
-            </div>
-        </fieldset>
-    </div>
-    <div>
-        <div class="header">Wounds</div>
-        <div class="line"></div>
-        <div class="section-wounds">
-            <div class="wounds-counter">
-                <div>
-                    <span>Wounds</span>
-                    <input type="number" disabled="true" name="attr_wounds" value="@{w_total}">/
-                    <input type="number" disabled="true" name="attr_wounds_max"
-                           value="ceil((@{body} + @{mind} + @{soul})/2)+@{wounds_max_bonus}">
-                </div>
-                <div class="wounds-tracker">
-                    <div>Severity</div>
-                    <div>Wounds</div>
-                </div>
-                <fieldset class="repeating_wounds-applied">
-                    <div class="wounds-tracker">
-                        <select name="attr_wound_taken" class="wound-selection">
-                            <option value="0" selected="selected">Select</option>
-                            <option value="1">Minor</option>
-                            <option value="2">Serious</option>
-                            <option value="3">Deadly</option>
-                        </select>
-                        <span name="attr_wound_taken"></span>
+        <div class="section-talents-wounds">
+            <div class="talents">
+                <div class="header">Talents</div>
+                <div class="line"></div>
+                <fieldset class="repeating_talents">
+                    <div class="talents-container">
+                        <!--due to css funkyness this is reversed to allow the checkbox to be at the back-->
+                        <button type="roll" name="talent-description" class="talents-button"
+                                value="&{template:default} {{name=@{talents}}} {{@{talents_description}}}">w
+                        </button>
+                        <input type="checkbox" class="sheet-block-switch talents-check" name="attr_block_switch"
+                               value="1"/>
+                        <span class="talents-check2"></span>
+                        <div class="sheet-block-a talents-block">
+                            <input type="text" name="attr_talents">
+                        </div>
+                        <div class="sheet-block-b talents-block">
+                            <input type="text" name="attr_talents">
+                            <textarea name="attr_talents_description"></textarea>
+                        </div>
                     </div>
                 </fieldset>
             </div>
-            <div class="death-saves">
-                <div>
-                    <span>Mortally Wounded</span>
-                    <input type="checkbox" name="attr_mortally_wounded" value="1">
+            <div>
+                <div class="header">Wounds</div>
+                <div class="line"></div>
+                <div class="section-wounds">
+                    <div class="wounds-counter">
+                        <div>
+                            <span>Wounds</span>
+                            <input type="number" class="no-spin" readonly="true" name="attr_wounds" value="0">/
+                            <input type="number" disabled="true" name="attr_wounds_max"
+                                   value="ceil((@{body} + @{mind} + @{soul})/2)+@{wounds_max_bonus}">
+                        </div>
+                        <div class="wounds-tracker">
+                            <div>Severity</div>
+                            <div>Wounds</div>
+                        </div>
+                        <fieldset class="repeating_wounds-applied">
+                            <div class="wounds-tracker">
+                                <select name="attr_wound_taken" class="wound-selection">
+                                    <option value="0" selected="selected">Select</option>
+                                    <option value="1">Minor</option>
+                                    <option value="2">Serious</option>
+                                    <option value="3">Deadly</option>
+                                </select>
+                                <span name="attr_wound_taken"></span>
+                            </div>
+                        </fieldset>
+                    </div>
+                    <div class="death-saves">
+                        <div>
+                            <span>Mortally Wounded</span>
+                            <input type="checkbox" name="attr_mortally_wounded" value="1">
+                        </div>
+                        <div>
+                            <span>Last Wound Taken</span>
+                            <select name="attr_last_wound" class="wound-selection">
+                                <option value="1">Minor</option>
+                                <option value="2">Serious</option>
+                                <option value="3">Deadly</option>
+                            </select>
+                        </div>
+                        <div>
+                            <span>Failures</span>
+                            <input type="checkbox" name="attr_death_tests_1" value="1" class="death-test-checkbox">
+                            <input type="checkbox" name="attr_death_tests_2" value="1">
+                        </div>
+                        <div>
+                            <span>Death Check</span>
+                            <button type="roll" name="death-save"
+                                    value="&{template:default} {{name=Death Test}} {{DN=[[4+@{death_tests_1}+@{death_tests_2}]]:@{last_wound}}} {{Successes=[[[[{@{body},@{mind},@{soul}}kh1]]d6s>[[4+@{death_tests_1}+@{death_tests_2}]]]]}}"></button>
+                        </div>
+                    </div>
                 </div>
-                <div>
-                    <span>Last Wound Taken</span>
-                    <select name="attr_last_wound" class="wound-selection">
-                        <option value="1">Minor</option>
-                        <option value="2">Serious</option>
-                        <option value="3">Deadly</option>
+            </div>
+        </div>
+        <div class="section-weapons">
+            <div class="header">Weapons</div>
+            <div class="line"></div>
+            <div class="header-minor">Melee Weapons</div>
+            <div class="weapons">
+                <div>weapon name</div>
+                <div>attack</div>
+                <div>pool</div>
+                <div>focus</div>
+                <div>damage</div>
+                <div>traits</div>
+            </div>
+            <fieldset class="repeating_melee">
+                <div class="weapons">
+                    <input type="text" name="attr_melee_name">
+                    <button type="roll" name="roll_melee_attack"
+                            value="&{template:default} {{name=@{melee_name}}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{weapon_skill_attribute}+@{weapon_skill_1}+@{weapon_skill_2}+@{weapon_skill_3}+?{Melee bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{Focus=[[@{weapon_skill_focus_1} + @{weapon_skill_focus_2} + @{weapon_skill_focus_3}]] focus points}} {{Extra Damage=@{melee_damage}}} {{Traits=@{melee_traits}}}"></button>
+                    <input type="number" disabled="true" name="attr_melee_pool"
+                           value="@{body} + @{weapon_skill_1} + @{weapon_skill_2} + @{weapon_skill_3}">
+                    <input type="number" name="attr_melee_focus" disabled="true"
+                           value="@{weapon_skill_focus_1} + @{weapon_skill_focus_2} + @{weapon_skill_focus_3}">
+                    <input type="number" name="attr_melee_damage" value="0">
+                    <input type="text" class=weapon-traits" name="attr_melee_traits">
+                </div>
+            </fieldset>
+            <div class="header-minor">Ranged Weapons</div>
+            <div class="weapons">
+                <div>weapon name</div>
+                <div>attack</div>
+                <div>pool</div>
+                <div>focus</div>
+                <div>damage</div>
+                <div>traits</div>
+            </div>
+            <fieldset class="repeating_ranged">
+                <div class="weapons">
+                    <input type="text" name="attr_ranged_name"/>
+                    <button type="roll" name="roll_ranged_attack"
+                            value="&{template:default} {{name=@{ranged_name}}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{ballistic_skill_attribute}+@{ballistic_skill_1}+@{ballistic_skill_2}+@{ballistic_skill_3}+?{Ranged bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{Focus=[[@{ballistic_skill_focus_1} + @{ballistic_skill_focus_2} + @{ballistic_skill_focus_3}]] focus points}} {{Extra Damage=@{ranged_damage}}} {{Traits=@{ranged_traits}}}"></button>
+                    <input type="number" disabled="true" name="attr_ranged_pool"
+                           value="@{body} + @{ballistic_skill_1} + @{ballistic_skill_2} + @{ballistic_skill_3}"/>
+                    <input type="number" name="attr_ranged_focus" disabled="true"
+                           value="@{ballistic_skill_focus_1} + @{ballistic_skill_focus_2} + @{ballistic_skill_focus_3}"/>
+                    <input type="number" name="attr_ranged_damage" value="0"/>
+                    <input type="text" class=weapon-traits" name="attr_ranged_traits"/>
+                </div>
+            </fieldset>
+        </div>
+        <div class="section-spells-miracles">
+            <div class="header">Spells and Miracles</div>
+            <div class="line"></div>
+            <div class="header-minor">Spells</div>
+            <div class="spells">
+                <div>Name</div>
+                <div>Cast</div>
+                <div>DN</div>
+                <div>Target</div>
+                <div>Range</div>
+                <div>Duration</div>
+                <div>Effect</div>
+            </div>
+            <fieldset class="repeating_spells">
+                <div class="spells">
+                    <input type="text" name="attr_spell_name"/>
+                    <button type="roll" name="roll_spell"
+                            value="&{template:default} {{name=@{spell_name}}} {{DN=@{spell_dn_target}:@{spell_dn_successes}}} {{Result=[[(@{mind} + @{channelling_1} + @{channelling_2} + @{channelling_3} + ?{Spellcasting bonus|0})d6s>@{spell_dn_target}]] success}} {{Focus=[[@{channelling_focus_1} + @{channelling_focus_2} + @{channelling_focus_3}]] focus points}}} {{Effect=@{spell_effect}}}"></button>
+                    <div class="spells-dn">
+                        <input type="number" name="attr_spell_dn_target"
+                               class="no-spin small-digit colon-separator-left">
+                        <span class="colon-separator">:</span>
+                        <input type="number" name="attr_spell_dn_successes" class="no-spin small-digit">
+                    </div>
+                    <input type="text" name="attr_spell_target" class="spells-target"/>
+                    <select name="attr_spell_range" class="spells-range">
+                        <option value="self">self</option>
+                        <option value="close">close</option>
+                        <option value="short">short</option>
+                        <option value="medium">medium</option>
+                        <option value="long">long</option>
+                    </select>
+                    <input type="text" name="attr_spell_duration" class="spells-duration"/>
+                    <textarea type="text" name="attr_spell_effect" class="spells-effect text-area"></textarea>
+                </div>
+            </fieldset>
+            <div class="header-minor">Miracles</div>
+            <div class="miracles">
+                <div>Name</div>
+                <div>Manifest</div>
+                <div>Cost</div>
+                <div>Target</div>
+                <div>Range</div>
+                <div>Duration</div>
+                <div>Effect</div>
+            </div>
+            <fieldset class="repeating_miracles">
+                <div class="miracles">
+                    <input type="text" name="attr_miracle_name"/>
+                    <button type="roll" name="roll_spell"
+                            value="&{template:default} {{name=@{miracle_name}}} {{Effect=@{miracle_effect}}}"></button>
+                    <input type="text" name="attr_miracle_cost" class="miracle-cost"/>
+                    <input type="text" name="attr_miracle_target" class="miracle-target"/>
+                    <select name="attr_miracle_range" class="miracle-range">
+                        <option value="self">self</option>
+                        <option value="close">close</option>
+                        <option value="short">short</option>
+                        <option value="medium">medium</option>
+                        <option value="long">long</option>
+                    </select>
+                    <input type="text" name="attr_miracle_duration" class="miracle-duration"/>
+                    <textarea name="attr_miracle_effect" class="miracle-effect text-area"></textarea>
+                </div>
+            </fieldset>
+        </div>
+        <div class="section-gear">
+            <div class="equip-and-currency">
+                <div class="header">Equipment</div>
+                <div class="line"></div>
+                <div class="equipment">
+                    <div>Head</div>
+                    <input type="text" name="attr_equip_head"/>
+                    <div>Cloak</div>
+                    <input type="text" name="attr_equip_cloak"/>
+                    <div>Armour</div>
+                    <input type="text" name="attr_equip_armour"/>
+                    <div>Right Hand</div>
+                    <input type="text" name="attr_equip_r_hand"/>
+                    <div>Left Hand</div>
+                    <input type="text" name="attr_equip_l_hand"/>
+                    <div>Arms</div>
+                    <input type="text" name="attr_equip_arms"/>
+                    <div>Boots</div>
+                    <input type="text" name="attr_equip_boots"/>
+                    <div>Jewelry</div>
+                    <input type="text" name="attr_equip_jewelry"/>
+                </div>
+
+                <fieldset class="repeating_equipother">
+                    <div class="equipment">
+                        <div>Other</div>
+                        <input type="text" name="attr_equip_other"/>
+                    </div>
+                </fieldset>
+
+                <div class="header">Currency</div>
+                <div class="line"></div>
+                <div class="currency">
+                    <div>
+                        <input type="number" name="attr_drops" value="0">
+                        <span>Drops</span>
+                    </div>
+                    <div>
+                        <input type="number" name="attr_phials" value="0">
+                        <span>Phials</span>
+                    </div>
+                    <div>
+                        <input type="number" name="attr_spheres" value="0">
+                        <span>Spheres</span>
+                    </div>
+                </div>
+            </div>
+            <div class="gear">
+                <div class="header">Other Gear</div>
+                <div class="line"></div>
+                <fieldset class="repeating_other-gear">
+                    <div class="gear">
+                        <input type="text" name="attr_gear"/>
+                    </div>
+                </fieldset>
+            </div>
+        </div>
+        <div class="section-misc">
+            <div class="header">Background</div>
+            <div class="line"></div>
+            <textarea name="attr_background" class="fluff-info text-area"></textarea>
+            <div class="header">Notes</div>
+            <div class="line"></div>
+            <textarea name="attr_notes" class="fluff-info text-area"></textarea>
+            <div class="header">Goals</div>
+            <div class="line"></div>
+            <textarea name="attr_goals" class="fluff-info text-area"></textarea>
+            <div class="header">Connections</div>
+            <div class="line"></div>
+            <textarea name="attr_connections" class="fluff-info text-area"></textarea>
+        </div>
+    </div>
+
+    <div class="sheet-npc">
+        <div class="section-npc-info">
+            <div class="npc-name">
+                <input type="text" class="npc-name" name="attr_character_name" value="Name"/>
+                <div class="options-check stack">
+                    <input type="checkbox" class="options-button" name="attr_options" value="1"/>
+                    <span></span>
+                </div>
+            </div>
+            <div class="line"></div>
+            <div class="npc-info">
+                <div class="npc-size">
+                    <input type="text" name="attr_npc_size"/>
+                    <span>Size</span>
+                </div>
+                <div class="npc-type">
+                    <input type="text" name="attr_npc_type"/>
+                    <span>Type</span>
+                </div>
+                <div class="npc-faction">
+                    <input type="text" name="attr_npc_faction"/>
+                    <span>Faction</span>
+                </div>
+                <div class="npc-role">
+                    <input type="text" name="attr_npc_role"/>
+                    <span>Role</span>
+                </div>
+            </div>
+            <div class="line"></div>
+            <div class="npc-combat-abilities">
+                <div class="npc-mel">
+                    <span>Melee</span>
+                    <select name="attr_npc_mel" class="npc-mel-select">
+                        <option value="Poor">Poor</option>
+                        <option value="Average">Average</option>
+                        <option value="Good">Good</option>
+                        <option value="Great">Great</option>
+                        <option value="Superb">Superb</option>
+                        <option value="Extraordinary">Extraordinary</option>
                     </select>
                 </div>
+                <div class="npc-acc">
+                    <span>Accuracy</span>
+                    <select name="attr_npc_acc" class="npc-acc-select">
+                        <option value="Poor">Poor</option>
+                        <option value="Average">Average</option>
+                        <option value="Good">Good</option>
+                        <option value="Great">Great</option>
+                        <option value="Superb">Superb</option>
+                        <option value="Extraordinary">Extraordinary</option>
+                    </select>
+                </div>
+                <div class="npc-def">
+                    <span>Defence</span>
+                    <select name="attr_npc_def" class="npc-def-select">
+                        <option value="Poor">Poor</option>
+                        <option value="Average">Average</option>
+                        <option value="Good">Good</option>
+                        <option value="Great">Great</option>
+                        <option value="Superb">Superb</option>
+                        <option value="Extraordinary">Extraordinary</option>
+                    </select>
+                </div>
+            </div>
+            <div class="line"></div>
+            <div class="npc-combat-stats">
+                <div>Armour</div>
+                <div>Toughness</div>
+                <div>Wounds</div>
+                <div>Mettle</div>
+                <div>Swarm</div>
+            </div>
+            <div class="npc-combat-stats">
+                <div class="npc-armour">
+                    <input type="number" name="attr_npc_armour" value="0"/>
+                </div>
+                <div class="npc-toughness">
+                    <input type="number" name="attr_npc_toughness" value="1"/>
+                </div>
+                <div class="npc-wounds">
+                    <input type="number" name="attr_npc_wounds" value="0"/>
+                </div>
+                <div class="npc-mettle">
+                    <input type="number" name="attr_npc_mettle" value="0"/>
+                </div>
+                <div class="npc-mettle">
+                    <input type="checkbox" name="attr_npc_swarm"
+                           value="?{Remaining Swarm Toughness? |@{npc_toughness}}"/>
+                </div>
+            </div>
+        </div>
+        <div class="section-npc-stats">
+            <div class="line"></div>
+            <div class="npc-details">
                 <div>
-                    <span>Failures</span>
-                    <input type="checkbox" name="attr_death_tests_1" value="1" class="death-test-checkbox">
-                    <input type="checkbox" name="attr_death_tests_2" value="1">
+                    <div>Speed:</div>
+                    <input type="text" name="attr_npc_speed"/>
                 </div>
                 <div>
-                    <span>Death Check</span>
-                    <button type="roll" name="death-save"
-                            value="&{template:default} {{name=Death Test}} {{DN=[[4+@{death_tests_1}+@{death_tests_2}]]:@{last_wound}}} {{Successes=[[[[{@{body},@{mind},@{soul}}kh1]]d6s>[[4+@{death_tests_1}+@{death_tests_2}]]]]}}"></button>
+                    <div>Initiative:</div>
+                    <input type="number" name="attr_initiative"/>
+                </div>
+                <div>
+                    <div>Natural Awareness:</div>
+                    <input type="number" name="attr_nat_awareness"/>
+                </div>
+            </div>
+        </div>
+        <div class="section-npc-skills-traits">
+            <div class="npc-skills-list">
+                <div class="header">Skills</div>
+                <div class="line"></div>
+                <div class="npc-skills">
+                    <div>Name</div>
+                    <div>Roll</div>
+                    <div>Base Stat</div>
+                    <div>Training</div>
+                    <div>Focus</div>
+                </div>
+                <fieldset class="repeating_skills">
+                    <div class="npc-skills">
+                        <input type="text" name="attr_skill_name"/>
+                        <button type="roll" name="roll_skill"
+                                value="&{template:default} {{name=@{skill_name}}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{skill_base}+@{skill_training}+?{@{skill_name} bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=@{skill_focus} focus points}}"></button>
+                        <select class="attribute-select" name="attr_skill_base">
+                            <option value="@{body}" selected="selected">body</option>
+                            <option value="@{mind}">mind</option>
+                            <option value="@{soul}">soul</option>
+                        </select>
+                        <input type="number" name="attr_skill_training" class="skill-training"/>
+                        <input type="number" name="attr_skill_focus" class="skill-focus"/>
+                    </div>
+                </fieldset>
+            </div>
+            <div class="npc-traits-list">
+                <div class="header">Traits</div>
+                <div class="line"></div>
+                <fieldset class="repeating_talents">
+                    <div class="talents-container">
+                        <!--due to css funkyness this is reversed to allow the checkbox to be at the back-->
+                        <button type="roll" name="talent-description" class="talents-button"
+                                value="&{template:default} {{name=@{talents}}} {{@{talents_description}}}">w
+                        </button>
+                        <input type="checkbox" class="sheet-block-switch talents-check" name="attr_block_switch"
+                               value="1"/>
+                        <span class="talents-check2"></span>
+                        <div class="sheet-block-a talents-block">
+                            <input type="text" name="attr_talents">
+                        </div>
+                        <div class="sheet-block-b talents-block">
+                            <input type="text" name="attr_talents">
+                            <textarea name="attr_talents_description"></textarea>
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+        </div>
+        <div class="section-npc-attacks">
+            <div class="header">Attacks</div>
+            <div class="line"></div>
+            <div class="npc-attacks">
+                <div>Name</div>
+                <div>Roll</div>
+                <div>Type</div>
+                <div>Proficiency</div>
+                <div>Dice</div>
+                <div>Damage</div>
+                <div>Focus</div>
+                <div>Range</div>
+                <div>Traits</div>
+            </div>
+            <fieldset class="repeating_npc-weapon">
+                <div class="npc-attacks">
+                    <input type="text" name="attr_npc_attack_name" class="npc-attack-name"/>
+                    <button type="roll" name="roll_npc_attack" class="npc-attack-roll"
+                            value="&{template:default} {{name=@{npc_attack_name}}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{npc_attack_pool}+@{npc_swarm}+?{@{npc_attack_name} bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{focus=@{npc_attack_focus} focus points}} {{Extra Damage=@{npc_attack_damage}}}  {{Range=@{npc_attack_range}}} {{Traits=@{npc_attack_traits}}}"></button>
+                    <select class="npc-attack-prof" name="attr_npc_attack_prof">
+                        <option value=" " selected="selected">Select</option>
+                        <option value="@{npc_mel}">Melee</option>
+                        <option value="@{npc_acc}">Ranged</option>
+                    </select>
+                    <input type="text" name="attr_npc_attack_proficiency" value="@{npc_attack_prof}" disabled="true"
+                           class="npc-attack-prof-val"/>
+                    <input type="number" name="attr_npc_attack_pool" value="1" class="npc-attack-pool"/>
+                    <input type="number" name="attr_npc_attack_damage" value="0" class="npc-attack-damage"/>
+                    <input type="number" name="attr_npc_attack_focus" value="0" class="npc-attack-focus"/>
+                    <input type="text" name="attr_npc_attack_range" class="npc-attack-range"/>
+                    <input type="text" name="attr_npc_attack_traits" class="npc-attack-traits"/>
+                </div>
+            </fieldset>
+        </div>
+        <div class="section-npc-stats">
+            <div class="line"></div>
+            <div class="npc-base-stats">
+                <div class="npc-body">
+                    <button type="roll" class="text-button npc-base-stat"
+                            value="&{template:default} {{name=Body}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[@{body}d6s>?{Target DN? |2|3|4|5|6}]] successes}}"
+                            name="roll_might">Body
+                    </button>
+                    <input type="number" name="attr_body" value="1"/>
+                </div>
+                <div class="npc-mind">
+                    <button type="roll" class="text-button npc-base-stat"
+                            value="&{template:default} {{name=Mind}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[@{mind}d6s>?{Target DN? |2|3|4|5|6}]] successes}}"
+                            name="roll_might">Mind
+                    </button>
+                    <input type="number" name="attr_mind" value="1"/>
+                </div>
+                <div class="npc-soul">
+                    <button type="roll" class="text-button npc-base-stat"
+                            value="&{template:default} {{name=Soul}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[@{soul}d6s>?{Target DN? |2|3|4|5|6}]] successes}}"
+                            name="roll_might">Soul
+                    </button>
+                    <input type="number" name="attr_soul" value="1"/>
                 </div>
             </div>
         </div>
     </div>
 </div>
-<div class="header">Weapons</div>
-<div class="line"></div>
-<div class="header-minor">Melee Weapons</div>
-<div class="weapons">
-    <div>weapon name</div>
-    <div>attack</div>
-    <div>pool</div>
-    <div>focus</div>
-    <div>damage</div>
-    <div>traits</div>
-</div>
-<fieldset class="repeating_melee">
-    <div class="weapons">
-        <input type="text" name="attr_melee_name">
-        <button type="roll" name="roll_melee_attack"
-                value="&{template:default} {{name=@{melee_name}}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{weapon_skill_attribute}+@{weapon_skill_1}+@{weapon_skill_2}+@{weapon_skill_3}+?{Melee bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{Focus=[[@{weapon_skill_focus_1} + @{weapon_skill_focus_2} + @{weapon_skill_focus_3}]] focus points}} {{Extra Damage=@{melee_damage}}} {{Traits=@{melee_traits}}}"></button>
-        <input type="number" disabled="true" name="attr_melee_pool"
-               value="@{body} + @{weapon_skill_1} + @{weapon_skill_2} + @{weapon_skill_3}">
-        <input type="number" name="attr_melee_focus" disabled="true"
-               value="@{weapon_skill_focus_1} + @{weapon_skill_focus_2} + @{weapon_skill_focus_3}">
-        <input type="number" name="attr_melee_damage" value="0">
-        <input type="text" name="attr_melee_traits">
-    </div>
-</fieldset>
-<div class="header-minor">Ranged Weapons</div>
-<div class="weapons">
-    <div>weapon name</div>
-    <div>attack</div>
-    <div>pool</div>
-    <div>focus</div>
-    <div>damage</div>
-    <div>traits</div>
-</div>
-<fieldset class="repeating_ranged">
-    <div class="weapons">
-        <input type="text" name="attr_ranged_name"/>
-        <button type="roll" name="roll_ranged_attack"
-                value="&{template:default} {{name=@{ranged_name}}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[(@{ballistic_skill_attribute}+@{ballistic_skill_1}+@{ballistic_skill_2}+@{ballistic_skill_3}+?{Ranged bonus|0})d6s>?{Target DN? |2|3|4|5|6}]] successes}} {{Focus=[[@{ballistic_skill_focus_1} + @{ballistic_skill_focus_2} + @{ballistic_skill_focus_3}]] focus points}} {{Extra Damage=@{ranged_damage}}} {{Traits=@{ranged_traits}}}"></button>
-        <input type="number" disabled="true" name="attr_ranged_pool"
-               value="@{body} + @{ballistic_skill_1} + @{ballistic_skill_2} + @{ballistic_skill_3}"/>
-        <input type="number" name="attr_ranged_focus" disabled="true"
-               value="@{ballistic_skill_focus_1} + @{ballistic_skill_focus_2} + @{ballistic_skill_focus_3}"/>
-        <input type="number" name="attr_ranged_damage" value="0"/>
-        <input type="text" name="attr_ranged_traits"/>
-    </div>
-</fieldset>
-<div class="header">Spells and Miracles</div>
-<div class="line"></div>
-<div class="header-minor">Spells</div>
-<div class="spells">
-    <div>Name</div>
-    <div>Cast</div>
-    <div>DN</div>
-    <div>Target</div>
-    <div>Range</div>
-    <div>Duration</div>
-    <div>Effect</div>
-</div>
-<fieldset class="repeating_spells">
-    <div class="spells">
-        <input type="text" name="attr_spell_name"/>
-        <button type="roll" name="roll_spell"
-                value="&{template:default} {{name=@{spell_name}}} {{DN=@{spell_dn_target}:@{spell_dn_successes}}} {{Result=[[(@{mind} + @{channelling_1} + @{channelling_2} + @{channelling_3} + ?{Spellcasting bonus|0})d6s>@{spell_dn_target}]] success}} {{Focus=[[@{channelling_focus_1} + @{channelling_focus_2} + @{channelling_focus_3}]] focus points}}} {{Effect=@{spell_effect}}}"></button>
-        <div class="spells-dn">
-            <input type="number" name="attr_spell_dn_target" class="no-spin small-digit colon-separator-left">
-            <span class="colon-separator">:</span>
-            <input type="number" name="attr_spell_dn_successes" class="no-spin small-digit">
-        </div>
-        <input type="text" name="attr_spell_target" class="spells-target"/>
-        <select name="attr_spell_range" class="spells-range">
-            <option value="self">self</option>
-            <option value="close">close</option>
-            <option value="short">short</option>
-            <option value="medium">medium</option>
-            <option value="long">long</option>
-        </select>
-        <input type="text" name="attr_spell_duration" class="spells-duration"/>
-        <textarea type="text" name="attr_spell_effect" class="spells-effect text-area"></textarea>
-    </div>
-</fieldset>
-<div class="header-minor">Miracles</div>
-<div class="miracles">
-    <div>Name</div>
-    <div>Manifest</div>
-    <div>Cost</div>
-    <div>Target</div>
-    <div>Range</div>
-    <div>Duration</div>
-    <div>Effect</div>
-</div>
-<fieldset class="repeating_miracles">
-    <div class="miracles">
-        <input type="text" name="attr_miracle_name"/>
-        <button type="roll" name="roll_spell"
-                value="&{template:default} {{name=@{miracle_name}}} {{Effect=@{miracle_effect}}}"></button>
-        <input type="text" name="attr_miracle_cost" class="miracle-cost"/>
-        <input type="text" name="attr_miracle_target" class="miracle-target"/>
-        <select name="attr_miracle_range" class="miracle-range">
-            <option value="self">self</option>
-            <option value="close">close</option>
-            <option value="short">short</option>
-            <option value="medium">medium</option>
-            <option value="long">long</option>
-        </select>
-        <input type="text" name="attr_miracle_duration" class="miracle-duration"/>
-        <textarea name="attr_miracle_effect" class="miracle-effect text-area"></textarea>
-    </div>
-</fieldset>
-
-<div class="section-gear">
-    <div class="equip-and-currency">
-        <div class="header">Equipment</div>
-        <div class="line"></div>
-        <div class="equipment">
-            <div>Head</div>
-            <input type="text" name="attr_equip_head"/>
-            <div>Cloak</div>
-            <input type="text" name="attr_equip_cloak"/>
-            <div>Armour</div>
-            <input type="text" name="attr_equip_armour"/>
-            <div>Right Hand</div>
-            <input type="text" name="attr_equip_r_hand"/>
-            <div>Left Hand</div>
-            <input type="text" name="attr_equip_l_hand"/>
-            <div>Arms</div>
-            <input type="text" name="attr_equip_arms"/>
-            <div>Boots</div>
-            <input type="text" name="attr_equip_boots"/>
-            <div>Jewelry</div>
-            <input type="text" name="attr_equip_jewelry"/>
-        </div>
-
-        <fieldset class="repeating_equipother">
-            <div class="equipment">
-                <div>Other</div>
-                <input type="text" name="attr_equip_other"/>
-            </div>
-        </fieldset>
-
-        <div class="header">Currency</div>
-        <div class="line"></div>
-        <div class="currency">
-            <div>
-                <input type="number" name="attr_drops" value="0">
-                <span>Drops</span>
-            </div>
-            <div>
-                <input type="number" name="attr_phials" value="0">
-                <span>Phials</span>
-            </div>
-            <div>
-                <input type="number" name="attr_spheres" value="0">
-                <span>Spheres</span>
-            </div>
-        </div>
-    </div>
-    <div class="gear">
-        <div class="header">Other Gear</div>
-        <div class="line"></div>
-        <fieldset class="repeating_other-gear">
-            <div class="gear">
-                <input type="text" name="attr_gear"/>
-            </div>
-        </fieldset>
-    </div>
-</div>
-<div class="header">Background</div>
-<div class="line"></div>
-<textarea name="attr_background" class="fluff-info text-area"></textarea>
-<div class="header">Notes</div>
-<div class="line"></div>
-<textarea name="attr_notes" class="fluff-info text-area"></textarea>
-<div class="header">Goals</div>
-<div class="line"></div>
-<textarea name="attr_goals" class="fluff-info text-area"></textarea>
-<div class="header">Connections</div>
-<div class="line"></div>
-<textarea name="attr_connections" class="fluff-info text-area"></textarea>
 
 <script type="text/worker">
-    on("change:body change:reflexes_1 change:reflexes_2 change:reflexes_3 change:defence_bonus", function() {
-        getAttrs(["body", "reflexes_1", "reflexes_2", "reflexes_3", "defence_bonus"], function(values) {
+    on("change:body change:reflexes_1 change:reflexes_2 change:reflexes_3 change:defence_bonus", function () {
+        getAttrs(["body", "reflexes_1", "reflexes_2", "reflexes_3", "defence_bonus"], function (values) {
             let defence = parseInt(values.body) + parseInt(values.reflexes_1) + parseInt(values.reflexes_2) + parseInt(values.reflexes_3) + (2 * parseInt(values.defence_bonus));
-            setAttrs({def_poor:0, def_average:0, def_good:0 , def_great:0, def_superb:0, def_extraordinary:0}, {silent:true});
-            if (defence === 1 || defence === 2){
-                setAttrs({ def_poor:1 }, {silent:true});
-            } else if (defence === 3 || defence === 4){
-                setAttrs({ def_average:1 }, {silent:true});
-            } else if (defence === 5 || defence === 6){
-                setAttrs({ def_good:1 }, {silent:true});
-            } else if (defence === 7 || defence === 8){
-                setAttrs({ def_great:1 }, {silent:true});
-            } else if (defence === 9 || defence === 10){
-                setAttrs({ def_superb:1 }, {silent:true});
-            } else if (defence === 11 || defence === 12){
-                setAttrs({ def_extraordinary:1 }, {silent:true});
+            setAttrs({
+                def_poor: 0,
+                def_average: 0,
+                def_good: 0,
+                def_great: 0,
+                def_superb: 0,
+                def_extraordinary: 0
+            }, {silent: true});
+            if (defence === 1 || defence === 2) {
+                setAttrs({def_poor: 1}, {silent: true});
+            } else if (defence === 3 || defence === 4) {
+                setAttrs({def_average: 1}, {silent: true});
+            } else if (defence === 5 || defence === 6) {
+                setAttrs({def_good: 1}, {silent: true});
+            } else if (defence === 7 || defence === 8) {
+                setAttrs({def_great: 1}, {silent: true});
+            } else if (defence === 9 || defence === 10) {
+                setAttrs({def_superb: 1}, {silent: true});
+            } else if (defence === 11 || defence === 12) {
+                setAttrs({def_extraordinary: 1}, {silent: true});
             }
         });
     });
 
-    on("change:body change:weapon_skill_1 change:weapon_skill_2 change:weapon_skill_3 change:melee_bonus", function() {
-        getAttrs(["body", "weapon_skill_1", "weapon_skill_2", "weapon_skill_3", "melee_bonus"], function(values) {
+    on("change:body change:weapon_skill_1 change:weapon_skill_2 change:weapon_skill_3 change:melee_bonus", function () {
+        getAttrs(["body", "weapon_skill_1", "weapon_skill_2", "weapon_skill_3", "melee_bonus"], function (values) {
             let melee = parseInt(values.body) + parseInt(values.weapon_skill_1) + parseInt(values.weapon_skill_2) + parseInt(values.weapon_skill_3) + (2 * parseInt(values.melee_bonus));
-            setAttrs({mel_poor:0, mel_average:0, mel_good:0 , mel_great:0, mel_superb:0, mel_extraordinary:0}, {silent:true});
-            if (melee === 1 || melee === 2){
-                setAttrs({ mel_poor:1 }, {silent:true});
-            } else if (melee === 3 || melee === 4){
-                setAttrs({ mel_average:1 }, {silent:true});
-            } else if (melee === 5 || melee === 6){
-                setAttrs({ mel_good:1 }, {silent:true});
-            } else if (melee === 7 || melee === 8){
-                setAttrs({ mel_great:1 }, {silent:true});
-            } else if (melee === 9 || melee === 10){
-                setAttrs({ mel_superb:1 }, {silent:true});
-            } else if (melee === 11 || melee === 12){
-                setAttrs({ mel_extraordinary:1 }, {silent:true});
+            setAttrs({
+                mel_poor: 0,
+                mel_average: 0,
+                mel_good: 0,
+                mel_great: 0,
+                mel_superb: 0,
+                mel_extraordinary: 0
+            }, {silent: true});
+            if (melee === 1 || melee === 2) {
+                setAttrs({mel_poor: 1}, {silent: true});
+            } else if (melee === 3 || melee === 4) {
+                setAttrs({mel_average: 1}, {silent: true});
+            } else if (melee === 5 || melee === 6) {
+                setAttrs({mel_good: 1}, {silent: true});
+            } else if (melee === 7 || melee === 8) {
+                setAttrs({mel_great: 1}, {silent: true});
+            } else if (melee === 9 || melee === 10) {
+                setAttrs({mel_superb: 1}, {silent: true});
+            } else if (melee === 11 || melee === 12) {
+                setAttrs({mel_extraordinary: 1}, {silent: true});
             }
         });
     });
 
-    on("change:mind change:ballistic_skill_1 change:ballistic_skill_2 change:ballistic_skill_3 change:accuracy_bonus", function() {
-        getAttrs(["mind", "ballistic_skill_1", "ballistic_skill_2", "ballistic_skill_3", "accuracy_bonus"], function(values) {
+    on("change:mind change:ballistic_skill_1 change:ballistic_skill_2 change:ballistic_skill_3 change:accuracy_bonus", function () {
+        getAttrs(["mind", "ballistic_skill_1", "ballistic_skill_2", "ballistic_skill_3", "accuracy_bonus"], function (values) {
             let accuracy = parseInt(values.mind) + parseInt(values.ballistic_skill_1) + parseInt(values.ballistic_skill_2) + parseInt(values.ballistic_skill_3) + (2 * parseInt(values.accuracy_bonus));
-            setAttrs({acc_poor:0, acc_average:0, acc_good:0 , acc_great:0, acc_superb:0, acc_extraordinary:0}, {silent:true});
-            if (accuracy === 1 || accuracy === 2){
-                setAttrs({ acc_poor:1 }, {silent:true});
-            } else if (accuracy === 3 || accuracy === 4){
-                setAttrs({ acc_average:1 }, {silent:true});
-            } else if (accuracy === 5 || accuracy === 6){
-                setAttrs({ acc_good:1 }, {silent:true});
-            } else if (accuracy === 7 || accuracy === 8){
-                setAttrs({ acc_great:1 }, {silent:true});
-            } else if (accuracy === 9 || accuracy === 10){
-                setAttrs({ acc_superb:1 }, {silent:true});
-            } else if (accuracy === 11 || accuracy === 12){
-                setAttrs({ acc_extraordinary:1 }, {silent:true});
+            setAttrs({
+                acc_poor: 0,
+                acc_average: 0,
+                acc_good: 0,
+                acc_great: 0,
+                acc_superb: 0,
+                acc_extraordinary: 0
+            }, {silent: true});
+            if (accuracy === 1 || accuracy === 2) {
+                setAttrs({acc_poor: 1}, {silent: true});
+            } else if (accuracy === 3 || accuracy === 4) {
+                setAttrs({acc_average: 1}, {silent: true});
+            } else if (accuracy === 5 || accuracy === 6) {
+                setAttrs({acc_good: 1}, {silent: true});
+            } else if (accuracy === 7 || accuracy === 8) {
+                setAttrs({acc_great: 1}, {silent: true});
+            } else if (accuracy === 9 || accuracy === 10) {
+                setAttrs({acc_superb: 1}, {silent: true});
+            } else if (accuracy === 11 || accuracy === 12) {
+                setAttrs({acc_extraordinary: 1}, {silent: true});
             }
         });
     });
 
-    on("change:mind change:awareness_1 change:awareness_2 change:awareness_3 change:reflexes_1 change:reflexes_2 change:reflexes_3 change:initiative_bonus", function() {
-        getAttrs(["mind", "awareness_1", "awareness_2", "awareness_3", "reflexes_1", "reflexes_2", "reflexes_3", "initiative_bonus"], function(values) {
+    on("change:mind change:awareness_1 change:awareness_2 change:awareness_3 change:reflexes_1 change:reflexes_2 change:reflexes_3 change:initiative_bonus", function () {
+        getAttrs(["mind", "awareness_1", "awareness_2", "awareness_3", "reflexes_1", "reflexes_2", "reflexes_3", "initiative_bonus"], function (values) {
             let mind = parseInt(values.mind);
             let awareness = (parseInt(values.awareness_1) + parseInt(values.awareness_2) + parseInt(values.awareness_3));
             let reflexes = (parseInt(values.reflexes_1) + parseInt(values.reflexes_2) + parseInt(values.reflexes_3));
             let initiativeBonus = parseInt(values.initiative_bonus);
             let initiative = mind + awareness + reflexes + initiativeBonus;
-            setAttrs({ initiative:initiative });
+            setAttrs({initiative: initiative});
         });
     });
 
@@ -1111,18 +1390,28 @@
     const repeatingSum = (destination, section, fields, multiplier = 1) => {
         if (!Array.isArray(fields)) fields = [fields];
         getSectionIDs(`repeating_${section}`, idArray => {
-            const attrArray = idArray.reduce( (m,id) => [...m, ...(fields.map(field => `repeating_${section}_${id}_${field}`))],[]);
+            const attrArray = idArray.reduce((m, id) => [...m, ...(fields.map(field => `repeating_${section}_${id}_${field}`))], []);
             getAttrs(attrArray, v => {
-                console.log("===== values of v: "+ JSON.stringify(v) +" =====");
-                     // getValue: if not a number, returns 1 if it is 'on' (checkbox), otherwise returns 0..
-                const getValue = (section, id,field) => parseFloat(v[`repeating_${section}_${id}_${field}`]) || (v[`repeating_${section}_${id}_${field}`] === 'on' ? 1 : 0);
-                const sumTotal = idArray.reduce((total, id) => total + fields.reduce((subtotal,field) => subtotal * getValue(section, id,field),1),0);
+                console.log("===== values of v: " + JSON.stringify(v) + " =====");
+                // getValue: if not a number, returns 1 if it is 'on' (checkbox), otherwise returns 0..
+                const getValue = (section, id, field) => parseFloat(v[`repeating_${section}_${id}_${field}`]) || (v[`repeating_${section}_${id}_${field}`] === 'on' ? 1 : 0);
+                const sumTotal = idArray.reduce((total, id) => total + fields.reduce((subtotal, field) => subtotal * getValue(section, id, field), 1), 0);
                 setAttrs({[destination]: sumTotal * multiplier});
             });
         });
     };
 
-    on('change:repeating_wounds-applied add:repeating_wounds-applied remove:repeating_wounds-applied', function() {
-        repeatingSum("w_total","wounds-applied","wound_taken");
+    on('sheet:opened change:repeating_wounds-applied add:repeating_wounds-applied remove:repeating_wounds-applied', function () {
+        repeatingSum("wounds", "wounds-applied", "wound_taken");
     });
+
+    const buttonList = ["player", "party", "npc"];
+    buttonList.forEach(button => {
+        on(`clicked:${button}`, function () {
+            setAttrs({
+                sheet_tab: button
+            });
+        });
+    });
+
 </script>

--- a/Age-of-Sigmar-Soulbound/soulbound.html
+++ b/Age-of-Sigmar-Soulbound/soulbound.html
@@ -1069,7 +1069,7 @@
     <div class="sheet-npc">
         <div class="section-npc-info">
             <div class="npc-name">
-                <input type="text" class="npc-name" name="attr_character_name" value="Name"/>
+                <input type="text" class="npc-name" name="attr_character_name"/>
                 <div class="options-check stack">
                     <input type="checkbox" class="options-button" name="attr_options" value="1"/>
                     <span></span>
@@ -1166,11 +1166,11 @@
                 </div>
                 <div>
                     <div>Initiative:</div>
-                    <input type="number" name="attr_initiative"/>
+                    <input type="number" name="attr_npc_initiative"/>
                 </div>
                 <div>
                     <div>Natural Awareness:</div>
-                    <input type="number" name="attr_nat_awareness"/>
+                    <input type="number" name="attr_npc_nat_awareness"/>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Changes / Comments

added new options menu (Accessible by the cog symbol) 
added npc sheet (toggle between player and npc switch in options menu)
fixed issue with wounds, sheetworker will update existing sheets




## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
Fixes an issue with wounds not being able to be used in token bars
- [x] Does this add functional enhancements (new features or extending existing features) ?
Adds options section
Adds cut down NPC version of the sheet
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
Minor changes to PC sheet to allow some text boxes to expand
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
Added on sheet:opened to the calculation for wounds, this coincidentally also fixes existing sheets
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
