### PR TITLE
[Dark Heresy 2e] allow plus sign in modifier query

### DIFF
--- a/Dark_Heresy_2ed/DarkHeresy2ed.html
+++ b/Dark_Heresy_2ed/DarkHeresy2ed.html
@@ -133,7 +133,7 @@
 						<!-- WeaponSkill (WS) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_WS" type="roll" value="/em rolls Weapon Skill: [[1d100]] Target: [[@{WeaponSkill}+ ?{Modifier|0}]]."><label>Weapon Skill (WS)</label></button>
+								<button name="roll_WS" type="roll" value="/em rolls Weapon Skill: [[1d100]] Target: [[@{WeaponSkill}+ [[?{Modifier|0}]]]]."><label>Weapon Skill (WS)</label></button>
 							</div>
 							<div class="sheet-col">
 							    <div class="sheet-unnatural_box">
@@ -159,7 +159,7 @@
 						<!-- BallisticSkill (BS) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_BS" type="roll" value="/em rolls Ballistic Skill: [[1d100]] Target: [[@{BallisticSkill}+ ?{Modifier|0}]]."><label>Ballistic Skill (BS)</label></button>
+								<button name="roll_BS" type="roll" value="/em rolls Ballistic Skill: [[1d100]] Target: [[@{BallisticSkill}+ [[?{Modifier|0}]]]]."><label>Ballistic Skill (BS)</label></button>
 							</div>
 							<div class="sheet-col">
 							    <div class="sheet-unnatural_box">
@@ -186,7 +186,7 @@
 						<!-- Strength (S) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_S" type="roll" value="/em rolls Strength: [[1d100]] Target: [[@{Strength}+ ?{Modifier|0}]]."><label>Strength (S)</label></button>
+								<button name="roll_S" type="roll" value="/em rolls Strength: [[1d100]] Target: [[@{Strength}+ [[?{Modifier|0}]]]]."><label>Strength (S)</label></button>
 							</div>
 							<div class="sheet-col">
 							    <div class="sheet-unnatural_box">
@@ -213,7 +213,7 @@
 						<!-- Toughness (T) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_T" type="roll" value="/em rolls Toughness: [[1d100]] Target: [[@{Toughness}+ ?{Modifier|0}]]."><label>Toughness (T)</label></button>
+								<button name="roll_T" type="roll" value="/em rolls Toughness: [[1d100]] Target: [[@{Toughness}+ [[?{Modifier|0}]]]]."><label>Toughness (T)</label></button>
 							</div>
 							<div class="sheet-col">
 							    <div class="sheet-unnatural_box">
@@ -240,7 +240,7 @@
 						<!-- Agility (Ag) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_Ag" type="roll" value="/em rolls Agility: [[1d100]] Target: [[@{Agility}+ ?{Modifier|0}]]."><label>Agility (Ag)</label></button>
+								<button name="roll_Ag" type="roll" value="/em rolls Agility: [[1d100]] Target: [[@{Agility}+ [[?{Modifier|0}]]]]."><label>Agility (Ag)</label></button>
 							</div>
 							<div class="sheet-col">
 							    <div class="sheet-unnatural_box">
@@ -271,7 +271,7 @@
 						<!-- Intelligence (Int) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_Int" type="roll" value="/em rolls Intelligence: [[1d100]] Target: [[@{Intelligence}+ ?{Modifier|0}]]."><label>Intelligence (Int)</label></button>
+								<button name="roll_Int" type="roll" value="/em rolls Intelligence: [[1d100]] Target: [[@{Intelligence}+ [[?{Modifier|0}]]]]."><label>Intelligence (Int)</label></button>
 							</div>
 							<div class="sheet-col">
 							    <div class="sheet-unnatural_box">
@@ -298,7 +298,7 @@
 						<!-- Perception (Per) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_Per" type="roll" value="/em rolls Perception: [[1d100]] Target: [[@{Perception}+ ?{Modifier|0}]]."><label>Perception (Per)</label></button>
+								<button name="roll_Per" type="roll" value="/em rolls Perception: [[1d100]] Target: [[@{Perception}+ [[?{Modifier|0}]]]]."><label>Perception (Per)</label></button>
 							</div>
 							<div class="sheet-col">
 							    <div class="sheet-unnatural_box">
@@ -325,7 +325,7 @@
 						<!-- Willpower (WP) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_WP" type="roll" value="/em rolls Willpower: [[1d100]] Target: [[@{Willpower}+ ?{Modifier|0}]]."><label>Willpower (WP)</label></button>
+								<button name="roll_WP" type="roll" value="/em rolls Willpower: [[1d100]] Target: [[@{Willpower}+ [[?{Modifier|0}]]]]."><label>Willpower (WP)</label></button>
 							</div>
 							<div class="sheet-col">
 							    <div class="sheet-unnatural_box">
@@ -352,7 +352,7 @@
 						<!-- Fellowship (Fel) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_Fel" type="roll" value="/em rolls Fellowship: [[1d100]] Target: [[@{Fellowship}+ ?{Modifier|0}]]."><label>Fellowship (Fel)</label></button>
+								<button name="roll_Fel" type="roll" value="/em rolls Fellowship: [[1d100]] Target: [[@{Fellowship}+ [[?{Modifier|0}]]]]."><label>Fellowship (Fel)</label></button>
 							</div>
 							<div class="sheet-col">
 							    <div class="sheet-unnatural_box">
@@ -379,7 +379,7 @@
 						<!-- Influence (Ifl) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_Inf" type="roll" value="/em rolls Influence: [[1d100]] Target: [[@{Influence}+ ?{Modifier|0}]]."><label>Influence (Inf)</label></button>
+								<button name="roll_Inf" type="roll" value="/em rolls Influence: [[1d100]] Target: [[@{Influence}+ [[?{Modifier|0}]]]]."><label>Influence (Inf)</label></button>
 							</div>
 							<div class="sheet-col">
 							    <div class="sheet-unnatural_box">
@@ -1726,7 +1726,7 @@
 							<td><input name="attr_advancedskillbox3" type="checkbox" value="10"></td>
 							<td><input name="attr_advancedskillbox4" type="checkbox" value="10"></td>
 							<td class="roll_advancedskill">
-								<button name="roll_advancedskill" type="roll" value="/em rolls @{advancedskillname}[[1d100]] Target [[@{advancedskill}+?{Modifier|0}]]">
+								<button name="roll_advancedskill" type="roll" value="/em rolls @{advancedskillname}[[1d100]] Target [[@{advancedskill}+[[?{Modifier|0}]]]]">
 									<input disabled="true" name="attr_advancedskill" type="number" value=" -20 +(@{advancedskillbox1})+@{advancedskillcharacteristic}+@{advancedskillbox2}+@{advancedskillbox3} +@{advancedskillbox4}">
 								</button>
 							</td>
@@ -1976,53 +1976,53 @@
 							<h3>Characteristics</h3>
 							<div class="sheet-row">
 								<div class="sheet-item" style="width: 8%;">
-									<button name="roll_NPCWSR" type="roll" value="/em rolls @{NPCName}'s Weapon Skill: [[1d100]] Target: [[@{NPCWS}+ ?{Modifier|0}]]."><label>WS</label></button>
+									<button name="roll_NPCWSR" type="roll" value="/em rolls @{NPCName}'s Weapon Skill: [[1d100]] Target: [[@{NPCWS}+ [[?{Modifier|0}]]]]."><label>WS</label></button>
 								</div>
 								<div class="sheet-item" style="width: 12%;"><input name="attr_NPCWS" type="number" value="0" style="text-align: center;"/></div>
 
 								<div class="sheet-item" style="width: 8%;">
-									<button name="roll_NPCBSR" type="roll" value="/em rolls @{NPCName}'s Ballistic Skill: [[1d100]] Target: [[@{NPCBS}+ ?{Modifier|0}]]."><label>BS</label></button>
+									<button name="roll_NPCBSR" type="roll" value="/em rolls @{NPCName}'s Ballistic Skill: [[1d100]] Target: [[@{NPCBS}+ [[?{Modifier|0}]]]]."><label>BS</label></button>
 								</div>
 								<div class="sheet-item" style="width: 12%;"><input name="attr_NPCBS" type="number" value="0" style="text-align: center;"/></div>
 
 								<div class="sheet-item" style="width: 8%;">
-									<button name="roll_NPCSR" type="roll" value="/em rolls @{NPCName}'s Strength: [[1d100]] Target: [[@{NPCS}+ ?{Modifier|0}]]."><label>S</label></button>
+									<button name="roll_NPCSR" type="roll" value="/em rolls @{NPCName}'s Strength: [[1d100]] Target: [[@{NPCS}+ [[?{Modifier|0}]]]]."><label>S</label></button>
 								</div>
 								<div class="sheet-item" style="width: 12%;"><input name="attr_NPCS" type="number" value="0" style="text-align: center;"/></div>
 
 								<div class="sheet-item" style="width: 8%;">
-									<button name="roll_NPCTR" type="roll" value="/em rolls @{NPCName}'s Toughness: [[1d100]] Target: [[@{NPCT}+ ?{Modifier|0}]]."><label>T</label></button>
+									<button name="roll_NPCTR" type="roll" value="/em rolls @{NPCName}'s Toughness: [[1d100]] Target: [[@{NPCT}+ [[?{Modifier|0}]]]]."><label>T</label></button>
 								</div>
 								<div class="sheet-item" style="width: 12%;"><input name="attr_NPCT" type="number" value="0" style="text-align: center;"/></div>
 
 								<div class="sheet-item" style="width: 8%;">
-									<button name="roll_NPCAcR" type="roll" value="/em rolls @{NPCName}'s Agility: [[1d100]] Target: [[@{NPCAc}+ ?{Modifier|0}]]."><label>Ag</label></button>
+									<button name="roll_NPCAcR" type="roll" value="/em rolls @{NPCName}'s Agility: [[1d100]] Target: [[@{NPCAc}+ [[?{Modifier|0}]]]]."><label>Ag</label></button>
 								</div>
 								<div class="sheet-item" style="width: 12%;"><input name="attr_NPCAc" type="number" value="0" style="text-align: center;"/></div>
 							</div>
 							<div class="sheet-row">
 								<div class="sheet-item" style="width: 8%;">
-									<button name="roll_NPCIntR" type="roll" value="/em rolls @{NPCName}'s Intelligence: [[1d100]] Target: [[@{NPCInt}+ ?{Modifier|0}]]."><label>Int</label></button>
+									<button name="roll_NPCIntR" type="roll" value="/em rolls @{NPCName}'s Intelligence: [[1d100]] Target: [[@{NPCInt}+ [[?{Modifier|0}]]]]."><label>Int</label></button>
 								</div>
 								<div class="sheet-item" style="width: 12%;"><input name="attr_NPCInt" type="number" value="0" style="text-align: center;"/></div>
 
 								<div class="sheet-item" style="width: 8%;">
-									<button name="roll_NPCPerR" type="roll" value="/em rolls @{NPCName}'s Perception: [[1d100]] Target: [[@{NPCPer}+ ?{Modifier|0}]]."><label>Per</label></button>
+									<button name="roll_NPCPerR" type="roll" value="/em rolls @{NPCName}'s Perception: [[1d100]] Target: [[@{NPCPer}+ [[?{Modifier|0}]]]]."><label>Per</label></button>
 								</div>
 								<div class="sheet-item" style="width: 12%;"><input name="attr_NPCPer" type="number" value="0" style="text-align: center;"/></div>
 
 								<div class="sheet-item" style="width: 8%;">
-									<button name="roll_NPCWPR" type="roll" value="/em rolls @{NPCName}'s Willpower: [[1d100]] Target: [[@{NPCWP}+ ?{Modifier|0}]]."><label>WP</label></button>
+									<button name="roll_NPCWPR" type="roll" value="/em rolls @{NPCName}'s Willpower: [[1d100]] Target: [[@{NPCWP}+ [[?{Modifier|0}]]]]."><label>WP</label></button>
 								</div>
 								<div class="sheet-item" style="width: 12%;"><input name="attr_NPCWP" type="number" value="0" style="text-align: center;"/></div>
 
 								<div class="sheet-item" style="width: 8%;">
-									<button name="roll_NPCFelR" type="roll" value="/em rolls @{NPCName}'s Fellowship: [[1d100]] Target: [[@{NPCFel}+ ?{Modifier|0}]]."><label>Fel</label></button>
+									<button name="roll_NPCFelR" type="roll" value="/em rolls @{NPCName}'s Fellowship: [[1d100]] Target: [[@{NPCFel}+ [[?{Modifier|0}]]]]."><label>Fel</label></button>
 								</div>
 								<div class="sheet-item" style="width: 12%;"><input name="attr_NPCFel" type="number" value="0" style="text-align: center;"/></div>
 
 								<div class="sheet-item" style="width: 8%;">
-									<button name="roll_NPCPerR" type="roll" value="/em rolls @{NPCName}'s Influence: [[1d100]] Target: [[@{NPCInf}+ ?{Modifier|0}]]."><label>Inf</label></button>
+									<button name="roll_NPCPerR" type="roll" value="/em rolls @{NPCName}'s Influence: [[1d100]] Target: [[@{NPCInf}+ [[?{Modifier|0}]]]]."><label>Inf</label></button>
 								</div>
 								<div class="sheet-item" style="width: 12%;"><input name="attr_NPCInf" type="number" value="0" style="text-align: center;"/></div>
 							</div>
@@ -2228,8 +2228,8 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width: 15%;"><label>Special:</label></div>
 									<div class="sheet-item" style="width: 73%;"><input name="attr_NPC1Rangedweaponspecial" type="text" /></div>
-									<div class="sheet-item" style="width: 6%;"><button name="roll_NPC1Rangedhit" type="roll" value="/me uses @{NPC1Rangedweaponname} [[1d100]] Target [[@{NPCBS} +[[ ?{Aim | Half aim (+10),+10| No aim (+0),+0 | Full aim (+20),+20} + ?{Range | Point Blank (+30),+30 | Short Range (+10),+10 | Standard range (+0),+0 | Long Range (-10),-10 | Extreme Range (-30),-30} + ?{Rate of Fire/Attack Type|Standard (+10),+10 | Semi auto (+0),+0 | Full Auto (-10),-10 | Called Shot (-20),-20 | Suppressing Fire (-20),-20} + ?{Modifier|0} ]]]]."> <label>R-H</label> </button></div>
-									<div class="sheet-item" style="width: 6%;"><button name="roll_NPC1Meleedhit" type="roll" value="/me uses @{NPC1Rangedweaponname} [[1d100]] Target [[@{NPCWS}+ [[?{Aim | Half aim (+10),+10 | No aim (+0),+0 | Full aim (+20),+20} + ?{Attack Type | All out (+30),+30| Charge (+20),+20 |Standard (+10),+10 | Swift Attack (+0),+0 | Lighting (-10),-10} + ?{Modifier|0}]]]]."> <label>M-H</label> </button></div>
+									<div class="sheet-item" style="width: 6%;"><button name="roll_NPC1Rangedhit" type="roll" value="/me uses @{NPC1Rangedweaponname} [[1d100]] Target [[@{NPCBS} +[[ ?{Aim | Half aim (+10),+10| No aim (+0),+0 | Full aim (+20),+20} + ?{Range | Point Blank (+30),+30 | Short Range (+10),+10 | Standard range (+0),+0 | Long Range (-10),-10 | Extreme Range (-30),-30} + ?{Rate of Fire/Attack Type|Standard (+10),+10 | Semi auto (+0),+0 | Full Auto (-10),-10 | Called Shot (-20),-20 | Suppressing Fire (-20),-20} + [[?{Modifier|0}]] ]]]]."> <label>R-H</label> </button></div>
+									<div class="sheet-item" style="width: 6%;"><button name="roll_NPC1Meleedhit" type="roll" value="/me uses @{NPC1Rangedweaponname} [[1d100]] Target [[@{NPCWS}+ [[?{Aim | Half aim (+10),+10 | No aim (+0),+0 | Full aim (+20),+20} + ?{Attack Type | All out (+30),+30| Charge (+20),+20 |Standard (+10),+10 | Swift Attack (+0),+0 | Lighting (-10),-10} + [[?{Modifier|0}]]]]]]."> <label>M-H</label> </button></div>
 								</div>
 							</div>
 						</div>
@@ -2270,8 +2270,8 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width: 15%;"><label>Special:</label></div>
 									<div class="sheet-item" style="width: 73%;"><input name="attr_NPC2Rangedweaponspecial" type="text" /></div>
-									<div class="sheet-item" style="width: 6%;"><button name="roll_NPC2Rangedhit" type="roll" value="/me uses @{NPC2Rangedweaponname} [[1d100]] Target [[@{NPCBS} +[[ ?{Aim | Half aim (+10),+10| No aim (+0),+0 | Full aim (+20),+20} + ?{Range | Point Blank (+30),+30 | Short Range (+10),+10 | Standard range (+0),+0 | Long Range (-10),-10 | Extreme Range (-30),-30} + ?{Rate of Fire/Attack Type|Standard (+10),+10 | Semi auto (+0),+0 | Full Auto (-10),-10 | Called Shot (-20),-20 | Suppressing Fire (-20),-20} + ?{Modifier|0} ]]]]."> <label>R-H</label> </button></div>
-									<div class="sheet-item" style="width: 6%;"><button name="roll_NPC2Meleedhit" type="roll" value="/me uses @{NPC2Rangedweaponname} [[1d100]] Target [[@{NPCWS}+ [[?{Aim | Half aim (+10),+10 | No aim (+0),+0 | Full aim (+20),+20} + ?{Attack Type | All out (+30),+30| Charge (+20),+20 |Standard (+10),+10 | Swift Attack (+0),+0 | Lighting (-10),-10} + ?{Modifier|0}]]]]."> <label>M-H</label> </button></div>
+									<div class="sheet-item" style="width: 6%;"><button name="roll_NPC2Rangedhit" type="roll" value="/me uses @{NPC2Rangedweaponname} [[1d100]] Target [[@{NPCBS} +[[ ?{Aim | Half aim (+10),+10| No aim (+0),+0 | Full aim (+20),+20} + ?{Range | Point Blank (+30),+30 | Short Range (+10),+10 | Standard range (+0),+0 | Long Range (-10),-10 | Extreme Range (-30),-30} + ?{Rate of Fire/Attack Type|Standard (+10),+10 | Semi auto (+0),+0 | Full Auto (-10),-10 | Called Shot (-20),-20 | Suppressing Fire (-20),-20} + [[?{Modifier|0}]] ]]]]."> <label>R-H</label> </button></div>
+									<div class="sheet-item" style="width: 6%;"><button name="roll_NPC2Meleedhit" type="roll" value="/me uses @{NPC2Rangedweaponname} [[1d100]] Target [[@{NPCWS}+ [[?{Aim | Half aim (+10),+10 | No aim (+0),+0 | Full aim (+20),+20} + ?{Attack Type | All out (+30),+30| Charge (+20),+20 |Standard (+10),+10 | Swift Attack (+0),+0 | Lighting (-10),-10} + [[?{Modifier|0}]]]]]]."> <label>M-H</label> </button></div>
 								</div>
 							</div>
 						</div>
@@ -2400,7 +2400,7 @@
 							<div class="sheet-item" style="width: 21%;"><input name="attr_PsyDamage" type="text" /></div>
 							<div class="sheet-item" style="width: 8%;"><label>Pen:</label></div>
 							<div class="sheet-item" style="width: 17%;"><input name="attr_PsyPen" type="text" /></div>
-							<div class="sheet-item" style="width: 12%;"><button name="roll_PsyHit" type="roll" value="/em uses @{PsyName} [[1d100]] Target [[@{PsyFocusPower} + ((@{PsyRating} - ?{Psy Use?|@{PsyRating}}) * 10) + @{PsyPowerModifier} + ?{Modifier|0}]]."> <label>Cast</label> </button></div>
+							<div class="sheet-item" style="width: 12%;"><button name="roll_PsyHit" type="roll" value="/em uses @{PsyName} [[1d100]] Target [[@{PsyFocusPower} + ((@{PsyRating} - ?{Psy Use?|@{PsyRating}}) * 10) + @{PsyPowerModifier} + [[?{Modifier|0}]]]]."> <label>Cast</label> </button></div>
 							<div class="sheet-item" style="width: 15%;"><button name="roll_PsyDamage" type="roll" value="/me does [[?{Damage|1d10})]] @{PsyDamageType} damage! Pen: [[?{Penetration|0}]]"> <label>Damage</label> </button></div>
 							<div class="sheet-item" style="width: 12%;"><button name="roll_PsyInfo" type="roll" value="&{template:default} {{name=@{PsyName}}} {{Action=@{PsyAction}}} {{SubType(s)=@{PsySubtype}}} {{Range=@{PsyRange}}} {{Sustained?=@{PsySustained}}} {{Effect=@{PsyPowersEffect}}} "> <label>Info</label> </button></div>			
 						</div>
@@ -2453,7 +2453,7 @@
 							<div class="sheet-item" style="width: 21%;"><input name="attr_PsyDamage2" type="text" /></div>
 							<div class="sheet-item" style="width: 8%;"><label>Pen:</label></div>
 							<div class="sheet-item" style="width: 17%;"><input name="attr_PsyPen2" type="text" /></div>
-							<div class="sheet-item" style="width: 12%;"><button name="roll_PsyHit2" type="roll" value="/em uses @{PsyName2} [[1d100]] Target [[@{PsyFocusPower2} + ((@{PsyRating} - ?{Psy Use?|1}) * 10) + @{PsyPowerModifier2} + ?{Modifier|0}]]."> <label>Cast</label> </button></div>
+							<div class="sheet-item" style="width: 12%;"><button name="roll_PsyHit2" type="roll" value="/em uses @{PsyName2} [[1d100]] Target [[@{PsyFocusPower2} + ((@{PsyRating} - ?{Psy Use?|1}) * 10) + @{PsyPowerModifier2} + [[?{Modifier|0}]]]]."> <label>Cast</label> </button></div>
 							<div class="sheet-item" style="width: 15%;"><button name="roll_PsyDamage2" type="roll" value="/me does [[?{Damage|1d10})]] @{PsyDamageType2} damage! Pen: [[?{Penetration|0}]]."> <label>Damage</label> </button></div>
 							<div class="sheet-item" style="width: 12%;"><button name="roll_PsyInfo2" type="roll" value="&{template:default} {{name=@{PsyName2}}} {{Action=@{PsyAction2}}} {{SubType(s)=@{PsySubtype2}}} {{Range=@{PsyRange2}}} {{Sustained?=@{PsySustained2}}} {{Effect=@{PsyPowersEffect2}}} "> <label>Info</label> </button></div>
 						</div>
@@ -2504,7 +2504,7 @@
 							<div class="sheet-item" style="width: 6%;"><input name="attr_Rangedweaponclip_max" type="text" value="0" /></div>
 							<div class="sheet-item" style="width: 15%;"><label>Reload:</label></div>
 							<div class="sheet-item" style="width: 15%;"><input name="attr_Rangedweaponreload" type="text" /></div>
-							<div class="sheet-item" style="width: 16%;"><button name="roll_Rangedhit" type="roll" value="/me uses @{Rangedweaponname} [[1d100]] Target [[@{BallisticSkill} +[[ ?{Aim | Half aim (+10),+10| No aim (+0),+0 | Full aim (+20),+20} + ?{Range | Point Blank (+30),+30 | Short Range (+10),+10 | Standard range (+0),+0 | Long Range (-10),-10 | Extreme Range (-30),-30} + ?{Rate of Fire/Attack Type|Standard (+10),+10 | Semi auto (+0),+0 | Full Auto (-10),-10 | Called Shot (-20),-20 | Suppressing Fire (-20),-20} + ?{Modifier|0} ]]]]."> <label>Hit</label> </button></div>
+							<div class="sheet-item" style="width: 16%;"><button name="roll_Rangedhit" type="roll" value="/me uses @{Rangedweaponname} [[1d100]] Target [[@{BallisticSkill} +[[ ?{Aim | Half aim (+10),+10| No aim (+0),+0 | Full aim (+20),+20} + ?{Range | Point Blank (+30),+30 | Short Range (+10),+10 | Standard range (+0),+0 | Long Range (-10),-10 | Extreme Range (-30),-30} + ?{Rate of Fire/Attack Type|Standard (+10),+10 | Semi auto (+0),+0 | Full Auto (-10),-10 | Called Shot (-20),-20 | Suppressing Fire (-20),-20} + [[?{Modifier|0}]] ]]]]."> <label>Hit</label> </button></div>
 						</div>
 						<div class="sheet-row">
 							<div class="sheet-item" style="width: 15%;"><label>Special:</label></div>
@@ -2530,7 +2530,7 @@
 							<div class="sheet-item" style="width: 18%;"><input name="attr_meleeweapontype" type="text" /></div>
 							<div class="sheet-item" style="width: 10%;"><label>Pen:</label></div>
 							<div class="sheet-item" style="width: 10%;"><input name="attr_meleeweaponpen" type="text" value="0" /></div>
-							<div class="sheet-item" style="width: 16%;"><button name="roll_meleehit" type="roll" value="/em uses @{meleeweaponname} [[1d100]] Target [[@{WeaponSkill}+ [[?{Aim | Half aim (+10),+10 | No aim (+0),+0 | Full aim (+20),+20} + ?{Attack Type | All out (+30),+30| Charge (+20),+20 |Standard (+10),+10 | Swift Attack (+0),+0 | Lighting (-10),-10} + ?{Modifier|0}]]]]"> <label>Hit</label> </button></div>
+							<div class="sheet-item" style="width: 16%;"><button name="roll_meleehit" type="roll" value="/em uses @{meleeweaponname} [[1d100]] Target [[@{WeaponSkill}+ [[?{Aim | Half aim (+10),+10 | No aim (+0),+0 | Full aim (+20),+20} + ?{Attack Type | All out (+30),+30| Charge (+20),+20 |Standard (+10),+10 | Swift Attack (+0),+0 | Lighting (-10),-10} + [[?{Modifier|0}]]]]]]"> <label>Hit</label> </button></div>
 						</div>
 							<div class="sheet-row">
 							<div class="sheet-item" style="width: 15%;"><label>Special:</label></div>
@@ -2691,7 +2691,7 @@
 				<div class="sheet-2colrow">
 					<div class="sheet-col sheet-col2" style="width:100%">
 						<div class="sheet-row">
-							<div class="sheet-item" style="width: 80%;"><button name="roll_CR" type="roll" value="/em rolls Crew Rating: [[1d100]] Target: [[@{ShipCrewRating}+ ?{Modifier|0}]]."><label>Crew Rating</label></button></div>
+							<div class="sheet-item" style="width: 80%;"><button name="roll_CR" type="roll" value="/em rolls Crew Rating: [[1d100]] Target: [[@{ShipCrewRating}+ [[?{Modifier|0}]]]]."><label>Crew Rating</label></button></div>
 							<div class="sheet-item" style="width: 20%;"><input name="attr_ShipCrewRating" type="number" value="0"></div>
 						</div>
 						<div class="sheet-row">
@@ -2826,7 +2826,7 @@
 						<input type="text" name="attr_ShipWeaponsDamage" />
 					</div>
 					<div class="sheet-item" style="width:15px;">
-						<button type="roll" name="roll_shipDamage" value="/me attacks with @{ShipName}'s weapon @{ShipWeaponsName}! Damage: [[ @{ShipWeaponsDamage} + ?{Modifier|0} ]].">
+						<button type="roll" name="roll_shipDamage" value="/me attacks with @{ShipName}'s weapon @{ShipWeaponsName}! Damage: [[ @{ShipWeaponsDamage} + [[?{Modifier|0}]] ]].">
 							<label>R</label>
 						</button>
 					</div>


### PR DESCRIPTION
## Changes / Comments
Before the fix putting a plus sign in the modifier query (e.g +10) caused a modification of the roll of 0. Now it makes no difference if you put a plus in front or not (10 === +10)





## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
