### PR TITLE
Fixing typo in Age of Ambition character sheet

### DIFF
--- a/Age of Ambition/aoa.html
+++ b/Age of Ambition/aoa.html
@@ -445,7 +445,7 @@
             <textarea class="lifepath-textarea" name="attr_Foundational_Event"placeholder="Foundational Event"></textarea>
             <h3 class="traits-header">Coming of Age</h3>
             <input type="text" name="attr_character_name" class="line-input lifepath-input" placeholder="Name" />
-            <h4 class="traits-header">Assign Stats: [ 7, 6, 6, 5, 4, 4, 3 ]</h4>
+            <h4 class="traits-header">Assign Stats: [ 7, 6, 6, 5, 5, 4, 4, 3 ]</h4>
             <input type="text" name="attr_Ambition1" class="line-input lifepath-input" placeholder="Adolescent Ambition" />
 
             <h3 class="traits-header">Finishing Touches</h3>


### PR DESCRIPTION
Fixed typo in the Age of Ambition character sheet. The character creation stat array was missing a value.