### PR TITLE
[Chronicles of Darkness] Fixed Geist repeating crisis points

### DIFF
--- a/Chronicles of Darkness/CofD.html
+++ b/Chronicles of Darkness/CofD.html
@@ -2025,14 +2025,14 @@
                                     <span data-i18n="vague">Vague</span>
                                 </div>
                                 <div class="input-group">
-                                    <input type="text" name="attr_trigger_1"/>
+                                    <input type="text" name="attr_trigger_2"/>
                                 </div>
                                 <div class="el_spacer"></div>
                                 <div class="subsubheader">
                                     <span data-i18n="specific">Specific</span>
                                 </div>
                                 <div class="input-group">
-                                    <input type="text" name="attr_trigger_1"/>
+                                    <input type="text" name="attr_trigger_3"/>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Changes / Comments

The Geist character sheet had a value called "crisis point" that had the same value for the three boxes, which means that whenever the player wrote something on any of those places, the three of them repeated. This was making it impossible to have different values on those text-boxes. I've made a simple change to fix it.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.

The Geist character sheet had a value called "crisis point" that had the same value for the three boxes, which means that whenever the player wrote something on any of those places, the three of them repeated. This was making it impossible to have different values on those text-boxes. I've made a simple change to fix it.