### PR TITLE
[CWOD-Technocracy] - Die pool update, minor formatting changes

### DIFF
--- a/CWOD-Technocracy/Technocracy.html
+++ b/CWOD-Technocracy/Technocracy.html
@@ -19,17 +19,17 @@
 <button type="roll" name="roll_SoakRoll" class="sheet-Dice"
     value="@{Whisper} &{template:generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle=?{Description}}} {{name=Soak}} {{Successes=[[ ( @{Stamina}+?{DP Mod|0} )d10s>6 ]] }}">Soak</button>
 <button type="roll" name="roll_DP1RollTop" class="sheet-Dice"
-    value="@{Whisper} &{template:generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle=Die Pool 1}} {{name=?{Description|Action}}} {{Successes=[[ ( @{DPAtt1}+@{DPAbi1}+@{Health}+?{DP Mod|0} )d10s>?{Difficulty|6}f1 ]] }}">Die
-    Pool 1</button>
+    value="@{Whisper} &{template:generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle=Die Pool @{DPAtt1}+@{DPAbi1}}} {{name=?{Description|Action}}} {{Successes=[[ ( @{DP1AttValue}+@{DP1AbiValue}+@{Health}+?{DP Mod|0} )d10s>?{Difficulty|6}f1 ]] }}">
+    Die Pool A</button>
 <button type="roll" name="roll_DP2RollTop" class="sheet-Dice"
-    value="@{Whisper} &{template:generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle=Die Pool 2}} {{name=?{Description|Action}}} {{Successes=[[ ( @{DPAtt2}+@{DPAbi2}+@{Health}+?{DP Mod|0} )d10s>?{Difficulty|6}f1 ]] }}">Die
-    Pool 2</button>
+    value="@{Whisper} &{template:generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle=Die Pool @{DPAtt1}+@{DPAbi1}}} {{name=?{Description|Action}}} {{Successes=[[ ( @{DP1AttValue}+@{DP1AbiValue}+@{Health}+?{DP Mod|0} )d10s>?{Difficulty|6}f1 ]] }}">
+    Die Pool B</button>
 <button type="roll" name="roll_DP3RollTop" class="sheet-Dice"
-    value="@{Whisper} &{template:generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle=Die Pool 3}} {{name=?{Description|Action}}} {{Successes=[[ ( @{DPAtt3}+@{DPAbi3}+@{Health}+?{DP Mod|0} )d10s>?{Difficulty|6}f1 ]] }}">Die
-    Pool 3</button>
+    value="@{Whisper} &{template:generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle=Die Pool @{DPAtt2}+@{DPAbi2}}} {{name=?{Description|Action}}} {{Successes=[[ ( @{DP2AttValue}+@{DP2AbiValue}+@{Health}+?{DP Mod|0} )d10s>?{Difficulty|6}f1 ]] }}">
+    Die Pool C</button>
 <button type="roll" name="roll_DP4RollTop" class="sheet-Dice"
-    value="@{Whisper} &{template:generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle=Die Pool 4}} {{name=?{Description|Action}}} {{Successes=[[ ( @{DPAtt4}+@{DPAbi4}+@{Health}+?{DP Mod|0} )d10s>?{Difficulty|6}f1 ]] }}">Die
-    Pool 4</button>
+    value="@{Whisper} &{template:generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle=Die Pool @{DPAtt3}+@{DPAbi3}}} {{name=?{Description|Action}}} {{Successes=[[ ( @{DP3AttValue}+@{DP3AbiValue}+@{Health}+?{DP Mod|0} )d10s>?{Difficulty|6}f1 ]] }}">
+    Die Pool D</button>
 
 <div class="clear"></div>
 <!-- Primary Sheet -->
@@ -43,9 +43,9 @@
     <!-- BASICS -->
     <div class="sheet-all">
         <div class="sheet-col sheet-bname">
-            <h3 class="sheet-col sheet-bname-left">Name:</h3>
-            <h3 class="sheet-col sheet-bname-left">Player:</h3>
-            <h3 class="sheet-col sheet-bname-left">Mentor:</h3>
+            <h3 class="sheet-col sheet-bname-left">Name:</h3><br>
+            <h3 class="sheet-col sheet-bname-left">Player:</h3><br>
+            <h3 class="sheet-col sheet-bname-left">Mentor:</h3><br>
         </div>
         <div class="sheet-col sheet-binput">
             <input type="text" class="sheet-binput" name="attr_character_name" /><br>
@@ -53,9 +53,9 @@
             <input type="text" class="sheet-binput" name="attr_Mentor" />
         </div>
         <div class="sheet-col sheet-bname">
-            <h3 class="sheet-col sheet-bname-left">Nature:</h3>
-            <h3 class="sheet-col sheet-bname-left">Demeanor:</h3>
-            <h3 class="sheet-col sheet-bname-left">Eidelon:</h3>
+            <h3 class="sheet-col sheet-bname-left">Nature:</h3><br>
+            <h3 class="sheet-col sheet-bname-left">Demeanor:</h3><br>
+            <h3 class="sheet-col sheet-bname-left">Eidelon:</h3><br>
         </div>
         <div class="sheet-col sheet-binput">
             <input type="text" class="sheet-binput" name="attr_Nature" /><br>
@@ -63,9 +63,9 @@
             <input type="text" class="sheet-binput" name="attr_Eidelon" />
         </div>
         <div class="sheet-col sheet-bname">
-            <h3 class="sheet-col sheet-bname-left">Convention:</h3>
-            <h3 class="sheet-col sheet-bname-left">Amalgm:</h3>
-            <h3 class="sheet-col sheet-bname-left">Concept:</h3>
+            <h3 class="sheet-col sheet-bname-left">Convention:</h3><br>
+            <h3 class="sheet-col sheet-bname-left">Amalgm:</h3><br>
+            <h3 class="sheet-col sheet-bname-left">Concept:</h3><br>
         </div>
         <div class="sheet-col sheet-binput">
             <input type="text" class="sheet-binput" name="attr_Convention" /><br>
@@ -1143,269 +1143,266 @@
                     <div class="sheet-row">
                         <select name="attr_DPAtt1" class="DP">
                             <option value="0" selected></option>
-                            <option value="@{Appearance}">Appearance</option>
-                            <option value="@{Charisma}">Charisma</option>
-                            <option value="@{Dexterity}">Dexterity</option>
-                            <option value="@{Intelligence}">Intelligence</option>
-                            <option value="@{Manipulation}">Manipulation</option>
-                            <option value="@{Perception}">Perception</option>
-                            <option value="@{Stamina}">Stamina</option>
-                            <option value="@{Strength}">Strength</option>
-                            <option value="@{Wits}">Wits</option>
+                            <option value="Appearance">Appearance</option>
+                            <option value="Charisma">Charisma</option>
+                            <option value="Dexterity">Dexterity</option>
+                            <option value="Intelligence">Intelligence</option>
+                            <option value="Manipulation">Manipulation</option>
+                            <option value="Perception">Perception</option>
+                            <option value="Stamina">Stamina</option>
+                            <option value="Strength">Strength</option>
+                            <option value="Wits">Wits</option>
                         </select>
                         <select name="attr_DPAbi1" class="DP">
                             <option value="0" selected></option>
-                            <option value="@{Academics}">Academics</option>
-                            <option value="@{Alertness}">Alertness</option>
-                            <option value="@{Art}">Art</option>
-                            <option value="@{Athletics}">Athletics</option>
-                            <option value="@{Awareness}">Awareness</option>
-                            <option value="@{Brawl}">Brawl</option>
-                            <option value="@{Computer}">Computer</option>
-                            <option value="@{Cosmology}">Cosmology</option>
-                            <option value="@{Crafts}">Crafts</option>
-                            <option value="@{Drive}">Drive</option>
-                            <option value="@{Dodge}">Dodge</option>
-                            <option value="@{Enigmas}">Enigmas</option>
-                            <option value="@{Esoterica}">Esoterica</option>
-                            <option value="@{Etiquette}">Etiquette</option>
-                            <option value="@{Expression}">Expression</option>
-                            <option value="@{Firearms}">Firearms</option>
-                            <option value="@{Intimidation}">Intimidation</option>
-                            <option value="@{Investigation}">Investigation</option>
-                            <option value="@{Law}">Law</option>
-                            <option value="@{Leadership}">Leadership</option>
-                            <option value="@{MartialArts}">Martial Arts</option>
-                            <option value="@{Medicine}">Medicine</option>
-                            <option value="@{Meditation}">Meditation</option>
-                            <option value="@{Melee}">Melee</option>
-                            <option value="@{Occult}">Occult</option>
-                            <option value="@{Politics}">Politics</option>
-                            <option value="@{Research}">Research</option>
-                            <option value="@{Science}">Science</option>
-                            <option value="@{Stealth}">Stealth</option>
-                            <option value="@{Streetwise}">Streetwise</option>
-                            <option value="@{Subterfuge}">Subterfuge</option>
-                            <option value="@{Survival}">Survival</option>
-                            <option value="@{Technology}">Technology</option>
-                            <option value="@{Abi1}">Extra Ability 1</option>
-                            <option value="@{Abi2}">Extra Ability 2</option>
-                            <option value="@{Abi3}">Extra Ability 3</option>
-                            <option value="@{Abi4}">Extra Ability 4</option>
-                            <option value="@{Abi5}">Extra Ability 5</option>
-                            <option value="@{Abi6}">Extra Ability 6</option>
-                            <option value="@{Other1}">Other Trait 1</option>
-                            <option value="@{Other2}">Other Trait 2</option>
-                            <option value="@{Other3}">Other Trait 3</option>
-                            <option value="@{Other4}">Other Trait 4</option>
-                            <option value="@{Other5}">Other Trait 5</option>
-                            <option value="@{Other6}">Other Trait 6</option>
-                            <option value="@{Other7}">Other Trait 7</option>
-                            <option value="@{Other8}">Other Trait 8</option>
+                            <option value="Academics">Academics</option>
+                            <option value="Alertness">Alertness</option>
+                            <option value="Athletics">Athletics</option>
+                            <option value="Awareness">Awareness</option>
+                            <option value="Brawl">Brawl</option>
+                            <option value="Computer">Computer</option>
+                            <option value="Drive">Drive</option>
+                            <option value="Dodge">Dodge</option>
+                            <option value="Enigmas">Enigmas</option>
+                            <option value="Etiquette">Etiquette</option>
+                            <option value="Expression">Expression</option>
+                            <option value="EnergyWeapons">Energy Weapons</option>
+                            <option value="Finance">Finance</option>
+                            <option value="Firearms">Firearms</option>
+                            <option value="Hypertech">Hypertech</option>
+                            <option value="Intimidation">Intimidation</option>
+                            <option value="Investigation">Investigation</option>
+                            <option value="Law">Law</option>
+                            <option value="Leadership">Leadership</option>
+                            <option value="Linguistics">Linguistics</option>
+                            <option value="Medicine">Medicine</option>
+                            <option value="Melee">Melee</option>
+                            <option value="Politics">Politics</option>
+                            <option value="Research">Research</option>
+                            <option value="Science">Science</option>
+                            <option value="Stealth">Stealth</option>
+                            <option value="Streetwise">Streetwise</option>
+                            <option value="Subterfuge">Subterfuge</option>
+                            <option value="Survival">Survival</option>
+                            <option value="Technology">Technology</option>
+                            <option value="Abi1">Extra Ability 1</option>
+                            <option value="Abi2">Extra Ability 2</option>
+                            <option value="Abi3">Extra Ability 3</option>
+                            <option value="Abi4">Extra Ability 4</option>
+                            <option value="Abi5">Extra Ability 5</option>
+                            <option value="Abi6">Extra Ability 6</option>
+                            <option value="Other1">Other Trait 1</option>
+                            <option value="Other2">Other Trait 2</option>
+                            <option value="Other3">Other Trait 3</option>
+                            <option value="Other4">Other Trait 4</option>
+                            <option value="Other5">Other Trait 5</option>
+                            <option value="Other6">Other Trait 6</option>
+                            <option value="Other7">Other Trait 7</option>
+                            <option value="Other8">Other Trait 8</option>
                         </select>
+                        <input type="hidden" name="attr_DP1AttValue" value="" />
+                        <input type="hidden" name="attr_DP1AbiValue" value="" />
                         <button type="roll" name="roll_DP1Roll" class="DP"
-                            value="@{Whisper} &{template:generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle=Die Pool 1}} {{name=?{Description|Action}}} {{Successes=[[ ( @{DPAtt1}+@{DPAbi1}+@{Health}+?{DP Mod|0} )d10s>?{Difficulty|6}f1 ]] }}"></button>
+                            value="@{Whisper} &{template:generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle=Die Pool @{DPAtt1}+@{DPAbi1}}} {{name=?{Description|Action}}} {{Successes=[[ ( @{DP1AttValue}+@{DP1AbiValue}+@{Health}+?{DP Mod|0} )d10s>?{Difficulty|6}f1 ]] }}"></button>
                     </div>
                     <!-- DP2 -->
                     <div class="sheet-row">
                         <select name="attr_DPAtt2" class="DP">
                             <option value="0" selected></option>
-                            <option value="@{Appearance}">Appearance</option>
-                            <option value="@{Charisma}">Charisma</option>
-                            <option value="@{Dexterity}">Dexterity</option>
-                            <option value="@{Intelligence}">Intelligence</option>
-                            <option value="@{Manipulation}">Manipulation</option>
-                            <option value="@{Perception}">Perception</option>
-                            <option value="@{Stamina}">Stamina</option>
-                            <option value="@{Strength}">Strength</option>
-                            <option value="@{Wits}">Wits</option>
+                            <option value="Appearance">Appearance</option>
+                            <option value="Charisma">Charisma</option>
+                            <option value="Dexterity">Dexterity</option>
+                            <option value="Intelligence">Intelligence</option>
+                            <option value="Manipulation">Manipulation</option>
+                            <option value="Perception">Perception</option>
+                            <option value="Stamina">Stamina</option>
+                            <option value="Strength">Strength</option>
+                            <option value="Wits">Wits</option>
                         </select>
                         <select name="attr_DPAbi2" class="DP">
                             <option value="0" selected></option>
-                            <option value="@{Academics}">Academics</option>
-                            <option value="@{Alertness}">Alertness</option>
-                            <option value="@{Art}">Art</option>
-                            <option value="@{Athletics}">Athletics</option>
-                            <option value="@{Awareness}">Awareness</option>
-                            <option value="@{Brawl}">Brawl</option>
-                            <option value="@{Computer}">Computer</option>
-                            <option value="@{Cosmology}">Cosmology</option>
-                            <option value="@{Crafts}">Crafts</option>
-                            <option value="@{Drive}">Drive</option>
-                            <option value="@{Dodge}">Dodge</option>
-                            <option value="@{Enigmas}">Enigmas</option>
-                            <option value="@{Esoterica}">Esoterica</option>
-                            <option value="@{Etiquette}">Etiquette</option>
-                            <option value="@{Expression}">Expression</option>
-                            <option value="@{Firearms}">Firearms</option>
-                            <option value="@{Intimidation}">Intimidation</option>
-                            <option value="@{Investigation}">Investigation</option>
-                            <option value="@{Law}">Law</option>
-                            <option value="@{Leadership}">Leadership</option>
-                            <option value="@{MartialArts}">Martial Arts</option>
-                            <option value="@{Medicine}">Medicine</option>
-                            <option value="@{Meditation}">Meditation</option>
-                            <option value="@{Melee}">Melee</option>
-                            <option value="@{Occult}">Occult</option>
-                            <option value="@{Politics}">Politics</option>
-                            <option value="@{Research}">Research</option>
-                            <option value="@{Science}">Science</option>
-                            <option value="@{Stealth}">Stealth</option>
-                            <option value="@{Streetwise}">Streetwise</option>
-                            <option value="@{Subterfuge}">Subterfuge</option>
-                            <option value="@{Survival}">Survival</option>
-                            <option value="@{Technology}">Technology</option>
-                            <option value="@{Abi1}">Extra Ability 1</option>
-                            <option value="@{Abi2}">Extra Ability 2</option>
-                            <option value="@{Abi3}">Extra Ability 3</option>
-                            <option value="@{Abi4}">Extra Ability 4</option>
-                            <option value="@{Abi5}">Extra Ability 5</option>
-                            <option value="@{Abi6}">Extra Ability 6</option>
-                            <option value="@{Other1}">Other Trait 1</option>
-                            <option value="@{Other2}">Other Trait 2</option>
-                            <option value="@{Other3}">Other Trait 3</option>
-                            <option value="@{Other4}">Other Trait 4</option>
-                            <option value="@{Other5}">Other Trait 5</option>
-                            <option value="@{Other6}">Other Trait 6</option>
-                            <option value="@{Other7}">Other Trait 7</option>
-                            <option value="@{Other8}">Other Trait 8</option>
+                            <option value="Academics">Academics</option>
+                            <option value="Alertness">Alertness</option>
+                            <option value="Athletics">Athletics</option>
+                            <option value="Awareness">Awareness</option>
+                            <option value="Brawl">Brawl</option>
+                            <option value="Computer">Computer</option>
+                            <option value="Drive">Drive</option>
+                            <option value="Dodge">Dodge</option>
+                            <option value="Enigmas">Enigmas</option>
+                            <option value="Etiquette">Etiquette</option>
+                            <option value="Expression">Expression</option>
+                            <option value="EnergyWeapons">Energy Weapons</option>
+                            <option value="Finance">Finance</option>
+                            <option value="Firearms">Firearms</option>
+                            <option value="Hypertech">Hypertech</option>
+                            <option value="Intimidation">Intimidation</option>
+                            <option value="Investigation">Investigation</option>
+                            <option value="Law">Law</option>
+                            <option value="Leadership">Leadership</option>
+                            <option value="Linguistics">Linguistics</option>
+                            <option value="Medicine">Medicine</option>
+                            <option value="Melee">Melee</option>
+                            <option value="Politics">Politics</option>
+                            <option value="Research">Research</option>
+                            <option value="Science">Science</option>
+                            <option value="Stealth">Stealth</option>
+                            <option value="Streetwise">Streetwise</option>
+                            <option value="Subterfuge">Subterfuge</option>
+                            <option value="Survival">Survival</option>
+                            <option value="Technology">Technology</option>
+                            <option value="Abi1">Extra Ability 1</option>
+                            <option value="Abi2">Extra Ability 2</option>
+                            <option value="Abi3">Extra Ability 3</option>
+                            <option value="Abi4">Extra Ability 4</option>
+                            <option value="Abi5">Extra Ability 5</option>
+                            <option value="Abi6">Extra Ability 6</option>
+                            <option value="Other1">Other Trait 1</option>
+                            <option value="Other2">Other Trait 2</option>
+                            <option value="Other3">Other Trait 3</option>
+                            <option value="Other4">Other Trait 4</option>
+                            <option value="Other5">Other Trait 5</option>
+                            <option value="Other6">Other Trait 6</option>
+                            <option value="Other7">Other Trait 7</option>
+                            <option value="Other8">Other Trait 8</option>
                         </select>
+                        <input type="hidden" name="attr_DP2AttValue" value="" />
+                        <input type="hidden" name="attr_DP2AbiValue" value="" />
                         <button type='roll' name='roll_DP2Roll' class="DP"
-                            value="@{Whisper} &{template:generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle=Die Pool 2}} {{name=?{Description|Action}}} {{Successes=[[ ( @{DPAtt2}+@{DPAbi2}+@{Health}+?{DP Mod|0} )d10s>?{Difficulty|6}f1 ]] }}"></button>
+                            value="@{Whisper} &{template:generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle=Die Pool @{DPAtt2}+@{DPAbi2}}} {{name=?{Description|Action}}} {{Successes=[[ ( @{DP2AttValue}+@{DP2AbiValue}+@{Health}+?{DP Mod|0} )d10s>?{Difficulty|6}f1 ]] }}"></button>
                     </div>
                     <!-- DP3 -->
                     <div class="sheet-row">
                         <select name="attr_DPAtt3" class="DP">
                             <option value="0" selected></option>
-                            <option value="@{Appearance}">Appearance</option>
-                            <option value="@{Charisma}">Charisma</option>
-                            <option value="@{Dexterity}">Dexterity</option>
-                            <option value="@{Intelligence}">Intelligence</option>
-                            <option value="@{Manipulation}">Manipulation</option>
-                            <option value="@{Perception}">Perception</option>
-                            <option value="@{Stamina}">Stamina</option>
-                            <option value="@{Strength}">Strength</option>
-                            <option value="@{Wits}">Wits</option>
+                            <option value="Appearance">Appearance</option>
+                            <option value="Charisma">Charisma</option>
+                            <option value="Dexterity">Dexterity</option>
+                            <option value="Intelligence">Intelligence</option>
+                            <option value="Manipulation">Manipulation</option>
+                            <option value="Perception">Perception</option>
+                            <option value="Stamina">Stamina</option>
+                            <option value="Strength">Strength</option>
+                            <option value="Wits">Wits</option>
                         </select>
                         <select name="attr_DPAbi3" class="DP">
                             <option value="0" selected></option>
-                            <option value="@{Academics}">Academics</option>
-                            <option value="@{Alertness}">Alertness</option>
-                            <option value="@{Art}">Art</option>
-                            <option value="@{Athletics}">Athletics</option>
-                            <option value="@{Awareness}">Awareness</option>
-                            <option value="@{Brawl}">Brawl</option>
-                            <option value="@{Computer}">Computer</option>
-                            <option value="@{Cosmology}">Cosmology</option>
-                            <option value="@{Crafts}">Crafts</option>
-                            <option value="@{Drive}">Drive</option>
-                            <option value="@{Dodge}">Dodge</option>
-                            <option value="@{Enigmas}">Enigmas</option>
-                            <option value="@{Esoterica}">Esoterica</option>
-                            <option value="@{Etiquette}">Etiquette</option>
-                            <option value="@{Expression}">Expression</option>
-                            <option value="@{Firearms}">Firearms</option>
-                            <option value="@{Intimidation}">Intimidation</option>
-                            <option value="@{Investigation}">Investigation</option>
-                            <option value="@{Law}">Law</option>
-                            <option value="@{Leadership}">Leadership</option>
-                            <option value="@{MartialArts}">Martial Arts</option>
-                            <option value="@{Medicine}">Medicine</option>
-                            <option value="@{Meditation}">Meditation</option>
-                            <option value="@{Melee}">Melee</option>
-                            <option value="@{Occult}">Occult</option>
-                            <option value="@{Politics}">Politics</option>
-                            <option value="@{Research}">Research</option>
-                            <option value="@{Science}">Science</option>
-                            <option value="@{Stealth}">Stealth</option>
-                            <option value="@{Streetwise}">Streetwise</option>
-                            <option value="@{Subterfuge}">Subterfuge</option>
-                            <option value="@{Survival}">Survival</option>
-                            <option value="@{Technology}">Technology</option>
-                            <option value="@{Abi1}">Extra Ability 1</option>
-                            <option value="@{Abi2}">Extra Ability 2</option>
-                            <option value="@{Abi3}">Extra Ability 3</option>
-                            <option value="@{Abi4}">Extra Ability 4</option>
-                            <option value="@{Abi5}">Extra Ability 5</option>
-                            <option value="@{Abi6}">Extra Ability 6</option>
-                            <option value="@{Other1}">Other Trait 1</option>
-                            <option value="@{Other2}">Other Trait 2</option>
-                            <option value="@{Other3}">Other Trait 3</option>
-                            <option value="@{Other4}">Other Trait 4</option>
-                            <option value="@{Other5}">Other Trait 5</option>
-                            <option value="@{Other6}">Other Trait 6</option>
-                            <option value="@{Other7}">Other Trait 7</option>
-                            <option value="@{Other8}">Other Trait 8</option>
+                            <option value="Academics">Academics</option>
+                            <option value="Alertness">Alertness</option>
+                            <option value="Athletics">Athletics</option>
+                            <option value="Awareness">Awareness</option>
+                            <option value="Brawl">Brawl</option>
+                            <option value="Computer">Computer</option>
+                            <option value="Drive">Drive</option>
+                            <option value="Dodge">Dodge</option>
+                            <option value="Enigmas">Enigmas</option>
+                            <option value="Etiquette">Etiquette</option>
+                            <option value="Expression">Expression</option>
+                            <option value="EnergyWeapons">Energy Weapons</option>
+                            <option value="Finance">Finance</option>
+                            <option value="Firearms">Firearms</option>
+                            <option value="Hypertech">Hypertech</option>
+                            <option value="Intimidation">Intimidation</option>
+                            <option value="Investigation">Investigation</option>
+                            <option value="Law">Law</option>
+                            <option value="Leadership">Leadership</option>
+                            <option value="Linguistics">Linguistics</option>
+                            <option value="Medicine">Medicine</option>
+                            <option value="Melee">Melee</option>
+                            <option value="Politics">Politics</option>
+                            <option value="Research">Research</option>
+                            <option value="Science">Science</option>
+                            <option value="Stealth">Stealth</option>
+                            <option value="Streetwise">Streetwise</option>
+                            <option value="Subterfuge">Subterfuge</option>
+                            <option value="Survival">Survival</option>
+                            <option value="Technology">Technology</option>
+                            <option value="Abi1">Extra Ability 1</option>
+                            <option value="Abi2">Extra Ability 2</option>
+                            <option value="Abi3">Extra Ability 3</option>
+                            <option value="Abi4">Extra Ability 4</option>
+                            <option value="Abi5">Extra Ability 5</option>
+                            <option value="Abi6">Extra Ability 6</option>
+                            <option value="Other1">Other Trait 1</option>
+                            <option value="Other2">Other Trait 2</option>
+                            <option value="Other3">Other Trait 3</option>
+                            <option value="Other4">Other Trait 4</option>
+                            <option value="Other5">Other Trait 5</option>
+                            <option value="Other6">Other Trait 6</option>
+                            <option value="Other7">Other Trait 7</option>
+                            <option value="Other8">Other Trait 8</option>
                         </select>
+                        <input type="hidden" name="attr_DP3AttValue" value="" />
+                        <input type="hidden" name="attr_DP3AbiValue" value="" />
                         <button type='roll' name='roll_DP3Roll' class="DP"
-                            value="@{Whisper} &{template:generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle=Die Pool 3}} {{name=?{Description|Action}}} {{Successes=[[ ( @{DPAtt3}+@{DPAbi3}+@{Health}+?{DP Mod|0} )d10s>?{Difficulty|6}f1 ]] }}"></button>
+                            value="@{Whisper} &{template:generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle=Die Pool @{DPAtt3}+@{DPAbi3}}} {{name=?{Description|Action}}} {{Successes=[[ ( @{DP3AttValue}+@{DP3AbiValue}+@{Health}+?{DP Mod|0} )d10s>?{Difficulty|6}f1 ]] }}"></button>
                     </div>
                     <!-- DP4 -->
                     <div class="sheet-row">
                         <select name="attr_DPAtt4" class="DP">
                             <option value="0" selected></option>
-                            <option value="@{Appearance}">Appearance</option>
-                            <option value="@{Charisma}">Charisma</option>
-                            <option value="@{Dexterity}">Dexterity</option>
-                            <option value="@{Intelligence}">Intelligence</option>
-                            <option value="@{Manipulation}">Manipulation</option>
-                            <option value="@{Perception}">Perception</option>
-                            <option value="@{Stamina}">Stamina</option>
-                            <option value="@{Strength}">Strength</option>
-                            <option value="@{Wits}">Wits</option>
+                            <option value="0" selected></option>
+                            <option value="Appearance">Appearance</option>
+                            <option value="Charisma">Charisma</option>
+                            <option value="Dexterity">Dexterity</option>
+                            <option value="Intelligence">Intelligence</option>
+                            <option value="Manipulation">Manipulation</option>
+                            <option value="Perception">Perception</option>
+                            <option value="Stamina">Stamina</option>
+                            <option value="Strength">Strength</option>
+                            <option value="Wits">Wits</option>
                         </select>
                         <select name="attr_DPAbi4" class="DP">
                             <option value="0" selected></option>
-                            <option value="@{Academics}">Academics</option>
-                            <option value="@{Alertness}">Alertness</option>
-                            <option value="@{Art}">Art</option>
-                            <option value="@{Athletics}">Athletics</option>
-                            <option value="@{Awareness}">Awareness</option>
-                            <option value="@{Brawl}">Brawl</option>
-                            <option value="@{Computer}">Computer</option>
-                            <option value="@{Cosmology}">Cosmology</option>
-                            <option value="@{Crafts}">Crafts</option>
-                            <option value="@{Drive}">Drive</option>
-                            <option value="@{Dodge}">Dodge</option>
-                            <option value="@{Enigmas}">Enigmas</option>
-                            <option value="@{Esoterica}">Esoterica</option>
-                            <option value="@{Etiquette}">Etiquette</option>
-                            <option value="@{Expression}">Expression</option>
-                            <option value="@{Firearms}">Firearms</option>
-                            <option value="@{Intimidation}">Intimidation</option>
-                            <option value="@{Investigation}">Investigation</option>
-                            <option value="@{Law}">Law</option>
-                            <option value="@{Leadership}">Leadership</option>
-                            <option value="@{MartialArts}">Martial Arts</option>
-                            <option value="@{Medicine}">Medicine</option>
-                            <option value="@{Meditation}">Meditation</option>
-                            <option value="@{Melee}">Melee</option>
-                            <option value="@{Occult}">Occult</option>
-                            <option value="@{Politics}">Politics</option>
-                            <option value="@{Research}">Research</option>
-                            <option value="@{Science}">Science</option>
-                            <option value="@{Stealth}">Stealth</option>
-                            <option value="@{Streetwise}">Streetwise</option>
-                            <option value="@{Subterfuge}">Subterfuge</option>
-                            <option value="@{Survival}">Survival</option>
-                            <option value="@{Technology}">Technology</option>
-                            <option value="@{Abi1}">Extra Ability 1</option>
-                            <option value="@{Abi2}">Extra Ability 2</option>
-                            <option value="@{Abi3}">Extra Ability 3</option>
-                            <option value="@{Abi4}">Extra Ability 4</option>
-                            <option value="@{Abi5}">Extra Ability 5</option>
-                            <option value="@{Abi6}">Extra Ability 6</option>
-                            <option value="@{Other1}">Other Trait 1</option>
-                            <option value="@{Other2}">Other Trait 2</option>
-                            <option value="@{Other3}">Other Trait 3</option>
-                            <option value="@{Other4}">Other Trait 4</option>
-                            <option value="@{Other5}">Other Trait 5</option>
-                            <option value="@{Other6}">Other Trait 6</option>
-                            <option value="@{Other7}">Other Trait 7</option>
-                            <option value="@{Other8}">Other Trait 8</option>
+                            <option value="Academics">Academics</option>
+                            <option value="Alertness">Alertness</option>
+                            <option value="Athletics">Athletics</option>
+                            <option value="Awareness">Awareness</option>
+                            <option value="Brawl">Brawl</option>
+                            <option value="Computer">Computer</option>
+                            <option value="Drive">Drive</option>
+                            <option value="Dodge">Dodge</option>
+                            <option value="Enigmas">Enigmas</option>
+                            <option value="Etiquette">Etiquette</option>
+                            <option value="Expression">Expression</option>
+                            <option value="EnergyWeapons">Energy Weapons</option>
+                            <option value="Finance">Finance</option>
+                            <option value="Firearms">Firearms</option>
+                            <option value="Hypertech">Hypertech</option>
+                            <option value="Intimidation">Intimidation</option>
+                            <option value="Investigation">Investigation</option>
+                            <option value="Law">Law</option>
+                            <option value="Leadership">Leadership</option>
+                            <option value="Linguistics">Linguistics</option>
+                            <option value="Medicine">Medicine</option>
+                            <option value="Melee">Melee</option>
+                            <option value="Politics">Politics</option>
+                            <option value="Research">Research</option>
+                            <option value="Science">Science</option>
+                            <option value="Stealth">Stealth</option>
+                            <option value="Streetwise">Streetwise</option>
+                            <option value="Subterfuge">Subterfuge</option>
+                            <option value="Survival">Survival</option>
+                            <option value="Technology">Technology</option>
+                            <option value="Abi1">Extra Ability 1</option>
+                            <option value="Abi2">Extra Ability 2</option>
+                            <option value="Abi3">Extra Ability 3</option>
+                            <option value="Abi4">Extra Ability 4</option>
+                            <option value="Abi5">Extra Ability 5</option>
+                            <option value="Abi6">Extra Ability 6</option>
+                            <option value="Other1">Other Trait 1</option>
+                            <option value="Other2">Other Trait 2</option>
+                            <option value="Other3">Other Trait 3</option>
+                            <option value="Other4">Other Trait 4</option>
+                            <option value="Other5">Other Trait 5</option>
+                            <option value="Other6">Other Trait 6</option>
+                            <option value="Other7">Other Trait 7</option>
+                            <option value="Other8">Other Trait 8</option>
                         </select>
+                        <input type="hidden" name="attr_DP4AttValue" value="" />
+                        <input type="hidden" name="attr_DP4AbiValue" value="" />
                         <button type='roll' name='roll_DP4Roll' class="DP"
-                            value="@{Whisper} &{template:generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle=Die Pool 4}} {{name=?{Description|Action}}} {{Successes=[[ ( @{DPAtt4}+@{DPAbi4}+@{Health}+?{DP Mod|0} )d10s>?{Difficulty|6}f1 ]] }}"></button>
+                            value="@{Whisper} &{template:generic} {{character_name=@{character_name}}} {{character_id=@{character_id}}} {{subtitle=Die Pool @{DPAtt4}+@{DPAbi4}}} {{name=?{Description|Action}}} {{Successes=[[ ( @{DP4AttValue}+@{DP4AbiValue}+@{Health}+?{DP Mod|0} )d10s>?{Difficulty|6}f1 ]] }}"></button>
                     </div>
                 </div>
             </div>
@@ -1606,4 +1603,63 @@
 			}
 		});
 	});
+</script>
+
+<script type="text/worker">
+    on('sheet:opened change:DPAtt1', () => {
+        getAttrs(['DPAtt1'], (values) => {
+            getAttrs([values['DPAtt1']], (values) => {
+                setAttrs({DP1AttValue: Object.values(values)[0]});
+            });
+        });
+    });
+    on('sheet:opened change:DPAbi1', () => {
+        getAttrs(['DPAbi1'], (values) => {
+            getAttrs([values['DPAbi1']], (values) => {
+                setAttrs({DP1AbiValue: Object.values(values)[0]});
+            });
+        });
+    });
+    on('sheet:opened change:DPAtt2', () => {
+        getAttrs(['DPAtt2'], (values) => {
+            getAttrs([values['DPAtt2']], (values) => {
+                setAttrs({DP2AttValue: Object.values(values)[0]});
+            });
+        });
+    });
+    on('sheet:opened change:DPAbi2', () => {
+        getAttrs(['DPAbi2'], (values) => {
+            getAttrs([values['DPAbi2']], (values) => {
+                setAttrs({DP2AbiValue: Object.values(values)[0]});
+            });
+        });
+    });
+    on('sheet:opened change:DPAtt3', () => {
+        getAttrs(['DPAtt3'], (values) => {
+            getAttrs([values['DPAtt3']], (values) => {
+                setAttrs({DP3AttValue: Object.values(values)[0]});
+            });
+        });
+    });
+    on('sheet:opened change:DPAbi3', () => {
+        getAttrs(['DPAbi3'], (values) => {
+            getAttrs([values['DPAbi3']], (values) => {
+                setAttrs({DP3AbiValue: Object.values(values)[0]});
+            });
+        });
+    });
+    on('sheet:opened change:DPAtt4', () => {
+        getAttrs(['DPAtt4'], (values) => {
+            getAttrs([values['DPAtt4']], (values) => {
+                setAttrs({DP4AttValue: Object.values(values)[0]});
+            });
+        });
+    });
+    on('sheet:opened change:DPAbi4', () => {
+        getAttrs(['DPAbi4'], (values) => {
+            getAttrs([values['DPAbi4']], (values) => {
+                setAttrs({DP4AbiValue: Object.values(values)[0]});
+            });
+        });
+    });
 </script>


### PR DESCRIPTION
## Changes / Comments
 - formatting changes - top section now enforces line breaks
 - bugfix: Added missing Abilities for die pool lists
 - updated Die Pool and sheet workers - die pool now prints out the attributes rolled (eg Dexterity+Dodge) instead of "Die Pool X". This will clear the settings for the Die Pools however will not lose or remove any attributes.

Workaround implemented: since the sheet is unable to query the state of a dropdown box for the displayed text, the original text is used as the value, and the on change event updates a hidden element with the actual value to be used.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
