### PR TITLE
[Soulbound] Party sheet and initiative improvements

### DIFF
--- a/Age-of-Sigmar-Soulbound/README.MD
+++ b/Age-of-Sigmar-Soulbound/README.MD
@@ -16,6 +16,17 @@ added npc sheet (toggle between player and npc switch in options menu)
 
 fixed issue with wounds, sheetworker will update existing sheets
 
+### V3.0 - Party sheet
+
+added party sheet
+
+added npc initiative to tracker
+
+added initiative rolls, can choose between none, d6 and 2d6
+
+made defaults for sheet type (only player/npc) and initiative dice
+
+
 ## Contributing/Issues
 For issues or contributions consider raising an issue on the [development repo](https://github.com/CloverFox/roll20-soulbound-sheet)
 

--- a/Age-of-Sigmar-Soulbound/sheet.json
+++ b/Age-of-Sigmar-Soulbound/sheet.json
@@ -4,5 +4,30 @@
   "authors": "Clover Fox",
   "roll20userid": "1341875",
   "preview": "soulbound-preview.jpg",
-  "instructions": "# Warhammer Age of Sigmar: Soulbound sheet\n## Key Features\n- all skills can be used with each attribute\n- all skill checks (including weapons and spells) will ask for bonus dice each roll\n## note\nin order for the sheet to auto calculate some fields you may have to change body/mind/soul at least once, then change it back, this only needs to be done when first creating a character"
+  "instructions": "# Warhammer Age of Sigmar: Soulbound sheet\n## Key Features\n- all skills can be used with each attribute\n- all skill checks (including weapons and spells) will ask for bonus dice each roll\n\n## Note\nin order for the sheet to auto calculate some fields you may have to change body/mind/soul at least once, then change it back, this only needs to be done when first creating a character",
+  "useroptions": [
+    {
+      "attribute": "sheet_tab",
+      "displayname": "Sheet Type: ",
+      "type": "select",
+      "options": [
+        "Player|player",
+        "NPC|npc"
+      ],
+      "default": "player",
+      "description": "Player is the normal sheet, NPC is a compact version of the same. Useful if the player characters have already been created and all new character sheets added to the game will likely representing non player characters."
+    },
+    {
+      "attribute": "initiative_dice",
+      "displayname": "Use optional rule for initiative dice: ",
+      "type": "select",
+      "options": [
+        "No|0",
+        "D6|d6",
+        "2D6|2d6"
+      ],
+      "default": "0",
+      "description": "Use the optional rule for adding variation to initiative rolls"
+    }
+  ]
 }

--- a/Age-of-Sigmar-Soulbound/soulbound.css
+++ b/Age-of-Sigmar-Soulbound/soulbound.css
@@ -695,3 +695,124 @@ input[type="number"].sheet-small-digit {
 .sheet-npc-def-select {
     width: auto;
 }
+
+.sheet-party-info {
+    display: flex;
+    justify-content: space-between;
+}
+
+.sheet-soulfire {
+    display: flex;
+    justify-content: space-between;
+}
+
+.sheet-soulfire-info {
+    text-align: center;
+    width: 38%;
+}
+
+.sheet-soulfire-sides {
+    width: 30%;
+}
+
+.sheet-soulfire-sides input[type="text"] {
+    width: 100%;
+}
+
+.sheet-soulfire-stat {
+    text-align: center;
+    margin-top: 10px;
+}
+
+.sheet-party-info > div{
+    width: 32%;
+}
+
+button[type="roll"].sheet-soulfire-entry {
+    font-size: 12px;
+    text-align: center;
+    margin-top: 5px;
+}
+
+.sheet-party-info textarea {
+    box-sizing: border-box;
+    max-width: 100%;
+    min-width: 100%;
+    height: 50px;
+}
+
+button[type="roll"].sheet-header {
+    font-size: 18px;
+    text-align: center;
+    height: 25.71px;
+}
+
+.sheet-dots{
+    display:flex;
+    justify-content: space-evenly;
+    margin-top: 10px;
+}
+button.sheet-dot {
+    padding: 0;
+    border: solid 1px #a8a8a8;
+    cursor: pointer;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: white;
+    background: white;
+}
+
+button.sheet-dot > span {
+    width: 30px;
+    height: 30px;
+    line-height: 30px;
+    border-radius: 50%;
+    background: black;
+    font-size: 20px;
+}
+
+/* Hide the "checked" section of the radio if the hidden attribute value is greater than the button value */
+input.sheet-dot[value="0"] ~ button.sheet-gt-0 > span.sheet-checked {
+    background: white;
+    color: black;
+}
+input.sheet-dot[value="1"] ~ button.sheet-gt-1 > span.sheet-checked {
+    background: white;
+    color: black;
+}
+input.sheet-dot[value="2"] ~ button.sheet-gt-2 > span.sheet-checked {
+    background: white;
+    color: black;
+}
+input.sheet-dot[value="3"] ~ button.sheet-gt-3 > span.sheet-checked {
+    background: white;
+    color: black;
+}
+input.sheet-dot[value="4"] ~ button.sheet-gt-4 > span.sheet-checked {
+    background: white;
+    color: black;
+}
+input.sheet-dot[value="5"] ~ button.sheet-gt-5 > span.sheet-checked {
+    background: white;
+    color: black;
+}
+input.sheet-dot[value="6"] ~ button.sheet-gt-6 > span.sheet-checked {
+    background: white;
+    color: black;
+}
+input.sheet-dot[value="7"] ~ button.sheet-gt-7 > span.sheet-checked {
+    background: white;
+    color: black;
+}
+input.sheet-dot[value="8"] ~ button.sheet-gt-8 > span.sheet-checked {
+    background: white;
+    color: black;
+}
+input.sheet-dot[value="9"] ~ button.sheet-gt-9 > span.sheet-checked {
+    background: white;
+    color: black;
+}

--- a/Age-of-Sigmar-Soulbound/soulbound.html
+++ b/Age-of-Sigmar-Soulbound/soulbound.html
@@ -18,10 +18,19 @@
         <select name="attr_sheet_tab">
             <option value="player" selected="selected">player</option>
             <option value="npc">npc</option>
+            <option value="party">party</option>
+        </select>
+    </div>
+    <div class="option-entry">
+        <div>Initiative:</div>
+        <select name="attr_initiative_dice">
+            <option value="0" selected="selected">none</option>
+            <option value="d6">d6</option>
+            <option value="2d6">2d6</option>
         </select>
     </div>
     <div>Sheet version:
-        <input type="text" name="attr_version" value="2.0" disabled="true" hidden="true">
+        <input type="text" name="attr_version" value="3.0" disabled="true" hidden="true">
         <span name="attr_version"></span>
     </div>
 </div>
@@ -93,21 +102,21 @@
                         <input type="number" name="attr_body" value="1">
                         <button type="roll" class="text-button text-big"
                                 value="&{template:default} {{name=Body}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[@{body}d6s>?{Target DN? |2|3|4|5|6}]] successes}}"
-                                name="roll_might">Body
+                                name="roll_body">Body
                         </button>
                     </div>
                     <div>
                         <input type="number" name="attr_mind" value="1">
                         <button type="roll" class="text-button text-big"
                                 value="&{template:default} {{name=Mind}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[@{mind}d6s>?{Target DN? |2|3|4|5|6}]] successes}}"
-                                name="roll_might">Mind
+                                name="roll_mind">Mind
                         </button>
                     </div>
                     <div>
                         <input type="number" name="attr_soul" value="1">
                         <button type="roll" class="text-button text-big"
                                 value="&{template:default} {{name=Soul}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[@{soul}d6s>?{Target DN? |2|3|4|5|6}]] successes}}"
-                                name="roll_might">Soul
+                                name="roll_soul">Soul
                         </button>
                     </div>
                 </div>
@@ -707,7 +716,7 @@
                     <div class="combat-misc">
                         <div class="combat-ability-entry">
                             <button type="roll" class="sheet-text-button"
-                                    value="&{template:default} {{name=Initiative}} {{Result=[[@{initiative} &{tracker}]]}}">
+                                    value="&{template:default} {{name=Initiative}} {{Result=[[@{initiative_dice} + @{initiative} &{tracker}]]}}">
                                 Initiative
                             </button>
                             <div>
@@ -1159,13 +1168,16 @@
         </div>
         <div class="section-npc-stats">
             <div class="line"></div>
-            <div class="npc-details">
+            <div class="npc-details combat-misc">
                 <div>
                     <div>Speed:</div>
                     <input type="text" name="attr_npc_speed"/>
                 </div>
                 <div>
-                    <div>Initiative:</div>
+                    <button type="roll" class="sheet-text-button"
+                            value="&{template:default} {{name=Initiative}} {{Result=[[@{initiative_dice} + @{npc_initiative} &{tracker}]]}}">
+                        Initiative:
+                    </button>
                     <input type="number" name="attr_npc_initiative"/>
                 </div>
                 <div>
@@ -1263,24 +1275,185 @@
                 <div class="npc-body">
                     <button type="roll" class="text-button npc-base-stat"
                             value="&{template:default} {{name=Body}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[@{body}d6s>?{Target DN? |2|3|4|5|6}]] successes}}"
-                            name="roll_might">Body
+                            name="roll_body">Body
                     </button>
                     <input type="number" name="attr_body" value="1"/>
                 </div>
                 <div class="npc-mind">
                     <button type="roll" class="text-button npc-base-stat"
                             value="&{template:default} {{name=Mind}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[@{mind}d6s>?{Target DN? |2|3|4|5|6}]] successes}}"
-                            name="roll_might">Mind
+                            name="roll_mind">Mind
                     </button>
                     <input type="number" name="attr_mind" value="1"/>
                 </div>
                 <div class="npc-soul">
                     <button type="roll" class="text-button npc-base-stat"
                             value="&{template:default} {{name=Soul}} {{DN=?{Target DN? |2|3|4|5|6}}} {{Result=[[@{soul}d6s>?{Target DN? |2|3|4|5|6}]] successes}}"
-                            name="roll_might">Soul
+                            name="roll_soul">Soul
                     </button>
                     <input type="number" name="attr_soul" value="1"/>
                 </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="sheet-party">
+        <div class="npc-name">
+            <input type="text" class="npc-name" name="attr_character_name"/>
+            <div class="options-check stack">
+                <input type="checkbox" class="options-button" name="attr_options" value="1"/>
+                <span></span>
+            </div>
+        </div>
+        <div class="soulfire">
+            <div class="soulfire-sides">
+                <div class="header">Party Members</div>
+                <div class="line"></div>
+                <fieldset class="repeating_party-members">
+                    <input type="text" name="attr_party_member">
+                </fieldset>
+            </div>
+            <div class="soulfire-info">
+                <div class="header">Using Soulfire</div>
+                <div class="line"></div>
+                <button type="roll" class="text-button soulfire-entry"
+                        value="/em uses soulfire to maximise successes - everything counts as a 6"
+                        name="roll_soulfire_success">Maximise Successes - Everything counts as a 6
+                </button>
+                <button type="roll" class="text-button soulfire-entry"
+                        value="/em uses soulfire to reroll as many dice as they like"
+                        name="roll_soulfire_reroll">Reroll as many dice as you like
+                </button>
+                <button type="roll" class="text-button soulfire-entry"
+                        value="/em uses soulfire to regain all of their spent Mettle"
+                        name="roll_soulfire_mettle">Regain all spent Mettle
+                </button>
+                <button type="roll" class="text-button soulfire-entry"
+                        value="/em uses soulfire to recover all of their Toughness"
+                        name="roll_soulfire_toughness">Recover all your Toughness
+                </button>
+                <button type="roll" class="text-button soulfire-entry"
+                        value="/em uses soulfire to cheat death - they are no longer Mortally Wounded"
+                        name="roll_soulfire_death">Cheat Death - you are no longer Mortally Wounded
+                </button>
+            </div>
+            <div class="soulfire-sides">
+                <button type="roll" class="sheet-text-button header"
+                        value="&{template:default} {{name=Souldfire}} {{Current Soulfire points=@{soulfire}/@{soulfire|max}}}"
+                        name="roll_soulfire">Soulfire
+                </button>
+                <div class="line"></div>
+                <div class="soulfire-stat">
+                    <input type="number" name="attr_soulfire">/
+                    <input type="number" name="attr_soulfire_max">
+                </div>
+            </div>
+        </div>
+        <div class="party-info">
+            <div class="party-goals">
+                <div>
+                    <div class="header">Short term goals</div>
+                    <div class="line"></div>
+                    <fieldset class="repeating_short-term-goals">
+                        <textarea name="attr_short_term_goal"></textarea>
+                    </fieldset>
+                </div>
+                <div>
+                    <div class="header">Long term goals</div>
+                    <div class="line"></div>
+                    <fieldset class="repeating_long-term-goals">
+                        <textarea name="attr_long_term_goal"></textarea>
+                    </fieldset>
+                </div>
+                <div>
+                    <div class="header">Rumours</div>
+                    <div class="line"></div>
+                    <fieldset class="repeating_rumours">
+                        <textarea name="attr_rumours"></textarea>
+                    </fieldset>
+                </div>
+            </div>
+            <div class="party-contacts">
+                <div>
+                    <div class="header">Allies</div>
+                    <div class="line"></div>
+                    <fieldset class="repeating_allies">
+                        <textarea name="attr_allies"></textarea>
+                    </fieldset>
+                </div>
+                <div>
+                    <div class="header">Enemies</div>
+                    <div class="line"></div>
+                    <fieldset class="repeating_enemies">
+                        <textarea name="attr_enemies"></textarea>
+                    </fieldset>
+                </div>
+                <div>
+                    <div class="header">Fears</div>
+                    <div class="line"></div>
+                    <fieldset class="repeating_fears">
+                        <textarea name="attr_fears"></textarea>
+                    </fieldset>
+                </div>
+            </div>
+            <div class="party-resources-threats">
+                <div>
+                    <div class="header">Resources</div>
+                    <div class="line"></div>
+                    <fieldset class="repeating_resources">
+                        <textarea name="attr_resources"></textarea>
+                    </fieldset>
+                </div>
+                <div>
+                    <div class="header">Threats</div>
+                    <div class="line"></div>
+                    <fieldset class="repeating_threats">
+                        <textarea name="attr_threats"></textarea>
+                    </fieldset>
+                </div>
+            </div>
+        </div>
+        <div class="doom">
+            <button type="roll" class="sheet-text-button header"
+                    value="&{template:default} {{name=Doom}} {{Current Doom level=@{doom}}}" name="roll_doom">Doom
+            </button>
+            <div class="line"></div>
+
+            <div class="dots">
+                <input type="hidden" name="attr_doom" class="dot" value="0"/>
+                <button type="action" name="act_doom_0" class="dot">
+                    <span class="checked">0</span>
+                </button>
+                <button type="action" name="act_doom_1" class="dot gt-0">
+                    <span class="checked">1</span>
+                </button>
+                <button type="action" name="act_doom_2" class="dot gt-0 gt-1">
+                    <span class="checked">2</span>
+                </button>
+                <button type="action" name="act_doom_3" class="dot gt-0 gt-1 gt-2">
+                    <span class="checked">3</span>
+                </button>
+                <button type="action" name="act_doom_4" class="dot gt-0 gt-1 gt-2 gt-3">
+                    <span class="checked">4</span>
+                </button>
+                <button type="action" name="act_doom_5" class="dot gt-0 gt-1 gt-2 gt-3 gt-4">
+                    <span class="checked">5</span>
+                </button>
+                <button type="action" name="act_doom_6" class="dot gt-0 gt-1 gt-2 gt-3 gt-4 gt-5">
+                    <span class="checked">6</span>
+                </button>
+                <button type="action" name="act_doom_7" class="dot gt-0 gt-1 gt-2 gt-3 gt-4 gt-5 gt-6">
+                    <span class="checked">7</span>
+                </button>
+                <button type="action" name="act_doom_8" class="dot gt-0 gt-1 gt-2 gt-3 gt-4 gt-5 gt-6 gt-7">
+                    <span class="checked">8</span>
+                </button>
+                <button type="action" name="act_doom_9" class="dot gt-0 gt-1 gt-2 gt-3 gt-4 gt-5 gt-6 gt-7 gt-8">
+                    <span class="checked">9</span>
+                </button>
+                <button type="action" name="act_doom_10" class="dot gt-0 gt-1 gt-2 gt-3 gt-4 gt-5 gt-6 gt-7 gt-8 gt-9">
+                    <span class="checked">10</span>
+                </button>
             </div>
         </div>
     </div>
@@ -1414,4 +1587,12 @@
         });
     });
 
+    const doomValues = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"];
+    doomValues.forEach(function (value) {
+        on(`clicked:doom_${value}`, function () {
+            setAttrs({
+                "doom": value
+            });
+        });
+    });
 </script>


### PR DESCRIPTION
## Changes / Comments

added party sheet
added npc initiative to tracker
added initiative rolls, can choose between none, d6 and 2d6
made defaults for sheet type (only player/npc) and initiative dice


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
all stat rolls were named the same, this PR fixes that so they have the correct names
- [x] Does this add functional enhancements (new features or extending existing features) ?
adds a party sheet and improves initiative to allow for the optional rule of adding d6/2d6
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
party sheet has its own aesthetics but is consistent with the rest of the sheet
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
