### PR TITLE
Fix blessure desc bug for Reve de Dragon - french

### DIFF
--- a/Reve de Dragon - french/RDD.html
+++ b/Reve de Dragon - french/RDD.html
@@ -539,11 +539,11 @@
         </tr>
         <tr>
         <td style="text-align:center;"><input type="checkbox" name="attr_blessure1_1"></td>
-        <td><input type="text" name="attr_blessure0_1_desc"></td>
+        <td><input type="text" name="attr_blessure1_1_desc"></td>
         </tr>
         <tr>
         <td style="text-align:center;"><input type="checkbox" name="attr_blessure1_2"></td>
-        <td><input type="text" name="attr_blessure0_2_desc"></td>
+        <td><input type="text" name="attr_blessure1_2_desc"></td>
         </tr>
         <tr>
         <td style="display=hidden;padding-top:20px;"></td>
@@ -551,7 +551,7 @@
         </tr>
         <tr>
         <td style="text-align:center;"><input type="checkbox" name="attr_blessure3_1"></td>
-        <td><input type="text" name="attr_blessure0_1_desc"></td>
+        <td><input type="text" name="attr_blessure3_1_desc"></td>
         </tr>
         </table>  
             


### PR DESCRIPTION
## Changes / Comments

Fix following attribute name for the "Reve de Dragon - french" sheet

- change attr_blessure0_1_desc to attr_blessure1_1_desc
- change attr_blessure0_2_desc to attr_blessure1_2_desc
- change attr_blessure0_1_desc to attr_blessure3_1_desc

Currently, the attr names are mispelled and stored to the wrong "blessure" (wound) :
Grave (Serious) and  critique (critical) wound descriptions are stored using légère (light) wound descriptions.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
