### PR TITLE
Update Reve de Dragon - french adding characteristic button rolls

### DIFF
--- a/Reve de Dragon - french/RDD.html
+++ b/Reve de Dragon - french/RDD.html
@@ -539,11 +539,11 @@
         </tr>
         <tr>
         <td style="text-align:center;"><input type="checkbox" name="attr_blessure1_1"></td>
-        <td><input type="text" name="attr_blessure0_1_desc"></td>
+        <td><input type="text" name="attr_blessure1_1_desc"></td>
         </tr>
         <tr>
         <td style="text-align:center;"><input type="checkbox" name="attr_blessure1_2"></td>
-        <td><input type="text" name="attr_blessure0_2_desc"></td>
+        <td><input type="text" name="attr_blessure1_2_desc"></td>
         </tr>
         <tr>
         <td style="display=hidden;padding-top:20px;"></td>
@@ -551,7 +551,7 @@
         </tr>
         <tr>
         <td style="text-align:center;"><input type="checkbox" name="attr_blessure3_1"></td>
-        <td><input type="text" name="attr_blessure0_1_desc"></td>
+        <td><input type="text" name="attr_blessure3_1_desc"></td>
         </tr>
         </table>  
             

--- a/Reve de Dragon - french/RDD.html
+++ b/Reve de Dragon - french/RDD.html
@@ -40,36 +40,43 @@
 		<div style="margin-top:15px;"><!-- Caractéristiques (+colonne xp)-->
 		<table>
 		<tr>
-		<td  style="width:120px; text-align:center">Attribut</td><td style="padding-left:5px">Valeur</td><td style="width:80px;padding-left:15px">Xp</td>
+        <td style="width:120px; text-align:center">Attribut</td><td style="padding-left:5px">Valeur</td><td style="padding-left:15px">Xp</td>
+        <td style="width: 50px;">&nbsp;</td>
         <td style="width:120px;text-align:center">Attribut</td><td style="padding-left:5px">Valeur</td><td style="padding-left:15px">Xp</td>
 		</tr>
 		<tr>
 		<td>TAILLE</td>
-		<td COLSPAN="2"><input type="number" name="attr_Taille" value="0" style="text-align:center"></td>
+        <td COLSPAN="3"><input type="number" name="attr_Taille" value="0" style="text-align:center"></td>
 		<td>VOLONTÉ</td>
 		<td><input type="number" name="attr_volonte_value" value="0" style="text-align:center"></td>
-		<td><input type="number" name="attr_volonte_xp" value="0" style="text-align:center"></td>
+        <td><input type="number" name="attr_volonte_xp" value="0" style="text-align:center"></td>
+        <td><button  type="roll" style="margin-left:0px;line_height:10px;height:20px;margin-bottom:2px;" title="Volonté" name="roll_Volonté" value="&{template:RDD}{{name=Volonté}} {{Roll=[[1D100cs<0cf>100]]}} {{difficulte=[[?{Difficulté ?|0}+@{etat_general}]]}}  {{attribut=[[@{volonte_value}]]}} {{echec_part=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{volonte_value}*5)))+80]]}}  {{signif=[[floor(0.5*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{volonte_value}*5)))]]}} {{reussite_par=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{volonte_value}*5)))]]}} {{cible=[[floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{volonte_value}*5))]]}} {{echec_tot=[[ceil(100-(100-floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{volonte_value}*5)))*0.1)+1]]}}"></button></td>
 		</tr>
 		<tr>
 		<td>APPARENCE</td>
 		<td><input type="number" name="attr_apparence_value" value="0" style="text-align:center"></td>
-		<td><input type="number" name="attr_apparence_xp" value="0" style="text-align:center"></td>	
+        <td><input type="number" name="attr_apparence_xp" value="0" style="text-align:center"></td>
+        <td><button  type="roll" style="margin-left:0px;line_height:10px;height:20px;margin-bottom:2px;" title="Apparence" name="roll_Apparence" value="&{template:RDD}{{name=Apparence}} {{Roll=[[1D100cs<0cf>100]]}} {{difficulte=[[?{Difficulté ?|0}+@{etat_general}]]}}  {{attribut=[[@{apparence_value}]]}} {{echec_part=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{apparence_value}*5)))+80]]}}  {{signif=[[floor(0.5*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{apparence_value}*5)))]]}} {{reussite_par=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{apparence_value}*5)))]]}} {{cible=[[floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{apparence_value}*5))]]}} {{echec_tot=[[ceil(100-(100-floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{apparence_value}*5)))*0.1)+1]]}}"></button></td>	
 		<td>INTELLECT</td>
 		<td><input type="number" name="attr_Intellect_value" value="0" style="text-align:center"></td>
-		<td><input type="number" name="attr_Intellect_xp" value="0" style="text-align:center"></td>			
+        <td><input type="number" name="attr_Intellect_xp" value="0" style="text-align:center"></td>
+        <td><button  type="roll" style="margin-left:0px;line_height:10px;height:20px;margin-bottom:2px;" title="Intellect" name="roll_Intellect" value="&{template:RDD}{{name=Intellect}} {{Roll=[[1D100cs<0cf>100]]}} {{difficulte=[[?{Difficulté ?|0}+@{etat_general}]]}}  {{attribut=[[@{Intellect_value}]]}} {{echec_part=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{Intellect_value}*5)))+80]]}}  {{signif=[[floor(0.5*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{Intellect_value}*5)))]]}} {{reussite_par=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{Intellect_value}*5)))]]}} {{cible=[[floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{Intellect_value}*5))]]}} {{echec_tot=[[ceil(100-(100-floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{Intellect_value}*5)))*0.1)+1]]}}"></button></td>
 		</tr>
 		<tr>
 		<td>CONSTITUTION</td>
 		<td><input type="number" name="attr_constitution_value" value="0" style="text-align:center"></td>
-		<td><input type="number" name="attr_constitution_xp" value="0" style="text-align:center"></td>	
+        <td><input type="number" name="attr_constitution_xp" value="0" style="text-align:center"></td>
+        <td><button  type="roll" style="margin-left:0px;line_height:10px;height:20px;margin-bottom:2px;" title="Constitution" name="roll_Constitution" value="&{template:RDD}{{name=Constitution}} {{Roll=[[1D100cs<0cf>100]]}} {{difficulte=[[?{Difficulté ?|0}+@{etat_general}]]}}  {{attribut=[[@{constitution_value}]]}} {{echec_part=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{constitution_value}*5)))+80]]}}  {{signif=[[floor(0.5*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{constitution_value}*5)))]]}} {{reussite_par=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{constitution_value}*5)))]]}} {{cible=[[floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{constitution_value}*5))]]}} {{echec_tot=[[ceil(100-(100-floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{constitution_value}*5)))*0.1)+1]]}}"></button></td>	
 		<td>EMPATHIE</td>
 		<td><input type="number" name="attr_empathie_value" value="0" style="text-align:center"></td>
-		<td><input type="number" name="attr_empathie_xp" value="0" style="text-align:center"></td>			
+        <td><input type="number" name="attr_empathie_xp" value="0" style="text-align:center"></td>
+        <td><button  type="roll" style="margin-left:0px;line_height:10px;height:20px;margin-bottom:2px;" title="Empathie" name="roll_Empathie" value="&{template:RDD}{{name=Empathie}} {{Roll=[[1D100cs<0cf>100]]}} {{difficulte=[[?{Difficulté ?|0}+@{etat_general}]]}}  {{attribut=[[@{empathie_value}]]}} {{echec_part=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{empathie_value}*5)))+80]]}}  {{signif=[[floor(0.5*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{empathie_value}*5)))]]}} {{reussite_par=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{empathie_value}*5)))]]}} {{cible=[[floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{empathie_value}*5))]]}} {{echec_tot=[[ceil(100-(100-floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{empathie_value}*5)))*0.1)+1]]}}"></button></td>			
 		</tr>
 		<tr>
 		<td>FORCE</td>
 		<td><input type="number" name="attr_force_value" value="0" style="text-align:center"></td>
-		<td><input type="number" name="attr_force_xp" value="0" style="text-align:center"></td>	
+        <td><input type="number" name="attr_force_xp" value="0" style="text-align:center"></td>	
+        <td><button  type="roll" style="margin-left:0px;line_height:10px;height:20px;margin-bottom:2px;" title="Force" name="roll_Force" value="&{template:RDD}{{name=Force}} {{Roll=[[1D100cs<0cf>100]]}} {{difficulte=[[?{Difficulté ?|0}+@{etat_general}]]}}  {{attribut=[[@{force_value}]]}} {{echec_part=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{force_value}*5)))+80]]}}  {{signif=[[floor(0.5*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{force_value}*5)))]]}} {{reussite_par=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{force_value}*5)))]]}} {{cible=[[floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{force_value}*5))]]}} {{echec_tot=[[ceil(100-(100-floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{force_value}*5)))*0.1)+1]]}}"></button></td>
 		<td>RÊVE</td>
 		<td><input type="number" name="attr_reve_value" value="0" style="text-align:center"></td>
 		<td><input type="number" name="attr_reve_xp" value="0" style="text-align:center"></td>	
@@ -79,43 +86,53 @@
 		<tr>
 		<td>AGILITÉ</td>
 		<td><input type="number" name="attr_agilite_value" value="0" style="text-align:center"></td>
-		<td><input type="number" name="attr_agilite_xp" value="0" style="text-align:center"></td>	
+        <td><input type="number" name="attr_agilite_xp" value="0" style="text-align:center"></td>
+        <td><button  type="roll" style="margin-left:0px;line_height:10px;height:20px;margin-bottom:2px;" title="Agilité" name="roll_Agilité" value="&{template:RDD}{{name=Agilité}} {{Roll=[[1D100cs<0cf>100]]}} {{difficulte=[[?{Difficulté ?|0}+@{etat_general}]]}}  {{attribut=[[@{agilite_value}]]}} {{echec_part=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{agilite_value}*5)))+80]]}}  {{signif=[[floor(0.5*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{agilite_value}*5)))]]}} {{reussite_par=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{agilite_value}*5)))]]}} {{cible=[[floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{agilite_value}*5))]]}} {{echec_tot=[[ceil(100-(100-floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{agilite_value}*5)))*0.1)+1]]}}"></button></td>
 		<td>CHANCE</td>
 		<td><input type="number" name="attr_chance_value" value="0" style="text-align:center"></td>
 		<td><input type="number" name="attr_chance_xp" value="0" style="text-align:center"></td>
-		<td style="display:none"><input type="number" name="attr_chance_xp" value="0" style="text-align:center"></td>			
+        <td style="display:none"><input type="number" name="attr_chance_xp" value="0" style="text-align:center"></td>
+        <td><button  type="roll" style="margin-left:0px;line_height:10px;height:20px;margin-bottom:2px;" title="Chance" name="roll_Chance" value="&{template:RDD}{{name=Chance}} {{Roll=[[1D100cs<0cf>100]]}} {{difficulte=[[?{Difficulté ?|0}+@{etat_general}]]}}  {{attribut=[[@{chance_value}]]}} {{echec_part=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{chance_value}*5)))+80]]}}  {{signif=[[floor(0.5*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{chance_value}*5)))]]}} {{reussite_par=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{chance_value}*5)))]]}} {{cible=[[floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{chance_value}*5))]]}} {{echec_tot=[[ceil(100-(100-floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{chance_value}*5)))*0.1)+1]]}}"></button></td>
 		</tr>
 		<tr>
 		<td>DEXTERITÉ</td>
 		<td><input type="number" name="attr_dexterite_value" value="0" style="text-align:center"></td>
-		<td><input type="number" name="attr_dexterite_xp" value="0" style="text-align:center"></td>	
+        <td><input type="number" name="attr_dexterite_xp" value="0" style="text-align:center"></td>
+        <td><button  type="roll" style="margin-left:0px;line_height:10px;height:20px;margin-bottom:2px;" title="Dextérité" name="roll_Dexterite" value="&{template:RDD}{{name=Dexterité}} {{Roll=[[1D100cs<0cf>100]]}} {{difficulte=[[?{Difficulté ?|0}+@{etat_general}]]}}  {{attribut=[[@{dexterite_value}]]}} {{echec_part=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{dexterite_value}*5)))+80]]}}  {{signif=[[floor(0.5*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{dexterite_value}*5)))]]}} {{reussite_par=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{dexterite_value}*5)))]]}} {{cible=[[floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{dexterite_value}*5))]]}} {{echec_tot=[[ceil(100-(100-floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{dexterite_value}*5)))*0.1)+1]]}}"></button></td>
 		<td>Mêlée</td>
-		<td><input type="number" name="attr_melee_value" value="0" style="text-align:center"></td>
-		<td style="display:none"><input type="number" name="attr_melee_xp" value="0" style="text-align:center"></td>			
+		<td COLSPAN="2"><input type="number" name="attr_melee_value" value="0" style="text-align:center"></td>
+        <td style="display:none"><input type="number" name="attr_melee_xp" value="0" style="text-align:center"></td>			
+        <td><button  type="roll" style="margin-left:0px;line_height:10px;height:20px;margin-bottom:2px;" title="Mêlée" name="roll_Melee" value="&{template:RDD}{{name=Mêlée}} {{Roll=[[1D100cs<0cf>100]]}} {{difficulte=[[?{Difficulté ?|0}+@{etat_general}]]}}  {{attribut=[[@{melee_value}]]}} {{echec_part=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{melee_value}*5)))+80]]}}  {{signif=[[floor(0.5*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{melee_value}*5)))]]}} {{reussite_par=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{melee_value}*5)))]]}} {{cible=[[floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{melee_value}*5))]]}} {{echec_tot=[[ceil(100-(100-floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{melee_value}*5)))*0.1)+1]]}}"></button></td>
 		</tr>
 		<tr>
 		<td>VUE</td>
 		<td><input type="number" name="attr_vue_value" value="0" style="text-align:center"></td>
-		<td><input type="number" name="attr_vue_xp" value="0" style="text-align:center"></td>	
+        <td><input type="number" name="attr_vue_xp" value="0" style="text-align:center"></td>
+        <td><button  type="roll" style="margin-left:0px;line_height:10px;height:20px;margin-bottom:2px;" title="Vue" name="roll_Vue" value="&{template:RDD}{{name=Vue}} {{Roll=[[1D100cs<0cf>100]]}} {{difficulte=[[?{Difficulté ?|0}+@{etat_general}]]}}  {{attribut=[[@{vue_value}]]}} {{echec_part=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{vue_value}*5)))+80]]}}  {{signif=[[floor(0.5*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{vue_value}*5)))]]}} {{reussite_par=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{vue_value}*5)))]]}} {{cible=[[floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{vue_value}*5))]]}} {{echec_tot=[[ceil(100-(100-floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{vue_value}*5)))*0.1)+1]]}}"></button></td>
 		<td>Tir</td>
-		<td><input type="number" name="attr_tir_value" value="0" style="text-align:center"></td>
-		<td style="display:none"><input type="number" name="attr_tir_xp" value="0" style="text-align:center"></td>			
+		<td COLSPAN="2"><input type="number" name="attr_tir_value" value="0" style="text-align:center"></td>
+        <td style="display:none"><input type="number" name="attr_tir_xp" value="0" style="text-align:center"></td>
+        <td><button  type="roll" style="margin-left:0px;line_height:10px;height:20px;margin-bottom:2px;" title="Tir" name="roll_Tir" value="&{template:RDD}{{name=Tir}} {{Roll=[[1D100cs<0cf>100]]}} {{difficulte=[[?{Difficulté ?|0}+@{etat_general}]]}}  {{attribut=[[@{tir_value}]]}} {{echec_part=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{tir_value}*5)))+80]]}}  {{signif=[[floor(0.5*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{tir_value}*5)))]]}} {{reussite_par=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{tir_value}*5)))]]}} {{cible=[[floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{tir_value}*5))]]}} {{echec_tot=[[ceil(100-(100-floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{tir_value}*5)))*0.1)+1]]}}"></button></td>
 		</tr>
 		<tr>
 		<td>OUÏE</td>
 		<td><input type="number" name="attr_ouie_value" value="0" style="text-align:center"></td>
-		<td><input type="number" name="attr_ouie_xp" value="0" style="text-align:center"></td>	
+        <td><input type="number" name="attr_ouie_xp" value="0" style="text-align:center"></td>
+        <td><button  type="roll" style="margin-left:0px;line_height:10px;height:20px;margin-bottom:2px;" title="Ouïe" name="roll_Ouie" value="&{template:RDD}{{name=Ouïe}} {{Roll=[[1D100cs<0cf>100]]}} {{difficulte=[[?{Difficulté ?|0}+@{etat_general}]]}}  {{attribut=[[@{ouie_value}]]}} {{echec_part=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{ouie_value}*5)))+80]]}}  {{signif=[[floor(0.5*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{ouie_value}*5)))]]}} {{reussite_par=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{ouie_value}*5)))]]}} {{cible=[[floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{ouie_value}*5))]]}} {{echec_tot=[[ceil(100-(100-floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{ouie_value}*5)))*0.1)+1]]}}"></button></td>	
 		<td>Lancer</td>
-		<td><input type="number" name="attr_lancer_value" value="0" style="text-align:center"></td>
-		<td style="display:none"><input type="number" name="attr_lancer_xp" value="0" style="text-align:center"></td>			
+		<td COLSPAN="2"><input type="number" name="attr_lancer_value" value="0" style="text-align:center"></td>
+        <td style="display:none"><input type="number" name="attr_lancer_xp" value="0" style="text-align:center"></td>
+        <td><button  type="roll" style="margin-left:0px;line_height:10px;height:20px;margin-bottom:2px;" title="Lancer" name="roll_Lancer" value="&{template:RDD}{{name=Lancer}} {{Roll=[[1D100cs<0cf>100]]}} {{difficulte=[[?{Difficulté ?|0}+@{etat_general}]]}}  {{attribut=[[@{lancer_value}]]}} {{echec_part=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{lancer_value}*5)))+80]]}}  {{signif=[[floor(0.5*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{lancer_value}*5)))]]}} {{reussite_par=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{lancer_value}*5)))]]}} {{cible=[[floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{lancer_value}*5))]]}} {{echec_tot=[[ceil(100-(100-floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{lancer_value}*5)))*0.1)+1]]}}"></button></td>
 		</tr>
 		<tr>
 		<td>ODORAT-GOÛT</td>
 		<td><input type="number" name="attr_odoratgout_value" value="0" style="text-align:center"></td>
-		<td><input type="number" name="attr_odoratgout_xp" value="0" style="text-align:center"></td>	
+        <td><input type="number" name="attr_odoratgout_xp" value="0" style="text-align:center"></td>
+        <td><button  type="roll" style="margin-left:0px;line_height:10px;height:20px;margin-bottom:2px;" title="Odorat-Goût" name="roll_Odoratgout" value="&{template:RDD}{{name=Odorat―Goût}} {{Roll=[[1D100cs<0cf>100]]}} {{difficulte=[[?{Difficulté ?|0}+@{etat_general}]]}}  {{attribut=[[@{odoratgout_value}]]}} {{echec_part=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{odoratgout_value}*5)))+80]]}}  {{signif=[[floor(0.5*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{odoratgout_value}*5)))]]}} {{reussite_par=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{odoratgout_value}*5)))]]}} {{cible=[[floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{odoratgout_value}*5))]]}} {{echec_tot=[[ceil(100-(100-floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{odoratgout_value}*5)))*0.1)+1]]}}"></button></td>
 		<td>Dérobée</td>
-		<td><input type="number" name="attr_derobee_value"></td>
-		<td style="display:none"><input type="number" name="attr_derobee_xp" value="0" style="text-align:center"></td>			
+		<td COLSPAN="2"><input type="number" name="attr_derobee_value"></td>
+        <td style="display:none"><input type="number" name="attr_derobee_xp" value="0" style="text-align:center"></td>
+        <td><button  type="roll" style="margin-left:0px;line_height:10px;height:20px;margin-bottom:2px;" title="Dérobée" name="roll_Derobee" value="&{template:RDD}{{name=Dérobée}} {{Roll=[[1D100cs<0cf>100]]}} {{difficulte=[[?{Difficulté ?|0}+@{etat_general}]]}}  {{attribut=[[@{derobee_value}]]}} {{echec_part=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{derobee_value}*5)))+80]]}}  {{signif=[[floor(0.5*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{derobee_value}*5)))]]}} {{reussite_par=[[ceil(0.2*floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{derobee_value}*5)))]]}} {{cible=[[floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{derobee_value}*5))]]}} {{echec_tot=[[ceil(100-(100-floor((((?{Difficulté ?|0}+@{etat_general})/10)+1)*(@{derobee_value}*5)))*0.1)+1]]}}"></button></td>
 		</tr>
 		</table>
 		</div><!-- fin caractéristiques -->


### PR DESCRIPTION
## Changes / Comments

Adding 

Adding rolling buttons for those "caractéristiques": 

- APPARENCE
- INTELLECT
- CONSTITUTION
- EMPATHIE
- FORCE
- AGILITÉ
- CHANCE
- DEXTERITÉ
- Mêlée
- VUE
- Tir
- OUÏE
- Lancer
- ODORAT-GOÛT
- Dérobée


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
