### PR TITLE
[PokemonTabletopAdventures_v3] Corrects Total Damage sheet worker

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -997,7 +997,7 @@
             const total = categoryModifier + extra + stab;
             
             setAttrs({
-                'repeating_moves_move_total_damage_bonus': total
+                'repeating_moves_move_totaldamage': total
             });
         });
     });


### PR DESCRIPTION
## Changes / Comments
- Corrects the attribute name for the total damage bonus used by the sheet worker reacting to field value changes
  - this ensures the users don't need to close/re-open their sheets to have the correct values indicated _(note: the correct value is still used in rolls)_





## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
_Yes, this corrects the attribute name used in a sheet worker script._
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme)? 
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data?
_Technically, this will be removing attributes for some sheets, but these are incorrectly created and shouldn't be used._
_Hopefully, the impact of this is minimal - as far as the user is concerned, the attribute being removed should not have been visible._
- [x] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository)?

If you do not know English. Please leave a comment in your native language.
