### PR TITLE
[PokemonTabletopAdventures_v3] PTA3 Sheet bug fixes

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -806,10 +806,11 @@ button[type="roll"].sheet-move-roller {
 }
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template span.sheet-targeted-defense {
-    font-weight: bold;
-    margin-left: 10px;
-    padding: 2px 5px;
-    text-transform: none;
+  font-size: smaller;  
+  font-weight: bold;
+  margin-left: 0px;
+  padding: 2px 5px;
+  text-transform: none;
 }
 
 /* Varying colour by effectiveness for damage roll and text  */

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -572,25 +572,25 @@
 
     <b>Moves</b>
     <fieldset class="repeating_moves">
-        <input type="text" name="attr_move_category_defense" class="hidden-setting"></input>
-        <input type="checkbox" name="attr_style-bug-move" class="hidden-setting color-setting-bug-move"></input>
-        <input type="checkbox" name="attr_style-dark-move" class="hidden-setting color-setting-dark-move"></input>
-        <input type="checkbox" name="attr_style-dragon-move" class="hidden-setting color-setting-dragon-move"></input>
-        <input type="checkbox" name="attr_style-electric-move" class="hidden-setting color-setting-electric-move"></input>
-        <input type="checkbox" name="attr_style-fairy-move" class="hidden-setting color-setting-fairy-move"></input>
-        <input type="checkbox" name="attr_style-fighting-move" class="hidden-setting color-setting-fighting-move"></input>
-        <input type="checkbox" name="attr_style-fire-move" class="hidden-setting color-setting-fire-move"></input>
-        <input type="checkbox" name="attr_style-flying-move" class="hidden-setting color-setting-flying-move"></input>
-        <input type="checkbox" name="attr_style-ghost-move" class="hidden-setting color-setting-ghost-move"></input>
-        <input type="checkbox" name="attr_style-grass-move" class="hidden-setting color-setting-grass-move"></input>
-        <input type="checkbox" name="attr_style-ground-move" class="hidden-setting color-setting-ground-move"></input>
-        <input type="checkbox" name="attr_style-ice-move" class="hidden-setting color-setting-ice-move"></input>
-        <input type="checkbox" name="attr_style-normal-move" class="hidden-setting color-setting-normal-move"></input>
-        <input type="checkbox" name="attr_style-poison-move" class="hidden-setting color-setting-poison-move"></input>
-        <input type="checkbox" name="attr_style-psychic-move" class="hidden-setting color-setting-psychic-move"></input>
-        <input type="checkbox" name="attr_style-rock-move" class="hidden-setting color-setting-rock-move"></input>
-        <input type="checkbox" name="attr_style-steel-move" class="hidden-setting color-setting-steel-move"></input>
-        <input type="checkbox" name="attr_style-water-move" class="hidden-setting color-setting-water-move"></input>
+        <input type="hidden" name="attr_move_category_defense" />
+        <input type="checkbox" name="attr_style-bug-move" class="hidden-setting color-setting-bug-move" />
+        <input type="checkbox" name="attr_style-dark-move" class="hidden-setting color-setting-dark-move" />
+        <input type="checkbox" name="attr_style-dragon-move" class="hidden-setting color-setting-dragon-move" />
+        <input type="checkbox" name="attr_style-electric-move" class="hidden-setting color-setting-electric-move" />
+        <input type="checkbox" name="attr_style-fairy-move" class="hidden-setting color-setting-fairy-move" />
+        <input type="checkbox" name="attr_style-fighting-move" class="hidden-setting color-setting-fighting-move" />
+        <input type="checkbox" name="attr_style-fire-move" class="hidden-setting color-setting-fire-move" />
+        <input type="checkbox" name="attr_style-flying-move" class="hidden-setting color-setting-flying-move" />
+        <input type="checkbox" name="attr_style-ghost-move" class="hidden-setting color-setting-ghost-move" />
+        <input type="checkbox" name="attr_style-grass-move" class="hidden-setting color-setting-grass-move" />
+        <input type="checkbox" name="attr_style-ground-move" class="hidden-setting color-setting-ground-move" />
+        <input type="checkbox" name="attr_style-ice-move" class="hidden-setting color-setting-ice-move" />
+        <input type="checkbox" name="attr_style-normal-move" class="hidden-setting color-setting-normal-move" checked />
+        <input type="checkbox" name="attr_style-poison-move" class="hidden-setting color-setting-poison-move" />
+        <input type="checkbox" name="attr_style-psychic-move" class="hidden-setting color-setting-psychic-move" />
+        <input type="checkbox" name="attr_style-rock-move" class="hidden-setting color-setting-rock-move" />
+        <input type="checkbox" name="attr_style-steel-move" class="hidden-setting color-setting-steel-move" />
+        <input type="checkbox" name="attr_style-water-move" class="hidden-setting color-setting-water-move" />
         <div class="pokemon-move">
             <div class="pokemon-move-info-header">
                 <input type="text" spellcheck="false" name="attr_move_name" placeholder="Move" />


### PR DESCRIPTION
## Changes / Comments

- Removes undesired margins causing _"vs Special Defense"_ to require a second line in the move roll template
  - Also reduces the font size for this label
- ~~Corrects the attribute name used in the sheet worker reacting to move field changes to update the total damage~~
  - This change was folded into a separate piece of refactoring work
- Marks the Normal move-type hidden checkbox as checked by default. This ensures new moves are styled correctly for the information indicated by the fields within the section


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features)?
- [x] Does this add or change functional aesthetics (such as layout or color scheme)? 
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data?
- [x] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository)?

If you do not know English. Please leave a comment in your native language.
