### PR TITLE
[PokemonTabletopAdventures_v3] Improves the Move roll template

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -404,6 +404,11 @@ div.sheet-character-stat-grid b, div.sheet-character-stat-grid p {
   grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
 }
 
+.sheet-pokemon-move-info-grid-2 b.sheet-info-tooltip {
+    border-bottom: 2px dotted;
+    border-color: var(--poke-foreground-color);
+}
+
 /* Remove arrows from number inputs */
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {

--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -390,13 +390,11 @@ div.sheet-character-stat-grid b, div.sheet-character-stat-grid p {
 }
 
 .sheet-pokemon-move-info-grid-2 {
-  align-items: center;
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
   justify-items: center;
-  margin-left: 8px;
-  margin-right: -8px;
+  align-items: center;
   text-align: left;
+  grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
 }
 
 /* Remove arrows from number inputs */

--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -317,13 +317,13 @@ div.sheet-character-stat-grid b, div.sheet-character-stat-grid p {
   width: 130px;
 }
 
-.sheet-top-information[type="number"] {
+.sheet-top-information[type="number"],
+.sheet-top-information[type="text"] {
   background-color: rgba(255, 153, 153, 0);
-  outline: none;
-  border-width: 2px;
-  border-color: var(--poke-foreground-color);
+  border: 2px var(--poke-foreground-color);
   border-style: none none solid none;
   font-weight: bold;
+  outline: none;
 }
 
 .sheet-top-select {
@@ -336,7 +336,14 @@ div.sheet-character-stat-grid b, div.sheet-character-stat-grid p {
 }
 
 .sheet-thin-number[type="number"] {
-  width: 24px !important;
+  width: 30px !important;
+}
+
+.sheet-total-display[type="text"] {
+  border: none;
+  color: var(--poke-foreground-color);
+  vertical-align: revert;
+  width: 70px !important;
 }
 
 .sheet-damage-dice-count[type="number"] {

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -663,6 +663,7 @@
                 <span>
                     <b>Critical Threshold</b>
                     <input type="number" name="attr_move_critthreshold" class="top-information thin-number" value="20" min="1" max="20"/>
+                    <b class="info-tooltip" title="Modify to change critical hits based on the dice roll, as per Focus Energy and Super Luck. For moves like Slash, see Effect Threshold">ℹ</b>
                 </span>
 
                 <span>
@@ -682,10 +683,10 @@
                 <span>
                     <b>Effect Threshold</b>
                     <input type="number" name="attr_move_effect1_threshold" class="top-information thin-number" value="0" min="0" max="20"/>
+                    <b class="info-tooltip" title="Enter the value shown in the move notes for effects like Burned, Poisoned, and Stunned">ℹ</b>
                 </span>
                 
                 <span>
-                    <input type="hidden" name="attr_move_effect1_name" />
                     <select name="attr_move_effect1" class="move-text">
                         <option value="98" selected>None</option>
                         <option value="99">Critical Hit</option>
@@ -701,6 +702,8 @@
                         <option value="10">Stunned</option>
                         <option value="11">Other</option>
                     </select>
+                    <input type="hidden" name="attr_move_effect1_name" />
+                    <b class="info-tooltip" title="Choose Critical Hit for moves where a high accuracy check scores a critical hit, like Slash and Karate Chop">ℹ</b>
                 </span>
 
                 <span>

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -641,16 +641,18 @@
                     <option value="1combat">1/combat</option>
                 </select>
 
-                <span><b>Damage</b><input type="number" name="attr_move_dicenumber"
-                    class="top-information damage-dice-count" value="0" /><select name="attr_damage_dice"
-                    class="damage-dice">
-                    <option value="4">d4</option>
-                    <option value="6">d6</option>
-                    <option value="8">d8</option>
-                    <option value="10">d10</option>
-                    <option value="12">d12</option>
-                    <option value="20">d20</option>
-                </select></span>
+                <span>
+                    <b>Damage</b>
+                    <input type="number" name="attr_move_dicenumber" class="top-information damage-dice-count" value="0" />
+                    <select name="attr_damage_dice" class="damage-dice">
+                        <option value="4">d4</option>
+                        <option value="6">d6</option>
+                        <option value="8">d8</option>
+                        <option value="10">d10</option>
+                        <option value="12">d12</option>
+                        <option value="20">d20</option>
+                    </select>
+                </span>
             </div>
             <div class="pokemon-move-info-grid-2">
                 <span>
@@ -660,11 +662,11 @@
 
                 <span>
                     <b>Critical Threshold</b>
-                    <input type="number" name="attr_move_critthreshold" class="top-information thin-number" value="20" />
+                    <input type="number" name="attr_move_critthreshold" class="top-information thin-number" value="20" min="1" max="20"/>
                 </span>
 
                 <span>
-                    <b>STAB Damage</b><input type="number" name="attr_move_stabbonus" class="top-information thin-number" value="0" />
+                    <b>STAB</b><input type="number" name="attr_move_stabbonus" class="top-information thin-number" value="0" />
                 </span>
 
                 <span>
@@ -672,12 +674,14 @@
                 </span>
 
                 <span class="readonly-field">
-                    <b>Total Damage:</b><input type="number" name="attr_move_totaldamage" readonly class="top-information thin-number" value="0" />
+                    <b>Damage Roll:</b>
+                    <input type="hidden" name="attr_move_totaldamage" />
+                    <input type="text" name="attr_move_totaldamage_display" readonly class="top-information total-display" value="" />
                 </span>
 
                 <span>
                     <b>Effect Threshold</b>
-                    <input type="number" name="attr_move_effect1_threshold" class="top-information thin-number" value="0"/>
+                    <input type="number" name="attr_move_effect1_threshold" class="top-information thin-number" value="0" min="1" max="20"/>
                 </span>
                 
                 <span>
@@ -701,7 +705,7 @@
 
                 <span>
                     <b>Effect Threshold</b>
-                    <input type="number" name="attr_move_effect2_threshold" class="top-information thin-number" value="0"/>
+                    <input type="number" name="attr_move_effect2_threshold" class="top-information thin-number" value="0" min="1" max="20"/>
                 </span>
                 
                 <span>
@@ -721,11 +725,17 @@
                         <option value="11">Other</option>
                     </select>
                 </span>
+
+                <span class="readonly-field">
+                    <b>Accuracy Roll:</b>
+                    <input type="hidden" name="attr_move_totalaccuracy"/>
+                    <input type="text" name="attr_move_totalaccuracy_display" readonly class="top-information total-display" value="" />
+                </span>
             </div>
             
             <div class="move-notes-roller">
                 <textarea spellcheck="false" name="attr_move_effect" placeholder="Additional Effect Notes" class="3row-textarea"></textarea>
-                <button type='roll' value='&{template:move-roll} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ [[ @{ATKMOD} * {{@{move_category}, 0}=1} + @{SPATKMOD} * {{@{move_category}, 0}=2} + @{SPDMOD} * {{@{move_category}, 0}=3} ]] + @{move_acmod} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}}'
+                <button type='roll' value='&{template:move-roll} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}}'
                 name='roll-movetemplate' class='move-roller'>T</button>
             </div>
         </div>
@@ -1138,24 +1148,31 @@
             const categories = idArray.map(id => `repeating_moves_${id}_move_category`);
             const extraBonuses = idArray.map(id => `repeating_moves_${id}_move_damagebonus`);
             const stabBonuses = idArray.map(id => `repeating_moves_${id}_move_stabbonus`);
+            const diceNumbers = idArray.map(id => `repeating_moves_${id}_move_dicenumber`);
+            const damageDice = idArray.map(id => `repeating_moves_${id}_damage_dice`);
             
             
             // Get the ATK and SPATK modifier attributes, as well the values for each moves category, extra bonus, and stab bonus.
-            getAttrs([`ATKMOD`, `SPATKMOD`, ...categories, ...extraBonuses, ...stabBonuses], function (values) {
-                
+            getAttrs([`ATKMOD`, `SPATKMOD`, ...categories, ...extraBonuses, ...stabBonuses, ...diceNumbers, ...damageDice], function (values) {
                 const rows = rowNames.reduce((obj, rowName) => {
                     
                     // For each move, get the value of its relevant attributes stored as a local var - default to 0 for easier maths
                     const category = parseInt(values[rowName + `_move_category`]) || 0;
                     const extra = parseInt(values[rowName + '_move_damagebonus']) || 0;
                     const stab = parseInt(values[rowName + '_move_stabbonus']) || 0;
+                    const dice = parseInt(values[rowName + '_move_dicenumber']) || 0;
+                    const points = parseInt(values[rowName + '_damage_dice']) || 0;
                     
                     // Get the modifier for the category selected 
                     const categoryModifier = parseInt(values[`${categoryDamageModifiers[category]}`]) || 0;
                     const total = categoryModifier + extra + stab;
-                    
+
+                    var display = `${total}`;
+                    if (dice > 0) display = `${dice}d${points} ${total < 0 ? "" : "+ "}${total}`;
+                            
                     // Assign the calculated damage bonus to the relevant move's total damage bonus attribute
                     obj[rowName + '_move_totaldamage'] = total;
+                    obj[rowName + '_move_totaldamage_display'] = display;
                     return obj;
                 }, {});
                 if (rows) setAttrs(rows);
@@ -1163,50 +1180,66 @@
         });
     });
     
-    on("change:repeating_moves:move_category change:repeating_moves:move_damagebonus change:repeating_moves:move_stabbonus", function(eventInfo) {
-        getAttrs(["ATKMOD", "SPATKMOD", "repeating_moves_move_category", "repeating_moves_move_damagebonus", "repeating_moves_move_stabbonus"], function(values) {
+    on("change:repeating_moves:move_category change:repeating_moves:move_damagebonus change:repeating_moves:move_stabbonus change:repeating_moves:move_dicenumber change:repeating_moves:damage_dice", function(eventInfo) {
+        getAttrs(["ATKMOD", "SPATKMOD", "repeating_moves_move_category", "repeating_moves_move_damagebonus", "repeating_moves_move_stabbonus", "repeating_moves_move_dicenumber", "repeating_moves_damage_dice"], function(values) {
             const category = parseInt(values.repeating_moves_move_category) || 0;
             const extra = parseInt(values.repeating_moves_move_damagebonus) || 0;
             const stab = parseInt(values.repeating_moves_move_stabbonus) || 0;
-            
+            const dice = parseInt(values.repeating_moves_move_dicenumber) || 0;
+            const points = parseInt(values.repeating_moves_damage_dice) || 0;
+
             const categoryModifier = parseInt(values[`${categoryDamageModifiers[category]}`]) || 0;
             const total = categoryModifier + extra + stab;
 
+            var display = `${total}`;
+            if (dice > 0) display = `${dice}d${points} ${total < 0 ? "" : "+ "}${total}`;
+
             setAttrs({
-                'repeating_moves_move_total_damage_bonus': total
+                'repeating_moves_move_totaldamage': total,
+                'repeating_moves_move_totaldamage_display': display
+            });
+        });
+    });
+    
+    categoryAccuracyModifiers = ["", "ATKMOD", "SPATKMOD", "SPDMOD"];
+    on("change:ATK change:SPATK change:SPD sheet:opened", function (eventInfo) {
+        getSectionIDs("repeating_moves", function (idArray) {
+            const rowNames = idArray.map(id => `repeating_moves_${id}`);
+            const categories = idArray.map(id => `repeating_moves_${id}_move_category`);
+            const accuracyMods = idArray.map(id => `repeating_moves_${id}_move_acmod`);
+
+            getAttrs([`ATKMOD`, `SPATKMOD`, `SPDMOD`, ...categories, ...accuracyMods], function (values) {
+                const rows = rowNames.reduce((obj, rowName) => {
+                    const category = parseInt(values[rowName + `_move_category`]) || 0;
+                    const accuracy = parseInt(values[rowName + `_move_acmod`]) || 0;
+                    
+                    const categoryModifier = parseInt(values[`${categoryAccuracyModifiers[category]}`]) || 0;
+                    const total = categoryModifier + accuracy;
+                    const roll = `d20 ${total < 0 ? "" : "+ "}${total}`;
+
+                    obj[rowName + '_move_totalaccuracy'] = total;
+                    obj[rowName + '_move_totalaccuracy_display'] = roll;
+                    return obj;
+                }, {});
+                if (rows) setAttrs(rows);
+            });
+        });
+    });
+
+    on("change:repeating_moves:move_category change:repeating_moves:move_acmod", function(eventInfo) {
+        getAttrs([`ATKMOD`, `SPATKMOD`, `SPDMOD`, `repeating_moves_move_category`, `repeating_moves_move_acmod`], function (values) {
+            const category = parseInt(values.repeating_moves_move_category) || 0;
+            const accuracy = parseInt(values.repeating_moves_move_acmod) || 0;
+            
+            const categoryModifier = parseInt(values[`${categoryAccuracyModifiers[category]}`]) || 0;
+            const total = categoryModifier + accuracy;
+            const roll = `d20 ${total < 0 ? "" : "+ "}${total}`
+
+            setAttrs({
+                'repeating_moves_move_totalaccuracy': total,
+                'repeating_moves_move_totalaccuracy_display': roll
             });
         });
     });
 
 </script>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -681,7 +681,7 @@
 
                 <span>
                     <b>Effect Threshold</b>
-                    <input type="number" name="attr_move_effect1_threshold" class="top-information thin-number" value="0" min="1" max="20"/>
+                    <input type="number" name="attr_move_effect1_threshold" class="top-information thin-number" value="0" min="0" max="20"/>
                 </span>
                 
                 <span>
@@ -705,7 +705,7 @@
 
                 <span>
                     <b>Effect Threshold</b>
-                    <input type="number" name="attr_move_effect2_threshold" class="top-information thin-number" value="0" min="1" max="20"/>
+                    <input type="number" name="attr_move_effect2_threshold" class="top-information thin-number" value="0" min="0" max="20"/>
                 </span>
                 
                 <span>

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -595,7 +595,8 @@
             <div class="pokemon-move-info-header">
                 <input type="text" spellcheck="false" name="attr_move_name" placeholder="Move" />
 
-                <span><b>Move Usage</b>
+                <span>
+                    <b>Move Usage</b>
                     <input type="number" name="attr_move_usage" value="0" />
                     <button name="act_incrementmoveusage" type="action">+</button>
                     <button name="act_resetmoveusage" type="action">Reset</button>
@@ -653,11 +654,13 @@
             </div>
             <div class="pokemon-move-info-grid-2">
                 <span>
-                    <b>Accuracy Modifier</b><input type="number" name="attr_move_acmod" class="top-information thin-number" value="0" />
+                    <b>Accuracy Modifier</b>
+                    <input type="number" name="attr_move_acmod" class="top-information thin-number" value="0" />
                 </span>
 
                 <span>
-                    <b>Critical Threshold</b><input type="number" name="attr_move_critthreshold" class="top-information thin-number" value="20" />
+                    <b>Critical Threshold</b>
+                    <input type="number" name="attr_move_critthreshold" class="top-information thin-number" value="20" />
                 </span>
 
                 <span>
@@ -672,12 +675,58 @@
                     <b>Total Damage:</b><input type="number" name="attr_move_totaldamage" readonly class="top-information thin-number" value="0" />
                 </span>
 
+                <span>
+                    <b>Effect Threshold</b>
+                    <input type="number" name="attr_move_effect1_threshold" class="top-information thin-number" value="0"/>
+                </span>
+                
+                <span>
+                    <input type="hidden" name="attr_move_effect1_name" />
+                    <select name="attr_move_effect1" class="move-text">
+                        <option value="98" selected>None</option>
+                        <option value="99">Critical Hit</option>
+                        <option value="1">Asleep</option>
+                        <option value="2">Burned</option>
+                        <option value="3">Confused</option>
+                        <option value="4">Cursed</option>
+                        <option value="5">Frozen</option>
+                        <option value="6">Infatuated</option>
+                        <option value="7">Paralyzed</option>
+                        <option value="8">Poisoned</option>
+                        <option value="9">Toxified</option>
+                        <option value="10">Stunned</option>
+                        <option value="11">Other</option>
+                    </select>
+                </span>
+
+                <span>
+                    <b>Effect Threshold</b>
+                    <input type="number" name="attr_move_effect2_threshold" class="top-information thin-number" value="0"/>
+                </span>
+                
+                <span>
+                    <input type="hidden" name="attr_move_effect2_name" />
+                    <select name="attr_move_effect2" class="move-text">
+                        <option value="98" selected>None</option>
+                        <option value="1">Asleep</option>
+                        <option value="2">Burned</option>
+                        <option value="3">Confused</option>
+                        <option value="4">Cursed</option>
+                        <option value="5">Frozen</option>
+                        <option value="6">Infatuated</option>
+                        <option value="7">Paralyzed</option>
+                        <option value="8">Poisoned</option>
+                        <option value="9">Toxified</option>
+                        <option value="10">Stunned</option>
+                        <option value="11">Other</option>
+                    </select>
+                </span>
             </div>
             
             <div class="move-notes-roller">
-                <textarea spellcheck="false" name="attr_move_effect" placeholder="Additional Effects" class="3row-textarea"></textarea>
-                <button type='roll' value='&{template:move-roll} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cs>@{move_critthreshold} + [[ [[ @{ATKMOD} * {{@{move_category}, 0}=1} + @{SPATKMOD} * {{@{move_category}, 0}=2} + @{SPDMOD} * {{@{move_category}, 0}=3} ]] + @{move_acmod} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{notes=@{move_effect}}}'
-                    name='roll-movetemplate' class='move-roller'>T</button>
+                <textarea spellcheck="false" name="attr_move_effect" placeholder="Additional Effect Notes" class="3row-textarea"></textarea>
+                <button type='roll' value='&{template:move-roll} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ [[ @{ATKMOD} * {{@{move_category}, 0}=1} + @{SPATKMOD} * {{@{move_category}, 0}=2} + @{SPDMOD} * {{@{move_category}, 0}=3} ]] + @{move_acmod} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}}'
+                name='roll-movetemplate' class='move-roller'>T</button>
             </div>
         </div>
     </fieldset>
@@ -724,33 +773,107 @@
                             {{/rollTotal() effectiveness-roll 1}}
                             <!-- Super -->
                             {{#rollTotal() effectiveness-roll 3}}
-                            The attack was super effective!
+                            It was super effective!
                             {{/rollTotal() effectiveness-roll 3}}
                             <!-- Extreme -->
                             {{#rollTotal() effectiveness-roll 4}}
-                            The attack was extremely effective!
+                            It was extremely effective!
                             {{/rollTotal() effectiveness-roll 4}}
                         </span>
                     </td>
                 </tr>
                 {{/^rollTotal() effectiveness-roll 2}}
+                
                 <!-- Damage Roll -->
+                <!-- Dice-Based Critical Hit -->
+                {{#rollWasCrit() accuracy}}
+                {{#rollGreater() critical-damage 0}}
                 <tr>
                     <td class="label"><span>{{move-type}} Damage:</span></td>
                     <td>
                         <span class="damage-roll {{effectiveness}}-effectiveness-color">
-                            {{#rollWasCrit() accuracy}}
                             {{critical-damage}}
                             <span class="crit-damage-text {{effectiveness}}-effectiveness-text-color">
                                 Critical Hit!
                             </span>
-                            {{/rollWasCrit() accuracy}}
-                            {{#^rollWasCrit() accuracy}}
-                            {{damage}}
-                            {{/^rollWasCrit() accuracy}}
                         </span>
                     </td>
                 </tr>
+                {{/rollGreater() critical-damage 0}}
+                {{/rollWasCrit() accuracy}}
+                
+                <!-- Effect-Based Critical Hit -->
+                {{#^rollWasCrit() accuracy}}
+                {{#rollGreater() critical-damage 0}}
+                
+                {{#rollTotal() effect1_roll 99}}
+                {{#^rollLess() accuracy effect1_threshold}}
+                <tr>
+                    <td class="label"><span>{{move-type}} Damage:</span></td>
+                    <td>
+                        <span class="damage-roll {{effectiveness}}-effectiveness-color">
+                            {{critical-damage}}
+                            <span class="crit-damage-text {{effectiveness}}-effectiveness-text-color">
+                                Critical Hit!
+                            </span>
+                        </span>
+                    </td>
+                </tr>
+                {{/^rollLess() accuracy effect1_threshold}}
+                
+                <!-- Effect-Based Critical Hit Miss -->
+                {{#rollLess() accuracy effect1_threshold}}
+                <tr>
+                    <td class="label"><span>{{move-type}} Damage:</span></td>
+                    <td>
+                        <span class="damage-roll {{effectiveness}}-effectiveness-color">
+                            {{damage}}
+                        </span>
+                    </td>
+                </tr>
+                {{/rollLess() accuracy effect1_threshold}}
+                {{/rollTotal() effect1_roll 99}}
+                
+                {{/rollGreater() critical-damage 0}}
+                {{/^rollWasCrit() accuracy}}
+                
+                <!-- Regular Hit -->
+                {{#^rollWasCrit() accuracy}}
+                {{#rollGreater() damage 0}}
+                {{#rollLess() effect1_roll 99}}
+                <tr>
+                    <td class="label"><span>{{move-type}} Damage:</span></td>
+                    <td>
+                        <span class="damage-roll {{effectiveness}}-effectiveness-color">
+                            {{damage}}
+                        </span>
+                    </td>
+                </tr>
+                {{/rollLess() effect1_roll 99}}
+                {{/rollGreater() damage 0}}
+                {{/^rollWasCrit() accuracy}}
+                
+                <!-- Effect Resoluton  -->
+                {{#rollBetween() effect1_roll 1 10}}
+                {{#^rollLess() accuracy effect1_threshold}}
+                <tr>
+                    <td class="effectiveness-text" colspan="2">
+                        <span>The opponent was {{effect1_name}}</span>
+                    </td>
+                </tr>
+                {{/^rollLess() accuracy effect1_threshold}}
+                {{/rollBetween() effect1_roll 1 10}}
+                
+                {{#rollBetween() effect2_roll 1 10}}
+                {{#^rollLess() accuracy effect2_threshold}}
+                <tr>
+                    <td class="effectiveness-text" colspan="2">
+                        <span>The opponent was {{effect2_name}}</span>
+                    </td>
+                </tr>
+                {{/^rollLess() accuracy effect2_threshold}}
+                {{/rollBetween() effect2_roll 1 10}}
+                
                 <!-- Additional Notes - if there are any -->
                 {{#notes}}
                 <tr>
@@ -948,6 +1071,59 @@
        });
     });
     
+    effects = ["Critical Hit", "put to Sleep", "Burned", "Confused", "Cursed", "Frozen", "Infatuated", "Paralyzed", "Poisoned", "Toxified", "Stunned", "Other"];
+    on("sheet:opened", function (eventInfo) {
+        getSectionIDs("repeating_moves", function (idArray) {
+            const rowNames = idArray.map(id => `repeating_moves_${id}`);
+            const effect1s = idArray.map(id => `repeating_moves_${id}_move_effect1`);
+            const effect2s = idArray.map(id => `repeating_moves_${id}_move_effect2`);
+            
+            getAttrs([...effect1s, ...effect2s], function (values) {
+                const rows = rowNames.reduce((obj, rowName) => {
+                    const index1 = parseInt(values[rowName + '_move_effect1']) || 99;
+                    const index2 = parseInt(values[rowName + '_move_effect2']) || 99;
+
+                    var name = "";
+                    if (index1 < effects.length) {
+                        name = effects[index1];
+                    }
+                    obj[rowName + '_move_effect1_name'] = name;
+                    
+                    name = "";
+                    if (index2 < effects.length) {
+                        name = effects[index2];
+                    }
+                    obj[rowName + '_move_effect2_name'] = name;
+
+                    return obj;
+                }, {});
+                if (rows) setAttrs(rows);
+            });
+        });
+    });
+    
+    on("change:repeating_moves:move_effect1 change:repeating_moves:move_effect2", function (eventInfo) {
+        getAttrs(["repeating_moves_move_effect1", "repeating_moves_move_effect2"], function (values) {
+            let index1 = parseInt(values.repeating_moves_move_effect1) || 99;
+            let index2 = parseInt(values.repeating_moves_move_effect2) || 99;
+
+            var effectNames = {};
+            var name = "";
+            if (index1 < effects.length) {
+                name = effects[index1];
+            }
+            effectNames["repeating_moves_move_effect1_name"] = name;
+            
+            name = "";
+            if (index2 < effects.length) {
+                name = effects[index2];
+            }
+            effectNames["repeating_moves_move_effect2_name"] = name;
+            
+            if (effectNames) setAttrs(effectNames);
+        });
+    });
+    
     // Calculating the Move Damage Bonus
     
     categoryDamageModifiers = ["", "ATKMOD", "SPATKMOD", ""];
@@ -995,7 +1171,7 @@
             
             const categoryModifier = parseInt(values[`${categoryDamageModifiers[category]}`]) || 0;
             const total = categoryModifier + extra + stab;
-            
+
             setAttrs({
                 'repeating_moves_move_total_damage_bonus': total
             });

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -56,9 +56,9 @@ https://discord.gg/F24Ka8E
 - Initial Commit
 
 
-## To do list
-- Display the full bonus to skill checks
-- Allow modifications to movement (maybe just an extra box)
-- Prevent critical range from going below 0 or above 20, maybe do similar to other fields
-- Handle temp stat changes somehow, this may be a lot of work
-- Add a Settings page
+## To-Do:
+- [x] ~~Prevent critical range from going below 0 or above 20, maybe do similar to other fields~~
+- [ ] Display the full bonus to skill checks
+- [ ] Allow modifications to movement (maybe just an extra box)
+- [ ] Handle temp stat changes somehow, this may be a lot of work
+- [ ] Add a Settings page

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -7,6 +7,17 @@ https://discord.gg/F24Ka8E
 
 ## Changelog
 
+### Oct 28, 2020
+- Extends the move roll template functionality to make it even easier for players and GMs to resolve attacks
+  - Correctly handles critical hits for high critical hit rate moves such as Slash and Karate Chop being based on the total of the accuracy check, rather than just the raw dice roll
+  - Indicates when moves such as Poison Sting and Thunder Punch should apply their secondary effects 
+- Adds fields to the move section of the character sheet to enable assignment of secondary effects of moves, and declaration of critical hit ranges based on the accuracy roll rather than the individual dice roll
+- Resolves an issue with the total damage bonus not updating when the move fields are changed
+- Resolves an issue with the special defense target text appearing on two lines with the default Roll20 spacing of the chat log
+  - Advice for future incarnations of this is to extend the chat log a little bit; it's hopefully not an issue anymore but only the Sith deal in absolutes...
+- Updates the total damage bonus field, and adds a similar accuracy field, to show the base roll information
+  - The raw total bonus can still be accessed with the correct attributes names
+
 ### Oct 22, 2020
 - Introduces roll templates to the character sheet
 - The skill-roll template is used for skill rolls by Trainer-type characters


### PR DESCRIPTION
## Changes / Comments
- Adds support for displaying whether conditional effects are applied when making an attack using the move roll template
- Adds support in the character sheet for providing detail about conditional effects that can apply as riders to attacks
- Adds a static field that provides the total accuracy bonus, and displays the total accuracy roll, for each move
  - Refactors the previous total damage roll to provide the same benefit and functionality
- Allows the move roll template to recognise when a move requires a customised critical hit calculation and performs that to ensure critical hits are reported as accurately as possible
- Prevents the damage field from displaying if the damage would be 0 to preserve valuable chat log real estate
- Greatly extends the move roll template's ability to support homebrew moves and attacks
- Fixes an issue where the sheet worker calculating the total bonus to damage stored the value in an incorrect attribute when reacting to changes to move fields within the character sheet
  - Removing this attribute causes no loss in player data, as it was over-written every time the sheet opened anyway.



## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [x] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
