### PR TITLE
[Fate] Updates for 2020-10-29

### DIFF
--- a/Fate/FateOmni.css
+++ b/Fate/FateOmni.css
@@ -606,6 +606,7 @@ input.sheet-icon[value="blank"] + span.sheet-icon::before {
 
 .sheet-pronounbox input {
 	text-align: center;
+	max-width: 96px;
 }
 
 .sheet-Bar div {
@@ -633,6 +634,13 @@ input.sheet-icon[value="blank"] + span.sheet-icon::before {
 	opacity: 0.75;
 	font-size: 80%;
 	display: block;
+}
+
+.sheet-aspect-category {
+	text-transform: uppercase;
+	font-size: 90%;
+	display: block;
+	font-weight: bold;
 }
 
 .sheet-track .sheet-name {

--- a/Fate/FateOmni.html
+++ b/Fate/FateOmni.html
@@ -63,6 +63,7 @@
 		<span><input type="checkbox" class="checkbox" name="attr_Show-Corruption" value="1"><span class="checker" data-i18n="corruption">Corruption</span> </span>
 		<span><input type="checkbox" class="checkbox" name="attr_Show-Extras" value="1"><span class="checker" data-i18n="extras">Extras</span> </span>
 		<span><input type="checkbox" class="checkbox" name="attr_Show-FP" value="1" checked><span class="checker" data-i18n="fp">Fate Points</span> </span>
+		<span><input type="checkbox" class="checkbox" name="attr_Show-Logo" value="1"><span class="checker" data-i18n="logo">Logo</span> </span>
 		<span><input type="checkbox" class="checkbox" name="attr_Show-Modes" value="1"><span class="checker" data-i18n="modes">Modes</span> </span>
 		<span><input type="checkbox" class="checkbox" name="attr_Show-Notes" value="1" checked><span class="checker" data-i18n="notes">Notes</span> </span>
 		<span><input type="checkbox" class="checkbox" name="attr_Show-Powers" value="1"><span class="checker" data-i18n="powers">Powers</span> </span>
@@ -90,6 +91,9 @@
 	</div>
 
 	<div class="topwrap">
+		<input type="checkbox" class="triggerbox" name="attr_Show-Logo" value="1"><div>
+			<img src="https://raw.githubusercontent.com/fredhicks/ehp-roll20/master/art/fate-logo.png" width="130" height="53" style="margin-left: 12px;"/>
+		</div>
 		<div class="fpbox">
 			<input type="checkbox" class="triggerbox" checked name="attr_Show-FP" value="1">
 			<div>
@@ -1020,19 +1024,20 @@
 							</div>
 							<div class="track">
 								<b style="font-size: 80%;"><span data-i18n="track-length"></span>:</b>
-								<input type="number" name="attr_track" value="1" min="1" max="9" class="compact">
+								<input type="number" name="attr_track" value="1" min="1" max="10" class="compact">
 							</div>
 							<div class="track">
 								<input type="hidden" name="attr_track" value="1" class="hideAllBut">
-								<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track1">
-								<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track2">
-								<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track3">
-								<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track4">
-								<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track5">
-								<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track6">
-								<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track7">
-								<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track8">
-								<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track9">
+								<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track1">
+								<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track2">
+								<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track3">
+								<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track4">
+								<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track5">
+								<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track6">
+								<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track7">
+								<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track8">
+								<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track9">
+								<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track10">
 							</div>
 							<div class="permissions cost aspect note stunt">
 								<textarea name="attr_text" rows=2 class="squat"></textarea>
@@ -1151,6 +1156,7 @@
 										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check7" value="1"><span class="tracker" name="attr_track7"></span></span>
 										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check8" value="1"><span class="tracker" name="attr_track8"></span></span>
 										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check9" value="1"><span class="tracker" name="attr_track9"></span></span>
+										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check10" value="1"><span class="tracker" name="attr_track10"></span></span>
 									</span>
 									<span name="attr_name"></span>
 								</div>
@@ -1222,6 +1228,8 @@
 						<input type="checkbox" class="deeptrigger" name="attr_Show-RollableAspects" value="1">
 						<fieldset class="repeating_aspects">
 							<div class="AspectSeparator">
+								<div class="fieldlabel" data-i18n="category header optional">Category Header (optional)</div>
+								<input name="attr_category" type="text" value="">
 								<div class="fieldlabel" data-i18n="label">Label</div>
 								<input name="attr_label" type="text" value="Aspect">
 								<div class="fieldlabel" data-i18n="aspect">Aspect</div>
@@ -1245,6 +1253,7 @@
 					<div class="AspectDisplay">
 						<input type="checkbox" class="deeptrigger" name="attr_Show-RollableAspects" value="1">
 						<fieldset class="repeating_aspects">
+							<input type="hidden" name="attr_category" value="" class="hideIfNull"><div class="aspect-category"><span name="attr_category"></span></div>
 							<div class="aspect">
 								<div class="AspectLabelBar">
 									<span class="label">
@@ -1367,20 +1376,21 @@
 								<input name="attr_label" type="text">
 								<div class="fieldlabel">
 									<span data-i18n="track-length">Track Length</span>
-									<select name="attr_track" style="width: 20%"><option selected>1</option> <option>2</option> <option>3</option> <option>4</option> <option>5</option> <option>6</option> <option>7</option> <option>8</option> <option>9</option></select>
+									<select name="attr_track" style="width: 20%"><option selected>1</option> <option>2</option> <option>3</option> <option>4</option> <option>5</option> <option>6</option> <option>7</option> <option>8</option> <option>9</option> <option>10</option></select>
 								</div>
 								<div class="fieldlabel" data-i18n="box-values">Box Values</div>
 								<div>
 									<input type="hidden" name="attr_track" value="1" class="hideAllBut">
-									<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track1">
-									<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track2">
-									<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track3">
-									<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track4">
-									<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track5">
-									<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track6">
-									<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track7">
-									<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track8">
-									<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track9">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track1">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track2">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track3">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track4">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track5">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track6">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track7">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track8">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track9">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track10">
 								</div>
 								<div class="fieldlabel" data-i18n="notes">Notes</div>
 								<input name="attr_notes" type="text" style="width: 100%;">
@@ -1410,7 +1420,7 @@
 											<div class="nowrap">
 												<span class="fieldlabel" data-i18n="track-length">Track Length</span>
 												<select name="attr_track" style="width: 20%">
-													<option selected>1</option> <option>2</option> <option>3</option> <option>4</option> <option>5</option> <option>6</option> <option>7</option> <option>8</option> <option>9</option>
+													<option selected>1</option> <option>2</option> <option>3</option> <option>4</option> <option>5</option> <option>6</option> <option>7</option> <option>8</option> <option>9</option> <option>10</option>
 												</select>
 											</div>
 											<div>
@@ -1435,6 +1445,7 @@
 										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check7" value="1"><span class="tracker" name="attr_track7"></span></span>
 										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check8" value="1"><span class="tracker" name="attr_track8"></span></span>
 										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check9" value="1"><span class="tracker" name="attr_track9"></span></span>
+										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check10" value="1"><span class="tracker" name="attr_track10"></span></span>
 									</span>
 								</div>
 							</div>
@@ -1534,20 +1545,21 @@
 								<input name="attr_label" type="text">
 								<div class="fieldlabel">
 									<span data-i18n="track-length">Track Length</span>
-									<select name="attr_track" style="width: 20%"><option selected>1</option> <option>2</option> <option>3</option> <option>4</option> <option>5</option> <option>6</option> <option>7</option> <option>8</option> <option>9</option></select>
+									<select name="attr_track" style="width: 20%"><option selected>1</option> <option>2</option> <option>3</option> <option>4</option> <option>5</option> <option>6</option> <option>7</option> <option>8</option> <option>9</option> <option>10</option></select>
 								</div>
 								<div class="fieldlabel" data-i18n="box-values">Box Values</div>
 								<div>
 									<input type="hidden" name="attr_track" value="1" class="hideAllBut">
-									<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track1">
-									<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track2">
-									<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track3">
-									<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track4">
-									<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track5">
-									<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track6">
-									<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track7">
-									<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track8">
-									<input type="text" value="" maxlength="1" size="1" class="tracker" name="attr_track9">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track1">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track2">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track3">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track4">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track5">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track6">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track7">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track8">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track9">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track10">
 								</div>
 								<div class="fieldlabel" data-i18n="notes">Notes</div>
 								<input name="attr_notes" type="text" style="width: 100%;">
@@ -1602,6 +1614,7 @@
 										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check7" value="1"><span class="tracker" name="attr_track7"></span></span>
 										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check8" value="1"><span class="tracker" name="attr_track8"></span></span>
 										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check9" value="1"><span class="tracker" name="attr_track9"></span></span>
+										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check10" value="1"><span class="tracker" name="attr_track10"></span></span>
 									</span>
 								</div>
 							</div>
@@ -1629,7 +1642,7 @@
 								<input name="attr_aspect" type="text">
 								<div class="fieldlabel">
 									<span data-i18n="free-invokes">Free Invokes</span>
-									<select name="attr_invokes" style="width: 20%"><option value="">0</option> <option selected>1</option> <option>2</option> <option>3</option> <option>4</option> <option>5</option> <option>6</option> <option>7</option> <option>8</option> <option>9</option> <option>10</option></select>
+									<select name="attr_invokes" style="width: 20%"><option>0</option> <option selected>1</option> <option>2</option> <option>3</option> <option>4</option> <option>5</option> <option>6</option> <option>7</option> <option>8</option> <option>9</option> <option>10</option></select>
 								</div>
 								<div class="fieldlabel" data-i18n="notes">Notes</div>
 								<input name="attr_notes" type="text" style="width: 100%;">
@@ -1661,7 +1674,7 @@
 											<div class="nowrap">
 												<span class="fieldlabel" data-i18n="free-invokes">Free Invokes</span>
 												<select name="attr_invokes" style="width: 20%">
-													<option value="">0</option> <option selected>1</option> <option>2</option> <option>3</option> <option>4</option> <option>5</option> <option>6</option> <option>7</option> <option>8</option> <option>9</option> <option>10</option>
+													<option>0</option> <option>1</option> <option>2</option> <option>3</option> <option>4</option> <option>5</option> <option>6</option> <option>7</option> <option>8</option> <option>9</option> <option>10</option>
 												</select>
 											</div>
 											<div>
@@ -1702,7 +1715,7 @@
 	<hr/>
 
 	<div>
-		<i>This Fate sheet was created by Evil Hat Productions. Some portions of the text here are &copy; Evil Hat Productions, LLC.</i> 
+		<i>This Fate sheet was created by Evil Hat Productions. Some portions of the text here are &copy; Evil Hat Productions, LLC. The Fate logo is &trade; Evil Hat Productions, LLC and may not be used elsewhere without permission.</i> 
 	</div>
 	<div class="space-above">
 		<i>Problems, suggestions, other feedback? Reach out to us at feedback@evilhat.com or via the contact form on our website, https://www.evilhat.com/</i>

--- a/Fate/sheet.json
+++ b/Fate/sheet.json
@@ -4,7 +4,7 @@
 	"authors": "Fred Hicks (Evil Hat Productions)",
 	"roll20userid": "3844812 (Evil Hat Productions)",
 	"preview": "FateOmni.png",
-	"instructions": "For more information about this highly versatile sheet, check out our series of posts at Evil Hat: https://www.evilhat.com/home/fate-on-roll20-part-1-character-sheet-setup/ -- and if you run into any issues, have suggestions, or anything else, please reach out to Evil Hat at feedback@evilhat.com.",
+	"instructions": "For more information about this highly versatile sheet, check out our series of posts at Evil Hat: https://www.evilhat.com/home/fate-on-roll20-part-1-character-sheet-setup/ -- and if you run into any issues, have suggestions, or anything else, please reach out to Evil Hat at feedback@evilhat.com. If you're a sheet developer and looking to make changes to this sheet's code, don't. We maintain an external copy as the authoritative source; problems that emerge with the sheet are our customer service problem, not yours. Changes you make are likely to be erased. So talk to us before making changes.",
 	"useroptions": [  
 		{
 			"attribute": "setgame",

--- a/Fate/translation.json
+++ b/Fate/translation.json
@@ -332,5 +332,7 @@
 	"Shapeshift": "Shapeshift",
 	"Thieving": "Thieving",
 	"Wisdom": "Wisdom",
+	"category header optional": "Category Header (optional)",
+	"logo": "Logo",
 	"zzzz-end-of-json": "<!-- End of JSON File -->"
 }


### PR DESCRIPTION
## Changes / Comments

- Pronoun box given more width
- Aspects can now have an optional category header to divide sections up if desired
- Sheet preferences now include the ability to toggle on or off a Fate logo (defaults to off)
- Stress and Condition tracks can now go up to 10 in length
- Situation aspects with zero free invokes were getting turned into one free invoke situation aspects; this was a bug. Fixed now, zero free invoke situation aspects should work correctly now.

None of these should affect existing stored data for characters already in use.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
