### PR TITLE
[Lex Arcana] fix encumbrance box 19

### DIFF
--- a/Lex Arcana/LexArcana.html
+++ b/Lex Arcana/LexArcana.html
@@ -407,7 +407,7 @@
                         <td>
                             19<br />
                             <input type="checkbox" title="punti vita" data-i18n-title="hit-points" name="attr_hp_19" />
-                            <input type="checkbox" title="ingombro" data-i18n-title="encumbrance" name="attr_eng_14" />
+                            <input type="checkbox" title="ingombro" data-i18n-title="encumbrance" name="attr_eng_19" />
                         </td>
                         <td>
                             18<br />


### PR DESCRIPTION
## Changes / Comments
This is a minor bug fix to remove a defect where the checkbox for the encumbrance 19 and 14 had a clashing name.
