### PR TITLE
[Quest] correct name in approved.yaml

### DIFF
--- a/approved.yaml
+++ b/approved.yaml
@@ -2862,8 +2862,8 @@ qinwarringstates:
 #QUEST RPG
 questrpg:
   - "Quest-rpg"
-  - "Quest-rpg"
-  - "Quest RPG"
+  - "Quest"
+  - "Quest"
 
 radiance:
   - "Radiance"


### PR DESCRIPTION
## Changes / Comments

As confusing as it is, the creators of the game have simply named it as "Quest", not "Quest RPG" or anything like that. O, it doesn't help that the publisher have a very generic name "The Adventure Guild, LLC", and a generic URL to their homepage. 

Source: publisher homepage: https://www.adventure.game/




## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
