### PR TITLE
[Old-School Essentials by Necrotic Gnome] - 1.7.0

### DIFF
--- a/Old School Essentials - AAC/CHANGELOG.md
+++ b/Old School Essentials - AAC/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [GitHub Project Status board](https://github.com/wesbaker/roll20-character-sheets/projects/1)
 
+## 1.6.3
+
+### Fixed
+
+- Fix a bug where the spell level input was wider than the space in the grid
+
 ## 1.6.2
 
 ### Fixed

--- a/Old School Essentials - AAC/CHANGELOG.md
+++ b/Old School Essentials - AAC/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 [GitHub Project Status board](https://github.com/wesbaker/roll20-character-sheets/projects/1)
 
-## 1.6.3
+## 1.7.0
+
+### Added
+
+- Add retainers tab for charisma based retainer modifiers
 
 ### Fixed
 

--- a/Old School Essentials - AAC/CHANGELOG.md
+++ b/Old School Essentials - AAC/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - Fix a bug where the spell level input was wider than the space in the grid
+- Fix a bug where setting the default sheet to DAC wouldn't create DAC characters
 
 ## 1.6.2
 

--- a/Old School Essentials - AAC/OSE-AAC.css
+++ b/Old School Essentials - AAC/OSE-AAC.css
@@ -208,6 +208,7 @@ div.sheet-flex > .sheet-shrink {
 }
 
 .charsheet .sheet-inline-flex-wide-label > *:first-child,
+.charsheet .sheet-inline-flex-wide-label > span:first-child,
 .charsheet .sheet-inline-flex-wide-label > button:first-child {
   flex-grow: 3;
 }
@@ -657,6 +658,7 @@ input.sheet-expand:checked ~ input.sheet-weapon-description {
 /* Tabs */
 
 .sheet-character,
+.sheet-retainers,
 .sheet-monster,
 .sheet-notes,
 .sheet-settings {
@@ -664,6 +666,7 @@ input.sheet-expand:checked ~ input.sheet-weapon-description {
 }
 
 input[name="attr_sheetTab"][value="character"] ~ div.sheet-character,
+input[name="attr_sheetTab"][value="retainers"] ~ div.sheet-retainers,
 input[name="attr_sheetTab"][value="monster"] ~ div.sheet-monster,
 input[name="attr_sheetTab"][value="notes"] ~ div.sheet-notes,
 input[name="attr_sheetTab"][value="settings"] ~ div.sheet-settings {
@@ -689,6 +692,9 @@ input[name="attr_sheetTab"][value="settings"] ~ div.sheet-settings {
 input[name="attr_sheetTab"][value="character"]
   ~ .sheet-button-select
   button[name="act_character"],
+input[name="attr_sheetTab"][value="retainers"]
+  ~ .sheet-button-select
+  button[name="act_retainers"],
 input[name="attr_sheetTab"][value="monster"]
   ~ .sheet-button-select
   button[name="act_monster"],

--- a/Old School Essentials - AAC/OSE-AAC.html
+++ b/Old School Essentials - AAC/OSE-AAC.html
@@ -14,6 +14,7 @@
   <button type="action" name="act_character" data-i18n="character">
     Character
   </button>
+  <button type="action" name="act_retainers" data-i18n="retainers">Retainers</button>
   <button type="action" name="act_monster" data-i18n="monster">Monster</button>
   <button type="action" name="act_notes" data-i18n="notes">Notes</button>
   <button type="action" name="act_settings" data-i18n="settings">
@@ -645,6 +646,26 @@
   <div class="sheet-notes-section">
     <h1 data-i18n="notes">Notes</h1>
     <textarea name="attr_characterNotes"></textarea>
+  </div>
+</div>
+
+<div class="sheet-retainers">
+  <div>
+    <h1 data-i18n="retainer-modifiers">Retainer Modifiers</h1>
+    <div class="flex">
+      <label class="inline-flex inline-flex-wide-label">
+        <span data-i18n="npc-reaction">NPC Reaction</span>
+        <input type="number" readOnly name="attr_chaMod" value="0" />
+      </label>
+      <label class="inline-flex inline-flex-wide-label">
+        <span data-i18n="max-retainers">Max Retainers</span>
+        <input type="number" readOnly name="attr_retainersMax" value="0" />
+      </label>
+      <label class="inline-flex inline-flex-wide-label">
+        <span data-i18n="loyalty">Loyalty</span>
+        <input type="number" readOnly name="attr_retainersLoyalty" value="0" />
+      </label>
+    </div>
   </div>
 </div>
 
@@ -1380,7 +1401,7 @@
   });
 
   // Tabs
-  const buttonlist = ["character", "monster", "notes", "settings"];
+  const buttonlist = ["character", "retainers", "monster", "notes", "settings"];
   buttonlist.forEach((button) => {
     on(`clicked:${button}`, function (event) {
       setAttrs({ sheetTab: button });
@@ -1440,6 +1461,20 @@
       setAttrs({ wisMod: getModifiers(values.wis) });
     });
   });
+  on("sheet:opened change:cha", function () {
+    getAttrs(["cha"], function (values) {
+      const [chaMod, retainersMax, retainersLoyalty] = getModifiers(values.cha, [
+        [-2, 1, 4],
+        [-1, 2, 5],
+        [-1, 3, 6],
+        [0, 4, 7],
+        [1, 5, 8],
+        [1, 6, 9],
+        [2, 7, 10]
+      ]);
+      setAttrs({ chaMod, retainersMax, retainersLoyalty })
+    })
+  })
 
   /**
    * Given a value and set of modifiers, return the correct modifiers

--- a/Old School Essentials - AAC/OSE-AAC.html
+++ b/Old School Essentials - AAC/OSE-AAC.html
@@ -561,7 +561,7 @@
           value="0" />
         <input type="text" name="attr_spellName" placeholder="Spell Name"
           data-i18n-placeholder="spell-name-placeholder" />
-        <input type="input" min="1" name="attr_spellLevel" value="1" />
+        <input type="number" min="1" name="attr_spellLevel" value="1" />
         <input type="text" name="attr_spellDuration" />
         <input type="text" name="attr_spellRange" />
         <input type="text" name="attr_spellDescription" placeholder="Description" data-i18n-placeholder="description" />

--- a/Old School Essentials - AAC/OSE-AAC.html
+++ b/Old School Essentials - AAC/OSE-AAC.html
@@ -302,7 +302,7 @@
           </label>
         </div>
         <!-- Armor Class Fields are dependent on AAC vs DAC -->
-        <input type="hidden" name="attr_armorClassType" value="aac" />
+        <input type="hidden" name="attr_armorClassType" />
         <div class="flex armor armor-aac">
           <label class="inline-flex">
             <span data-i18n="armor-class-abbr" title="Armor Class" data-i18n-title="armor-class">AC</span>
@@ -391,7 +391,7 @@
         </label>
       </div>
     </div>
-    <input type="hidden" name="attr_armorClassType" value="aac" />
+    <input type="hidden" name="attr_armorClassType" />
     <div class="matrix">
       <h2>Attack Value Matrix</h2>
       <div class="flex grid-spacing">
@@ -450,7 +450,7 @@
       <span data-i18n="damage-modifier">+Damage</span>
       <span data-i18n="weight">Weight</span>
     </div>
-    <input type="hidden" name="attr_armorClassType" value="aac" />
+    <input type="hidden" name="attr_armorClassType" />
     <fieldset class="repeating_weapons">
       <input type="hidden" name="attr_weaponAttributeBonus" value="@{BonusSTR}" />
       <input type="hidden" name="attr_weaponAttributeBonusDamage" value="@{BonusSTR}" />
@@ -787,7 +787,7 @@
             </button>
             <input type="number" name="attr_initiative" value="0" />
           </label>
-          <input type="hidden" name="attr_armorClassType" value="aac" />
+          <input type="hidden" name="attr_armorClassType" />
           <label class="inline-flex show-aac">
             <span data-i18n="base-attack-bonus-abbr" title="Base Attack Bonus"
               data-i18n-title="base-attack-bonus">BAB</span>
@@ -827,7 +827,7 @@
         </table>
       </div>
     </div>
-    <input type="hidden" name="attr_armorClassType" value="aac" />
+    <input type="hidden" name="attr_armorClassType" />
     <div class="matrix">
       <h2>Attack Value Matrix</h2>
       <div class="flex grid-spacing">
@@ -885,7 +885,7 @@
       <span data-i18n="damage">Damage</span>
       <span data-i18n="description">Description</span>
     </div>
-    <input type="hidden" name="attr_armorClassType" value="aac" />
+    <input type="hidden" name="attr_armorClassType" />
     <fieldset class="repeating_weapons">
       <div class="weapons-grid">
         <!-- AAC Attack -->
@@ -1021,7 +1021,7 @@
   <label class="setting">
     <span data-i18n="armor-class-type">Armor Class Type</span>
     <select name="attr_armorClassType">
-      <option value="aac" selected data-i18n="ascending-armor-class">Ascending Armor Class</option>
+      <option value="aac" data-i18n="ascending-armor-class">Ascending Armor Class</option>
       <option value="dac" data-i18n="descending-armor-class">Descending Armor Class</option>
     </select>
   </label>

--- a/Old School Essentials - AAC/OSE-AAC.html
+++ b/Old School Essentials - AAC/OSE-AAC.html
@@ -1491,15 +1491,15 @@
               });
             }
           } else if (attackType.toLowerCase() === 'melee') {
-              setAttrs({
-                [`repeating_weapons_${id}_weaponAttributeBonus`]: values.BonusSTR,
-                [`repeating_weapons_${id}_weaponAttributeBonusDamage`]: values.BonusSTR,
-              });
+            setAttrs({
+              [`repeating_weapons_${id}_weaponAttributeBonus`]: values.BonusSTR,
+              [`repeating_weapons_${id}_weaponAttributeBonusDamage`]: values.BonusSTR,
+            });
           } else if (attackType.toLowerCase() === 'ranged') {
-              setAttrs({
-                [`repeating_weapons_${id}_weaponAttributeBonus`]: values.BonusDEX,
-                [`repeating_weapons_${id}_weaponAttributeBonusDamage`]: "0",
-              });
+            setAttrs({
+              [`repeating_weapons_${id}_weaponAttributeBonus`]: values.BonusDEX,
+              [`repeating_weapons_${id}_weaponAttributeBonusDamage`]: "0",
+            });
           }
         });
       });
@@ -1520,15 +1520,19 @@
   // Armor Calculation
   on("sheet:opened change:dex change:repeating_armor remove:repeating_armor",
     function () {
-      repeatingSum("ArmorWorn", "armor", "armorWorn", { callback: () => {
-        repeatingSum("ArmorTotal", "armor", ["armorValue", "armorWorn"], { callback: () => {
-          getAttrs(["ArmorWorn", "ArmorTotal", "BonusDEX", "aacAcUnarmored", "dacAcUnarmored"], function(values) {
-            const aacAc = values.ArmorWorn > 0 ? values.ArmorTotal + values.BonusDEX : values.aacAcUnarmored;
-            const dacAc = values.ArmorWorn > 0 ? values.ArmorTotal - values.BonusDEX : values.dacAcUnarmored;
-            setAttrs({ aacAc, dacAc });
-          })
-        }});
-      }});
+      repeatingSum("ArmorWorn", "armor", "armorWorn", {
+        callback: () => {
+          repeatingSum("ArmorTotal", "armor", ["armorValue", "armorWorn"], {
+            callback: () => {
+              getAttrs(["ArmorWorn", "ArmorTotal", "BonusDEX", "aacAcUnarmored", "dacAcUnarmored"], function (values) {
+                const aacAc = values.ArmorWorn > 0 ? values.ArmorTotal + values.BonusDEX : values.aacAcUnarmored;
+                const dacAc = values.ArmorWorn > 0 ? values.ArmorTotal - values.BonusDEX : values.dacAcUnarmored;
+                setAttrs({ aacAc, dacAc });
+              })
+            }
+          });
+        }
+      });
     }
   );
 
@@ -1599,7 +1603,7 @@
   });
   function setAttackMatrix(thac0) {
     const matrix = {};
-    for (let ac = 0; ac < 10; ac++) {
+    for (let ac = 0; ac < 10; ac++) {
       matrix[`attackMatrix${ac}`] = Math.min(thac0 - ac, 20);
     }
     setAttrs(matrix);
@@ -1620,7 +1624,7 @@
   });
   function setAttackMatrix(thac0, type = 'attackMatrix') {
     const matrix = {};
-    for (let ac = 0; ac < 10; ac++) {
+    for (let ac = 0; ac < 10; ac++) {
       matrix[`${type}${ac}`] = Math.min(thac0 - ac, 20);
     }
     setAttrs(matrix);

--- a/Old School Essentials - AAC/translation.json
+++ b/Old School Essentials - AAC/translation.json
@@ -170,5 +170,10 @@
   "gold": "Gold",
   "electrum": "Electrum",
   "silver": "Silver",
-  "copper": "Copper"
+  "copper": "Copper",
+  "retainers": "Retainers",
+  "retainer-modifiers": "Retainer Modifiers",
+  "npc-reaction": "NPC Reaction",
+  "max-retainers": "Max Retainers",
+  "loyalty": "Loyalty"
 }


### PR DESCRIPTION
## Changes / Comments

### Added

- Add retainers tab for charisma based retainer modifiers. Closes wesbaker#14

### Fixed

- Fix a bug where the spell level input was wider than the space in the grid. Closes wesbaker#51
- Fix a bug where setting the default sheet to DAC wouldn't create DAC characters. Closes wesbaker#54

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [X] Does this add functional enhancements (new features or extending existing features) ?
- [X] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
