### PR TITLE
Revert "Fix to Character sheet ImperioDeJade.html"

### DIFF
--- a/Império De Jade/ImperioDeJade.html
+++ b/Império De Jade/ImperioDeJade.html
@@ -371,10 +371,10 @@
                     </div>
                     <div class="sheet-row">
                         <fieldset class="repeating_armas">
-                            <input type="hidden" name="attr_ataquemelee" value="{{corpoacorpo=[[1d20cs>@{critrangearma}+(@{CorpoaCorpo})+(@{bonusarma})]]}}">
-                            <input type="hidden" name="attr_ataqueranged" value="{{adistancia=[[1d20cs>@{critrangearma}+(@{ADistancia})+(@{bonusarma})]]}}">
+                            <input type="hidden" name="attr_ataquemelee" value="{{corpoacorpo=[[1d20cs>@{critrangearma}+(@{CorpoaCorpo})-(@{for_mod})+(@{atributochavearma})+(@{bonusarma})]]}}">
+                            <input type="hidden" name="attr_ataqueranged" value="{{adistancia=[[1d20cs>@{critrangearma}+(@{ADistancia})-(@{des_mod})+(@{atributochavearma})+(@{bonusarma})]]}}">
                             <input type="hidden" name="attr_tipoataquearma">
-                            <button type="roll" value="&{template:trpg} {{nome=@{Char_Name}}} {{efeitoarma=@{efeitoarma}}} {{nomearma=@{nomearma}}} {{rangearma=@{rangearma}}} {{corpoacorpo=[[1d20cs>(@{critrangearma} - 1)+(@{CorpoaCorpo})+(@{bonusarma})]]}} {{adistancia=[[1d20cs>(@{critrangearma} - 1)+(@{ADistancia})+(@{bonusarma})]]}} {{crit=[[(@{danoarma})*@{multiplierarma}]]}}  {{dano=[[@{danoarma}]]}} {{tipodano=@{tipoarma}}}" style="margin-left:2px;border-radius: 10px; border:1px solid #ccc; background-color:white">
+                            <button type="roll" value="&{template:trpg} {{nome=@{Char_Name}}} {{efeitoarma=@{efeitoarma}}} {{nomearma=@{nomearma}}} {{rangearma=@{rangearma}}} {{corpoacorpo=[[1d20cs>@{critrangearma}+(@{CorpoaCorpo})-(@{for_mod})+(@{atributochavearma})+(@{bonusarma})]]}} {{adistancia=[[1d20cs>@{critrangearma}+(@{ADistancia})-(@{des_mod})+(@{atributochavearma})+(@{bonusarma})]]}} {{crit=[[(@{danoarma})*@{multiplierarma}]]}}  {{dano=[[@{danoarma}]]}} {{tipodano=@{tipoarma}}}" style="margin-left:2px;border-radius: 10px; border:1px solid #ccc; background-color:white">
                                 <div class="sheet-texto" style="line-height:20px;margin-left:-1px;border-bottom: 1px solid black; width:150px;">
                                     <span name="attr_nomearma"></span><input type="hidden" name="attr_nomearma">
                                 </div> 


### PR DESCRIPTION
Reverts Roll20/roll20-character-sheets#7613

The previous modifications totally broke the character sheet.

About the Critical:
"1d20cs>(@{critrangearma} - 1)" will aways return 1, without rolling dice. Besides, the old macro was totally right. Even if this modification was not breaking the rolls, it would be breaking the game rules, basically increasing the critical range of the weapon by 1.

About the attributes that were removed from the attack rolls, they were there for a reason. The logic is messy, but they allow you to change the main attribute from your attack.

(I appologise by my grammar, i had a busy day and I'm quite tired. Thanks for you attention).
