### PR TITLE
[Ironsworn][Fix] Added missing page numbers and corrected Ask the Oracle logic.

### DIFF
--- a/Ironsworn/Ironsworn.html
+++ b/Ironsworn/Ironsworn.html
@@ -5544,7 +5544,7 @@
                                   <div class="move-description">
                                     <p>When <strong>you focus on your skills, receive training, find inspiration, earn a reward, or gain a companion,</strong> you may spend 3 experience to add a new asset, or 2 experience to upgrade an asset.</p>
                                   </div>
-                                  <div class="oracle-footer move-page-footer">Ironsworn - page X</div>
+                                  <div class="oracle-footer move-page-footer">Ironsworn - page 103</div>
                           </div>
                           <input class="advance-a-threat hide" type="radio" name="attr_move_preview" value="advance_a_threat"/>
                           <div class="advance-a-threat showhide">
@@ -5572,7 +5572,7 @@
                                   <div class="move-description">
                                     <p>When <strong>you <em>Secure an Advantage</em> in direct support of an ally,</strong> and score a hit, they (instead of you) can take the benefits of the move. If you are in combat and score a <strong>strong hit,</strong> you and your ally have initiative.</p>
                                   </div>
-                                  <div class="oracle-footer move-page-footer">Ironsworn - page X</div>
+                                  <div class="oracle-footer move-page-footer">Ironsworn - page 76</div>
                           </div>
                           <input class="ask-the-oracle hide" type="radio" name="attr_move_preview" value="ask_the_oracle"/>
                           <div class="ask-the-oracle showhide">
@@ -6315,7 +6315,7 @@
                                     <p>On a <strong>weak hit,</strong> you arrive but face an unforeseen hazard or complication. Envision what you find (<em>Ask the Oracle</em> if unsure).</p>
                                     <p>On a <strong>miss,</strong> you have gone hopelessly astray, your objective is lost to you, or you were misled about your destination. If your journey continues, clear all but one filled progress, and raise the journey’s rank by one (if not already epic).</p>
                                   </div>
-                                  <div class="oracle-footer move-page-footer">Ironsworn - page X</div>
+                                  <div class="oracle-footer move-page-footer">Ironsworn - page 68</div>
                           </div>
                           <input class="resupply hide" type="radio" name="attr_move_preview" value="resupply"/>
                           <div class="resupply showhide">
@@ -11519,81 +11519,251 @@
     <div class="sheet-result-row">
       <div class="sheet-oracle-dice"><span>{{almostCertain}}</span></div>
       <div class="sheet-oracle-table-text"><span>Yes</span></div>
-    </div>{{#rollTotal() almostCertain 11}}
-    <div class="sheet-result-row">
-      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
-    </div>{{/rollTotal() almostCertain 11}}
-    {{/rollBetween() almostCertain 11 100}}
+    </div>{{/rollBetween() almostCertain 11 100}}
     {{#^rollBetween() almostCertain 11 100}}
     <div class="sheet-result-row">
       <div class="sheet-oracle-dice"><span>{{almostCertain}}</span></div>
       <div class="sheet-oracle-table-text"><span>No</span></div>
-    </div>{{/^rollBetween() almostCertain 11 100}}
-    {{/almostCertain}}
+    </div>{{/^rollBetween() almostCertain 11 100}}{{#rollTotal() almostCertain 11}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 11}}
+    {{#rollTotal() almostCertain 22}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 22}}
+    {{#rollTotal() almostCertain 33}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 33}}
+    {{#rollTotal() almostCertain 44}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 44}}
+    {{#rollTotal() almostCertain 55}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 55}}
+    {{#rollTotal() almostCertain 66}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 66}}
+    {{#rollTotal() almostCertain 77}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 77}}
+    {{#rollTotal() almostCertain 88}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 88}}
+    {{#rollTotal() almostCertain 99}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 99}}
+    {{#rollTotal() almostCertain 100}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 100}}{{/almostCertain}}
     {{#likely}}
     {{#rollBetween() likely 26 100}}
     <div class="sheet-result-row">
       <div class="sheet-oracle-dice"><span>{{likely}}</span></div>
       <div class="sheet-oracle-table-text"><span>Yes</span></div>
-    </div>{{#rollTotal() likely 26}}
-    <div class="sheet-result-row">
-      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
-    </div>{{/rollTotal() likely 26}}
-    {{/rollBetween() likely 26 100}}
+    </div>{{/rollBetween() likely 26 100}}
     {{#^rollBetween() likely 26 100}}
     <div class="sheet-result-row">
       <div class="sheet-oracle-dice"><span>{{likely}}</span></div>
       <div class="sheet-oracle-table-text"><span>No</span></div>
-    </div>{{/^rollBetween() likely 26 100}}
-    {{/likely}}
+    </div>{{/^rollBetween() likely 26 100}}{{#rollTotal() almostCertain 11}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 11}}
+    {{#rollTotal() almostCertain 22}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 22}}
+    {{#rollTotal() almostCertain 33}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 33}}
+    {{#rollTotal() almostCertain 44}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 44}}
+    {{#rollTotal() almostCertain 55}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 55}}
+    {{#rollTotal() almostCertain 66}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 66}}
+    {{#rollTotal() almostCertain 77}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 77}}
+    {{#rollTotal() almostCertain 88}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 88}}
+    {{#rollTotal() almostCertain 99}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 99}}
+    {{#rollTotal() almostCertain 100}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 100}}{{/likely}}
     {{#fiftyFifty}}
     {{#rollBetween() fiftyFifty 51 100}}
     <div class="sheet-result-row">
       <div class="sheet-oracle-dice"><span>{{fiftyFifty}}</span></div>
       <div class="sheet-oracle-table-text"><span>Yes</span></div>
-    </div>{{#rollTotal() fiftyFifty 51}}
-    <div class="sheet-result-row">
-      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
-    </div>{{/rollTotal() fiftyFifty 51}}
-    {{/rollBetween() fiftyFifty 51 100}}
+    </div>{{/rollBetween() fiftyFifty 51 100}}
     {{#^rollBetween() fiftyFifty 51 100}}
     <div class="sheet-result-row">
       <div class="sheet-oracle-dice"><span>{{fiftyFifty}}</span></div>
       <div class="sheet-oracle-table-text"><span>No</span></div>
-    </div>{{/^rollBetween() fiftyFifty 51 100}}
-    {{/fiftyFifty}}
+    </div>{{/^rollBetween() fiftyFifty 51 100}}{{#rollTotal() almostCertain 11}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 11}}
+    {{#rollTotal() almostCertain 22}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 22}}
+    {{#rollTotal() almostCertain 33}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 33}}
+    {{#rollTotal() almostCertain 44}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 44}}
+    {{#rollTotal() almostCertain 55}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 55}}
+    {{#rollTotal() almostCertain 66}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 66}}
+    {{#rollTotal() almostCertain 77}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 77}}
+    {{#rollTotal() almostCertain 88}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 88}}
+    {{#rollTotal() almostCertain 99}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 99}}
+    {{#rollTotal() almostCertain 100}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 100}}{{/fiftyFifty}}
     {{#unlikely}}
     {{#rollBetween() unlikely 76 100}}
     <div class="sheet-result-row">
       <div class="sheet-oracle-dice"><span>{{unlikely}}</span></div>
       <div class="sheet-oracle-table-text"><span>Yes</span></div>
-    </div>{{#rollTotal() unlikely 76}}
-    <div class="sheet-result-row">
-      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
-    </div>{{/rollTotal() unlikely 76}}
-    {{/rollBetween() unlikely 76 100}}
+    </div>{{/rollBetween() unlikely 76 100}}
     {{#^rollBetween() unlikely 76 100}}
     <div class="sheet-result-row">
       <div class="sheet-oracle-dice"><span>{{unlikely}}</span></div>
       <div class="sheet-oracle-table-text"><span>No</span></div>
-    </div>{{/^rollBetween() unlikely 76 100}}
-    {{/unlikely}}
+    </div>{{/^rollBetween() unlikely 76 100}}{{#rollTotal() almostCertain 11}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 11}}
+    {{#rollTotal() almostCertain 22}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 22}}
+    {{#rollTotal() almostCertain 33}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 33}}
+    {{#rollTotal() almostCertain 44}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 44}}
+    {{#rollTotal() almostCertain 55}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 55}}
+    {{#rollTotal() almostCertain 66}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 66}}
+    {{#rollTotal() almostCertain 77}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 77}}
+    {{#rollTotal() almostCertain 88}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 88}}
+    {{#rollTotal() almostCertain 99}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 99}}
+    {{#rollTotal() almostCertain 100}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 100}}{{/unlikely}}
     {{#smallChance}}
     {{#rollBetween() smallChance 91 100}}
     <div class="sheet-result-row">
       <div class="sheet-oracle-dice"><span>{{smallChance}}</span></div>
       <div class="sheet-oracle-table-text"><span>Yes</span></div>
-    </div>{{#rollTotal() smallChance 91}}
-    <div class="sheet-result-row">
-      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
-    </div>{{/rollTotal() smallChance 91}}
-    {{/rollBetween() smallChance 91 100}}
+    </div>{{/rollBetween() smallChance 91 100}}
     {{#^rollBetween() smallChance 91 100}}
     <div class="sheet-result-row">
       <div class="sheet-oracle-dice"><span>{{smallChance}}</span></div>
       <div class="sheet-oracle-table-text"><span>No</span></div>
-    </div>{{/^rollBetween() smallChance 91 100}}
-    {{/smallChance}}
+    </div>{{/^rollBetween() smallChance 91 100}}{{#rollTotal() almostCertain 11}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 11}}
+    {{#rollTotal() almostCertain 22}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 22}}
+    {{#rollTotal() almostCertain 33}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 33}}
+    {{#rollTotal() almostCertain 44}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 44}}
+    {{#rollTotal() almostCertain 55}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 55}}
+    {{#rollTotal() almostCertain 66}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 66}}
+    {{#rollTotal() almostCertain 77}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 77}}
+    {{#rollTotal() almostCertain 88}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 88}}
+    {{#rollTotal() almostCertain 99}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 99}}
+    {{#rollTotal() almostCertain 100}}
+    <div class="sheet-result-row">
+      <div class="sheet-subfooter sheet-opportunity">An extreme result or twist has occurred.</div>
+    </div>{{/rollTotal() almostCertain 100}}{{/smallChance}}
     {{#payThePrice}}
     <div class="sheet-result-row">
       <div class="sheet-oracle-dice"><span>{{payThePrice}}</span></div>

--- a/Ironsworn/src/data/move-list.pug
+++ b/Ironsworn/src/data/move-list.pug
@@ -4,7 +4,7 @@
       title: 'Advance',
       name: 'advance',
       class: 'advance',
-      page: 'Ironsworn - page X',
+      page: 'Ironsworn - page 103',
       system: 'ironsworn',
       content: [
         {
@@ -40,7 +40,7 @@
       title: 'Aid Your Ally',
       name: 'aidYourAlly',
       class: 'aid-your-ally',
-      page: 'Ironsworn - page X',
+      page: 'Ironsworn - page 76',
       radio: 'aid_your_ally',
       stat: `?{Stat|Edge, @{edge}|Iron, @{iron}|Heart, @{heart}|Shadow, @{shadow}|Wits, @{wits}}`,
       system: 'ironsworn',
@@ -990,7 +990,7 @@
       title: 'Reach Your Destination',
       name: 'reachYourDestination',
       class: 'reach-your-destination',
-      page: 'Ironsworn - page X',
+      page: 'Ironsworn - page 68',
       radio: 'reach_your_destination',
       roll: true,
       system: 'ironsworn',

--- a/Ironsworn/src/roll-templates/oracles/raw-oracles.pug
+++ b/Ironsworn/src/roll-templates/oracles/raw-oracles.pug
@@ -1,3 +1,39 @@
+mixin matchText
+  .sheet-result-row
+    .sheet-subfooter.sheet-opportunity An extreme result or twist has occurred.
+
+mixin matchRolls
+  | {{#rollTotal() almostCertain 11}}
+  +matchText
+  | {{/rollTotal() almostCertain 11}}
+  | {{#rollTotal() almostCertain 22}}
+  +matchText
+  | {{/rollTotal() almostCertain 22}}
+  | {{#rollTotal() almostCertain 33}}
+  +matchText
+  | {{/rollTotal() almostCertain 33}}
+  | {{#rollTotal() almostCertain 44}}
+  +matchText
+  | {{/rollTotal() almostCertain 44}}
+  | {{#rollTotal() almostCertain 55}}
+  +matchText
+  | {{/rollTotal() almostCertain 55}}
+  | {{#rollTotal() almostCertain 66}}
+  +matchText
+  | {{/rollTotal() almostCertain 66}}
+  | {{#rollTotal() almostCertain 77}}
+  +matchText
+  | {{/rollTotal() almostCertain 77}}
+  | {{#rollTotal() almostCertain 88}}
+  +matchText
+  | {{/rollTotal() almostCertain 88}}
+  | {{#rollTotal() almostCertain 99}}
+  +matchText
+  | {{/rollTotal() almostCertain 99}}
+  | {{#rollTotal() almostCertain 100}}
+  +matchText
+  | {{/rollTotal() almostCertain 100}}
+
 mixin rawOracles
   | {{#almostCertain}}
   | {{#rollBetween() almostCertain 11 100}}
@@ -6,10 +42,6 @@ mixin rawOracles
       span {{almostCertain}}
     .sheet-oracle-table-text
       span Yes
-  | {{#rollTotal() almostCertain 11}}
-  .sheet-result-row
-    .sheet-subfooter.sheet-opportunity An extreme result or twist has occurred.
-  | {{/rollTotal() almostCertain 11}}
   | {{/rollBetween() almostCertain 11 100}}
   | {{#^rollBetween() almostCertain 11 100}}
   .sheet-result-row
@@ -18,6 +50,7 @@ mixin rawOracles
     .sheet-oracle-table-text
       span No
   | {{/^rollBetween() almostCertain 11 100}}
+  +matchRolls
   | {{/almostCertain}}
   | {{#likely}}
   | {{#rollBetween() likely 26 100}}
@@ -26,10 +59,6 @@ mixin rawOracles
       span {{likely}}
     .sheet-oracle-table-text
       span Yes
-  | {{#rollTotal() likely 26}}
-  .sheet-result-row
-    .sheet-subfooter.sheet-opportunity An extreme result or twist has occurred.
-  | {{/rollTotal() likely 26}}
   | {{/rollBetween() likely 26 100}}
   | {{#^rollBetween() likely 26 100}}
   .sheet-result-row
@@ -38,6 +67,7 @@ mixin rawOracles
     .sheet-oracle-table-text
       span No
   | {{/^rollBetween() likely 26 100}}
+  +matchRolls
   | {{/likely}}
   | {{#fiftyFifty}}
   | {{#rollBetween() fiftyFifty 51 100}}
@@ -46,10 +76,6 @@ mixin rawOracles
       span {{fiftyFifty}}
     .sheet-oracle-table-text
       span Yes
-  | {{#rollTotal() fiftyFifty 51}}
-  .sheet-result-row
-    .sheet-subfooter.sheet-opportunity An extreme result or twist has occurred.
-  | {{/rollTotal() fiftyFifty 51}}
   | {{/rollBetween() fiftyFifty 51 100}}
   | {{#^rollBetween() fiftyFifty 51 100}}
   .sheet-result-row
@@ -58,6 +84,7 @@ mixin rawOracles
     .sheet-oracle-table-text
       span No
   | {{/^rollBetween() fiftyFifty 51 100}}
+  +matchRolls
   | {{/fiftyFifty}}
   | {{#unlikely}}
   | {{#rollBetween() unlikely 76 100}}
@@ -66,10 +93,6 @@ mixin rawOracles
       span {{unlikely}}
     .sheet-oracle-table-text
       span Yes
-  | {{#rollTotal() unlikely 76}}
-  .sheet-result-row
-    .sheet-subfooter.sheet-opportunity An extreme result or twist has occurred.
-  | {{/rollTotal() unlikely 76}}
   | {{/rollBetween() unlikely 76 100}}
   | {{#^rollBetween() unlikely 76 100}}
   .sheet-result-row
@@ -78,6 +101,7 @@ mixin rawOracles
     .sheet-oracle-table-text
       span No
   | {{/^rollBetween() unlikely 76 100}}
+  +matchRolls
   | {{/unlikely}}
   | {{#smallChance}}
   | {{#rollBetween() smallChance 91 100}}
@@ -86,10 +110,6 @@ mixin rawOracles
       span {{smallChance}}
     .sheet-oracle-table-text
       span Yes
-  | {{#rollTotal() smallChance 91}}
-  .sheet-result-row
-    .sheet-subfooter.sheet-opportunity An extreme result or twist has occurred.
-  | {{/rollTotal() smallChance 91}}
   | {{/rollBetween() smallChance 91 100}}
   | {{#^rollBetween() smallChance 91 100}}
   .sheet-result-row
@@ -98,6 +118,7 @@ mixin rawOracles
     .sheet-oracle-table-text
       span No
   | {{/^rollBetween() smallChance 91 100}}
+  +matchRolls
   | {{/smallChance}}
 
   | {{#payThePrice}}


### PR DESCRIPTION
## Changes / Comments
- A couple page references were missing for moves. These have now been added
- The Ask the Oracle logic had been implemented incorrectly for matching rolls, it was meant to match based on the dice rolled (technically it rolls 2d10 and matches the 2 numbers displayed). Now it will show the match for 11, 22, 33, 44, 55, 66, 77, 88, 99, and 100.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
