### PR TITLE
PokemonTabletopAdventures_v3 - Bluff and Deception use SPDMODEF

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -1279,8 +1279,8 @@
     
     // Bluff/Deception
     on("change:SPDEF change:blufftalent1 change:blufftalent2 change:bluff sheet:opened", function (eventInfo) {
-        getAttrs([`SPDMODEF`, `blufftalent1`, `blufftalent2`, `bluff`, `bluff_total`], function (values){
-            const stat = parseInt(values.SPDMODEF) || 0;
+        getAttrs([`SPDEFMOD`, `blufftalent1`, `blufftalent2`, `bluff`, `bluff_total`], function (values){
+            const stat = parseInt(values.SPDEFMOD) || 0;
             const talent1 = parseInt(values.blufftalent1) || 0;
             const talent2 = parseInt(values.blufftalent2) || 0;
             const total = parseInt(values.bluff_total) || -1;

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -7,6 +7,9 @@ https://discord.gg/F24Ka8E
 
 ## Changelog
 
+### Nov 25, 2020
+- Fixed a bug in Bluff/Deception where it never pulls the correct stat
+
 ### Nov 8, 2020
 - Combined the skill roll button with the skill name
   - Added fancy colors for the new skill roll button so that it matches the stat field when hovered over to help highlight which stat it uses


### PR DESCRIPTION
## Changes / Comments

- Fixes a bug in Bluff and Deception where the correct modifier is not pulled.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
