### PR TITLE
[Pokemon Tabletop Adventures v3] Refactors skill talents

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -358,7 +358,7 @@ div.sheet-character-stat-grid b, div.sheet-character-stat-grid p {
 
 .sheet-character-skill-labels {
   display: grid;
-  grid-template-columns: 2fr 10fr 1fr 1fr 2fr 16fr;
+  grid-template-columns: 2fr 10fr 2fr 2fr 16fr;
   align-items: center;
 }
 

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -333,8 +333,7 @@
         <div class="character-skill-labels">
             <b>Total</b>
             <b>Skill Name</b>
-            <b>+2</b>
-            <b>+5</b>
+            <b>Talent</b>
             <b>Bonus</b>
             <b>Inventory</b>
         </div>
@@ -347,7 +346,7 @@
                     Acrobatics (SPD)
                 </button>
                 <input type="checkbox" name="attr_acrobaticstalent1" value="2" />
-                <input type="checkbox" name="attr_acrobaticstalent2" value="3" />
+                <input type="checkbox" name="attr_acrobaticstalent2" value="2" />
                 <input type="number" name="attr_acrobatics" value="0" />
 
                 <input type="number" readonly name="attr_athletics_total" class="attack-read-color" />
@@ -356,7 +355,7 @@
                     Athletics (ATK)
                 </button>
                 <input type="checkbox" name="attr_athleticstalent1" value="2" />
-                <input type="checkbox" name="attr_athleticstalent2" value="3" />
+                <input type="checkbox" name="attr_athleticstalent2" value="2" />
                 <input type="number" name="attr_athletics" value="0" />
 
                 <input type="number" readonly name="attr_bluff_total" class="spdef-read-color" />
@@ -365,7 +364,7 @@
                     Bluff/Deception (SPDEF)
                 </button>
                 <input type="checkbox" name="attr_blufftalent1" value="2" />
-                <input type="checkbox" name="attr_blufftalent2" value="3" />
+                <input type="checkbox" name="attr_blufftalent2" value="2" />
                 <input type="number" name="attr_bluff" value="0" />
 
                 <input type="number" readonly name="attr_concentration_total" class="defense-read-color" />
@@ -374,7 +373,7 @@
                     Concentration (DEF)
                 </button>
                 <input type="checkbox" name="attr_concentrationtalent1" value="2" />
-                <input type="checkbox" name="attr_concentrationtalent2" value="3" />
+                <input type="checkbox" name="attr_concentrationtalent2" value="2" />
                 <input type="number" name="attr_concentration" value="0" />
 
                 <input type="number" readonly name="attr_constitution_total" class="defense-read-color" />
@@ -383,7 +382,7 @@
                     Constitution (DEF)
                 </button>
                 <input type="checkbox" name="attr_constitutiontalent1" value="2" />
-                <input type="checkbox" name="attr_constitutiontalent2" value="3" />
+                <input type="checkbox" name="attr_constitutiontalent2" value="2" />
                 <input type="number" name="attr_constitution" value="0" />
 
                 <input type="number" readonly name="attr_diplomacy_total" class="spdef-read-color" />
@@ -392,7 +391,7 @@
                     Diplomacy/Persuasion (SPDEF)
                 </button>
                 <input type="checkbox" name="attr_diplomacytalent1" value="2" />
-                <input type="checkbox" name="attr_diplomacytalent2" value="3" />
+                <input type="checkbox" name="attr_diplomacytalent2" value="2" />
                 <input type="number" name="attr_diplomacy" value="0" />
 
                 <input type="number" readonly name="attr_engineering_total" class="spatk-read-color" />
@@ -401,7 +400,7 @@
                     Engineering/Operation (SPATK)
                 </button>
                 <input type="checkbox" name="attr_engineeringtalent1" value="2" />
-                <input type="checkbox" name="attr_engineeringtalent2" value="3" />
+                <input type="checkbox" name="attr_engineeringtalent2" value="2" />
                 <input type="number" name="attr_engineering" value="0" />
 
                 <input type="number" readonly name="attr_history_total" class="spatk-read-color" />
@@ -410,7 +409,7 @@
                     History (SPATK)
                 </button>
                 <input type="checkbox" name="attr_historytalent1" value="2" />
-                <input type="checkbox" name="attr_historytalent2" value="3" />
+                <input type="checkbox" name="attr_historytalent2" value="2" />
                 <input type="number" name="attr_history" value="0" />
 
                 <input type="number" readonly name="attr_insight_total" class="spdef-read-color" />
@@ -419,7 +418,7 @@
                     Insight (SPDEF)
                 </button>
                 <input type="checkbox" name="attr_insighttalent1" value="2" />
-                <input type="checkbox" name="attr_insighttalent2" value="3" />
+                <input type="checkbox" name="attr_insighttalent2" value="2" />
                 <input type="number" name="attr_insight" value="0" />
 
                 <input type="number" readonly name="attr_investigate_total" class="spatk-read-color" />
@@ -428,7 +427,7 @@
                     Investigate (SPATK)
                 </button>
                 <input type="checkbox" name="attr_investigatetalent1" value="2" />
-                <input type="checkbox" name="attr_investigatetalent2" value="3" />
+                <input type="checkbox" name="attr_investigatetalent2" value="2" />
                 <input type="number" name="attr_investigate" value="0" />
 
                 <input type="number" readonly name="attr_medicine_total" class="spatk-read-color" />
@@ -437,7 +436,7 @@
                     Medicine (SPATK)
                 </button>
                 <input type="checkbox" name="attr_medicinetalent1" value="2" />
-                <input type="checkbox" name="attr_medicinetalent2" value="3" />
+                <input type="checkbox" name="attr_medicinetalent2" value="2" />
                 <input type="number" name="attr_medicine" value="0" />
 
                 <input type="number" readonly name="attr_nature_total" class="spatk-read-color" />
@@ -446,7 +445,7 @@
                     Nature (SPATK)
                 </button>
                 <input type="checkbox" name="attr_naturetalent1" value="2" />
-                <input type="checkbox" name="attr_naturetalent2" value="3" />
+                <input type="checkbox" name="attr_naturetalent2" value="2" />
                 <input type="number" name="attr_nature" value="0" />
 
                 <input type="number" readonly name="attr_perception_total" class="spdef-read-color" />
@@ -455,7 +454,7 @@
                     Perception (SPDEF)
                 </button>
                 <input type="checkbox" name="attr_perceptiontalent1" value="2" />
-                <input type="checkbox" name="attr_perceptiontalent2" value="3" />
+                <input type="checkbox" name="attr_perceptiontalent2" value="2" />
                 <input type="number" name="attr_perception" value="0" />
 
                 <input type="number" readonly name="attr_perform_total" class="spdef-read-color" />
@@ -464,7 +463,7 @@
                     Perform (SPDEF)
                 </button>
                 <input type="checkbox" name="attr_performtalent1" value="2" />
-                <input type="checkbox" name="attr_performtalent2" value="3" />
+                <input type="checkbox" name="attr_performtalent2" value="2" />
                 <input type="number" name="attr_perform" value="0" />
 
                 <input type="number" readonly name="attr_handling_total" class="spdef-read-color" />
@@ -473,7 +472,7 @@
                     Pokémon Handling (SPDEF)
                 </button>
                 <input type="checkbox" name="attr_handlingtalent1" value="2" />
-                <input type="checkbox" name="attr_handlingtalent2" value="3" />
+                <input type="checkbox" name="attr_handlingtalent2" value="2" />
                 <input type="number" name="attr_handling" value="0" />
 
                 <input type="number" readonly name="attr_programming_total" class="spatk-read-color" />
@@ -482,7 +481,7 @@
                     Programming (SPATK)
                 </button>
                 <input type="checkbox" name="attr_programmingtalent1" value="2" />
-                <input type="checkbox" name="attr_programmingtalent2" value="3" />
+                <input type="checkbox" name="attr_programmingtalent2" value="2" />
                 <input type="number" name="attr_programming" value="0" />
 
                 <input type="number" readonly name="attr_sleightofhand_total" class="speed-read-color" />
@@ -491,7 +490,7 @@
                     Sleight of Hand (SPD)
                 </button>
                 <input type="checkbox" name="attr_sleightofhandtalent1" value="2" />
-                <input type="checkbox" name="attr_sleightofhandtalent2" value="3" />
+                <input type="checkbox" name="attr_sleightofhandtalent2" value="2" />
                 <input type="number" name="attr_sleightofhand" value="0" />
 
                 <input type="number" readonly name="attr_stealth_total" class="speed-read-color" />
@@ -500,7 +499,7 @@
                     Stealth (SPD)
                 </button>
                 <input type="checkbox" name="attr_stealthtalent1" value="2" />
-                <input type="checkbox" name="attr_stealthtalent2" value="3" />
+                <input type="checkbox" name="attr_stealthtalent2" value="2" />
                 <input type="number" name="attr_stealth" value="0" />
             </div>
 
@@ -918,58 +917,57 @@
 <!-- SCRIPTS -->
 
 <script type="text/worker">
-    on("change:ATK sheet:opened", function () {
-        getAttrs(["ATK"], function (values) {
+    // Handling Stat Changes
+    on("change:ATK change:atkbonus sheet:opened", function () {
+        getAttrs(["ATK", "atkbonus"], function (values) {
             let atk = parseInt(values.ATK) || 0;
-            let atkmod = Math.floor(atk / 2);
-            setAttrs({
-                "ATKMOD": atkmod
-            });
+            let bonus = parseInt(values.atkbonus) || 0;
+            calcModFor("ATK", atk, bonus);
         });
     });
     
-    on("change:DEF sheet:opened", function () {
-        getAttrs(["DEF"], function (values) {
+    on("change:DEF change:defbonus sheet:opened", function () {
+        getAttrs(["DEF", "defbonus"], function (values) {
             let def = parseInt(values.DEF) || 0;
-            let defmod = Math.floor(def / 2);
-            setAttrs({
-                "DEFMOD": defmod
-            });
+            let bonus = parseInt(values.defbonus) || 0;
+            calcModFor("DEF", def, bonus);
         });
     });
     
-    on("change:SPATK sheet:opened", function () {
-        getAttrs(["SPATK"], function (values) {
+    on("change:SPATK change:spatkbonus sheet:opened", function () {
+        getAttrs(["SPATK", "spatkbonus"], function (values) {
             let spatk = parseInt(values.SPATK) || 0;
-            let spatkmod = Math.floor(spatk / 2);
-            setAttrs({
-                "SPATKMOD": spatkmod
-            });
+            let bonus = parseInt(values.spatkbonus) || 0;
+            calcModFor("SPATK", spatk, bonus);
         });
     });
     
-    on("change:SPDEF sheet:opened", function () {
-        getAttrs(["SPDEF"], function (values) {
+    on("change:SPDEF change:spdefbonus sheet:opened", function () {
+        getAttrs(["SPDEF", "spdefbonus"], function (values) {
             let spdef = parseInt(values.SPDEF) || 0;
-            let spdefmod = Math.floor(spdef / 2);
-            setAttrs({
-                "SPDEFMOD": spdefmod
-            });
+            let bonus = parseInt(values.spdefbonus) || 0;
+            calcModFor("SPDEF", spdef, bonus);
         });
     });
     
-    on("change:SPD sheet:opened", function () {
-        getAttrs(["SPD"], function (values) {
+    on("change:SPD change:spdbonus sheet:opened", function () {
+        getAttrs(["SPD", "spdbonus"], function (values) {
             let spd = parseInt(values.SPD) || 0;
-            let spdmod = Math.floor(spd / 2);
-            let move = spd * 5;
-            setAttrs({
-                "SPDMOD": spdmod,
-                "movement": move
-            });
+            let bonus = parseInt(values.spdbonus) || 0;
+            calcModFor("SPD", spd, bonus);
         });
     });
     
+    function calcModFor(ability, stat, bonus) {
+        const combined = stat + bonus;
+        const modifier = Math.floor(combined / 2);
+        const name = `${ability}MOD`;
+        const attrs = { [name]:  modifier}
+        if (ability == "SPD") attrs["movement"] = combined * 5;
+        setAttrs(attrs);
+    }
+    
+    // Handling Colour Changes
     types = ["bug", "dark", "dragon", "electric", "fairy", "fighting", "fire", "flying", "ghost", "grass", "ground", "ice", "normal", "poison", "psychic", "rock", "steel", "water"]
     on("change:type1 sheet:opened", function (event) {
         getAttrs(["type1"], function (values) {
@@ -1001,6 +999,7 @@
         });
     });
     
+    // Handling Targeted Defense Changes
     defenses = ["", "Defense", "Special Defense", "Speed"];
     on("sheet:opened", function (eventInfo) {
         getSectionIDs("repeating_moves", function (idArray) {
@@ -1028,6 +1027,7 @@
         });
     });
     
+    // Handling Move and Feature Usage
     on("clicked:repeating_moves:incrementmoveusage", function () {
         getAttrs(["repeating_moves_move_usage"], function (values) {
             const currentusage = +values.repeating_moves_move_usage || 0;
@@ -1082,6 +1082,7 @@
         });
     });
     
+    // Handling Move Effects
     effects = ["Critical Hit", "put to Sleep", "Burned", "Confused", "Cursed", "Frozen", "Infatuated", "Paralyzed", "Poisoned", "Toxified", "Stunned", "Other"];
     on("sheet:opened", function (eventInfo) {
         getSectionIDs("repeating_moves", function (idArray) {
@@ -1135,43 +1136,31 @@
         });
     });
     
-    // Calculating the Move Damage Bonus
-    
+    // Handling Move Damage Bonuses
     categoryDamageModifiers = ["", "ATKMOD", "SPATKMOD", ""];
-    on("change:ATK change:SPATK sheet:opened", function (eventInfo) {
-        // Get all the section IDs for each move
+    on("change:ATKMOD change:SPATKMOD sheet:opened", function (eventInfo) {
         getSectionIDs("repeating_moves", function (idArray) {
-    
-            // Get all the section IDs mapped into an array including the repeating_moves_ prefix, so we can read and set attributes correctly
             const rowNames = idArray.map(id => `repeating_moves_${id}`);
-    
-            // Create arrays of all the Category, Extra Bonus, and STAB Bonus attribute names of each move
             const categories = idArray.map(id => `repeating_moves_${id}_move_category`);
             const extraBonuses = idArray.map(id => `repeating_moves_${id}_move_damagebonus`);
             const stabBonuses = idArray.map(id => `repeating_moves_${id}_move_stabbonus`);
             const diceNumbers = idArray.map(id => `repeating_moves_${id}_move_dicenumber`);
             const damageDice = idArray.map(id => `repeating_moves_${id}_damage_dice`);
     
-    
-            // Get the ATK and SPATK modifier attributes, as well the values for each moves category, extra bonus, and stab bonus.
             getAttrs([`ATKMOD`, `SPATKMOD`, ...categories, ...extraBonuses, ...stabBonuses, ...diceNumbers, ...damageDice], function (values) {
                 const rows = rowNames.reduce((obj, rowName) => {
-    
-                    // For each move, get the value of its relevant attributes stored as a local var - default to 0 for easier maths
                     const category = parseInt(values[rowName + `_move_category`]) || 0;
                     const extra = parseInt(values[rowName + '_move_damagebonus']) || 0;
                     const stab = parseInt(values[rowName + '_move_stabbonus']) || 0;
                     const dice = parseInt(values[rowName + '_move_dicenumber']) || 0;
                     const points = parseInt(values[rowName + '_damage_dice']) || 0;
-    
-                    // Get the modifier for the category selected 
+
                     const categoryModifier = parseInt(values[`${categoryDamageModifiers[category]}`]) || 0;
                     const total = categoryModifier + extra + stab;
     
                     var display = `${total}`;
                     if (dice > 0) display = `${dice}d${points} ${total < 0 ? "" : "+ "}${total}`;
     
-                    // Assign the calculated damage bonus to the relevant move's total damage bonus attribute
                     obj[rowName + '_move_totaldamage'] = total;
                     obj[rowName + '_move_totaldamage_display'] = display;
                     return obj;
@@ -1202,8 +1191,9 @@
         });
     });
     
+    // Handling Move Accuracy Bonuses
     categoryAccuracyModifiers = ["", "ATKMOD", "SPATKMOD", "SPDMOD"];
-    on("change:ATK change:SPATK change:SPD sheet:opened", function (eventInfo) {
+    on("change:ATKMOD change:SPATKMOD change:SPDMOD sheet:opened", function (eventInfo) {
         getSectionIDs("repeating_moves", function (idArray) {
             const rowNames = idArray.map(id => `repeating_moves_${id}`);
             const categories = idArray.map(id => `repeating_moves_${id}_move_category`);
@@ -1244,292 +1234,247 @@
     });
     
     // Skills Sheet Workers
-    
+
     // Acrobatics
-    on("change:SPD change:acrobaticstalent1 change:acrobaticstalent2 change:acrobatics sheet:opened", function (eventInfo) {
-        getAttrs([`SPDMOD`, `acrobaticstalent1`, `acrobaticstalent2`, `acrobatics`, `acrobatics_total`], function (values){
+    on("change:SPDMOD change:acrobaticstalent1 change:acrobaticstalent2 change:acrobatics sheet:opened", function (eventInfo) {
+        getAttrs([`SPDMOD`, `acrobaticstalent1`, `acrobaticstalent2`, `acrobatics`, `acrobatics_total`], function (values) {
             const stat = parseInt(values.SPDMOD) || 0;
             const talent1 = parseInt(values.acrobaticstalent1) || 0;
             const talent2 = parseInt(values.acrobaticstalent2) || 0;
             const total = parseInt(values.acrobatics_total) || -1;
             const userBonus = parseInt(values.acrobatics) || 0;
-            
-            const calculated = stat + talent1 + talent2 + userBonus;
-            if (calculated != total) setAttrs({
-                'acrobatics_total': calculated
-            });
+
+            assignSkillTotal('acrobatics_total', stat, talent1, talent2, total, userBonus);
         });
     });
-    
+
     // Athletics
-    on("change:ATK change:athleticstalent1 change:athleticstalent2 change:athletics sheet:opened", function (eventInfo) {
-        getAttrs([`ATKMOD`, `athleticstalent1`, `athleticstalent2`, `athletics`, `athletics_total`], function (values){
+    on("change:ATKMOD change:athleticstalent1 change:athleticstalent2 change:athletics sheet:opened", function (eventInfo) {
+        getAttrs([`ATKMOD`, `athleticstalent1`, `athleticstalent2`, `athletics`, `athletics_total`], function (values) {
             const stat = parseInt(values.ATKMOD) || 0;
             const talent1 = parseInt(values.athleticstalent1) || 0;
             const talent2 = parseInt(values.athleticstalent2) || 0;
             const total = parseInt(values.athletics_total) || -1;
             const userBonus = parseInt(values.athletics) || 0;
-            
-            const calculated = stat + talent1 + talent2 + userBonus;
-            if (calculated != total) setAttrs({
-                'athletics_total': calculated
-            });
+
+            assignSkillTotal('athletics_total', stat, talent1, talent2, total, userBonus);
         });
     });
-    
+
     // Bluff/Deception
-    on("change:SPDEF change:blufftalent1 change:blufftalent2 change:bluff sheet:opened", function (eventInfo) {
-        getAttrs([`SPDEFMOD`, `blufftalent1`, `blufftalent2`, `bluff`, `bluff_total`], function (values){
+    on("change:SPDEFMOD change:blufftalent1 change:blufftalent2 change:bluff sheet:opened", function (eventInfo) {
+        getAttrs([`SPDEFMOD`, `blufftalent1`, `blufftalent2`, `bluff`, `bluff_total`], function (values) {
             const stat = parseInt(values.SPDEFMOD) || 0;
             const talent1 = parseInt(values.blufftalent1) || 0;
             const talent2 = parseInt(values.blufftalent2) || 0;
             const total = parseInt(values.bluff_total) || -1;
             const userBonus = parseInt(values.bluff) || 0;
-            
-            const calculated = stat + talent1 + talent2 + userBonus;
-            if (calculated != total) setAttrs({
-                'bluff_total': calculated
-            });
+
+            assignSkillTotal('bluff_total', stat, talent1, talent2, total, userBonus);
         });
     });
-    
+
     // Concentration
-    on("change:DEF change:concentrationtalent1 change:concentrationtalent2 change:concentration sheet:opened", function (eventInfo) {
-        getAttrs([`DEFMOD`, `concentrationtalent1`, `concentrationtalent2`, `concentration`, `concentration_total`], function (values){
+    on("change:DEFMOD change:concentrationtalent1 change:concentrationtalent2 change:concentration sheet:opened", function (eventInfo) {
+        getAttrs([`DEFMOD`, `concentrationtalent1`, `concentrationtalent2`, `concentration`, `concentration_total`], function (values) {
             const stat = parseInt(values.DEFMOD) || 0;
             const talent1 = parseInt(values.concentrationtalent1) || 0;
             const talent2 = parseInt(values.concentrationtalent2) || 0;
             const total = parseInt(values.concentration_total) || -1;
             const userBonus = parseInt(values.concentration) || 0;
-            
-            const calculated = stat + talent1 + talent2 + userBonus;
-            if (calculated != total) setAttrs({
-                'concentration_total': calculated
-            });
+
+            assignSkillTotal('concentration_total', stat, talent1, talent2, total, userBonus);
         });
     });
-    
+
     // Constitution
-    on("change:DEF change:constitutiontalent1 change:constitutiontalent2 change:constitution sheet:opened", function (eventInfo) {
-        getAttrs([`DEFMOD`, `constitutiontalent1`, `constitutiontalent2`, `constitution`, `constitution_total`], function (values){
+    on("change:DEFMOD change:constitutiontalent1 change:constitutiontalent2 change:constitution sheet:opened", function (eventInfo) {
+        getAttrs([`DEFMOD`, `constitutiontalent1`, `constitutiontalent2`, `constitution`, `constitution_total`], function (values) {
             const stat = parseInt(values.DEFMOD) || 0;
             const talent1 = parseInt(values.constitutiontalent1) || 0;
             const talent2 = parseInt(values.constitutiontalent2) || 0;
             const total = parseInt(values.constitution_total) || -1;
             const userBonus = parseInt(values.constitution) || 0;
-            
-            const calculated = stat + talent1 + talent2 + userBonus;
-            if (calculated != total) setAttrs({
-                'constitution_total': calculated
-            });
+
+            assignSkillTotal('constitution_total', stat, talent1, talent2, total, userBonus);
         });
     });
-    
+
     // Diplomacy/Persuasion
-    on("change:SPDEF change:diplomacytalent1 change:diplomacytalent2 change:diplomacy sheet:opened", function (eventInfo) {
-        getAttrs([`SPDEFMOD`, `diplomacytalent1`, `diplomacytalent2`, `diplomacy`, `diplomacy_total`], function (values){
+    on("change:SPDEFMOD change:diplomacytalent1 change:diplomacytalent2 change:diplomacy sheet:opened", function (eventInfo) {
+        getAttrs([`SPDEFMOD`, `diplomacytalent1`, `diplomacytalent2`, `diplomacy`, `diplomacy_total`], function (values) {
             const stat = parseInt(values.SPDEFMOD) || 0;
             const talent1 = parseInt(values.diplomacytalent1) || 0;
             const talent2 = parseInt(values.diplomacytalent2) || 0;
             const total = parseInt(values.diplomacy_total) || -1;
             const userBonus = parseInt(values.diplomacy) || 0;
-            
-            const calculated = stat + talent1 + talent2 + userBonus;
-            if (calculated != total) setAttrs({
-                'diplomacy_total': calculated
-            });
+
+            assignSkillTotal('diplomacy_total', stat, talent1, talent2, total, userBonus);
         });
     });
-    
+
     // Engineering/Operation
-    on("change:SPATK change:engineeringtalent1 change:engineeringtalent2 change:engineering sheet:opened", function (eventInfo) {
-        getAttrs([`SPATKMOD`, `engineeringtalent1`, `engineeringtalent2`, `engineering`, `engineering_total`], function (values){
+    on("change:SPATKMOD change:engineeringtalent1 change:engineeringtalent2 change:engineering sheet:opened", function (eventInfo) {
+        getAttrs([`SPATKMOD`, `engineeringtalent1`, `engineeringtalent2`, `engineering`, `engineering_total`], function (values) {
             const stat = parseInt(values.SPATKMOD) || 0;
             const talent1 = parseInt(values.engineeringtalent1) || 0;
             const talent2 = parseInt(values.engineeringtalent2) || 0;
             const total = parseInt(values.engineering_total) || -1;
             const userBonus = parseInt(values.engineering) || 0;
-            
-            const calculated = stat + talent1 + talent2 + userBonus;
-            if (calculated != total) setAttrs({
-                'engineering_total': calculated
-            });
+
+            assignSkillTotal('engineering_total', stat, talent1, talent2, total, userBonus);
         });
     });
-    
+
     // History
-    on("change:SPATK change:historytalent1 change:historytalent2 change:history sheet:opened", function (eventInfo) {
-        getAttrs([`SPATKMOD`, `historytalent1`, `historytalent2`, `history`, `history_total`], function (values){
+    on("change:SPATKMOD change:historytalent1 change:historytalent2 change:history sheet:opened", function (eventInfo) {
+        getAttrs([`SPATKMOD`, `historytalent1`, `historytalent2`, `history`, `history_total`], function (values) {
             const stat = parseInt(values.SPATKMOD) || 0;
             const talent1 = parseInt(values.historytalent1) || 0;
             const talent2 = parseInt(values.historytalent2) || 0;
             const total = parseInt(values.history_total) || -1;
             const userBonus = parseInt(values.history) || 0;
-            
-            const calculated = stat + talent1 + talent2 + userBonus;
-            if (calculated != total) setAttrs({
-                'history_total': calculated
-            });
+
+            assignSkillTotal('history_total', stat, talent1, talent2, total, userBonus);
         });
     });
-    
+
     // Insight
-    on("change:SPDEF change:insighttalent1 change:insighttalent2 change:insight sheet:opened", function (eventInfo) {
-        getAttrs([`SPDEFMOD`, `insighttalent1`, `insighttalent2`, `insight`, `insight_total`], function (values){
+    on("change:SPDEFMOD change:insighttalent1 change:insighttalent2 change:insight sheet:opened", function (eventInfo) {
+        getAttrs([`SPDEFMOD`, `insighttalent1`, `insighttalent2`, `insight`, `insight_total`], function (values) {
             const stat = parseInt(values.SPDEFMOD) || 0;
             const talent1 = parseInt(values.insighttalent1) || 0;
             const talent2 = parseInt(values.insighttalent2) || 0;
             const total = parseInt(values.insight_total) || -1;
             const userBonus = parseInt(values.insight) || 0;
-            
-            const calculated = stat + talent1 + talent2 + userBonus;
-            if (calculated != total) setAttrs({
-                'insight_total': calculated
-            });
+
+            assignSkillTotal('insight_total', stat, talent1, talent2, total, userBonus);
         });
     });
-    
+
     // Investigate
-    on("change:SPATK change:investigatetalent1 change:investigatetalent2 change:investigate sheet:opened", function (eventInfo) {
-        getAttrs([`SPATKMOD`, `investigatetalent1`, `investigatetalent2`, `investigate`, `investigate_total`], function (values){
+    on("change:SPATKMOD change:investigatetalent1 change:investigatetalent2 change:investigate sheet:opened", function (eventInfo) {
+        getAttrs([`SPATKMOD`, `investigatetalent1`, `investigatetalent2`, `investigate`, `investigate_total`], function (values) {
             const stat = parseInt(values.SPATKMOD) || 0;
             const talent1 = parseInt(values.investigatetalent1) || 0;
             const talent2 = parseInt(values.investigatetalent2) || 0;
             const total = parseInt(values.investigate_total) || -1;
             const userBonus = parseInt(values.investigate) || 0;
-            
-            const calculated = stat + talent1 + talent2 + userBonus;
-            if (calculated != total) setAttrs({
-                'investigate_total': calculated
-            });
+
+            assignSkillTotal('investigate_total', stat, talent1, talent2, total, userBonus);
         });
     });
-    
+
     // Medicine
-    on("change:SPATK change:medicinetalent1 change:medicinetalent2 change:medicine sheet:opened", function (eventInfo) {
-        getAttrs([`SPATKMOD`, `medicinetalent1`, `medicinetalent2`, `medicine`, `medicine_total`], function (values){
+    on("change:SPATKMOD change:medicinetalent1 change:medicinetalent2 change:medicine sheet:opened", function (eventInfo) {
+        getAttrs([`SPATKMOD`, `medicinetalent1`, `medicinetalent2`, `medicine`, `medicine_total`], function (values) {
             const stat = parseInt(values.SPATKMOD) || 0;
             const talent1 = parseInt(values.medicinetalent1) || 0;
             const talent2 = parseInt(values.medicinetalent2) || 0;
             const total = parseInt(values.medicine_total) || -1;
             const userBonus = parseInt(values.medicine) || 0;
-            
-            const calculated = stat + talent1 + talent2 + userBonus;
-            if (calculated != total) setAttrs({
-                'medicine_total': calculated
-            });
+
+            assignSkillTotal('medicine_total', stat, talent1, talent2, total, userBonus);
         });
     });
-    
+
     // Nature
-    on("change:SPATK change:naturetalent1 change:naturetalent2 change:nature sheet:opened", function (eventInfo) {
-        getAttrs([`SPATKMOD`, `naturetalent1`, `naturetalent2`, `nature`, `nature_total`], function (values){
+    on("change:SPATKMOD change:naturetalent1 change:naturetalent2 change:nature sheet:opened", function (eventInfo) {
+        getAttrs([`SPATKMOD`, `naturetalent1`, `naturetalent2`, `nature`, `nature_total`], function (values) {
             const stat = parseInt(values.SPATKMOD) || 0;
             const talent1 = parseInt(values.naturetalent1) || 0;
             const talent2 = parseInt(values.naturetalent2) || 0;
             const total = parseInt(values.nature_total) || -1;
             const userBonus = parseInt(values.nature) || 0;
-            
-            const calculated = stat + talent1 + talent2 + userBonus;
-            if (calculated != total) setAttrs({
-                'nature_total': calculated
-            });
+
+            assignSkillTotal('nature_total', stat, talent1, talent2, total, userBonus);
         });
     });
-    
+
     // Perception
-    on("change:SPDEF change:perceptiontalent1 change:perceptiontalent2 change:perception sheet:opened", function (eventInfo) {
-        getAttrs([`SPDEFMOD`, `perceptiontalent1`, `perceptiontalent2`, `perception`, `perception_total`], function (values){
+    on("change:SPDEFMOD change:perceptiontalent1 change:perceptiontalent2 change:perception sheet:opened", function (eventInfo) {
+        getAttrs([`SPDEFMOD`, `perceptiontalent1`, `perceptiontalent2`, `perception`, `perception_total`], function (values) {
             const stat = parseInt(values.SPDEFMOD) || 0;
             const talent1 = parseInt(values.perceptiontalent1) || 0;
             const talent2 = parseInt(values.perceptiontalent2) || 0;
             const total = parseInt(values.perception_total) || -1;
             const userBonus = parseInt(values.perception) || 0;
-            
-            const calculated = stat + talent1 + talent2 + userBonus;
-            if (calculated != total) setAttrs({
-                'perception_total': calculated
-            });
+
+            assignSkillTotal('perception_total', stat, talent1, talent2, total, userBonus);
         });
     });
-    
+
     // Perform
-    on("change:SPDEF change:performtalent1 change:performtalent2 change:perform sheet:opened", function (eventInfo) {
-        getAttrs([`SPDEFMOD`, `performtalent1`, `performtalent2`, `perform`, `perform_total`], function (values){
+    on("change:SPDEFMOD change:performtalent1 change:performtalent2 change:perform sheet:opened", function (eventInfo) {
+        getAttrs([`SPDEFMOD`, `performtalent1`, `performtalent2`, `perform`, `perform_total`], function (values) {
             const stat = parseInt(values.SPDEFMOD) || 0;
             const talent1 = parseInt(values.performtalent1) || 0;
             const talent2 = parseInt(values.performtalent2) || 0;
             const total = parseInt(values.perform_total) || -1;
             const userBonus = parseInt(values.perform) || 0;
-            
-            const calculated = stat + talent1 + talent2 + userBonus;
-            if (calculated != total) setAttrs({
-                'perform_total': calculated
-            });
+
+            assignSkillTotal('perform_total', stat, talent1, talent2, total, userBonus);
         });
     });
-    
+
     // Pokémon Handling
-    on("change:SPDEF change:handlingtalent1 change:handlingtalent2 change:handling sheet:opened", function (eventInfo) {
-        getAttrs([`SPDEFMOD`, `handlingtalent1`, `handlingtalent2`, `handling`, `handling_total`], function (values){
+    on("change:SPDEFMOD change:handlingtalent1 change:handlingtalent2 change:handling sheet:opened", function (eventInfo) {
+        getAttrs([`SPDEFMOD`, `handlingtalent1`, `handlingtalent2`, `handling`, `handling_total`], function (values) {
             const stat = parseInt(values.SPDEFMOD) || 0;
             const talent1 = parseInt(values.handlingtalent1) || 0;
             const talent2 = parseInt(values.handlingtalent2) || 0;
             const total = parseInt(values.handling_total) || -1;
             const userBonus = parseInt(values.handling) || 0;
-            
-            const calculated = stat + talent1 + talent2 + userBonus;
-            if (calculated != total) setAttrs({
-                'handling_total': calculated
-            });
+
+            assignSkillTotal('handling_total', stat, talent1, talent2, total, userBonus);
         });
     });
-    
+
     // Programming
-    on("change:SPATK change:programmingtalent1 change:programmingtalent2 change:programming sheet:opened", function (eventInfo) {
-        getAttrs([`SPATKMOD`, `programmingtalent1`, `programmingtalent2`, `programming`, `programming_total`], function (values){
+    on("change:SPATKMOD change:programmingtalent1 change:programmingtalent2 change:programming sheet:opened", function (eventInfo) {
+        getAttrs([`SPATKMOD`, `programmingtalent1`, `programmingtalent2`, `programming`, `programming_total`], function (values) {
             const stat = parseInt(values.SPATKMOD) || 0;
             const talent1 = parseInt(values.programmingtalent1) || 0;
             const talent2 = parseInt(values.programmingtalent2) || 0;
             const total = parseInt(values.programming_total) || -1;
             const userBonus = parseInt(values.programming) || 0;
-            
-            const calculated = stat + talent1 + talent2 + userBonus;
-            if (calculated != total) setAttrs({
-                'programming_total': calculated
-            });
+
+            assignSkillTotal('programming_total', stat, talent1, talent2, total, userBonus);
         });
     });
-    
+
     // Sleight of Hand
-    on("change:SPD change:sleightofhandtalent1 change:sleightofhandtalent2 change:sleightofhand sheet:opened", function (eventInfo) {
-        getAttrs([`SPDMOD`, `sleightofhandtalent1`, `sleightofhandtalent2`, `sleightofhand`, `sleightofhand_total`], function (values){
+    on("change:SPDMOD change:sleightofhandtalent1 change:sleightofhandtalent2 change:sleightofhand sheet:opened", function (eventInfo) {
+        getAttrs([`SPDMOD`, `sleightofhandtalent1`, `sleightofhandtalent2`, `sleightofhand`, `sleightofhand_total`], function (values) {
             const stat = parseInt(values.SPDMOD) || 0;
             const talent1 = parseInt(values.sleightofhandtalent1) || 0;
             const talent2 = parseInt(values.sleightofhandtalent2) || 0;
             const total = parseInt(values.sleightofhand_total) || -1;
             const userBonus = parseInt(values.sleightofhand) || 0;
-            
-            const calculated = stat + talent1 + talent2 + userBonus;
-            if (calculated != total) setAttrs({
-                'sleightofhand_total': calculated
-            });
+
+            assignSkillTotal('sleightofhand_total', stat, talent1, talent2, total, userBonus);
         });
     });
-    
+
     // Stealth
-    on("change:SPD change:stealthtalent1 change:stealthtalent2 change:stealth sheet:opened", function (eventInfo) {
-        getAttrs([`SPDMOD`, `stealthtalent1`, `stealthtalent2`, `stealth`, `stealth_total`], function (values){
+    on("change:SPDMOD change:stealthtalent1 change:stealthtalent2 change:stealth sheet:opened", function (eventInfo) {
+        getAttrs([`SPDMOD`, `stealthtalent1`, `stealthtalent2`, `stealth`, `stealth_total`], function (values) {
             const stat = parseInt(values.SPDMOD) || 0;
             const talent1 = parseInt(values.stealthtalent1) || 0;
             const talent2 = parseInt(values.stealthtalent2) || 0;
             const total = parseInt(values.stealth_total) || -1;
             const userBonus = parseInt(values.stealth) || 0;
-            
-            const calculated = stat + talent1 + talent2 + userBonus;
-            if (calculated != total) setAttrs({
-                'stealth_total': calculated
-            });
+
+            assignSkillTotal('stealth_total', stat, talent1, talent2, total, userBonus);
         });
     });
+
+    function assignSkillTotal(skillName, stat, leftTalent, rightTalent, oldTotal, userBonus) {
+        const talentAccumulator = leftTalent + rightTalent == 4 ? 1 : 0;
+        const talent = leftTalent + rightTalent + talentAccumulator;
+
+        const newBonus = stat + talent + userBonus;
+        const attrs = { [skillName]: newBonus };
+        if (newBonus != oldTotal) setAttrs(attrs);
+    }
 </script>

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -7,8 +7,13 @@ https://discord.gg/F24Ka8E
 
 ## Changelog
 
+### Nov 28, 2020
+- Added support for temporary bonuses!
+
 ### Nov 25, 2020
-- Fixed a bug in Bluff/Deception where it never pulls the correct stat
+- Changed the header of the talent checkboxes to Talent to make it easier to identify their purpose
+- Fixed a bug where the sheet would reacting to attribute score changes rather than modifiers, which meant attribute changes sometimes did not propagate through to any associated values
+- Fixed a bug where the Bluff/Deception skill wasn't fetching the Special Defense modifier
 
 ### Nov 8, 2020
 - Combined the skill roll button with the skill name
@@ -66,10 +71,11 @@ https://discord.gg/F24Ka8E
 
 
 ## To-Do:
-Things we want to add to the character sheet, presented in no particular order of priority.
-- [x] ~~Prevent critical range from going below 0 or above 20, maybe do similar to other fields~~
+Things we want to add to the character sheet, presented in no particular order of priority:
 - [x] ~~Display the full bonus to skill checks~~
+- [x] ~~Handle temporary stat changes somehow, this may be a lot of work~~
+- [x] ~~Prevent critical range from going below 0 or above 20, maybe do similar to other fields~~
 - [ ] Add a Settings page
 - [ ] Allow formula calculations for the extra damage fields
 - [ ] Allow modifications to movement (maybe just an extra box)
-- [ ] Handle temporary stat changes somehow, this may be a lot of work
+- [ ] Display the adjusted stat score when temporary stat changes are provided


### PR DESCRIPTION
## Changes / Comments
- Changes the header of the talent checkboxes to Talent to make it easier for users to identify their purpose
- Sets the value of each checkbox to 2 to eliminate the need to select talent in a particular order
- Updates the skill total sheet workers to add the extra +1 if both checkboxes are on
- Updates the skill total sheet workers to encapsulate some repeated code into a function to make the scripts section neater
- Updates sheet workers to react to attribute mods, which ensures attribute changes have time to propagate to the mod before being used
- Updates the README


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.
- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add or change functional aesthetics (such as layout or color scheme)? 

