### PR TITLE
[Vulcania] fixed height bug using Firefox

### DIFF
--- a/Vulcania/vulcsheet.css
+++ b/Vulcania/vulcsheet.css
@@ -17,7 +17,7 @@
     background-size: cover;
     max-width: 800px;
     min-width: 800px;
-    height: 1060px;
+    height: 100%;
 }
 .sheet-info{
     display: flex;


### PR DESCRIPTION
## Changes / Comments

Fixed height bug on Firefox. I think browsers have a different way to count pixels (like Firefox and Chrome), so i use 100% instead of pixels and now all works fine.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
