### PR TITLE
Small changes and fixes for Basic_Roleplaying

### DIFF
--- a/Basic_Roleplaying/Basic_Roleplaying.css
+++ b/Basic_Roleplaying/Basic_Roleplaying.css
@@ -15,6 +15,7 @@
 
 .charsheet{
 	background-color: lightgray;
+    width: 825px
 }
 
 /*Hide stuff*/
@@ -53,7 +54,6 @@
 input.sheet-showstrike-rank:checked ~ .repcontainer[data-groupname="repeating_Hand-to-Hand"] sheet-strike-rank  {
     display: inline;
 }
-
 div[data-groupname="repeating_Hand-to-Hand"] .sheet-strike-rank
 {
     display: inline-block;
@@ -84,7 +84,6 @@ div[data-groupname="repeating_Hand-to-Hand"] .sheet-strike-rank
 .charsheet div.sheet-skills-alphabetical{
     display: inline;    
 }
-
 .charsheet input.sheet-toggle-alphabetical:not(:checked) ~ div.sheet-skills-alphabetical {
     display: none;
 */

--- a/Basic_Roleplaying/Basic_Roleplaying.html
+++ b/Basic_Roleplaying/Basic_Roleplaying.html
@@ -1220,8 +1220,8 @@
 				<th>Skill %</th>
 				<th>Special</th>
 				<th>Damage</th>
-				<th>Attacks</th>
 				<th>HP</th>
+				<th>Damage<br>Bonus?</td></th>					
 				<th></th>
 			</thead>
 			<tbody>
@@ -1254,10 +1254,15 @@
 								<option value="En">En</option>								
 						</select>
 					</td>	
-					<td ><input type="text" name="attr_Brawl-Damage" style="width: 60px" /></td>
-					<td ><input style="width:35px" type="number" name="attr_Brawl-ApR" /></td>
+					<td ><input type="text" value="1d3" name="attr_Brawl-Damage" style="width: 60px" /></td>
 					<td ><input style="width: 40px" type="text" name="attr_Brawl-HP"/></td>
-					<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Brawl-Damage}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Brawl}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Brawl}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Brawl}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Brawl}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}} {{1/2success=[[ceil((@{Brawl}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{skillvalue=@{Brawl}}}  {{roll=[[1d100]]}} {{skillname=Brawl}}" /></td>
+					<td>
+					<select style="font-size: 9px; margin-bottom: 0px; width: 45px" name="attr_weapon_typeB">
+						<option selected="selected" value="1">Full</option>
+						<option value="0.5">Half</option>
+					</select>
+					</td>					
+					<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Brawl-Damage}+(ceil(@{Damage_Bonus}*@{weapon_typeB}))]]}} {{success=[[ceil(@{Brawl}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Brawl}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Brawl}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Brawl}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}} {{1/2success=[[ceil((@{Brawl}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{skillvalue=@{Brawl}}}  {{roll=[[1d100]]}} {{skillname=Brawl}}" /></td>
 				</tr>
 				
 				<tr>
@@ -1289,10 +1294,15 @@
 								<option value="En"Selected>En</option>							
 					</select>
 					</td>
-					<td><input type="text" name="attr_Grapple-Damage" style="width: 60px" /></td>
-					<td><input style="width:35px" type="number" name="attr_Grapple-ApR" /></td>
+					<td><input type="text" value="1d3" name="attr_Grapple-Damage" style="width: 60px" /></td>
 					<td><input style="width:40px" type="text" name="attr_Grapple-HP" style="width: 40px" /></td>
-					<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Grapple-Damage}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Grapple}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Grapple}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Grapple}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Grapple}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}} {{1/2success=[[ceil((@{Grapple}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{roll=[[1d100]]}} {{skillname=Grapple}}" /></td>						
+					<td>
+					<select style="font-size: 9px; margin-bottom: 0px; width: 45px" name="attr_weapon_typeG">
+						<option selected="selected" value="1">Full</option>
+						<option value="0.5">Half</option>
+					</select>
+					</td>					
+					<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Grapple-Damage}+(ceil(@{Damage_Bonus}*@{weapon_typeG}))]]}} {{success=[[ceil(@{Grapple}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Grapple}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Grapple}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Grapple}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}} {{1/2success=[[ceil((@{Grapple}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{roll=[[1d100]]}} {{skillname=Grapple}}" /></td>						
 				</tr>
 				
 			</tbody>
@@ -1326,9 +1336,14 @@
 						</select>
 					</td>	
 					<td><input style="width:62px" type="text" name="attr_Damagex"  /></td>
-					<td><input style="width:36px; margin-right:3px" type="number" name="attr_Attacks-Round" /></td>
 					<td><input  style="width:40px" type="text" name="attr_HP" /></td>
-					<td><button type="roll" value="&{template:melee-roll} {{name=@{Name}}}{{tot=[[@{Damagex}+@{Damage_Bonus}]]}} {{success=[[ceil(@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}} {{1/2success=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{skillvalue=@{Score}}}  {{roll=[[1d100]]}} {{skillname=@{Attack-Weapon}}}" /></td>					   				
+					<td>
+					<select style="font-size: 9px; margin-bottom: 0px; width: 45px" name="attr_weapon_type">
+						<option selected="selected" value="1">Full</option>
+						<option value="0.5">Half</option>
+					</select>						
+					</td>					
+					<td><button type="roll" value="&{template:melee-roll} {{name=@{Name}}}{{tot=[[@{Damagex}+(ceil(@{Damage_Bonus}*@{weapon_type}))]]}} {{success=[[ceil(@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}} {{1/2success=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{skillvalue=@{Score}}}  {{roll=[[1d100]]}} {{skillname=@{Attack-Weapon}}}" /></td>					   				
 				</tr>
 		</tbody>
 			</table>
@@ -1384,7 +1399,7 @@
 						<option value="0.5">Yes</option>
 					</select>						
 					</td>
-						<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Damage}+ceil(@{Damage_Bonus})*@{weapon_type})]]}} {{success=[[ceil(@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{1/2success=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{skillvalue=@{Score}}}  {{roll=[[1d100]]}} {{skillname=@{Firearm}}}" /></td>
+						<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Damage}+(ceil(@{Damage_Bonus}*@{weapon_type}))]]}} {{success=[[ceil(@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})]]}} {{fumble=[[ceil(95+(@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20))]]}} {{crit=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/20)+1]]}} {{special=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/5)+1]]}}  {{1/2success=[[ceil((@{Score}*?{Multiplier|Normal - 1, 1|Easy - 2, 2|Difficult - 1/2, 1/2|1/3|1/4|1/5|1/6|1/8|1/10|1/20}+?{Mods|0})/2)+1]]}}  {{skillvalue=@{Score}}}  {{roll=[[1d100]]}} {{skillname=@{Firearm}}}" /></td>
 				</tr>
 			</table>
 		</fieldset>
@@ -1455,7 +1470,7 @@
 		<fieldset class="repeating_hlocations">
 			<table>
 				<tr>
-					<td><input type="text" name="attr_hloc" style="width: 59px" /></td>
+					<td><input type="text" name="attr_hloc" style="width: 100px" /></td>
 					<td><input class="sheet-armor-name" type="text" name="attr_atype"  /></td>
 					<td><input type="number" name="attr_app"  /></td>
 					<td><input type="number" name="attr_mhp"/></td>


### PR DESCRIPTION
## Changes / Comments
Added a width to the CCS to prevent the sheets from stretching or deforming when resizing the window.

Replaced the Attks entry on the Hand-to-Hand weapons with a Damage Bonus drop down menu (since melee weapons universally have 1 attack)

Increased the width on the repeating Hit Locations entry to match the rest of the sheet.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ X ] Does this add functional enhancements (new features or extending existing features) ?
- [ X ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
