### PR TITLE
Warhammer_v2_french : Removed missing pictures in templates

### DIFF
--- a/Warhammer_v2_french/Warhammer_v2_french.html
+++ b/Warhammer_v2_french/Warhammer_v2_french.html
@@ -690,13 +690,7 @@
          <rolltemplate class="sheet-rolltemplate-war2_test">
         <table>
             <tr><th COLSPAN="2">{{name}}</th></tr>
-           
-            <tr>
-            <td COLSPAN="2">
-                <img class="sheet-imghr" src="https://lh3.googleusercontent.com/-ptR_NzBo340/VYslrf-t9NI/AAAAAAAAV4Q/rV7U24IJdAc/w745-h10-no/co_hr.png" />
-            </td>
-            </tr>  
-            
+                       
             <td class="tcat">Base :</td>
             <td>{{Carac}} %</td> 
             </tr>
@@ -717,26 +711,14 @@
                             <td COLSPAN="2" style="text-align:center;font-style:oblique;font-weight:bolder;color: #3FB315;">Succès !</td>
                         {{/rollTotal() Roll Carac}}
 			{{/Roll}}
-            <tr>
-        <tr>
-            <td COLSPAN="2">
-                <img class="sheet-imghr" src="https://lh3.googleusercontent.com/-ptR_NzBo340/VYslrf-t9NI/AAAAAAAAV4Q/rV7U24IJdAc/w745-h10-no/co_hr.png" />
-            </td>
-        </tr>
-            
+            <tr>            
         </table>
 </rolltemplate>
 
          <rolltemplate class="sheet-rolltemplate-war2_combat">
         <table>
             <tr><th COLSPAN="2">{{name}}</th></tr>
-            <tr> 
-            
             <tr>
-            <td COLSPAN="2">
-                <img class="sheet-imghr" src="https://lh3.googleusercontent.com/-ptR_NzBo340/VYslrf-t9NI/AAAAAAAAV4Q/rV7U24IJdAc/w745-h10-no/co_hr.png" />
-            </td>
-            </tr>  
             
             <td class="tcat">Base :</td>
             <td>{{Carac}} %</td> 
@@ -793,10 +775,6 @@
                     {{/rollLess() Roll Carac}}
 			{{/Roll}}
             </tr>
-           
-            <td COLSPAN="2">
-                <img class="sheet-imghr" src="https://lh3.googleusercontent.com/-ptR_NzBo340/VYslrf-t9NI/AAAAAAAAV4Q/rV7U24IJdAc/w745-h10-no/co_hr.png" />
-            </td>
             </tr>  
             
         </table>


### PR DESCRIPTION
Removed missing pictures in templates which were replaced by a huge and ugly placeholder.
Deleted it alltogether in the 2 templates (test & combat)

## Changes / Comments
- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 

The pictures displayed in the roll template used throughout the sheet is no longer accessible, I juste removed the <tr></tr> containing them in the 2 templates.
Here is the former picture link wich is no longer valide :
https://lh3.googleusercontent.com/-ptR_NzBo340/VYslrf-t9NI/AAAAAAAAV4Q/rV7U24IJdAc/w745-h10-no/co_hr.png