### PR TITLE
[Anima-Beyond-Fantasy] Sheet A-BF : add turn tracker to init roll

### DIFF
--- a/Anima-Beyond-Fantasy/A-BF.html
+++ b/Anima-Beyond-Fantasy/A-BF.html
@@ -4009,7 +4009,7 @@
 			<h2 data-i18n="initiative">Initiative</h2>
 			<fieldset class="repeating_initiative">
 				<input type="hidden" name="attr_init_option" value="0" />
-				<button type="roll" name="roll_init" value="@{diceRollD100} {{subname=^{initiative}}} {{subtitle=@{init_label}}} {{result=[[1d100@{ord}cs>[[@{orr}]]cf<[[@{fr}]]+[[@{init_final}]]+?{@{modifiersTrad} ?|0}]]}}">
+				<button type="roll" name="roll_init" value="@{diceRollD100} {{subname=^{initiative}}} {{subtitle=@{init_label}}} {{result=[[1d100@{ord}cs>[[@{orr}]]cf<[[@{fr}]]+[[@{init_final}]]+?{@{modifiersTrad} ?|0}&{tracker}]]}}">
 					<input type="text" name="attr_init_label" value=""/>
 					<span name="attr_init_final" />
 				</button>


### PR DESCRIPTION
## Changes / Comments

Add turn tracker to init roll.
The open rolls are not handled. If anyone has an idea how to do that, I'm interested.

- Does the pull request title have the sheet name(s)? Yes
- Is this a bug fix? No
- Does this add functional enhancements (new features or extending existing features) ? Yes
- Does this add or change functional aesthetics (such as layout or color scheme) ? No
- If changing or removing attributes, what steps have you taken, if any, to preserve player data ? No change is made to player data.
- If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ? This is not a new sheet.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix? 
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [x] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?
