### PR TITLE
[Gurps 2.5.3.1] important

### DIFF
--- a/GURPS/gurps.html
+++ b/GURPS/gurps.html
@@ -4271,6 +4271,7 @@
 				</h4>
 
 				<ul>
+					<li>Urgent bugfix. Remove target option from melee button. </li>
 					<li>Combat Tab > Melee table. Display swing & thrust damage, also widened the damage column a little to make easier to enter field values and formulas. Requested by PL M.</li>
 					<li>Combat Tab. An Active Defense can now be linked to a melee weapon. This allows you assign a defense to melee weapon that has additional skill bonuses, like weapon bond.</li>
 					<li>New Rolltemplate. A generic, simple template for use with macros. Click on <b>View All Updates</b> for details.</li>

--- a/GURPS/gurps.html
+++ b/GURPS/gurps.html
@@ -14912,9 +14912,9 @@ See notes for weapon.</textarea>
 
 	var noop = function () {}; // do nothing callback function.
 
-	var version = "2.5.3";  
+	var version = "2.5.3.1";  
 
-	var latestChangesDate = "11/30/2020";
+	var latestChangesDate = "12/04/2020";
 
 	var modCascade = true;
 	

--- a/GURPS/gurps.html
+++ b/GURPS/gurps.html
@@ -10525,7 +10525,7 @@ visualize what it will look like in chat.
 										<input type="text" name="attr_skill" title="Macro table name: repeating_melee. Field name: skill" />
 									</div>
 									<div class="cell col6">
-										<button type="roll" class="template-attack-roll" value="@{roll}&{template:skillRoll} {{sheetStyle=@{sheetstyle}}} {{type=Melee Attack}} {{against=@{target|token_name}}} {{activeDefense=[[0]]}} {{isSkillRoll=[[1]]}} {{showHitLabel=[[1]]}} {{characterName=@{character_name}}} {{skillName=@{name}}} {{rollResult=[[3d6]]}} {{effectiveSkill=[[{@{skill} + @{modifier} + @{melee_roll_modifier}, @{melee_roll_max_nine_value} }kl1]]}} {{useModToll=[[@{use_melee_modifier_tool}]]}} {{maxNine=[[@{melee_roll_max_nine}]]}} {{rollModifier=[[@{melee_roll_modifier}]]}} {{rollModifierSummary=@{melee_roll_modifier_summary}}} {{rollTraitSummary=@{melee_roll_trait_summary}}} {{hitLocation=@{melee_roll_hit_location}}} {{maneuver=@{melee_roll_maneuver}}} {{allOutAttack=@{melee_roll_allout_attack}}} {{reach=@{reach}}} {{notes=@{notes}}} {{showNotes=[[1]]}} {{useCriticalPlusTen=[[@{use_critical_plus_10}]]}}" name="roll_vsSL" />
+										<button type="roll" class="template-attack-roll" value="@{roll}&{template:skillRoll} {{sheetStyle=@{sheetstyle}}} {{type=Melee Attack}} {{activeDefense=[[0]]}} {{isSkillRoll=[[1]]}} {{showHitLabel=[[1]]}} {{characterName=@{character_name}}} {{skillName=@{name}}} {{rollResult=[[3d6]]}} {{effectiveSkill=[[{@{skill} + @{modifier} + @{melee_roll_modifier}, @{melee_roll_max_nine_value} }kl1]]}} {{useModToll=[[@{use_melee_modifier_tool}]]}} {{maxNine=[[@{melee_roll_max_nine}]]}} {{rollModifier=[[@{melee_roll_modifier}]]}} {{rollModifierSummary=@{melee_roll_modifier_summary}}} {{rollTraitSummary=@{melee_roll_trait_summary}}} {{hitLocation=@{melee_roll_hit_location}}} {{maneuver=@{melee_roll_maneuver}}} {{allOutAttack=@{melee_roll_allout_attack}}} {{reach=@{reach}}} {{notes=@{notes}}} {{showNotes=[[1]]}} {{useCriticalPlusTen=[[@{use_critical_plus_10}]]}}" name="roll_vsSL" />
 									</div>
 								</div> <!-- .row -->
 								<div class="melee-notebox">
@@ -12703,6 +12703,7 @@ visualize what it will look like in chat.
 			<p>Pull Request: <span name="attr_latest_changes"></span></p>
 
 			<ul>
+				<li>Urgent bugfix. Remove target option from melee button. </li>
 				<li>Combat Tab > Melee table. Display swing & thrust damage, also widened the damage column a little to make easier to enter field values and formulas. Requested by PL M.</li>
 				<li>Combat Tab. An Active Defense can now be linked to a melee weapon. This allows you assign a defense to melee weapon that has additional skill bonuses, like weapon bond.</li>
 				<li>New Rolltemplate. A generic, simple template for use with macros. See below.</li>


### PR DESCRIPTION
## Changes / Comments

Remove Target Token macro from melee attack rolls. This was supposed to be for a future feature to add optional targeting.

### Files Updates

GURPS/gurps.html


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
