### PR TITLE
[Pokemon Tabletop Adventures V3] More Trainer Rolls

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -630,34 +630,6 @@ input.sheet-select-hybrid:checked ~ div.sheet-tab-hybrid {
   outline: none;
 }
 
-button[type="roll"].sheet-stat-roller {
-  align-items: center;
-  background: #00000000;
-  border: none;
-  box-shadow: none;
-  font-size: 1em;
-  font-style: italic;
-  font-weight: bold;
-  padding: 0px 10px;
-  margin: 5px 0px;
-  text-shadow: none;
-}
-
-button[type="roll"].sheet-stat-roller:hover {
-  box-shadow: inset 0 1px 0 #ffffff80, 0 1px 2px #00000080;
-  transition-duration: 0.1s;
-}
-
-button[type="roll"].sheet-stat-roller:active {
-  box-shadow: inset 0 1px 2px #00000080, 0 1px 2px #ffffff80;
-  transition-duration: 0.1s;
-}
-
-button[type="roll"].sheet-move-roller:before,
-button[type="roll"].sheet-stat-roller:before {
-  content: "";
-}
-
 button[type="roll"].sheet-atk-skill:hover {
   background-color: var(--stat-ro-atk);
 }
@@ -693,6 +665,10 @@ button[type="roll"].sheet-move-roller {
   color: var(--poke-foreground-color);
 }
 
+button[type="roll"].sheet-move-roller:before {
+  content: "";
+}
+
 button[type="roll"].sheet-skill-roller {
   background: transparent;
   border: 2px var(--poke-foreground-color);
@@ -702,6 +678,33 @@ button[type="roll"].sheet-skill-roller {
   font-weight: bold;
   text-align: left;
   text-shadow: 0 0 transparent;
+}
+
+button[type="roll"].sheet-stat-roller {
+  align-items: center;
+  background: #00000000;
+  border: none;
+  box-shadow: none;
+  font-size: 1em;
+  font-style: italic;
+  font-weight: bold;
+  padding: 0px 10px;
+  margin: 5px 0px;
+  text-shadow: none;
+}
+
+button[type="roll"].sheet-stat-roller:active {
+  box-shadow: inset 0 1px 2px #00000080, 0 1px 2px #ffffff80;
+  transition-duration: 0.1s;
+}
+
+button[type="roll"].sheet-stat-roller:before {
+  font-style: normal;
+}
+
+button[type="roll"].sheet-stat-roller:hover {
+  box-shadow: inset 0 1px 0 #ffffff80, 0 1px 2px #00000080;
+  transition-duration: 0.1s;
 }
 
 .sheet-move-notes-roller {

--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -62,7 +62,6 @@
   --spdef-header: #99ff9980;
   --spd-gradient: #bb55bb;
   --spd-header: #ff99ff80;
-
 }
 
 .charsheet + .charactersheet {
@@ -198,26 +197,29 @@ input.sheet-color-setting-water-move:checked ~ div.sheet-pokemon-move {
   --poke-foreground-color: var(--poke-water-shaded);
 }
 
-div.sheet-wrapper b, div.sheet-wrapper p,
-div.sheet-pokemon-move b, div.sheet-pokemon-move p {
+div.sheet-wrapper b,
+div.sheet-wrapper p,
+div.sheet-pokemon-move b,
+div.sheet-pokemon-move p {
   color: var(--poke-foreground-color);
 }
 
 div.sheet-pokemon-move span.sheet-readonly-field,
 div.sheet-pokemon-move span.sheet-readonly-field input[type="number"] {
-    border: none;
-    color: var(--poke-foreground-color);
-    font-style: italic;
+  border: none;
+  color: var(--poke-foreground-color);
+  font-style: italic;
 }
 
-div.sheet-wrapper, div.sheet-pokemon-move {
+div.sheet-wrapper,
+div.sheet-pokemon-move {
   background-color: var(--poke-background-color);
 }
 
-
 /* End fancy colors */
 
-div.sheet-character-stat-grid b, div.sheet-character-stat-grid p {
+div.sheet-character-stat-grid b,
+div.sheet-character-stat-grid p {
   padding-bottom: 10px;
   padding-top: 5px;
 }
@@ -425,8 +427,8 @@ select.sheet-ball-selector::-ms-expand {
 }
 
 .sheet-pokemon-move-info-grid-2 b.sheet-info-tooltip {
-    border-bottom: 2px dotted;
-    border-color: var(--poke-foreground-color);
+  border-bottom: 2px dotted;
+  border-color: var(--poke-foreground-color);
 }
 
 /* Remove arrows from number inputs */
@@ -473,7 +475,7 @@ select {
 textarea {
   background-color: rgba(255, 255, 255, 0.3);
   box-sizing: border-box;
-  font-weight: bold
+  font-weight: bold;
 }
 
 .sheet-pokemon-move {
@@ -677,9 +679,10 @@ button[type="roll"].sheet-move-roller {
   margin-bottom: 5px;
   margin-right: 10px;
   margin-top: 10px;
-  font-family: 'dicefontd20'; 
+  font-family: "dicefontd20";
   font-size: 75px;
-  box-shadow: inset 0px 0px 10px var(--poke-foreground-color), 0px 0px 10px 1px var(--poke-foreground-color);
+  box-shadow: inset 0px 0px 10px var(--poke-foreground-color),
+    0px 0px 10px 1px var(--poke-foreground-color);
   color: var(--poke-foreground-color);
 }
 
@@ -878,25 +881,43 @@ button[type="roll"].sheet-skill-roller {
   width: 100%;
 }
 
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-crit-damage-text {
+.sheet-rolltemplate-move-roll
+  .sheet-container
+  table.sheet-move-template
+  .sheet-crit-damage-text {
   font-weight: bold;
   margin-left: 10px;
   padding: 2px 5px;
 }
 
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-damage-roll .inlinerollresult {
+.sheet-rolltemplate-move-roll
+  .sheet-container
+  table.sheet-move-template
+  .sheet-damage-roll
+  .inlinerollresult {
   border: 2px solid;
 }
 
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
-.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template .sheet-skill-roll .inlinerollresult {
+.sheet-rolltemplate-move-roll
+  .sheet-container
+  table.sheet-move-template
+  .sheet-accuracy-roll
+  .inlinerollresult,
+.sheet-rolltemplate-skill-roll
+  .sheet-container
+  table.sheet-skill-template
+  .sheet-skill-roll
+  .inlinerollresult {
   background: black;
   border: 2px solid black;
   color: white;
 }
 
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template span.sheet-targeted-defense {
-  font-size: smaller;  
+.sheet-rolltemplate-move-roll
+  .sheet-container
+  table.sheet-move-template
+  span.sheet-targeted-defense {
+  font-size: smaller;
   font-weight: bold;
   margin-left: 0px;
   padding: 2px 5px;
@@ -904,39 +925,74 @@ button[type="roll"].sheet-skill-roller {
 }
 
 /* Varying colour by effectiveness for damage roll and text  */
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-text-color {
-    background: #800000;
-    border-color: #800000;
-    color: white;
+.sheet-rolltemplate-move-roll
+  .sheet-container
+  table.sheet-move-template
+  .userscript--2-effectiveness-color
+  .inlinerollresult,
+.sheet-rolltemplate-move-roll
+  .sheet-container
+  table.sheet-move-template
+  .userscript--2-effectiveness-text-color {
+  background: #800000;
+  border-color: #800000;
+  color: white;
 }
 
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-text-color {
-    background: #cf6800;
-    border-color: #cf6800;
-    color: white;
+.sheet-rolltemplate-move-roll
+  .sheet-container
+  table.sheet-move-template
+  .userscript--1-effectiveness-color
+  .inlinerollresult,
+.sheet-rolltemplate-move-roll
+  .sheet-container
+  table.sheet-move-template
+  .userscript--1-effectiveness-text-color {
+  background: #cf6800;
+  border-color: #cf6800;
+  color: white;
 }
 
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-text-color {
-    background: black;
-    border-color: black;
-    color: white;
+.sheet-rolltemplate-move-roll
+  .sheet-container
+  table.sheet-move-template
+  .userscript-0-effectiveness-color
+  .inlinerollresult,
+.sheet-rolltemplate-move-roll
+  .sheet-container
+  table.sheet-move-template
+  .userscript-0-effectiveness-text-color {
+  background: black;
+  border-color: black;
+  color: white;
 }
 
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-text-color {
-    background: #000080;
-    border-color: #000080;
-    color: white;
+.sheet-rolltemplate-move-roll
+  .sheet-container
+  table.sheet-move-template
+  .userscript-1-effectiveness-color
+  .inlinerollresult,
+.sheet-rolltemplate-move-roll
+  .sheet-container
+  table.sheet-move-template
+  .userscript-1-effectiveness-text-color {
+  background: #000080;
+  border-color: #000080;
+  color: white;
 }
 
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-text-color {
-    background: #008000;
-    border-color: #008000;
-    color: white;
+.sheet-rolltemplate-move-roll
+  .sheet-container
+  table.sheet-move-template
+  .userscript-2-effectiveness-color
+  .inlinerollresult,
+.sheet-rolltemplate-move-roll
+  .sheet-container
+  table.sheet-move-template
+  .userscript-2-effectiveness-text-color {
+  background: #008000;
+  border-color: #008000;
+  color: white;
 }
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template a,
@@ -951,10 +1007,13 @@ button[type="roll"].sheet-skill-roller {
 }
 
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template td {
-    padding: 8px 2px;
+  padding: 8px 2px;
 }
 
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-effectiveness-text {
+.sheet-rolltemplate-move-roll
+  .sheet-container
+  table.sheet-move-template
+  td.sheet-effectiveness-text {
   font-weight: bold;
   line-height: 20px;
   padding: 2px 5px;
@@ -962,23 +1021,38 @@ button[type="roll"].sheet-skill-roller {
   text-transform: none;
 }
 
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-label,
-.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template td.sheet-label {
+.sheet-rolltemplate-move-roll
+  .sheet-container
+  table.sheet-move-template
+  td.sheet-label,
+.sheet-rolltemplate-skill-roll
+  .sheet-container
+  table.sheet-skill-template
+  td.sheet-label {
   font-weight: bold;
   line-height: 14px;
   text-align: center;
   width: 80px;
 }
 
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text {
+.sheet-rolltemplate-move-roll
+  .sheet-container
+  table.sheet-move-template
+  td.sheet-notes-text {
   font-size: 12px;
   line-height: 12px;
   padding: 8px;
   text-transform: none;
 }
 
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
-.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template td.sheet-subhead {
+.sheet-rolltemplate-move-roll
+  .sheet-container
+  table.sheet-move-template
+  td.sheet-subhead,
+.sheet-rolltemplate-skill-roll
+  .sheet-container
+  table.sheet-skill-template
+  td.sheet-subhead {
   padding: 4px;
   background: var(--box-bg);
   font-size: 12px;
@@ -994,12 +1068,24 @@ button[type="roll"].sheet-skill-roller {
   background: var(--header-bg);
 }
 
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template tr:nth-child(odd),
-.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template tr:nth-child(odd) {
+.sheet-rolltemplate-move-roll
+  .sheet-container
+  table.sheet-move-template
+  tr:nth-child(odd),
+.sheet-rolltemplate-skill-roll
+  .sheet-container
+  table.sheet-skill-template
+  tr:nth-child(odd) {
   background: var(--odd-row-bg);
 }
 
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
-.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template tr:nth-child(even) {
+.sheet-rolltemplate-move-roll
+  .sheet-container
+  table.sheet-move-template
+  tr:nth-child(even),
+.sheet-rolltemplate-skill-roll
+  .sheet-container
+  table.sheet-skill-template
+  tr:nth-child(even) {
   background: var(--row-bg);
 }

--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -365,9 +365,16 @@ div.sheet-character-stat-grid p {
 }
 
 .sheet-character-skills {
+  align-items: center;
   display: grid;
   grid-template-columns: 2fr 10fr 1fr 1fr 2fr;
-  align-items: center;
+}
+
+.sheet-skill-separator {
+  border: 2px var(--poke-foreground-color);
+  border-style: solid none none none;
+  margin: 7px;
+  margin-left: 2px;
 }
 
 .sheet-capture-pokemon-skill {

--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -368,6 +368,26 @@ div.sheet-character-stat-grid b, div.sheet-character-stat-grid p {
   align-items: center;
 }
 
+.sheet-capture-pokemon-skill {
+  display: grid;
+  grid-template-columns: 2fr 10fr 4fr;
+  align-items: center;
+}
+
+select.sheet-ball-selector {
+  border: none;
+  width: auto;
+  /* for Firefox */
+  -moz-appearance: none;
+  /* for Chrome */
+  -webkit-appearance: none;
+}
+
+/* For IE10 */
+select.sheet-ball-selector::-ms-expand {
+  display: none;
+}
+
 .sheet-pokemon-all-stats-bounds {
   max-width: 400px;
   margin-left: auto;

--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -621,7 +621,31 @@ input.sheet-select-hybrid:checked ~ div.sheet-tab-hybrid {
   outline: none;
 }
 
-button[type="roll"].sheet-move-roller:before {
+button[type="roll"].sheet-stat-roller {
+  align-items: center;
+  background: #00000000;
+  border: none;
+  box-shadow: none;
+  font-size: 1em;
+  font-style: italic;
+  font-weight: bold;
+  padding: 0px 10px;
+  margin: 5px 0px;
+  text-shadow: none;
+}
+
+button[type="roll"].sheet-stat-roller:hover {
+  box-shadow: inset 0 1px 0 #ffffff80, 0 1px 2px #00000080;
+  transition-duration: 0.1s;
+}
+
+button[type="roll"].sheet-stat-roller:active {
+  box-shadow: inset 0 1px 2px #00000080, 0 1px 2px #ffffff80;
+  transition-duration: 0.1s;
+}
+
+button[type="roll"].sheet-move-roller:before,
+button[type="roll"].sheet-stat-roller:before {
   content: "";
 }
 

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -983,556 +983,990 @@
 <script type="text/worker">
     // Handling Stat Changes
     on("change:ATK change:atkbonus sheet:opened", function () {
-        getAttrs(["ATK", "atkbonus"], function (values) {
-            let atk = parseInt(values.ATK) || 0;
-            let bonus = parseInt(values.atkbonus) || 0;
-            calcModFor("ATK", atk, bonus);
-        });
+      getAttrs(["ATK", "atkbonus"], function (values) {
+        let atk = parseInt(values.ATK) || 0;
+        let bonus = parseInt(values.atkbonus) || 0;
+        calcModFor("ATK", atk, bonus);
+      });
     });
     
     on("change:DEF change:defbonus sheet:opened", function () {
-        getAttrs(["DEF", "defbonus"], function (values) {
-            let def = parseInt(values.DEF) || 0;
-            let bonus = parseInt(values.defbonus) || 0;
-            calcModFor("DEF", def, bonus);
-        });
+      getAttrs(["DEF", "defbonus"], function (values) {
+        let def = parseInt(values.DEF) || 0;
+        let bonus = parseInt(values.defbonus) || 0;
+        calcModFor("DEF", def, bonus);
+      });
     });
     
     on("change:SPATK change:spatkbonus sheet:opened", function () {
-        getAttrs(["SPATK", "spatkbonus"], function (values) {
-            let spatk = parseInt(values.SPATK) || 0;
-            let bonus = parseInt(values.spatkbonus) || 0;
-            calcModFor("SPATK", spatk, bonus);
-        });
+      getAttrs(["SPATK", "spatkbonus"], function (values) {
+        let spatk = parseInt(values.SPATK) || 0;
+        let bonus = parseInt(values.spatkbonus) || 0;
+        calcModFor("SPATK", spatk, bonus);
+      });
     });
     
     on("change:SPDEF change:spdefbonus sheet:opened", function () {
-        getAttrs(["SPDEF", "spdefbonus"], function (values) {
-            let spdef = parseInt(values.SPDEF) || 0;
-            let bonus = parseInt(values.spdefbonus) || 0;
-            calcModFor("SPDEF", spdef, bonus);
-        });
+      getAttrs(["SPDEF", "spdefbonus"], function (values) {
+        let spdef = parseInt(values.SPDEF) || 0;
+        let bonus = parseInt(values.spdefbonus) || 0;
+        calcModFor("SPDEF", spdef, bonus);
+      });
     });
     
     on("change:SPD change:spdbonus sheet:opened", function () {
-        getAttrs(["SPD", "spdbonus"], function (values) {
-            let spd = parseInt(values.SPD) || 0;
-            let bonus = parseInt(values.spdbonus) || 0;
-            calcModFor("SPD", spd, bonus);
-        });
+      getAttrs(["SPD", "spdbonus"], function (values) {
+        let spd = parseInt(values.SPD) || 0;
+        let bonus = parseInt(values.spdbonus) || 0;
+        calcModFor("SPD", spd, bonus);
+      });
     });
     
     function calcModFor(ability, stat, bonus) {
-        const combined = stat + bonus;
-        const modifier = Math.floor(combined / 2);
-        const name = `${ability}MOD`;
-        const attrs = { [name]:  modifier}
-        if (ability == "SPD") attrs["movement"] = combined * 5;
-        setAttrs(attrs);
+      const combined = stat + bonus;
+      const modifier = Math.floor(combined / 2);
+      const name = `${ability}MOD`;
+      const attrs = { [name]: modifier };
+      if (ability == "SPD") attrs["movement"] = combined * 5;
+      setAttrs(attrs);
     }
     
     // Handling Colour Changes
-    types = ["bug", "dark", "dragon", "electric", "fairy", "fighting", "fire", "flying", "ghost", "grass", "ground", "ice", "normal", "poison", "psychic", "rock", "steel", "water"]
+    types = [
+      "bug",
+      "dark",
+      "dragon",
+      "electric",
+      "fairy",
+      "fighting",
+      "fire",
+      "flying",
+      "ghost",
+      "grass",
+      "ground",
+      "ice",
+      "normal",
+      "poison",
+      "psychic",
+      "rock",
+      "steel",
+      "water",
+    ];
     on("change:type1 sheet:opened", function (event) {
-        getAttrs(["type1"], function (values) {
-            var typeAttrs = {};
-            var selectedType = values.type1;
-            types.forEach((type) => {
-                if (type == selectedType) {
-                    typeAttrs["style-" + type] = "on";
-                } else {
-                    typeAttrs["style-" + type] = "off";
-                }
-            })
-            setAttrs(typeAttrs);
+      getAttrs(["type1"], function (values) {
+        var typeAttrs = {};
+        var selectedType = values.type1;
+        types.forEach((type) => {
+          if (type == selectedType) {
+            typeAttrs["style-" + type] = "on";
+          } else {
+            typeAttrs["style-" + type] = "off";
+          }
         });
+        setAttrs(typeAttrs);
+      });
     });
     
     on("change:repeating_moves:move_type", function (event) {
-        getAttrs(["repeating_moves_move_type"], function (values) {
-            var typeAttrs = {};
-            var selectedType = values.repeating_moves_move_type;
-            types.forEach((type) => {
-                if (type == selectedType) {
-                    typeAttrs["repeating_moves_style-" + type + "-move"] = "on";
-                } else {
-                    typeAttrs["repeating_moves_style-" + type + "-move"] = "off";
-                }
-            })
-            setAttrs(typeAttrs);
+      getAttrs(["repeating_moves_move_type"], function (values) {
+        var typeAttrs = {};
+        var selectedType = values.repeating_moves_move_type;
+        types.forEach((type) => {
+          if (type == selectedType) {
+            typeAttrs["repeating_moves_style-" + type + "-move"] = "on";
+          } else {
+            typeAttrs["repeating_moves_style-" + type + "-move"] = "off";
+          }
         });
+        setAttrs(typeAttrs);
+      });
     });
     
     // Handling Targeted Defense Changes
     defenses = ["", "Defense", "Special Defense", "Speed"];
     on("sheet:opened", function (eventInfo) {
-        getSectionIDs("repeating_moves", function (idArray) {
-            const categories = idArray.map(id => `repeating_moves_${id}_move_category`);
+      getSectionIDs("repeating_moves", function (idArray) {
+        const categories = idArray.map(
+          (id) => `repeating_moves_${id}_move_category`
+        );
     
-            getAttrs([...categories], function (values) {
-                const rows = categories.reduce((obj, rowName) => {
-                    const cat = parseInt(values[rowName]) || 0;
-                    const defense = defenses[cat];
+        getAttrs([...categories], function (values) {
+          const rows = categories.reduce((obj, rowName) => {
+            const cat = parseInt(values[rowName]) || 0;
+            const defense = defenses[cat];
     
-                    obj[rowName + '_defense'] = defense;
-                    return obj;
-                }, {});
-                if (rows) setAttrs(rows);
-            });
+            obj[rowName + "_defense"] = defense;
+            return obj;
+          }, {});
+          if (rows) setAttrs(rows);
         });
+      });
     });
     
     on("change:repeating_moves:move_category", function (event) {
-        getAttrs(["repeating_moves_move_name", "repeating_moves_move_category"], function (values) {
-            var attrs = {};
-            let cat = parseInt(values.repeating_moves_move_category) || 0;
-            attrs["repeating_moves_move_category_defense"] = defenses[cat];
-            setAttrs(attrs);
-        });
+      getAttrs(
+        ["repeating_moves_move_name", "repeating_moves_move_category"],
+        function (values) {
+          var attrs = {};
+          let cat = parseInt(values.repeating_moves_move_category) || 0;
+          attrs["repeating_moves_move_category_defense"] = defenses[cat];
+          setAttrs(attrs);
+        }
+      );
     });
     
     // Handling Move and Feature Usage
     on("clicked:repeating_moves:incrementmoveusage", function () {
-        getAttrs(["repeating_moves_move_usage"], function (values) {
-            const currentusage = +values.repeating_moves_move_usage || 0;
-            const newusage = currentusage + 1;
-            setAttrs({
-                repeating_moves_move_usage: newusage
-            });
+      getAttrs(["repeating_moves_move_usage"], function (values) {
+        const currentusage = +values.repeating_moves_move_usage || 0;
+        const newusage = currentusage + 1;
+        setAttrs({
+          repeating_moves_move_usage: newusage,
         });
+      });
     });
     
     on("clicked:repeating_moves:resetmoveusage", function () {
-        getAttrs(["repeating_moves_move_usage"], function (values) {
-            setAttrs({
-                repeating_moves_move_usage: 0
-            });
+      getAttrs(["repeating_moves_move_usage"], function (values) {
+        setAttrs({
+          repeating_moves_move_usage: 0,
         });
+      });
     });
     
     on("clicked:incrementoriginusage", function () {
-        getAttrs(["origin_usage"], function (values) {
-            const currentusage = +values.origin_usage || 0;
-            const newusage = currentusage + 1;
-            setAttrs({
-                origin_usage: newusage
-            });
+      getAttrs(["origin_usage"], function (values) {
+        const currentusage = +values.origin_usage || 0;
+        const newusage = currentusage + 1;
+        setAttrs({
+          origin_usage: newusage,
         });
+      });
     });
     
     on("clicked:resetoriginusage", function () {
-        getAttrs(["origin_usage"], function (values) {
-            setAttrs({
-                origin_usage: 0
-            });
+      getAttrs(["origin_usage"], function (values) {
+        setAttrs({
+          origin_usage: 0,
         });
+      });
     });
     
     on("clicked:repeating_features:incrementfeatureusage", function () {
-        getAttrs(["repeating_features_feature_usage"], function (values) {
-            const currentusage = +values.repeating_features_feature_usage || 0;
-            const newusage = currentusage + 1;
-            setAttrs({
-                repeating_features_feature_usage: newusage
-            });
+      getAttrs(["repeating_features_feature_usage"], function (values) {
+        const currentusage = +values.repeating_features_feature_usage || 0;
+        const newusage = currentusage + 1;
+        setAttrs({
+          repeating_features_feature_usage: newusage,
         });
+      });
     });
     
     on("clicked:repeating_features:resetfeatureusage", function () {
-        getAttrs(["repeating_features_feature_usage"], function (values) {
-            setAttrs({
-                repeating_features_feature_usage: 0
-            });
+      getAttrs(["repeating_features_feature_usage"], function (values) {
+        setAttrs({
+          repeating_features_feature_usage: 0,
         });
+      });
     });
     
     // Handling Move Effects
-    effects = ["Critical Hit", "put to Sleep", "Burned", "Confused", "Cursed", "Frozen", "Infatuated", "Paralyzed", "Poisoned", "Toxified", "Stunned", "Other"];
+    effects = [
+      "Critical Hit",
+      "put to Sleep",
+      "Burned",
+      "Confused",
+      "Cursed",
+      "Frozen",
+      "Infatuated",
+      "Paralyzed",
+      "Poisoned",
+      "Toxified",
+      "Stunned",
+      "Other",
+    ];
     on("sheet:opened", function (eventInfo) {
-        getSectionIDs("repeating_moves", function (idArray) {
-            const rowNames = idArray.map(id => `repeating_moves_${id}`);
-            const effect1s = idArray.map(id => `repeating_moves_${id}_move_effect1`);
-            const effect2s = idArray.map(id => `repeating_moves_${id}_move_effect2`);
+      getSectionIDs("repeating_moves", function (idArray) {
+        const rowNames = idArray.map((id) => `repeating_moves_${id}`);
+        const effect1s = idArray.map((id) => `repeating_moves_${id}_move_effect1`);
+        const effect2s = idArray.map((id) => `repeating_moves_${id}_move_effect2`);
     
-            getAttrs([...effect1s, ...effect2s], function (values) {
-                const rows = rowNames.reduce((obj, rowName) => {
-                    const index1 = parseInt(values[rowName + '_move_effect1']) || 99;
-                    const index2 = parseInt(values[rowName + '_move_effect2']) || 99;
+        getAttrs([...effect1s, ...effect2s], function (values) {
+          const rows = rowNames.reduce((obj, rowName) => {
+            const index1 = parseInt(values[rowName + "_move_effect1"]) || 99;
+            const index2 = parseInt(values[rowName + "_move_effect2"]) || 99;
     
-                    var name = "";
-                    if (index1 < effects.length) {
-                        name = effects[index1];
-                    }
-                    obj[rowName + '_move_effect1_name'] = name;
+            var name = "";
+            if (index1 < effects.length) {
+              name = effects[index1];
+            }
+            obj[rowName + "_move_effect1_name"] = name;
     
-                    name = "";
-                    if (index2 < effects.length) {
-                        name = effects[index2];
-                    }
-                    obj[rowName + '_move_effect2_name'] = name;
+            name = "";
+            if (index2 < effects.length) {
+              name = effects[index2];
+            }
+            obj[rowName + "_move_effect2_name"] = name;
     
-                    return obj;
-                }, {});
-                if (rows) setAttrs(rows);
-            });
+            return obj;
+          }, {});
+          if (rows) setAttrs(rows);
         });
+      });
     });
     
-    on("change:repeating_moves:move_effect1 change:repeating_moves:move_effect2", function (eventInfo) {
-        getAttrs(["repeating_moves_move_effect1", "repeating_moves_move_effect2"], function (values) {
+    on(
+      "change:repeating_moves:move_effect1 change:repeating_moves:move_effect2",
+      function (eventInfo) {
+        getAttrs(
+          ["repeating_moves_move_effect1", "repeating_moves_move_effect2"],
+          function (values) {
             let index1 = parseInt(values.repeating_moves_move_effect1) || 99;
             let index2 = parseInt(values.repeating_moves_move_effect2) || 99;
     
             var effectNames = {};
             var name = "";
             if (index1 < effects.length) {
-                name = effects[index1];
+              name = effects[index1];
             }
             effectNames["repeating_moves_move_effect1_name"] = name;
     
             name = "";
             if (index2 < effects.length) {
-                name = effects[index2];
+              name = effects[index2];
             }
             effectNames["repeating_moves_move_effect2_name"] = name;
     
             if (effectNames) setAttrs(effectNames);
-        });
-    });
+          }
+        );
+      }
+    );
     
     // Handling Move Damage Bonuses
     categoryDamageModifiers = ["", "ATKMOD", "SPATKMOD", ""];
     on("change:ATKMOD change:SPATKMOD sheet:opened", function (eventInfo) {
-        getSectionIDs("repeating_moves", function (idArray) {
-            const rowNames = idArray.map(id => `repeating_moves_${id}`);
-            const categories = idArray.map(id => `repeating_moves_${id}_move_category`);
-            const extraBonuses = idArray.map(id => `repeating_moves_${id}_move_damagebonus`);
-            const stabBonuses = idArray.map(id => `repeating_moves_${id}_move_stabbonus`);
-            const diceNumbers = idArray.map(id => `repeating_moves_${id}_move_dicenumber`);
-            const damageDice = idArray.map(id => `repeating_moves_${id}_damage_dice`);
+      getSectionIDs("repeating_moves", function (idArray) {
+        const rowNames = idArray.map((id) => `repeating_moves_${id}`);
+        const categories = idArray.map(
+          (id) => `repeating_moves_${id}_move_category`
+        );
+        const extraBonuses = idArray.map(
+          (id) => `repeating_moves_${id}_move_damagebonus`
+        );
+        const stabBonuses = idArray.map(
+          (id) => `repeating_moves_${id}_move_stabbonus`
+        );
+        const diceNumbers = idArray.map(
+          (id) => `repeating_moves_${id}_move_dicenumber`
+        );
+        const damageDice = idArray.map((id) => `repeating_moves_${id}_damage_dice`);
     
-            getAttrs([`ATKMOD`, `SPATKMOD`, ...categories, ...extraBonuses, ...stabBonuses, ...diceNumbers, ...damageDice], function (values) {
-                const rows = rowNames.reduce((obj, rowName) => {
-                    const category = parseInt(values[rowName + `_move_category`]) || 0;
-                    const extra = parseInt(values[rowName + '_move_damagebonus']) || 0;
-                    const stab = parseInt(values[rowName + '_move_stabbonus']) || 0;
-                    const dice = parseInt(values[rowName + '_move_dicenumber']) || 0;
-                    const points = parseInt(values[rowName + '_damage_dice']) || 0;
-
-                    const categoryModifier = parseInt(values[`${categoryDamageModifiers[category]}`]) || 0;
-                    const total = categoryModifier + extra + stab;
+        getAttrs(
+          [
+            `ATKMOD`,
+            `SPATKMOD`,
+            ...categories,
+            ...extraBonuses,
+            ...stabBonuses,
+            ...diceNumbers,
+            ...damageDice,
+          ],
+          function (values) {
+            const rows = rowNames.reduce((obj, rowName) => {
+              const category = parseInt(values[rowName + `_move_category`]) || 0;
+              const extra = parseInt(values[rowName + "_move_damagebonus"]) || 0;
+              const stab = parseInt(values[rowName + "_move_stabbonus"]) || 0;
+              const dice = parseInt(values[rowName + "_move_dicenumber"]) || 0;
+              const points = parseInt(values[rowName + "_damage_dice"]) || 0;
     
-                    var display = `${total}`;
-                    if (dice > 0) display = `${dice}d${points} ${total < 0 ? "" : "+ "}${total}`;
+              const categoryModifier =
+                parseInt(values[`${categoryDamageModifiers[category]}`]) || 0;
+              const total = categoryModifier + extra + stab;
     
-                    obj[rowName + '_move_totaldamage'] = total;
-                    obj[rowName + '_move_totaldamage_display'] = display;
-                    return obj;
-                }, {});
-                if (rows) setAttrs(rows);
-            });
-        });
+              var display = `${total}`;
+              if (dice > 0)
+                display = `${dice}d${points} ${total < 0 ? "" : "+ "}${total}`;
+    
+              obj[rowName + "_move_totaldamage"] = total;
+              obj[rowName + "_move_totaldamage_display"] = display;
+              return obj;
+            }, {});
+            if (rows) setAttrs(rows);
+          }
+        );
+      });
     });
     
-    on("change:repeating_moves:move_category change:repeating_moves:move_damagebonus change:repeating_moves:move_stabbonus change:repeating_moves:move_dicenumber change:repeating_moves:damage_dice", function (eventInfo) {
-        getAttrs(["ATKMOD", "SPATKMOD", "repeating_moves_move_category", "repeating_moves_move_damagebonus", "repeating_moves_move_stabbonus", "repeating_moves_move_dicenumber", "repeating_moves_damage_dice"], function (values) {
+    on(
+      "change:repeating_moves:move_category change:repeating_moves:move_damagebonus change:repeating_moves:move_stabbonus change:repeating_moves:move_dicenumber change:repeating_moves:damage_dice",
+      function (eventInfo) {
+        getAttrs(
+          [
+            "ATKMOD",
+            "SPATKMOD",
+            "repeating_moves_move_category",
+            "repeating_moves_move_damagebonus",
+            "repeating_moves_move_stabbonus",
+            "repeating_moves_move_dicenumber",
+            "repeating_moves_damage_dice",
+          ],
+          function (values) {
             const category = parseInt(values.repeating_moves_move_category) || 0;
             const extra = parseInt(values.repeating_moves_move_damagebonus) || 0;
             const stab = parseInt(values.repeating_moves_move_stabbonus) || 0;
             const dice = parseInt(values.repeating_moves_move_dicenumber) || 0;
             const points = parseInt(values.repeating_moves_damage_dice) || 0;
     
-            const categoryModifier = parseInt(values[`${categoryDamageModifiers[category]}`]) || 0;
+            const categoryModifier =
+              parseInt(values[`${categoryDamageModifiers[category]}`]) || 0;
             const total = categoryModifier + extra + stab;
     
             var display = `${total}`;
-            if (dice > 0) display = `${dice}d${points} ${total < 0 ? "" : "+ "}${total}`;
+            if (dice > 0)
+              display = `${dice}d${points} ${total < 0 ? "" : "+ "}${total}`;
     
             setAttrs({
-                'repeating_moves_move_totaldamage': total,
-                'repeating_moves_move_totaldamage_display': display
+              repeating_moves_move_totaldamage: total,
+              repeating_moves_move_totaldamage_display: display,
             });
-        });
-    });
+          }
+        );
+      }
+    );
     
     // Handling Move Accuracy Bonuses
     categoryAccuracyModifiers = ["", "ATKMOD", "SPATKMOD", "SPDMOD"];
-    on("change:ATKMOD change:SPATKMOD change:SPDMOD sheet:opened", function (eventInfo) {
+    on(
+      "change:ATKMOD change:SPATKMOD change:SPDMOD sheet:opened",
+      function (eventInfo) {
         getSectionIDs("repeating_moves", function (idArray) {
-            const rowNames = idArray.map(id => `repeating_moves_${id}`);
-            const categories = idArray.map(id => `repeating_moves_${id}_move_category`);
-            const accuracyMods = idArray.map(id => `repeating_moves_${id}_move_acmod`);
+          const rowNames = idArray.map((id) => `repeating_moves_${id}`);
+          const categories = idArray.map(
+            (id) => `repeating_moves_${id}_move_category`
+          );
+          const accuracyMods = idArray.map(
+            (id) => `repeating_moves_${id}_move_acmod`
+          );
     
-            getAttrs([`ATKMOD`, `SPATKMOD`, `SPDMOD`, ...categories, ...accuracyMods], function (values) {
-                const rows = rowNames.reduce((obj, rowName) => {
-                    const category = parseInt(values[rowName + `_move_category`]) || 0;
-                    const accuracy = parseInt(values[rowName + `_move_acmod`]) || 0;
+          getAttrs(
+            [`ATKMOD`, `SPATKMOD`, `SPDMOD`, ...categories, ...accuracyMods],
+            function (values) {
+              const rows = rowNames.reduce((obj, rowName) => {
+                const category = parseInt(values[rowName + `_move_category`]) || 0;
+                const accuracy = parseInt(values[rowName + `_move_acmod`]) || 0;
     
-                    const categoryModifier = parseInt(values[`${categoryAccuracyModifiers[category]}`]) || 0;
-                    const total = categoryModifier + accuracy;
-                    const roll = `d20 ${total < 0 ? "" : "+ "}${total}`;
+                const categoryModifier =
+                  parseInt(values[`${categoryAccuracyModifiers[category]}`]) || 0;
+                const total = categoryModifier + accuracy;
+                const roll = `d20 ${total < 0 ? "" : "+ "}${total}`;
     
-                    obj[rowName + '_move_totalaccuracy'] = total;
-                    obj[rowName + '_move_totalaccuracy_display'] = roll;
-                    return obj;
-                }, {});
-                if (rows) setAttrs(rows);
-            });
+                obj[rowName + "_move_totalaccuracy"] = total;
+                obj[rowName + "_move_totalaccuracy_display"] = roll;
+                return obj;
+              }, {});
+              if (rows) setAttrs(rows);
+            }
+          );
         });
-    });
+      }
+    );
     
-    on("change:repeating_moves:move_category change:repeating_moves:move_acmod", function (eventInfo) {
-        getAttrs([`ATKMOD`, `SPATKMOD`, `SPDMOD`, `repeating_moves_move_category`, `repeating_moves_move_acmod`], function (values) {
+    on(
+      "change:repeating_moves:move_category change:repeating_moves:move_acmod",
+      function (eventInfo) {
+        getAttrs(
+          [
+            `ATKMOD`,
+            `SPATKMOD`,
+            `SPDMOD`,
+            `repeating_moves_move_category`,
+            `repeating_moves_move_acmod`,
+          ],
+          function (values) {
             const category = parseInt(values.repeating_moves_move_category) || 0;
             const accuracy = parseInt(values.repeating_moves_move_acmod) || 0;
     
-            const categoryModifier = parseInt(values[`${categoryAccuracyModifiers[category]}`]) || 0;
+            const categoryModifier =
+              parseInt(values[`${categoryAccuracyModifiers[category]}`]) || 0;
             const total = categoryModifier + accuracy;
-            const roll = `d20 ${total < 0 ? "" : "+ "}${total}`
+            const roll = `d20 ${total < 0 ? "" : "+ "}${total}`;
     
             setAttrs({
-                'repeating_moves_move_totalaccuracy': total,
-                'repeating_moves_move_totalaccuracy_display': roll
+              repeating_moves_move_totalaccuracy: total,
+              repeating_moves_move_totalaccuracy_display: roll,
             });
-        });
-    });
+          }
+        );
+      }
+    );
     
     // Skills Sheet Workers
-
+    
     // Acrobatics
-    on("change:SPDMOD change:acrobaticstalent1 change:acrobaticstalent2 change:acrobatics sheet:opened", function (eventInfo) {
-        getAttrs([`SPDMOD`, `acrobaticstalent1`, `acrobaticstalent2`, `acrobatics`, `acrobatics_total`], function (values) {
+    on(
+      "change:SPDMOD change:acrobaticstalent1 change:acrobaticstalent2 change:acrobatics sheet:opened",
+      function (eventInfo) {
+        getAttrs(
+          [
+            `SPDMOD`,
+            `acrobaticstalent1`,
+            `acrobaticstalent2`,
+            `acrobatics`,
+            `acrobatics_total`,
+          ],
+          function (values) {
             const stat = parseInt(values.SPDMOD) || 0;
             const talent1 = parseInt(values.acrobaticstalent1) || 0;
             const talent2 = parseInt(values.acrobaticstalent2) || 0;
             const total = parseInt(values.acrobatics_total) || -1;
             const userBonus = parseInt(values.acrobatics) || 0;
-
-            assignSkillTotal('acrobatics_total', stat, talent1, talent2, total, userBonus);
-        });
-    });
-
+    
+            assignSkillTotal(
+              "acrobatics_total",
+              stat,
+              talent1,
+              talent2,
+              total,
+              userBonus
+            );
+          }
+        );
+      }
+    );
+    
     // Athletics
-    on("change:ATKMOD change:athleticstalent1 change:athleticstalent2 change:athletics sheet:opened", function (eventInfo) {
-        getAttrs([`ATKMOD`, `athleticstalent1`, `athleticstalent2`, `athletics`, `athletics_total`], function (values) {
+    on(
+      "change:ATKMOD change:athleticstalent1 change:athleticstalent2 change:athletics sheet:opened",
+      function (eventInfo) {
+        getAttrs(
+          [
+            `ATKMOD`,
+            `athleticstalent1`,
+            `athleticstalent2`,
+            `athletics`,
+            `athletics_total`,
+          ],
+          function (values) {
             const stat = parseInt(values.ATKMOD) || 0;
             const talent1 = parseInt(values.athleticstalent1) || 0;
             const talent2 = parseInt(values.athleticstalent2) || 0;
             const total = parseInt(values.athletics_total) || -1;
             const userBonus = parseInt(values.athletics) || 0;
-
-            assignSkillTotal('athletics_total', stat, talent1, talent2, total, userBonus);
-        });
-    });
-
+    
+            assignSkillTotal(
+              "athletics_total",
+              stat,
+              talent1,
+              talent2,
+              total,
+              userBonus
+            );
+          }
+        );
+      }
+    );
+    
     // Bluff/Deception
-    on("change:SPDEFMOD change:blufftalent1 change:blufftalent2 change:bluff sheet:opened", function (eventInfo) {
-        getAttrs([`SPDEFMOD`, `blufftalent1`, `blufftalent2`, `bluff`, `bluff_total`], function (values) {
+    on(
+      "change:SPDEFMOD change:blufftalent1 change:blufftalent2 change:bluff sheet:opened",
+      function (eventInfo) {
+        getAttrs(
+          [`SPDEFMOD`, `blufftalent1`, `blufftalent2`, `bluff`, `bluff_total`],
+          function (values) {
             const stat = parseInt(values.SPDEFMOD) || 0;
             const talent1 = parseInt(values.blufftalent1) || 0;
             const talent2 = parseInt(values.blufftalent2) || 0;
             const total = parseInt(values.bluff_total) || -1;
             const userBonus = parseInt(values.bluff) || 0;
-
-            assignSkillTotal('bluff_total', stat, talent1, talent2, total, userBonus);
-        });
-    });
-
+    
+            assignSkillTotal(
+              "bluff_total",
+              stat,
+              talent1,
+              talent2,
+              total,
+              userBonus
+            );
+          }
+        );
+      }
+    );
+    
     // Concentration
-    on("change:DEFMOD change:concentrationtalent1 change:concentrationtalent2 change:concentration sheet:opened", function (eventInfo) {
-        getAttrs([`DEFMOD`, `concentrationtalent1`, `concentrationtalent2`, `concentration`, `concentration_total`], function (values) {
+    on(
+      "change:DEFMOD change:concentrationtalent1 change:concentrationtalent2 change:concentration sheet:opened",
+      function (eventInfo) {
+        getAttrs(
+          [
+            `DEFMOD`,
+            `concentrationtalent1`,
+            `concentrationtalent2`,
+            `concentration`,
+            `concentration_total`,
+          ],
+          function (values) {
             const stat = parseInt(values.DEFMOD) || 0;
             const talent1 = parseInt(values.concentrationtalent1) || 0;
             const talent2 = parseInt(values.concentrationtalent2) || 0;
             const total = parseInt(values.concentration_total) || -1;
             const userBonus = parseInt(values.concentration) || 0;
-
-            assignSkillTotal('concentration_total', stat, talent1, talent2, total, userBonus);
-        });
-    });
-
+    
+            assignSkillTotal(
+              "concentration_total",
+              stat,
+              talent1,
+              talent2,
+              total,
+              userBonus
+            );
+          }
+        );
+      }
+    );
+    
     // Constitution
-    on("change:DEFMOD change:constitutiontalent1 change:constitutiontalent2 change:constitution sheet:opened", function (eventInfo) {
-        getAttrs([`DEFMOD`, `constitutiontalent1`, `constitutiontalent2`, `constitution`, `constitution_total`], function (values) {
+    on(
+      "change:DEFMOD change:constitutiontalent1 change:constitutiontalent2 change:constitution sheet:opened",
+      function (eventInfo) {
+        getAttrs(
+          [
+            `DEFMOD`,
+            `constitutiontalent1`,
+            `constitutiontalent2`,
+            `constitution`,
+            `constitution_total`,
+          ],
+          function (values) {
             const stat = parseInt(values.DEFMOD) || 0;
             const talent1 = parseInt(values.constitutiontalent1) || 0;
             const talent2 = parseInt(values.constitutiontalent2) || 0;
             const total = parseInt(values.constitution_total) || -1;
             const userBonus = parseInt(values.constitution) || 0;
-
-            assignSkillTotal('constitution_total', stat, talent1, talent2, total, userBonus);
-        });
-    });
-
+    
+            assignSkillTotal(
+              "constitution_total",
+              stat,
+              talent1,
+              talent2,
+              total,
+              userBonus
+            );
+          }
+        );
+      }
+    );
+    
     // Diplomacy/Persuasion
-    on("change:SPDEFMOD change:diplomacytalent1 change:diplomacytalent2 change:diplomacy sheet:opened", function (eventInfo) {
-        getAttrs([`SPDEFMOD`, `diplomacytalent1`, `diplomacytalent2`, `diplomacy`, `diplomacy_total`], function (values) {
+    on(
+      "change:SPDEFMOD change:diplomacytalent1 change:diplomacytalent2 change:diplomacy sheet:opened",
+      function (eventInfo) {
+        getAttrs(
+          [
+            `SPDEFMOD`,
+            `diplomacytalent1`,
+            `diplomacytalent2`,
+            `diplomacy`,
+            `diplomacy_total`,
+          ],
+          function (values) {
             const stat = parseInt(values.SPDEFMOD) || 0;
             const talent1 = parseInt(values.diplomacytalent1) || 0;
             const talent2 = parseInt(values.diplomacytalent2) || 0;
             const total = parseInt(values.diplomacy_total) || -1;
             const userBonus = parseInt(values.diplomacy) || 0;
-
-            assignSkillTotal('diplomacy_total', stat, talent1, talent2, total, userBonus);
-        });
-    });
-
+    
+            assignSkillTotal(
+              "diplomacy_total",
+              stat,
+              talent1,
+              talent2,
+              total,
+              userBonus
+            );
+          }
+        );
+      }
+    );
+    
     // Engineering/Operation
-    on("change:SPATKMOD change:engineeringtalent1 change:engineeringtalent2 change:engineering sheet:opened", function (eventInfo) {
-        getAttrs([`SPATKMOD`, `engineeringtalent1`, `engineeringtalent2`, `engineering`, `engineering_total`], function (values) {
+    on(
+      "change:SPATKMOD change:engineeringtalent1 change:engineeringtalent2 change:engineering sheet:opened",
+      function (eventInfo) {
+        getAttrs(
+          [
+            `SPATKMOD`,
+            `engineeringtalent1`,
+            `engineeringtalent2`,
+            `engineering`,
+            `engineering_total`,
+          ],
+          function (values) {
             const stat = parseInt(values.SPATKMOD) || 0;
             const talent1 = parseInt(values.engineeringtalent1) || 0;
             const talent2 = parseInt(values.engineeringtalent2) || 0;
             const total = parseInt(values.engineering_total) || -1;
             const userBonus = parseInt(values.engineering) || 0;
-
-            assignSkillTotal('engineering_total', stat, talent1, talent2, total, userBonus);
-        });
-    });
-
+    
+            assignSkillTotal(
+              "engineering_total",
+              stat,
+              talent1,
+              talent2,
+              total,
+              userBonus
+            );
+          }
+        );
+      }
+    );
+    
     // History
-    on("change:SPATKMOD change:historytalent1 change:historytalent2 change:history sheet:opened", function (eventInfo) {
-        getAttrs([`SPATKMOD`, `historytalent1`, `historytalent2`, `history`, `history_total`], function (values) {
+    on(
+      "change:SPATKMOD change:historytalent1 change:historytalent2 change:history sheet:opened",
+      function (eventInfo) {
+        getAttrs(
+          [
+            `SPATKMOD`,
+            `historytalent1`,
+            `historytalent2`,
+            `history`,
+            `history_total`,
+          ],
+          function (values) {
             const stat = parseInt(values.SPATKMOD) || 0;
             const talent1 = parseInt(values.historytalent1) || 0;
             const talent2 = parseInt(values.historytalent2) || 0;
             const total = parseInt(values.history_total) || -1;
             const userBonus = parseInt(values.history) || 0;
-
-            assignSkillTotal('history_total', stat, talent1, talent2, total, userBonus);
-        });
-    });
-
+    
+            assignSkillTotal(
+              "history_total",
+              stat,
+              talent1,
+              talent2,
+              total,
+              userBonus
+            );
+          }
+        );
+      }
+    );
+    
     // Insight
-    on("change:SPDEFMOD change:insighttalent1 change:insighttalent2 change:insight sheet:opened", function (eventInfo) {
-        getAttrs([`SPDEFMOD`, `insighttalent1`, `insighttalent2`, `insight`, `insight_total`], function (values) {
+    on(
+      "change:SPDEFMOD change:insighttalent1 change:insighttalent2 change:insight sheet:opened",
+      function (eventInfo) {
+        getAttrs(
+          [
+            `SPDEFMOD`,
+            `insighttalent1`,
+            `insighttalent2`,
+            `insight`,
+            `insight_total`,
+          ],
+          function (values) {
             const stat = parseInt(values.SPDEFMOD) || 0;
             const talent1 = parseInt(values.insighttalent1) || 0;
             const talent2 = parseInt(values.insighttalent2) || 0;
             const total = parseInt(values.insight_total) || -1;
             const userBonus = parseInt(values.insight) || 0;
-
-            assignSkillTotal('insight_total', stat, talent1, talent2, total, userBonus);
-        });
-    });
-
+    
+            assignSkillTotal(
+              "insight_total",
+              stat,
+              talent1,
+              talent2,
+              total,
+              userBonus
+            );
+          }
+        );
+      }
+    );
+    
     // Investigate
-    on("change:SPATKMOD change:investigatetalent1 change:investigatetalent2 change:investigate sheet:opened", function (eventInfo) {
-        getAttrs([`SPATKMOD`, `investigatetalent1`, `investigatetalent2`, `investigate`, `investigate_total`], function (values) {
+    on(
+      "change:SPATKMOD change:investigatetalent1 change:investigatetalent2 change:investigate sheet:opened",
+      function (eventInfo) {
+        getAttrs(
+          [
+            `SPATKMOD`,
+            `investigatetalent1`,
+            `investigatetalent2`,
+            `investigate`,
+            `investigate_total`,
+          ],
+          function (values) {
             const stat = parseInt(values.SPATKMOD) || 0;
             const talent1 = parseInt(values.investigatetalent1) || 0;
             const talent2 = parseInt(values.investigatetalent2) || 0;
             const total = parseInt(values.investigate_total) || -1;
             const userBonus = parseInt(values.investigate) || 0;
-
-            assignSkillTotal('investigate_total', stat, talent1, talent2, total, userBonus);
-        });
-    });
-
+    
+            assignSkillTotal(
+              "investigate_total",
+              stat,
+              talent1,
+              talent2,
+              total,
+              userBonus
+            );
+          }
+        );
+      }
+    );
+    
     // Medicine
-    on("change:SPATKMOD change:medicinetalent1 change:medicinetalent2 change:medicine sheet:opened", function (eventInfo) {
-        getAttrs([`SPATKMOD`, `medicinetalent1`, `medicinetalent2`, `medicine`, `medicine_total`], function (values) {
+    on(
+      "change:SPATKMOD change:medicinetalent1 change:medicinetalent2 change:medicine sheet:opened",
+      function (eventInfo) {
+        getAttrs(
+          [
+            `SPATKMOD`,
+            `medicinetalent1`,
+            `medicinetalent2`,
+            `medicine`,
+            `medicine_total`,
+          ],
+          function (values) {
             const stat = parseInt(values.SPATKMOD) || 0;
             const talent1 = parseInt(values.medicinetalent1) || 0;
             const talent2 = parseInt(values.medicinetalent2) || 0;
             const total = parseInt(values.medicine_total) || -1;
             const userBonus = parseInt(values.medicine) || 0;
-
-            assignSkillTotal('medicine_total', stat, talent1, talent2, total, userBonus);
-        });
-    });
-
+    
+            assignSkillTotal(
+              "medicine_total",
+              stat,
+              talent1,
+              talent2,
+              total,
+              userBonus
+            );
+          }
+        );
+      }
+    );
+    
     // Nature
-    on("change:SPATKMOD change:naturetalent1 change:naturetalent2 change:nature sheet:opened", function (eventInfo) {
-        getAttrs([`SPATKMOD`, `naturetalent1`, `naturetalent2`, `nature`, `nature_total`], function (values) {
+    on(
+      "change:SPATKMOD change:naturetalent1 change:naturetalent2 change:nature sheet:opened",
+      function (eventInfo) {
+        getAttrs(
+          [`SPATKMOD`, `naturetalent1`, `naturetalent2`, `nature`, `nature_total`],
+          function (values) {
             const stat = parseInt(values.SPATKMOD) || 0;
             const talent1 = parseInt(values.naturetalent1) || 0;
             const talent2 = parseInt(values.naturetalent2) || 0;
             const total = parseInt(values.nature_total) || -1;
             const userBonus = parseInt(values.nature) || 0;
-
-            assignSkillTotal('nature_total', stat, talent1, talent2, total, userBonus);
-        });
-    });
-
+    
+            assignSkillTotal(
+              "nature_total",
+              stat,
+              talent1,
+              talent2,
+              total,
+              userBonus
+            );
+          }
+        );
+      }
+    );
+    
     // Perception
-    on("change:SPDEFMOD change:perceptiontalent1 change:perceptiontalent2 change:perception sheet:opened", function (eventInfo) {
-        getAttrs([`SPDEFMOD`, `perceptiontalent1`, `perceptiontalent2`, `perception`, `perception_total`], function (values) {
+    on(
+      "change:SPDEFMOD change:perceptiontalent1 change:perceptiontalent2 change:perception sheet:opened",
+      function (eventInfo) {
+        getAttrs(
+          [
+            `SPDEFMOD`,
+            `perceptiontalent1`,
+            `perceptiontalent2`,
+            `perception`,
+            `perception_total`,
+          ],
+          function (values) {
             const stat = parseInt(values.SPDEFMOD) || 0;
             const talent1 = parseInt(values.perceptiontalent1) || 0;
             const talent2 = parseInt(values.perceptiontalent2) || 0;
             const total = parseInt(values.perception_total) || -1;
             const userBonus = parseInt(values.perception) || 0;
-
-            assignSkillTotal('perception_total', stat, talent1, talent2, total, userBonus);
-        });
-    });
-
+    
+            assignSkillTotal(
+              "perception_total",
+              stat,
+              talent1,
+              talent2,
+              total,
+              userBonus
+            );
+          }
+        );
+      }
+    );
+    
     // Perform
-    on("change:SPDEFMOD change:performtalent1 change:performtalent2 change:perform sheet:opened", function (eventInfo) {
-        getAttrs([`SPDEFMOD`, `performtalent1`, `performtalent2`, `perform`, `perform_total`], function (values) {
+    on(
+      "change:SPDEFMOD change:performtalent1 change:performtalent2 change:perform sheet:opened",
+      function (eventInfo) {
+        getAttrs(
+          [
+            `SPDEFMOD`,
+            `performtalent1`,
+            `performtalent2`,
+            `perform`,
+            `perform_total`,
+          ],
+          function (values) {
             const stat = parseInt(values.SPDEFMOD) || 0;
             const talent1 = parseInt(values.performtalent1) || 0;
             const talent2 = parseInt(values.performtalent2) || 0;
             const total = parseInt(values.perform_total) || -1;
             const userBonus = parseInt(values.perform) || 0;
-
-            assignSkillTotal('perform_total', stat, talent1, talent2, total, userBonus);
-        });
-    });
-
+    
+            assignSkillTotal(
+              "perform_total",
+              stat,
+              talent1,
+              talent2,
+              total,
+              userBonus
+            );
+          }
+        );
+      }
+    );
+    
     // Pokémon Handling
-    on("change:SPDEFMOD change:handlingtalent1 change:handlingtalent2 change:handling sheet:opened", function (eventInfo) {
-        getAttrs([`SPDEFMOD`, `handlingtalent1`, `handlingtalent2`, `handling`, `handling_total`], function (values) {
+    on(
+      "change:SPDEFMOD change:handlingtalent1 change:handlingtalent2 change:handling sheet:opened",
+      function (eventInfo) {
+        getAttrs(
+          [
+            `SPDEFMOD`,
+            `handlingtalent1`,
+            `handlingtalent2`,
+            `handling`,
+            `handling_total`,
+          ],
+          function (values) {
             const stat = parseInt(values.SPDEFMOD) || 0;
             const talent1 = parseInt(values.handlingtalent1) || 0;
             const talent2 = parseInt(values.handlingtalent2) || 0;
             const total = parseInt(values.handling_total) || -1;
             const userBonus = parseInt(values.handling) || 0;
-
-            assignSkillTotal('handling_total', stat, talent1, talent2, total, userBonus);
-        });
-    });
-
+    
+            assignSkillTotal(
+              "handling_total",
+              stat,
+              talent1,
+              talent2,
+              total,
+              userBonus
+            );
+          }
+        );
+      }
+    );
+    
     // Programming
-    on("change:SPATKMOD change:programmingtalent1 change:programmingtalent2 change:programming sheet:opened", function (eventInfo) {
-        getAttrs([`SPATKMOD`, `programmingtalent1`, `programmingtalent2`, `programming`, `programming_total`], function (values) {
+    on(
+      "change:SPATKMOD change:programmingtalent1 change:programmingtalent2 change:programming sheet:opened",
+      function (eventInfo) {
+        getAttrs(
+          [
+            `SPATKMOD`,
+            `programmingtalent1`,
+            `programmingtalent2`,
+            `programming`,
+            `programming_total`,
+          ],
+          function (values) {
             const stat = parseInt(values.SPATKMOD) || 0;
             const talent1 = parseInt(values.programmingtalent1) || 0;
             const talent2 = parseInt(values.programmingtalent2) || 0;
             const total = parseInt(values.programming_total) || -1;
             const userBonus = parseInt(values.programming) || 0;
-
-            assignSkillTotal('programming_total', stat, talent1, talent2, total, userBonus);
-        });
-    });
-
+    
+            assignSkillTotal(
+              "programming_total",
+              stat,
+              talent1,
+              talent2,
+              total,
+              userBonus
+            );
+          }
+        );
+      }
+    );
+    
     // Sleight of Hand
-    on("change:SPDMOD change:sleightofhandtalent1 change:sleightofhandtalent2 change:sleightofhand sheet:opened", function (eventInfo) {
-        getAttrs([`SPDMOD`, `sleightofhandtalent1`, `sleightofhandtalent2`, `sleightofhand`, `sleightofhand_total`], function (values) {
+    on(
+      "change:SPDMOD change:sleightofhandtalent1 change:sleightofhandtalent2 change:sleightofhand sheet:opened",
+      function (eventInfo) {
+        getAttrs(
+          [
+            `SPDMOD`,
+            `sleightofhandtalent1`,
+            `sleightofhandtalent2`,
+            `sleightofhand`,
+            `sleightofhand_total`,
+          ],
+          function (values) {
             const stat = parseInt(values.SPDMOD) || 0;
             const talent1 = parseInt(values.sleightofhandtalent1) || 0;
             const talent2 = parseInt(values.sleightofhandtalent2) || 0;
             const total = parseInt(values.sleightofhand_total) || -1;
             const userBonus = parseInt(values.sleightofhand) || 0;
-
-            assignSkillTotal('sleightofhand_total', stat, talent1, talent2, total, userBonus);
-        });
-    });
-
+    
+            assignSkillTotal(
+              "sleightofhand_total",
+              stat,
+              talent1,
+              talent2,
+              total,
+              userBonus
+            );
+          }
+        );
+      }
+    );
+    
     // Stealth
-    on("change:SPDMOD change:stealthtalent1 change:stealthtalent2 change:stealth sheet:opened", function (eventInfo) {
-        getAttrs([`SPDMOD`, `stealthtalent1`, `stealthtalent2`, `stealth`, `stealth_total`], function (values) {
+    on(
+      "change:SPDMOD change:stealthtalent1 change:stealthtalent2 change:stealth sheet:opened",
+      function (eventInfo) {
+        getAttrs(
+          [
+            `SPDMOD`,
+            `stealthtalent1`,
+            `stealthtalent2`,
+            `stealth`,
+            `stealth_total`,
+          ],
+          function (values) {
             const stat = parseInt(values.SPDMOD) || 0;
             const talent1 = parseInt(values.stealthtalent1) || 0;
             const talent2 = parseInt(values.stealthtalent2) || 0;
             const total = parseInt(values.stealth_total) || -1;
             const userBonus = parseInt(values.stealth) || 0;
-
-            assignSkillTotal('stealth_total', stat, talent1, talent2, total, userBonus);
-        });
-    });
-
+    
+            assignSkillTotal(
+              "stealth_total",
+              stat,
+              talent1,
+              talent2,
+              total,
+              userBonus
+            );
+          }
+        );
+      }
+    );
+    
     // Capture
     on("change:SPDMOD change:capture sheet:opened", function (eventInfo) {
       getAttrs([`SPDMOD`, `capture_total`], function (values) {
@@ -1542,13 +1976,21 @@
         assignSkillTotal("capture_total", stat, 0, 0, total, 0);
       });
     });
-
-    function assignSkillTotal(skillName, stat, leftTalent, rightTalent, oldTotal, userBonus) {
-        const talentAccumulator = leftTalent + rightTalent == 4 ? 1 : 0;
-        const talent = leftTalent + rightTalent + talentAccumulator;
-
-        const newBonus = stat + talent + userBonus;
-        const attrs = { [skillName]: newBonus };
-        if (newBonus != oldTotal) setAttrs(attrs);
+    
+    function assignSkillTotal(
+      skillName,
+      stat,
+      leftTalent,
+      rightTalent,
+      oldTotal,
+      userBonus
+    ) {
+      const talentAccumulator = leftTalent + rightTalent == 4 ? 1 : 0;
+      const talent = leftTalent + rightTalent + talentAccumulator;
+    
+      const newBonus = stat + talent + userBonus;
+      const attrs = { [skillName]: newBonus };
+      if (newBonus != oldTotal) setAttrs(attrs);
     }
+    
 </script>

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -526,7 +526,7 @@
                     <input type="checkbox" name="attr_stealthtalent2" value="2" />
                     <input type="number" name="attr_stealth" value="0" />
                 </div>
-
+                <hr class="skill-separator"/>
                 <div class="capture-pokemon-skill tab-trainer">
                     <input type="number" readonly name="attr_capture_total" class="speed-read-color" />
                     <button type='roll' name='roll_capturecheck' class='skill-roller spd-skill'

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -339,170 +339,211 @@
         </div>
 
         <div class="2col-centered">
-            <div class="character-skills">
-                <input type="number" readonly name="attr_acrobatics_total" class="speed-read-color" />
-                <button type='roll' name='roll_acrobaticscheck' class='skill-roller spd-skill'
-                    value='&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Acrobatics}} {{skill-roll=[[ 1d20!kh2 + [[ @{acrobatics_total} + ?{Temporary Bonus|0} ]] ]]}}'>
-                    Acrobatics (SPD)
-                </button>
-                <input type="checkbox" name="attr_acrobaticstalent1" value="2" />
-                <input type="checkbox" name="attr_acrobaticstalent2" value="2" />
-                <input type="number" name="attr_acrobatics" value="0" />
+            <div>
+                <div class="character-skills">
+                    <input type="number" readonly name="attr_acrobatics_total" class="speed-read-color" />
+                    <button type='roll' name='roll_acrobaticscheck' class='skill-roller spd-skill'
+                        value='&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Acrobatics}} {{skill-roll=[[ 1d20!kh2 + [[ @{acrobatics_total} + ?{Temporary Bonus|0} ]] ]]}}'>
+                        Acrobatics (SPD)
+                    </button>
+                    <input type="checkbox" name="attr_acrobaticstalent1" value="2" />
+                    <input type="checkbox" name="attr_acrobaticstalent2" value="2" />
+                    <input type="number" name="attr_acrobatics" value="0" />
 
-                <input type="number" readonly name="attr_athletics_total" class="attack-read-color" />
-                <button type='roll' name='roll_athleticscheck' class='skill-roller atk-skill'
-                    value='&{template:skill-roll} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Athletics}} {{skill-roll=[[ 1d20!kh2 + [[ @{athletics_total} + ?{Temporary Bonus|0} ]] ]]}}'>
-                    Athletics (ATK)
-                </button>
-                <input type="checkbox" name="attr_athleticstalent1" value="2" />
-                <input type="checkbox" name="attr_athleticstalent2" value="2" />
-                <input type="number" name="attr_athletics" value="0" />
+                    <input type="number" readonly name="attr_athletics_total" class="attack-read-color" />
+                    <button type='roll' name='roll_athleticscheck' class='skill-roller atk-skill'
+                        value='&{template:skill-roll} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Athletics}} {{skill-roll=[[ 1d20!kh2 + [[ @{athletics_total} + ?{Temporary Bonus|0} ]] ]]}}'>
+                        Athletics (ATK)
+                    </button>
+                    <input type="checkbox" name="attr_athleticstalent1" value="2" />
+                    <input type="checkbox" name="attr_athleticstalent2" value="2" />
+                    <input type="number" name="attr_athletics" value="0" />
 
-                <input type="number" readonly name="attr_bluff_total" class="spdef-read-color" />
-                <button type='roll' name='roll_bluffcheck' class='skill-roller spdef-skill'
-                    value='&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Bluff/Deception}} {{skill-roll=[[ 1d20!kh2 + [[ @{bluff_total} + ?{Temporary Bonus|0} ]] ]]}}'>
-                    Bluff/Deception (SPDEF)
-                </button>
-                <input type="checkbox" name="attr_blufftalent1" value="2" />
-                <input type="checkbox" name="attr_blufftalent2" value="2" />
-                <input type="number" name="attr_bluff" value="0" />
+                    <input type="number" readonly name="attr_bluff_total" class="spdef-read-color" />
+                    <button type='roll' name='roll_bluffcheck' class='skill-roller spdef-skill'
+                        value='&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Bluff/Deception}} {{skill-roll=[[ 1d20!kh2 + [[ @{bluff_total} + ?{Temporary Bonus|0} ]] ]]}}'>
+                        Bluff/Deception (SPDEF)
+                    </button>
+                    <input type="checkbox" name="attr_blufftalent1" value="2" />
+                    <input type="checkbox" name="attr_blufftalent2" value="2" />
+                    <input type="number" name="attr_bluff" value="0" />
 
-                <input type="number" readonly name="attr_concentration_total" class="defense-read-color" />
-                <button type='roll' name='roll_concentrationcheck' class='skill-roller def-skill'
-                    value='&{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Concentration}} {{skill-roll=[[ 1d20!kh2 + [[ @{concentration_total} + ?{Temporary Bonus|0} ]] ]]}}'>
-                    Concentration (DEF)
-                </button>
-                <input type="checkbox" name="attr_concentrationtalent1" value="2" />
-                <input type="checkbox" name="attr_concentrationtalent2" value="2" />
-                <input type="number" name="attr_concentration" value="0" />
+                    <input type="number" readonly name="attr_concentration_total" class="defense-read-color" />
+                    <button type='roll' name='roll_concentrationcheck' class='skill-roller def-skill'
+                        value='&{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Concentration}} {{skill-roll=[[ 1d20!kh2 + [[ @{concentration_total} + ?{Temporary Bonus|0} ]] ]]}}'>
+                        Concentration (DEF)
+                    </button>
+                    <input type="checkbox" name="attr_concentrationtalent1" value="2" />
+                    <input type="checkbox" name="attr_concentrationtalent2" value="2" />
+                    <input type="number" name="attr_concentration" value="0" />
 
-                <input type="number" readonly name="attr_constitution_total" class="defense-read-color" />
-                <button type='roll' name='roll_constitutioncheck' class='skill-roller def-skill'
-                    value='&{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Constitution}} {{skill-roll=[[ 1d20!kh2 + [[ @{constitution_total} + ?{Temporary Bonus|0} ]] ]]}}'>
-                    Constitution (DEF)
-                </button>
-                <input type="checkbox" name="attr_constitutiontalent1" value="2" />
-                <input type="checkbox" name="attr_constitutiontalent2" value="2" />
-                <input type="number" name="attr_constitution" value="0" />
+                    <input type="number" readonly name="attr_constitution_total" class="defense-read-color" />
+                    <button type='roll' name='roll_constitutioncheck' class='skill-roller def-skill'
+                        value='&{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Constitution}} {{skill-roll=[[ 1d20!kh2 + [[ @{constitution_total} + ?{Temporary Bonus|0} ]] ]]}}'>
+                        Constitution (DEF)
+                    </button>
+                    <input type="checkbox" name="attr_constitutiontalent1" value="2" />
+                    <input type="checkbox" name="attr_constitutiontalent2" value="2" />
+                    <input type="number" name="attr_constitution" value="0" />
 
-                <input type="number" readonly name="attr_diplomacy_total" class="spdef-read-color" />
-                <button type='roll' name='roll_diplomacycheck' class='skill-roller spdef-skill'
-                    value='&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Diplomacy/Persuasion}} {{skill-roll=[[ 1d20!kh2 + [[ @{diplomacy_total} + ?{Temporary Bonus|0} ]] ]]}}'>
-                    Diplomacy/Persuasion (SPDEF)
-                </button>
-                <input type="checkbox" name="attr_diplomacytalent1" value="2" />
-                <input type="checkbox" name="attr_diplomacytalent2" value="2" />
-                <input type="number" name="attr_diplomacy" value="0" />
+                    <input type="number" readonly name="attr_diplomacy_total" class="spdef-read-color" />
+                    <button type='roll' name='roll_diplomacycheck' class='skill-roller spdef-skill'
+                        value='&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Diplomacy/Persuasion}} {{skill-roll=[[ 1d20!kh2 + [[ @{diplomacy_total} + ?{Temporary Bonus|0} ]] ]]}}'>
+                        Diplomacy/Persuasion (SPDEF)
+                    </button>
+                    <input type="checkbox" name="attr_diplomacytalent1" value="2" />
+                    <input type="checkbox" name="attr_diplomacytalent2" value="2" />
+                    <input type="number" name="attr_diplomacy" value="0" />
 
-                <input type="number" readonly name="attr_engineering_total" class="spatk-read-color" />
-                <button type='roll' name='roll_engineeringcheck' class='skill-roller spatk-skill'
-                    value='&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Engineering/Operation}} {{skill-roll=[[ 1d20!kh2 + [[ @{engineering_total} + ?{Temporary Bonus|0} ]] ]]}}'>
-                    Engineering/Operation (SPATK)
-                </button>
-                <input type="checkbox" name="attr_engineeringtalent1" value="2" />
-                <input type="checkbox" name="attr_engineeringtalent2" value="2" />
-                <input type="number" name="attr_engineering" value="0" />
+                    <input type="number" readonly name="attr_engineering_total" class="spatk-read-color" />
+                    <button type='roll' name='roll_engineeringcheck' class='skill-roller spatk-skill'
+                        value='&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Engineering/Operation}} {{skill-roll=[[ 1d20!kh2 + [[ @{engineering_total} + ?{Temporary Bonus|0} ]] ]]}}'>
+                        Engineering/Operation (SPATK)
+                    </button>
+                    <input type="checkbox" name="attr_engineeringtalent1" value="2" />
+                    <input type="checkbox" name="attr_engineeringtalent2" value="2" />
+                    <input type="number" name="attr_engineering" value="0" />
 
-                <input type="number" readonly name="attr_history_total" class="spatk-read-color" />
-                <button type='roll' name='roll_historycheck' class='skill-roller spatk-skill'
-                    value='&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=History}} {{skill-roll=[[ 1d20!kh2 + [[ @{history_total} + ?{Temporary Bonus|0} ]] ]]}}'>
-                    History (SPATK)
-                </button>
-                <input type="checkbox" name="attr_historytalent1" value="2" />
-                <input type="checkbox" name="attr_historytalent2" value="2" />
-                <input type="number" name="attr_history" value="0" />
+                    <input type="number" readonly name="attr_history_total" class="spatk-read-color" />
+                    <button type='roll' name='roll_historycheck' class='skill-roller spatk-skill'
+                        value='&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=History}} {{skill-roll=[[ 1d20!kh2 + [[ @{history_total} + ?{Temporary Bonus|0} ]] ]]}}'>
+                        History (SPATK)
+                    </button>
+                    <input type="checkbox" name="attr_historytalent1" value="2" />
+                    <input type="checkbox" name="attr_historytalent2" value="2" />
+                    <input type="number" name="attr_history" value="0" />
 
-                <input type="number" readonly name="attr_insight_total" class="spdef-read-color" />
-                <button type='roll' name='roll_insightcheck' class='skill-roller spdef-skill'
-                    value='&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Insight}} {{skill-roll=[[ 1d20!kh2 + [[ @{insight_total} + ?{Temporary Bonus|0} ]] ]]}}'>
-                    Insight (SPDEF)
-                </button>
-                <input type="checkbox" name="attr_insighttalent1" value="2" />
-                <input type="checkbox" name="attr_insighttalent2" value="2" />
-                <input type="number" name="attr_insight" value="0" />
+                    <input type="number" readonly name="attr_insight_total" class="spdef-read-color" />
+                    <button type='roll' name='roll_insightcheck' class='skill-roller spdef-skill'
+                        value='&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Insight}} {{skill-roll=[[ 1d20!kh2 + [[ @{insight_total} + ?{Temporary Bonus|0} ]] ]]}}'>
+                        Insight (SPDEF)
+                    </button>
+                    <input type="checkbox" name="attr_insighttalent1" value="2" />
+                    <input type="checkbox" name="attr_insighttalent2" value="2" />
+                    <input type="number" name="attr_insight" value="0" />
 
-                <input type="number" readonly name="attr_investigate_total" class="spatk-read-color" />
-                <button type='roll' name='roll_investigatecheck' class='skill-roller spatk-skill'
-                    value='&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Investigate}} {{skill-roll=[[ 1d20!kh2 + [[ @{investigate_total} + ?{Temporary Bonus|0} ]] ]]}}'>
-                    Investigate (SPATK)
-                </button>
-                <input type="checkbox" name="attr_investigatetalent1" value="2" />
-                <input type="checkbox" name="attr_investigatetalent2" value="2" />
-                <input type="number" name="attr_investigate" value="0" />
+                    <input type="number" readonly name="attr_investigate_total" class="spatk-read-color" />
+                    <button type='roll' name='roll_investigatecheck' class='skill-roller spatk-skill'
+                        value='&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Investigate}} {{skill-roll=[[ 1d20!kh2 + [[ @{investigate_total} + ?{Temporary Bonus|0} ]] ]]}}'>
+                        Investigate (SPATK)
+                    </button>
+                    <input type="checkbox" name="attr_investigatetalent1" value="2" />
+                    <input type="checkbox" name="attr_investigatetalent2" value="2" />
+                    <input type="number" name="attr_investigate" value="0" />
 
-                <input type="number" readonly name="attr_medicine_total" class="spatk-read-color" />
-                <button type='roll' name='roll_medicinecheck' class='skill-roller spatk-skill'
-                    value='&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Medicine}} {{skill-roll=[[ 1d20!kh2 + [[ @{medicine_total} + ?{Temporary Bonus|0} ]] ]]}}'>
-                    Medicine (SPATK)
-                </button>
-                <input type="checkbox" name="attr_medicinetalent1" value="2" />
-                <input type="checkbox" name="attr_medicinetalent2" value="2" />
-                <input type="number" name="attr_medicine" value="0" />
+                    <input type="number" readonly name="attr_medicine_total" class="spatk-read-color" />
+                    <button type='roll' name='roll_medicinecheck' class='skill-roller spatk-skill'
+                        value='&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Medicine}} {{skill-roll=[[ 1d20!kh2 + [[ @{medicine_total} + ?{Temporary Bonus|0} ]] ]]}}'>
+                        Medicine (SPATK)
+                    </button>
+                    <input type="checkbox" name="attr_medicinetalent1" value="2" />
+                    <input type="checkbox" name="attr_medicinetalent2" value="2" />
+                    <input type="number" name="attr_medicine" value="0" />
 
-                <input type="number" readonly name="attr_nature_total" class="spatk-read-color" />
-                <button type='roll' name='roll_naturecheck' class='skill-roller spatk-skill'
-                    value='&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Nature}} {{skill-roll=[[ 1d20!kh2 + [[ @{nature_total} + ?{Temporary Bonus|0} ]] ]]}}'>
-                    Nature (SPATK)
-                </button>
-                <input type="checkbox" name="attr_naturetalent1" value="2" />
-                <input type="checkbox" name="attr_naturetalent2" value="2" />
-                <input type="number" name="attr_nature" value="0" />
+                    <input type="number" readonly name="attr_nature_total" class="spatk-read-color" />
+                    <button type='roll' name='roll_naturecheck' class='skill-roller spatk-skill'
+                        value='&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Nature}} {{skill-roll=[[ 1d20!kh2 + [[ @{nature_total} + ?{Temporary Bonus|0} ]] ]]}}'>
+                        Nature (SPATK)
+                    </button>
+                    <input type="checkbox" name="attr_naturetalent1" value="2" />
+                    <input type="checkbox" name="attr_naturetalent2" value="2" />
+                    <input type="number" name="attr_nature" value="0" />
 
-                <input type="number" readonly name="attr_perception_total" class="spdef-read-color" />
-                <button type='roll' name='roll_perceptioncheck' class='skill-roller spdef-skill'
-                    value='&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perception}} {{skill-roll=[[ 1d20!kh2 + [[ @{perception_total} + ?{Temporary Bonus|0} ]] ]]}}'>
-                    Perception (SPDEF)
-                </button>
-                <input type="checkbox" name="attr_perceptiontalent1" value="2" />
-                <input type="checkbox" name="attr_perceptiontalent2" value="2" />
-                <input type="number" name="attr_perception" value="0" />
+                    <input type="number" readonly name="attr_perception_total" class="spdef-read-color" />
+                    <button type='roll' name='roll_perceptioncheck' class='skill-roller spdef-skill'
+                        value='&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perception}} {{skill-roll=[[ 1d20!kh2 + [[ @{perception_total} + ?{Temporary Bonus|0} ]] ]]}}'>
+                        Perception (SPDEF)
+                    </button>
+                    <input type="checkbox" name="attr_perceptiontalent1" value="2" />
+                    <input type="checkbox" name="attr_perceptiontalent2" value="2" />
+                    <input type="number" name="attr_perception" value="0" />
 
-                <input type="number" readonly name="attr_perform_total" class="spdef-read-color" />
-                <button type='roll' name='roll_performcheck' class='skill-roller spdef-skill'
-                    value='&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perform}} {{skill-roll=[[ 1d20!kh2 + [[ @{perform_total} + ?{Temporary Bonus|0} ]] ]]}}'>
-                    Perform (SPDEF)
-                </button>
-                <input type="checkbox" name="attr_performtalent1" value="2" />
-                <input type="checkbox" name="attr_performtalent2" value="2" />
-                <input type="number" name="attr_perform" value="0" />
+                    <input type="number" readonly name="attr_perform_total" class="spdef-read-color" />
+                    <button type='roll' name='roll_performcheck' class='skill-roller spdef-skill'
+                        value='&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perform}} {{skill-roll=[[ 1d20!kh2 + [[ @{perform_total} + ?{Temporary Bonus|0} ]] ]]}}'>
+                        Perform (SPDEF)
+                    </button>
+                    <input type="checkbox" name="attr_performtalent1" value="2" />
+                    <input type="checkbox" name="attr_performtalent2" value="2" />
+                    <input type="number" name="attr_perform" value="0" />
 
-                <input type="number" readonly name="attr_handling_total" class="spdef-read-color" />
-                <button type='roll' name='roll_handlingcheck' class='skill-roller spdef-skill'
-                    value='&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Pokemon Handling}} {{skill-roll=[[ 1d20!kh2 + [[ @{handling_total} + ?{Temporary Bonus|0} ]] ]]}}'>
-                    Pokémon Handling (SPDEF)
-                </button>
-                <input type="checkbox" name="attr_handlingtalent1" value="2" />
-                <input type="checkbox" name="attr_handlingtalent2" value="2" />
-                <input type="number" name="attr_handling" value="0" />
+                    <input type="number" readonly name="attr_handling_total" class="spdef-read-color" />
+                    <button type='roll' name='roll_handlingcheck' class='skill-roller spdef-skill'
+                        value='&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Pokemon Handling}} {{skill-roll=[[ 1d20!kh2 + [[ @{handling_total} + ?{Temporary Bonus|0} ]] ]]}}'>
+                        Pokémon Handling (SPDEF)
+                    </button>
+                    <input type="checkbox" name="attr_handlingtalent1" value="2" />
+                    <input type="checkbox" name="attr_handlingtalent2" value="2" />
+                    <input type="number" name="attr_handling" value="0" />
 
-                <input type="number" readonly name="attr_programming_total" class="spatk-read-color" />
-                <button type='roll' name='roll_programmingcheck' class='skill-roller spatk-skill'
-                    value='&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Programming}} {{skill-roll=[[ 1d20!kh2 + [[ @{programming_total} + ?{Temporary Bonus|0} ]] ]]}}'>
-                    Programming (SPATK)
-                </button>
-                <input type="checkbox" name="attr_programmingtalent1" value="2" />
-                <input type="checkbox" name="attr_programmingtalent2" value="2" />
-                <input type="number" name="attr_programming" value="0" />
+                    <input type="number" readonly name="attr_programming_total" class="spatk-read-color" />
+                    <button type='roll' name='roll_programmingcheck' class='skill-roller spatk-skill'
+                        value='&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Programming}} {{skill-roll=[[ 1d20!kh2 + [[ @{programming_total} + ?{Temporary Bonus|0} ]] ]]}}'>
+                        Programming (SPATK)
+                    </button>
+                    <input type="checkbox" name="attr_programmingtalent1" value="2" />
+                    <input type="checkbox" name="attr_programmingtalent2" value="2" />
+                    <input type="number" name="attr_programming" value="0" />
 
-                <input type="number" readonly name="attr_sleightofhand_total" class="speed-read-color" />
-                <button type='roll' name='roll_sleightofhandcheck' class='skill-roller spd-skill'
-                    value='&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Sleight of Hand}} {{skill-roll=[[ 1d20!kh2 + [[ @{sleightofhand_total} + ?{Temporary Bonus|0} ]] ]]}}'>
-                    Sleight of Hand (SPD)
-                </button>
-                <input type="checkbox" name="attr_sleightofhandtalent1" value="2" />
-                <input type="checkbox" name="attr_sleightofhandtalent2" value="2" />
-                <input type="number" name="attr_sleightofhand" value="0" />
+                    <input type="number" readonly name="attr_sleightofhand_total" class="speed-read-color" />
+                    <button type='roll' name='roll_sleightofhandcheck' class='skill-roller spd-skill'
+                        value='&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Sleight of Hand}} {{skill-roll=[[ 1d20!kh2 + [[ @{sleightofhand_total} + ?{Temporary Bonus|0} ]] ]]}}'>
+                        Sleight of Hand (SPD)
+                    </button>
+                    <input type="checkbox" name="attr_sleightofhandtalent1" value="2" />
+                    <input type="checkbox" name="attr_sleightofhandtalent2" value="2" />
+                    <input type="number" name="attr_sleightofhand" value="0" />
 
-                <input type="number" readonly name="attr_stealth_total" class="speed-read-color" />
-                <button type='roll' name='roll_stealthcheck' class='skill-roller spd-skill'
-                    value='&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Stealth}} {{skill-roll=[[ 1d20!kh2 + [[ @{stealth_total} + ?{Temporary Bonus|0} ]] ]]}}'>
-                    Stealth (SPD)
-                </button>
-                <input type="checkbox" name="attr_stealthtalent1" value="2" />
-                <input type="checkbox" name="attr_stealthtalent2" value="2" />
-                <input type="number" name="attr_stealth" value="0" />
+                    <input type="number" readonly name="attr_stealth_total" class="speed-read-color" />
+                    <button type='roll' name='roll_stealthcheck' class='skill-roller spd-skill'
+                        value='&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Stealth}} {{skill-roll=[[ 1d20!kh2 + [[ @{stealth_total} + ?{Temporary Bonus|0} ]] ]]}}'>
+                        Stealth (SPD)
+                    </button>
+                    <input type="checkbox" name="attr_stealthtalent1" value="2" />
+                    <input type="checkbox" name="attr_stealthtalent2" value="2" />
+                    <input type="number" name="attr_stealth" value="0" />
+                </div>
+
+                <div class="capture-pokemon-skill tab-trainer">
+                    <input type="number" readonly name="attr_capture_total" class="speed-read-color" />
+                    <button type='roll' name='roll_capturecheck' class='skill-roller spd-skill'
+                        value='&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Capture Pokémon}} {{skill-roll=[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 + @{ball_capture_modifier} ]] }}'>
+                        Capture Pokémon (SPD)
+                    </button>
+                    <select name="attr_ball_capture_modifier" class="ball-selector">
+                        <option value="5" selected>Basic Ball</option>
+                        <option value="0">Great Ball</option>
+                        <option value="-5">Ultra Ball</option>
+                        <option value="-20">Park Ball</option>
+                        <option value="-20">Safari Ball</option>
+                        <option value="-20">Sport Ball</option>
+                        <option value="-5">Cherish Ball</option>
+                        <option value="-5">Luxury Ball</option>
+                        <option value="-5">Premier Ball</option>
+                        <option value="-12">Dive Ball</option>
+                        <option value="-7">Dusk Ball</option>
+                        <option value="-8">Fast Ball</option>
+                        <option value="-10">Lure Ball</option>
+                        <option value="-20">Quick Ball</option>
+                        <option value="-10">Repeat Ball</option>
+                        <option value="-10">1m Timer Ball</option>
+                        <option value="-25">2m Timer Ball</option>
+                        <option value="0">Friend Ball</option>
+                        <option value="0">Heal Ball</option>
+                        <option value="-10">Dream Ball</option>
+                        <option value="-15">Heavy Ball</option>
+                        <option value="-10">Level Ball</option>
+                        <option value="-10">Love Ball</option>
+                        <option value="-10">Moon Ball</option>
+                        <option value="-10">Nest Ball</option>
+                        <option value="-15">Type Ball</option>
+                        <option value="-12">Terrain Ball</option>
+                        <option value="-10">Save Ball</option>
+                        <option value="-100">Master Ball</option>
+                        <option value="?{Custom Ball Modifier|0}">Custom Ball</option>
+                    </select>
+                </div>
             </div>
-
             <textarea spellcheck="false" name="attr_inventory" class="inventory"
                 placeholder="Pokéballs, Berries, Medicine, Accessories, etc."></textarea>
 
@@ -1467,6 +1508,16 @@
 
             assignSkillTotal('stealth_total', stat, talent1, talent2, total, userBonus);
         });
+    });
+
+    // Capture
+    on("change:SPDMOD change:capture sheet:opened", function (eventInfo) {
+      getAttrs([`SPDMOD`, `capture_total`], function (values) {
+        const stat = parseInt(values.SPDMOD) || 0;
+        const total = parseInt(values.capture_total) || -1;
+    
+        assignSkillTotal("capture_total", stat, 0, 0, total, 0);
+      });
     });
 
     function assignSkillTotal(skillName, stat, leftTalent, rightTalent, oldTotal, userBonus) {

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -807,6 +807,9 @@
 
     <b>Notes</b>
     <textarea spellcheck="false" name="attr_notes"></textarea>
+
+    <!-- General-Purpose Hidden Attributes -->
+    <input type="hidden" name="attr_initiative-tie-breaker" value="[[d20]]"/>
 </div>
 
 <!-- ROLL TEMPLATES -->

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -220,32 +220,46 @@
             <div class="ball atk-ball">
                 <b>Attack</b><br />
                 <input type="number" name="attr_ATK" class="stat-ball-color" /><br />
-                <input type="number" name="attr_ATKMOD" readonly class="stat-read-ball-color" /><br />
+                <button type="roll" name="roll_attack_check" class="stat-roller"
+                value='&{template:skill-roll} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Attack Check}} {{skill-roll=[[ 1d20 + [[ @{ATKMOD} + ?{Temp Modifier|0} ]] ]]}}'>
+                    <span name="attr_ATKMOD"></span>
+                </button><br />
                 <p>ATK mod</p>
             </div>
             <div class="ball def-ball">
                 <b>Defense</b><br />
                 <input type="number" name="attr_DEF" class="stat-ball-color" /><br />
-                <input type="number" name="attr_DEFMOD" readonly
-                    class="stat-read-ball-color tab-pokemon tab-hybrid" /><br />
+                <button type="roll" name="roll_defense_check" class="stat-roller"
+                value='&{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Defense Check}} {{skill-roll=[[ 1d20 + [[ @{DEFMOD} + ?{Temp Modifier|0} ]] ]]}}'>
+                    <span name="attr_DEFMOD"></span>
+                </button><br />
                 <p>DEF mod</p>
             </div>
             <div class="ball spatk-ball">
                 <b>Special Attack</b><br />
                 <input type="number" name="attr_SPATK" class="stat-ball-color" /><br />
-                <input type="number" name="attr_SPATKMOD" readonly class="stat-read-ball-color" /><br />
+                <button type="roll" name="roll_special-attack_check" class="stat-roller"
+                value='&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Attack Check}} {{skill-roll=[[ 1d20 + [[ @{SPATKMOD} + ?{Temp Modifier|0} ]] ]]}}'>
+                    <span name="attr_SPATKMOD"></span>
+                </button><br />
                 <p>SPATK mod</p>
             </div>
             <div class="ball spdef-ball">
                 <b>Special Defense</b><br />
                 <input type="number" name="attr_SPDEF" class="stat-ball-color" /><br />
-                <input type="number" name="attr_SPDEFMOD" readonly class="stat-read-ball-color" /><br />
+                <button type="roll" name="roll_special-defense_check" class="stat-roller"
+                value='&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Defense Check}} {{skill-roll=[[ 1d20 + [[ @{SPDEFMOD} + ?{Temp Modifier|0} ]] ]]}}'>
+                    <span name="attr_SPDEFMOD"></span>
+                </button><br />
                 <p>SPDEF mod</p>
             </div>
             <div class="ball spd-ball">
                 <b>Speed</b><br />
                 <input type="number" name="attr_SPD" class="stat-ball-color" /><br />
-                <input type="number" name="attr_SPDMOD" readonly class="stat-read-ball-color" /><br />
+                <button type="roll" name="roll_speed_check" class="stat-roller"
+                value='&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Speed Check}} {{skill-roll=[[ 1d20 + [[ @{SPDMOD} + ?{Temp Modifier|0} ]] ]]}}'>
+                    <span name="attr_SPDMOD"></span>
+                </button><br />
                 <p>SPD mod</p>
             </div>
         </div>
@@ -262,7 +276,10 @@
             <div class="ball atk-ball">
                 <b>Attack</b><br />
                 <input type="number" name="attr_ATK" class="stat-ball-color" /><br />
-                <input type="number" name="attr_ATKMOD" readonly class="stat-read-ball-color" /><br />
+                <button type="roll" name="roll_attack_check" class="stat-roller"
+                value='&{template:skill-roll} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Attack Check}} {{skill-roll=[[ 1d20 + [[ @{ATKMOD} + ?{Temp Modifier|0} ]] ]]}}'>
+                    <span name="attr_ATKMOD"></span>
+                </button><br />
                 <p>ATK mod</p>
             </div>
             <div class="ball def-ball">
@@ -272,7 +289,10 @@
             <div class="ball spatk-ball">
                 <b>Special Attack</b><br />
                 <input type="number" name="attr_SPATK" class="stat-ball-color" /><br />
-                <input type="number" name="attr_SPATKMOD" readonly class="stat-read-ball-color" /><br />
+                <button type="roll" name="roll_special-attack_check" class="stat-roller"
+                value='&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Attack Check}} {{skill-roll=[[ 1d20 + [[ @{SPATKMOD} + ?{Temp Modifier|0} ]] ]]}}'>
+                    <span name="attr_SPATKMOD"></span>
+                </button><br />
                 <p>SPATK mod</p>
             </div>
             <div class="ball spdef-ball">
@@ -282,7 +302,10 @@
             <div class="ball spd-ball">
                 <b>Speed</b><br />
                 <input type="number" name="attr_SPD" class="stat-ball-color" /><br />
-                <input type="number" name="attr_SPDMOD" readonly class="stat-read-ball-color" /><br />
+                <button type="roll" name="roll_speed_check" class="stat-roller"
+                value='&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Speed Check}} {{skill-roll=[[ 1d20 + [[ @{SPDMOD} + ?{Temp Modifier|0} ]] ]]}}'>
+                    <span name="attr_SPDMOD"></span>
+                </button><br />
                 <p>SPD mod</p>
             </div>
         </div>

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -1,4 +1,5 @@
 # Pokemon Tabletop Adventures 3
+
 This is the Roll20 character sheet for the Pokemon Tabletop Adventures 3
 system written by DrMrStark.
 
@@ -11,25 +12,30 @@ https://discord.gg/F24Ka8E
 
 - Added a Capture Pokemon skill to make life easier for everyone.
 - Added generic attribute checks - click on the modifier values to roll them.
+- Ran the code through the Prettifier linter to ensure we're not missing any gaps - this kind of messes up the formatting but it should at least standardise it from now on!
 
 ### Nov 28, 2020
+
 - Added support for temporary bonuses!
 
 ### Nov 25, 2020
+
 - Changed the header of the talent checkboxes to Talent to make it easier to identify their purpose
 - Fixed a bug where the sheet would reacting to attribute score changes rather than modifiers, which meant attribute changes sometimes did not propagate through to any associated values
 - Fixed a bug where the Bluff/Deception skill wasn't fetching the Special Defense modifier
 
 ### Nov 8, 2020
+
 - Combined the skill roll button with the skill name
   - Added fancy colors for the new skill roll button so that it matches the stat field when hovered over to help highlight which stat it uses
 - Repurposed the stat modifier display to show the total skill modifier
 - Added sheet workers to update the total skill modifier when relevant values are changed
 
 ### Oct 28, 2020
+
 - Extends the move roll template functionality to make it even easier for players and GMs to resolve attacks
   - Correctly handles critical hits for high critical hit rate moves such as Slash and Karate Chop being based on the total of the accuracy check, rather than just the raw dice roll
-  - Indicates when moves such as Poison Sting and Thunder Punch should apply their secondary effects 
+  - Indicates when moves such as Poison Sting and Thunder Punch should apply their secondary effects
 - Adds fields to the move section of the character sheet to enable assignment of secondary effects of moves, and declaration of critical hit ranges based on the accuracy roll rather than the individual dice roll
 - Resolves an issue with the total damage bonus not updating when the move fields are changed
 - Resolves an issue with the special defense target text appearing on two lines with the default Roll20 spacing of the chat log
@@ -38,6 +44,7 @@ https://discord.gg/F24Ka8E
   - The raw total bonus can still be accessed with the correct attributes names
 
 ### Oct 22, 2020
+
 - Introduces roll templates to the character sheet
 - The skill-roll template is used for skill rolls by Trainer-type characters
 - The move-roll template is used for rolling attacks by all types of characters. This has variable fields, depending on how the move section of the character sheet is configured
@@ -54,6 +61,7 @@ https://discord.gg/F24Ka8E
 - Adds a new attribute to each move section that indicates the total static damage bonus applied to a roll, and uses that within the roll template for moves. This is intended to make creating custom macros for rolling damage way easier than needing to calculate the correct bonus.
 
 ### Oct 14, 2020
+
 - Added Readme with Changelog and other details
 - Added 1/combat as an option for move frequencies
 - Added Pokemon moves section to the Trainer sheet, since Trainers often use moves. Now this section is on all sheets.
@@ -61,22 +69,26 @@ https://discord.gg/F24Ka8E
 - Changed Nature selection to a dropdown
 
 ### Oct 3, 2020
-- Max HP now references the built in _max that allows it to be used for token health bars.
+
+- Max HP now references the built in \_max that allows it to be used for token health bars.
 - Pokemon moves have been completely reorganized, and now have buttons to roll for accuracy and damage.
 - The background now changes to match the Pokemon's type.
 - Moves now change color to match the move's type.
 - Resized some text boxes to better fit actual play.
 
 ### Sept 22, 2020
+
 - Incorrect logo image was used, causing elements to be blocked. (It had a bunch of extra transparent space.) Replaced with the correct image.
 - Special Defense for Pokemon was missing a line break, so if you opened the window too wide, the display would show on the same line and would no longer be in the ball. Added this missing line break.
 
 ### Sept 16, 2020
+
 - Initial Commit
 
-
 ## To-Do:
+
 Things we want to add to the character sheet, presented in no particular order of priority:
+
 - [x] ~~Display the full bonus to skill checks~~
 - [x] ~~Handle temporary stat changes somehow, this may be a lot of work~~
 - [x] ~~Prevent critical range from going below 0 or above 20, maybe do similar to other fields~~
@@ -84,3 +96,4 @@ Things we want to add to the character sheet, presented in no particular order o
 - [ ] Allow formula calculations for the extra damage fields
 - [ ] Allow modifications to movement (maybe just an extra box)
 - [ ] Display the adjusted stat score when temporary stat changes are provided
+- [ ] Refactor the sheet workers to remove the cascading change observation; each `setAttrs` call takes way too long, so we want to capitalise on making them as low as possible

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -12,6 +12,7 @@ https://discord.gg/F24Ka8E
 
 - Added a Capture Pokemon skill to make life easier for everyone.
 - Added generic attribute checks - click on the modifier values to roll them.
+- Added a hidden attribute for use in initiative checks: `initiative-tie-breaker` which rolls a d20 when accessed.
 - Ran the code through the Prettifier linter to ensure we're not missing any gaps - this kind of messes up the formatting but it should at least standardise it from now on!
 
 ### Nov 28, 2020

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -10,6 +10,7 @@ https://discord.gg/F24Ka8E
 ### Dec 7, 2020
 
 - Added a Capture Pokemon skill to make life easier for everyone.
+- Added generic attribute checks - click on the modifier values to roll them.
 
 ### Nov 28, 2020
 - Added support for temporary bonuses!

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -7,6 +7,10 @@ https://discord.gg/F24Ka8E
 
 ## Changelog
 
+### Dec 7, 2020
+
+- Added a Capture Pokemon skill to make life easier for everyone.
+
 ### Nov 28, 2020
 - Added support for temporary bonuses!
 


### PR DESCRIPTION
## Changes / Comments

- feature: Added a pokemon capture skill
  - Adds a new skill to the end of the skill list - placement intentionally breaking alphabetical order for fast location, and because the format doesn't match the rest of the table
- feature: Added generic stat checks
  - Changes the readonly input field for stat modifiers to be buttons with attribute-backed span titles to allow for making them rollable
  - Added dice rolls for generic stat checks to the new dice modifier buttons
    - This means Pokémon character sheets don't have checks for DEF and SPDEF, as those mods aren't used for Pokémon; this may change in the future
- chore: Ran code through linter
  - Installed the Prettifier linter to ensure the code is presented in a "standard" format
    - Helps to catch any errors missed _(such as missing semi-colons, of which there were a few!)_
  - Added task to the to-do concerning the cascading sheet workers



## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Does this add functional enhancements (new features or extending existing features)?
- [x] Does this add or change functional aesthetics (such as layout or color scheme)?
