### PR TITLE
Shadowrun5th Will as Drain Attribute

### DIFF
--- a/Shadowrun5th/Shadowrun5th.html
+++ b/Shadowrun5th/Shadowrun5th.html
@@ -6604,6 +6604,7 @@ Can lift overhead (Strength + Nethits) x 5kg}}" />
                         <option value="@{cha_total}">CHA</option>
                         <option value="@{bod_total}">BOD</option>
                         <option value="@{mag_total}">MAG</option>
+                        <option value="@{wil_total}">WILL</option>
                     </select>
                 </div>
             </div>


### PR DESCRIPTION
Adding will to the possible Drain Attributes

## Changes / Comments

Adding Will power to the drain attributes for mages

This is a change to Shadowrun5th. Adding Will as one of the possible drain attributes. This fix patches https://github.com/Roll20/roll20-character-sheets/issues/7954

There are no appearance changes as part of this pull request.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x]  Is this a bug fix?
- [ ]  Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ?
- [ ]  If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow Building Character Sheets standards ?
