### PR TITLE
ChroniquesGalactiques v3.110

### DIFF
--- a/ChroniquesGalactiques/ReadMe.md
+++ b/ChroniquesGalactiques/ReadMe.md
@@ -9,9 +9,20 @@ Cette feuilles de personnage inclue quelques jets et r&egrave;gles optionnelles.
 Le jeu complet est paru dans le magazine [Casus Belli](http://www.black-book-editions.fr/catalogue.php?id=207) #17,18 et 19.
 
 # Version courante
-V3.11 [Screenshot](cog_v3.png)
+V3.110 [Screenshot](cog_v3.png)
 
 # Notes de version
+
+## V3.110 (2020.12.21)
+
+- Case à cocher sur l'onglet Capacités de la fiche de PJ permettant de basculer entre :
+  - le mode Affichage, avec nom et description textuelle complète des capacités
+  - le mode Edition, où l'utilisateur peut entrer le texte des capacités (la première ligne de texte est toujours considérée comme étant le nom de la capacité).
+- Possibilité de lier un jet de capacité avec l'une des capacités de la grille, en indiquant le numéro de voie et le rang correspondant. Cette information est principalement utilisée par le script API [COlib](https://github.com/stephaned68/COlib).
+- Sur la fiche de vaisseau :
+  - gestion des Points d'Energie, avec contrôle par rapport aux PE max
+  - gestion de l'occupation des postes, avec prise en compte ou pas des bonus d'équipage sur les jets de vaisseau (Init et DEF (Rapidité) à 0 pour un vaisseau sans pilote)
+  - pas d'affichage de la section des traits physiques (sexe, âge, taille, poids)
 
 ## V3.11 (2020.08.15)
 * Amélioration de la logique d'import d'un statblock de PNJ ou de créature

--- a/ChroniquesGalactiques/cog.css
+++ b/ChroniquesGalactiques/cog.css
@@ -1,4 +1,4 @@
-/* @import url('https://fonts.googleapis.com/css?family=Fira+Sans&display=swap'); */
+@import url('https://fonts.googleapis.com/css?family=Titillium+Web&display=swap');
 
 /* Couleurs
     Base bleu = #2F5860
@@ -16,12 +16,12 @@ tr,
 td,
 th {
   box-sizing: border-box;
-  font-family: Verdana;
+  font-family: 'Verdana';
   font-size: 12px;
 }
 
 div.sheet-mainBg {
-  width: 832px; /* 850px; */
+  width: 850px;
   background: linear-gradient(#9b9e99, #cecbc4, #dddad2, #ecede8, #fdfefd);
   border: 2px solid #2f5860;
   border-radius: 10px;
@@ -45,14 +45,14 @@ table.sheet-tabsep {
 }
 
 .sheet-imghr {
-  width: 820px;
+  width: 850px;
   height: 5px;
   padding: 0px;
   /* box-shadow: 1px 1px 8px #555; */
 }
 
 .sheet-imghr-up {
-  width: 820px;
+  width: 850px;
   height: 5px;
   padding: 0px;
   text-align: center;
@@ -61,7 +61,7 @@ table.sheet-tabsep {
 }
 
 .sheet-boxtitre {
-  font-family: 'Contrail One';
+  font-family: 'Titillium Web';
   font-size: 15px;
   background-color: #2f5860;
   text-align: center;
@@ -75,7 +75,7 @@ table.sheet-tabsep {
 }
 
 .sheet-boxtitresmall {
-  font-family: 'Contrail One';
+  font-family: 'Titillium Web';
   font-size: 13px;
   background-color: #2f5860;
   text-align: center;
@@ -131,13 +131,33 @@ table.sheet-tabsep {
   white-space: nowrap;
 }
 
+.sheet-boxtext {
+  width: 266px;
+  padding: 2px;
+}
+
+span.sheet-label {
+  padding: 0;
+}
+
 textarea.sheet-boxability {
   width: 92%;
 }
 
+span.sheet-boxability,
+div.sheet-boxability {
+  white-space: pre-wrap;
+  font-size: x-small;
+  user-select: text;
+}
+
+div.sheet-boxability {
+  padding: 5px;
+}
+
 .sheet-textfat {
-  font-family: 'Contrail One';
-  /* 'Contrail One'; */
+  font-family: 'Titillium Web';
+  /* var(--main-font); */
   font-size: 15px;
   font-weight: bold;
   color: #2f5860;
@@ -146,8 +166,8 @@ textarea.sheet-boxability {
 }
 
 .sheet-textfatleft {
-  font-family: 'Contrail One';
-  /* 'Contrail One'; */
+  font-family: 'Titillium Web';
+  /* var(--main-font); */
   font-size: 15px;
   font-weight: bold;
   color: #2f5860;
@@ -158,8 +178,8 @@ textarea.sheet-boxability {
 }
 
 .sheet-textbase {
-  font-family: 'Contrail One';
-  /* 'Contrail One'; */
+  font-family: 'Titillium Web';
+  /* var(--main-font); */
   font-size: 14px;
   color: #2f5860;
   border: none;
@@ -180,8 +200,8 @@ textarea.sheet-boxability {
 
 button[type='roll'].sheet-boxtitre {
   height: 20px;
-  font-family: 'Contrail One';
-  /* 'Contrail One'; */
+  font-family: 'Titillium Web';
+  /* var(--main-font); */
   font-size: 15px;
   font-weight: normal;
   text-decoration: none;
@@ -399,6 +419,25 @@ input.sheet-hidden-tab {
   display: none;
 }
 
+/*Optional block switch, no margin */
+.sheet-optional-block-switch {
+  display: none;
+  position: relative;
+}
+
+.sheet-optional-block {
+  position: relative;
+}
+
+.sheet-optional-block-switch:checked ~ .sheet-optional-block {
+  display: block;
+}
+
+.sheet-optional-block,
+.sheet-optional-block-switch:checked {
+  display: none;
+}
+
 /* Switch -- styled checkboxes */
 
 input[type='checkbox'].sheet-block-switch {
@@ -484,6 +523,16 @@ input[type='checkbox'].sheet-block-switch:checked + span::before {
   display: block;
 }
 
+.sheet-setup-abilities {
+  float: right;
+}
+
+.sheet-ship-epbox {
+  margin: 0;
+  padding: 0;
+  float: left;
+}
+
 /* TEMPLATES */
 .sheet-rolltemplate-co1 .sheet-imghr {
   width: 100%;
@@ -513,7 +562,7 @@ input[type='checkbox'].sheet-block-switch:checked + span::before {
   padding: 0px 5px 0px 5px;
   font-size: 16px;
   text-align: left;
-  font-family: 'Contrail One';
+  font-family: 'Titillium Web';
   font-variant: small-caps;
   font-weight: bold;
   white-space: nowrap;
@@ -567,7 +616,7 @@ input[type='checkbox'].sheet-block-switch:checked + span::before {
   border-color: #7f989d;
   border-style: solid;
   border-radius: 25%;
-  font-family: 'Contrail One';
+  font-family: 'Titillium Web';
   font-size: 16px;
 }
 
@@ -577,7 +626,7 @@ input[type='checkbox'].sheet-block-switch:checked + span::before {
   border-color: #3fb315;
   border-style: solid;
   border-radius: 25%;
-  font-family: 'Contrail One';
+  font-family: 'Titillium Web';
   font-size: 16px;
 }
 
@@ -587,7 +636,7 @@ input[type='checkbox'].sheet-block-switch:checked + span::before {
   border-color: #b31515;
   border-style: solid;
   border-radius: 25%;
-  font-family: 'Contrail One';
+  font-family: 'Titillium Web';
   font-size: 16px;
 }
 
@@ -597,6 +646,6 @@ input[type='checkbox'].sheet-block-switch:checked + span::before {
   border-color: #2f5860;
   border-style: solid;
   border-radius: 25%;
-  font-family: 'Contrail One';
+  font-family: 'Titillium Web';
   font-size: 16px;
 }

--- a/ChroniquesGalactiques/cog.html
+++ b/ChroniquesGalactiques/cog.html
@@ -1,10 +1,14 @@
 <div class="sheet-mainBg">
   <!-- FDP -->
   <!-- INPUT HIDDEN Version FdP -->
-  <input type="hidden" name="attr_verfdp" value="3.11.0" />
-  <input type="hidden" name="attr_VERSION" value="3.11.0" />
+  <input type="hidden" name="attr_verfdp" value="3.110.0" />
+  <input type="hidden" name="attr_VERSION" value="3.110.0" />
   <!-- INPUT HIDDEN Univers (COF, CG, COC) -->
   <input type="hidden" name="attr_UNIVERS" value="CG" />
+    <!-- INPUT HIDDEN Libellés -->
+  <input type="hidden" name="attr_lib_profil" value="Profil" />
+  <input type="hidden" name="attr_lib_famille" value="Famille" />
+  <input type="hidden" name="attr_lib_origine" value="Origine" />
   <!-- INPUT HIDDEN Type de jets -->
   <input type="hidden" name="attr_JETNORMAL" value="1d@{ETATDE}" />
   <input type="hidden" name="attr_JETSUP" value="2d@{ETATDE}kh1" />
@@ -76,10 +80,10 @@
   <div class="sheet-container">
     <!-- Identité -->
     <div style="width: 420px; vertical-align: middle; text-align: center;">
-      <img width="340" title="Version 3.8 - 28/09/2019"
+      <img width="340" title="Version 3.110 - 21/12/2020"
         src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_logo.png" />
     </div>
-    <div style="width: 250px;">
+    <div style="width: 270px;">
       <table>
         <tr>
           <td class="sheet-textfatleft">Nom</td>
@@ -87,12 +91,16 @@
           </td>
         </tr>
         <tr>
-          <td class="sheet-textfatleft">Race</td>
-          <td colspan="3"><input class="sheet-nobox" name="attr_RACE" type="text" title="@{RACE}" /></td>
+          <td class="sheet-textfatleft"><span class="sheet-textfatleft sheet-label" name="attr_lib_profil"></span></td>
+          <td colspan="3"><input class="sheet-nobox" name="attr_PROFIL" type="text" title="@{PROFIL}" /></td>
         </tr>
         <tr>
-          <td class="sheet-textfatleft">Profil</td>
-          <td colspan="3"><input class="sheet-nobox" name="attr_PROFIL" type="text" title="@{PROFIL}" /></td>
+          <td class="sheet-textfatleft"><span class="sheet-textfatleft sheet-label" name="attr_lib_famille"></span></td>
+          <td colspan="3"><input class="sheet-nobox" name="attr_FAMILLE" type="text" title="@{FAMILLE}" /></td>
+        </tr>
+        <tr>
+          <td class="sheet-textfatleft"><span class="sheet-textfatleft sheet-label" name="attr_lib_origine"></span></td>
+          <td colspan="3"><input class="sheet-nobox" name="attr_RACE" type="text" title="@{RACE}" /></td>
         </tr>
         <tr>
           <td class="sheet-textfatleft">Niveau</td>
@@ -109,25 +117,28 @@
         </tr>
       </table>
     </div>
-    <div style="width: 110px;">
-      <table>
-        <tr>
-          <td class="sheet-textfatleft">Sexe</td>
-          <td><input class="sheet-nobox" name="attr_SEXE" type="text" title="@{SEXE}" /></td>
-        </tr>
-        <tr>
-          <td class="sheet-textfatleft">Âge</td>
-          <td><input class="sheet-nobox" name="attr_AGE" type="text" title="@{AGE}" /></td>
-        </tr>
-        <tr>
-          <td class="sheet-textfatleft">Taille</td>
-          <td><input class="sheet-nobox" name="attr_TAILLE" type="text" title="@{TAILLE}" /></td>
-        </tr>
-        <tr>
-          <td class="sheet-textfatleft">Poids</td>
-          <td><input class="sheet-nobox" name="attr_POIDS" type="text" title="@{POIDS}" /></td>
-        </tr>
-      </table>
+    <div style="width: 120px; margin-left: 10px;">
+      <input type="checkbox" class="optional-block-switch" name="attr_physical" value="1" ><span></span>
+      <div class="optional-block">
+        <table>
+          <tr>
+            <td class="sheet-textfatleft">Sexe</td>
+            <td><input class="sheet-nobox" name="attr_SEXE" type="text" title="@{SEXE}" /></td>
+          </tr>
+          <tr>
+            <td class="sheet-textfatleft">Âge</td>
+            <td><input class="sheet-nobox" name="attr_AGE" type="text" title="@{AGE}" /></td>
+          </tr>
+          <tr>
+            <td class="sheet-textfatleft">Taille</td>
+            <td><input class="sheet-nobox" name="attr_TAILLE" type="text" title="@{TAILLE}" /></td>
+          </tr>
+          <tr>
+            <td class="sheet-textfatleft">Poids</td>
+            <td><input class="sheet-nobox" name="attr_POIDS" type="text" title="@{POIDS}" /></td>
+          </tr>
+        </table>
+      </div>
     </div>
   </div> <!-- FIN Identité -->
   <input type="radio" name="attr_type_fiche" class="sheet-hidden-tab sheet-fp1" value="pj" checked="checked"><span
@@ -867,311 +878,626 @@
     </div>
     <div class="sheet-tab-content sheet-tab2">
       <div>
-        <!-- Voies -->
-        <table>
-          <tr>
-            <td class="sheet-textfatleft" colspan="5">CAPACITÉS DU PERSONNAGE</td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
-            <td class="sheet-boxtitresmall">Voie 1</td>
-            <td class="sheet-boxtitresmall">Voie 2</td>
-            <td class="sheet-boxtitresmall">Voie 3</td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">R</td>
-            <td class="sheet-boxinputleft">
-              <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie1nom" title="@{voie1nom}"
-                placeholder="Nom de la Voie n°1" />
-            </td>
-            <td class="sheet-boxinput">
-              <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie2nom" title="@{voie2nom}"
-                placeholder="Nom de la Voie n°2" />
-            </td>
-            <td class="sheet-boxinput">
-              <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie3nom" title="@{voie3nom}"
-                placeholder="Nom de la Voie n°3" />
-            </td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">1</td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v1r1" value="1" />
-              <textarea name="attr_voie1-1" class="sheet-boxability" title="@{voie1-1}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v2r1" value="1" />
-              <textarea name="attr_voie2-1" class="sheet-boxability" title="@{voie2-1}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v3r1" value="1" />
-              <textarea name="attr_voie3-1" class="sheet-boxability" title="@{voie3-1}"></textarea>
-            </td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">2</td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v1r2" value="1" />
-              <textarea name="attr_voie1-2" class="sheet-boxability" title="@{voie1-2}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v2r2" value="1" />
-              <textarea name="attr_voie2-2" class="sheet-boxability" title="@{voie2-2}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v3r2" value="1" />
-              <textarea name="attr_voie3-2" class="sheet-boxability" title="@{voie3-2}"></textarea>
-            </td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">3</td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v1r3" value="1" />
-              <textarea name="attr_voie1-3" class="sheet-boxability" title="@{voie1-3}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v2r3" value="1" />
-              <textarea name="attr_voie2-3" class="sheet-boxability" title="@{voie2-3}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v3r3" value="1" />
-              <textarea name="attr_voie3-3" class="sheet-boxability" title="@{voie3-3}"></textarea>
-            </td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">4</td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v1r4" value="1" />
-              <textarea name="attr_voie1-4" class="sheet-boxability" title="@{voie1-4}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v2r4" value="1" />
-              <textarea name="attr_voie2-4" class="sheet-boxability" title="@{voie2-4}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v3r4" value="1" />
-              <textarea name="attr_voie3-4" class="sheet-boxability" title="@{voie3-4}"></textarea>
-            </td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">5</td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v1r5" value="1" />
-              <textarea name="attr_voie1-5" class="sheet-boxability" title="@{voie1-5}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v2r5" value="1" />
-              <textarea name="attr_voie2-5" class="sheet-boxability" title="@{voie2-5}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v3r5" value="1" />
-              <textarea name="attr_voie3-5" class="sheet-boxability" title="@{voie3-5}"></textarea>
-            </td>
-          </tr>
-        </table>
-        <table>
-          <tr>
-            <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
-            <td class="sheet-boxtitresmall">Voie 4</td>
-            <td class="sheet-boxtitresmall">Voie 5</td>
-            <td class="sheet-boxtitresmall">Voie 6</td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">R</td>
-            <td class="sheet-boxinputleft">
-              <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie4nom" title="@{voie4nom}"
-                placeholder="Nom de la Voie n°4" />
-            </td>
-            <td class="sheet-boxinput">
-              <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie5nom" title="@{voie5nom}"
-                placeholder="Nom de la Voie n°5" />
-            </td>
-            <td class="sheet-boxinput">
-              <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie6nom" title="@{voie6nom}"
-                placeholder="Nom de la Voie n°6" />
-            </td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">1</td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v4r1" value="1" />
-              <textarea name="attr_voie4-1" class="sheet-boxability" title="@{voie4-1}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v5r1" value="1" />
-              <textarea name="attr_voie5-1" class="sheet-boxability" title="@{voie5-1}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v6r1" value="1" />
-              <textarea name="attr_voie6-1" class="sheet-boxability" title="@{voie6-1}"></textarea>
-            </td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">2</td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v4r2" value="1" />
-              <textarea name="attr_voie4-2" class="sheet-boxability" title="@{voie4-2}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v5r2" value="1" />
-              <textarea name="attr_voie5-2" class="sheet-boxability" title="@{voie5-2}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v6r2" value="1" />
-              <textarea name="attr_voie6-2" class="sheet-boxability" title="@{voie6-2}"></textarea>
-            </td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">3</td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v4r3" value="1" />
-              <textarea name="attr_voie4-3" class="sheet-boxability" title="@{voie4-3}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v5r3" value="1" />
-              <textarea name="attr_voie5-3" class="sheet-boxability" title="@{voie5-3}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v6r3" value="1" />
-              <textarea name="attr_voie6-3" class="sheet-boxability" title="@{voie6-3}"></textarea>
-            </td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">4</td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v4r4" value="1" />
-              <textarea name="attr_voie4-4" class="sheet-boxability" title="@{voie4-4}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v5r4" value="1" />
-              <textarea name="attr_voie5-4" class="sheet-boxability" title="@{voie5-4}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v6r4" value="1" />
-              <textarea name="attr_voie6-4" class="sheet-boxability" title="@{voie6-4}"></textarea>
-            </td>
-          </tr>
-          <tr>
-            <td class="sheet-boxtitresmall">5</td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v4r5" value="1" />
-              <textarea name="attr_voie4-5" class="sheet-boxability" title="@{voie4-5}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v5r5" value="1" />
-              <textarea name="attr_voie5-5" class="sheet-boxability" title="@{voie5-5}"></textarea>
-            </td>
-            <td class="sheet-boxvoie">
-              <input type="checkbox" name="attr_v6r5" value="1" />
-              <textarea name="attr_voie6-5" class="sheet-boxability" title="@{voie6-5}"></textarea>
-            </td>
-          </tr>
-        </table>
-        <div>
-          <input type="checkbox" class="sheet-block-switch" name="attr_voies789" title="@{voies789}"
-            value="1"><span>Plus de voies</span>
-          <div class="sheet-block-hidden"></div>
-          <div class="sheet-block-show">
-            <table>
-              <tr>
-                <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
-                <td class="sheet-boxtitresmall">Voie 7</td>
-                <td class="sheet-boxtitresmall">Voie 8</td>
-                <td class="sheet-boxtitresmall">Voie 9</td>
-              </tr>
-              <tr>
-                <td class="sheet-boxtitresmall">R</td>
-                <td class="sheet-boxinputleft">
-                  <input type="text" style="font-weight: bold; text-align: center;" name="attr_voie7nom"
-                    title="@{voie7nom}" placeholder="Nom de la Voie n°7" />
-                </td>
-                <td class="sheet-boxinput">
-                  <input type="text" style="font-weight: bold; text-align: center;" name="attr_voie8nom"
-                    title="@{voie8nom}" placeholder="Nom de la Voie n°8" />
-                </td>
-                <td class="sheet-boxinput">
-                  <input type="text" style="font-weight: bold; text-align: center;" name="attr_voie9nom"
-                    title="@{voie9nom}" placeholder="Nom de la Voie n°9" />
-                </td>
-              </tr>
-              <tr>
-                <td class="sheet-boxtitresmall">1</td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v7r1" value="1" />
-                  <textarea name="attr_voie7-1" class="sheet-boxability" title="@{voie7-1}"></textarea>
-                </td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v8r1" value="1" />
-                  <textarea name="attr_voie8-1" class="sheet-boxability" title="@{voie8-1"></textarea>
-                </td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v9r1" value="1" />
-                  <textarea name="attr_voie9-1" class="sheet-boxability" title="@{voie9-1}"></textarea>
-                </td>
-              </tr>
-              <tr>
-                <td class="sheet-boxtitresmall">2</td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v7r2" value="1" />
-                  <textarea name="attr_voie7-2" class="sheet-boxability" title="@{voie7-2}"></textarea>
-                </td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v8r2" value="1" />
-                  <textarea name="attr_voie8-2" class="sheet-boxability" title="@{voie8-2}"></textarea>
-                </td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v9r2" value="1" />
-                  <textarea name="attr_voie9-2" class="sheet-boxability" title="@{voie9-2}"></textarea>
-                </td>
-              </tr>
-              <tr>
-                <td class="sheet-boxtitresmall">3</td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v7r3" value="1" />
-                  <textarea name="attr_voie7-3" class="sheet-boxability" title="@{voie7-3}"></textarea>
-                </td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v8r3" value="1" />
-                  <textarea name="attr_voie8-3" class="sheet-boxability" title="@{voie8-3}"></textarea>
-                </td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v9r3" value="1" />
-                  <textarea name="attr_voie9-3" class="sheet-boxability" title="@{voie9-3}"></textarea>
-                </td>
-              </tr>
-              <tr>
-                <td class="sheet-boxtitresmall">4</td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v7r4" value="1" />
-                  <textarea name="attr_voie7-4" class="sheet-boxability" title="@{voie7-4}"></textarea>
-                </td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v8r4" value="1" />
-                  <textarea name="attr_voie8-4" class="sheet-boxability" title="@{voie8-4}"></textarea>
-                </td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v9r4" value="1" />
-                  <textarea name="attr_voie9-4" class="sheet-boxability" title="@{voie9-4}"></textarea>
-                </td>
-              </tr>
-              <tr>
-                <td class="sheet-boxtitresmall">5</td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v7r5" value="1" />
-                  <textarea name="attr_voie7-5" class="sheet-boxability" title="@{voie7-5}"></textarea>
-                </td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v8r5" value="1" />
-                  <textarea name="attr_voie8-5" class="sheet-boxability" title="@{voie8-5}"></textarea>
-                </td>
-                <td class="sheet-boxvoie">
-                  <input type="checkbox" name="attr_v9r5" value="1" />
-                  <textarea name="attr_voie9-5" class="sheet-boxability" title="@{voie9-5}"></textarea>
-                </td>
-              </tr>
-            </table>
+        <input class="block-switch" name="attr_setup_abilities" type="checkbox" value="1" checked>
+        <div class="block-hidden">
+          <table>
+            <tr>
+              <td class="sheet-textfatleft" colspan="5">
+                CAPACITÉS DU PERSONNAGE
+                <input type="checkbox" class="sheet-setup-abilities" name="attr_setup_abilities"
+                  title="Editer les capacités" value="1">
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
+              <td class="sheet-boxtitresmall">Voie 1</td>
+              <td class="sheet-boxtitresmall">Voie 2</td>
+              <td class="sheet-boxtitresmall">Voie 3</td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">R</td>
+              <td class="sheet-boxinputleft">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie1nom"
+                  title="@{voie1nom}" placeholder="Nom de la Voie n°1" />
+              </td>
+              <td class="sheet-boxinput">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie2nom"
+                  title="@{voie2nom}" placeholder="Nom de la Voie n°2" />
+              </td>
+              <td class="sheet-boxinput">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie3nom"
+                  title="@{voie3nom}" placeholder="Nom de la Voie n°3" />
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">1</td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v1r1" value="1" />
+                <span name="attr_voie1-1" class="sheet-boxability" title="@{voie1-1}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v2r1" value="1" />
+                <span name="attr_voie2-1" class="sheet-boxability" title="@{voie2-1}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v3r1" value="1" />
+                <span name="attr_voie3-1" class="sheet-boxability" title="@{voie3-1}"></span>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">2</td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v1r2" value="1" />
+                <span name="attr_voie1-2" class="sheet-boxability" title="@{voie1-2}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v2r2" value="1" />
+                <span name="attr_voie2-2" class="sheet-boxability" title="@{voie2-2}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v3r2" value="1" />
+                <span name="attr_voie3-2" class="sheet-boxability" title="@{voie3-2}"></span>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">3</td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v1r3" value="1" />
+                <span name="attr_voie1-3" class="sheet-boxability" title="@{voie1-3}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v2r3" value="1" />
+                <span name="attr_voie2-3" class="sheet-boxability" title="@{voie2-3}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v3r3" value="1" />
+                <span name="attr_voie3-3" class="sheet-boxability" title="@{voie3-3}"></span>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">4</td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v1r4" value="1" />
+                <span name="attr_voie1-4" class="sheet-boxability" title="@{voie1-4}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v2r4" value="1" />
+                <span name="attr_voie2-4" class="sheet-boxability" title="@{voie2-4}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v3r4" value="1" />
+                <span name="attr_voie3-4" class="sheet-boxability" title="@{voie3-4}"></span>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">5</td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v1r5" value="1" />
+                <span name="attr_voie1-5" class="sheet-boxability" title="@{voie1-5}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v2r5" value="1" />
+                <span name="attr_voie2-5" class="sheet-boxability" title="@{voie2-5}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v3r5" value="1" />
+                <span name="attr_voie3-5" class="sheet-boxability" title="@{voie3-5}"></span>
+              </td>
+            </tr>
+          </table>
+          <table>
+            <tr>
+              <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
+              <td class="sheet-boxtitresmall">Voie 4</td>
+              <td class="sheet-boxtitresmall">Voie 5</td>
+              <td class="sheet-boxtitresmall">Voie 6</td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">R</td>
+              <td class="sheet-boxinputleft">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie4nom"
+                  title="@{voie4nom}" placeholder="Nom de la Voie n°4" />
+              </td>
+              <td class="sheet-boxinput">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie5nom"
+                  title="@{voie5nom}" placeholder="Nom de la Voie n°5" />
+              </td>
+              <td class="sheet-boxinput">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie6nom"
+                  title="@{voie6nom}" placeholder="Nom de la Voie n°6" />
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">1</td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v4r1" value="1" />
+                <span name="attr_voie4-1" class="sheet-boxability" title="@{voie4-1}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v5r1" value="1" />
+                <span name="attr_voie5-1" class="sheet-boxability" title="@{voie5-1}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v6r1" value="1" />
+                <span name="attr_voie6-1" class="sheet-boxability" title="@{voie6-1}"></span>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">2</td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v4r2" value="1" />
+                <span name="attr_voie4-2" class="sheet-boxability" title="@{voie4-2}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v5r2" value="1" />
+                <span name="attr_voie5-2" class="sheet-boxability" title="@{voie5-2}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v6r2" value="1" />
+                <span name="attr_voie6-2" class="sheet-boxability" title="@{voie6-2}"></span>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">3</td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v4r3" value="1" />
+                <span name="attr_voie4-3" class="sheet-boxability" title="@{voie4-3}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v5r3" value="1" />
+                <span name="attr_voie5-3" class="sheet-boxability" title="@{voie5-3}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v6r3" value="1" />
+                <span name="attr_voie6-3" class="sheet-boxability" title="@{voie6-3}"></span>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">4</td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v4r4" value="1" />
+                <span name="attr_voie4-4" class="sheet-boxability" title="@{voie4-4}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v5r4" value="1" />
+                <span name="attr_voie5-4" class="sheet-boxability" title="@{voie5-4}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v6r4" value="1" />
+                <span name="attr_voie6-4" class="sheet-boxability" title="@{voie6-4}"></span>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">5</td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v4r5" value="1" />
+                <span name="attr_voie4-5" class="sheet-boxability" title="@{voie4-5}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v5r5" value="1" />
+                <span name="attr_voie5-5" class="sheet-boxability" title="@{voie5-5}"></span>
+              </td>
+              <td class="sheet-boxvoie sheet-boxtext">
+                <input type="checkbox" name="attr_v6r5" value="1" />
+                <span name="attr_voie6-5" class="sheet-boxability" title="@{voie6-5}"></span>
+              </td>
+            </tr>
+          </table>
+          <div>
+            <input type="checkbox" class="sheet-block-switch" name="attr_voies789"><span>Plus de voies</span>
+            <div class="sheet-block-hidden"></div>
+            <div class="sheet-block-show">
+              <table>
+                <tr>
+                  <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
+                  <td class="sheet-boxtitresmall">Voie 7</td>
+                  <td class="sheet-boxtitresmall">Voie 8</td>
+                  <td class="sheet-boxtitresmall">Voie 9</td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">R</td>
+                  <td class="sheet-boxinputleft">
+                    <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie7nom"
+                      title="@{voie7nom}" placeholder="Nom de la Voie n°7" />
+                  </td>
+                  <td class="sheet-boxinput">
+                    <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie8nom"
+                      title="@{voie8nom}" placeholder="Nom de la Voie n°8" />
+                  </td>
+                  <td class="sheet-boxinput">
+                    <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie9nom"
+                      title="@{voie9nom}" placeholder="Nom de la Voie n°9" />
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">1</td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v7r1" value="1" />
+                    <span name="attr_voie7-1" class="sheet-boxability" title="@{voie7-1}"></span>
+                  </td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v8r1" value="1" />
+                    <span name="attr_voie8-1" class="sheet-boxability" title="@{voie8-1"></span>
+                  </td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v9r1" value="1" />
+                    <span name="attr_voie9-1" class="sheet-boxability" title="@{voie9-1}"></span>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">2</td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v7r2" value="1" />
+                    <span name="attr_voie7-2" class="sheet-boxability" title="@{voie7-2}"></span>
+                  </td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v8r2" value="1" />
+                    <span name="attr_voie8-2" class="sheet-boxability" title="@{voie8-2}"></span>
+                  </td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v9r2" value="1" />
+                    <span name="attr_voie9-2" class="sheet-boxability" title="@{voie9-2}"></span>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">3</td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v7r3" value="1" />
+                    <span name="attr_voie7-3" class="sheet-boxability" title="@{voie7-3}"></span>
+                  </td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v8r3" value="1" />
+                    <span name="attr_voie8-3" class="sheet-boxability" title="@{voie8-3}"></span>
+                  </td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v9r3" value="1" />
+                    <span name="attr_voie9-3" class="sheet-boxability" title="@{voie9-3}"></span>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">4</td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v7r4" value="1" />
+                    <span name="attr_voie7-4" class="sheet-boxability" title="@{voie7-4}"></span>
+                  </td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v8r4" value="1" />
+                    <span name="attr_voie8-4" class="sheet-boxability" title="@{voie8-4}"></span>
+                  </td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v9r4" value="1" />
+                    <span name="attr_voie9-4" class="sheet-boxability" title="@{voie9-4}"></span>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">5</td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v7r5" value="1" />
+                    <span name="attr_voie7-5" class="sheet-boxability" title="@{voie7-5}"></span>
+                  </td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v8r5" value="1" />
+                    <span name="attr_voie8-5" class="sheet-boxability" title="@{voie8-5}"></span>
+                  </td>
+                  <td class="sheet-boxvoie sheet-boxtext">
+                    <input type="checkbox" name="attr_v9r5" value="1" />
+                    <span name="attr_voie9-5" class="sheet-boxability" title="@{voie9-5}"></span>
+                  </td>
+                </tr>
+              </table>
+            </div>
           </div>
         </div>
+        <div class="block-show">
+          <table>
+            <tr>
+              <td class="sheet-textfatleft" colspan="5">
+                CAPACITÉS DU PERSONNAGE
+                <input type="checkbox" class="sheet-setup-abilities" name="attr_setup_abilities"
+                  title="Editer les capacités" value="1" checked>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
+              <td class="sheet-boxtitresmall">Voie 1</td>
+              <td class="sheet-boxtitresmall">Voie 2</td>
+              <td class="sheet-boxtitresmall">Voie 3</td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">R</td>
+              <td class="sheet-boxinputleft">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie1nom"
+                  title="@{voie1nom}" placeholder="Nom de la Voie n°1" />
+              </td>
+              <td class="sheet-boxinput">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie2nom"
+                  title="@{voie2nom}" placeholder="Nom de la Voie n°2" />
+              </td>
+              <td class="sheet-boxinput">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie3nom"
+                  title="@{voie3nom}" placeholder="Nom de la Voie n°3" />
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">1</td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v1r1" value="1" />
+                <textarea name="attr_voie1-1" class="sheet-boxability" title="@{voie1-1}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v2r1" value="1" />
+                <textarea name="attr_voie2-1" class="sheet-boxability" title="@{voie2-1}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v3r1" value="1" />
+                <textarea name="attr_voie3-1" class="sheet-boxability" title="@{voie3-1}"></textarea>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">2</td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v1r2" value="1" />
+                <textarea name="attr_voie1-2" class="sheet-boxability" title="@{voie1-2}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v2r2" value="1" />
+                <textarea name="attr_voie2-2" class="sheet-boxability" title="@{voie2-2}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v3r2" value="1" />
+                <textarea name="attr_voie3-2" class="sheet-boxability" title="@{voie3-2}"></textarea>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">3</td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v1r3" value="1" />
+                <textarea name="attr_voie1-3" class="sheet-boxability" title="@{voie1-3}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v2r3" value="1" />
+                <textarea name="attr_voie2-3" class="sheet-boxability" title="@{voie2-3}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v3r3" value="1" />
+                <textarea name="attr_voie3-3" class="sheet-boxability" title="@{voie3-3}"></textarea>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">4</td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v1r4" value="1" />
+                <textarea name="attr_voie1-4" class="sheet-boxability" title="@{voie1-4}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v2r4" value="1" />
+                <textarea name="attr_voie2-4" class="sheet-boxability" title="@{voie2-4}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v3r4" value="1" />
+                <textarea name="attr_voie3-4" class="sheet-boxability" title="@{voie3-4}"></textarea>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">5</td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v1r5" value="1" />
+                <textarea name="attr_voie1-5" class="sheet-boxability" title="@{voie1-5}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v2r5" value="1" />
+                <textarea name="attr_voie2-5" class="sheet-boxability" title="@{voie2-5}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v3r5" value="1" />
+                <textarea name="attr_voie3-5" class="sheet-boxability" title="@{voie3-5}"></textarea>
+              </td>
+            </tr>
+          </table>
+          <table>
+            <tr>
+              <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
+              <td class="sheet-boxtitresmall">Voie 4</td>
+              <td class="sheet-boxtitresmall">Voie 5</td>
+              <td class="sheet-boxtitresmall">Voie 6</td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">R</td>
+              <td class="sheet-boxinputleft">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie4nom"
+                  title="@{voie4nom}" placeholder="Nom de la Voie n°4" />
+              </td>
+              <td class="sheet-boxinput">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie5nom"
+                  title="@{voie5nom}" placeholder="Nom de la Voie n°5" />
+              </td>
+              <td class="sheet-boxinput">
+                <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie6nom"
+                  title="@{voie6nom}" placeholder="Nom de la Voie n°6" />
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">1</td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v4r1" value="1" />
+                <textarea name="attr_voie4-1" class="sheet-boxability" title="@{voie4-1}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v5r1" value="1" />
+                <textarea name="attr_voie5-1" class="sheet-boxability" title="@{voie5-1}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v6r1" value="1" />
+                <textarea name="attr_voie6-1" class="sheet-boxability" title="@{voie6-1}"></textarea>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">2</td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v4r2" value="1" />
+                <textarea name="attr_voie4-2" class="sheet-boxability" title="@{voie4-2}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v5r2" value="1" />
+                <textarea name="attr_voie5-2" class="sheet-boxability" title="@{voie5-2}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v6r2" value="1" />
+                <textarea name="attr_voie6-2" class="sheet-boxability" title="@{voie6-2}"></textarea>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">3</td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v4r3" value="1" />
+                <textarea name="attr_voie4-3" class="sheet-boxability" title="@{voie4-3}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v5r3" value="1" />
+                <textarea name="attr_voie5-3" class="sheet-boxability" title="@{voie5-3}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v6r3" value="1" />
+                <textarea name="attr_voie6-3" class="sheet-boxability" title="@{voie6-3}"></textarea>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">4</td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v4r4" value="1" />
+                <textarea name="attr_voie4-4" class="sheet-boxability" title="@{voie4-4}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v5r4" value="1" />
+                <textarea name="attr_voie5-4" class="sheet-boxability" title="@{voie5-4}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v6r4" value="1" />
+                <textarea name="attr_voie6-4" class="sheet-boxability" title="@{voie6-4}"></textarea>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheet-boxtitresmall">5</td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v4r5" value="1" />
+                <textarea name="attr_voie4-5" class="sheet-boxability" title="@{voie4-5}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v5r5" value="1" />
+                <textarea name="attr_voie5-5" class="sheet-boxability" title="@{voie5-5}"></textarea>
+              </td>
+              <td class="sheet-boxvoie">
+                <input type="checkbox" name="attr_v6r5" value="1" />
+                <textarea name="attr_voie6-5" class="sheet-boxability" title="@{voie6-5}"></textarea>
+              </td>
+            </tr>
+          </table>
+          <div>
+            <input type="checkbox" class="sheet-block-switch" name="attr_voies789"><span>Plus de voies</span>
+            <div class="sheet-block-hidden"></div>
+            <div class="sheet-block-show">
+              <table>
+                <tr>
+                  <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
+                  <td class="sheet-boxtitresmall">Voie 7</td>
+                  <td class="sheet-boxtitresmall">Voie 8</td>
+                  <td class="sheet-boxtitresmall">Voie 9</td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">R</td>
+                  <td class="sheet-boxinputleft">
+                    <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie7nom"
+                      title="@{voie7nom}" placeholder="Nom de la Voie n°7" />
+                  </td>
+                  <td class="sheet-boxinput">
+                    <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie8nom"
+                      title="@{voie8nom}" placeholder="Nom de la Voie n°8" />
+                  </td>
+                  <td class="sheet-boxinput">
+                    <input type="text" style="font-weight: bold;text-align: center;" name="attr_voie9nom"
+                      title="@{voie9nom}" placeholder="Nom de la Voie n°9" />
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">1</td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v7r1" value="1" />
+                    <textarea name="attr_voie7-1" class="sheet-boxability" title="@{voie7-1}"></textarea>
+                  </td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v8r1" value="1" />
+                    <textarea name="attr_voie8-1" class="sheet-boxability" title="@{voie8-1"></textarea>
+                  </td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v9r1" value="1" />
+                    <textarea name="attr_voie9-1" class="sheet-boxability" title="@{voie9-1}"></textarea>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">2</td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v7r2" value="1" />
+                    <textarea name="attr_voie7-2" class="sheet-boxability" title="@{voie7-2}"></textarea>
+                  </td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v8r2" value="1" />
+                    <textarea name="attr_voie8-2" class="sheet-boxability" title="@{voie8-2}"></textarea>
+                  </td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v9r2" value="1" />
+                    <textarea name="attr_voie9-2" class="sheet-boxability" title="@{voie9-2}"></textarea>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">3</td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v7r3" value="1" />
+                    <textarea name="attr_voie7-3" class="sheet-boxability" title="@{voie7-3}"></textarea>
+                  </td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v8r3" value="1" />
+                    <textarea name="attr_voie8-3" class="sheet-boxability" title="@{voie8-3}"></textarea>
+                  </td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v9r3" value="1" />
+                    <textarea name="attr_voie9-3" class="sheet-boxability" title="@{voie9-3}"></textarea>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">4</td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v7r4" value="1" />
+                    <textarea name="attr_voie7-4" class="sheet-boxability" title="@{voie7-4}"></textarea>
+                  </td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v8r4" value="1" />
+                    <textarea name="attr_voie8-4" class="sheet-boxability" title="@{voie8-4}"></textarea>
+                  </td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v9r4" value="1" />
+                    <textarea name="attr_voie9-4" class="sheet-boxability" title="@{voie9-4}"></textarea>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheet-boxtitresmall">5</td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v7r5" value="1" />
+                    <textarea name="attr_voie7-5" class="sheet-boxability" title="@{voie7-5}"></textarea>
+                  </td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v8r5" value="1" />
+                    <textarea name="attr_voie8-5" class="sheet-boxability" title="@{voie8-5}"></textarea>
+                  </td>
+                  <td class="sheet-boxvoie">
+                    <input type="checkbox" name="attr_v9r5" value="1" />
+                    <textarea name="attr_voie9-5" class="sheet-boxability" title="@{voie9-5}"></textarea>
+                  </td>
+                </tr>
+              </table>
+            </div>
+          </div>
+        </div>
+        <!-- Voies -->
         <img class="sheet-imghr"
           src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
         <table class="sheet-tabsep" title="repeating_jetcapas">
@@ -1189,7 +1515,7 @@
               </td>
               <td class="sheet-boxinputleft" style="min-width:200px;">
                 <input type="text" name="attr_jetcapanom" title="@{jetcapanom}" style="font-weight: bold;"
-                  placeholder="Nom du jet de capacité" />
+                  placeholder="Nom du Jet de capacité" />
               </td>
               <td class="sheet-boxinputleft">
                 <input type="checkbox" name="attr_jetcapa_al" style="width: 12px;"
@@ -1197,27 +1523,27 @@
                 <input type="hidden" name="attr_jetcapalim" value="" />
                 <input type="number" style="width:32px;" name="attr_jetcapanbde" value="1"
                   title="@{jetcapanbde} Nombre de dés" />
-                <select class="sheet-carac" style="width:50px;" name="attr_jetcapade" size="1"
-                  title="@{jetcapade} Dé (d20 => d12 si Affaibli)">
+                <select class="sheet-carac" style="width:50px;" name="attr_jetcapade" size="1" title="@{jetcapade} Dé">
                   <option value="4">d4</option>
                   <option value="6">d6</option>
                   <option value="8">d8</option>
                   <option value="10">d10</option>
                   <option value="12">d12</option>
                   <option value="@{ETATDE}" selected>d20 (ou d12 si Affaibli)</option>
-                </select>
-                (<select class="sheet-carac" style="width:30px;" name="attr_jetcapatypjet" size="1"
+                </select>&nbsp;(
+                <select class="sheet-carac" style="width:30px;" name="attr_jetcapatypjet" size="1"
                   title="@{jetcapatypjet} Option du jet : normal, meilleur dé, moins bon dé, sans limite">
-                  <option value="">N - Normal</option>
+                  <option value="">N - Normal / additionner tous les dés</option>
                   <option value="kh1">S - Garder le meilleur dé</option>
                   <option value="kl1">I - Garder le moins bon dé</option>
                   <option value="!">E - Explosif (jet sans limite)</option>
-                </select>)
-                +<select class="sheet-carac" style="width:60px;" name="attr_jetcapacarac" size="1"
+                </select>)&nbsp;+
+                <select class="sheet-carac" style="width:60px;" name="attr_jetcapacarac" size="1"
                   title="@{jetcapacarac} Modificateur du jet">
-                  <option value="0">-</option>
-                  <optgroup label="Mod. de base">
-                    <option value="@{FOR}" selected>FOR</option>
+                  <option value="0" selected>-</option>
+                  <option value="@{NIVEAU}">NIV</option>
+                  <optgroup label="Mod. de Base">
+                    <option value="@{FOR}">FOR</option>
                     <option value="@{DEX}">DEX</option>
                     <option value="@{CON}">CON</option>
                     <option value="@{INT}">INT</option>
@@ -1225,7 +1551,7 @@
                     <option value="@{CHA}">CHA</option>
                     <option value="@{QRYMOD}">Choix</option>
                   </optgroup>
-                  <optgroup label="Mod. de test">
+                  <optgroup label="Mod. de Test">
                     <option value="@{FOR_TEST}">FOR</option>
                     <option value="@{DEX_TEST}">DEX</option>
                     <option value="@{CON_TEST}">CON</option>
@@ -1237,8 +1563,9 @@
                   <optgroup label="Attaques">
                     <option value="@{ATKCAC}">ATC</option>
                     <option value="@{ATKTIR}">ATD</option>
-                    <option value="@{ATKPSYINFLU}">Influ. Psy</option>
-                    <option value="@{ATKPSYINTUI}">Intui. Psy</option>
+                    <option value="@{ATKMEN}">MEN</option>
+                    <option value="@{ATKMAG}">MAG</option>
+                    <option value="@{ATKPIL}">PIL</option>
                   </optgroup>
                 </select>+&nbsp;(
                 <select class="sheet-carac" style="width:40px;" name="attr_jetcapacoeff" size="1"
@@ -1261,25 +1588,48 @@
                   <option value="@{RANG_VOIE9}">Voie 9</option>
                 </select>)&nbsp;+
                 <input type="hidden" name="attr_jetcapaskill" value="" />
-                <input type="number" style="width:32px;" name="attr_jetcapadiv" value="0" title="@{jetcapadiv} Bonus divers" />
+                <input type="number" style="width:32px;" name="attr_jetcapadiv" value="0"
+                  title="@{jetcapadiv} Bonus divers" />
               </td>
+              <td class="sheet-boxinputleft" style="width: 25%;">
+                &nbsp;Voie :&nbsp;
+                <select class="sheet-selectmin" name="attr_jetcapavoieno" title="@{jetcapavoieno}">
+                  <option value="">-</option>
+                  <option value="v1">1</option>
+                  <option value="v2">2</option>
+                  <option value="v3">3</option>
+                  <option value="v4">4</option>
+                  <option value="v5">5</option>
+                  <option value="v6">6</option>
+                  <option value="v7">7</option>
+                  <option value="v8">8</option>
+                  <option value="v9">9</option>
+                </select>
+                &nbsp;Rang :&nbsp;
+                <select class="sheet-selectmin" name="attr_jetcapavoierang" title="@{jetcapavoierang}">
+                  <option value="">-</option>
+                  <option value="r1">1</option>
+                  <option value="r2">2</option>
+                  <option value="r3">3</option>
+                  <option value="r4">4</option>
+                  <option value="r5">5</option>
+                </select>
+                <input type="hidden" name="attr_jetcapavr" value="" />
+              </td>
+            </tr>
+            <tr>
+              <td>&nbsp;</td>
               <td class="sheet-boxinputleft" style="width: 25%;">
                 <input type="text" name="attr_jetcapatitre" style="width:100%;" placeholder="Compétence (CARAC)"
                   title="@{jetcapatitre}" />
               </td>
-              </tr>
-              <tr>
-                <td>&nbsp;</td>
-                <td class="sheet-boxinputleft" style="width: 25%;">
-                  <input type="text" name="attr_jetcapavoie" style="width:100%;" placeholder="Voie, rang" title="@{jetcapavoie}" />
-                </td>
-                <td class="sheet-boxinputleft" colspan="3">
-                  <textarea name="attr_jetcapadesc" placeholder="Description" title="@{jetcapadesc}"></textarea>
-                </td>
-              </tr>
+              <td class="sheet-boxinputleft" colspan="3">
+                <textarea name="attr_jetcapadesc" placeholder="Description" title="@{jetcapadesc}"></textarea>
+              </td>
+            </tr>
           </table>
         </fieldset>
-      </div> <!-- FIN Voies -->
+      </div>
       <img class="sheet-imghr"
         src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
       <div>
@@ -1573,14 +1923,14 @@
                 <!-- Caracs -->
                 <tr>
                   <td class="sheet-textfat">CARAC.</td>
-                  <td></td>
                   <td class="sheet-textbase">Valeur</td>
                   <td class="sheet-textfat">Mod.</td>
+                  <td class="sheet-textbase">PE</td>
                   <td class="sheet-textbase">Bonus</td>
                   <td class="sheet-textfat">Test</td>
                 </tr>
                 <tr>
-                  <td class="sheet-boxtitre" colspan="2"><button class="sheet-boxtitre" type="roll" name="roll_jet_forv"
+                  <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="roll_jet_forv"
                       title="%{jet_forv} Jet de Puissance"
                       value="@(togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Test}} {{name=Salle des Machines (MOT)}} {{carac=[[1d20cs20cf1[Dé] +[[@{FOR_TEST}]][Puissance] +@{POSTE_MOT} ]] }} {{jet=Puissance}} {{desc=Mécano : @{POSTE_MOT_NOM}}}">
                       FOR</button></td>
@@ -1588,13 +1938,17 @@
                       min="0" /></td>
                   <td class="sheet-boxinputlight"><input type="number" name="attr_FOR" title="@{FOR}"
                       value="floor((@{FORCE}-10)/2)" disabled /></td>
+                  <td style="width: 20px;">
+                    <input type="checkbox" class="sheet-ship-epbox" name="attr_for_1pe" title="@{for_1pe}" value="1" />
+                    <input type="checkbox" class="sheet-ship-epbox" name="attr_for_2pe" title="@{for_2pe}" value="1" />
+                  </td>
                   <td class="sheet-boxinputlight"><input type="number" name="attr_FOR_BONUS"
                       title="@{FOR_BONUS} Bonus au Test" value="@{FOR_BUFF}" disabled /></td>
                   <td class="sheet-boxinputlight"><input type="number" name="attr_FOR_TEST" title="@{FOR_TEST}"
                       value="@{FOR}+@{FOR_BONUS}" disabled /></td>
                 </tr>
                 <tr>
-                  <td class="sheet-boxtitre" colspan="2"><button class="sheet-boxtitre" type="roll" name="roll_jet_dexv"
+                  <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="roll_jet_dexv"
                       title="%{jet_dexv} Jet de Manoeuvrabilit&eacute;"
                       value="@(togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Test}} {{name= Poste de Pilotage (PIL)}} {{carac=[[1d20cs20cf1[Dé] +[[@{DEX_TEST}]][Manoeuvrabilit&eacute;] +@{POSTE_PIL} ]] }} {{jet=Manoeuvrabilit&eacute;}} {{desc=Pilote : @{POSTE_PIL_NOM}}}">
                       DEX</button></td>
@@ -1602,13 +1956,17 @@
                       min="0" /></td>
                   <td class="sheet-boxinputlight"><input type="number" name="attr_DEX" title="@{DEX}"
                       value="floor((@{DEXTERITE}-10)/2)" disabled /></td>
+                  <td style="width: 20px;">
+                    <input type="checkbox" class="sheet-ship-epbox" name="attr_dex_1pe" title="@{dex_1pe}" value="1" />
+                    <input type="checkbox" class="sheet-ship-epbox" name="attr_dex_2pe" title="@{dex_2pe}" value="1" />
+                  </td>
                   <td class="sheet-boxinputlight"><input type="number" name="attr_DEX_BONUS"
                       title="@{DEX_BONUS} Bonus au Test" value="@{DEX_BUFF}" disabled /></td>
                   <td class="sheet-boxinputlight"><input type="number" name="attr_DEX_TEST" title="@{DEX_TEST}"
                       value="@{DEX}+@{DEX_BONUS}" disabled /></td>
                 </tr>
                 <tr>
-                  <td class="sheet-boxtitre" colspan="2"><button class="sheet-boxtitre" type="roll" name="roll_jet_conv"
+                  <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="roll_jet_conv"
                       title="%{jet_conv} Jet de Coque"
                       value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Test}} {{name=Coque}} {{carac=[[1d20cs20cf1[Dé] + [[@{CON_TEST}]][Bonus] ]] }}">
                       CON</button></td>
@@ -1616,13 +1974,14 @@
                       value="10" min="0" /></td>
                   <td class="sheet-boxinputlight"><input type="number" name="attr_CON" title="@{CON}"
                       value="floor((@{CONSTITUTION}-10)/2)" disabled /></td>
+                  <td>&nbsp;</td>
                   <td class="sheet-boxinputlight"><input type="number" name="attr_CON_BONUS"
                       title="@{CON_BONS} Bonus au Test" value="@{CON_BUFF}" disabled /></td>
                   <td class="sheet-boxinputlight"><input type="number" name="attr_CON_TEST" title="@{CON_TEST}"
                       value="@{CON}+@{CON_BONUS}" disabled /></td>
                 </tr>
                 <tr>
-                  <td class="sheet-boxtitre" colspan="2"><button class="sheet-boxtitre" type="roll" name="roll_jet_intv"
+                  <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="roll_jet_intv"
                       title="%{jet_intv} Jet d'Ordinateurs de Vis&eacute;e"
                       value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Test}} {{name=Ordinateur de Visée}} {{carac=[[1d20cs20cf1[Dé] +[[@{INT_TEST}]][Bonus] ]] }}">
                       INT</button></td>
@@ -1630,13 +1989,17 @@
                       value="10" min="0" /></td>
                   <td class="sheet-boxinputlight"><input type="number" name="attr_INT" title="@{INT}"
                       value="floor((@{INTELLIGENCE}-10)/2)" disabled /></td>
+                  <td style="width: 20px;">
+                    <input type="checkbox" class="sheet-ship-epbox" name="attr_int_1pe" title="@{int_1pe}" value="1" />
+                    <input type="checkbox" class="sheet-ship-epbox" name="attr_int_2pe" title="@{int_2pe}" value="1" />
+                  </td>
                   <td class="sheet-boxinputlight"><input type="number" name="attr_INT_BONUS"
                       title="@{INT_BONUS} Bonus au Test" value="@{INT_BUFF}" disabled /></td>
                   <td class="sheet-boxinputlight"><input type="number" name="attr_INT_TEST" title="@{INT_TEST}"
                       value="@{INT}+@{INT_BONUS}" disabled /></td>
                 </tr>
                 <tr>
-                  <td class="sheet-boxtitre" colspan="2"><button class="sheet-boxtitre" type="roll" name="roll_jet_perv"
+                  <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="roll_jet_perv"
                       title="%{jet_perv} Jet de Senseurs"
                       value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Test}} {{name=Senseurs (SEN)}} {{carac=[[1d20cs20cf1[Dé] +[[@{PER_TEST}]][Senseurs] +@{POSTE_SEN} ]] }} {{jet=Détection}} {{desc=Opérateur : @{POSTE_SEN_NOM}}}">
                       PER</button></td>
@@ -1644,13 +2007,17 @@
                       value="10" min="0" /></td>
                   <td class="sheet-boxinputlight"><input type="number" name="attr_PER" title="@{PER}"
                       value="floor((@{PERCEPTION}-10)/2)" disabled /></td>
+                  <td style="width: 20px;">
+                    <input type="checkbox" class="sheet-ship-epbox" name="attr_per_1pe" title="@{per_1pe}" value="1" />
+                    <input type="checkbox" class="sheet-ship-epbox" name="attr_per_2pe" title="@{per_2pe}" value="1" />
+                  </td>                      
                   <td class="sheet-boxinputlight"><input type="number" name="attr_PER_BONUS"
                       title="@{PER_BONUS} Bonus au Test" value="@{PER_BUFF}" disabled /></td>
                   <td class="sheet-boxinputlight"><input type="number" name="attr_PER_TEST" title="@{PER_TEST}"
                       value="@{PER}+@{PER_BONUS}" disabled /></td>
                 </tr>
                 <tr>
-                  <td class="sheet-boxtitre" colspan="2"><button class="sheet-boxtitre" type="roll" name="roll_jet_chav"
+                  <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="roll_jet_chav"
                       title="%{jet_chav} Jet de Communications"
                       value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Test}} {{name=Communications (CHA)}} {{carac=[[1d20cs20cf1[Dé] + [[@{CHA_TEST}]][Comm.Systèmes] +@{POSTE_ORD} ]] }} {{jet=Ordinateur}} {{desc=Opérateur : @{POSTE_ORD_NOM}}}">
                       CHA</button></td>
@@ -1658,6 +2025,10 @@
                       min="0" /></td>
                   <td class="sheet-boxinputlight"><input type="number" name="attr_CHA" title="@{CHA}"
                       value="floor((@{CHARISME}-10)/2)" disabled /></td>
+                  <td style="width: 20px;">
+                    <input type="checkbox" class="sheet-ship-epbox" name="attr_cha_1pe" title="@{cha_1pe}" value="1" />
+                    <input type="checkbox" class="sheet-ship-epbox" name="attr_cha_2pe" title="@{cha_2pe}" value="1" />
+                  </td>                      
                   <td class="sheet-boxinputlight"><input type="number" name="attr_CHA_BONUS"
                       title="@{CHA_BONUS} Bonus au Test" value="@{CHA_BUFF}" disabled /></td>
                   <td class="sheet-boxinputlight"><input type="number" name="attr_CHA_TEST" title="@{CHA_TEST}"
@@ -1667,21 +2038,28 @@
               <table class="sheet-tabsep" style="margin-top: 20px;">
                 <!-- Energie -->
                 <tr>
-                  <td class="sheet-boxtitre" title="Points d'énergie">PE</td>
-                  <td class="sheet-boxinput"><input type="number" name="attr_PEV" value="0"
+                  <td class="sheet-boxtitre" title="Points d'énergie">
+                    <button class="sheet-boxtitre" type="roll" name="roll_jet_pe"
+                      title="%{jet_pe} Jet de Répartition d'Energie"
+                      value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Test}} {{name=Répartition d'Energie}} {{carac=[[1d20cs20cf1[Dé] + [[@{CHA_TEST}]][Comm.Systèmes] +@{POSTE_ORD} ]] vs [[10+@{PEV}]] | [[15+@{PEV}]] }} {{jet=Répartition}} {{desc=Opérateur : @{POSTE_ORD_NOM}}}">
+                      PE</button>
+                  </td>
+                  <td class="sheet-boxinput"><input type="number" style="width: 35px;" name="attr_PEV" value="0"
                       title="@{PEV} Points d'énergie utilisés ou courants" /></td>
                   <td>/</td>
-                  <td class="sheet-boxinputlight"><input type="number" name="attr_PEVBASE"
+                  <td class="sheet-boxinputlight" style="min-width: 35px;">
+                    <input type="hidden" name="attr_PEV_max" value="0">
+                    <span name="attr_PEV_max" title="@{PEV_max} Points d'énergie maximums"></span>
+                  </td>
+                  <td>=</td>
+                  <td class="sheet-boxinputlight"><input type="number" style="width: 30px;" name="attr_PEVBASE"
                       title="@{PEVBASE} Points d'énergie de base" value="@{NIVEAU}" disabled /></td>
                   <td>+</td>
-                  <td class="sheet-boxinputlight"><input type="number" name="attr_PEVDIV"
+                  <td class="sheet-boxinputlight"><input type="number" style="width: 30px;" name="attr_PEVDIV"
                       title="@{PEVDIV} Points d'énergie additionnels" value="@{PEV_BUFF}" disabled /></td>
                   <td>+</td>
-                  <td class="sheet-boxinputlight"><input type="number" name="attr_PEVCAR" value="@{FOR}"
+                  <td class="sheet-boxinputlight"><input type="number" style="width: 30px;" name="attr_PEVCAR" value="@{FOR}"
                       title="@{PEVCAR} Mod. de puissance (FOR)" disabled /></td>
-                  <td>=</td>
-                  <td class="sheet-boxinputlight"><input type="number" name="attr_PEV_max"
-                      value="@{PEVBASE}+@{PEVDIV}+@{PEVCAR}" title="Points d'énergie maximums" disabled /></td>
                 </tr>
               </table> <!-- FIN Energie -->
             </td> <!-- FIN Caracs + Chance -->
@@ -1717,7 +2095,9 @@
                             value="@{ATKTIRV_BASE}+@{ATKTIRV_CARAC}+@{ATKTIRV_DIV}" disabled /></td>
                       </tr>
                       <tr>
-                        <td class="sheet-boxtitre" title="Poste de pilotage (PIL)">Pilotage</td>
+                        <td class="sheet-boxtitre" title="Poste de pilotage (PIL)">Pilotage
+                          <input type="checkbox" style="float: right;" name="attr_POSTE_PIL_OQP" title="@{POSTE_PIL_OQP} Poste PIL occupé" value="1">
+                        </td>
                         <td class="sheet-boxinput" colspan="4">
                           <input type="text" style="width: 220px;" name="attr_POSTE_PIL_NOM" title="@{POSTE_PIL_NOM}"
                             placeholder="Nom du pilote" />
@@ -1726,7 +2106,9 @@
                         </td>
                       </tr>
                       <tr>
-                        <td class="sheet-boxtitre" title="Salle des machines (MOT)">Machines</td>
+                        <td class="sheet-boxtitre" title="Salle des machines (MOT)">Machines&nbsp;
+                          <input type="checkbox" style="float: right;" name="attr_POSTE_MOT_OQP" title="@{POSTE_MOT_OQP} Salle MOT occupée" value="1">
+                        </td>
                         <td class="sheet-boxinput" colspan="4">
                           <input type="text" style="width: 220px;" name="attr_POSTE_MOT_NOM" title="@{POSTE_MOT_NOM}"
                             placeholder="Nom du mécanicien" />
@@ -1735,7 +2117,9 @@
                         </td>
                       </tr>
                       <tr>
-                        <td class="sheet-boxtitre" title="Console des senseurs (SEN)">Senseurs</td>
+                        <td class="sheet-boxtitre" title="Console des senseurs (SEN)">Senseurs&nbsp;
+                          <input type="checkbox" style="float: right;" name="attr_POSTE_SEN_OQP" title="@{POSTE_SEN_OQP} Poste SEN occupé" value="1">
+                        </td>
                         <td class="sheet-boxinput" colspan="4">
                           <input type="text" style="width: 220px;" name="attr_POSTE_SEN_NOM" title="@{POSTE_SEN_NOM}"
                             placeholder="Nom du scantech" />
@@ -1744,7 +2128,9 @@
                         </td>
                       </tr>
                       <tr>
-                        <td class="sheet-boxtitre" title="Console du système (ORD)">Ordinateurs</td>
+                        <td class="sheet-boxtitre" title="Console du système (ORD)">Ordinateurs&nbsp;
+                          <input type="checkbox" style="float: right;" name="attr_POSTE_ORD_OQP" title="@{POSTE_ORD_OQP} Poste ORD occupé" value="1">
+                        </td>
                         <td class="sheet-boxinput" colspan="4">
                           <input type="text" style="width: 220px;" name="attr_POSTE_ORD_NOM" title="@{POSTE_ORD_NOM}"
                             placeholder="Nom de l'infotech" />
@@ -1755,7 +2141,7 @@
                       <tr>
                         <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="roll_jet_initv"
                             title="%{jet_initv} Initiative"
-                            value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Initiative}} {{subtags=Combat}} {{carac=[[@{INITV} + @{INIT_VAR}[Dé(s)] &{tracker}]]}}">
+                            value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Initiative}} {{subtags=Combat}} {{carac=[[@{POSTE_PIL_OQP}[Pilote]*(@{INITV} + @{INIT_VAR})[Dé(s)] &{tracker}]]}}">
                             INITIATIVE</button></td>
                         <td>&nbsp;</td>
                         <td class="sheet-boxinputlight"><input type="number" name="attr_INITV_CARAC"
@@ -1805,8 +2191,13 @@
                       </tr>
                       <tr>
                         <td class="sheet-boxtitre" title="Boucliers (réduction des dommages)">RD</td>
-                        <td class="sheet-boxinput"><input type="number" name="attr_RD"
-                            title="@{RD} Réduction des dommages" value="0" /></td>
+                        <td class="sheet-boxinput">
+                          <input type="hidden" name="attr_RDE" value="0" />
+                          (<span name="attr_RDE" title="@{RDE} Réduction des DM effective"></span>)
+                          <input type="checkbox" name="attr_rd_1pe" title="@{rd_1pe} Ecrans chargés" value="1" />
+                          <input type="number" name="attr_RD" style="width: 30px;"
+                            title="@{RD} Ecrans déflecteurs" value="0" />
+                          </td>
                       </tr>
                       <tr>
                         <td>&nbsp;</td>
@@ -1839,7 +2230,7 @@
                         <td class="sheet-boxinputlight"><input type="number" name="attr_DEFVSEN" value="@{DEFVSEN_BUFF}"
                             title="@{DEFVSEN} Bonus du Scantech" disabled /></td>
                         <td class="sheet-boxinputlight"><input type="number" name="attr_DEFRAP"
-                            value="10+@{DEFVDEX}+@{DEFVPIL}+@{DEFVPER}+@{DEFVSEN}"
+                            value="(10+@{DEFVDEX}+@{DEFVPIL}+@{DEFVPER}+@{DEFVSEN})*@{POSTE_PIL_OQP}"
                             title="@{DEFRAP} D&eacute;fense (rapidit&eacute;)" disabled /></td>
                       </tr>
                       <tr>
@@ -1962,6 +2353,7 @@
                       title="@{armeinct} Seuil d'incident de tir (par défaut 1)" />
                   </td>
                   <td class="sheet-boxinputleft" style="width: 250px;">
+                    <input type="checkbox" name="attr_armecan_oqp" title="@{armecan_oqp} Poste CAN occupé" value="1" />
                     <input type="text" style="width: 220px;" name="attr_armecan_nom"
                       title="@{armecan_nom} Nom du canonnier (CAN)" />
                     <input type="number" style="width: 32px;" name="attr_armecan_bonus"
@@ -1974,6 +2366,34 @@
           </div>
         </fieldset>
       </div>
+      <img class="sheet-imghr"
+        src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
+      <div class="sheet-2colrow">
+          <div class="sheet-col">
+            <table>
+              <tr>
+                <td class="sheet-boxtitre">Equipage</td>
+              </tr>
+              <tr>
+                <td class="sheet-boxinputleft"><textarea name="attr_equipage" style="height:10em;"
+                    title="@{equipage}"></textarea></td>
+              </tr>
+            </table>
+          </div>
+          <div class="sheet-col">
+            <table>
+              <tr>
+                <td class="sheet-boxtitre">Cargo
+                  <input style="float: right;" type="number" name="attr_cargo" value="0" />
+                </td>
+              </tr>
+              <tr>
+                <td class="sheet-boxinputleft"><textarea name="attr_cargo_notes" style="height:10em;"
+                    title="@{cargo_notes}"></textarea></td>
+              </tr>
+            </table>
+          </div>
+        </div>
       <img class="sheet-imghr"
         src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
     </div>
@@ -2937,7 +3357,7 @@ function processBaseAttributes(universe, pnjObj) {
   var jnor = '1d20';
   var jsup = '2d20kh1';
   var pnjAttrs = {};
-  if (pnjObj.character_name !== '') {
+  if (pnjObj.character_name != '') {
     pnjAttrs['character_name'] = pnjObj.character_name;
   }
   delete pnjObj['character_name'];
@@ -3448,12 +3868,12 @@ function migrateSheet(verfdp) {
         let attr = Object.keys(values)[0];
         let buffList = [];
         for (let b = 1; b < 6; b++) {
-          let desc = values[`${attr}_BUFF${b}_DESC`] || "";
+          let desc = values[`${attr}_BUFF${b}_DESC`] || '';
           let buff = values[`${attr}_BUFF${b}`] || 0;
-          if (desc !== "") buffList.push(`${desc} : ${buff}`);
+          if (desc !== '') buffList.push(`${desc} : ${buff}`);
         }
         let buffAttr = {};
-        buffAttr[`${attr}_BUFF_LIST`] = buffList.join(";");
+        buffAttr[`${attr}_BUFF_LIST`] = buffList.join(';');
         setAttrs(buffAttr);
       });
     }
@@ -3569,10 +3989,19 @@ function migrateSheet(verfdp) {
         if (values[name] !== '') {
           vrFlags[flag] = '1';
         } else {
-          vrFlags[flag] = "0";
+          vrFlags[flag] = '0';
         }
       });
       setAttrs(vrFlags);
+    });
+  }
+  if (verfdp.major == 3 && verfdp.minor < 110) {
+    getAttrs(['type_personnage'], function (value) {
+      const physical = value.type_personnage === 'vaisseau' ? '0' : '1';
+      attrs = { physical: physical };
+      if (value.type_personnage === 'vaisseau') attrs.lib_profil = 'Classe';
+      if (value.type_personnage === 'vaisseau') attrs.lib_famille = 'Taille';
+      setAttrs(attrs);
     });
   }
 }
@@ -3636,19 +4065,20 @@ on('sheet:opened', function () {
     function (values) {
       if (values.UNIVERS == 'CG') {
         if (values.type_personnage == 'vaisseau' && values.PE_ONCE !== '') {
-          var for_buff_desc = values.FOR_BUFF1_DESC || values.PE_ONCE;
-          var dex_buff_desc = values.DEX_BUFF1_DESC || values.PE_ONCE;
-          var int_buff_desc = values.INT_BUFF1_DESC || values.PE_ONCE;
-          var per_buff_desc = values.PER_BUFF1_DESC || values.PE_ONCE;
-          var cha_buff_desc = values.CHA_BUFF1_DESC || values.PE_ONCE;
-          var atktirv_buff_desc = values.ATKTIRV_BUFF1_DESC || values.PE_ONCE;
-          var init_buff_desc = values.INIT_BUFF1_DESC || 'Valeur DEX pilote';
-          var defvpil_buff1_desc =
+          const for_buff_desc = values.FOR_BUFF1_DESC || values.PE_ONCE;
+          const dex_buff_desc = values.DEX_BUFF1_DESC || values.PE_ONCE;
+          const int_buff_desc = values.INT_BUFF1_DESC || values.PE_ONCE;
+          const per_buff_desc = values.PER_BUFF1_DESC || values.PE_ONCE;
+          const cha_buff_desc = values.CHA_BUFF1_DESC || values.PE_ONCE;
+          const atktirv_buff_desc = values.ATKTIRV_BUFF1_DESC || values.PE_ONCE;
+          const init_buff_desc = values.INIT_BUFF1_DESC || 'Valeur DEX pilote';
+          const defvpil_buff1_desc =
             values.DEFVPIL_BUFF1_DESC || 'Mod. DEX Pilote';
-          var defvpil_buff2_desc = values.DEFVPIL_BUFF2_DESC || 'Rang Pilotage';
-          var defvsen_buff1_desc =
+          const defvpil_buff2_desc =
+            values.DEFVPIL_BUFF2_DESC || 'Rang Pilotage';
+          const defvsen_buff1_desc =
             values.DEFVSEN_BUFF1_DESC || 'Mod. INT Scantech';
-          var defvsen_buff2_desc =
+          const defvsen_buff2_desc =
             values.DEFVSEN_BUFF2_DESC || 'Rang Electronique';
           setAttrs({
             FOR_BUFF1_DESC: for_buff_desc,
@@ -3703,6 +4133,8 @@ on('sheet:opened', function () {
   updateINIT();
   // update DEF
   updateDEF();
+  // update ship EP
+  updateShipEP();
 });
 
 /**
@@ -4212,6 +4644,21 @@ on(
 
 on(
   [
+    'change:init_buff1',
+    'change:init_buff2',
+    'change:init_buff3',
+    'change:init_buff4',
+    'change:init_buff5',
+  ].join(' '),
+  function () {
+    getAttrs(attrBuff('INIT'), function (values) {
+      setBuff(values, 'INIT');
+    });
+  }
+);
+
+on(
+  [
     'change:defvpil_buff1',
     'change:defvpil_buff2',
     'change:defvpil_buff3',
@@ -4297,22 +4744,23 @@ on('change:poisse', function () {
  * - Set the 'BLESSURE' attribute
  */
 on('change:pv', function () {
-  getAttrs(['PV', 'PV_max', 'LAST_PV', 'SEUILBG', 'BLESSURE'], function (
-    values
-  ) {
-    var seuilbg = parseInt(values.SEUILBG) || 0;
-    var max_pv = parseInt(values.PV_max) || 0;
-    var last_pv = parseInt(values.LAST_PV) || max_pv;
-    var curr_pv = parseInt(values.PV) || 0;
-    var blessure = values.BLESSURE;
-    if (seuilbg > 0) {
-      if (last_pv - curr_pv >= seuilbg || curr_pv === 0) blessure = '1';
+  getAttrs(
+    ['PV', 'PV_max', 'LAST_PV', 'SEUILBG', 'BLESSURE'],
+    function (values) {
+      var seuilbg = parseInt(values.SEUILBG) || 0;
+      var max_pv = parseInt(values.PV_max) || 0;
+      var last_pv = parseInt(values.LAST_PV) || max_pv;
+      var curr_pv = parseInt(values.PV) || 0;
+      var blessure = values.BLESSURE;
+      if (seuilbg > 0) {
+        if (last_pv - curr_pv >= seuilbg || curr_pv === 0) blessure = '1';
+      }
+      setAttrs({
+        LAST_PV: values.PV,
+        BLESSURE: blessure,
+      });
     }
-    setAttrs({
-      LAST_PV: values.PV,
-      BLESSURE: blessure,
-    });
-  });
+  );
 });
 
 /**
@@ -4537,20 +4985,25 @@ on('change:type_personnage', function (eventInfo) {
     convertToPC();
   // if (eventInfo.previousValue === 'pj' && eventInfo.newValue === 'pnj') convertToNPC();
   getAttrs(['type_personnage'], function (value) {
-    let attrs = {};
-    attrs['type_fiche'] = value.type_personnage;
-    if (value.type_personnage === 'pnj') attrs['pnj_togm'] = '/w gm ';
+    let attrs = { physical: '1' };
+    attrs.type_fiche = value.type_personnage;
+    if (value.type_personnage === 'pnj') attrs.pnj_togm = '/w gm ';
+    if (value.type_personnage === 'vaisseau') {
+      attrs.physical = '0';
+      attrs.lib_profil = 'Classe';
+      attrs.lib_famille = 'Taille';
+    }
     setAttrs(attrs);
     consoleLog(attrs);
   });
 });
 
 /**
- * Return attributes array for a starsgip station
+ * Return attributes array for a starship station
  * @param {string} attr Spaceship station shortname
  */
 function attrStation(attr) {
-  return [`POSTE_${attr}_NOM`, `POSTE_${attr}_BONUS`];
+  return [`POSTE_${attr}_OQP`, `POSTE_${attr}_NOM`, `POSTE_${attr}_BONUS`];
 }
 
 /**
@@ -4560,15 +5013,19 @@ function attrStation(attr) {
  * @param {array} fill Fillers for attribute formulas
  */
 function setStation(v, attr, fill) {
+  let attrx = '';
   let attrn = '';
   let attrb = '';
   if (attr === 'CAN') {
+    attrx = 'repeating_armesv_armecan_oqp';
     attrn = 'repeating_armesv_armecan_nom';
     attrb = 'repeating_armesv_armecan_bonus';
   } else {
+    attrx = `POSTE_${attr}_OQP`;
     attrn = `POSTE_${attr}_NOM`;
     attrb = `POSTE_${attr}_BONUS`;
   }
+  let station_held = parseInt(v[attrx]) || 0;
   let station_name = v[attrn] || '';
   station_name = station_name != '' ? `@{${station_name}|${fill[0]}}` : '0';
   let station_bonus = parseInt(v[attrb]) || 0;
@@ -4581,7 +5038,7 @@ function setStation(v, attr, fill) {
   }
   station[
     station_attr
-  ] = `[[${station_name}]][${fill[1]}] + ${station_bonus}[${fill[2]}]`;
+  ] = `[[${station_name}*${station_held}]][${fill[1]}] + [[${station_bonus}*${station_held}]][${fill[2]}]`;
   setAttrs(station);
 }
 
@@ -4589,44 +5046,155 @@ function setStation(v, attr, fill) {
  * On change of spaceship stations character names of bonus
  * - Rebuild hidden macro formulas
  */
-on(['change:poste_pil_nom', 'change:poste_pil_bonus'].join(' '), function () {
-  getAttrs(attrStation('PIL'), function (values) {
-    setStation(values, 'PIL', ['DEX', 'DEX pilote', 'Pilotage']);
-  });
-});
-
-on(['change:poste_mot_nom', 'change:poste_mot_bonus'].join(' '), function () {
-  getAttrs(attrStation('MOT'), function (values) {
-    setStation(values, 'MOT', ['INT', 'INT mécano', 'Moteurs']);
-  });
-});
-
-on(['change:poste_sen_nom', 'change:poste_sen_bonus'].join(' '), function () {
-  getAttrs(attrStation('SEN'), function (values) {
-    setStation(values, 'SEN', [
-      'INT',
-      'INT scan',
-      'Electronique/Investigation',
-    ]);
-  });
-});
-
-on(['change:poste_ord_nom', 'change:poste_ord_bonus'].join(' '), function () {
-  getAttrs(attrStation('ORD'), function (values) {
-    setStation(values, 'ORD', ['INT', 'INT info', 'Electronique']);
-  });
-});
+on(
+  [
+    'change:poste_pil_oqp',
+    'change:poste_pil_nom',
+    'change:poste_pil_bonus',
+  ].join(' '),
+  function () {
+    getAttrs(attrStation('PIL'), function (values) {
+      setStation(values, 'PIL', ['DEX', 'DEX pilote', 'Pilotage']);
+    });
+  }
+);
 
 on(
   [
+    'change:poste_mot_oqp',
+    'change:poste_mot_nom',
+    'change:poste_mot_bonus',
+  ].join(' '),
+  function () {
+    getAttrs(attrStation('MOT'), function (values) {
+      setStation(values, 'MOT', ['INT', 'INT mécano', 'Moteurs']);
+    });
+  }
+);
+
+on(
+  [
+    'change:poste_sen_oqp',
+    'change:poste_sen_nom',
+    'change:poste_sen_bonus',
+  ].join(' '),
+  function () {
+    getAttrs(attrStation('SEN'), function (values) {
+      setStation(values, 'SEN', [
+        'INT',
+        'INT scan',
+        'Electronique/Investigation',
+      ]);
+    });
+  }
+);
+
+on(
+  [
+    'change:poste_ord_oqp',
+    'change:poste_ord_nom',
+    'change:poste_ord_bonus',
+  ].join(' '),
+  function () {
+    getAttrs(attrStation('ORD'), function (values) {
+      setStation(values, 'ORD', ['INT', 'INT info', 'Electronique']);
+    });
+  }
+);
+
+on(
+  [
+    'change:repeating_armesv:armecan_oqp',
     'change:repeating_armesv:armecan_nom',
     'change:repeating_armesv:armecan_bonus',
   ].join(' '),
   function () {
     getAttrs(
-      ['repeating_armesv_armecan_nom', 'repeating_armesv_armecan_bonus'],
+      [
+        'repeating_armesv_armecan_oqp',
+        'repeating_armesv_armecan_nom',
+        'repeating_armesv_armecan_bonus',
+      ],
       function (values) {
         setStation(values, 'CAN', ['DEX', 'DEX canonnier', 'Armes lourdes']);
+      }
+    );
+  }
+);
+
+function updateShipEP() {
+  getAttrs(['type_fiche', 'NIVEAU', 'PEV_BUFF', 'FOR'], function (values) {
+    if (values.type_fiche !== 'vaisseau') return;
+    let pev_max = 0;
+    pev_max += parseInt(values.NIVEAU) || 0;
+    pev_max += parseInt(values.PEV_BUFF) || 0;
+    pev_max += parseInt(values.FOR) || 0;
+    setAttrs({ PEV_max: pev_max });
+  });
+}
+
+on('change:niveau change:pev_buff change:for', function () {
+  updateShipEP();
+});
+
+on(
+  [
+    'change:for_1pe',
+    'change:for_2pe',
+    'change:dex_1pe',
+    'change:dex_2pe',
+    'change:int_1pe',
+    'change:int_2pe',
+    'change:per_1pe',
+    'change:per_2pe',
+    'change:cha_1pe',
+    'change:cha_2pe',
+    'change:rd_1pe',
+  ].join(' '),
+  function (eventInfo) {
+    getAttrs(
+      [
+        'RD',
+        'PEV_max',
+        'for_1pe',
+        'for_2pe',
+        'dex_1pe',
+        'dex_2pe',
+        'int_1pe',
+        'int_2pe',
+        'per_1pe',
+        'per_2pe',
+        'cha_1pe',
+        'cha_2pe',
+        'rd_1pe',
+      ],
+      function (values) {
+        const pev_max = parseInt(values.PEV_max) || 0;
+        if (pev_max == 0) return;
+        delete values.PEV_max;
+        const base_rd = parseInt(values.RD) || 0;
+        delete values.RD;
+        let epts = { FOR: 0, DEX: 0, INT: 0, PER: 0, CHA: 0, RD: 0 };
+        let ep_total = 0;
+        for (const attr in values) {
+          const ep = parseInt(values[attr]) || 0;
+          ep_total += ep;
+          epts[attr.split('_')[0].toUpperCase()] += ep;
+        }
+        let attrs = {};
+        if (ep_total <= pev_max) {
+          attrs.PEV = ep_total;
+        } else {
+          const attr = eventInfo.sourceAttribute;
+          attrs[attr] = '0';
+          epts[attr.split('_')[0].toUpperCase()]--;
+        }
+        for (const attr in epts) {
+          attrs[`${attr}_BUFF1`] = epts[attr];
+        }
+        attrs.RDE = base_rd * epts.RD;
+        attrs.ATKTIRV_BUFF1 = attrs.INT_BUFF1;
+        setAttrs(attrs);
       }
     );
   }
@@ -4860,11 +5428,12 @@ function setArmorMalus() {
  * On changing the armor attributes
  * - Re-compute the armor malus
  */
-on(['change:defarmureon', 'change:defarmuremalus'].join(' '), function (
-  eventInfo
-) {
-  setArmorMalus();
-});
+on(
+  ['change:defarmureon', 'change:defarmuremalus'].join(' '),
+  function (eventInfo) {
+    setArmorMalus();
+  }
+);
 
 /**
  * On changing the 2nd damage info
@@ -4990,6 +5559,40 @@ on(
         }
         setAttrs({
           repeating_jetcapas_jetcapaskill: skill,
+        });
+      }
+    );
+  }
+);
+
+/**
+ * On changing path & rank number attributes
+ * - Set the path & rank identifier (v?r?)
+ */
+on(
+  [
+    'change:repeating_jetcapas:jetcapavoieno',
+    'change:repeating_jetcapas:jetcapavoierang',
+  ].join(' '),
+  function () {
+    getAttrs(
+      [
+        'repeating_jetcapas_jetcapavoieno',
+        'repeating_jetcapas_jetcapavoierang',
+      ],
+      function (values) {
+        const vr = `${values.repeating_jetcapas_jetcapavoieno}${values.repeating_jetcapas_jetcapavoierang}`;
+        if (vr.length !== 4) return;
+        getAttrs([vr.replace('v', 'voie').replace('r', '-')], function (value) {
+          const rankData = value[Object.keys(value)[0]].split('\n');
+          const rankName = rankData.shift();
+          const rankDesc = rankData.length > 0 ? rankData.join('\n') : '';
+          const updated = {
+            repeating_jetcapas_jetcapanom: rankName,
+            repeating_jetcapas_jetcapadesc: rankDesc,
+            repeating_jetcapas_jetcapavr: vr,
+          };
+          setAttrs(updated);
         });
       }
     );
@@ -5505,7 +6108,15 @@ on(
  */
 function hitPoints(attr) {
   getAttrs(
-    ['NIVEAU', 'DV', 'CONSTITUTION', 'PV_NIVEAU', 'PV_BUFF', 'prog_pv'],
+    [
+      'type_fiche',
+      'NIVEAU',
+      'DV',
+      'CONSTITUTION',
+      'PV_NIVEAU',
+      'PV_BUFF',
+      'prog_pv',
+    ],
     function (values) {
       let niveau = parseInt(values.NIVEAU) || 0;
       if (niveau === 0) return;
@@ -5522,41 +6133,45 @@ function hitPoints(attr) {
       let average = parseInt(values.prog_pv) || 0 === 1 ? 1 + dv / 2 : 0;
       let pv_buff = parseInt(values.PV_BUFF) || 0;
       let pv_max = 0;
-      for (let n = 1; n <= niveau; n++) {
-        let pvie = 0;
-        if (n === 1) {
-          pvie = dv + modcon; // niveau 1 : Max. DV + Mod. CON
-        } else {
-          if (n > 10) {
-            // niveaux > 10 : 1 ou 2 PV selon DV
-            if (dv >= 10) pvie = 2;
-            else pvie = 1;
+      if (values.type_fiche == 'vaisseau') {
+        pv_max = (dv + modcon) * niveau;
+      } else {
+        for (let n = 1; n <= niveau; n++) {
+          let pvie = 0;
+          if (n === 1) {
+            pvie = dv + modcon; // niveau 1 : Max. DV + Mod. CON
           } else {
-            // niveaux <= 10
-            if (n % 2 === 0) {
-              // niveau pair
-              if (n > pv.length) {
-                // nouveau niveau
-                if (average !== 0) {
-                  pvie = average; // ... soit moyenne du DV + 1
-                } else {
-                  pvie = getRandom(dv); // ... soit tirage de DV
-                }
-                if (modcon < 0) pvie += modcon; // ... + Mod. CON si négative
-                if (pvie < 0) pvie = 0; // ... mais on ne perd pas de PV
-              } else {
-                // niveau existant
-                pvie = pv[n - 1];
-              }
+            if (n > 10) {
+              // niveaux > 10 : 1 ou 2 PV selon DV
+              if (dv >= 10) pvie = 2;
+              else pvie = 1;
             } else {
-              // niveau impair
-              if (modcon > 0) pvie = modcon; // Mod. CON si positif
+              // niveaux <= 10
+              if (n % 2 === 0) {
+                // niveau pair
+                if (n > pv.length) {
+                  // nouveau niveau
+                  if (average !== 0) {
+                    pvie = average; // ... soit moyenne du DV + 1
+                  } else {
+                    pvie = getRandom(dv); // ... soit tirage de DV
+                  }
+                  if (modcon < 0) pvie += modcon; // ... + Mod. CON si négative
+                  if (pvie < 0) pvie = 0; // ... mais on ne perd pas de PV
+                } else {
+                  // niveau existant
+                  pvie = pv[n - 1];
+                }
+              } else {
+                // niveau impair
+                if (modcon > 0) pvie = modcon; // Mod. CON si positif
+              }
             }
           }
+          if (n > pv.length) pv.push(pvie);
+          else pv[n - 1] = pvie;
+          pv_max += pvie;
         }
-        if (n > pv.length) pv.push(pvie);
-        else pv[n - 1] = pvie;
-        pv_max += pvie;
       }
       pv_max += pv_buff;
       setAttrs({

--- a/ChroniquesGalactiques/sheet.json
+++ b/ChroniquesGalactiques/sheet.json
@@ -4,5 +4,5 @@
 	"authors": "Natha, Stéphane D and Ulti",
 	"roll20userid": ["75857","84776","1794854"],
 	"preview": "cog_v3.png",
-	"instructions": "Feuille de Personnage (incluant quelques jets) pour Chroniques Galactiques (Chroniques Oubli&eacute;es Science-Fiction) paru dans le magazine Casus Belli 17,18 et 19 (http://www.black-book-editions.fr/catalogue.php?id=207). v1.3 (02/102017). [Lisez-moi](https://github.com/Roll20/roll20-character-sheets/blob/master/ChroniquesGalactiques/ReadMe.md)."
+	"instructions": "Feuille de Personnage (incluant quelques jets) pour Chroniques Galactiques (Chroniques Oubli&eacute;es Science-Fiction) paru dans le magazine Casus Belli 17,18 et 19 (http://www.black-book-editions.fr/catalogue.php?id=207). Version 3.110 (21/12/2020). [Lisez-moi](https://github.com/Roll20/roll20-character-sheets/blob/master/ChroniquesGalactiques/ReadMe.md)."
 }


### PR DESCRIPTION
## Changes / Comments
- Added a checkbox on the Abilities tab of the PC sheet to toggle between:
  - Display mode, where the name and full description of the abilities is displayed as wrapped text
  - Edit mode, where the player can enter the ability name and description (first line of text is assumed to be the ability name).
- Added fields to bind an ability roll with an ability in grid, by specifying the ability path number and rank in the path. This information is primarily used by the [COlib](https://github.com/stephaned68/COlib) API script.
- On the starship sheet :
  - added support for energy points allocation, including a check with the maximum energy potential
  - added checkboxes for crew stations occupation, in order to include or not the crew bonuses on the starship action rolls (including Init(iative) et Agility DEF(ense) reduced to 0 when no-one is piloting the starship
  - added code to remove the display of the physical traits section (sex, age, height, weight)
 
## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
