### PR TITLE
[Only War (Enhanced)] Fix Firefox Skill rolls without compatibility mode

### DIFF
--- a/Only-War-Enhanced/OnlyWarEnhanced.css
+++ b/Only-War-Enhanced/OnlyWarEnhanced.css
@@ -27,6 +27,11 @@ input[type="number"] {
 -moz-appearance: textfield;
 }
 
+/* Prevent disabled inputs from consuming mouse clicks */
+input[disabled] {
+	pointer-events: none;
+}
+
 /* All horizontal rule elements receive the following CSS property. */
 hr { border-top: 1px dotted black; }
 


### PR DESCRIPTION
Firefox users were having issues rolling Skills because the buttons were behind disabled inputs (used to display custom text) which ultimately consumed the mouse click.

To fix this, use CSS to prevent the click from being consumed by the disabled input and instead have it fall through to the parent button.

Fix taken from here: https://stackoverflow.com/a/32925830

Disclaimer: I am not a Pro user so haven't properly tested it outside of the Firefox debugger. I'm also not the best person to judge whether this provides the opportunity to clean up some of the Firefox compatibility code from the Only War (Enhanced) sheet.

## Changes / Comments






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
