### PR TITLE
Added Discipline to weapon skill options dropdown for Star Wars FFG API-Compatible

### DIFF
--- a/Star Wars FFG API-Compatible/FFG-SWRPG-CharacterSheet.html
+++ b/Star Wars FFG API-Compatible/FFG-SWRPG-CharacterSheet.html
@@ -1729,6 +1729,7 @@
                                                     <option value="skill(@{rankMechanics}|@{intellect})" data-i18n="mechanics">Mechanics</option>
                                                     <option value="skill(@{rankMedicine}|@{intellect})" data-i18n="medecine">Medicine</option>
                                                     <option value="skill(@{rankResilience}|@{brawn})" data-i18n="resilience">Resilience</option>
+                                                    <option value="skill(@{rankDiscipline}|@{willpower})" data-i18n="discipline">Discipline</option>
                                                 </optgroup>
                                             </select>
                                         </td>


### PR DESCRIPTION
## Changes / Comments

i added this  `<option value="skill(@{rankDiscipline}|@{willpower})" data-i18n="discipline">Discipline</option>`
to line 1732
so that Discipline can be used for the Unleash power on attacks



## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [yes] Does the pull request title have the sheet name(s)? Include each sheet name.
- [no just something that was missing] Is this a bug fix?
- [yes] Does this add functional enhancements (new features or extending existing features) ?
- [no] Does this add or change functional aesthetics (such as layout or color scheme) ? 
