### PR TITLE
[Pokemon Tabletop Adventures_v3] Upgrades the Move Repeating Section

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -1,5 +1,7 @@
 .charsheet,
-.sheet-rolltemplate-move-roll {
+.sheet-rolltemplate-move-roll,
+.sheet-rolltemplate-dual-hit-move-roll,
+.sheet-rolltemplate-multi-hit-move-roll {
   --poke-bug: #c6d16e;
   --poke-bug-background: #ffffb280;
   --poke-bug-shaded: #828d2a;
@@ -767,7 +769,9 @@ button[type="roll"].sheet-stat-roller:hover {
 
 /* Roll Templates */
 
-.sheet-rolltemplate-move-roll {
+.sheet-rolltemplate-move-roll,
+.sheet-rolltemplate-dual-hit-move-roll,
+.sheet-rolltemplate-multi-hit-move-roll {
   --header-text: white;
 }
 
@@ -776,6 +780,8 @@ button[type="roll"].sheet-stat-roller:hover {
 }
 
 .sheet-rolltemplate-move-roll,
+.sheet-rolltemplate-dual-hit-move-roll,
+.sheet-rolltemplate-multi-hit-move-roll,
 .sheet-rolltemplate-skill-roll {
   --main-text: black;
   --odd-row-bg: #d9d9d6;
@@ -922,12 +928,16 @@ button[type="roll"].sheet-stat-roller:hover {
 }
 
 .sheet-rolltemplate-move-roll .sheet-container hr.sheet-border,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container hr.sheet-border,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container hr.sheet-border,
 .sheet-rolltemplate-skill-roll .sheet-container hr.sheet-border {
   margin: 5px 0 5px 0;
   border-top: 1px solid var(--border-color);
 }
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template,
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template {
   border: 1px solid;
   border-color: var(--border-color);
@@ -937,21 +947,28 @@ button[type="roll"].sheet-stat-roller:hover {
   width: 100%;
 }
 
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-crit-damage-text {
+.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-crit-damage-text,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-crit-damage-text,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-crit-damage-text {
   font-weight: bold;
   margin-left: 10px;
   padding: 2px 5px;
 }
 
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-damage-roll .inlinerollresult {
-  border: 2px solid;
+.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
+.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template .sheet-skill-roll .inlinerollresult {
+  background: #000000;
+  border: 2px solid #000000;
+  color: #ffffff;
 }
 
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
-.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template .sheet-skill-roll .inlinerollresult {
-  background: black;
-  border: 2px solid black;
-  color: white;
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-damage-roll,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-damage-roll {
+  text-align: center;
 }
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template span.sheet-targeted-defense {
@@ -964,50 +981,78 @@ button[type="roll"].sheet-stat-roller:hover {
 
 /* Varying colour by effectiveness for damage roll and text  */
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-text-color {
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-text-color,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-text-color,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-text-color {
   background: #800000;
   border-color: #800000;
   color: #ffffff;
 }
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-text-color {
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-text-color,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-text-color,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-text-color {
   background: #cf6800;
   border-color: #cf6800;
   color: #ffffff;
 }
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-text-color,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-text-color,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-text-color,
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-text-color {
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-text-color,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-text-color,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-text-color {
   background: #000000;
   border-color: #000000;
   color: #ffffff;
 }
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-text-color {
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-text-color,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-text-color,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-text-color {
   background: #000080;
   border-color: #000080;
   color: #ffffff;
 }
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-text-color {
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-text-color,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-text-color,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-text-color {
   background: #008000;
   border-color: #008000;
   color: #ffffff;
 }
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template a,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template a,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template a,
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template a {
   color: var(--header-text);
   padding: 3px;
   font-style: italic;
 }
 
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td {
+.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td {
   padding: 4px 2px;
 }
 
@@ -1015,7 +1060,11 @@ button[type="roll"].sheet-stat-roller:hover {
   padding: 8px 2px;
 }
 
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-effectiveness-text {
+.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-effectiveness-text,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td.sheet-effectiveness-text,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td.sheet-effectiveness-text,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td.sheet-targeted-defense,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td.sheet-targeted-defense {
   font-weight: bold;
   line-height: 20px;
   padding: 2px 5px;
@@ -1024,6 +1073,8 @@ button[type="roll"].sheet-stat-roller:hover {
 }
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-label,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td.sheet-label,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td.sheet-label,
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template td.sheet-label {
   font-weight: bold;
   line-height: 14px;
@@ -1031,7 +1082,9 @@ button[type="roll"].sheet-stat-roller:hover {
   width: 80px;
 }
 
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text {
+.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text {
   font-size: 12px;
   line-height: 12px;
   padding: 8px;
@@ -1039,6 +1092,8 @@ button[type="roll"].sheet-stat-roller:hover {
 }
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template td.sheet-subhead {
   padding: 4px;
   background: var(--box-bg);
@@ -1047,6 +1102,8 @@ button[type="roll"].sheet-stat-roller:hover {
 }
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template th,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template th,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template th,
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template th {
   color: var(--header-text);
   padding: 6px;
@@ -1056,11 +1113,15 @@ button[type="roll"].sheet-stat-roller:hover {
 }
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template tr:nth-child(odd),
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(odd),
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(odd),
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template tr:nth-child(odd) {
   background: var(--odd-row-bg);
 }
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template tr:nth-child(even) {
   background: var(--row-bg);
 }

--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -967,35 +967,37 @@ button[type="roll"].sheet-stat-roller:hover {
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-text-color {
   background: #800000;
   border-color: #800000;
-  color: white;
+  color: #ffffff;
 }
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-text-color {
   background: #cf6800;
   border-color: #cf6800;
-  color: white;
+  color: #ffffff;
 }
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-text-color {
-  background: black;
-  border-color: black;
-  color: white;
+.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-text-color,
+.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-text-color {
+  background: #000000;
+  border-color: #000000;
+  color: #ffffff;
 }
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-text-color {
   background: #000080;
   border-color: #000080;
-  color: white;
+  color: #ffffff;
 }
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-text-color {
   background: #008000;
   border-color: #008000;
-  color: white;
+  color: #ffffff;
 }
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template a,
@@ -1073,14 +1075,18 @@ button[type="roll"].sheet-stat-roller:hover {
   display: none;
 }
 
-.sheet-display button[type="roll"]:hover {
+.sheet-pokemon-move button[type="roll"].sheet-inline-roller:hover {
   background-color: var(--text-background-color);
   color: #555555;
 }
 
-.sheet-display button[type="roll"] {
+.sheet-pokemon-move button[type="roll"].sheet-inline-roller {
   border: none;
-  min-width: 50%;
+  min-width: 35%;
+}
+
+.sheet-pokemon-move-info-header input[type="text"] {
+  width: 37%;
 }
 
 .sheet-options-flag {

--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -1143,11 +1143,15 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-pokemon-move button[type="roll"].sheet-inline-roller {
   border: none;
-  min-width: 35%;
+  min-width: 85%;
+}
+
+.sheet-pokemon-move .sheet-fill-space {
+  width: 30%;
 }
 
 .sheet-pokemon-move-info-header input[type="text"] {
-  width: 37%;
+  width: 30%;
 }
 
 .sheet-options-flag {

--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -261,6 +261,7 @@ div.sheet-pokemon-move span.sheet-readonly-field input[type="number"] {
 div.sheet-wrapper,
 div.sheet-pokemon-move {
   background-color: var(--background-color);
+  border-color: var(--foreground-color);
 }
 
 /* End fancy colors */
@@ -553,7 +554,7 @@ textarea {
 .sheet-pokemon-move {
   margin: 2px;
   padding: 2px;
-  border: 1px solid grey;
+  border: 1px solid;
   background-color: rgba(204, 204, 204, 0.5);
 }
 
@@ -1060,4 +1061,69 @@ button[type="roll"].sheet-stat-roller:hover {
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template tr:nth-child(even) {
   background: var(--row-bg);
+}
+
+.sheet-options-flag:not(:checked) ~ div.sheet-display,
+.sheet-options-flag:checked ~ div.sheet-options {
+  display: block;
+}
+
+.sheet-options-flag:checked ~ div.sheet-display,
+.sheet-options-flag:not(:checked) ~ div.sheet-options {
+  display: none;
+}
+
+.sheet-display button[type="roll"]:hover {
+  background-color: var(--text-background-color);
+  color: #555555;
+}
+
+.sheet-display button[type="roll"] {
+  border: none;
+  min-width: 50%;
+}
+
+.sheet-options-flag {
+  opacity: 0;
+  position: absolute;
+  top: 13px;
+  left: 4px;
+  height: 18px;
+  width: 18px;
+  z-index: 2;
+}
+
+.sheet-options-flag + span {
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: absolute;
+  top: 13px;
+  left: 4px;
+  white-space: nowrap;
+  height: 18px;
+  width: 18px;
+  font-size: 20px;
+  font-family: pictos;
+  color: var(--foreground-color);
+  cursor: pointer;
+  margin-top: 0px;
+  display: none;
+}
+
+.sheet-options-flag:hover + span {
+  color: #555555;
+}
+
+.sheet-options-flag:checked + span {
+  color: #555555;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.sheet-pokemon-move:hover .sheet-options-flag + span {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
 }

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -795,7 +795,7 @@
               class="skill-roller inline-roller"
               name="roll-movetemplate"
               type="roll"
-              value="&{template:move-roll} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}}"
+              value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} ]]}} {{damage-2=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-3=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-4=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-5=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}}"
             >
               <span name="attr_move_name"></span>
             </button>
@@ -804,7 +804,7 @@
               class="skill-roller inline-roller"
               name="roll-quick-move"
               type="roll"
-              value="&{template:move-roll} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}}"
+              value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} {{damage-2=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-3=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-4=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-5=[[ @{move_dicenumber}d@{damage_dice} ]]}}"
             >
               Quick Roll
             </button>
@@ -826,7 +826,7 @@
               class="skill-roller inline-roller"
               name="roll-quick-move"
               type="roll"
-              value="&{template:move-roll} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}}"
+              value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} {{damage-2=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-3=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-4=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-5=[[ @{move_dicenumber}d@{damage_dice} ]]}}"
             >
               Quick Roll
             </button>
@@ -1023,6 +1023,18 @@
                 value="d20 + 0"
               />
             </span>
+
+            <span>
+              <b>Scatter</b>
+              <b class="info-tooltip" title="Choose the Scatter type of the attack. This will effect which roll template is used for the chat log output.">ℹ</b>
+            </span>
+            <span>
+              <select class="move-text" name="attr_move_template" title="Attribute: move_template">
+                <option value="move-roll" selected>None</option>
+                <option value="dual-hit-move-roll">Dual Hit</option>
+                <option value="multi-hit-move-roll">Multi Hit</option>
+              </select>
+            </span>
           </div>
 
           <div class="move-notes-roller">
@@ -1037,7 +1049,7 @@
               class="move-roller"
               name="roll-movetemplate"
               type="roll"
-              value="&{template:move-roll} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}}"
+              value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} ]]}} {{damage-2=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-3=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-4=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-5=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}}"
             >
               T
             </button>
@@ -1111,21 +1123,21 @@
 <!-- ROLL TEMPLATES -->
 <div class="rolltemplates">
   <rolltemplate class="sheet-rolltemplate-move-roll">
-    <div class="container sheet-rolltemplate-color-setting-{{move-type}}-move">
-      <table class="move-template">
+    <div class="sheet-container sheet-rolltemplate-color-setting-{{move-type}}-move">
+      <table class="sheet-move-template">
         <tr>
           <th colspan="2">{{move-name}}</th>
         </tr>
         <tr>
-          <td colspan="2" class="subhead">[{{character-name}}](https://journal.roll20.net/character/{{character-id}}" name="name-link")</td>
+          <td colspan="2" class="sheet-subhead">[{{character-name}}](https://journal.roll20.net/character/{{character-id}}" name="name-link")</td>
         </tr>
 
         <!-- Accuracy Check -->
         <tr>
-          <td class="label"><span>Accuracy Check:</span></td>
-          <td class="accuracy-roll">
+          <td class="sheet-label"><span>Accuracy Check:</span></td>
+          <td class="sheet-accuracy-roll">
             {{accuracy}} {{#target}}
-            <span class="targeted-defense">vs {{target}}</span>
+            <span class="sheet-targeted-defense">vs {{target}}</span>
             {{/target}}
           </td>
         </tr>
@@ -1133,8 +1145,8 @@
         <!-- Effectiveness -->
         {{#^rollTotal() effectiveness-roll 2}}
         <tr>
-          <!--<td class="label"><span>Effect:</span></td>-->
-          <td class="effectiveness-text" colspan="2">
+          <!--<td class="sheet-label"><span>Effect:</span></td>-->
+          <td class="sheet-effectiveness-text" colspan="2">
             <span>
               <!-- Shielded -->
               {{#rollTotal() effectiveness-roll 0}} It was *really* ineffective... {{/rollTotal() effectiveness-roll 0}}
@@ -1153,11 +1165,11 @@
         <!-- Dice-Based Critical Hit -->
         {{#rollWasCrit() accuracy}} {{#rollGreater() critical-damage 0}}
         <tr>
-          <td class="label"><span>{{move-type}} Damage:</span></td>
+          <td class="sheet-label"><span>{{move-type}} Damage:</span></td>
           <td>
-            <span class="damage-roll {{effectiveness}}-effectiveness-color">
+            <span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color">
               {{critical-damage}}
-              <span class="crit-damage-text {{effectiveness}}-effectiveness-text-color"> Critical Hit! </span>
+              <span class="sheet-crit-damage-text sheet-{{effectiveness}}-effectiveness-text-color"> Critical Hit! </span>
             </span>
           </td>
         </tr>
@@ -1169,11 +1181,11 @@
         <!-- Effect 1 is Critical Hit and we hit the Threshold -->
         {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy effect1_threshold}}
         <tr>
-          <td class="label"><span>{{move-type}} Damage:</span></td>
+          <td class="sheet-label"><span>{{move-type}} Damage:</span></td>
           <td>
-            <span class="damage-roll {{effectiveness}}-effectiveness-color">
+            <span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color">
               {{critical-damage}}
-              <span class="crit-damage-text {{effectiveness}}-effectiveness-text-color"> Critical Hit! </span>
+              <span class="sheet-crit-damage-text sheet-{{effectiveness}}-effectiveness-text-color"> Critical Hit! </span>
             </span>
           </td>
         </tr>
@@ -1182,9 +1194,9 @@
         <!-- Effect-Based Critical Hit Dealing Regular Damage -->
         {{#rollLess() accuracy effect1_threshold}}
         <tr>
-          <td class="label"><span>{{move-type}} Damage:</span></td>
+          <td class="sheet-label"><span>{{move-type}} Damage:</span></td>
           <td>
-            <span class="damage-roll {{effectiveness}}-effectiveness-color"> {{damage}} </span>
+            <span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage}} </span>
           </td>
         </tr>
         {{/rollLess() accuracy effect1_threshold}}
@@ -1192,20 +1204,20 @@
         {{/rollTotal() effect1_roll 99}} {{/rollGreater() critical-damage 0}} {{/^rollWasCrit() accuracy}}
 
         <!-- Regular Hit -->
-        {{#^rollWasCrit() accuracy}} {{#rollGreater() damage 0}} {{#rollLess() effect1_roll 99}}
+        {{#^rollWasCrit() accuracy}} {{#rollLess() effect1_roll 99}}
         <tr>
-          <td class="label"><span>{{move-type}} Damage:</span></td>
+          <td class="sheet-label"><span>{{move-type}} Damage:</span></td>
           <td>
-            <span class="damage-roll {{effectiveness}}-effectiveness-color"> {{damage}} </span>
+            <span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage}} </span>
           </td>
         </tr>
-        {{/rollLess() effect1_roll 99}} {{/rollGreater() damage 0}} {{/^rollWasCrit() accuracy}}
+        {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy}}
 
         <!-- Effect Resoluton  -->
         <!-- Effect 1 -->
         {{#rollBetween() effect1_roll 1 10}} {{#^rollLess() accuracy effect1_threshold}}
         <tr>
-          <td class="effectiveness-text" colspan="2">
+          <td class="sheet-effectiveness-text" colspan="2">
             <span>The opponent was {{effect1_name}}</span>
           </td>
         </tr>
@@ -1214,7 +1226,7 @@
         <!-- Effect 2 -->
         {{#rollBetween() effect2_roll 1 10}} {{#^rollLess() accuracy effect2_threshold}}
         <tr>
-          <td class="effectiveness-text" colspan="2">
+          <td class="sheet-effectiveness-text" colspan="2">
             <span>The opponent was {{effect2_name}}</span>
           </td>
         </tr>
@@ -1223,9 +1235,490 @@
         <!-- Additional Notes - if there are any -->
         {{#notes}}
         <tr>
-          <td class="notes-text" colspan="2"><span>{{notes}}</span></td>
+          <td class="sheet-notes-text" colspan="2"><span>{{notes}}</span></td>
         </tr>
         {{/notes}}
+      </table>
+    </div>
+  </rolltemplate>
+
+  <rolltemplate class="sheet-rolltemplate-dual-hit-move-roll">
+    <div class="sheet-container sheet-rolltemplate-color-setting-{{move-type}}-move">
+      <table class="sheet-move-template">
+        <tbody>
+          <tr>
+            <th colspan="4">{{move-name}}</th>
+          </tr>
+          <tr>
+            <td colspan="4" class="sheet-subhead">[{{character-name}}](https://journal.roll20.net/character/{{character-id}}" name="name-link")</td>
+          </tr>
+
+          <!-- Targeted Defense -->
+          {{#target}}
+          <tr>
+            <td class="sheet-targeted-defense" colspan="4">Attacking against {{target}}</td>
+          </tr>
+          {{/target}}
+
+          <!-- Effectiveness -->
+          {{#^rollTotal() effectiveness-roll 2}}
+          <tr>
+            <!--<td class="sheet-label"><span>Effect:</span></td>-->
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>
+                <!-- Shielded -->
+                {{#rollTotal() effectiveness-roll 0}} It was *really* ineffective... {{/rollTotal() effectiveness-roll 0}}
+                <!-- Resisted -->
+                {{#rollTotal() effectiveness-roll 1}} It wasn't very effective... {{/rollTotal() effectiveness-roll 1}}
+                <!-- Super -->
+                {{#rollTotal() effectiveness-roll 3}} It was super effective! {{/rollTotal() effectiveness-roll 3}}
+                <!-- Extreme -->
+                {{#rollTotal() effectiveness-roll 4}} It was extremely effective! {{/rollTotal() effectiveness-roll 4}}
+              </span>
+            </td>
+          </tr>
+          {{/^rollTotal() effectiveness-roll 2}}
+
+          <!-- Scatter Attack 1 -->
+          <tr>
+            <td class="sheet-label"><span>Accuracy Check:</span></td>
+            <td class="sheet-accuracy-roll">{{accuracy}}</td>
+
+            <!-- Damage Rolls -->
+            <!-- Dice-Based Critical Hit -->
+            {{#rollWasCrit() accuracy}} {{#rollGreater() critical-damage 0}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage}} </span></td>
+            {{/rollGreater() critical-damage 0}} {{/rollWasCrit() accuracy}}
+
+            <!-- Effect-Based Critical Hit -->
+            <!-- Not a Natural Crit, and we deal Critical Damage -->
+            {{#^rollWasCrit() accuracy}} {{#rollGreater() critical-damage 0}}
+
+            <!-- Effect 1 is Critical Hit and we hit the Threshold -->
+            {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage}} </span></td>
+            {{/^rollLess() accuracy effect1_threshold}}
+
+            <!-- Effect 1 is Critical Hit but we missed the Threshold -->
+            {{#rollLess() accuracy effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage}} </span></td>
+            {{/rollLess() accuracy effect1_threshold}}
+            <!-- Closing The Critical Hit Section -->
+            {{/rollTotal() effect1_roll 99}} {{/rollGreater() critical-damage 0}} {{/^rollWasCrit() accuracy}}
+
+            <!-- Regular Hit -->
+            {{#^rollWasCrit() accuracy}} {{#rollLess() effect1_roll 99}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage}} </span></td>
+            {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy}}
+          </tr>
+          <!-- Effect Resoluton  -->
+          <!-- Effect 1 -->
+          {{#rollBetween() effect1_roll 1 10}} {{#^rollLess() accuracy effect1_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect1_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy effect1_threshold}} {{/rollBetween() effect1_roll 1 10}}
+
+          <!-- Effect 2 -->
+          {{#rollBetween() effect2_roll 1 10}} {{#^rollLess() accuracy effect2_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect2_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy effect2_threshold}} {{/rollBetween() effect2_roll 1 10}}
+
+          <!-- Scatter Attack 2 -->
+          <tr>
+            <td class="sheet-label"><span>Accuracy Check:</span></td>
+            <td class="sheet-accuracy-roll">{{accuracy-2}}</td>
+
+            <!-- Damage Rolls -->
+            <!-- Dice-Based Critical Hit -->
+            {{#rollWasCrit() accuracy-2}} {{#rollGreater() critical-damage-extra 0}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/rollGreater() critical-damage-extra 0}} {{/rollWasCrit() accuracy-2}}
+
+            <!-- Effect-Based Critical Hit -->
+            <!-- Not a Natural Crit, and we deal Critical Damage -->
+            {{#^rollWasCrit() accuracy-2}} {{#rollGreater() critical-damage-extra 0}}
+
+            <!-- Effect 1 is Critical Hit and we hit the Threshold -->
+            {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy-2 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/^rollLess() accuracy-2 effect1_threshold}}
+
+            <!-- Effect 1 is Critical Hit but we missed the Threshold -->
+            {{#rollLess() accuracy-2 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-2}} </span></td>
+            {{/rollLess() accuracy-2 effect1_threshold}}
+            <!-- Closing The Critical Hit Section -->
+            {{/rollTotal() effect1_roll 99}} {{/rollGreater() critical-damage-extra 0}} {{/^rollWasCrit() accuracy-2}}
+
+            <!-- Regular Hit -->
+            {{#^rollWasCrit() accuracy-2}} {{#rollLess() effect1_roll 99}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-2}} </span></td>
+            {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy-2}}
+          </tr>
+          <!-- Effect Resoluton  -->
+          <!-- Effect 1 -->
+          {{#rollBetween() effect1_roll 1 10}} {{#^rollLess() accuracy-2 effect1_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect1_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-2 effect1_threshold}} {{/rollBetween() effect1_roll 1 10}}
+
+          <!-- Effect 2 -->
+          {{#rollBetween() effect2_roll 1 10}} {{#^rollLess() accuracy-2 effect2_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect2_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-2 effect2_threshold}} {{/rollBetween() effect2_roll 1 10}}
+
+          <!-- Notes -->
+          {{#notes}}
+          <tr>
+            <td class="sheet-notes-text" colspan="4"><span>{{notes}}</span></td>
+          </tr>
+          {{/notes}}
+        </tbody>
+      </table>
+    </div>
+  </rolltemplate>
+
+  <rolltemplate class="sheet-rolltemplate-multi-hit-move-roll">
+    <div class="sheet-container sheet-rolltemplate-color-setting-{{move-type}}-move">
+      <table class="sheet-move-template">
+        <tbody>
+          <tr>
+            <th colspan="4">{{move-name}}</th>
+          </tr>
+          <tr>
+            <td colspan="4" class="sheet-subhead">[{{character-name}}](https://journal.roll20.net/character/{{character-id}}" name="name-link")</td>
+          </tr>
+
+          <!-- Targeted Defense -->
+          {{#target}}
+          <tr>
+            <td class="sheet-targeted-defense" colspan="4">Attacking against {{target}}</td>
+          </tr>
+          {{/target}}
+
+          <!-- Effectiveness -->
+          {{#^rollTotal() effectiveness-roll 2}}
+          <tr>
+            <!--<td class="sheet-label"><span>Effect:</span></td>-->
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>
+                <!-- Shielded -->
+                {{#rollTotal() effectiveness-roll 0}} It was *really* ineffective... {{/rollTotal() effectiveness-roll 0}}
+                <!-- Resisted -->
+                {{#rollTotal() effectiveness-roll 1}} It wasn't very effective... {{/rollTotal() effectiveness-roll 1}}
+                <!-- Super -->
+                {{#rollTotal() effectiveness-roll 3}} It was super effective! {{/rollTotal() effectiveness-roll 3}}
+                <!-- Extreme -->
+                {{#rollTotal() effectiveness-roll 4}} It was extremely effective! {{/rollTotal() effectiveness-roll 4}}
+              </span>
+            </td>
+          </tr>
+          {{/^rollTotal() effectiveness-roll 2}}
+
+          <!-- Scatter Attack 1 -->
+          <tr>
+            <td class="sheet-label"><span>Accuracy Check:</span></td>
+            <td class="sheet-accuracy-roll">{{accuracy}}</td>
+
+            <!-- Damage Rolls -->
+            <!-- Dice-Based Critical Hit -->
+            {{#rollWasCrit() accuracy}} {{#rollGreater() critical-damage 0}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage}} </span></td>
+            {{/rollGreater() critical-damage 0}} {{/rollWasCrit() accuracy}}
+
+            <!-- Effect-Based Critical Hit -->
+            <!-- Not a Natural Crit, and we deal Critical Damage -->
+            {{#^rollWasCrit() accuracy}} {{#rollGreater() critical-damage 0}}
+
+            <!-- Effect 1 is Critical Hit and we hit the Threshold -->
+            {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage}} </span></td>
+            {{/^rollLess() accuracy effect1_threshold}}
+
+            <!-- Effect 1 is Critical Hit but we missed the Threshold -->
+            {{#rollLess() accuracy effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage}} </span></td>
+            {{/rollLess() accuracy effect1_threshold}}
+            <!-- Closing The Critical Hit Section -->
+            {{/rollTotal() effect1_roll 99}} {{/rollGreater() critical-damage 0}} {{/^rollWasCrit() accuracy}}
+
+            <!-- Regular Hit -->
+            {{#^rollWasCrit() accuracy}} {{#rollLess() effect1_roll 99}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage}} </span></td>
+            {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy}}
+          </tr>
+          <!-- Effect Resoluton  -->
+          <!-- Effect 1 -->
+          {{#rollBetween() effect1_roll 1 10}} {{#^rollLess() accuracy effect1_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect1_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy effect1_threshold}} {{/rollBetween() effect1_roll 1 10}}
+
+          <!-- Effect 2 -->
+          {{#rollBetween() effect2_roll 1 10}} {{#^rollLess() accuracy effect2_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect2_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy effect2_threshold}} {{/rollBetween() effect2_roll 1 10}}
+
+          <!-- Scatter Attack 2 -->
+          <tr>
+            <td class="sheet-label"><span>Accuracy Check:</span></td>
+            <td class="sheet-accuracy-roll">{{accuracy-2}}</td>
+
+            <!-- Damage Rolls -->
+            <!-- Dice-Based Critical Hit -->
+            {{#rollWasCrit() accuracy-2}} {{#rollGreater() critical-damage-extra 0}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/rollGreater() critical-damage-extra 0}} {{/rollWasCrit() accuracy-2}}
+
+            <!-- Effect-Based Critical Hit -->
+            <!-- Not a Natural Crit, and we deal Critical Damage -->
+            {{#^rollWasCrit() accuracy-2}} {{#rollGreater() critical-damage-extra 0}}
+
+            <!-- Effect 1 is Critical Hit and we hit the Threshold -->
+            {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy-2 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/^rollLess() accuracy-2 effect1_threshold}}
+
+            <!-- Effect 1 is Critical Hit but we missed the Threshold -->
+            {{#rollLess() accuracy-2 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-2}} </span></td>
+            {{/rollLess() accuracy-2 effect1_threshold}}
+            <!-- Closing The Critical Hit Section -->
+            {{/rollTotal() effect1_roll 99}} {{/rollGreater() critical-damage-extra 0}} {{/^rollWasCrit() accuracy-2}}
+
+            <!-- Regular Hit -->
+            {{#^rollWasCrit() accuracy-2}} {{#rollLess() effect1_roll 99}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-2}} </span></td>
+            {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy-2}}
+          </tr>
+          <!-- Effect Resoluton  -->
+          <!-- Effect 1 -->
+          {{#rollBetween() effect1_roll 1 10}} {{#^rollLess() accuracy-2 effect1_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect1_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-2 effect1_threshold}} {{/rollBetween() effect1_roll 1 10}}
+
+          <!-- Effect 2 -->
+          {{#rollBetween() effect2_roll 1 10}} {{#^rollLess() accuracy-2 effect2_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect2_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-2 effect2_threshold}} {{/rollBetween() effect2_roll 1 10}}
+
+          <!-- Scatter Attack 3 -->
+          <tr>
+            <td class="sheet-label"><span>Accuracy Check:</span></td>
+            <td class="sheet-accuracy-roll">{{accuracy-3}}</td>
+
+            <!-- Damage Rolls -->
+            <!-- Dice-Based Critical Hit -->
+            {{#rollWasCrit() accuracy-3}} {{#rollGreater() critical-damage-extra 0}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/rollGreater() critical-damage-extra 0}} {{/rollWasCrit() accuracy-3}}
+
+            <!-- Effect-Based Critical Hit -->
+            <!-- Not a Natural Crit, and we deal Critical Damage -->
+            {{#^rollWasCrit() accuracy-3}} {{#rollGreater() critical-damage-extra 0}}
+
+            <!-- Effect 1 is Critical Hit and we hit the Threshold -->
+            {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy-3 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/^rollLess() accuracy-3 effect1_threshold}}
+
+            <!-- Effect 1 is Critical Hit but we missed the Threshold -->
+            {{#rollLess() accuracy-3 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-3}} </span></td>
+            {{/rollLess() accuracy-3 effect1_threshold}}
+            <!-- Closing The Critical Hit Section -->
+            {{/rollTotal() effect1_roll 99}} {{/rollGreater() critical-damage-extra 0}} {{/^rollWasCrit() accuracy-3}}
+
+            <!-- Regular Hit -->
+            {{#^rollWasCrit() accuracy-3}} {{#rollLess() effect1_roll 99}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-3}} </span></td>
+            {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy-3}}
+          </tr>
+          <!-- Effect Resoluton  -->
+          <!-- Effect 1 -->
+          {{#rollBetween() effect1_roll 1 10}} {{#^rollLess() accuracy-3 effect1_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect1_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-3 effect1_threshold}} {{/rollBetween() effect1_roll 1 10}}
+
+          <!-- Effect 2 -->
+          {{#rollBetween() effect2_roll 1 10}} {{#^rollLess() accuracy-3 effect2_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect2_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-3 effect2_threshold}} {{/rollBetween() effect2_roll 1 10}}
+
+          <!-- Scatter Attack 4 -->
+          <tr>
+            <td class="sheet-label"><span>Accuracy Check:</span></td>
+            <td class="sheet-accuracy-roll">{{accuracy-4}}</td>
+
+            <!-- Damage Rolls -->
+            <!-- Dice-Based Critical Hit -->
+            {{#rollWasCrit() accuracy-4}} {{#rollGreater() critical-damage-extra 0}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/rollGreater() critical-damage-extra 0}} {{/rollWasCrit() accuracy-4}}
+
+            <!-- Effect-Based Critical Hit -->
+            <!-- Not a Natural Crit, and we deal Critical Damage -->
+            {{#^rollWasCrit() accuracy-4}} {{#rollGreater() critical-damage-extra 0}}
+
+            <!-- Effect 1 is Critical Hit and we hit the Threshold -->
+            {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy-4 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/^rollLess() accuracy-4 effect1_threshold}}
+
+            <!-- Effect 1 is Critical Hit but we missed the Threshold -->
+            {{#rollLess() accuracy-4 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-4}} </span></td>
+            {{/rollLess() accuracy-4 effect1_threshold}}
+            <!-- Closing The Critical Hit Section -->
+            {{/rollTotal() effect1_roll 99}} {{/rollGreater() critical-damage-extra 0}} {{/^rollWasCrit() accuracy-4}}
+
+            <!-- Regular Hit -->
+            {{#^rollWasCrit() accuracy-4}} {{#rollLess() effect1_roll 99}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-4}} </span></td>
+            {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy-4}}
+          </tr>
+          <!-- Effect Resoluton  -->
+          <!-- Effect 1 -->
+          {{#rollBetween() effect1_roll 1 10}} {{#^rollLess() accuracy-4 effect1_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect1_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-4 effect1_threshold}} {{/rollBetween() effect1_roll 1 10}}
+
+          <!-- Effect 2 -->
+          {{#rollBetween() effect2_roll 1 10}} {{#^rollLess() accuracy-4 effect2_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect2_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-4 effect2_threshold}} {{/rollBetween() effect2_roll 1 10}}
+
+          <!-- Scatter Attack 5 -->
+          <tr>
+            <td class="sheet-label"><span>Accuracy Check:</span></td>
+            <td class="sheet-accuracy-roll">{{accuracy-5}}</td>
+
+            <!-- Damage Rolls -->
+            <!-- Dice-Based Critical Hit -->
+            {{#rollWasCrit() accuracy-5}} {{#rollGreater() critical-damage-extra 0}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/rollGreater() critical-damage-extra 0}} {{/rollWasCrit() accuracy-5}}
+
+            <!-- Effect-Based Critical Hit -->
+            <!-- Not a Natural Crit, and we deal Critical Damage -->
+            {{#^rollWasCrit() accuracy-5}} {{#rollGreater() critical-damage-extra 0}}
+
+            <!-- Effect 1 is Critical Hit and we hit the Threshold -->
+            {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy-5 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/^rollLess() accuracy-5 effect1_threshold}}
+
+            <!-- Effect 1 is Critical Hit but we missed the Threshold -->
+            {{#rollLess() accuracy-5 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-5}} </span></td>
+            {{/rollLess() accuracy-5 effect1_threshold}}
+            <!-- Closing The Critical Hit Section -->
+            {{/rollTotal() effect1_roll 99}} {{/rollGreater() critical-damage-extra 0}} {{/^rollWasCrit() accuracy-5}}
+
+            <!-- Regular Hit -->
+            {{#^rollWasCrit() accuracy-5}} {{#rollLess() effect1_roll 99}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-5}} </span></td>
+            {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy-5}}
+          </tr>
+          <!-- Effect Resoluton  -->
+          <!-- Effect 1 -->
+          {{#rollBetween() effect1_roll 1 10}} {{#^rollLess() accuracy-5 effect1_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect1_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-5 effect1_threshold}} {{/rollBetween() effect1_roll 1 10}}
+
+          <!-- Effect 2 -->
+          {{#rollBetween() effect2_roll 1 10}} {{#^rollLess() accuracy-5 effect2_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect2_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-5 effect2_threshold}} {{/rollBetween() effect2_roll 1 10}}
+
+          <!-- Notes -->
+          {{#notes}}
+          <tr>
+            <td class="sheet-notes-text" colspan="4"><span>{{notes}}</span></td>
+          </tr>
+          {{/notes}}
+        </tbody>
       </table>
     </div>
   </rolltemplate>
@@ -1242,7 +1735,7 @@
 
         <!-- Skill Check -->
         <tr>
-          <td class="label"><span>Skill Check:</span></td>
+          <td class="sheet-label"><span>Skill Check:</span></td>
           <td class="skill-roll">{{skill-roll}}</td>
         </tr>
       </table>

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -787,211 +787,243 @@
       <input name="attr_move_category_defense" type="hidden" />
       <input class="sheet-color-setting-move" name="attr_move_type" type="hidden" value="normal" />
       <div class="pokemon-move">
-        <div class="pokemon-move-info-header">
-          <input name="attr_move_name" placeholder="Move" spellcheck="false" title="Attribute: move_name" type="text" />
-
-          <span>
-            <b>Move Usage</b>
-            <input name="attr_move_usage" title="Attribute: move_usage" type="number" value="0" />
-            <button name="act_incrementmoveusage" type="action">+</button>
-            <button name="act_resetmoveusage" type="action">Reset</button>
-          </span>
-        </div>
-
-        <div class="pokemon-move-info-grid-1">
-          <input class="move-text" name="attr_move_range" placeholder="Range" spellcheck="false" title="Attribute: move_range" type="text" />
-          <select class="move-text sheet-no-dropdown" name="attr_move_type" title="Attribute: move_type">
-            <option value="bug">Bug</option>
-            <option value="dark">Dark</option>
-            <option value="dragon">Dragon</option>
-            <option value="electric">Electric</option>
-            <option value="fairy">Fairy</option>
-            <option value="fighting">Fighting</option>
-            <option value="fire">Fire</option>
-            <option value="flying">Flying</option>
-            <option value="ghost">Ghost</option>
-            <option value="grass">Grass</option>
-            <option value="ground">Ground</option>
-            <option value="ice">Ice</option>
-            <option value="normal" selected>Normal</option>
-            <option value="poison">Poison</option>
-            <option value="psychic">Psychic</option>
-            <option value="rock">Rock</option>
-            <option value="steel">Steel</option>
-            <option value="water">Water</option>
-          </select>
-          <select class="move-text sheet-no-dropdown" name="attr_move_category" title="Attribute: move_category">
-            <option value="0">Category</option>
-            <option value="1">Attack</option>
-            <option value="2">Special Attack</option>
-            <option value="3">Effect</option>
-          </select>
-          <select class="move-text sheet-no-dropdown" name="attr_move_frequency" title="Attribute: move_frequency">
-            <option value="">Frequency</option>
-            <option value="atwill">At-Will</option>
-            <!-- 1day and 3day are switched, I know, but if we fix it we mess up existing sheets -->
-            <option value="1day">3/day</option>
-            <option value="3day">1/day</option>
-            <option value="1combat">1/combat</option>
-          </select>
-
-          <span>
-            <b>Damage</b>
-            <input class="top-information damage-dice-count" name="attr_move_dicenumber" title="Attribute: move_dicenumber" type="number" value="0" />
-            <select name="attr_damage_dice" class="damage-dice">
-              <option value="4">d4</option>
-              <option value="6">d6</option>
-              <option value="8">d8</option>
-              <option value="10">d10</option>
-              <option value="12">d12</option>
-              <option value="20">d20</option>
-            </select>
-          </span>
-        </div>
-        <div class="pokemon-move-info-grid-2">
-          <span>
-            <b>Accuracy Modifier</b>
-            <input class="top-information thin-number" name="attr_move_acmod" title="Attribute: move_acmod" type="number" value="0" />
-          </span>
-
-          <span>
-            <b title="Modify to change critical hits based on the dice roll, as per Focus Energy and Super Luck. For moves like Slash, see Effect Threshold"
-              >Critical Threshold</b
+        <input checked class="sheet-options-flag" name="attr_options_flag" type="checkbox" />
+        <span name="attr_flag">-</span>
+        <div class="sheet-display">
+          <div class="pokemon-move-info-header">
+            <button
+              class="skill-roller inline-move"
+              name="roll-movetemplate"
+              type="roll"
+              value="&{template:move-roll} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}}"
             >
-            <b
-              class="info-tooltip"
-              title="Modify to change critical hits based on the dice roll, as per Focus Energy and Super Luck. For moves like Slash, see Effect Threshold"
-              >ℹ</b
-            >
-            <input
-              class="top-information thin-number"
-              max="20"
-              min="1"
-              name="attr_move_critthreshold"
-              title="Attribute: move_critthreshold"
-              type="number"
-              value="20"
-            />
-          </span>
+              <span name="attr_move_name"></span>
+            </button>
 
-          <span>
-            <b>STAB</b>
-            <input class="top-information thin-number" name="attr_move_stabbonus" title="Attribute: move_stabbonus" type="number" value="0" />
-          </span>
-
-          <span>
-            <b>Extra Damage</b>
-            <input class="top-information thin-number" name="attr_move_damagebonus" title="Attribute: move_damagebonus" type="number" value="0" />
-          </span>
-
-          <span class="readonly-field">
-            <b>Damage Roll:</b>
-            <input name="attr_move_totaldamage" type="hidden" />
-            <input
-              class="top-information total-display"
-              name="attr_move_totaldamage_display"
-              readonly
-              title="Attribute: move_totaldamage_display (move_totaldamage for only the numerical bonus)"
-              type="text"
-              value=""
-            />
-          </span>
-
-          <span>
-            <b title="Enter the value shown in the move notes for effects like Burned, Poisoned, and Stunned">Effect Threshold</b>
-            <b class="info-tooltip" title="Enter the value shown in the move notes for effects like Burned, Poisoned, and Stunned">ℹ</b>
-            <input
-              class="top-information thin-number"
-              max="20"
-              min="0"
-              name="attr_move_effect1_threshold"
-              title="Attribute: move_effect1_threshold"
-              type="number"
-              value="0"
-            />
-          </span>
-
-          <span>
-            <select class="move-text" name="attr_move_effect1" title="Attribute: move_effect1_name (move_effect1 for the numerical value used in calculations)">
-              <option value="98" selected>None</option>
-              <option value="99">Critical Hit</option>
-              <option value="1">Asleep</option>
-              <option value="2">Burned</option>
-              <option value="3">Confused</option>
-              <option value="4">Cursed</option>
-              <option value="5">Frozen</option>
-              <option value="6">Infatuated</option>
-              <option value="7">Paralyzed</option>
-              <option value="8">Poisoned</option>
-              <option value="9">Toxified</option>
-              <option value="10">Stunned</option>
-              <option value="11">Other</option>
-            </select>
-            <input type="hidden" name="attr_move_effect1_name" />
-            <b class="info-tooltip" title="Choose Critical Hit for moves where a high accuracy check scores a critical hit, like Slash and Karate Chop">ℹ</b>
-          </span>
-
-          <span>
-            <b>Effect Threshold</b>
-            <input
-              class="top-information thin-number"
-              max="20"
-              min="0"
-              name="attr_move_effect2_threshold"
-              title="Attribute: move_effect2_threshold"
-              type="number"
-              value="0"
-            />
-          </span>
-
-          <span>
-            <input name="attr_move_effect2_name" type="hidden" />
-            <select class="move-text" name="attr_move_effect2" title="Attribute: move_effect2_name (move_effect2 for the numerical value used in calculations)">
-              <option value="98" selected>None</option>
-              <option value="1">Asleep</option>
-              <option value="2">Burned</option>
-              <option value="3">Confused</option>
-              <option value="4">Cursed</option>
-              <option value="5">Frozen</option>
-              <option value="6">Infatuated</option>
-              <option value="7">Paralyzed</option>
-              <option value="8">Poisoned</option>
-              <option value="9">Toxified</option>
-              <option value="10">Stunned</option>
-              <option value="11">Other</option>
-            </select>
-          </span>
-
-          <span class="readonly-field">
-            <b>Accuracy Roll:</b>
-            <input name="attr_move_totalaccuracy" type="hidden" />
-            <input
-              class="top-information total-display"
-              name="attr_move_totalaccuracy_display"
-              readonly
-              title="Attribute: move_totalaccuracy_display (move_totalaccuracy for only the numerical bonus)"
-              type="text"
-              value=""
-            />
-          </span>
+            <span>
+              <b>Move Usage</b>
+              <input name="attr_move_usage" title="Attribute: move_usage" type="number" value="0" />
+              <button name="act_incrementmoveusage" type="action">+</button>
+              <button name="act_resetmoveusage" type="action">Reset</button>
+            </span>
+          </div>
         </div>
 
-        <div class="move-notes-roller">
-          <textarea
-            class="3row-textarea"
-            name="attr_move_effect"
-            placeholder="Additional Effect Notes"
-            spellcheck="false"
-            title="Attribute: move_effect"
-          ></textarea>
-          <button
-            class="move-roller"
-            name="roll-movetemplate"
-            type="roll"
-            value="&{template:move-roll} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}}"
-          >
-            T
-          </button>
+        <div class="sheet-options">
+          <div class="pokemon-move-info-header">
+            <input name="attr_move_name" placeholder="Move" spellcheck="false" title="Attribute: move_name" type="text" />
+
+            <span>
+              <b>Move Usage</b>
+              <input name="attr_move_usage" title="Attribute: move_usage" type="number" value="0" />
+              <button name="act_incrementmoveusage" type="action">+</button>
+              <button name="act_resetmoveusage" type="action">Reset</button>
+            </span>
+          </div>
+
+          <div class="pokemon-move-info-grid-1">
+            <input class="move-text" name="attr_move_range" placeholder="Range" spellcheck="false" title="Attribute: move_range" type="text" />
+            <select class="move-text sheet-no-dropdown" name="attr_move_type" title="Attribute: move_type">
+              <option value="bug">Bug</option>
+              <option value="dark">Dark</option>
+              <option value="dragon">Dragon</option>
+              <option value="electric">Electric</option>
+              <option value="fairy">Fairy</option>
+              <option value="fighting">Fighting</option>
+              <option value="fire">Fire</option>
+              <option value="flying">Flying</option>
+              <option value="ghost">Ghost</option>
+              <option value="grass">Grass</option>
+              <option value="ground">Ground</option>
+              <option value="ice">Ice</option>
+              <option value="normal" selected>Normal</option>
+              <option value="poison">Poison</option>
+              <option value="psychic">Psychic</option>
+              <option value="rock">Rock</option>
+              <option value="steel">Steel</option>
+              <option value="water">Water</option>
+            </select>
+            <select class="move-text sheet-no-dropdown" name="attr_move_category" title="Attribute: move_category">
+              <option value="0">Category</option>
+              <option value="1">Attack</option>
+              <option value="2">Special Attack</option>
+              <option value="3">Effect</option>
+            </select>
+            <select class="move-text sheet-no-dropdown" name="attr_move_frequency" title="Attribute: move_frequency">
+              <option value="">Frequency</option>
+              <option value="atwill">At-Will</option>
+              <!-- 1day and 3day are switched, I know, but if we fix it we mess up existing sheets -->
+              <option value="1day">3/day</option>
+              <option value="3day">1/day</option>
+              <option value="1combat">1/combat</option>
+            </select>
+
+            <span>
+              <b>Damage</b>
+              <input class="top-information damage-dice-count" name="attr_move_dicenumber" title="Attribute: move_dicenumber" type="number" value="0" />
+              <select name="attr_damage_dice" class="damage-dice">
+                <option value="4">d4</option>
+                <option value="6">d6</option>
+                <option value="8">d8</option>
+                <option value="10">d10</option>
+                <option value="12">d12</option>
+                <option value="20">d20</option>
+              </select>
+            </span>
+          </div>
+          <div class="pokemon-move-info-grid-2">
+            <span>
+              <b>Accuracy Modifier</b>
+              <input class="top-information thin-number" name="attr_move_acmod" title="Attribute: move_acmod" type="number" value="0" />
+            </span>
+
+            <span>
+              <b title="Modify to change critical hits based on the dice roll, as per Focus Energy and Super Luck. For moves like Slash, see Effect Threshold"
+                >Critical Threshold</b
+              >
+              <b
+                class="info-tooltip"
+                title="Modify to change critical hits based on the dice roll, as per Focus Energy and Super Luck. For moves like Slash, see Effect Threshold"
+                >ℹ</b
+              >
+              <input
+                class="top-information thin-number"
+                max="20"
+                min="1"
+                name="attr_move_critthreshold"
+                title="Attribute: move_critthreshold"
+                type="number"
+                value="20"
+              />
+            </span>
+
+            <span>
+              <b>STAB</b>
+              <input class="top-information thin-number" name="attr_move_stabbonus" title="Attribute: move_stabbonus" type="number" value="0" />
+            </span>
+
+            <span>
+              <b>Extra Damage</b>
+              <input class="top-information thin-number" name="attr_move_damagebonus" title="Attribute: move_damagebonus" type="number" value="0" />
+            </span>
+
+            <span class="readonly-field">
+              <b>Damage Roll:</b>
+              <input name="attr_move_totaldamage" type="hidden" />
+              <input
+                class="top-information total-display"
+                name="attr_move_totaldamage_display"
+                readonly
+                title="Attribute: move_totaldamage_display (move_totaldamage for only the numerical bonus)"
+                type="text"
+                value=""
+              />
+            </span>
+
+            <span>
+              <b title="Enter the value shown in the move notes for effects like Burned, Poisoned, and Stunned">Effect Threshold</b>
+              <b class="info-tooltip" title="Enter the value shown in the move notes for effects like Burned, Poisoned, and Stunned">ℹ</b>
+              <input
+                class="top-information thin-number"
+                max="20"
+                min="0"
+                name="attr_move_effect1_threshold"
+                title="Attribute: move_effect1_threshold"
+                type="number"
+                value="0"
+              />
+            </span>
+
+            <span>
+              <select
+                class="move-text"
+                name="attr_move_effect1"
+                title="Attribute: move_effect1_name (move_effect1 for the numerical value used in calculations)"
+              >
+                <option value="98" selected>None</option>
+                <option value="99">Critical Hit</option>
+                <option value="1">Asleep</option>
+                <option value="2">Burned</option>
+                <option value="3">Confused</option>
+                <option value="4">Cursed</option>
+                <option value="5">Frozen</option>
+                <option value="6">Infatuated</option>
+                <option value="7">Paralyzed</option>
+                <option value="8">Poisoned</option>
+                <option value="9">Toxified</option>
+                <option value="10">Stunned</option>
+                <option value="11">Other</option>
+              </select>
+              <input type="hidden" name="attr_move_effect1_name" />
+              <b class="info-tooltip" title="Choose Critical Hit for moves where a high accuracy check scores a critical hit, like Slash and Karate Chop">ℹ</b>
+            </span>
+
+            <span>
+              <b>Effect Threshold</b>
+              <input
+                class="top-information thin-number"
+                max="20"
+                min="0"
+                name="attr_move_effect2_threshold"
+                title="Attribute: move_effect2_threshold"
+                type="number"
+                value="0"
+              />
+            </span>
+
+            <span>
+              <input name="attr_move_effect2_name" type="hidden" />
+              <select
+                class="move-text"
+                name="attr_move_effect2"
+                title="Attribute: move_effect2_name (move_effect2 for the numerical value used in calculations)"
+              >
+                <option value="98" selected>None</option>
+                <option value="1">Asleep</option>
+                <option value="2">Burned</option>
+                <option value="3">Confused</option>
+                <option value="4">Cursed</option>
+                <option value="5">Frozen</option>
+                <option value="6">Infatuated</option>
+                <option value="7">Paralyzed</option>
+                <option value="8">Poisoned</option>
+                <option value="9">Toxified</option>
+                <option value="10">Stunned</option>
+                <option value="11">Other</option>
+              </select>
+            </span>
+
+            <span class="readonly-field">
+              <b>Accuracy Roll:</b>
+              <input name="attr_move_totalaccuracy" type="hidden" />
+              <input
+                class="top-information total-display"
+                name="attr_move_totalaccuracy_display"
+                readonly
+                title="Attribute: move_totalaccuracy_display (move_totalaccuracy for only the numerical bonus)"
+                type="text"
+                value="d20 + 0"
+              />
+            </span>
+          </div>
+
+          <div class="move-notes-roller">
+            <textarea
+              class="3row-textarea"
+              name="attr_move_effect"
+              placeholder="Additional Effect Notes"
+              spellcheck="false"
+              title="Attribute: move_effect"
+            ></textarea>
+            <button
+              class="move-roller"
+              name="roll-movetemplate"
+              type="roll"
+              value="&{template:move-roll} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}}"
+            >
+              T
+            </button>
+          </div>
         </div>
       </div>
     </fieldset>
@@ -1301,10 +1333,8 @@
   });
 
   on("clicked:repeating_moves:resetmoveusage", function () {
-    getAttrs(["repeating_moves_move_usage"], function (values) {
-      setAttrs({
-        repeating_moves_move_usage: 0,
-      });
+    setAttrs({
+      repeating_moves_move_usage: 0,
     });
   });
 
@@ -1763,6 +1793,12 @@
     const attrs = { [skillName]: newBonus };
     if (newBonus != oldTotal) setAttrs(attrs);
   }
+
+  // Move Collapsing
+  on("change:repeating_moves:options_flag", function (eventInfo) {
+    const flag = eventInfo.newValue == "on" ? "-" : "+";
+    setAttrs({ repeating_moves_flag: flag });
+  });
 
   // ATTRIBUTE DEPRECATION SHEET WORKERS
 

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -792,12 +792,21 @@
         <div class="sheet-display">
           <div class="pokemon-move-info-header">
             <button
-              class="skill-roller inline-move"
+              class="skill-roller inline-roller"
               name="roll-movetemplate"
               type="roll"
               value="&{template:move-roll} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}}"
             >
               <span name="attr_move_name"></span>
+            </button>
+
+            <button
+              class="skill-roller inline-roller"
+              name="roll-quick-move"
+              type="roll"
+              value="&{template:move-roll} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}}"
+            >
+              Quick Roll
             </button>
 
             <span>
@@ -812,6 +821,15 @@
         <div class="sheet-options">
           <div class="pokemon-move-info-header">
             <input name="attr_move_name" placeholder="Move" spellcheck="false" title="Attribute: move_name" type="text" />
+
+            <button
+              class="skill-roller inline-roller"
+              name="roll-quick-move"
+              type="roll"
+              value="&{template:move-roll} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}}"
+            >
+              Quick Roll
+            </button>
 
             <span>
               <b>Move Usage</b>

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -791,23 +791,35 @@
         <span name="attr_flag">-</span>
         <div class="sheet-display">
           <div class="pokemon-move-info-header">
-            <button
-              class="skill-roller inline-roller"
-              name="roll-movetemplate"
-              type="roll"
-              value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} ]]}} {{damage-2=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-3=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-4=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-5=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}}"
-            >
-              <span name="attr_move_name"></span>
-            </button>
+            <span class="sheet-fill-space">
+              <button
+                class="sheet-skill-roller sheet-inline-roller"
+                name="roll-movetemplate"
+                title="Click this to roll this attack with the option of choosing temporary modifiers or effectiveness."
+                type="roll"
+                value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} ]]}} {{damage-2=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-3=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-4=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-5=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}}"
+              >
+                <span name="attr_move_name"></span>
+              </button>
+              <b class="sheet-info-tooltip" title="Click this to roll this attack with the option of choosing temporary modifiers or effectiveness.">ℹ</b>
+            </span>
 
-            <button
-              class="skill-roller inline-roller"
-              name="roll-quick-move"
-              type="roll"
-              value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} {{damage-2=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-3=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-4=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-5=[[ @{move_dicenumber}d@{damage_dice} ]]}}"
-            >
-              Quick Roll
-            </button>
+            <span class="sheet-fill-space">
+              <button
+                class="sheet-skill-roller sheet-inline-roller"
+                name="roll-quick-move"
+                title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers."
+                type="roll"
+                value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} {{damage-2=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-3=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-4=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-5=[[ @{move_dicenumber}d@{damage_dice} ]]}}"
+              >
+                Quick Roll
+              </button>
+              <b
+                class="sheet-info-tooltip"
+                title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers."
+                >ℹ</b
+              >
+            </span>
 
             <span>
               <b>Move Usage</b>
@@ -822,14 +834,22 @@
           <div class="pokemon-move-info-header">
             <input name="attr_move_name" placeholder="Move" spellcheck="false" title="Attribute: move_name" type="text" />
 
-            <button
-              class="skill-roller inline-roller"
-              name="roll-quick-move"
-              type="roll"
-              value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} {{damage-2=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-3=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-4=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-5=[[ @{move_dicenumber}d@{damage_dice} ]]}}"
-            >
-              Quick Roll
-            </button>
+            <span class="sheet-fill-space">
+              <button
+                class="skill-roller inline-roller"
+                name="roll-quick-move"
+                title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers."
+                type="roll"
+                value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} {{damage-2=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-3=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-4=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-5=[[ @{move_dicenumber}d@{damage_dice} ]]}}"
+              >
+                Quick Roll
+              </button>
+              <b
+                class="sheet-info-tooltip"
+                title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers."
+                >ℹ</b
+              >
+            </span>
 
             <span>
               <b>Move Usage</b>
@@ -900,7 +920,7 @@
                 >Critical Threshold</b
               >
               <b
-                class="info-tooltip"
+                class="sheet-info-tooltip"
                 title="Modify to change critical hits based on the dice roll, as per Focus Energy and Super Luck. For moves like Slash, see Effect Threshold"
                 >ℹ</b
               >
@@ -940,7 +960,7 @@
 
             <span>
               <b title="Enter the value shown in the move notes for effects like Burned, Poisoned, and Stunned">Effect Threshold</b>
-              <b class="info-tooltip" title="Enter the value shown in the move notes for effects like Burned, Poisoned, and Stunned">ℹ</b>
+              <b class="sheet-info-tooltip" title="Enter the value shown in the move notes for effects like Burned, Poisoned, and Stunned">ℹ</b>
               <input
                 class="top-information thin-number"
                 max="20"
@@ -973,7 +993,9 @@
                 <option value="11">Other</option>
               </select>
               <input type="hidden" name="attr_move_effect1_name" />
-              <b class="info-tooltip" title="Choose Critical Hit for moves where a high accuracy check scores a critical hit, like Slash and Karate Chop">ℹ</b>
+              <b class="sheet-info-tooltip" title="Choose Critical Hit for moves where a high accuracy check scores a critical hit, like Slash and Karate Chop"
+                >ℹ</b
+              >
             </span>
 
             <span>
@@ -1026,7 +1048,9 @@
 
             <span>
               <b>Scatter</b>
-              <b class="info-tooltip" title="Choose the Scatter type of the attack. This will effect which roll template is used for the chat log output.">ℹ</b>
+              <b class="sheet-info-tooltip" title="Choose the Scatter type of the attack. This will effect which roll template is used for the chat log output."
+                >ℹ</b
+              >
             </span>
             <span>
               <select class="move-text" name="attr_move_template" title="Attribute: move_template">

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -8,6 +8,13 @@ https://discord.gg/F24Ka8E
 
 ## Changelog
 
+### Jan 7th, 2020
+
+- Added support for scatter moves
+- Added roll templates for dual hit and multi hit scatter attacks
+- Added a quick roll button that rolls a move without any query boxes for temporary modifiers or effectiveness, rolling with +0/+0/Neutral values
+- Streamlined move displays to show the configuration only when desired via a collapsible control
+
 ### Dec 12, 2020
 
 - Migrated the character sheet style attributes to new fields


### PR DESCRIPTION
## Changes / Comments
- feature: Streamlines combat moves
  - Makes the pokemon-move repeating section fields collapsible to hide the clutter of the roll customisation options
    - Adds an inline roll command for the move to make using it easier
- feature: Adds quick roll options to moves
  - Adds an extra inline move roller to the top segment of both move display types to allow for quickly rolling a move without configuring it with effectiveness and temporary modifiers
- feature: Added support for scatter-type moves
  - Adds a move configuration option for Scatter typing
  - Adds new roll templates that support the additional attacks that scatter moves come with
- feature: Adds tooltip information to the inline roller buttons
- Updates README with relevant changes from this branch

<details>
  <summary>Screenshot of final state after changes</summary>
  <img src="https://user-images.githubusercontent.com/25342733/103937324-84939580-5120-11eb-9a78-fff6ac15bf11.png">
</details>

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name. _Yes_
- [x] Is this a bug fix? _No_
- [x] Does this add functional enhancements (new features or extending existing features)? _Yes_
- [x] Does this add or change functional aesthetics (such as layout or color scheme)? _Yes_
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data? _None changed_
- [x] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository)? _Not a new sheet_

If you do not know English. Please leave a comment in your native language.
