### PR TITLE
[Pokemon Tabletop Adventures_v3] Changing Skill Ability Modifiers

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -275,10 +275,14 @@ div.sheet-character-stat-grid p {
 }
 
 .sheet-configuration-grid {
-  align-items: center;
+  align-items: start;
   display: grid;
   grid-template-columns: 1fr 1fr;
   padding: 6px;
+}
+
+div.sheet-skill-selection .sheet-no-dropdown {
+  width: 45%;
 }
 
 .sheet-logo {
@@ -628,36 +632,32 @@ input.sheet-character-type[value="hybrid"] ~ div.sheet-tab-hybrid {
   background-color: var(--stat-spd);
 }
 
-.sheet-attack-read-color[type="number"] {
+input.sheet-skill-color-setting[value="ATK"] + input[type="number"].sheet-skill-total,
+input.sheet-skill-color-setting[value="ATK"] + .sheet-skill-total + button[type="roll"].sheet-skill-roller:hover {
   background-color: var(--stat-ro-atk);
-  border: none;
-  font-style: italic;
-  font-weight: bold;
 }
 
-.sheet-defense-read-color[type="number"] {
+input.sheet-skill-color-setting[value="DEF"] + input[type="number"].sheet-skill-total,
+input.sheet-skill-color-setting[value="DEF"] + .sheet-skill-total + button[type="roll"].sheet-skill-roller:hover {
   background-color: var(--stat-ro-def);
-  border: none;
-  font-style: italic;
-  font-weight: bold;
 }
 
-.sheet-spatk-read-color[type="number"] {
+input.sheet-skill-color-setting[value="SPATK"] + input[type="number"].sheet-skill-total,
+input.sheet-skill-color-setting[value="SPATK"] + .sheet-skill-total + button[type="roll"].sheet-skill-roller:hover {
   background-color: var(--stat-ro-spatk);
-  border: none;
-  font-style: italic;
-  font-weight: bold;
 }
 
-.sheet-spdef-read-color[type="number"] {
+input.sheet-skill-color-setting[value="SPDEF"] + input[type="number"].sheet-skill-total,
+input.sheet-skill-color-setting[value="SPDEF"] + .sheet-skill-total + button[type="roll"].sheet-skill-roller:hover {
   background-color: var(--stat-ro-spdef);
-  border: none;
-  font-style: italic;
-  font-weight: bold;
 }
 
-.sheet-speed-read-color[type="number"] {
+input.sheet-skill-color-setting[value="SPD"] + input[type="number"].sheet-skill-total,
+input.sheet-skill-color-setting[value="SPD"] + .sheet-skill-total + button[type="roll"].sheet-skill-roller:hover {
   background-color: var(--stat-ro-spd);
+}
+
+input[type="number"].sheet-skill-total {
   border: none;
   font-style: italic;
   font-weight: bold;
@@ -677,26 +677,6 @@ input.sheet-character-type[value="hybrid"] ~ div.sheet-tab-hybrid {
   font-style: italic;
   font-weight: bold;
   outline: none;
-}
-
-button[type="roll"].sheet-atk-skill:hover {
-  background-color: var(--stat-ro-atk);
-}
-
-button[type="roll"].sheet-def-skill:hover {
-  background-color: var(--stat-ro-def);
-}
-
-button[type="roll"].sheet-spatk-skill:hover {
-  background-color: var(--stat-ro-spatk);
-}
-
-button[type="roll"].sheet-spdef-skill:hover {
-  background-color: var(--stat-ro-spdef);
-}
-
-button[type="roll"].sheet-spd-skill:hover {
-  background-color: var(--stat-ro-spd);
 }
 
 button[type="roll"].sheet-move-roller {

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -424,235 +424,253 @@
       <div class="2col-centered">
         <div>
           <div class="character-skills">
-            <input class="speed-read-color" name="attr_acrobatics_total" readonly title="Attribute: acrobatics_total" type="number" />
+            <input class="sheet-skill-color-setting" name="attr_acrobatics_ability_mod" type="hidden" value="SPD" />
+            <input class="sheet-skill-total" name="attr_acrobatics_total" readonly title="Attribute: acrobatics_total" type="number" />
             <button
-              class="skill-roller spd-skill"
+              class="skill-roller"
               name="roll_acrobaticscheck"
               type="roll"
               value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Acrobatics}} {{skill-roll=[[ 1d20!kh2 + [[ @{acrobatics_total} + ?{Temporary Bonus|0} ]] ]]}}"
             >
-              Acrobatics (SPD)
+              Acrobatics (<span name="attr_acrobatics_ability_mod"></span>)
             </button>
             <input name="attr_acrobaticstalent1" value="2" title="Attribute: acrobaticstalent1" type="checkbox" />
             <input name="attr_acrobaticstalent2" value="2" title="Attribute: acrobaticstalent2" type="checkbox" />
             <input name="attr_acrobatics" value="0" title="Attribute: acrobatics" type="number" />
 
-            <input class="attack-read-color" name="attr_athletics_total" readonly title="Attribute: athletics_total" type="number" />
+            <input class="sheet-skill-color-setting" name="attr_athletics_ability_mod" type="hidden" value="ATK" />
+            <input class="sheet-skill-total" name="attr_athletics_total" readonly title="Attribute: athletics_total" type="number" />
             <button
-              class="skill-roller atk-skill"
+              class="skill-roller"
               name="roll_athleticscheck"
               type="roll"
               value="&{template:skill-roll} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Athletics}} {{skill-roll=[[ 1d20!kh2 + [[ @{athletics_total} + ?{Temporary Bonus|0} ]] ]]}}"
             >
-              Athletics (ATK)
+              Athletics (<span name="attr_athletics_ability_mod"></span>)
             </button>
             <input name="attr_athleticstalent1" value="2" title="Attribute: athleticstalent1" type="checkbox" />
             <input name="attr_athleticstalent2" value="2" title="Attribute: athleticstalent2" type="checkbox" />
             <input name="attr_athletics" value="0" title="Attribute: athletics" type="number" />
 
-            <input class="spdef-read-color" name="attr_bluff_total" readonly title="Attribute: bluff_total" type="number" />
+            <input class="sheet-skill-color-setting" name="attr_bluff_ability_mod" type="hidden" value="SPDEF" />
+            <input class="sheet-skill-total" name="attr_bluff_total" readonly title="Attribute: bluff_total" type="number" />
             <button
-              class="skill-roller spdef-skill"
+              class="skill-roller"
               name="roll_bluffcheck"
               type="roll"
               value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Bluff/Deception}} {{skill-roll=[[ 1d20!kh2 + [[ @{bluff_total} + ?{Temporary Bonus|0} ]] ]]}}"
             >
-              Bluff/Deception (SPDEF)
+              Bluff/Deception (<span name="attr_bluff_ability_mod"></span>)
             </button>
             <input name="attr_blufftalent1" value="2" title="Attribute: blufftalent1" type="checkbox" />
             <input name="attr_blufftalent2" value="2" title="Attribute: blufftalent2" type="checkbox" />
             <input name="attr_bluff" value="0" title="Attribute: bluff" type="number" />
 
-            <input class="defense-read-color" name="attr_concentration_total" readonly title="Attribute: concentration_total" type="number" />
+            <input class="sheet-skill-color-setting" name="attr_concentration_ability_mod" type="hidden" value="DEF" />
+            <input class="sheet-skill-total" name="attr_concentration_total" readonly title="Attribute: concentration_total" type="number" />
             <button
-              class="skill-roller def-skill"
+              class="skill-roller"
               name="roll_concentrationcheck"
               type="roll"
               value="&{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Concentration}} {{skill-roll=[[ 1d20!kh2 + [[ @{concentration_total} + ?{Temporary Bonus|0} ]] ]]}}"
             >
-              Concentration (DEF)
+              Concentration (<span name="attr_concentration_ability_mod"></span>)
             </button>
             <input name="attr_concentrationtalent1" value="2" title="Attribute: concentrationtalent1" type="checkbox" />
             <input name="attr_concentrationtalent2" value="2" title="Attribute: concentrationtalent2" type="checkbox" />
             <input name="attr_concentration" value="0" title="Attribute: concentration" type="number" />
 
-            <input class="defense-read-color" name="attr_constitution_total" readonly title="Attribute: constitution_total" type="number" />
+            <input class="sheet-skill-color-setting" name="attr_constitution_ability_mod" type="hidden" value="DEF" />
+            <input class="sheet-skill-total" name="attr_constitution_total" readonly title="Attribute: constitution_total" type="number" />
             <button
-              class="skill-roller def-skill"
+              class="skill-roller"
               name="roll_constitutioncheck"
               type="roll"
               value="&{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Constitution}} {{skill-roll=[[ 1d20!kh2 + [[ @{constitution_total} + ?{Temporary Bonus|0} ]] ]]}}"
             >
-              Constitution (DEF)
+              Constitution (<span name="attr_constitution_ability_mod"></span>)
             </button>
             <input name="attr_constitutiontalent1" value="2" title="Attribute: constitutiontalent1" type="checkbox" />
             <input name="attr_constitutiontalent2" value="2" title="Attribute: constitutiontalent2" type="checkbox" />
             <input name="attr_constitution" value="0" title="Attribute: constitution" type="number" />
 
-            <input class="spdef-read-color" name="attr_diplomacy_total" readonly title="Attribute: diplomacy_total" type="number" />
+            <input class="sheet-skill-color-setting" name="attr_diplomacy_ability_mod" type="hidden" value="SPDEF" />
+            <input class="sheet-skill-total" name="attr_diplomacy_total" readonly title="Attribute: diplomacy_total" type="number" />
             <button
-              class="skill-roller spdef-skill"
+              class="skill-roller"
               name="roll_diplomacycheck"
               type="roll"
               value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Diplomacy/Persuasion}} {{skill-roll=[[ 1d20!kh2 + [[ @{diplomacy_total} + ?{Temporary Bonus|0} ]] ]]}}"
             >
-              Diplomacy/Persuasion (SPDEF)
+              Diplomacy/Persuasion (<span name="attr_diplomacy_ability_mod"></span>)
             </button>
             <input name="attr_diplomacytalent1" value="2" title="Attribute: diplomacytalent1" type="checkbox" />
             <input name="attr_diplomacytalent2" value="2" title="Attribute: diplomacytalent2" type="checkbox" />
             <input name="attr_diplomacy" value="0" title="Attribute: diplomacy" type="number" />
 
-            <input class="spatk-read-color" name="attr_engineering_total" readonly title="Attribute: engineering_total" type="number" />
+            <input class="sheet-skill-color-setting" name="attr_engineering_ability_mod" type="hidden" value="SPATK" />
+            <input class="sheet-skill-total" name="attr_engineering_total" readonly title="Attribute: engineering_total" type="number" />
             <button
-              class="skill-roller spatk-skill"
+              class="skill-roller"
               name="roll_engineeringcheck"
               type="roll"
               value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Engineering/Operation}} {{skill-roll=[[ 1d20!kh2 + [[ @{engineering_total} + ?{Temporary Bonus|0} ]] ]]}}"
             >
-              Engineering/Operation (SPATK)
+              Engineering/Operation (<span name="attr_engineering_ability_mod"></span>)
             </button>
             <input name="attr_engineeringtalent1" value="2" title="Attribute: engineeringtalent1" type="checkbox" />
             <input name="attr_engineeringtalent2" value="2" title="Attribute: engineeringtalent2" type="checkbox" />
             <input name="attr_engineering" value="0" title="Attribute: engineering" type="number" />
 
-            <input class="spatk-read-color" name="attr_history_total" readonly title="Attribute: history_total" type="number" />
+            <input class="sheet-skill-color-setting" name="attr_history_ability_mod" type="hidden" value="SPATK" />
+            <input class="sheet-skill-total" name="attr_history_total" readonly title="Attribute: history_total" type="number" />
             <button
-              class="skill-roller spatk-skill"
+              class="skill-roller"
               name="roll_historycheck"
               type="roll"
               value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=History}} {{skill-roll=[[ 1d20!kh2 + [[ @{history_total} + ?{Temporary Bonus|0} ]] ]]}}"
             >
-              History (SPATK)
+              History (<span name="attr_history_ability_mod"></span>)
             </button>
             <input name="attr_historytalent1" value="2" title="Attribute: historytalent1" type="checkbox" />
             <input name="attr_historytalent2" value="2" title="Attribute: historytalent2" type="checkbox" />
             <input name="attr_history" value="0" title="Attribute: history" type="number" />
 
-            <input class="spdef-read-color" name="attr_insight_total" readonly title="Attribute: insight_total" type="number" />
+            <input class="sheet-skill-color-setting" name="attr_insight_ability_mod" type="hidden" value="SPDEF" />
+            <input class="sheet-skill-total" name="attr_insight_total" readonly title="Attribute: insight_total" type="number" />
             <button
-              class="skill-roller spdef-skill"
+              class="skill-roller"
               name="roll_insightcheck"
               type="roll"
               value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Insight}} {{skill-roll=[[ 1d20!kh2 + [[ @{insight_total} + ?{Temporary Bonus|0} ]] ]]}}"
             >
-              Insight (SPDEF)
+              Insight (<span name="attr_insight_ability_mod"></span>)
             </button>
             <input name="attr_insighttalent1" value="2" title="Attribute: insighttalent1" type="checkbox" />
             <input name="attr_insighttalent2" value="2" title="Attribute: insighttalent2" type="checkbox" />
             <input name="attr_insight" value="0" title="Attribute: insight" type="number" />
 
-            <input class="spatk-read-color" name="attr_investigate_total" readonly title="Attribute: investigate_total" type="number" />
+            <input class="sheet-skill-color-setting" name="attr_investigate_ability_mod" type="hidden" value="SPATK" />
+            <input class="sheet-skill-total" name="attr_investigate_total" readonly title="Attribute: investigate_total" type="number" />
             <button
-              class="skill-roller spatk-skill"
+              class="skill-roller"
               name="roll_investigatecheck"
               type="roll"
               value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Investigate}} {{skill-roll=[[ 1d20!kh2 + [[ @{investigate_total} + ?{Temporary Bonus|0} ]] ]]}}"
             >
-              Investigate (SPATK)
+              Investigate (<span name="attr_investigate_ability_mod"></span>)
             </button>
             <input name="attr_investigatetalent1" value="2" title="Attribute: investigatetalent1" type="checkbox" />
             <input name="attr_investigatetalent2" value="2" title="Attribute: investigatetalent2" type="checkbox" />
             <input name="attr_investigate" value="0" title="Attribute: investigate" type="number" />
 
-            <input class="spatk-read-color" name="attr_medicine_total" readonly title="Attribute: medicine_total" type="number" />
+            <input class="sheet-skill-color-setting" name="attr_medicine_ability_mod" type="hidden" value="SPATK" />
+            <input class="sheet-skill-total" name="attr_medicine_total" readonly title="Attribute: medicine_total" type="number" />
             <button
-              class="skill-roller spatk-skill"
+              class="skill-roller"
               name="roll_medicinecheck"
               type="roll"
               value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Medicine}} {{skill-roll=[[ 1d20!kh2 + [[ @{medicine_total} + ?{Temporary Bonus|0} ]] ]]}}"
             >
-              Medicine (SPATK)
+              Medicine (<span name="attr_medicine_ability_mod"></span>)
             </button>
             <input name="attr_medicinetalent1" value="2" title="Attribute: medicinetalent1" type="checkbox" />
             <input name="attr_medicinetalent2" value="2" title="Attribute: medicinetalent2" type="checkbox" />
             <input name="attr_medicine" value="0" title="Attribute: medicine" type="number" />
 
-            <input class="spatk-read-color" name="attr_nature_total" readonly title="Attribute: nature_total" type="number" />
+            <input class="sheet-skill-color-setting" name="attr_nature_ability_mod" type="hidden" value="SPATK" />
+            <input class="sheet-skill-total" name="attr_nature_total" readonly title="Attribute: nature_total" type="number" />
             <button
-              class="skill-roller spatk-skill"
+              class="skill-roller"
               name="roll_naturecheck"
               type="roll"
               value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Nature}} {{skill-roll=[[ 1d20!kh2 + [[ @{nature_total} + ?{Temporary Bonus|0} ]] ]]}}"
             >
-              Nature (SPATK)
+              Nature (<span name="attr_nature_ability_mod"></span>)
             </button>
             <input name="attr_naturetalent1" value="2" title="Attribute: naturetalent1" type="checkbox" />
             <input name="attr_naturetalent2" value="2" title="Attribute: naturetalent2" type="checkbox" />
             <input name="attr_nature" value="0" title="Attribute: nature" type="number" />
 
-            <input class="spdef-read-color" name="attr_perception_total" readonly title="Attribute: perception_total" type="number" />
+            <input class="sheet-skill-color-setting" name="attr_perception_ability_mod" type="hidden" value="SPDEF" />
+            <input class="sheet-skill-total" name="attr_perception_total" readonly title="Attribute: perception_total" type="number" />
             <button
-              class="skill-roller spdef-skill"
+              class="skill-roller"
               name="roll_perceptioncheck"
               type="roll"
               value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perception}} {{skill-roll=[[ 1d20!kh2 + [[ @{perception_total} + ?{Temporary Bonus|0} ]] ]]}}"
             >
-              Perception (SPDEF)
+              Perception (<span name="attr_perception_ability_mod"></span>)
             </button>
             <input name="attr_perceptiontalent1" value="2" title="Attribute: perceptiontalent1" type="checkbox" />
             <input name="attr_perceptiontalent2" value="2" title="Attribute: perceptiontalent2" type="checkbox" />
             <input name="attr_perception" value="0" title="Attribute: perception" type="number" />
 
-            <input class="spdef-read-color" name="attr_perform_total" readonly title="Attribute: perform_total" type="number" />
+            <input class="sheet-skill-color-setting" name="attr_perform_ability_mod" type="hidden" value="SPDEF" />
+            <input class="sheet-skill-total" name="attr_perform_total" readonly title="Attribute: perform_total" type="number" />
             <button
-              class="skill-roller spdef-skill"
+              class="skill-roller"
               name="roll_performcheck"
               type="roll"
               value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perform}} {{skill-roll=[[ 1d20!kh2 + [[ @{perform_total} + ?{Temporary Bonus|0} ]] ]]}}"
             >
-              Perform (SPDEF)
+              Perform (<span name="attr_perform_ability_mod"></span>)
             </button>
             <input name="attr_performtalent1" value="2" title="Attribute: performtalent1" type="checkbox" />
             <input name="attr_performtalent2" value="2" title="Attribute: performtalent2" type="checkbox" />
             <input name="attr_perform" value="0" title="Attribute: perform" type="number" />
 
-            <input class="spdef-read-color" name="attr_handling_total" readonly title="Attribute: handling_total" type="number" />
+            <input class="sheet-skill-color-setting" name="attr_handling_ability_mod" type="hidden" value="SPDEF" />
+            <input class="sheet-skill-total" name="attr_handling_total" readonly title="Attribute: handling_total" type="number" />
             <button
-              class="skill-roller spdef-skill"
+              class="skill-roller"
               name="roll_handlingcheck"
               type="roll"
               value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Pokemon Handling}} {{skill-roll=[[ 1d20!kh2 + [[ @{handling_total} + ?{Temporary Bonus|0} ]] ]]}}"
             >
-              Pokémon Handling (SPDEF)
+              Pokémon Handling (<span name="attr_handling_ability_mod"></span>)
             </button>
             <input name="attr_handlingtalent1" value="2" title="Attribute: handlingtalent1" type="checkbox" />
             <input name="attr_handlingtalent2" value="2" title="Attribute: handlingtalent2" type="checkbox" />
             <input name="attr_handling" value="0" title="Attribute: handling" type="number" />
 
-            <input class="spatk-read-color" name="attr_programming_total" readonly title="Attribute: programming_total" type="number" />
+            <input class="sheet-skill-color-setting" name="attr_programming_ability_mod" type="hidden" value="SPATK" />
+            <input class="sheet-skill-total" name="attr_programming_total" readonly title="Attribute: programming_total" type="number" />
             <button
-              class="skill-roller spatk-skill"
+              class="skill-roller"
               name="roll_programmingcheck"
               type="roll"
               value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Programming}} {{skill-roll=[[ 1d20!kh2 + [[ @{programming_total} + ?{Temporary Bonus|0} ]] ]]}}"
             >
-              Programming (SPATK)
+              Programming (<span name="attr_programming_ability_mod"></span>)
             </button>
             <input name="attr_programmingtalent1" value="2" title="Attribute: programmingtalent1" type="checkbox" />
             <input name="attr_programmingtalent2" value="2" title="Attribute: programmingtalent2" type="checkbox" />
             <input name="attr_programming" value="0" title="Attribute: programming" type="number" />
 
-            <input class="speed-read-color" name="attr_sleightofhand_total" readonly title="Attribute: sleightofhand_total" type="number" />
+            <input class="sheet-skill-color-setting" name="attr_sleight_ability_mod" type="hidden" value="SPD" />
+            <input class="sheet-skill-total" name="attr_sleightofhand_total" readonly title="Attribute: sleightofhand_total" type="number" />
             <button
-              class="skill-roller spd-skill"
+              class="skill-roller"
               name="roll_sleightofhandcheck"
               type="roll"
               value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Sleight of Hand}} {{skill-roll=[[ 1d20!kh2 + [[ @{sleightofhand_total} + ?{Temporary Bonus|0} ]] ]]}}"
             >
-              Sleight of Hand (SPD)
+              Sleight of Hand (<span name="attr_sleight_ability_mod"></span>)
             </button>
             <input name="attr_sleightofhandtalent1" value="2" title="Attribute: sleightofhandtalent1" type="checkbox" />
             <input name="attr_sleightofhandtalent2" value="2" title="Attribute: sleightofhandtalent2" type="checkbox" />
             <input name="attr_sleightofhand" value="0" title="Attribute: sleightofhand" type="number" />
 
-            <input class="speed-read-color" name="attr_stealth_total" readonly title="Attribute: stealth_total" type="number" />
+            <input class="sheet-skill-color-setting" name="attr_stealth_ability_mod" type="hidden" value="SPD" />
+            <input class="sheet-skill-total" name="attr_stealth_total" readonly title="Attribute: stealth_total" type="number" />
             <button
-              class="skill-roller spd-skill"
+              class="skill-roller"
               name="roll_stealthcheck"
               type="roll"
               value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Stealth}} {{skill-roll=[[ 1d20!kh2 + [[ @{stealth_total} + ?{Temporary Bonus|0} ]] ]]}}"
             >
-              Stealth (SPD)
+              Stealth (<span name="attr_stealth_ability_mod"></span>)
             </button>
             <input name="attr_stealthtalent1" value="2" title="Attribute: stealthtalent1" type="checkbox" />
             <input name="attr_stealthtalent2" value="2" title="Attribute: stealthtalent2" type="checkbox" />
@@ -660,14 +678,15 @@
           </div>
           <hr class="skill-separator" />
           <div class="capture-pokemon-skill tab-trainer">
-            <input class="speed-read-color" name="attr_capture_total" readonly title="Attribute: capture_total" type="number" />
+            <input class="sheet-skill-color-setting" name="attr_capture_ability_mod" type="hidden" value="SPD" />
+            <input class="sheet-skill-total" name="attr_capture_total" readonly title="Attribute: capture_total" type="number" />
             <button
-              class="skill-roller spd-skill"
+              class="skill-roller"
               name="roll_capturecheck"
               type="roll"
               value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Capture Pokémon}} {{skill-roll=[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 + @{ball_capture_modifier} ]] }}"
             >
-              Capture Pokémon (SPD)
+              Capture Pokémon (<span name="attr_capture_ability_mod"></span>)
             </button>
             <select class="sheet-ball-picker sheet-no-dropdown" name="attr_ball_capture_modifier" title="Attribute: ball_capture_modifier">
               <option value="5" selected>Basic Ball</option>
@@ -1113,7 +1132,7 @@
           <br />For best results, leave this as something you can add to a die-roll.
         </p>
       </div>
-      <div>
+      <div class="sheet-type-color-selection">
         <b title="Default value: Normal">Type & Background Color:</b>
         <b class="sheet-info-tooltip" title="Default value: Normal"> ℹ </b>
         <select class="sheet-no-dropdown" name="attr_type1" title="Attribute: type1">
@@ -1137,7 +1156,46 @@
           <option value="water">Water</option>
         </select>
         <p class="sheet-dark-text">
-          This setting will update the first type for Pokémon-type characters, and also change the background color and theme for all types of characters.
+          This setting will update the first type for Pokémon-type characters, and also change the character sheet color theme for all types of characters.
+        </p>
+      </div>
+      <div class="sheet-skill-modifier-selection">
+        <b>Skill Modifier Selection</b>
+        <div class="sheet-skill-selection">
+          <select class="sheet-no-dropdown" name="attr_skill_modifier_selection" title="Select the skill you want to modify">
+            <option selected value="acrobatics">Acrobatics</option>
+            <option value="athletics">Athletics</option>
+            <option value="bluff">Bluff/Deception</option>
+            <option value="concentration">Concentration</option>
+            <option value="constitution">Constitution</option>
+            <option value="diplomacy">Diplomacy/Persuasion</option>
+            <option value="engineering">Engineering/Operation</option>
+            <option value="history">History</option>
+            <option value="insight">Insight</option>
+            <option value="investigate">Investigate</option>
+            <option value="medicine">Medicine</option>
+            <option value="nature">Nature</option>
+            <option value="perception">Perception</option>
+            <option value="perform">Perform</option>
+            <option value="handling">Pokémon Handling</option>
+            <option value="programming">Programming</option>
+            <option value="sleight">Sleight of Hand</option>
+            <option value="stealth">Stealth</option>
+            <option value="capture">Capture Pokémon</option>
+          </select>
+          <b class="sheet-info-tooltip" title="Select the skill you want to modify"> ℹ </b>
+          <select class="sheet-no-dropdown" name="attr_skill_modifier_ability" title="Select the attribute you want to use for the selected skill.">
+            <option value="ATK">Attack</option>
+            <option value="DEF">Defense</option>
+            <option value="SPATK">Special Attack</option>
+            <option value="SPDEF">Special Defense</option>
+            <option selected value="SPD">Speed</option>
+          </select>
+          <b class="sheet-info-tooltip" title="Select the attribute you want to use for the selected skill."> ℹ </b>
+        </div>
+        <p class="sheet-dark-text">
+          This setting area allows you to change the base ability modifier added to each skill total. Select the skill you want to modify with the left
+          selector, and then assign the stat you want to use with the right selector.
         </p>
       </div>
     </div>
@@ -1847,7 +1905,7 @@
     });
   });
 
-  on("change:repeating_moves:move_category", function (event) {
+  on(`change:repeating_moves:move_category`, function (event) {
     getAttrs(["repeating_moves_move_name", "repeating_moves_move_category"], function (values) {
       var attrs = {};
       let cat = parseInt(values.repeating_moves_move_category) || 0;
@@ -1868,8 +1926,10 @@
   });
 
   on("clicked:repeating_moves:resetmoveusage", function () {
-    setAttrs({
-      repeating_moves_move_usage: 0,
+    getAttrs(["repeating_moves_move_usage"], function (values) {
+      setAttrs({
+        repeating_moves_move_usage: 0,
+      });
     });
   });
 
@@ -2076,242 +2136,191 @@
 
   // Skills Sheet Workers
 
-  // Acrobatics
-  on("change:SPDMOD change:acrobaticstalent1 change:acrobaticstalent2 change:acrobatics sheet:opened", function (eventInfo) {
-    getAttrs([`SPDMOD`, `acrobaticstalent1`, `acrobaticstalent2`, `acrobatics`, `acrobatics_total`], function (values) {
-      const stat = parseInt(values.SPDMOD) || 0;
-      const talent1 = parseInt(values.acrobaticstalent1) || 0;
-      const talent2 = parseInt(values.acrobaticstalent2) || 0;
-      const total = parseInt(values.acrobatics_total) || -1;
-      const userBonus = parseInt(values.acrobatics) || 0;
+  const cMods = "change:ATKMOD change:DEFMOD change:SPATKMOD change:SPDEFMOD change:SPDMOD";
+  const abilities = ["ATKMOD", "DEFMOD", "SPATKMOD", "SPDEFMOD", "SPDMOD"];
 
-      assignSkillTotal("acrobatics_total", stat, talent1, talent2, total, userBonus);
+  // Acrobatics
+  on(`${cMods} change:acrobatics_ability_mod change:acrobaticstalent1 change:acrobaticstalent2 change:acrobatics sheet:opened`, function (event) {
+    getAttrs(["acrobatics_ability_mod"], function (mod) {
+      const abiMod = `${mod.acrobatics_ability_mod}MOD`;
+      const source = event.sourceAttribute;
+      if (source && abilities.includes(source.toUpperCase()) && source.toUpperCase() != abiMod) return;
+      getSkillAttributes(abiMod, "acrobaticstalent1", "acrobaticstalent2", "acrobatics", "acrobatics_total");
     });
   });
 
   // Athletics
-  on("change:ATKMOD change:athleticstalent1 change:athleticstalent2 change:athletics sheet:opened", function (eventInfo) {
-    getAttrs([`ATKMOD`, `athleticstalent1`, `athleticstalent2`, `athletics`, `athletics_total`], function (values) {
-      const stat = parseInt(values.ATKMOD) || 0;
-      const talent1 = parseInt(values.athleticstalent1) || 0;
-      const talent2 = parseInt(values.athleticstalent2) || 0;
-      const total = parseInt(values.athletics_total) || -1;
-      const userBonus = parseInt(values.athletics) || 0;
-
-      assignSkillTotal("athletics_total", stat, talent1, talent2, total, userBonus);
+  on(`${cMods} change:athletics_ability_mod change:athleticstalent1 change:athleticstalent2 change:athletics sheet:opened`, function (event) {
+    getAttrs(["athletics_ability_mod"], function (mod) {
+      const abiMod = `${mod.athletics_ability_mod}MOD`;
+      const source = event.sourceAttribute;
+      if (source && abilities.includes(source.toUpperCase()) && source.toUpperCase() != abiMod) return;
+      getSkillAttributes(abiMod, "athleticstalent1", "athleticstalent2", "athletics", "athletics_total");
     });
   });
 
   // Bluff/Deception
-  on("change:SPDEFMOD change:blufftalent1 change:blufftalent2 change:bluff sheet:opened", function (eventInfo) {
-    getAttrs([`SPDEFMOD`, `blufftalent1`, `blufftalent2`, `bluff`, `bluff_total`], function (values) {
-      const stat = parseInt(values.SPDEFMOD) || 0;
-      const talent1 = parseInt(values.blufftalent1) || 0;
-      const talent2 = parseInt(values.blufftalent2) || 0;
-      const total = parseInt(values.bluff_total) || -1;
-      const userBonus = parseInt(values.bluff) || 0;
-
-      assignSkillTotal("bluff_total", stat, talent1, talent2, total, userBonus);
+  on(`${cMods} change:bluff_ability_mod change:blufftalent1 change:blufftalent2 change:bluff sheet:opened`, function (event) {
+    getAttrs(["bluff_ability_mod"], function (mod) {
+      const abiMod = `${mod.bluff_ability_mod}MOD`;
+      const source = event.sourceAttribute;
+      if (source && abilities.includes(source.toUpperCase()) && source.toUpperCase() != abiMod) return;
+      getSkillAttributes(abiMod, "blufftalent1", "blufftalent2", "bluff", "bluff_total");
     });
   });
 
   // Concentration
-  on("change:DEFMOD change:concentrationtalent1 change:concentrationtalent2 change:concentration sheet:opened", function (eventInfo) {
-    getAttrs([`DEFMOD`, `concentrationtalent1`, `concentrationtalent2`, `concentration`, `concentration_total`], function (values) {
-      const stat = parseInt(values.DEFMOD) || 0;
-      const talent1 = parseInt(values.concentrationtalent1) || 0;
-      const talent2 = parseInt(values.concentrationtalent2) || 0;
-      const total = parseInt(values.concentration_total) || -1;
-      const userBonus = parseInt(values.concentration) || 0;
-
-      assignSkillTotal("concentration_total", stat, talent1, talent2, total, userBonus);
+  on(`${cMods} change:concentration_ability_mod change:concentrationtalent1 change:concentrationtalent2 change:concentration sheet:opened`, function (event) {
+    getAttrs(["concentration_ability_mod"], function (mod) {
+      const abiMod = `${mod.concentration_ability_mod}MOD`;
+      const source = event.sourceAttribute;
+      if (source && abilities.includes(source.toUpperCase()) && source.toUpperCase() != abiMod) return;
+      getSkillAttributes(abiMod, "concentrationtalent1", "concentrationtalent2", "concentration", "concentration_total");
     });
   });
 
   // Constitution
-  on("change:DEFMOD change:constitutiontalent1 change:constitutiontalent2 change:constitution sheet:opened", function (eventInfo) {
-    getAttrs([`DEFMOD`, `constitutiontalent1`, `constitutiontalent2`, `constitution`, `constitution_total`], function (values) {
-      const stat = parseInt(values.DEFMOD) || 0;
-      const talent1 = parseInt(values.constitutiontalent1) || 0;
-      const talent2 = parseInt(values.constitutiontalent2) || 0;
-      const total = parseInt(values.constitution_total) || -1;
-      const userBonus = parseInt(values.constitution) || 0;
-
-      assignSkillTotal("constitution_total", stat, talent1, talent2, total, userBonus);
+  on(`${cMods} change:constitution_ability_mod change:constitutiontalent1 change:constitutiontalent2 change:constitution sheet:opened`, function (event) {
+    getAttrs(["constitution_ability_mod"], function (mod) {
+      const abiMod = `${mod.constitution_ability_mod}MOD`;
+      const source = event.sourceAttribute;
+      if (source && abilities.includes(source.toUpperCase()) && source.toUpperCase() != abiMod) return;
+      getSkillAttributes(abiMod, "constitutiontalent1", "constitutiontalent2", "constitution", "constitution_total");
     });
   });
 
   // Diplomacy/Persuasion
-  on("change:SPDEFMOD change:diplomacytalent1 change:diplomacytalent2 change:diplomacy sheet:opened", function (eventInfo) {
-    getAttrs([`SPDEFMOD`, `diplomacytalent1`, `diplomacytalent2`, `diplomacy`, `diplomacy_total`], function (values) {
-      const stat = parseInt(values.SPDEFMOD) || 0;
-      const talent1 = parseInt(values.diplomacytalent1) || 0;
-      const talent2 = parseInt(values.diplomacytalent2) || 0;
-      const total = parseInt(values.diplomacy_total) || -1;
-      const userBonus = parseInt(values.diplomacy) || 0;
-
-      assignSkillTotal("diplomacy_total", stat, talent1, talent2, total, userBonus);
+  on(`${cMods} change:diplomacy_ability_mod change:diplomacytalent1 change:diplomacytalent2 change:diplomacy sheet:opened`, function (event) {
+    getAttrs(["diplomacy_ability_mod"], function (mod) {
+      const abiMod = `${mod.diplomacy_ability_mod}MOD`;
+      const source = event.sourceAttribute;
+      if (source && abilities.includes(source.toUpperCase()) && source.toUpperCase() != abiMod) return;
+      getSkillAttributes(abiMod, "diplomacytalent1", "diplomacytalent2", "diplomacy", "diplomacy_total");
     });
   });
 
   // Engineering/Operation
-  on("change:SPATKMOD change:engineeringtalent1 change:engineeringtalent2 change:engineering sheet:opened", function (eventInfo) {
-    getAttrs([`SPATKMOD`, `engineeringtalent1`, `engineeringtalent2`, `engineering`, `engineering_total`], function (values) {
-      const stat = parseInt(values.SPATKMOD) || 0;
-      const talent1 = parseInt(values.engineeringtalent1) || 0;
-      const talent2 = parseInt(values.engineeringtalent2) || 0;
-      const total = parseInt(values.engineering_total) || -1;
-      const userBonus = parseInt(values.engineering) || 0;
-
-      assignSkillTotal("engineering_total", stat, talent1, talent2, total, userBonus);
+  on(`${cMods} change:engineering_ability_mod change:engineeringtalent1 change:engineeringtalent2 change:engineering sheet:opened`, function (event) {
+    getAttrs(["engineering_ability_mod"], function (mod) {
+      const abiMod = `${mod.engineering_ability_mod}MOD`;
+      const source = event.sourceAttribute;
+      if (source && abilities.includes(source.toUpperCase()) && source.toUpperCase() != abiMod) return;
+      getSkillAttributes(abiMod, "engineeringtalent1", "engineeringtalent2", "engineering", "engineering_total");
     });
   });
 
   // History
-  on("change:SPATKMOD change:historytalent1 change:historytalent2 change:history sheet:opened", function (eventInfo) {
-    getAttrs([`SPATKMOD`, `historytalent1`, `historytalent2`, `history`, `history_total`], function (values) {
-      const stat = parseInt(values.SPATKMOD) || 0;
-      const talent1 = parseInt(values.historytalent1) || 0;
-      const talent2 = parseInt(values.historytalent2) || 0;
-      const total = parseInt(values.history_total) || -1;
-      const userBonus = parseInt(values.history) || 0;
-
-      assignSkillTotal("history_total", stat, talent1, talent2, total, userBonus);
+  on(`${cMods} change:history_ability_mod change:historytalent1 change:historytalent2 change:history sheet:opened`, function (event) {
+    getAttrs(["history_ability_mod"], function (mod) {
+      const abiMod = `${mod.history_ability_mod}MOD`;
+      const source = event.sourceAttribute;
+      if (source && abilities.includes(source.toUpperCase()) && source.toUpperCase() != abiMod) return;
+      getSkillAttributes(abiMod, "historytalent1", "historytalent2", "history", "history_total");
     });
   });
 
   // Insight
-  on("change:SPDEFMOD change:insighttalent1 change:insighttalent2 change:insight sheet:opened", function (eventInfo) {
-    getAttrs([`SPDEFMOD`, `insighttalent1`, `insighttalent2`, `insight`, `insight_total`], function (values) {
-      const stat = parseInt(values.SPDEFMOD) || 0;
-      const talent1 = parseInt(values.insighttalent1) || 0;
-      const talent2 = parseInt(values.insighttalent2) || 0;
-      const total = parseInt(values.insight_total) || -1;
-      const userBonus = parseInt(values.insight) || 0;
-
-      assignSkillTotal("insight_total", stat, talent1, talent2, total, userBonus);
+  on(`${cMods} change:insight_ability_mod change:insighttalent1 change:insighttalent2 change:insight sheet:opened`, function (event) {
+    getAttrs(["insight_ability_mod"], function (mod) {
+      const abiMod = `${mod.insight_ability_mod}MOD`;
+      const source = event.sourceAttribute;
+      if (source && abilities.includes(source.toUpperCase()) && source.toUpperCase() != abiMod) return;
+      getSkillAttributes(abiMod, "insighttalent1", "insighttalent2", "insight", "insight_total");
     });
   });
 
   // Investigate
-  on("change:SPATKMOD change:investigatetalent1 change:investigatetalent2 change:investigate sheet:opened", function (eventInfo) {
-    getAttrs([`SPATKMOD`, `investigatetalent1`, `investigatetalent2`, `investigate`, `investigate_total`], function (values) {
-      const stat = parseInt(values.SPATKMOD) || 0;
-      const talent1 = parseInt(values.investigatetalent1) || 0;
-      const talent2 = parseInt(values.investigatetalent2) || 0;
-      const total = parseInt(values.investigate_total) || -1;
-      const userBonus = parseInt(values.investigate) || 0;
-
-      assignSkillTotal("investigate_total", stat, talent1, talent2, total, userBonus);
+  on(`${cMods} change:investigate_ability_mod change:investigatetalent1 change:investigatetalent2 change:investigate sheet:opened`, function (event) {
+    getAttrs(["investigate_ability_mod"], function (mod) {
+      const abiMod = `${mod.investigate_ability_mod}MOD`;
+      const source = event.sourceAttribute;
+      if (source && abilities.includes(source.toUpperCase()) && source.toUpperCase() != abiMod) return;
+      getSkillAttributes(abiMod, "investigatetalent1", "investigatetalent2", "investigate", "investigate_total");
     });
   });
 
   // Medicine
-  on("change:SPATKMOD change:medicinetalent1 change:medicinetalent2 change:medicine sheet:opened", function (eventInfo) {
-    getAttrs([`SPATKMOD`, `medicinetalent1`, `medicinetalent2`, `medicine`, `medicine_total`], function (values) {
-      const stat = parseInt(values.SPATKMOD) || 0;
-      const talent1 = parseInt(values.medicinetalent1) || 0;
-      const talent2 = parseInt(values.medicinetalent2) || 0;
-      const total = parseInt(values.medicine_total) || -1;
-      const userBonus = parseInt(values.medicine) || 0;
-
-      assignSkillTotal("medicine_total", stat, talent1, talent2, total, userBonus);
+  on(`${cMods} change:medicine_ability_mod change:medicinetalent1 change:medicinetalent2 change:medicine sheet:opened`, function (event) {
+    getAttrs(["medicine_ability_mod"], function (mod) {
+      const abiMod = `${mod.medicine_ability_mod}MOD`;
+      const source = event.sourceAttribute;
+      if (source && abilities.includes(source.toUpperCase()) && source.toUpperCase() != abiMod) return;
+      getSkillAttributes(abiMod, "medicinetalent1", "medicinetalent2", "medicine", "medicine_total");
     });
   });
 
   // Nature
-  on("change:SPATKMOD change:naturetalent1 change:naturetalent2 change:nature sheet:opened", function (eventInfo) {
-    getAttrs([`SPATKMOD`, `naturetalent1`, `naturetalent2`, `nature`, `nature_total`], function (values) {
-      const stat = parseInt(values.SPATKMOD) || 0;
-      const talent1 = parseInt(values.naturetalent1) || 0;
-      const talent2 = parseInt(values.naturetalent2) || 0;
-      const total = parseInt(values.nature_total) || -1;
-      const userBonus = parseInt(values.nature) || 0;
-
-      assignSkillTotal("nature_total", stat, talent1, talent2, total, userBonus);
+  on(`${cMods} change:nature_ability_mod change:naturetalent1 change:naturetalent2 change:nature sheet:opened`, function (event) {
+    getAttrs(["nature_ability_mod"], function (mod) {
+      const abiMod = `${mod.nature_ability_mod}MOD`;
+      const source = event.sourceAttribute;
+      if (source && abilities.includes(source.toUpperCase()) && source.toUpperCase() != abiMod) return;
+      getSkillAttributes(abiMod, "naturetalent1", "naturetalent2", "nature", "nature_total");
     });
   });
 
   // Perception
-  on("change:SPDEFMOD change:perceptiontalent1 change:perceptiontalent2 change:perception sheet:opened", function (eventInfo) {
-    getAttrs([`SPDEFMOD`, `perceptiontalent1`, `perceptiontalent2`, `perception`, `perception_total`], function (values) {
-      const stat = parseInt(values.SPDEFMOD) || 0;
-      const talent1 = parseInt(values.perceptiontalent1) || 0;
-      const talent2 = parseInt(values.perceptiontalent2) || 0;
-      const total = parseInt(values.perception_total) || -1;
-      const userBonus = parseInt(values.perception) || 0;
-
-      assignSkillTotal("perception_total", stat, talent1, talent2, total, userBonus);
+  on(`${cMods} change:perception_ability_mod change:perceptiontalent1 change:perceptiontalent2 change:perception sheet:opened`, function (event) {
+    getAttrs(["perception_ability_mod"], function (mod) {
+      const abiMod = `${mod.perception_ability_mod}MOD`;
+      const source = event.sourceAttribute;
+      if (source && abilities.includes(source.toUpperCase()) && source.toUpperCase() != abiMod) return;
+      getSkillAttributes(abiMod, "perceptiontalent1", "perceptiontalent2", "perception", "perception_total");
     });
   });
 
   // Perform
-  on("change:SPDEFMOD change:performtalent1 change:performtalent2 change:perform sheet:opened", function (eventInfo) {
-    getAttrs([`SPDEFMOD`, `performtalent1`, `performtalent2`, `perform`, `perform_total`], function (values) {
-      const stat = parseInt(values.SPDEFMOD) || 0;
-      const talent1 = parseInt(values.performtalent1) || 0;
-      const talent2 = parseInt(values.performtalent2) || 0;
-      const total = parseInt(values.perform_total) || -1;
-      const userBonus = parseInt(values.perform) || 0;
-
-      assignSkillTotal("perform_total", stat, talent1, talent2, total, userBonus);
+  on(`${cMods} change:perform_ability_mod change:performtalent1 change:performtalent2 change:perform sheet:opened`, function (event) {
+    getAttrs(["perform_ability_mod"], function (mod) {
+      const abiMod = `${mod.perform_ability_mod}MOD`;
+      const source = event.sourceAttribute;
+      if (source && abilities.includes(source.toUpperCase()) && source.toUpperCase() != abiMod) return;
+      getSkillAttributes(abiMod, "performtalent1", "performtalent2", "perform", "perform_total");
     });
   });
 
   // Pokémon Handling
-  on("change:SPDEFMOD change:handlingtalent1 change:handlingtalent2 change:handling sheet:opened", function (eventInfo) {
-    getAttrs([`SPDEFMOD`, `handlingtalent1`, `handlingtalent2`, `handling`, `handling_total`], function (values) {
-      const stat = parseInt(values.SPDEFMOD) || 0;
-      const talent1 = parseInt(values.handlingtalent1) || 0;
-      const talent2 = parseInt(values.handlingtalent2) || 0;
-      const total = parseInt(values.handling_total) || -1;
-      const userBonus = parseInt(values.handling) || 0;
-
-      assignSkillTotal("handling_total", stat, talent1, talent2, total, userBonus);
+  on(`${cMods} change:handling_ability_mod change:handlingtalent1 change:handlingtalent2 change:handling sheet:opened`, function (event) {
+    getAttrs(["handling_ability_mod"], function (mod) {
+      const abiMod = `${mod.handling_ability_mod}MOD`;
+      const source = event.sourceAttribute;
+      if (source && abilities.includes(source.toUpperCase()) && source.toUpperCase() != abiMod) return;
+      getSkillAttributes(abiMod, "handlingtalent1", "handlingtalent2", "handling", "handling_total");
     });
   });
 
   // Programming
-  on("change:SPATKMOD change:programmingtalent1 change:programmingtalent2 change:programming sheet:opened", function (eventInfo) {
-    getAttrs([`SPATKMOD`, `programmingtalent1`, `programmingtalent2`, `programming`, `programming_total`], function (values) {
-      const stat = parseInt(values.SPATKMOD) || 0;
-      const talent1 = parseInt(values.programmingtalent1) || 0;
-      const talent2 = parseInt(values.programmingtalent2) || 0;
-      const total = parseInt(values.programming_total) || -1;
-      const userBonus = parseInt(values.programming) || 0;
-
-      assignSkillTotal("programming_total", stat, talent1, talent2, total, userBonus);
+  on(`${cMods} change:programming_ability_mod change:programmingtalent1 change:programmingtalent2 change:programming sheet:opened`, function (event) {
+    getAttrs(["programming_ability_mod"], function (mod) {
+      const abiMod = `${mod.programming_ability_mod}MOD`;
+      const source = event.sourceAttribute;
+      if (source && abilities.includes(source.toUpperCase()) && source.toUpperCase() != abiMod) return;
+      getSkillAttributes(abiMod, "programmingtalent1", "programmingtalent2", "programming", "programming_total");
     });
   });
 
   // Sleight of Hand
-  on("change:SPDMOD change:sleightofhandtalent1 change:sleightofhandtalent2 change:sleightofhand sheet:opened", function (eventInfo) {
-    getAttrs([`SPDMOD`, `sleightofhandtalent1`, `sleightofhandtalent2`, `sleightofhand`, `sleightofhand_total`], function (values) {
-      const stat = parseInt(values.SPDMOD) || 0;
-      const talent1 = parseInt(values.sleightofhandtalent1) || 0;
-      const talent2 = parseInt(values.sleightofhandtalent2) || 0;
-      const total = parseInt(values.sleightofhand_total) || -1;
-      const userBonus = parseInt(values.sleightofhand) || 0;
-
-      assignSkillTotal("sleightofhand_total", stat, talent1, talent2, total, userBonus);
+  on(`${cMods} change:sleight_ability_mod change:sleightofhandtalent1 change:sleightofhandtalent2 change:sleightofhand sheet:opened`, function (event) {
+    getAttrs(["sleight_ability_mod"], function (mod) {
+      const abiMod = `${mod.sleight_ability_mod}MOD`;
+      const source = event.sourceAttribute;
+      if (source && abilities.includes(source.toUpperCase()) && source.toUpperCase() != abiMod) return;
+      getSkillAttributes(abiMod, "sleightofhandtalent1", "sleightofhandtalent2", "sleightofhand", "sleightofhand_total");
     });
   });
 
   // Stealth
-  on("change:SPDMOD change:stealthtalent1 change:stealthtalent2 change:stealth sheet:opened", function (eventInfo) {
-    getAttrs([`SPDMOD`, `stealthtalent1`, `stealthtalent2`, `stealth`, `stealth_total`], function (values) {
-      const stat = parseInt(values.SPDMOD) || 0;
-      const talent1 = parseInt(values.stealthtalent1) || 0;
-      const talent2 = parseInt(values.stealthtalent2) || 0;
-      const total = parseInt(values.stealth_total) || -1;
-      const userBonus = parseInt(values.stealth) || 0;
-
-      assignSkillTotal("stealth_total", stat, talent1, talent2, total, userBonus);
+  on(`${cMods} change:stealth_ability_mod change:stealthtalent1 change:stealthtalent2 change:stealth sheet:opened`, function (event) {
+    getAttrs(["stealth_ability_mod"], function (mod) {
+      const abiMod = `${mod.stealth_ability_mod}MOD`;
+      const source = event.sourceAttribute;
+      if (source && abilities.includes(source.toUpperCase()) && source.toUpperCase() != abiMod) return;
+      getSkillAttributes(abiMod, "stealthtalent1", "stealthtalent2", "stealth", "stealth_total");
     });
   });
 
   // Capture
-  on("change:SPDMOD change:capture sheet:opened", function (eventInfo) {
+  on("change:SPDMOD change:capture sheet:opened", function () {
     getAttrs([`SPDMOD`, `capture_total`], function (values) {
       const stat = parseInt(values.SPDMOD) || 0;
       const total = parseInt(values.capture_total) || -1;
@@ -2319,6 +2328,18 @@
       assignSkillTotal("capture_total", stat, 0, 0, total, 0);
     });
   });
+
+  function getSkillAttributes(statLabel, talent1Label, talent2Label, userBonusLabel, totalLabel) {
+    getAttrs([statLabel, talent1Label, talent2Label, totalLabel, userBonusLabel], function (attributes) {
+      const stat = parseInt(attributes[statLabel]) || 0;
+      const talent1 = parseInt(attributes[talent1Label]) || 0;
+      const talent2 = parseInt(attributes[talent2Label]) || 0;
+      const total = parseInt(attributes[totalLabel]) || -1;
+      const userBonus = parseInt(attributes[userBonusLabel]) || 0;
+
+      assignSkillTotal(totalLabel, stat, talent1, talent2, total, userBonus);
+    });
+  }
 
   function assignSkillTotal(skillName, stat, leftTalent, rightTalent, oldTotal, userBonus) {
     const talentAccumulator = leftTalent + rightTalent == 4 ? 1 : 0;
@@ -2331,8 +2352,27 @@
 
   // Move Collapsing
   on("change:repeating_moves:options_flag", function (eventInfo) {
-    const flag = eventInfo.newValue == "on" ? "-" : "+";
+    const flag = eventInfo.newValue == 1 ? "-" : "+";
     setAttrs({ repeating_moves_flag: flag });
+  });
+
+  // Changing Skill Ability Modifiers
+  var skills = ["acrobatics", "athletics", "bluff", "concentration", "constitution", "diplomacy", "engineering", "history", "insight"];
+  skills.push("investigate", "medicine", "nature", "perception", "perform", "handling", "programming", "sleight", "stealth");
+
+  on("change:skill_modifier_selection", function (eventInfo) {
+    const abilityMod = eventInfo.newValue + "_ability_mod";
+    getAttrs([abilityMod], function (attributes) {
+      setAttrs({ skill_modifier_ability: attributes[abilityMod] });
+    });
+  });
+
+  on("change:skill_modifier_ability", function (eventInfo) {
+    getAttrs(["skill_modifier_selection"], function (attributes) {
+      const skill = attributes.skill_modifier_selection;
+      const skillMod = skill + "_ability_mod";
+      setAttrs({ [skillMod]: eventInfo.newValue });
+    });
   });
 
   // ATTRIBUTE DEPRECATION SHEET WORKERS

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -8,6 +8,11 @@ https://discord.gg/F24Ka8E
 
 ## Changelog
 
+### Jan 8th, 2020
+
+- Added the ability to change which ability applies to which skills to the Configuration page
+  - Unfortunately you'll still need to add any second ability modifier applied to the manual bonus column - support for multiple abilities has been added to the to-do list
+
 ### Jan 7th, 2020
 
 - Added support for scatter moves
@@ -111,6 +116,7 @@ Things we want to add to the character sheet, presented in no particular order o
 - [x] ~~Handle temporary stat changes somehow, this may be a lot of work~~
 - [x] ~~Prevent critical range from going below 0 or above 20, maybe do similar to other fields~~
 - [x] ~~Add a Settings page~~
+- [ ] Allow a second ability score to apply to skill checks
 - [ ] Allow formula calculations for the extra damage fields
 - [ ] Allow modifications to movement (maybe just an extra box)
 - [ ] Display the adjusted stat score when temporary stat changes are provided


### PR DESCRIPTION

## Changes / Comments

- Adds a new option to the configuration page which allows swapping the associated ability for each skill - _and the capture pokémon meta-skill_
- Updates CSS to allow for attribute-based colouring of each skill field
- Updates sheet workers to allow for double-dipping into getting attributes, and slightly refactors them to be more generic! Woo!




## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name. _Yes_
- [x] Is this a bug fix? _No_
- [x] Does this add functional enhancements (new features or extending existing features)? _Yes_
- [x] Does this add or change functional aesthetics (such as layout or color scheme)? _Yeah... kinda_ 
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data? _Nothing removed_
- [x] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository)? _Nope!_

If you do not know English. Please leave a comment in your native language.
