### PR TITLE
[Opera RPG] Changes on layout of some fields and of the Roll Template

### DIFF
--- a/OperaRPG/operarpg.css
+++ b/OperaRPG/operarpg.css
@@ -288,7 +288,7 @@
 }
 
 .sheet-long-range-weapons-hidden {
-	grid-template-columns: 100px 50px 60px 70px 70px;
+	grid-template-columns: 50px 60px 70px 70px;
 }
 
 .sheet-weapons-die-label {

--- a/OperaRPG/operarpg.css
+++ b/OperaRPG/operarpg.css
@@ -249,7 +249,7 @@
 	display: grid;
 	justify-items: stretch;
 	align-items: center;
-	column-gap: 10px;
+	column-gap: 5px;
 	row-gap: 5px;
 }
 
@@ -349,6 +349,7 @@
 	flex-direction: row;
 	align-items: center;
 	justify-content: flex-end;
+	margin-bottom: 10px;
 }
 
 /*----------------- TAB CONTROL ------------------*/

--- a/OperaRPG/operarpg.css
+++ b/OperaRPG/operarpg.css
@@ -274,12 +274,21 @@
 	grid-template-columns: auto 60px 60px 24px;
 }
 
-.sheet-weapons {
-	grid-template-columns: auto 40px 100px 90px 90px 65px 65px 45px 24px;
+.sheet-contact-weapons {
+	grid-template-columns: 100px 40px 60px 60px 60px 24px;
 }
 
-.sheet-fight-span {
-	grid-column: 6/10;
+.sheet-contact-weapons-hidden {
+	grid-template-columns: 100px 100px 100px;
+	margin-bottom: 5px;
+}
+
+.sheet-long-range-weapons {
+	grid-template-columns: 100px 40px 60px 60px 60px 24px;
+}
+
+.sheet-long-range-weapons-hidden {
+	grid-template-columns: 100px 50px 60px 70px 70px;
 }
 
 .sheet-weapons-die-label {
@@ -310,10 +319,6 @@
 	grid-template-columns: auto auto auto;
 	column-gap: 2px;
 	align-items: center;
-}
-
-.sheet-weapon-hidden {
-	grid-template-columns: 70px 70px 70px;
 }
 
 .sheet-powers {
@@ -428,7 +433,8 @@
 	content: ')';
 }
 
-.sheet-main-container .repcontainer[data-groupname="repeating_weapons"]>.repitem .itemcontrol, 
+.sheet-main-container .repcontainer[data-groupname="repeating_contactweapons"]>.repitem .itemcontrol, 
+.sheet-main-container .repcontainer[data-groupname="repeating_longrangeweapons"]>.repitem .itemcontrol, 
 .sheet-main-container .repcontainer[data-groupname="repeating_equipments"]>.repitem .itemcontrol,
 .sheet-main-container .repcontainer[data-groupname="repeating_skills"]>.repitem .itemcontrol,
 .sheet-main-container .repcontainer[data-groupname="repeating_powers"]>.repitem .itemcontrol,
@@ -438,7 +444,8 @@
 	font-family: 'Pictos'
 }
 
-.sheet-main-container .repcontainer[data-groupname="repeating_weapons"]>.repitem .repcontrol_del, 
+.sheet-main-container .repcontainer[data-groupname="repeating_contactweapons"]>.repitem .repcontrol_del, 
+.sheet-main-container .repcontainer[data-groupname="repeating_longrangeweapons"]>.repitem .repcontrol_del, 
 .sheet-main-container .repcontainer[data-groupname="repeating_equipments"]>.repitem .repcontrol_del,
 .sheet-main-container .repcontainer[data-groupname="repeating_skills"]>.repitem .repcontrol_del,
 .sheet-main-container .repcontainer[data-groupname="repeating_powers"]>.repitem .repcontrol_del,

--- a/OperaRPG/operarpg.html
+++ b/OperaRPG/operarpg.html
@@ -572,7 +572,7 @@
               <input class="weapons-base" disabled="true" name="attr_fightblowtotal" type="text"
                 title="@{fightblowtotal}" value="@{fightblow} + (@{chardexterity} @{weaponeffect})" />
               <button type="roll" class="roll-button" name="roll_fightblow_check" title="@{fightblow_check}"
-                value="&{template:main} {{charname=@{character_name}}} {{action=@{fight}}} {{value=@{blow}}} {{damage=[[@{fightdamage}+@{physicaldamage}]]}} {{bodyroll=[[2d6cs0cf0]]}} {{roll=[[2d6cs>2cf<5 + @{fightblow} + (@{chardexterity} @{weaponeffect}) ]] }}"></button>
+                value="&{template:main} {{charname=@{character_name}}} {{action=@{fight}}} {{value=@{blow}}} {{damage=[[@{fightdamagetotal}]]}} {{bodyroll=[[2d6cs0cf0]]}} {{roll=[[2d6cs>2cf<5 + @{fightblow} + (@{chardexterity} @{weaponeffect}) ]] }}"></button>
             </div>
 
             <div class="weapons-subheader-grid">
@@ -662,7 +662,7 @@
                     disabled="true"
                     value="@{weaponlevel} + @{weaponblow} + @{fightblow} + (@{chardexterity} @{weaponeffect})" />
                   <button type="roll" class="roll-button" name="roll_weaponblow_check" title="@{weaponblow_check}"
-                    value="&{template:main} {{charname=@{character_name}}} {{action=@{weaponname}}} {{value=@{blow}}} {{damage=[[@{weapondamage}+@{physicaldamage}]]}} {{bodyroll=[[2d6cs0cf0]]}} {{roll=[[2d6cs>2cf<5 + @{weaponlevel} + @{weaponblow} + @{fightblow} + (@{chardexterity} @{weaponeffect}) ]] }}"></button>
+                    value="&{template:main} {{charname=@{character_name}}} {{action=@{weaponname}}} {{value=@{blow}}} {{damage=[[@{weapondamagetotal}]]}} {{bodyroll=[[2d6cs0cf0]]}} {{roll=[[2d6cs>2cf<5 + @{weaponlevel} + @{weaponblow} + @{fightblow} + (@{chardexterity} @{weaponeffect}) ]] }}"></button>
                 </div>
 
                 <div class="weapons-subheader-grid">
@@ -768,15 +768,15 @@
                 <input class="row-item-margin" name="attr_weaponname" type="text" title="@{weaponname}" />
                 <input class="row-item-margin" name="attr_weaponlevel" type="text" title="@{weaponlevel}" value="0" />
 
-                <input class="weapons-damage-total" readonly="true" name="attr_weapondamagetotal" type="text"
-                  title="@{weapondamagetotal}" value="0" />
+                <input class="weapons-damage-total" name="attr_weapondamagetotal" type="text"
+                  title="@{weapondamagetotal}" />
 
                 <div class="weapons-die-label">
                   <input class="row-item-margin" name="attr_weaponfastshot" type="number" title="@{weaponfastshot}"
                     value="0" />
                   <button type="roll" class="roll-button" name="roll_weaponfastshot_check"
                     title="@{weaponfastshot_check}"
-                    value="&{template:main} {{charname=@{character_name}}} {{action=@{weaponname}}} {{value=@{fast_shot}}} {{damage=[[@{weapondamage}]]}} {{bodyroll=[[2d6cs0cf0]]}} {{roll=[[2d6cs<5cf>2 + @{chardexterity} + @{weaponlevel} + @{weaponfastshot} ]] }}"></button>
+                    value="&{template:main} {{charname=@{character_name}}} {{action=@{weaponname}}} {{value=@{fast_shot}}} {{damage=[[@{weapondamagetotal}]]}} {{bodyroll=[[2d6cs0cf0]]}} {{roll=[[2d6cs<5cf>2 + @{chardexterity} + @{weaponlevel} + @{weaponfastshot} ]] }}"></button>
                 </div>
 
                 <div class="weapons-die-label">
@@ -784,7 +784,7 @@
                     value="0" />
                   <button type="roll" class="roll-button" name="roll_weaponaimedshot_check"
                     title="@{weaponaimedshot_check}"
-                    value="&{template:main} {{charname=@{character_name}}} {{action=@{weaponname}}} {{value=@{aimed_shot}}} {{damage=[[@{weapondamage}]]}} {{bodyroll=[[2d6cs0cf0]]}} {{roll=[[2d6cs<5cf>2 + @{chardexterity} + @{weaponlevel} + @{weaponaimedshot} ]] }}"></button>
+                    value="&{template:main} {{charname=@{character_name}}} {{action=@{weaponname}}} {{value=@{aimed_shot}}} {{damage=[[@{weapondamagetotal}]]}} {{bodyroll=[[2d6cs0cf0]]}} {{roll=[[2d6cs<5cf>2 + @{chardexterity} + @{weaponlevel} + @{weaponaimedshot} ]] }}"></button>
                 </div>
 
                 <div class="showhidebutton arrowtype">
@@ -800,28 +800,14 @@
               <div class="showhide flex-column">
 
                 <div class="repeatable-grid long-range-weapons-hidden">
-                  <div>
-                    <span class="column-header  secondary-font" data-i18n="damage">Dano</span>
-                    <div class="weapons-subheader-grid">
-                      <span class="column-subheader  secondary-font" data-i18n="base">Base</span>
-                      <span class="column-subheader  secondary-font" data-i18n="total">Total</span>
-                    </div>
-                  </div>
                   <span class="column-header  secondary-font" data-i18n="shots">Carga</span>
                   <span class="column-header  secondary-font" data-i18n="reload_actions">Ações de Recarga</span>
                   <span class="column-header  secondary-font" data-i18n="range">Alcance</span>
                   <span class="column-header  secondary-font" data-i18n="rate_of_fire">Cad</span>
 
-                  <div class="weapons-subheader-grid">
-                    <input class="weapons-damage-base" name="attr_weapondamage" type="text" title="@{weapondamage}"
-                      value="0" />
-                    <input class="weapons-damage-total" readonly="true" name="attr_weapondamagetotal" type="text"
-                      title="@{weapondamagetotal}" value="0" />
-                  </div>
-                  <input class="row-item-margin" name="attr_weaponrshots" type="number" title="@{weaponshots}"
-                    value="0" />
+                  <input class="row-item-margin" name="attr_weaponrshots" type="number" title="@{weaponshots}" />
                   <input class="row-item-margin" name="attr_weaponreloadactions" type="number"
-                    title="@{weaponreloadactions}" value="0" />
+                    title="@{weaponreloadactions}" />
                   <input class="row-item-margin" name="attr_weaponrange" type="text" title="@{weaponrange}" />
                   <input class="row-item-margin" name="attr_weaponrateoffire" type="text" title="@{weaponrateoffire}" />
 
@@ -1188,13 +1174,13 @@
     });
   }
 
-  /*Controling fight damage total*/
+  /*Controlling fight damage total*/
   on('sheet:opened change:fightdamage change:physicaldamage', function(eventInfo) {
     
     setRollTotal(['fightdamage', 'physicaldamage'], 'fightdamagetotal');
   });
 
-  /*Controling contact weapons damage total*/
+  /*Controlling contact weapons damage total*/
   on('change:repeating_contactweapons:weapondamage change:physicaldamage', function(eventInfo) {
     console.log('weapon damage total');
     setRollTotal(['repeating_contactweapons_weapondamage', 'physicaldamage'], 'repeating_contactweapons_weapondamagetotal');

--- a/OperaRPG/operarpg.html
+++ b/OperaRPG/operarpg.html
@@ -85,14 +85,14 @@
 
       <div class="actions-label">
         <button type="roll" class="roll-button" name="roll_initiative_check" title="@{initiative_check}"
-          value="&{template:main} {{charname=@{character_name}}} {{action=@{initiative}}} {{value=[[@{initiativetotal}]]}} {{result=[[2d6cs>2cf<5+@{initiativetotal}}+?{@{modifier}|0}]]}}"></button>
+          value="&{template:main} {{charname=@{character_name}}} {{action=@{initiative}}} {{value=[[@{initiativetotal}]]}} {{roll=[[2d6cs>2cf<5+@{initiativetotal}}]]}}"></button>
         <span class="label secondary-font" data-i18n="initiative">Iniciativa</span>
       </div>
 
       <div class="init-grid">
 
         <span class="column-header secondary-font" data-i18n="base">Base</span>
-        <span class="column-header  secondary-font" data-i18n="effect">Effect</span>
+        <span class="column-header  secondary-font" data-i18n="effect">Efeito</span>
         <span class="column-header secondary-font" data-i18n="modifier">Mod</span>
         <span class="column-header secondary-font" data-i18n="total">Total</span>
 
@@ -112,7 +112,7 @@
 
       <div class="actions-label">
         <button type="roll" class="roll-button" name="roll_dodge_check" title="@{dodge_check}"
-          value="&{template:main} {{charname=@{character_name}}} {{action=@{dodge}}} {{value=[[@{dodgetotal}]]}} {{result=[[2d6cs>2cf<5+@{dodgetotal}}+?{@{modifier}|0}]]}}"></button>
+          value="&{template:main} {{charname=@{character_name}}} {{action=@{dodge}}} {{value=[[@{dodgetotal}]]}} {{roll=[[2d6cs>2cf<5+@{dodgetotal}}]]}}"></button>
         <span class="label secondary-font" data-i18n="dodge">Esquiva</span>
       </div>
 
@@ -175,7 +175,7 @@
             <span class="column-header  secondary-font" data-i18n="total">Total</span>
 
             <button type="roll" class="roll-button" name="roll_physique_check" title="@{physique_check}"
-              value="&{template:main} {{charname=@{character_name}}} {{action=@{physique}}} {{value=[[@{charphysique}]]}} {{result=[[?{@{normalorcontest} | @{normal}, 2d6cs<5cf>2 | @{contest}, 2d6cs>2cf<5+@{charphysique}}+?{@{modifier}|0}]]}}"></button>
+              value="&{template:main} {{charname=@{character_name}}} {{action=@{physique}}} {{value=[[@{charphysique}]]}} {{roll=[[2d6cs<5cf>2]]}} {{dispute=[[2d6cs>2cf<5+@{charphysique}]]}}"></button>
             <span class="label secondary-font" data-i18n="physique">Físico</span>
             <input name="attr_charphysique" type="number" title="@{charphysique}" value="0" />
             <select class="select" name="attr_charphysiquemodoperator" title="@{physiquemodoperator}">
@@ -190,7 +190,7 @@
               value="floor(@{charphysique} @{charphysicalfeatureeffect}) - @{charphysiquedamage}" />
 
             <button type="roll" class="roll-button" name="roll_dexterity_check" title="@{dexterity_check}"
-              value="&{template:main} {{charname=@{character_name}}} {{action=@{dexterity}}} {{value=[[@{chardexterity}]]}} {{result=[[?{@{normalorcontest} | @{normal}, 2d6cs<5cf>2 | @{contest}, 2d6cs>2cf<5+@{chardexterity}}+?{@{modifier}|0}]]}}"></button>
+              value="&{template:main} {{charname=@{character_name}}} {{action=@{dexterity}}} {{value=[[@{chardexterity}]]}} {{roll=[[2d6cs<5cf>2]]}} {{dispute=[[2d6cs>2cf<5+@{chardexterity}]]}}"></button>
             <span class="label secondary-font" data-i18n="dexterity">Destreza</span>
             <input name="attr_chardexterity" type="number" title="@{chardexterity}" value="0" />
             <select class="select" name="attr_chardexteritymodoperator" title="@{dexteritymodoperator}">
@@ -205,7 +205,7 @@
               value="floor(@{chardexterity} @{chardexterityfeatureeffect}) - @{chardexteritydamage}" />
 
             <button type="roll" class="roll-button" name="roll_intelligence_check" title="@{intelligence_check}"
-              value="&{template:main} {{charname=@{character_name}}} {{action=@{intelligence}}} {{value=[[@{charintelligence}]]}} {{result=[[?{@{normalorcontest} | @{normal}, 2d6cs<5cf>2 | @{contest}, 2d6cs>2cf<5+@{charintelligence}}+?{@{modifier}|0}]]}}"></button>
+              value="&{template:main} {{charname=@{character_name}}} {{action=@{intelligence}}} {{value=[[@{charintelligence}]]}} {{roll=[[2d6cs<5cf>2]]}} {{dispute=[[2d6cs>2cf<5+@{charintelligence}]]}}"></button>
             <span class="label secondary-font" data-i18n="intelligence">Inteligência</span>
             <input name="attr_charintelligence" type="number" title="@{charintelligence}" value="0" />
             <select class="select" name="attr_charintelligencemodoperator" title="@{intelligencemodoperator}">
@@ -220,7 +220,7 @@
               value="floor(@{charintelligence} @{charintelligencefeatureeffect}) - @{charintelligencedamage}" />
 
             <button type="roll" class="roll-button" name="roll_perception_check" title="@{perception_check}"
-              value="&{template:main} {{charname=@{character_name}}} {{action=@{perception}}} {{value=[[@{charperception}]]}} {{result=[[?{@{normalorcontest} | @{normal}, 2d6cs<5cf>2 | @{contest}, 2d6cs>2cf<5+@{charperception}}+?{@{modifier}|0}]]}}"></button>
+              value="&{template:main} {{charname=@{character_name}}} {{action=@{perception}}} {{value=[[@{charperception}]]}} {{roll=[[2d6cs<5cf>2]]}} {{dispute=[[2d6cs>2cf<5+@{charperception}]]}}"></button>
             <span class="label secondary-font" data-i18n="perception">Percepção</span>
             <input name="attr_charperception" type="number" title="@{charperception}" value="0" />
             <select class="select" name="attr_charperceptionmodoperator" title="@{perceptionmodoperator}">
@@ -235,7 +235,7 @@
               value="floor(@{charperception} @{charperceptionfeatureeffect}) - @{charperceptiondamage}" />
 
             <button type="roll" class="roll-button" name="roll_will_check" title="@{will_check}"
-              value="&{template:main} {{charname=@{character_name}}} {{action=@{will}}} {{value=[[@{charwill}]]}} {{result=[[?{@{normalorcontest} | @{normal}, 2d6cs<5cf>2 | @{contest}, 2d6cs>2cf<5+@{charwill}}+?{@{modifier}|0}]]}}"></button>
+              value="&{template:main} {{charname=@{character_name}}} {{action=@{will}}} {{value=[[@{charwill}]]}} {{roll=[[2d6cs<5cf>2]]}} {{dispute=[[2d6cs>2cf<5+@{charwill}]]}}"></button>
             <span class="label secondary-font" data-i18n="will">Vontade</span>
             <input name="attr_charwill" type="number" title="@{charwill}" value="6" />
             <select class="select" name="attr_charwillmodoperator" title="@{willmodoperator}">
@@ -249,7 +249,7 @@
               value="floor(@{charwill} @{charwillfeatureeffect}) - @{charwilldamage}" />
 
             <button type="roll" class="roll-button" name="roll_mind_check" title="@{mind_check}"
-              value="&{template:main} {{charname=@{character_name}}} {{action=@{mind}}} {{value=[[@{charmind}]]}} {{result=[[?{@{normalorcontest} | @{normal}, 2d6cs<5cf>2 | @{contest}, 2d6cs>2cf<5+@{charmind}}+?{@{modifier}|0}]]}}"></button>
+              value="&{template:main} {{charname=@{character_name}}} {{action=@{mind}}} {{value=[[@{charmind}]]}} {{roll=[[2d6cs<5cf>2]]}} {{dispute=[[2d6cs>2cf<5+@{charmind}]]}}"></button>
             <span class="label secondary-font" data-i18n="mind">Mente</span>
             <input name="attr_charmind" type="number" title="@{charmind}" value="8" />
             <select class="select" name="attr_charmindmodoperator" title="@{mindmodoperator}">
@@ -263,7 +263,7 @@
               value="floor(@{charmind} @{charmindfeatureeffect}) - @{charminddamage}" />
 
             <button type="roll" class="roll-button" name="roll_magic_check" title="@{magic_check}"
-              value="&{template:main} {{charname=@{character_name}}} {{action=@{magic}}} {{value=[[@{charmagic}]]}} {{result=[[?{@{normalorcontest} | @{normal}, 2d6cs<5cf>2 | @{contest}, 2d6cs>2cf<5+@{charmagic}}+?{@{modifier}|0}]]}}"></button>
+              value="&{template:main} {{charname=@{character_name}}} {{action=@{magic}}} {{value=[[@{charmagic}]]}} {{roll=[[2d6cs<5cf>2]]}} {{dispute=[[2d6cs>2cf<5+@{charmagic}]]}}"></button>
             <span class="label secondary-font" data-i18n="magic">Magia</span>
             <input name="attr_charmagic" type="number" title="@{charmagic}" value="0" />
             <select class="select" name="attr_charmagicmodoperator" title="@{charmagicmodoperator}">
@@ -277,7 +277,7 @@
               value="floor(@{charmagic} @{charmagicfeatureeffect}) - @{charmagicdamage}" />
 
             <button type="roll" class="roll-button" name="roll_luck_check" title="@{luck_check}"
-              value="&{template:main} {{charname=@{character_name}}} {{action=@{luck}}} {{value=[[@{charluck}]]}} {{result=[[?{@{normalorcontest} | @{normal}, 2d6cs<5cf>2 | @{contest}, 2d6cs>2cf<5+@{charluck}}+?{@{modifier}|0}]]}}"></button>
+              value="&{template:main} {{charname=@{character_name}}} {{action=@{luck}}} {{value=[[@{charluck}]]}} {{roll=[[2d6cs<5cf>2]]}} {{dispute=[[2d6cs>2cf<5+@{charluck}]]}}"></button>
             <span class="label secondary-font" data-i18n="luck">Sorte</span>
             <input name="attr_charluck" type="number" title="@{charluck}" value="0" />
             <select class="select" name="attr_charluckmodoperator" title="@{luckmodoperator}">
@@ -508,77 +508,16 @@
 
         </div>
 
-      </div>
-
-      <!-- Middle column 2 -->
-      <div class="middle-column">
-
         <div class="box flex-column">
 
-          <span class="box-title main-font" data-i18n="skills">Habilidades</span>
-          <div class="repeatable-grid skills">
-            <div></div>
-            <span class="column-header  secondary-font" data-i18n="skill">Habilidade</span>
-            <span class="column-header  secondary-font" data-i18n="attribute">Atributo</span>
-            <span class="column-header  secondary-font" data-i18n="level">Nível</span>
-            <span class="column-header  secondary-font" data-i18n="cost">Custo</span>
-            <span class="column-header  secondary-font" data-i18n="total">Total</span>
-            <div></div>
-          </div>
+          <span class="box-title main-font" data-i18n="equipments">Equipamentos</span>
 
-          <div class="repeatable-grid skills">
-            <button type="roll" class="roll-button" name="roll_fight_check" title="@{fight_check}"
-              value="&{template:main} {{charname=@{character_name}}} {{action=@{fight}}} {{value=[[@{fighttotal}]]}} {{result=[[?{@{normalorcontest} | @{normal}, 2d6cs<5cf>2 | @{contest}, 2d6cs>2cf<5+@{fighttotal}}+?{@{modifier}|0}]]}}"></button>
-            <input class="row-item-margin" readonly="true" name="attr_fight_name" type="text" title="@{fight_name}"
-              data-i18n-placeholder="fight" placeholder="Briga" />
-            <span class="secondary-font" data-i18n="dexterity">Destreza</span>
-            <input type="hidden" name="attr_fightattribute" value="@{chardexterity}" />
-            <select class="select row-item-margin" name="attr_fightlevel" title="@{fightlevel}">
-              <option value="0" selected="selected">0</option>
-              <option value="1">1</option>
-              <option value="2">2</option>
-              <option value="3">3</option>
-              <option value="4">4</option>
-            </select>
-            <input class="row-item-margin" name="attr_fightcost" type="text" readonly title="@{fightcost}" value="1" />
-            <input class="row-item-margin" name="attr_fighttotal" type="number" disabled="true" title="@{fighttotal}"
-              value="@{fightattribute} + @{fightlevel}" />
-
-            <div>
-            </div>
-
-          </div>
-
-          <input type="hidden" name="attr_skills_total_cost" />
-
-          <fieldset class="repeating_skills">
+          <fieldset class="repeating_equipments">
 
             <div class="repeatable-item">
-
-              <div class="repeatable-grid skills">
-                <button type="roll" class="roll-button" name="roll_skill_check" title="@{skill_check}"
-                  value="&{template:main} {{charname=@{character_name}}} {{action=@{skill}}} {{value=[[@{skilltotal}]]}} {{result=[[?{@{normalorcontest} | @{normal}, 2d6cs<5cf>2 | @{contest}, 2d6cs>2cf<5+@{skilltotal}}+?{@{modifier}|0}]]}}"></button>
-                <input class="row-item-margin" name="attr_skill" type="text" title="@{skill}" />
-                <select class="select row-item-margin" name="attr_skillattribute" title="@{skillattribute}">
-                  <option value="@{charphysique}" data-i18n="physique" selected="selected">Físico</option>
-                  <option value="@{chardexterity}" data-i18n="dexterity">Destreza</option>
-                  <option value="@{charintelligence}" data-i18n="intelligence">Inteligência</option>
-                  <option value="@{charwill}" data-i18n="will">Vontade</option>
-                  <option value="@{charmind}" data-i18n="mind">Mente</option>
-                  <option value="@{charmagic}" data-i18n="magic">Magia</option>
-                  <option value="@{charperception}" data-i18n="perception">Percepção</option>
-                  <option value="@{charluck}" data-i18n="luck">Sorte</option>
-                </select>
-                <select class="select row-item-margin" name="attr_skilllevel" title="@{skilllevel}">
-                  <option value="1" selected="selected">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                </select>
-                <input class="row-item-margin" name="attr_skillcost" type="text" readonly title="@{skillcost}"
-                  value="1" />
-                <input class="row-item-margin" name="attr_skilltotal" type="number" disabled="true"
-                  title="@{skilltotal}" value="@{skillattribute} + @{skilllevel}" />
+              <div class="repeatable-row">
+                <input name="attr_equipment" type="text" data-i18n-placeholder="equipment" placeholder="Equipamento"
+                  title="@{equipment}" />
 
                 <div class="showhidebutton arrowtype">
                   <input type="checkbox" name="attr_showhide_checkbox" value="1" />
@@ -592,10 +531,307 @@
 
               <div class="showhide flex-column">
                 <span class="column-header  secondary-font" data-i18n="description">Descrição</span>
-                <textarea name="attr_skilldescription" title="@{skilldescription}"></textarea>
+                <textarea name="attr_equipmentdescription" title="@{equipmentdescription}"></textarea>
               </div>
             </div>
 
+          </fieldset>
+
+        </div>
+
+      </div>
+
+      <!-- Middle column 2 -->
+      <div class="middle-column">
+
+        <div class="box flex-column">
+
+          <span class="box-title main-font" data-i18n="contact_weapons">Armas de contato</span>
+
+          <div class="repeatable-grid contact-weapons">
+            <span class="column-header  secondary-font" data-i18n="weapon">Arma</span>
+            <span class="column-header  secondary-font" data-i18n="level">Nível</span>
+            <span class="column-header  secondary-font" data-i18n="damage">Dano</span>
+            <span class="column-header  secondary-font" data-i18n="blow">Golpe</span>
+            <span class="column-header  secondary-font" data-i18n="parry">Aparo</span>
+            <div></div>
+
+          </div>
+
+          <div class="repeatable-grid contact-weapons">
+
+            <input class="row-item-margin" readonly="true" name="attr_fight_name" type="text" title="@{fight_name}"
+              data-i18n-placeholder="fight" placeholder="Briga" />
+            <input class="row-item-margin" readonly="true" name="attr_fightlevel" type="text" title="@{fightlevel}" />
+
+            <input class="weapons-damage-total" readonly="true" name="attr_fightdamagetotal" type="text"
+              title="@{fightdamagetotal}" value="0" />
+
+            <div class="weapons-subheader-grid">
+              <div></div>
+              <input class="weapons-base" disabled="true" name="attr_fightblowtotal" type="text"
+                title="@{fightblowtotal}" value="@{fightblow} + (@{chardexterity} @{weaponeffect})" />
+              <button type="roll" class="roll-button" name="roll_fightblow_check" title="@{fightblow_check}"
+                value="&{template:main} {{charname=@{character_name}}} {{action=@{fight}}} {{value=@{blow}}} {{damage=[[@{fightdamage}+@{physicaldamage}]]}} {{bodyroll=[[2d6cs0cf0]]}} {{roll=[[2d6cs>2cf<5 + @{fightblow} + (@{chardexterity} @{weaponeffect}) ]] }}"></button>
+            </div>
+
+            <div class="weapons-subheader-grid">
+              <div></div>
+              <input class="weapons-base" disabled="true" name="attr_fightparrytotal" type="text"
+                title="@{fightparrytotal}" value="@{fightparry} + (@{chardexterity} @{weaponeffect})" />
+              <button type="roll" class="roll-button" name="roll_fightparry_check" title="@{fightparry_check}"
+                value="&{template:main} {{charname=@{character_name}}} {{action=@{fight}}} {{value=@{parry}}} {{roll=[[2d6cs>2cf<5 + @{fightparry} + (@{chardexterity} @{weaponeffect}) ]] }}"></button>
+            </div>
+
+            <div class="showhidebutton arrowtype">
+              <input type="checkbox" name="attr_fight_showhide_checkbox" value="1" />
+              <span></span>
+            </div>
+
+          </div>
+
+          <!-- Hidden checkbox that controls show/hide section. See Sheet Workers-->
+          <input class="toggle-checkbox" type="checkbox" name="attr_fight_showhide_checkbox_invisible" value="1" />
+
+          <div class="showhide flex-column">
+
+            <div class="repeatable-grid contact-weapons-hidden">
+
+              <div>
+                <span class="column-header  secondary-font" data-i18n="damage">Dano</span>
+                <div class="weapons-subheader-grid">
+                  <span class="column-subheader  secondary-font" data-i18n="base">Base</span>
+                  <span class="column-subheader  secondary-font" data-i18n="total">Total</span>
+                </div>
+              </div>
+              <div>
+                <span class="column-header  secondary-font" data-i18n="blow">Golpe</span>
+                <div class="weapons-subheader-grid">
+                  <span class="column-subheader  secondary-font" data-i18n="base">Base</span>
+                  <span class="column-subheader  secondary-font" data-i18n="total">Total</span>
+                </div>
+              </div>
+              <div>
+                <span class="column-header  secondary-font" data-i18n="parry">Aparo</span>
+                <div class="weapons-subheader-grid">
+                  <span class="column-subheader  secondary-font" data-i18n="base">Base</span>
+                  <span class="column-subheader  secondary-font" data-i18n="total">Total</span>
+                </div>
+              </div>
+
+              <div class="weapons-subheader-grid">
+                <input class="weapons-damage-base" readonly="true" name="attr_fightdamage" type="text"
+                  title="@{fightdamage}" value="d2-1" />
+                <input class="weapons-damage-total" readonly="true" name="attr_fightdamagetotal" type="text"
+                  title="@{fightdamagetotal}" value="0" />
+              </div>
+              <div class="weapons-subheader-grid">
+                <input class="weapons-damage-base" readonly="true" name="attr_fightblow" type="text"
+                  title="@{fightblow}" value="0" />
+                <input class="weapons-damage-total" disabled="true" name="attr_fightblowtotal" type="text"
+                  title="@{fightblowtotal}" value="@{fightblow} + (@{chardexterity} @{weaponeffect})" />
+              </div>
+
+              <div class="weapons-subheader-grid">
+                <input class="weapons-damage-base" readonly="true" name="attr_fightparry" type="text"
+                  title="@{fightparry}" value="0" />
+                <input class="weapons-damage-total" disabled="true" name="attr_fightparrytotal" type="text"
+                  title="@{fightparrytotal}" value="@{fightparry} + (@{chardexterity} @{weaponeffect})" />
+              </div>
+
+            </div>
+          </div>
+
+          <input type="hidden" name="attr_weaponeffect" value="+0" />
+
+          <fieldset class="repeating_contactweapons">
+
+            <div class="repeatable-item">
+
+              <div class="repeatable-grid contact-weapons">
+
+                <input class="row-item-margin" name="attr_weaponname" type="text" title="@{weaponname}" />
+                <input class="row-item-margin" name="attr_weaponlevel" type="text" title="@{weaponlevel}" value="0" />
+
+                <input class="weapons-damage-total" readonly="true" name="attr_weapondamagetotal" type="text"
+                  title="@{weapondamagetotal}" value="0" />
+
+                <div class="weapons-subheader-grid">
+                  <div></div>
+                  <input class="weapons-base" name="attr_weaponblowtotal" type="text" title="@{weaponblowtotal}"
+                    disabled="true"
+                    value="@{weaponlevel} + @{weaponblow} + @{fightblow} + (@{chardexterity} @{weaponeffect})" />
+                  <button type="roll" class="roll-button" name="roll_weaponblow_check" title="@{weaponblow_check}"
+                    value="&{template:main} {{charname=@{character_name}}} {{action=@{weaponname}}} {{value=@{blow}}} {{damage=[[@{weapondamage}+@{physicaldamage}]]}} {{bodyroll=[[2d6cs0cf0]]}} {{roll=[[2d6cs>2cf<5 + @{weaponlevel} + @{weaponblow} + @{fightblow} + (@{chardexterity} @{weaponeffect}) ]] }}"></button>
+                </div>
+
+                <div class="weapons-subheader-grid">
+                  <div></div>
+                  <input class="weapons-base" name="attr_weaponparrytotal" type="text" title="@{weaponparrytotal}"
+                    disabled="true"
+                    value="@{weaponlevel} + @{weaponparry} + @{fightparry} + (@{chardexterity} @{weaponeffect})" />
+                  <button type="roll" class="roll-button" name="roll_weaponparry_check" title="@{weaponparry_check}"
+                    value="&{template:main} {{charname=@{character_name}}} {{action=@{weaponname}}} {{value=@{parry}}} {{roll=[[2d6cs>2cf<5 + @{weaponlevel} + @{weaponparry} + @{fightparry} + (@{chardexterity} @{weaponeffect}) ]] }}"></button>
+                </div>
+
+                <div class="showhidebutton arrowtype">
+                  <input type="checkbox" name="attr_showhide_checkbox" value="1" />
+                  <span></span>
+                </div>
+
+              </div>
+
+              <!-- Hidden checkbox that controls show/hide section. See Sheet Workers-->
+              <input class="toggle-checkbox" type="checkbox" name="attr_showhide_checkbox_invisible" value="1" />
+
+              <div class="showhide flex-column">
+
+                <div class="repeatable-grid contact-weapons-hidden">
+
+                  <div>
+                    <span class="column-header  secondary-font" data-i18n="damage">Dano</span>
+                    <div class="weapons-subheader-grid">
+                      <span class="column-subheader  secondary-font" data-i18n="base">Base</span>
+                      <span class="column-subheader  secondary-font" data-i18n="total">Total</span>
+                    </div>
+                  </div>
+                  <div>
+                    <span class="column-header  secondary-font" data-i18n="blow">Golpe</span>
+                    <div class="weapons-subheader-grid">
+                      <span class="column-subheader  secondary-font" data-i18n="base">Base</span>
+                      <span class="column-subheader  secondary-font" data-i18n="total">Total</span>
+                    </div>
+                  </div>
+                  <div>
+                    <span class="column-header  secondary-font" data-i18n="parry">Aparo</span>
+                    <div class="weapons-subheader-grid">
+                      <span class="column-subheader  secondary-font" data-i18n="base">Base</span>
+                      <span class="column-subheader  secondary-font" data-i18n="total">Total</span>
+                    </div>
+                  </div>
+
+                  <div class="weapons-subheader-grid">
+                    <input class="weapons-damage-base" name="attr_weapondamage" type="text" title="@{weapondamage}"
+                      value="0" />
+                    <input class="weapons-damage-total" readonly="true" name="attr_weapondamagetotal" type="text"
+                      title="@{weapondamagetotal}" value="0" />
+                  </div>
+                  <div class="weapons-subheader-grid">
+                    <input class="weapons-damage-base" name="attr_weaponblow" type="text" title="@{weaponblow}"
+                      value="0" />
+                    <input class="weapons-damage-total" name="attr_weaponblowtotal" type="text"
+                      title="@{weaponblowtotal}" disabled="true"
+                      value="@{weaponlevel} + @{weaponblow} + @{fightblow} + (@{chardexterity} @{weaponeffect})" />
+                  </div>
+
+                  <div class="weapons-subheader-grid">
+                    <input class="weapons-damage-base" name="attr_weaponparry" type="text" title="@{weaponparry}"
+                      value="0" />
+                    <input class="weapons-damage-total" name="attr_weaponparrytotal" type="text"
+                      title="@{weaponparrytotal}" disabled="true"
+                      value="@{weaponlevel} + @{weaponparry} + @{fightparry} + (@{chardexterity} @{weaponeffect})" />
+                  </div>
+
+                </div>
+
+                <span class="column-header  secondary-font" data-i18n="description">Descrição</span>
+                <textarea name="attr_weapondescription" title="@{weapondescription}"></textarea>
+              </div>
+
+            </div>
+          </fieldset>
+
+        </div>
+
+        <div class="box flex-column">
+
+          <span class="box-title main-font" data-i18n="long_range_weapons">Armas de Longo Alcance</span>
+
+          <div class="repeatable-grid long-range-weapons">
+            <span class="column-header  secondary-font" data-i18n="weapon">Arma</span>
+            <span class="column-header  secondary-font" data-i18n="level">Nível</span>
+            <span class="column-header  secondary-font" data-i18n="damage">Dano</span>
+            <span class="column-header  secondary-font" data-i18n="fast_shot">Tiro Rápido</span>
+            <span class="column-header  secondary-font" data-i18n="aimed_shot">Tiro Mirado</span>
+            <div></div>
+
+          </div>
+
+          <input type="hidden" name="attr_weaponeffect" value="+0" />
+
+          <fieldset class="repeating_longrangeweapons">
+
+            <div class="repeatable-item">
+
+              <div class="repeatable-grid long-range-weapons">
+
+                <input class="row-item-margin" name="attr_weaponname" type="text" title="@{weaponname}" />
+                <input class="row-item-margin" name="attr_weaponlevel" type="text" title="@{weaponlevel}" value="0" />
+
+                <input class="weapons-damage-total" readonly="true" name="attr_weapondamagetotal" type="text"
+                  title="@{weapondamagetotal}" value="0" />
+
+                <div class="weapons-die-label">
+                  <input class="row-item-margin" name="attr_weaponfastshot" type="number" title="@{weaponfastshot}"
+                    value="0" />
+                  <button type="roll" class="roll-button" name="roll_weaponfastshot_check"
+                    title="@{weaponfastshot_check}"
+                    value="&{template:main} {{charname=@{character_name}}} {{action=@{weaponname}}} {{value=@{fast_shot}}} {{damage=[[@{weapondamage}]]}} {{bodyroll=[[2d6cs0cf0]]}} {{roll=[[2d6cs<5cf>2 + @{chardexterity} + @{weaponlevel} + @{weaponfastshot} ]] }}"></button>
+                </div>
+
+                <div class="weapons-die-label">
+                  <input class="row-item-margin" name="attr_weaponaimedshot" type="number" title="@{weaponaimedshot}"
+                    value="0" />
+                  <button type="roll" class="roll-button" name="roll_weaponaimedshot_check"
+                    title="@{weaponaimedshot_check}"
+                    value="&{template:main} {{charname=@{character_name}}} {{action=@{weaponname}}} {{value=@{aimed_shot}}} {{damage=[[@{weapondamage}]]}} {{bodyroll=[[2d6cs0cf0]]}} {{roll=[[2d6cs<5cf>2 + @{chardexterity} + @{weaponlevel} + @{weaponaimedshot} ]] }}"></button>
+                </div>
+
+                <div class="showhidebutton arrowtype">
+                  <input type="checkbox" name="attr_showhide_checkbox" value="1" />
+                  <span></span>
+                </div>
+
+              </div>
+
+              <!-- Hidden checkbox that controls show/hide section. See Sheet Workers-->
+              <input class="toggle-checkbox" type="checkbox" name="attr_showhide_checkbox_invisible" value="1" />
+
+              <div class="showhide flex-column">
+
+                <div class="repeatable-grid long-range-weapons-hidden">
+                  <div>
+                    <span class="column-header  secondary-font" data-i18n="damage">Dano</span>
+                    <div class="weapons-subheader-grid">
+                      <span class="column-subheader  secondary-font" data-i18n="base">Base</span>
+                      <span class="column-subheader  secondary-font" data-i18n="total">Total</span>
+                    </div>
+                  </div>
+                  <span class="column-header  secondary-font" data-i18n="shots">Carga</span>
+                  <span class="column-header  secondary-font" data-i18n="reload_actions">Ações de Recarga</span>
+                  <span class="column-header  secondary-font" data-i18n="range">Alcance</span>
+                  <span class="column-header  secondary-font" data-i18n="rate_of_fire">Cad</span>
+
+                  <div class="weapons-subheader-grid">
+                    <input class="weapons-damage-base" name="attr_weapondamage" type="text" title="@{weapondamage}"
+                      value="0" />
+                    <input class="weapons-damage-total" readonly="true" name="attr_weapondamagetotal" type="text"
+                      title="@{weapondamagetotal}" value="0" />
+                  </div>
+                  <input class="row-item-margin" name="attr_weaponrshots" type="number" title="@{weaponshots}"
+                    value="0" />
+                  <input class="row-item-margin" name="attr_weaponreloadactions" type="number"
+                    title="@{weaponreloadactions}" value="0" />
+                  <input class="row-item-margin" name="attr_weaponrange" type="text" title="@{weaponrange}" />
+                  <input class="row-item-margin" name="attr_weaponrateoffire" type="text" title="@{weaponrateoffire}" />
+
+                </div>
+
+                <span class="column-header  secondary-font" data-i18n="description">Descrição</span>
+                <textarea name="attr_weapondescription" title="@{weapondescription}"></textarea>
+              </div>
+
+            </div>
           </fieldset>
 
         </div>
@@ -660,14 +896,70 @@
 
         <div class="box flex-column">
 
-          <span class="box-title main-font" data-i18n="equipments">Equipamentos</span>
+          <span class="box-title main-font" data-i18n="skills">Habilidades</span>
+          <div class="repeatable-grid skills">
+            <div></div>
+            <span class="column-header  secondary-font" data-i18n="skill">Habilidade</span>
+            <span class="column-header  secondary-font" data-i18n="attribute">Atributo</span>
+            <span class="column-header  secondary-font" data-i18n="level">Nível</span>
+            <span class="column-header  secondary-font" data-i18n="cost">Custo</span>
+            <span class="column-header  secondary-font" data-i18n="total">Total</span>
+            <div></div>
+          </div>
 
-          <fieldset class="repeating_equipments">
+          <div class="repeatable-grid skills">
+            <button type="roll" class="roll-button" name="roll_fight_check" title="@{fight_check}"
+              value="&{template:main} {{charname=@{character_name}}} {{action=@{fight}}} {{value=[[@{fighttotal}]]}} {{roll=[[2d6cs<5cf>2]]}} {{dispute=[[2d6cs>2cf<5+@{fighttotal}]]}}"></button>
+            <input class="row-item-margin" readonly="true" name="attr_fight_name" type="text" title="@{fight_name}"
+              data-i18n-placeholder="fight" placeholder="Briga" />
+            <span class="secondary-font" data-i18n="dexterity">Destreza</span>
+            <input type="hidden" name="attr_fightattribute" value="@{chardexterity}" />
+            <select class="select row-item-margin" name="attr_fightlevel" title="@{fightlevel}">
+              <option value="0" selected="selected">0</option>
+              <option value="1">1</option>
+              <option value="2">2</option>
+              <option value="3">3</option>
+              <option value="4">4</option>
+            </select>
+            <input class="row-item-margin" name="attr_fightcost" type="text" readonly title="@{fightcost}" value="1" />
+            <input class="row-item-margin" name="attr_fighttotal" type="number" disabled="true" title="@{fighttotal}"
+              value="@{fightattribute} + @{fightlevel}" />
+
+            <div>
+            </div>
+
+          </div>
+
+          <input type="hidden" name="attr_skills_total_cost" />
+
+          <fieldset class="repeating_skills">
 
             <div class="repeatable-item">
-              <div class="repeatable-row">
-                <input name="attr_equipment" type="text" data-i18n-placeholder="equipment" placeholder="Equipamento"
-                  title="@{equipment}" />
+
+              <div class="repeatable-grid skills">
+                <button type="roll" class="roll-button" name="roll_skill_check" title="@{skill_check}"
+                  value="&{template:main} {{charname=@{character_name}}} {{action=@{skill}}} {{value=[[@{skilltotal}]]}} {{roll=[[2d6cs<5cf>2]]}} {{dispute=[[2d6cs>2cf<5+@{skilltotal}]]}}"></button>
+                <input class="row-item-margin" name="attr_skill" type="text" title="@{skill}" />
+                <select class="select row-item-margin" name="attr_skillattribute" title="@{skillattribute}">
+                  <option value="@{charphysique}" data-i18n="physique" selected="selected">Físico</option>
+                  <option value="@{chardexterity}" data-i18n="dexterity">Destreza</option>
+                  <option value="@{charintelligence}" data-i18n="intelligence">Inteligência</option>
+                  <option value="@{charwill}" data-i18n="will">Vontade</option>
+                  <option value="@{charmind}" data-i18n="mind">Mente</option>
+                  <option value="@{charmagic}" data-i18n="magic">Magia</option>
+                  <option value="@{charperception}" data-i18n="perception">Percepção</option>
+                  <option value="@{charluck}" data-i18n="luck">Sorte</option>
+                </select>
+                <select class="select row-item-margin" name="attr_skilllevel" title="@{skilllevel}">
+                  <option value="1" selected="selected">1</option>
+                  <option value="2">2</option>
+                  <option value="3">3</option>
+                  <option value="4">4</option>
+                </select>
+                <input class="row-item-margin" name="attr_skillcost" type="text" readonly title="@{skillcost}"
+                  value="1" />
+                <input class="row-item-margin" name="attr_skilltotal" type="number" disabled="true"
+                  title="@{skilltotal}" value="@{skillattribute} + @{skilllevel}" />
 
                 <div class="showhidebutton arrowtype">
                   <input type="checkbox" name="attr_showhide_checkbox" value="1" />
@@ -681,7 +973,7 @@
 
               <div class="showhide flex-column">
                 <span class="column-header  secondary-font" data-i18n="description">Descrição</span>
-                <textarea name="attr_equipmentdescription" title="@{equipmentdescription}"></textarea>
+                <textarea name="attr_skilldescription" title="@{skilldescription}"></textarea>
               </div>
             </div>
 
@@ -695,155 +987,6 @@
         </div>
 
       </div>
-
-    </div>
-
-    <div class="box flex-column">
-
-      <span class="box-title main-font" data-i18n="weapons">Armas</span>
-
-      <div class="repeatable-grid weapons">
-        <span class="column-header  secondary-font" data-i18n="weapon">Arma</span>
-        <span class="column-header  secondary-font" data-i18n="level">Nível</span>
-        <div>
-          <span class="column-header  secondary-font" data-i18n="damage">Dano</span>
-          <div class="weapons-subheader-grid">
-            <span class="column-subheader  secondary-font" data-i18n="base">Base</span>
-            <span class="column-subheader  secondary-font" data-i18n="total">Total</span>
-          </div>
-        </div>
-        <div>
-          <span class="column-header  secondary-font" data-i18n="blow">Golpe</span>
-          <div class="weapons-subheader-grid">
-            <span class="column-subheader  secondary-font" data-i18n="base">Base</span>
-            <span class="column-subheader  secondary-font" data-i18n="total">Total</span>
-          </div>
-        </div>
-        <div>
-          <span class="column-header  secondary-font" data-i18n="parry">Aparo</span>
-          <div class="weapons-subheader-grid">
-            <span class="column-subheader  secondary-font" data-i18n="base">Base</span>
-            <span class="column-subheader  secondary-font" data-i18n="total">Total</span>
-          </div>
-        </div>
-        <span class="column-header  secondary-font" data-i18n="fast_shot">Tiro Rápido</span>
-        <span class="column-header  secondary-font" data-i18n="aimed_shot">Tiro Mirado</span>
-        <span class="column-header  secondary-font" data-i18n="rate_of_fire">Cad</span>
-        <div></div>
-
-      </div>
-
-      <div class="repeatable-grid weapons">
-
-        <input class="row-item-margin" readonly="true" name="attr_fight_name" type="text" title="@{fight_name}"
-          data-i18n-placeholder="fight" placeholder="Briga" />
-        <input class="row-item-margin" readonly="true" name="attr_fightlevel" type="text" title="@{fightlevel}" />
-        <div class="weapons-subheader-grid">
-          <input class="weapons-damage-base" readonly="true" name="attr_fightdamage" type="text" title="@{fightdamage}"
-            value="d2-1" />
-          <input class="weapons-damage-total" readonly="true" name="attr_fightdamagetotal" type="text"
-            title="@{fightdamagetotal}" value="0" />
-        </div>
-        <div class="weapons-subheader-grid">
-          <input class="weapons-base" readonly="true" name="attr_fightblow" type="text" title="@{fightblow}"
-            value="0" />
-          <input class="weapons-base" disabled="true" name="attr_fightblowtotal" type="text"
-            title="@{fightblowtotal}" value="@{fightblow} + (@{chardexterity} @{weaponeffect})" />
-          <button type="roll" class="roll-button" name="roll_fightblow_check" title="@{fightblow_check}"
-            value="&{template:main} {{charname=@{character_name}}} {{action=@{fight}}} {{value=@{blow}}} {{damage=[[@{fightdamage}+@{physicaldamage}]]}} {{bodyroll=[[2d6cs0cf0]]}} {{result=[[2d6cs>2cf<5 + @{fightblow} + (@{chardexterity} @{weaponeffect}) + ?{@{modifier}|0} ]] }}"></button>
-        </div>
-
-        <div class="weapons-subheader-grid">
-          <input class="weapons-base" readonly="true" name="attr_fightparry" type="text" title="@{fightparry}"
-            value="0" />
-          <input class="weapons-base" disabled="true" name="attr_fightparrytotal" type="text"
-            title="@{fightparrytotal}" value="@{fightparry} + (@{chardexterity} @{weaponeffect})" />
-          <button type="roll" class="roll-button" name="roll_fightparry_check" title="@{fightparry_check}"
-            value="&{template:main} {{charname=@{character_name}}} {{action=@{fight}}} {{value=@{parry}}} {{result=[[2d6cs>2cf<5 + @{fightparry} + (@{chardexterity} @{weaponeffect}) + ?{@{modifier}|0} ]] }}"></button>
-        </div>
-
-        <div class="fight-span"></div>
-
-      </div>
-
-      <input type="hidden" name="attr_weaponeffect" value="+0" />
-
-      <fieldset class="repeating_weapons">
-
-        <div class="repeatable-item">
-
-          <div class="repeatable-grid weapons">
-
-            <input class="row-item-margin" name="attr_weaponname" type="text" title="@{weaponname}" />
-            <input class="row-item-margin" name="attr_weaponlevel" type="text" title="@{weaponlevel}" value="0" />
-            <div class="weapons-subheader-grid">
-              <input class="weapons-damage-base" name="attr_weapondamage" type="text" title="@{weapondamage}" value="0" />
-              <input class="weapons-damage-total" readonly="true" name="attr_weapondamagetotal" type="text"
-                title="@{weapondamagetotal}" value="0" />
-            </div>
-            <div class="weapons-subheader-grid">
-              <input class="weapons-base" name="attr_weaponblow" type="text" title="@{weaponblow}" value="0" />
-              <input class="weapons-base" name="attr_weaponblowtotal" type="text" title="@{weaponblowtotal}" 
-                disabled="true" value="@{weaponlevel} + @{weaponblow} + @{fightblow} + (@{chardexterity} @{weaponeffect})" />
-              <button type="roll" class="roll-button" name="roll_weaponblow_check" title="@{weaponblow_check}"
-                value="&{template:main} {{charname=@{character_name}}} {{action=@{weaponname}}} {{value=@{blow}}} {{damage=[[@{weapondamage}+@{physicaldamage}]]}} {{bodyroll=[[2d6cs0cf0]]}} {{result=[[2d6cs>2cf<5 + @{weaponlevel} + @{weaponblow} + @{fightblow} + (@{chardexterity} @{weaponeffect}) + ?{@{modifier}|0} ]] }}"></button>
-            </div>
-
-            <div class="weapons-subheader-grid">
-              <input class="weapons-base" name="attr_weaponparry" type="text" title="@{weaponparry}" value="0" />
-              <input class="weapons-base" name="attr_weaponparrytotal" type="text" title="@{weaponparrytotal}" 
-                disabled="true" value="@{weaponlevel} + @{weaponparry} + @{fightparry} + (@{chardexterity} @{weaponeffect})" />
-              <button type="roll" class="roll-button" name="roll_weaponparry_check" title="@{weaponparry_check}"
-                value="&{template:main} {{charname=@{character_name}}} {{action=@{weaponname}}} {{value=@{parry}}} {{result=[[2d6cs>2cf<5 + @{weaponlevel} + @{weaponparry} + @{fightparry} + (@{chardexterity} @{weaponeffect}) + ?{@{modifier}|0} ]] }}"></button>
-            </div>
-
-            <div class="weapons-die-label">
-              <input class="row-item-margin" name="attr_weaponfastshot" type="number" title="@{weaponfastshot}"
-                value="0" />
-              <button type="roll" class="roll-button" name="roll_weaponfastshot_check" title="@{weaponfastshot_check}"
-                value="&{template:main} {{charname=@{character_name}}} {{action=@{weaponname}}} {{value=@{fast_shot}}} {{damage=[[@{weapondamage}]]}} {{bodyroll=[[2d6cs0cf0]]}} {{result=[[2d6cs<5cf>2 + @{chardexterity} + @{weaponlevel} + @{weaponfastshot} + ?{@{modifier}|0} ]] }}"></button>
-            </div>
-
-            <div class="weapons-die-label">
-              <input class="row-item-margin" name="attr_weaponaimedshot" type="number" title="@{weaponaimedshot}"
-                value="0" />
-              <button type="roll" class="roll-button" name="roll_weaponaimedshot_check" title="@{weaponaimedshot_check}"
-                value="&{template:main} {{charname=@{character_name}}} {{action=@{weaponname}}} {{value=@{aimed_shot}}} {{damage=[[@{weapondamage}]]}} {{bodyroll=[[2d6cs0cf0]]}} {{result=[[2d6cs<5cf>2 + @{chardexterity} + @{weaponlevel} + @{weaponaimedshot} + ?{@{modifier}|0} ]] }}"></button>
-            </div>
-
-            <input class="row-item-margin" name="attr_weaponrateoffire" type="number" title="@{weaponrateoffire}"
-              value="0" />
-
-            <div class="showhidebutton arrowtype">
-              <input type="checkbox" name="attr_showhide_checkbox" value="1" />
-              <span></span>
-            </div>
-
-          </div>
-
-          <!-- Hidden checkbox that controls show/hide section. See Sheet Workers-->
-          <input class="toggle-checkbox" type="checkbox" name="attr_showhide_checkbox_invisible" value="1" />
-
-          <div class="showhide flex-column">
-
-            <div class="repeatable-grid weapon-hidden">
-              <span class="column-header  secondary-font" data-i18n="shots">Carga</span>
-              <span class="column-header  secondary-font" data-i18n="reload_actions">Ações de Recarga</span>
-              <span class="column-header  secondary-font" data-i18n="range">Alcance</span>
-
-              <input class="row-item-margin" name="attr_weaponrshots" type="number" title="@{weaponshots}" value="0" />
-              <input class="row-item-margin" name="attr_weaponreloadactions" type="number"
-                title="@{weaponreloadactions}" value="0" />
-              <input class="row-item-margin" name="attr_weaponrange" type="text" title="@{weaponrange}" />
-
-            </div>
-
-            <span class="column-header  secondary-font" data-i18n="description">Descrição</span>
-            <textarea name="attr_weapondescription" title="@{weapondescription}"></textarea>
-          </div>
-
-        </div>
-      </fieldset>
 
     </div>
 
@@ -894,14 +1037,23 @@
     </div>
     {{/action}}
 
-    {{#result}}
+    {{#roll}}
 
     <div class="template-row">
-      <span class="template-label secondary-font" data-i18n="result">Resultado</span>
-      {{result}}
+      <span class="template-label secondary-font" data-i18n="roll">Rolagem</span>
+      {{roll}}
     </div>
 
-    {{/result}}
+    {{/roll}}
+
+    {{#dispute}}
+
+    <div class="template-row">
+      <span class="template-label secondary-font" data-i18n="dispute_test">Teste de Disputa</span>
+      {{dispute}}
+    </div>
+
+    {{/dispute}}
 
     {{#damage}}
 
@@ -992,12 +1144,14 @@
 
   /*Controls show hide checkbox button from repeating sections*/
   on("change:repeating_equipments:showhide_checkbox " + 
-     "change:repeating_weapons:showhide_checkbox " + 
+     "change:repeating_contactweapons:showhide_checkbox " + 
+     "change:repeating_longrangeweapons:showhide_checkbox " + 
      "change:repeating_protection:showhide_checkbox " +
      "change:repeating_skills:showhide_checkbox " +
      "change:powers_showhide_checkbox " +
      "change:repeating_powers:showhide_checkbox " +
      "change:features_showhide_checkbox " +
+     "change:fight_showhide_checkbox " +
      "change:repeating_features:showhide_checkbox" , function(eventInfo) {
     
     let source = eventInfo.sourceAttribute;
@@ -1040,10 +1194,10 @@
     setRollTotal(['fightdamage', 'physicaldamage'], 'fightdamagetotal');
   });
 
-  /*Controling weapons damage total*/
-  on('change:repeating_weapons:weapondamage change:physicaldamage', function(eventInfo) {
+  /*Controling contact weapons damage total*/
+  on('change:repeating_contactweapons:weapondamage change:physicaldamage', function(eventInfo) {
     console.log('weapon damage total');
-    setRollTotal(['repeating_weapons_weapondamage', 'physicaldamage'], 'repeating_weapons_weapondamagetotal');
+    setRollTotal(['repeating_contactweapons_weapondamage', 'physicaldamage'], 'repeating_contactweapons_weapondamagetotal');
   });
 
   /* calculating physical damage */

--- a/OperaRPG/translation.json
+++ b/OperaRPG/translation.json
@@ -6,7 +6,7 @@
 	"creation_points": "Pontos de Criação",
 	"physical_actions": "Ações Físicas",
 	"base": "Base",
-	"effect": "Effect",
+	"effect": "Efeito",
 	"total": "Total",
 	"mind_actions": "Ações Mentais",
 	"initiative": "Iniciativa",
@@ -113,5 +113,9 @@
 	"left_leg_h": "Perna esquerda(H)",
 	"body_area": "Área do Corpo Atingida",
 	"physical_damage": "Dano por Físico",
-	"base_total": "Base/Total"
+	"base_total": "Base/Total",
+	"contact_weapons": "Armas de Contato",
+	"long_range_weapons": "Armas de Longo Alcance",
+	"roll": "Rolagem",
+	"dispute_test": "Teste de Disputa"
 }


### PR DESCRIPTION
## Changes / Comments

- Splitting weapons in two types;
- moving fields around;
- Changing the roll template layout




## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
