### PR TITLE
[Wildsea] Fix a typo that broke the salvage section of inventory

### DIFF
--- a/Wildsea/wildsea.html
+++ b/Wildsea/wildsea.html
@@ -336,7 +336,7 @@
             <div class="salvage skillSection">
                 <label>Salvage</label>
                 <fieldset class="repeating_salvage">
-                    <input class="inv-name" type="test" name="attr_salvageName" placeholder="Name">
+                    <input class="inv-name" type="text" name="attr_salvageName" placeholder="Name">
                     <input class="inv-tag" type="text" name="attr_salvageTags" placeholder="Tags"
                     
                     <!-- blank space -->


### PR DESCRIPTION
## Changes / Comments

- Changed the salvage name input type from "test" to "text" to fix the data disappearing on unfocus




## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
