### PR TITLE
CyberpunkRED_raycw: Added Assault Rifle weapon mod that was missing.

### DIFF
--- a/CyberpunkRED_raycw/cyberpunkred-raycw.html
+++ b/CyberpunkRED_raycw/cyberpunkred-raycw.html
@@ -1626,6 +1626,9 @@
 					case "SMG (Autofire)":
 					weaponmod = REF + Autofire;
 					break;
+					case "Assault Rifle":
+					weaponmod = REF + ShoulderArms;
+					break;
 					case "Shotgun (Slug)":
 					weaponmod = REF + ShoulderArms;
 					break;


### PR DESCRIPTION
## Changes / Comments

The weapon mods used to autocalculate hits were missing the Assault Rifle value. I fixed this by adding it.
To my knowledge, this shouldn't influence existing player data.



## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
