### PR TITLE
[PokemonTabletopAdventures_v3] Resolves issues with Roll Templates

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -1283,17 +1283,17 @@
         </tr>
         {{/rollLess() accuracy effect1_threshold}}
         <!-- Closing The Critical Hit Section -->
-        {{/rollTotal() effect1_roll 99}} {{/rollGreater() critical-damage 0}} {{/^rollWasCrit() accuracy}}
+        {{/rollTotal() effect1_roll 99}} {{/rollGreater() critical-damage 0}}
 
         <!-- Regular Hit -->
-        {{#^rollWasCrit() accuracy}} {{#rollLess() effect1_roll 99}}
+        {{#rollLess() effect1_roll 99}} {{#rollGreater() damage 0}}
         <tr>
           <td class="sheet-label"><span>{{move-type}} Damage:</span></td>
           <td>
             <span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage}} </span>
           </td>
         </tr>
-        {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy}}
+        {{/rollGreater() damage 0}} {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy}}
 
         <!-- Effect Resoluton  -->
         <!-- Effect 1 -->
@@ -1368,14 +1368,14 @@
 
             <!-- Damage Rolls -->
             <!-- Dice-Based Critical Hit -->
-            {{#rollWasCrit() accuracy}} {{#rollGreater() critical-damage 0}}
+            {{#rollWasCrit() accuracy}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage}} </span></td>
-            {{/rollGreater() critical-damage 0}} {{/rollWasCrit() accuracy}}
+            {{/rollWasCrit() accuracy}}
 
             <!-- Effect-Based Critical Hit -->
             <!-- Not a Natural Crit, and we deal Critical Damage -->
-            {{#^rollWasCrit() accuracy}} {{#rollGreater() critical-damage 0}}
+            {{#^rollWasCrit() accuracy}}
 
             <!-- Effect 1 is Critical Hit and we hit the Threshold -->
             {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy effect1_threshold}}
@@ -1387,12 +1387,10 @@
             {{#rollLess() accuracy effect1_threshold}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage}} </span></td>
-            {{/rollLess() accuracy effect1_threshold}}
-            <!-- Closing The Critical Hit Section -->
-            {{/rollTotal() effect1_roll 99}} {{/rollGreater() critical-damage 0}} {{/^rollWasCrit() accuracy}}
+            {{/rollLess() accuracy effect1_threshold}} {{/rollTotal() effect1_roll 99}}
 
             <!-- Regular Hit -->
-            {{#^rollWasCrit() accuracy}} {{#rollLess() effect1_roll 99}}
+            {{#rollLess() effect1_roll 99}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage}} </span></td>
             {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy}}
@@ -1423,14 +1421,14 @@
 
             <!-- Damage Rolls -->
             <!-- Dice-Based Critical Hit -->
-            {{#rollWasCrit() accuracy-2}} {{#rollGreater() critical-damage-extra 0}}
+            {{#rollWasCrit() accuracy-2}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
-            {{/rollGreater() critical-damage-extra 0}} {{/rollWasCrit() accuracy-2}}
+            {{/rollWasCrit() accuracy-2}}
 
             <!-- Effect-Based Critical Hit -->
             <!-- Not a Natural Crit, and we deal Critical Damage -->
-            {{#^rollWasCrit() accuracy-2}} {{#rollGreater() critical-damage-extra 0}}
+            {{#^rollWasCrit() accuracy-2}}
 
             <!-- Effect 1 is Critical Hit and we hit the Threshold -->
             {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy-2 effect1_threshold}}
@@ -1442,12 +1440,10 @@
             {{#rollLess() accuracy-2 effect1_threshold}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-2}} </span></td>
-            {{/rollLess() accuracy-2 effect1_threshold}}
-            <!-- Closing The Critical Hit Section -->
-            {{/rollTotal() effect1_roll 99}} {{/rollGreater() critical-damage-extra 0}} {{/^rollWasCrit() accuracy-2}}
+            {{/rollLess() accuracy-2 effect1_threshold}} {{/rollTotal() effect1_roll 99}}
 
             <!-- Regular Hit -->
-            {{#^rollWasCrit() accuracy-2}} {{#rollLess() effect1_roll 99}}
+            {{#rollLess() effect1_roll 99}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-2}} </span></td>
             {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy-2}}
@@ -1526,14 +1522,14 @@
 
             <!-- Damage Rolls -->
             <!-- Dice-Based Critical Hit -->
-            {{#rollWasCrit() accuracy}} {{#rollGreater() critical-damage 0}}
+            {{#rollWasCrit() accuracy}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage}} </span></td>
-            {{/rollGreater() critical-damage 0}} {{/rollWasCrit() accuracy}}
+            {{/rollWasCrit() accuracy}}
 
             <!-- Effect-Based Critical Hit -->
             <!-- Not a Natural Crit, and we deal Critical Damage -->
-            {{#^rollWasCrit() accuracy}} {{#rollGreater() critical-damage 0}}
+            {{#^rollWasCrit() accuracy}}
 
             <!-- Effect 1 is Critical Hit and we hit the Threshold -->
             {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy effect1_threshold}}
@@ -1545,12 +1541,10 @@
             {{#rollLess() accuracy effect1_threshold}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage}} </span></td>
-            {{/rollLess() accuracy effect1_threshold}}
-            <!-- Closing The Critical Hit Section -->
-            {{/rollTotal() effect1_roll 99}} {{/rollGreater() critical-damage 0}} {{/^rollWasCrit() accuracy}}
+            {{/rollLess() accuracy effect1_threshold}} {{/rollTotal() effect1_roll 99}}
 
             <!-- Regular Hit -->
-            {{#^rollWasCrit() accuracy}} {{#rollLess() effect1_roll 99}}
+            {{#rollLess() effect1_roll 99}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage}} </span></td>
             {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy}}
@@ -1581,14 +1575,14 @@
 
             <!-- Damage Rolls -->
             <!-- Dice-Based Critical Hit -->
-            {{#rollWasCrit() accuracy-2}} {{#rollGreater() critical-damage-extra 0}}
+            {{#rollWasCrit() accuracy-2}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
-            {{/rollGreater() critical-damage-extra 0}} {{/rollWasCrit() accuracy-2}}
+            {{/rollWasCrit() accuracy-2}}
 
             <!-- Effect-Based Critical Hit -->
             <!-- Not a Natural Crit, and we deal Critical Damage -->
-            {{#^rollWasCrit() accuracy-2}} {{#rollGreater() critical-damage-extra 0}}
+            {{#^rollWasCrit() accuracy-2}}
 
             <!-- Effect 1 is Critical Hit and we hit the Threshold -->
             {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy-2 effect1_threshold}}
@@ -1600,12 +1594,10 @@
             {{#rollLess() accuracy-2 effect1_threshold}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-2}} </span></td>
-            {{/rollLess() accuracy-2 effect1_threshold}}
-            <!-- Closing The Critical Hit Section -->
-            {{/rollTotal() effect1_roll 99}} {{/rollGreater() critical-damage-extra 0}} {{/^rollWasCrit() accuracy-2}}
+            {{/rollLess() accuracy-2 effect1_threshold}} {{/rollTotal() effect1_roll 99}}
 
             <!-- Regular Hit -->
-            {{#^rollWasCrit() accuracy-2}} {{#rollLess() effect1_roll 99}}
+            {{#rollLess() effect1_roll 99}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-2}} </span></td>
             {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy-2}}
@@ -1636,14 +1628,14 @@
 
             <!-- Damage Rolls -->
             <!-- Dice-Based Critical Hit -->
-            {{#rollWasCrit() accuracy-3}} {{#rollGreater() critical-damage-extra 0}}
+            {{#rollWasCrit() accuracy-3}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
-            {{/rollGreater() critical-damage-extra 0}} {{/rollWasCrit() accuracy-3}}
+            {{/rollWasCrit() accuracy-3}}
 
             <!-- Effect-Based Critical Hit -->
             <!-- Not a Natural Crit, and we deal Critical Damage -->
-            {{#^rollWasCrit() accuracy-3}} {{#rollGreater() critical-damage-extra 0}}
+            {{#^rollWasCrit() accuracy-3}}
 
             <!-- Effect 1 is Critical Hit and we hit the Threshold -->
             {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy-3 effect1_threshold}}
@@ -1655,12 +1647,10 @@
             {{#rollLess() accuracy-3 effect1_threshold}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-3}} </span></td>
-            {{/rollLess() accuracy-3 effect1_threshold}}
-            <!-- Closing The Critical Hit Section -->
-            {{/rollTotal() effect1_roll 99}} {{/rollGreater() critical-damage-extra 0}} {{/^rollWasCrit() accuracy-3}}
+            {{/rollLess() accuracy-3 effect1_threshold}} {{/rollTotal() effect1_roll 99}}
 
             <!-- Regular Hit -->
-            {{#^rollWasCrit() accuracy-3}} {{#rollLess() effect1_roll 99}}
+            {{#rollLess() effect1_roll 99}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-3}} </span></td>
             {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy-3}}
@@ -1691,14 +1681,14 @@
 
             <!-- Damage Rolls -->
             <!-- Dice-Based Critical Hit -->
-            {{#rollWasCrit() accuracy-4}} {{#rollGreater() critical-damage-extra 0}}
+            {{#rollWasCrit() accuracy-4}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
-            {{/rollGreater() critical-damage-extra 0}} {{/rollWasCrit() accuracy-4}}
+            {{/rollWasCrit() accuracy-4}}
 
             <!-- Effect-Based Critical Hit -->
             <!-- Not a Natural Crit, and we deal Critical Damage -->
-            {{#^rollWasCrit() accuracy-4}} {{#rollGreater() critical-damage-extra 0}}
+            {{#^rollWasCrit() accuracy-4}}
 
             <!-- Effect 1 is Critical Hit and we hit the Threshold -->
             {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy-4 effect1_threshold}}
@@ -1710,12 +1700,10 @@
             {{#rollLess() accuracy-4 effect1_threshold}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-4}} </span></td>
-            {{/rollLess() accuracy-4 effect1_threshold}}
-            <!-- Closing The Critical Hit Section -->
-            {{/rollTotal() effect1_roll 99}} {{/rollGreater() critical-damage-extra 0}} {{/^rollWasCrit() accuracy-4}}
+            {{/rollLess() accuracy-4 effect1_threshold}} {{/rollTotal() effect1_roll 99}}
 
             <!-- Regular Hit -->
-            {{#^rollWasCrit() accuracy-4}} {{#rollLess() effect1_roll 99}}
+            {{#rollLess() effect1_roll 99}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-4}} </span></td>
             {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy-4}}
@@ -1746,14 +1734,14 @@
 
             <!-- Damage Rolls -->
             <!-- Dice-Based Critical Hit -->
-            {{#rollWasCrit() accuracy-5}} {{#rollGreater() critical-damage-extra 0}}
+            {{#rollWasCrit() accuracy-5}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
-            {{/rollGreater() critical-damage-extra 0}} {{/rollWasCrit() accuracy-5}}
+            {{/rollWasCrit() accuracy-5}}
 
             <!-- Effect-Based Critical Hit -->
             <!-- Not a Natural Crit, and we deal Critical Damage -->
-            {{#^rollWasCrit() accuracy-5}} {{#rollGreater() critical-damage-extra 0}}
+            {{#^rollWasCrit() accuracy-5}}
 
             <!-- Effect 1 is Critical Hit and we hit the Threshold -->
             {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy-5 effect1_threshold}}
@@ -1765,12 +1753,10 @@
             {{#rollLess() accuracy-5 effect1_threshold}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-5}} </span></td>
-            {{/rollLess() accuracy-5 effect1_threshold}}
-            <!-- Closing The Critical Hit Section -->
-            {{/rollTotal() effect1_roll 99}} {{/rollGreater() critical-damage-extra 0}} {{/^rollWasCrit() accuracy-5}}
+            {{/rollLess() accuracy-5 effect1_threshold}} {{/rollTotal() effect1_roll 99}}
 
             <!-- Regular Hit -->
-            {{#^rollWasCrit() accuracy-5}} {{#rollLess() effect1_roll 99}}
+            {{#rollLess() effect1_roll 99}}
             <td class="sheet-label"><span>Damage:</span></td>
             <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-5}} </span></td>
             {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy-5}}

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -8,12 +8,17 @@ https://discord.gg/F24Ka8E
 
 ## Changelog
 
-### Jan 8th, 2020
+### Jan 23rd, 2021
+
+- Fixed January update dates to be the correct year
+- Fixed the display of zero-damage attacks for all move templates
+
+### Jan 8th, 2021
 
 - Added the ability to change which ability applies to which skills to the Configuration page
   - Unfortunately you'll still need to add any second ability modifier applied to the manual bonus column - support for multiple abilities has been added to the to-do list
 
-### Jan 7th, 2020
+### Jan 7th, 2021
 
 - Added support for scatter moves
 - Added roll templates for dual hit and multi hit scatter attacks


### PR DESCRIPTION
## Changes / Comments

- ensures single-hit roll template doesn't show the damage row when total damage is less than or equal to 0
- ensures dual- and multi-hit roll templates - used for scatter moves - always show damage to ensure the roll template table isn't left incomplete
- adds fix to readme, and corrects dates therein

## Roll20 Requests

- [x] Does the pull request title have the sheet name(s)? Include each sheet name. _Yes_
- [x] Is this a bug fix? _Yes_
- [x] Does this add functional enhancements (new features or extending existing features)? _No_
- [x] Does this add or change functional aesthetics (such as layout or color scheme)? _No_ 
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data? _N/A_
- [x] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository)? _No_

If you do not know English. Please leave a comment in your native language.
