### PR TITLE
[Warhammer Fantasy Roleplay 4e Official] Prevent negative encumbrance

### DIFF
--- a/Warhammer Fantasy Roleplay 4e Official/src/js/sheetworkers.js
+++ b/Warhammer Fantasy Roleplay 4e Official/src/js/sheetworkers.js
@@ -1549,7 +1549,7 @@ const wfrpModule = ( () => {
                             const enc = parseInt(values[`repeating_armour_${id}_armour_enc`])
                             const total = (worn === "on") ? enc - 1 : enc || 0
 
-                            total_enc += total;
+                            total_enc += total >= 0 ? total : 0;
                         });
 
                         weapons_array.forEach(id => {
@@ -1566,7 +1566,7 @@ const wfrpModule = ( () => {
 
                             const total = (worn === "on") ? (enc - 1) * amount : enc * amount;
 
-                            if (inenc === "on") total_enc += total;
+                            if (inenc === "on") total_enc += total >= 0 ? total : 0;
                         });
 
                         setAttrs({encumbrance:total_enc})


### PR DESCRIPTION
## Changes / Comments
Fix for issue with encumbrance. According to rules if item is worn it's encumbrance should be reduced by 1, however it cannot be less than 0 (this doesn't make any sense).
Link to bug report at forum https://app.roll20.net/forum/permalink/9663326/

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
