### PR TITLE
[Warhammer Fantasy Roleplay 4e Official] Do not use localized strings as value for spell type

### DIFF
--- a/Warhammer Fantasy Roleplay 4e Official/src/pug/components/repeating/spell-row.pug
+++ b/Warhammer Fantasy Roleplay 4e Official/src/pug/components/repeating/spell-row.pug
@@ -40,8 +40,8 @@ mixin spell-row
             .wfrp-settings__row
                 .wfrp-settings__label(data-i18n=`Type`) 
                 select.wfrp-settings__input(name=`attr_spell_type`)
-                    option(data-i18n="Spell")
-                    option(data-i18n="Prayer")
+                    option(value="Spell",data-i18n="Spell")
+                    option(value="Prayer",data-i18n="Prayer")
         
             .wfrp-settings__row.control__hide--Spell
                 .wfrp-settings__label(data-i18n=`Lore`) 


### PR DESCRIPTION
## Changes / Comments
Do not use localized strings for spell type value since it breaks visibility of some related fields.
Closes: #7747



## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
