### PR TITLE
revert weight from number to text

### DIFF
--- a/Only-War-Enhanced/OnlyWarEnhanced.html
+++ b/Only-War-Enhanced/OnlyWarEnhanced.html
@@ -1065,7 +1065,7 @@
 			  <div class='equipment_ranged_weapons_gs32'>Reload</div>
 			  <input class='equipment_ranged_weapons_gs33 full_width' type='text' value='0' name='attr_R_weapon_reload' />
 			  <div class='equipment_ranged_weapons_gs34'>Weight</div>
-			  <input class='equipment_ranged_weapons_gs35 full_width' type='number' value='0' name='attr_R_weapon_weight' />
+			  <input class='equipment_ranged_weapons_gs35 full_width' type='text' value='0' name='attr_R_weapon_weight' />
 			</div>
 			<div class='equipment_ranged_weapons_grid6'>
 			  <div class='equipment_ranged_weapons_gs36' title='Las, Plasma, etc'>Domain</div>
@@ -1838,7 +1838,7 @@
 				<div class='equipment_ranged_weapons_gs32'>Reload</div>
 				<input class='equipment_ranged_weapons_gs33 full_width' type='text' value='0' name='attr_V_R_weapon_reload' />
 				<div class='equipment_ranged_weapons_gs34'>Weight</div>
-				<input class='equipment_ranged_weapons_gs35 full_width' type='number' value='0' name='attr_V_R_weapon_weight' />
+				<input class='equipment_ranged_weapons_gs35 full_width' type='text' value='0' name='attr_V_R_weapon_weight' />
 			  </div>
 			  <div class='equipment_ranged_weapons_grid6'>
 				<div class='equipment_ranged_weapons_gs36' title='Las, Plasma, etc'>Domain</div>


### PR DESCRIPTION


## Changes / Comments
reverting an earlier change that disallowed "text" in the Weight section. turns out decimal points are "text"





## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
