### PR TITLE
[Chronicles of Darkness] Alternate Beats/Experiences

### DIFF
--- a/Chronicles of Darkness/CofD.css
+++ b/Chronicles of Darkness/CofD.css
@@ -675,10 +675,6 @@ input.sheet-rolltype-select[value="rote"] ~ * button.sheet-rolltype-rote {
     align-items: center;
 }
 
-.sheet-checkboxes.sheet-left {
-    justify-content: start;
-}
-
 /* Styles common to dot, checkbox, healthbox, and radio */
 button.sheet-dot,
 .sheet-checkbox > input[type="hidden"] + button,

--- a/Chronicles of Darkness/CofD.html
+++ b/Chronicles of Darkness/CofD.html
@@ -1927,7 +1927,7 @@
                         </div>
                         <div class="game-line mage2 promethean2 hunter2 geist2 demon">
                             <div class="input-group">
-                                <div class="flex left">
+                                <div class="flex">
                                     <span data-i18n="arcane" class="game-line mage2">Arcane</span>
                                     <span data-i18n="vitriol" class="game-line promethean2">Vitriol</span>
                                     <span data-i18n="practical" class="game-line hunter2">Practical</span>
@@ -1961,7 +1961,7 @@
                                 </div>
                             </div>
                             <div class="input-group">
-                                <div class="flex left">
+                                <div class="flex">
                                     <span data-i18n="arcane" class="game-line mage2">Arcane</span>
                                     <span data-i18n="vitriol" class="game-line promethean2">Vitriol</span>
                                     <span data-i18n="practical" class="game-line hunter2">Practical</span>

--- a/Chronicles of Darkness/CofD.html
+++ b/Chronicles of Darkness/CofD.html
@@ -3478,14 +3478,11 @@
         }
 
         var updateHealth = function() {
-            getAttrs(["stamina","resistance","base_size","giant","small_framed","sheettype","entity","resilience","bonus_health"], function(v) {
+            getAttrs(["stamina","resistance","base_size","giant","small_framed","sheettype","entity","bonus_health"], function(v) {
                 var health = 1;
                 switch (v.entity) {
                     case "corporeal":
                         health = Number(v.stamina) + Number(v.base_size) + Number(v.giant) + Number(v.small_framed) + Number(v.bonus_health);
-                        if(v.sheettype.indexOf("vampire2")) {
-                            health = health + Number(v.resilience);
-                        }
                         break;
                     case "ephemeral":
                         health = (Number(v.resistance) || 1) + (Number(v.base_size) || 1) + Number(v.giant) + Number(v.small_framed) + Number(v.bonus_health);

--- a/Chronicles of Darkness/CofD.html
+++ b/Chronicles of Darkness/CofD.html
@@ -1894,33 +1894,84 @@
                         </div>
                         <!-- !geist2-geist -->
                         <div class="game-line mortal vampire werewolf mage promethean changeling hunter geist1 geist2 geist2-organization mummy demon beast homebrew wod-demon">
+                            <div class="2nd input-group">
+                                <span class="preserve-whitespace"><span data-i18n="beats">Beats</span>: </span>
+                                <div class="checkboxes">
+                                    <div class="checkbox">
+                                        <input type="hidden" name="attr_beat_box1" />
+                                        <button type="action" name="act_beat_box1"></button>
+                                    </div>
+                                    <div class="checkbox">
+                                        <input type="hidden" name="attr_beat_box2" />
+                                        <button type="action" name="act_beat_box2"></button>
+                                    </div>
+                                    <div class="checkbox">
+                                        <input type="hidden" name="attr_beat_box3" />
+                                        <button type="action" name="act_beat_box3"></button>
+                                    </div>
+                                    <div class="checkbox">
+                                        <input type="hidden" name="attr_beat_box4" />
+                                        <button type="action" name="act_beat_box4"></button>
+                                    </div>
+                                    <div class="checkbox">
+                                        <input type="hidden" name="attr_beat_box5" />
+                                        <button type="action" name="act_beat_box5"></button>
+                                    </div>
+                                </div>
+                            </div>
                             <div class="input-group">
                                 <span data-i18n="experience">Experience</span>
                                 <span>:</span>
                                 <input type="text" name="attr_experience">
                             </div>
-                            <div class="2nd checkboxes left">
-                                <span class="preserve-whitespace"><span data-i18n="beats">Beats</span>: </span>
-                                <div class="checkbox">
-                                    <input type="hidden" name="attr_beat_box1" />
-                                    <button type="action" name="act_beat_box1"></button>
+                        </div>
+                        <div class="game-line mage2 promethean2 hunter2 geist2 demon">
+                            <div class="input-group">
+                                <div class="flex left">
+                                    <span data-i18n="arcane" class="game-line mage2">Arcane</span>
+                                    <span data-i18n="vitriol" class="game-line promethean2">Vitriol</span>
+                                    <span data-i18n="practical" class="game-line hunter2">Practical</span>
+                                    <span data-i18n="synergy" class="game-line geist2">Synergy</span>
+                                    <span data-i18n="cover" class="game-line demon">Cover</span>
+                                    <span class="preserve-whitespace"> </span>
+                                    <span data-i18n="beats">Beats</span>
+                                    <span>:</span>
                                 </div>
-                                <div class="checkbox">
-                                    <input type="hidden" name="attr_beat_box2" />
-                                    <button type="action" name="act_beat_box2"></button>
+                                <div class="checkboxes">
+                                    <div class="checkbox">
+                                        <input type="hidden" name="attr_beat_alt_box1" />
+                                        <button type="action" name="act_beat_alt_box1"></button>
+                                    </div>
+                                    <div class="checkbox">
+                                        <input type="hidden" name="attr_beat_alt_box2" />
+                                        <button type="action" name="act_beat_alt_box2"></button>
+                                    </div>
+                                    <div class="checkbox">
+                                        <input type="hidden" name="attr_beat_alt_box3" />
+                                        <button type="action" name="act_beat_alt_box3"></button>
+                                    </div>
+                                    <div class="checkbox">
+                                        <input type="hidden" name="attr_beat_alt_box4" />
+                                        <button type="action" name="act_beat_alt_box4"></button>
+                                    </div>
+                                    <div class="checkbox">
+                                        <input type="hidden" name="attr_beat_alt_box5" />
+                                        <button type="action" name="act_beat_alt_box5"></button>
+                                    </div>
                                 </div>
-                                <div class="checkbox">
-                                    <input type="hidden" name="attr_beat_box3" />
-                                    <button type="action" name="act_beat_box3"></button>
+                            </div>
+                            <div class="input-group">
+                                <div class="flex left">
+                                    <span data-i18n="arcane" class="game-line mage2">Arcane</span>
+                                    <span data-i18n="vitriol" class="game-line promethean2">Vitriol</span>
+                                    <span data-i18n="practical" class="game-line hunter2">Practical</span>
+                                    <span data-i18n="synergy" class="game-line geist2">Synergy</span>
+                                    <span data-i18n="cover" class="game-line demon">Cover</span>
+                                    <span class="preserve-whitespace"> </span>
+                                    <span data-i18n="experience">Experience</span>
+                                    <span>:</span>
                                 </div>
-                                <div class="checkbox">
-                                    <input type="hidden" name="attr_beat_box4" />
-                                    <button type="action" name="act_beat_box4"></button>
-                                </div>
-                                <div class="checkbox">
-                                    <input type="hidden" name="attr_beat_box5" />
-                                    <button type="action" name="act_beat_box5"></button>
-                                </div>
+                                <input type="text" name="attr_experience_alt">
                             </div>
                         </div>
                     </div>
@@ -2877,7 +2928,7 @@
             });
         });
 
-        const checkboxSeriesAttributes = ["willpower", "vitae", "beat", "faith-temp"];
+        const checkboxSeriesAttributes = ["willpower", "vitae", "beat", "beat_alt", "faith-temp"];
         const checkboxAttributes = [
             ...checkboxSeriesAttributes
                 .map((checkboxSeriesAttribute) => new Array(30)

--- a/Chronicles of Darkness/README.md
+++ b/Chronicles of Darkness/README.md
@@ -17,6 +17,7 @@ This is the community-contributed version of the [Chronicles of Darkness by Roll
 
 ## Backlog
 * Replace Specializations text inputs with repeating section for each Skill
+* Include ability description in page 2 sheet rolls
 * Spirit, Angel, generic Ephemeral sheets
 * Absent sheet (Geist: The Sin-Eaters Second Edition)
 * Clean up Vampire, Mage ability translations (deprecated)

--- a/Chronicles of Darkness/README.md
+++ b/Chronicles of Darkness/README.md
@@ -13,11 +13,10 @@ This is the community-contributed version of the [Chronicles of Darkness by Roll
 8. Ghost sheet
 9. Repeating Merits and Abilities sections
 10. Select any Ability for sheet roll
+11. Alternate Beat/Experience types (Mage, Promethean, Hunter, Geist, Demon)
 
 ## Backlog
 * Replace Specializations text inputs with repeating section for each Skill
-* Include ability description in page 2 sheet rolls
-* Alternate Beat/Experience types (Vampire, Werewolf, Mage, Geist, Promethean?)
 * Spirit, Angel, generic Ephemeral sheets
 * Absent sheet (Geist: The Sin-Eaters Second Edition)
 * Clean up Vampire, Mage ability translations (deprecated)

--- a/Chronicles of Darkness/translation.json
+++ b/Chronicles of Darkness/translation.json
@@ -379,5 +379,8 @@
     "house": "House:",
     "apocalyptic-form": "Apocalyptic Form",
     "followers": "Followers",
-    "second-edition-translation-guides": "2nd Edition: Translation Guides"
+    "second-edition-translation-guides": "2nd Edition: Translation Guides",
+    "arcane": "Arcane",
+    "vitriol": "Vitriol",
+    "practical": "Practical"
 }


### PR DESCRIPTION
## Changes / Comments

Add a new section for the alternate beats/experiences used in some 2nd Edition game lines:

* Mage: Arcane
* Promethean: Vitriol
* Hunter: Practical
* Geist: Synergy
* Demon: Cover

(Also rearrange the display of Beats and Experience)

Minor: Remove Vampire 2nd Edition health modifier from Resilience; deprecated when Disciplines were moved to repeating section.

### Current
![image](https://user-images.githubusercontent.com/4495480/106315681-3e1dec00-6231-11eb-8927-b5fe06cbf5f5.png)

### New
![image](https://user-images.githubusercontent.com/4495480/106315703-4413cd00-6231-11eb-805d-313d11cf4ace.png)

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
