### PR TITLE
[Log Horizon TRPG] Minor fix for text position

### DIFF
--- a/Log Horizon TRPG/LHsheet.html
+++ b/Log Horizon TRPG/LHsheet.html
@@ -154,7 +154,7 @@
 		</div>
 		<div style="width: 50px; height: 35px; margin-top: 5px; margin-left: 2px; background-color: white; border: solid 1px black; border-radius: 5px;">
 			<input type="text" name="attr_fatigue" class="iconInput" value="0" style="font-size: 16px; width: 3em; text-align: center;">
-			<b style="position: absolute; margin-left: 6px; margin-top: -7px; font-size: 10px;">Fatigue</b>
+			<b style="font-size: 10px; position: absolute; margin-top: 20px; margin-left: -39px;">Fatigue</b>
 		</div>
 	</div>
 	<div style="float: left; background-image: url(https://i.imgur.com/zzSYrKx.png); height: 100px; width: 100px; margin-left: 10px;">


### PR DESCRIPTION
## Changes / Comments
Small fix for the position of the fatigue text on the character sheet. It was incorrectly placed outside its box. This puts it in the correct position.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
