### PR TITLE
Cyberpunk Red Tabbed: Updates and fixes

### DIFF
--- a/Cyberpunk Red Tabbed/cyberpunk-red-tabbed.html
+++ b/Cyberpunk Red Tabbed/cyberpunk-red-tabbed.html
@@ -748,6 +748,7 @@
                   <input
                     type="hidden"
                     name="attr_role_solo_precisionattack_calc"
+                    value="0"
                   />
                   Precision Attack (+<span
                     name="attr_role_solo_precisionattack_calc"
@@ -3296,7 +3297,7 @@
                   </div>
                   <div class="column">
                     <select name="attr_armor_penalty">
-                      <option value="0">0</option>
+                      <option value="0" selected="selected">0</option>
                       <option value="-2">-2</option>
                       <option value="-4">-4</option>
                     </select>
@@ -3927,6 +3928,8 @@
       </div>
     </div>
   </div>
+
+  <!-- The "modifiers" component is included twice but only needs one set of JS -->
   <script type="text/worker">
     /**
      * Convert from Roll20's handling of checkbox values to

--- a/Cyberpunk Red Tabbed/cyberpunk-red-tabbed.html
+++ b/Cyberpunk Red Tabbed/cyberpunk-red-tabbed.html
@@ -2987,7 +2987,7 @@
                 <input type="number" value="0" name="attr_evasionmodifier" />
                 <button
                   type="roll"
-                  value="&{template:skill}{{charactername=@{character_name}}} {{skillname=Evasion}} {{skillvalue=@{skill_evasion}}} {{statname=REF}} {{statvalue=@{stat_ref}}} {{finalmodifier=@{finalmodifier}}} {{roll=[[1d10 + @{skill_evasion} + @{stat_ref} + @{armor_penalty} + @{finalmodifier} + @{evasionmodifier}]]}} {{critroll=[[1d10]]}}"
+                  value="&{template:skill}{{charactername=@{character_name}}} {{skillname=Evasion}} {{skillvalue=@{skill_evasion}}} {{statname=DEX}} {{statvalue=@{stat_dex}}} {{finalmodifier=@{finalmodifier}}} {{roll=[[1d10 + @{skill_evasion} + @{stat_dex} + @{armor_penalty} + @{finalmodifier} + @{evasionmodifier}]]}} {{critroll=[[1d10]]}}"
                 >
                   Evasion
                 </button>
@@ -3155,7 +3155,7 @@
                   class="autofirebutton"
                   type="roll"
                   name="roll_autofire"
-                  value="&{template:attack}{{charactername=@{character_name}}}{{weapon=@{weaponname} (Autofire)}}{{specialrule=See full Autofire rules on p.173}}{{roll=[[1d10+@{skill_autofire}+@{stat_ref}+@{armor_penalty}+@{weaponmodifier}+@{finalmodifier}]]}}{{critroll=[[1d10]]}}"
+                  value="&{template:attack}{{charactername=@{character_name}}}{{weapon=@{weaponname} (Autofire)}}{{specialrule=See full Autofire rules on p.173}}{{roll=[[1d10+@{skill_autofire}+@{stat_ref}+@{armor_penalty}+@{weaponmodifier}+@{role_solo_precisionattack_calc}+@{finalmodifier}]]}}{{critroll=[[1d10]]}}"
                 >
                   Autofire
                 </button>
@@ -3168,14 +3168,14 @@
                   class="suppfirebutton"
                   type="roll"
                   name="roll_suppfire"
-                  value="&{template:attack}{{charactername=@{character_name}}}{{weapon=@{weaponname} (Suppressing Fire)}}{{specialrule=Opponents need to make a Concentration check. (See p.174)}}{{roll=[[1d10+@{skill_autofire}+@{stat_ref}+@{armor_penalty}+@{weaponmodifier}+@{finalmodifier}]]}}{{critroll=[[1d10]]}}"
+                  value="&{template:attack}{{charactername=@{character_name}}}{{weapon=@{weaponname} (Suppressing Fire)}}{{specialrule=Opponents need to make a Concentration check. (See p.174)}}{{roll=[[1d10+@{skill_autofire}+@{stat_ref}+@{armor_penalty}+@{weaponmodifier}+@{role_solo_precisionattack_calc}+@{finalmodifier}]]}}{{critroll=[[1d10]]}}"
                 >
                   Suppressing Fire
                 </button>
                 <button
                   type="roll"
                   name="roll_attack"
-                  value="&{template:attack}{{charactername=@{character_name}}}{{weapon=@{weaponname}}}{{roll=[[1d10+@{weaponskill}+@{armor_penalty}+@{weaponmodifier}+@{finalmodifier}]]}}{{critroll=[[1d10]]}}"
+                  value="&{template:attack}{{charactername=@{character_name}}}{{weapon=@{weaponname}}}{{roll=[[1d10+@{weaponskill}+@{armor_penalty}+@{weaponmodifier}+@{role_solo_precisionattack_calc}+@{finalmodifier}]]}}{{critroll=[[1d10]]}}"
                 >
                   Attack
                 </button>
@@ -3206,11 +3206,6 @@
               <div class="martialart">
                 <div class="columns">
                   <div class="column">
-                    <!--
-                    Roll20 won't allow us to just read values from the shared 
-                    repeating fieldset in roll templates, there needs to be an
-                    input field to actually give us a readable value to include.
-                    -->
                     <div style="display: none">
                       <input type="text" name="attr_skillname" />
                       <input type="number" name="attr_skillvalue" />
@@ -3702,7 +3697,7 @@
               <fieldset class="repeating_cyberinternal">
                 <div class="columns">
                   <div class="column label">Name</div>
-                  <div lass="column column-5">
+                  <div class="column column-5">
                     <input type="text" name="attr_cyberwarename" />
                   </div>
                 </div>
@@ -3932,8 +3927,6 @@
       </div>
     </div>
   </div>
-
-  <!-- The "modifiers" component is included twice but only needs one set of JS -->
   <script type="text/worker">
     /**
      * Convert from Roll20's handling of checkbox values to


### PR DESCRIPTION
## Changes / Comments

Updates to the Cyberpunk Red Tabbed character sheet: 

* Add Precision Attack from the Solo Role to attack rolls automatically.
* Fix the Evasion button in the Combat section to be based on DEX not REF.

There are no changes to page aesthetics, styles, or data storage. These changes only affect triggers for dice rolls in a few places to include adjusted modifiers.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name. Yes
- [x] Is this a bug fix? Yes
- [ ] Does this add functional enhancements (new features or extending existing features) ? No
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? No
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ? No changes were made to attributes.
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ? This is not a new sheet.

If you do not know English. Please leave a comment in your native language.
