### PR TITLE
[PARANOIA 25th Anniversary Edition] Added missing "fallback_for" translation entry

### DIFF
--- a/PARANOIA 25th Anniversary Edition/README.md
+++ b/PARANOIA 25th Anniversary Edition/README.md
@@ -31,7 +31,8 @@ You should then update `translation.json` with the new default translation value
 4. Copy the returned string without the beginning and ending quotes if applicable.
 5. Remove backslashes from the escaped quotes if applicable.
 6. Prettify the JSON object. (You may do so by pasting the translation data in a Roll20 non-sandbox custom game, saving it, and copying it back.)
-7. Replace the contents of `translation.json` with the final output.
+7. Replace the contents of `translation.json` with the prettified output.
+8. **IMPORTANT** - Make sure that the "fallback_for" entry appears in-between "roll" and "rating", as due to a bug in Roll20, `i18nOutput` doesn't extract that entry automatically as of this writing.
 
 You should also update `paranoia25.png` with a new screenshot after loading the resulting `paranoia25.html`, `paranoia25.css` and `translation.json` in Roll20. As per Roll20's guidelines, the image should be 500x500 px. (For 1920x1080 screen resolutions, reducing the screenshot size by 59% before cropping it generates the best results.)
 

--- a/PARANOIA 25th Anniversary Edition/translation.json
+++ b/PARANOIA 25th Anniversary Edition/translation.json
@@ -99,6 +99,7 @@
 	"public_information": "Public information",
 	"secrets": "Secrets",
 	"roll": "Roll",
+	"fallback_for": "fallback for",
 	"rating": "Rating",
 	"modifiers": "Modifiers",
 	"1d20_result": "1d20 result",


### PR DESCRIPTION
## Changes / Comments

I just noticed that due to a bug, the i18nOutput console command didn't extract the "fallback_for" translation entry, messing up my previous release of the PARANOIA 25th Anniversary Edition character sheet. This has been fixed and documented. Note that I'm reporting the i18nOutput bug separately through normal support channels.

On an unrelated note, my Roll20 profile has yet to be credited as a sheet author despite identifying my user ID in `sheet.json`. Please verify.

## Roll20 Requests

- Does the pull request title have the sheet name(s)? Yes.
- Is this a bug fix? Yes.
- Does this add functional enhancements (new features or extending existing features) ? No.
- Does this add or change functional aesthetics (such as layout or color scheme) ? No.
- If changing or removing attributes, what steps have you taken, if any, to preserve player data ? N/A
-  If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ? N/A