### PR TITLE
Serenity: Rearrange asset/comp description, put divider between, opt-out of legacy sanitization

### DIFF
--- a/Serenity/serenity.css
+++ b/Serenity/serenity.css
@@ -3,6 +3,7 @@
     font-size: 12pt;
     position: relative;
     max-width: 930px;
+    width: 930px;
     box-sizing: border-box;
     /* Mixin */
 }

--- a/Serenity/serenity.html
+++ b/Serenity/serenity.html
@@ -3552,9 +3552,6 @@
           title="Assets"
         >
           <fieldset class="repeating_assets">
-            <div class="sheet-serenity-asset-description">
-              <span name="attr_Asset"></span>
-            </div>
             <select class="sheet-serenity-assets" name="attr_Asset">
               <option
                 value="-1 reduction in wound penalty"
@@ -3624,15 +3621,15 @@
                 Specialization*
               </option>
               <option
-                value="+4 to pilot rolls for land or air/space"
-                title="+4 to pilot rolls for land or air/space"
+                value="Related plot points spent increased by 2"
+                title="Related plot points spent increased by 2"
               >
                 Born Behind the Wheel (major) - Cost: 4 - *Requires
                 Specialization*
               </option>
               <option
-                value="Related plot points spent increased by 2"
-                title="Related plot points spent increased by 2"
+                value="+4 to pilot rolls for land or air/space"
+                title="+4 to pilot rolls for land or air/space"
               >
                 Born Behind the Wheel (major) - Cost: 4 - *Requires
                 Specialization*
@@ -3659,25 +3656,25 @@
                 value="Difficulty to find info on you in the Cortex is +8"
                 title="Difficulty to find info on you in the Cortex is +8"
               >
-                Cortex Specter (minor) - Cost: 4
+                Cortex Specter (minor) - Cost: 2
               </option>
               <option
                 value="Difficulty to find info on you in the Cortex is +8"
                 title="Difficulty to find info on you in the Cortex is +8"
               >
-                Cortex Specter (minor) - Cost: 2
-              </option>
-              <option
-                value="You don't exist in the Cortex at all"
-                title="You don't exist in the Cortex at all"
-              >
-                Cortex Specter (major) - Cost: 8
+                Cortex Specter (minor) - Cost: 4
               </option>
               <option
                 value="You don't exist in the Cortex at all"
                 title="You don't exist in the Cortex at all"
               >
                 Cortex Specter (major) - Cost: 4
+              </option>
+              <option
+                value="You don't exist in the Cortex at all"
+                title="You don't exist in the Cortex at all"
+              >
+                Cortex Specter (major) - Cost: 8
               </option>
               <option value="1.5x Movement Speed" title="1.5x Movement Speed">
                 Fast on Your Feet (minor) - Cost: 2
@@ -3692,14 +3689,14 @@
                 Fightin' Type (major) - Cost: 4
               </option>
               <option
-                value="+2 in 'proper' social standing rolls (restaurant club) to acquire temporary assets/influence"
-                title="+2 in 'proper' social standing rolls (restaurant club) to acquire temporary assets/influence"
+                value="Spend plot points for a favor: 1/2 - 500 credit loan/minor equipment 3/4 - 5000 credit loan/lift a land lock/important event invitation 5/6 - 10000 credit loan/security clearance/use of a ship"
+                title="Spend plot points for a favor: 1/2 - 500 credit loan/minor equipment 3/4 - 5000 credit loan/lift a land lock/important event invitation 5/6 - 10000 credit loan/security clearance/use of a ship"
               >
                 Friends in High Places (minor) - Cost: 2
               </option>
               <option
-                value="Spend plot points for a favor: 1/2 - 500 credit loan/minor equipment 3/4 - 5000 credit loan/lift a land lock/important event invitation 5/6 - 10000 credit loan/security clearance/use of a ship"
-                title="Spend plot points for a favor: 1/2 - 500 credit loan/minor equipment 3/4 - 5000 credit loan/lift a land lock/important event invitation 5/6 - 10000 credit loan/security clearance/use of a ship"
+                value="+2 in 'proper' social standing rolls (restaurant club) to acquire temporary assets/influence"
+                title="+2 in 'proper' social standing rolls (restaurant club) to acquire temporary assets/influence"
               >
                 Friends in High Places (minor) - Cost: 2
               </option>
@@ -3710,14 +3707,14 @@
                 Friends in High Places (major) - Cost: 4
               </option>
               <option
-                value="+2 in 'proper' social standing rolls (back alley dive) to acquire temporary assets/influence"
-                title="+2 in 'proper' social standing rolls (back alley dive) to acquire temporary assets/influence"
+                value="Spend plot points for a favor: 1/2 - 500 credit loan (with interest)/information/imprinted goods 3/4 - 5000 credit loan (with interest)/a cut on a smuggling job 5/6 - 10000 credit loan (with interest)/protection from rival crime lord"
+                title="Spend plot points for a favor: 1/2 - 500 credit loan (with interest)/information/imprinted goods 3/4 - 5000 credit loan (with interest)/a cut on a smuggling job 5/6 - 10000 credit loan (with interest)/protection from rival crime lord"
               >
                 Friends in Low Places (minor) - Cost: 2
               </option>
               <option
-                value="Spend plot points for a favor: 1/2 - 500 credit loan (with interest)/information/imprinted goods 3/4 - 5000 credit loan (with interest)/a cut on a smuggling job 5/6 - 10000 credit loan (with interest)/protection from rival crime lord"
-                title="Spend plot points for a favor: 1/2 - 500 credit loan (with interest)/information/imprinted goods 3/4 - 5000 credit loan (with interest)/a cut on a smuggling job 5/6 - 10000 credit loan (with interest)/protection from rival crime lord"
+                value="+2 in 'proper' social standing rolls (back alley dive) to acquire temporary assets/influence"
+                title="+2 in 'proper' social standing rolls (back alley dive) to acquire temporary assets/influence"
               >
                 Friends in Low Places (minor) - Cost: 2
               </option>
@@ -3752,14 +3749,14 @@
                 Healthy as a Horse (major) - Cost: 4
               </option>
               <option
-                value="+4 bonus to resist alcohol drugs gas or poison"
-                title="+4 bonus to resist alcohol drugs gas or poison"
+                value="+2 bonus to resist alcohol drugs gas or poison"
+                title="+2 bonus to resist alcohol drugs gas or poison"
               >
                 Heavy Tolerance (minor) - Cost: 2
               </option>
               <option
-                value="+2 bonus to resist alcohol drugs gas or poison"
-                title="+2 bonus to resist alcohol drugs gas or poison"
+                value="+4 bonus to resist alcohol drugs gas or poison"
+                title="+4 bonus to resist alcohol drugs gas or poison"
               >
                 Heavy Tolerance (minor) - Cost: 2
               </option>
@@ -3962,14 +3959,14 @@
                 Nose for Trouble (minor) - Cost: 2
               </option>
               <option
-                value="+4 bonus to rolls to determine surprise"
-                title="+4 bonus to rolls to determine surprise"
+                value="Can spend 1 plot point to negate all effects of surprise"
+                title="Can spend 1 plot point to negate all effects of surprise"
               >
                 Nose for Trouble (major) - Cost: 4
               </option>
               <option
-                value="Can spend 1 plot point to negate all effects of surprise"
-                title="Can spend 1 plot point to negate all effects of surprise"
+                value="+4 bonus to rolls to determine surprise"
+                title="+4 bonus to rolls to determine surprise"
               >
                 Nose for Trouble (major) - Cost: 4
               </option>
@@ -4010,16 +4007,16 @@
                 Registered Companion (minor) - Cost: 2
               </option>
               <option
-                value="(follower) +2 Willpower skills in crisis"
-                title="(follower) +2 Willpower skills in crisis"
-              >
-                Religiosity (minor) - Cost: 2
-              </option>
-              <option
                 value="(follower of chosen religion) +2 bonus to Willpower once per session"
                 title="(follower of chosen religion) +2 bonus to Willpower once per session"
               >
                 Religiosity (minor) - Cost: 2 - *Requires Specialization*
+              </option>
+              <option
+                value="(follower) +2 Willpower skills in crisis"
+                title="(follower) +2 Willpower skills in crisis"
+              >
+                Religiosity (minor) - Cost: 2
               </option>
               <option
                 value="(teacher of chosen religion) Related plot points spent increased by 2 with those who respect your station"
@@ -4088,14 +4085,14 @@
                 Sweet and Cheerful (minor) - Cost: 2
               </option>
               <option
-                value="+1 bonus to chosen skill in all situations"
-                title="+1 bonus to chosen skill in all situations"
+                value="+2 bonus to chosen skill specialty in all situations"
+                title="+2 bonus to chosen skill specialty in all situations"
               >
                 Talented (minor) - Cost: 2 - *Requires Specialization*
               </option>
               <option
-                value="+2 bonus to chosen skill specialty in all situations"
-                title="+2 bonus to chosen skill specialty in all situations"
+                value="+1 bonus to chosen skill in all situations"
+                title="+1 bonus to chosen skill in all situations"
               >
                 Talented (minor) - Cost: 2 - *Requires Specialization*
               </option>
@@ -4130,24 +4127,24 @@
                 Things go Smooth (major) - Cost: 4
               </option>
               <option
+                value="+2 bonus to any knowledge skill (you never forget details you've experienced). You may spend a plot point to remember verbatim or with photographic calrity"
+                title="+2 bonus to any knowledge skill (you never forget details you've experienced). You may spend a plot point to remember verbatim or with photographic calrity"
+              >
+                Total Recall (major) - Cost: 4
+              </option>
+              <option
                 value="+2 bonus to any knowledge skill (you never forget details you've experienced)"
                 title="+2 bonus to any knowledge skill (you never forget details you've experienced)"
               >
                 Total Recall (major) - Cost: 4
               </option>
               <option
-                value="+2 bonus to any knowledge skill (you never forget details you've experienced). You may spend a plot point to remember verbatim or with photographic calrity"
-                title="+2 bonus to any knowledge skill (you never forget details you've experienced). You may spend a plot point to remember verbatim or with photographic calrity"
-              >
-                Total Recall (major) - Cost: 4
-              </option>
-              <option value="Resist 1 melee dmg" title="Resist 1 melee dmg">
-                Tough as Nails (minor) - Cost: 2
-              </option>
-              <option
                 value="You gain 2 extra life points"
                 title="You gain 2 extra life points"
               >
+                Tough as Nails (minor) - Cost: 2
+              </option>
+              <option value="Resist 1 melee dmg" title="Resist 1 melee dmg">
                 Tough as Nails (minor) - Cost: 2
               </option>
               <option
@@ -4208,16 +4205,16 @@
                 Walking Timepiece (minor) - Cost: 2
               </option>
               <option
-                value="+2 to social influence in region (local law enforcement)"
-                title="+2 to social influence in region (local law enforcement)"
-              >
-                Wears a Badge (minor) - Cost: 4
-              </option>
-              <option
                 value="+2 to Influence-based actions when dealing with those who respect your position in chosen region or planet"
                 title="+2 to Influence-based actions when dealing with those who respect your position in chosen region or planet"
               >
                 Wears a Badge (minor) - Cost: 2 - *Requires Specialization*
+              </option>
+              <option
+                value="+2 to social influence in region (local law enforcement)"
+                title="+2 to social influence in region (local law enforcement)"
+              >
+                Wears a Badge (minor) - Cost: 4
               </option>
               <option
                 value="Your authority covers most of the system"
@@ -4240,6 +4237,10 @@
                 title="Asset Specialization (if applicable)"
               />
             </div>
+            <div class="sheet-serenity-asset-description">
+              <span name="attr_Asset"></span>
+            </div>
+            <hr />
           </fieldset>
           <label class="sheet-serenity-character-custom-assets">
             <input
@@ -4272,6 +4273,7 @@
                     <option value="Minor">Minor</option>
                   </select>
                 </div>
+                <hr />
               </fieldset>
             </div>
           </label>
@@ -4283,9 +4285,6 @@
           title="Complications"
         >
           <fieldset class="repeating_complications">
-            <div class="sheet-serenity-complication-description">
-              <span name="attr_Complication"></span>
-            </div>
             <select
               class="sheet-serenity-complications"
               name="attr_Complication"
@@ -4303,14 +4302,14 @@
                 Allergy (minor) - Cost: 2 - *Requires Specialization*
               </option>
               <option
-                value="-4 to all physical skills in presence of chosen substance with an endurance check to avoid anaphylactic shock"
-                title="-4 to all physical skills in presence of chosen substance with an endurance check to avoid anaphylactic shock"
+                value="Take d2 points of Stun each turn in presence of chosen substance for d4 turns (when your emergency injection kicks in)."
+                title="Take d2 points of Stun each turn in presence of chosen substance for d4 turns (when your emergency injection kicks in)."
               >
                 Allergy (major) - Cost: 4 - *Requires Specialization*
               </option>
               <option
-                value="Take d2 points of Stun each turn in presence of chosen substance for d4 turns (when your emergency injection kicks in)."
-                title="Take d2 points of Stun each turn in presence of chosen substance for d4 turns (when your emergency injection kicks in)."
+                value="-4 to all physical skills in presence of chosen substance with an endurance check to avoid anaphylactic shock"
+                title="-4 to all physical skills in presence of chosen substance with an endurance check to avoid anaphylactic shock"
               >
                 Allergy (major) - Cost: 4 - *Requires Specialization*
               </option>
@@ -4333,14 +4332,14 @@
                 Amorous (over sexed) (minor) - Cost: 2
               </option>
               <option
-                value="-2 to physical skills unable to do work requiring 2 of chosen appendage base move reduced if it's a leg"
-                title="-2 to physical skills unable to do work requiring 2 of chosen appendage base move reduced if it's a leg"
+                value="-2 to physical skills requiring 2 of chosen appendage base move reduced to 5 ft per turn if it's a leg and -4 to movement actions"
+                title="-2 to physical skills requiring 2 of chosen appendage base move reduced to 5 ft per turn if it's a leg and -4 to movement actions"
               >
                 Amputee (minor) - Cost: 2 - *Requires Specialization*
               </option>
               <option
-                value="-2 to physical skills requiring 2 of chosen appendage base move reduced to 5 ft per turn if it's a leg and -4 to movement actions"
-                title="-2 to physical skills requiring 2 of chosen appendage base move reduced to 5 ft per turn if it's a leg and -4 to movement actions"
+                value="-2 to physical skills unable to do work requiring 2 of chosen appendage base move reduced if it's a leg"
+                title="-2 to physical skills unable to do work requiring 2 of chosen appendage base move reduced if it's a leg"
               >
                 Amputee (minor) - Cost: 2 - *Requires Specialization*
               </option>
@@ -4363,26 +4362,26 @@
                 Branded (minor) - Cost: 2
               </option>
               <option
-                value="-4 to social skills where your reputation comes into play"
-                title="-4 to social skills where your reputation comes into play"
-              >
-                Branded (major) - Cost: 4
-              </option>
-              <option
                 value="Everyone knows your reputation (some sympathize however)"
                 title="Everyone knows your reputation (some sympathize however)"
               >
                 Branded (major) - Cost: 4
               </option>
               <option
-                value="Anger Management Issues - Must make a willpower check when provoked or attack automatically. -2 to Willpower checks to avoid violence"
-                title="Anger Management Issues - Must make a willpower check when provoked or attack automatically. -2 to Willpower checks to avoid violence"
+                value="-4 to social skills where your reputation comes into play"
+                title="-4 to social skills where your reputation comes into play"
               >
-                Chip On Your Shoulder (minor) - Cost: 2
+                Branded (major) - Cost: 4
               </option>
               <option
                 value="Anger management issues -2 to peaceable social actions with tension"
                 title="Anger management issues -2 to peaceable social actions with tension"
+              >
+                Chip On Your Shoulder (minor) - Cost: 2
+              </option>
+              <option
+                value="Anger Management Issues - Must make a willpower check when provoked or attack automatically. -2 to Willpower checks to avoid violence"
+                title="Anger Management Issues - Must make a willpower check when provoked or attack automatically. -2 to Willpower checks to avoid violence"
               >
                 Chip On Your Shoulder (minor) - Cost: 2
               </option>
@@ -4513,14 +4512,14 @@
                 Easy Mark (major) - Cost: 4
               </option>
               <option
-                value="You always leave a token or mark behind - +2 for others to track you easily framed"
-                title="You always leave a token or mark behind - +2 for others to track you easily framed"
+                value="You always leave a token or mark behind. Easily framed easier to track. GM tool."
+                title="You always leave a token or mark behind. Easily framed easier to track. GM tool."
               >
                 Ego Signature (minor) - Cost: 2
               </option>
               <option
-                value="You always leave a token or mark behind. Easily framed easier to track. GM tool."
-                title="You always leave a token or mark behind. Easily framed easier to track. GM tool."
+                value="You always leave a token or mark behind - +2 for others to track you easily framed"
+                title="You always leave a token or mark behind - +2 for others to track you easily framed"
               >
                 Ego Signature (minor) - Cost: 2
               </option>
@@ -4531,14 +4530,14 @@
                 Filcher (minor) - Cost: 2
               </option>
               <option
-                value="You lie all the time. Compelled to not tell the truth -4 to influence rolls due to your reputation -2 to group credibility rolls if you are present"
-                title="You lie all the time. Compelled to not tell the truth -4 to influence rolls due to your reputation -2 to group credibility rolls if you are present"
+                value="You lie all the time. Compelled to not tell the truth -4 to influence rolls due to your reputation"
+                title="You lie all the time. Compelled to not tell the truth -4 to influence rolls due to your reputation"
               >
                 Forked Tongue (minor) - Cost: 2
               </option>
               <option
-                value="You lie all the time. Compelled to not tell the truth -4 to influence rolls due to your reputation"
-                title="You lie all the time. Compelled to not tell the truth -4 to influence rolls due to your reputation"
+                value="You lie all the time. Compelled to not tell the truth -4 to influence rolls due to your reputation -2 to group credibility rolls if you are present"
+                title="You lie all the time. Compelled to not tell the truth -4 to influence rolls due to your reputation -2 to group credibility rolls if you are present"
               >
                 Forked Tongue (minor) - Cost: 2
               </option>
@@ -4561,14 +4560,14 @@
                 Good Samaritan (minor) - Cost: 2
               </option>
               <option
-                value="Willpower roll required to avoid making really bad decision for money"
-                title="Willpower roll required to avoid making really bad decision for money"
+                value="You will take almost any opportunity to acquire money"
+                title="You will take almost any opportunity to acquire money"
               >
                 Greedy (minor) - Cost: 2
               </option>
               <option
-                value="You will take almost any opportunity to acquire money"
-                title="You will take almost any opportunity to acquire money"
+                value="Willpower roll required to avoid making really bad decision for money"
+                title="Willpower roll required to avoid making really bad decision for money"
               >
                 Greedy (minor) - Cost: 2
               </option>
@@ -4579,26 +4578,26 @@
                 Hero Worship (minor) - Cost: 2 - *Requires Specialization*
               </option>
               <option
-                value="Not overly dangerous (cigarettes functioning alcoholic) -2 to all attributes if you go longer than 2 days without a fix"
-                title="Not overly dangerous (cigarettes functioning alcoholic) -2 to all attributes if you go longer than 2 days without a fix"
-              >
-                Hooked (minor) - Cost: 2
-              </option>
-              <option
                 value="Not overly dangerous (cigarettes functioning alcoholic) -2 to all attributes for a week until you get your next dose (daily)"
                 title="Not overly dangerous (cigarettes functioning alcoholic) -2 to all attributes for a week until you get your next dose (daily)"
               >
                 Hooked (minor) - Cost: 2
               </option>
               <option
-                value="Abusing a dangerous substance -4 to all attributes if you do not get a dose daily"
-                title="Abusing a dangerous substance -4 to all attributes if you do not get a dose daily"
+                value="Not overly dangerous (cigarettes functioning alcoholic) -2 to all attributes if you go longer than 2 days without a fix"
+                title="Not overly dangerous (cigarettes functioning alcoholic) -2 to all attributes if you go longer than 2 days without a fix"
               >
-                Hooked (major) - Cost: 4
+                Hooked (minor) - Cost: 2
               </option>
               <option
                 value="Abusing a dangerous substance -4 to all attributes for 2 weeks until you get your next dose (daily)"
                 title="Abusing a dangerous substance -4 to all attributes for 2 weeks until you get your next dose (daily)"
+              >
+                Hooked (major) - Cost: 4
+              </option>
+              <option
+                value="Abusing a dangerous substance -4 to all attributes if you do not get a dose daily"
+                title="Abusing a dangerous substance -4 to all attributes if you do not get a dose daily"
               >
                 Hooked (major) - Cost: 4
               </option>
@@ -4657,14 +4656,14 @@
                 Lily Soft Hands (minor) - Cost: 2
               </option>
               <option
-                value="+2 to ranged defenses -2 to movement actions and athletic skills"
-                title="+2 to ranged defenses -2 to movement actions and athletic skills"
+                value="+4 to ranged defenses -2 to movement actions speed reduced to 8 feet per turn"
+                title="+4 to ranged defenses -2 to movement actions speed reduced to 8 feet per turn"
               >
                 Little Person (minor) - Cost: 2
               </option>
               <option
-                value="+4 to ranged defenses -2 to movement actions speed reduced to 8 feet per turn"
-                title="+4 to ranged defenses -2 to movement actions speed reduced to 8 feet per turn"
+                value="+2 to ranged defenses -2 to movement actions and athletic skills"
+                title="+2 to ranged defenses -2 to movement actions and athletic skills"
               >
                 Little Person (minor) - Cost: 2
               </option>
@@ -4723,14 +4722,14 @@
                 Overconfident (minor) - Cost: 2
               </option>
               <option
-                value="-4 to athletic and movement rolls -4 to melee combat"
-                title="-4 to athletic and movement rolls -4 to melee combat"
+                value="-4 to melee actions. Unassisted: Move 2 feet per turn Manual Wheelchair: Move 5 feet per turn -4 to movement actions Electric Wheelchair: Normal movement"
+                title="-4 to melee actions. Unassisted: Move 2 feet per turn Manual Wheelchair: Move 5 feet per turn -4 to movement actions Electric Wheelchair: Normal movement"
               >
                 Paralyzed (major) - Cost: 4
               </option>
               <option
-                value="-4 to melee actions. Unassisted: Move 2 feet per turn Manual Wheelchair: Move 5 feet per turn -4 to movement actions Electric Wheelchair: Normal movement"
-                title="-4 to melee actions. Unassisted: Move 2 feet per turn Manual Wheelchair: Move 5 feet per turn -4 to movement actions Electric Wheelchair: Normal movement"
+                value="-4 to athletic and movement rolls -4 to melee combat"
+                title="-4 to athletic and movement rolls -4 to melee combat"
               >
                 Paralyzed (major) - Cost: 4
               </option>
@@ -4747,26 +4746,26 @@
                 Phobia (minor) - Cost: 2 - *Requires Specialization*
               </option>
               <option
-                value="-2 to all athletic covert and movement rolls -2 to interaction rolls with fitness-focused individuals"
-                title="-2 to all athletic covert and movement rolls -2 to interaction rolls with fitness-focused individuals"
-              >
-                Portly (minor) - Cost: 2
-              </option>
-              <option
                 value="-2 to all athletic rolls -2 to interaction rolls with fitness-focused individuals"
                 title="-2 to all athletic rolls -2 to interaction rolls with fitness-focused individuals"
               >
                 Portly (minor) - Cost: 2
               </option>
               <option
-                value="-4 to all athletic covert and movement rolls -4 to interaction rolls with fitness-focused individuals"
-                title="-4 to all athletic covert and movement rolls -4 to interaction rolls with fitness-focused individuals"
+                value="-2 to all athletic covert and movement rolls -2 to interaction rolls with fitness-focused individuals"
+                title="-2 to all athletic covert and movement rolls -2 to interaction rolls with fitness-focused individuals"
               >
-                Portly (major) - Cost: 4
+                Portly (minor) - Cost: 2
               </option>
               <option
                 value="-4 to all athletic rolls -4 to interaction rolls with fitness-focused individuals -2 to all covert rolls involving disguise and hiding movement reduced to 5 feet per turn"
                 title="-4 to all athletic rolls -4 to interaction rolls with fitness-focused individuals -2 to all covert rolls involving disguise and hiding movement reduced to 5 feet per turn"
+              >
+                Portly (major) - Cost: 4
+              </option>
+              <option
+                value="-4 to all athletic covert and movement rolls -4 to interaction rolls with fitness-focused individuals"
+                title="-4 to all athletic covert and movement rolls -4 to interaction rolls with fitness-focused individuals"
               >
                 Portly (major) - Cost: 4
               </option>
@@ -4825,26 +4824,26 @@
                 Shy (minor) - Cost: 2
               </option>
               <option
-                value="-2 to any Lore skill roll because you didn't learn it as well as you thought"
-                title="-2 to any Lore skill roll because you didn't learn it as well as you thought"
-              >
-                Slow Learner (minor) - Cost: 2
-              </option>
-              <option
                 value="-2 to use of chosen Skill improvements cost 2 additional points to Skill or its Specialties"
                 title="-2 to use of chosen Skill improvements cost 2 additional points to Skill or its Specialties"
               >
                 Slow Learner (minor) - Cost: 2 - *Requires Specialization*
               </option>
               <option
-                value="+1 vulnerability when you take melee dmg you take 1 more pt"
-                title="+1 vulnerability when you take melee dmg you take 1 more pt"
+                value="-2 to any Lore skill roll because you didn't learn it as well as you thought"
+                title="-2 to any Lore skill roll because you didn't learn it as well as you thought"
               >
-                Soft (minor) - Cost: 2
+                Slow Learner (minor) - Cost: 2
               </option>
               <option
                 value="When taking any damage you take one more point of Stun. Must roll Average Willpower+Discipline to keep from weeping and wailing when Wounded"
                 title="When taking any damage you take one more point of Stun. Must roll Average Willpower+Discipline to keep from weeping and wailing when Wounded"
+              >
+                Soft (minor) - Cost: 2
+              </option>
+              <option
+                value="+1 vulnerability when you take melee dmg you take 1 more pt"
+                title="+1 vulnerability when you take melee dmg you take 1 more pt"
               >
                 Soft (minor) - Cost: 2
               </option>
@@ -4903,14 +4902,14 @@
                 Traumatic Flashes (minor) - Cost: 2
               </option>
               <option
-                value="Twice per session GM can trigger -4 to all attributes for 10 min"
-                title="Twice per session GM can trigger -4 to all attributes for 10 min"
+                value="Twice per session GM can trigger incapable of action for d2 turns -2 to all attributes for 10 min"
+                title="Twice per session GM can trigger incapable of action for d2 turns -2 to all attributes for 10 min"
               >
                 Traumatic Flashes (major) - Cost: 4
               </option>
               <option
-                value="Twice per session GM can trigger incapable of action for d2 turns -2 to all attributes for 10 min"
-                title="Twice per session GM can trigger incapable of action for d2 turns -2 to all attributes for 10 min"
+                value="Twice per session GM can trigger -4 to all attributes for 10 min"
+                title="Twice per session GM can trigger -4 to all attributes for 10 min"
               >
                 Traumatic Flashes (major) - Cost: 4
               </option>
@@ -4951,14 +4950,14 @@
                 Weak Stomach (minor) - Cost: 2
               </option>
               <option
-                value="Make a willpower roll to avoid fainting -4 to attributes if you avoid fainting"
-                title="Make a willpower roll to avoid fainting -4 to attributes if you avoid fainting"
+                value="Make an Average Vitality+Willpower roll to avoid fainting for 2d4 minutes every 5 minutes"
+                title="Make an Average Vitality+Willpower roll to avoid fainting for 2d4 minutes every 5 minutes"
               >
                 Weak Stomach (major) - Cost: 4
               </option>
               <option
-                value="Make an Average Vitality+Willpower roll to avoid fainting for 2d4 minutes every 5 minutes"
-                title="Make an Average Vitality+Willpower roll to avoid fainting for 2d4 minutes every 5 minutes"
+                value="Make a willpower roll to avoid fainting -4 to attributes if you avoid fainting"
+                title="Make a willpower roll to avoid fainting -4 to attributes if you avoid fainting"
               >
                 Weak Stomach (major) - Cost: 4
               </option>
@@ -4981,13 +4980,18 @@
                 Young'un (major) - Cost: 4
               </option>
             </select>
-            <span class="sheet-serenity-complication-specialization"
-              >Specialization (if applicable):
+            <div class="sheet-serenity-complication-specialization">
+              Specialization (if applicable):
               <input
                 type="text"
                 name="attr_Specialization"
                 title="Complication Specialization (if applicable)"
-            /></span>
+              />
+            </div>
+            <div class="sheet-serenity-complication-description">
+              <span name="attr_Complication"></span>
+            </div>
+            <hr />
           </fieldset>
           <label class="sheet-serenity-character-custom-complications">
             <input
@@ -5020,6 +5024,7 @@
                     <option value="Minor">Minor</option>
                   </select>
                 </div>
+                <hr />
               </fieldset>
             </div>
           </label>

--- a/Serenity/sheet.json
+++ b/Serenity/sheet.json
@@ -1,9 +1,9 @@
 {
-  "html": "serenity.html",
-  "css": "serenity.css",
-  "authors": "Nico Marrero",
-  "roll20userid": "581781",
-  "preview": "serenity.png",
-  "instructions": "This is a character sheet for SerenityRPG based off of the one made by Kizyr. To clear Stun/Wound/Shock just click the label.",
-  "legacy": true
+	"html": "serenity.html",
+	"css": "serenity.css",
+	"authors": "Nico Marrero",
+	"roll20userid": "581781",
+	"preview": "serenity.png",
+	"instructions": "This is a character sheet for SerenityRPG based off of the one made by Kizyr. To clear Stun/Wound/Shock just click the label.",
+	"legacy": false
 }


### PR DESCRIPTION
## Changes / Comments
* Rearranges asset & complication descriptions to put text after title
* Adds divider between assets and between complications
* Make sheet start full width
* Opt-out of legacy sanitization to allow details/summary elements to work (when deployed)
  * This sheet doesn't depend on automatic changes like "sheet-" prepending 

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
