### PR TITLE
[PokemonTabletopAdventures_v3] HTML Class Name Sanitisation

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -1,6 +1,6 @@
 <!-- Background coloring strategy inspired by the GURPS sheet -->
 <input class="sheet-color-setting" name="attr_type1" type="hidden" value="normal" />
-<div class="wrapper color-background">
+<div class="sheet-wrapper sheet-color-background">
   <div class="sheet-page-selection">
     <button class="sheet-page-selection-option" name="act_character-page" type="action">Character</button>
     <button class="sheet-page-selection-option" name="act_configuration-page" type="action">Configuration</button>
@@ -11,54 +11,54 @@
   <div class="sheet-character-page">
     <input class="sheet-character-type" name="attr_character-type" type="hidden" value="trainer" />
 
-    <p class="logo">
+    <p class="sheet-logo">
       <img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/PokemonTabletopAdventures_v3/images/PTA3SmallLogo.png" />
     </p>
 
-    <div class="tab-trainer">
-      <div class="2col-centered">
-        <div class="character-name-grid">
+    <div class="sheet-tab-trainer">
+      <div class="sheet-2col-centered">
+        <div class="sheet-character-name-grid">
           <b>Name</b>
-          <input class="top-information" name="attr_character_name" spellcheck="false" title="Attribute: character_name" type="text" />
+          <input class="sheet-top-information" name="attr_character_name" spellcheck="false" title="Attribute: character_name" type="text" />
           <b>Origin</b>
-          <input class="top-information" name="attr_origin" spellcheck="false" title="Attribute: origin" type="text" />
+          <input class="sheet-top-information" name="attr_origin" spellcheck="false" title="Attribute: origin" type="text" />
           <b>Honors</b>
-          <input class="top-information" name="attr_honor_count" title="Attribute: honor_count" type="number" />
+          <input class="sheet-top-information" name="attr_honor_count" title="Attribute: honor_count" type="number" />
           <b>Credits</b>
-          <input class="top-information long-number" name="attr_credits" title="Attribute: credits" type="number" />
+          <input class="sheet-top-information long-number" name="attr_credits" title="Attribute: credits" type="number" />
         </div>
 
-        <div class="character-class-grid">
+        <div class="sheet-character-class-grid">
           <b>Class</b>
-          <input class="top-information" name="attr_class1" spellcheck="false" title="Attribute: class1" type="text" />
+          <input class="sheet-top-information" name="attr_class1" spellcheck="false" title="Attribute: class1" type="text" />
           <b>Level</b>
-          <input class="top-information" name="attr_level1" title="Attribute: level1" type="number" />
+          <input class="sheet-top-information" name="attr_level1" title="Attribute: level1" type="number" />
           <b>Class</b>
-          <input class="top-information" name="attr_class2" spellcheck="false" title="Attribute: class2" type="text" />
+          <input class="sheet-top-information" name="attr_class2" spellcheck="false" title="Attribute: class2" type="text" />
           <b>Level</b>
-          <input class="top-information" name="attr_level2" title="Attribute: level2" type="number" />
+          <input class="sheet-top-information" name="attr_level2" title="Attribute: level2" type="number" />
           <b>Class</b>
-          <input class="top-information" name="attr_class3" spellcheck="false" title="Attribute: class3" type="text" />
+          <input class="sheet-top-information" name="attr_class3" spellcheck="false" title="Attribute: class3" type="text" />
           <b>Level</b>
-          <input class="top-information" name="attr_level3" title="Attribute: level3" type="number" />
+          <input class="sheet-top-information" name="attr_level3" title="Attribute: level3" type="number" />
           <b>Class</b>
-          <input class="top-information" name="attr_class4" spellcheck="false" title="Attribute: class4" type="text" />
+          <input class="sheet-top-information" name="attr_class4" spellcheck="false" title="Attribute: class4" type="text" />
           <b>Level</b>
-          <input class="top-information" name="attr_level4" title="Attribute: level4" type="number" />
+          <input class="sheet-top-information" name="attr_level4" title="Attribute: level4" type="number" />
         </div>
       </div>
     </div>
 
-    <div class="tab-pokemon">
-      <div class="2col-centered">
-        <div class="character-name-grid">
+    <div class="sheet-tab-pokemon">
+      <div class="sheet-2col-centered">
+        <div class="sheet-character-name-grid">
           <b>Name</b>
-          <input class="top-information" name="attr_character_name" spellcheck="false" title="Attribute: character_name" type="text" />
+          <input class="sheet-top-information" name="attr_character_name" spellcheck="false" title="Attribute: character_name" type="text" />
           <b>Species</b>
-          <input class="top-information" name="attr_species" spellcheck="false" title="Attribute: species" type="text" />
+          <input class="sheet-top-information" name="attr_species" spellcheck="false" title="Attribute: species" type="text" />
           <b>Type</b>
           <span>
-            <select class="half-text sheet-no-dropdown" name="attr_type1" title="Attribute: type1">
+            <select class="sheet-half-text sheet-no-dropdown" name="attr_type1" title="Attribute: type1">
               <option value="bug">Bug</option>
               <option value="dark">Dark</option>
               <option value="dragon">Dragon</option>
@@ -78,7 +78,7 @@
               <option value="steel">Steel</option>
               <option value="water">Water</option>
             </select>
-            <select class="half-text sheet-no-dropdown" name="attr_type2" title="Attribute: type2">
+            <select class="sheet-half-text sheet-no-dropdown" name="attr_type2" title="Attribute: type2">
               <option value=""></option>
               <option value="bug">Bug</option>
               <option value="dark">Dark</option>
@@ -101,7 +101,7 @@
             </select>
           </span>
           <b>Nature</b>
-          <select class="sheet-no-dropdown top-select" name="attr_nature-type" title="Attribute: nature-type">
+          <select class="sheet-no-dropdown sheet-top-select" name="attr_nature-type" title="Attribute: nature-type">
             <option value=""></option>
             <option value="onely">Lonely (+Atk, -Def)</option>
             <option value="brave">Brave (+Atk, -Spd)</option>
@@ -131,45 +131,45 @@
             <option value="other">Other</option>
           </select>
           <b>Held Item</b>
-          <input class="top-information" name="attr_item" spellcheck="false" title="Attribute: item" type="text" />
+          <input class="sheet-top-information" name="attr_item" spellcheck="false" title="Attribute: item" type="text" />
         </div>
 
-        <div class="character-name-grid">
+        <div class="sheet-character-name-grid">
           <b>Size</b>
-          <input class="top-information" name="attr_size" spellcheck="false" title="Attribute: size" type="text" />
+          <input class="sheet-top-information" name="attr_size" spellcheck="false" title="Attribute: size" type="text" />
           <b>Weight</b>
-          <input class="top-information" name="attr_weight" spellcheck="false" title="Attribute: weight" type="text" />
+          <input class="sheet-top-information" name="attr_weight" spellcheck="false" title="Attribute: weight" type="text" />
           <b>Sex</b>
-          <input class="top-information" name="attr_pokemon_sex" spellcheck="false" title="Attribute: pokemon_sex" type="text" />
+          <input class="sheet-top-information" name="attr_pokemon_sex" spellcheck="false" title="Attribute: pokemon_sex" type="text" />
           <b>Egg Group</b>
-          <input class="top-information" name="attr_egg_group" spellcheck="false" title="Attribute: egg_group" type="text" />
+          <input class="sheet-top-information" name="attr_egg_group" spellcheck="false" title="Attribute: egg_group" type="text" />
           <b>Diet</b>
-          <input class="top-information" name="attr_diet" spellcheck="false" title="Attribute: diet" type="text" />
+          <input class="sheet-top-information" name="attr_diet" spellcheck="false" title="Attribute: diet" type="text" />
         </div>
       </div>
     </div>
 
-    <div class="tab-hybrid">
-      <div class="2col-centered">
-        <div class="character-name-grid">
+    <div class="sheet-tab-hybrid">
+      <div class="sheet-2col-centered">
+        <div class="sheet-character-name-grid">
           <b>Name</b>
-          <input class="top-information" name="attr_character_name" spellcheck="false" title="Attribute: character_name" type="text" />
+          <input class="sheet-top-information" name="attr_character_name" spellcheck="false" title="Attribute: character_name" type="text" />
           <b>Species</b>
-          <input class="top-information" name="attr_species" spellcheck="false" title="Attribute: species" type="text" />
+          <input class="sheet-top-information" name="attr_species" spellcheck="false" title="Attribute: species" type="text" />
           <b>Nature</b>
           <input class="sheet-caps top-information" name="attr_nature-type" spellcheck="false" title="Attribute: nature-type" type="text" />
           <b>Origin</b>
-          <input class="top-information" name="attr_origin" spellcheck="false" title="Attribute: origin" type="text" />
+          <input class="sheet-top-information" name="attr_origin" spellcheck="false" title="Attribute: origin" type="text" />
           <b>Honors</b>
-          <input class="top-information" name="attr_honor_count" title="Attribute: honor_count" type="number" />
+          <input class="sheet-top-information" name="attr_honor_count" title="Attribute: honor_count" type="number" />
           <b>Credits</b>
-          <input class="top-information long-number" name="attr_credits" title="Attribute: credits" type="number" />
+          <input class="sheet-top-information sheet-long-number" name="attr_credits" title="Attribute: credits" type="number" />
         </div>
 
-        <div class="character-name-grid">
+        <div class="sheet-character-name-grid">
           <b>Type</b>
           <span>
-            <select class="half-text sheet-no-dropdown" name="attr_type1" title="type1">
+            <select class="sheet-half-text sheet-no-dropdown" name="attr_type1" title="type1">
               <option value="bug">Bug</option>
               <option value="dark">Dark</option>
               <option value="dragon">Dragon</option>
@@ -189,7 +189,7 @@
               <option value="steel">Steel</option>
               <option value="water">Water</option>
             </select>
-            <select class="half-text sheet-no-dropdown" name="attr_type2" title="type2">
+            <select class="sheet-half-text sheet-no-dropdown" name="attr_type2" title="type2">
               <option value=""></option>
               <option value="bug">Bug</option>
               <option value="dark">Dark</option>
@@ -213,96 +213,76 @@
           </span>
           <b>Size / Weight</b>
           <span>
-            <input class="half-text top-information" name="attr_size" spellcheck="false" title="Attribute: size" type="text" />
-            <input class="half-text top-information" name="attr_weight" spellcheck="false" title="Attribute: weight" type="text" />
+            <input class="sheet-half-text sheet-top-information" name="attr_size" spellcheck="false" title="Attribute: size" type="text" />
+            <input class="sheet-half-text sheet-top-information" name="attr_weight" spellcheck="false" title="Attribute: weight" type="text" />
           </span>
           <b>Sex</b>
-          <input class="top-information" name="attr_pokemon_sex" spellcheck="false" title="Attribute: pokemon_sex" type="text" />
+          <input class="sheet-top-information" name="attr_pokemon_sex" spellcheck="false" title="Attribute: pokemon_sex" type="text" />
           <b>Egg Group</b>
-          <input class="top-information" name="attr_egg_group" spellcheck="false" title="Attribute: egg_group" type="text" />
+          <input class="sheet-top-information" name="attr_egg_group" spellcheck="false" title="Attribute: egg_group" type="text" />
           <b>Diet</b>
-          <input class="top-information" name="attr_diet" spellcheck="false" title="Attribute: diet" type="text" />
+          <input class="sheet-top-information" name="attr_diet" spellcheck="false" title="Attribute: diet" type="text" />
           <b>Held Item</b>
-          <input class="top-information" name="attr_item" spellcheck="false" title="Attribute: item" type="text" />
+          <input class="sheet-top-information" name="attr_item" spellcheck="false" title="Attribute: item" type="text" />
         </div>
       </div>
     </div>
 
     <br />
 
-    <div class="tab-trainer tab-hybrid">
-      <div class="character-stat-grid">
-        <div class="ball hp-ball">
+    <div class="sheet-tab-trainer sheet-tab-hybrid">
+      <div class="sheet-character-stat-grid">
+        <div class="sheet-ball sheet-hp-ball">
           <b>Current HP</b><br />
-          <input class="stat-ball-color" name="attr_HP" title="Attribute: HP" type="number" /><br />
-          <input class="stat-ball-color" name="attr_HP_max" title="Attribute: HP_max" type="number" /><br />
+          <input class="sheet-stat-ball-color" name="attr_HP" title="Attribute: HP" type="number" /><br />
+          <input class="sheet-stat-ball-color" name="attr_HP_max" title="Attribute: HP_max" type="number" /><br />
           <p>Max HP</p>
         </div>
-        <div class="ball atk-ball">
+        <div class="sheet-ball sheet-atk-ball">
           <b>Attack</b><br />
-          <input class="stat-ball-color" name="attr_ATK" title="Attribute: ATK" type="number" /><br />
-          <button
-            class="stat-roller"
-            name="roll_attack_check"
-            type="roll"
-            value="&{template:skill-roll} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Attack Check}} {{skill-roll=[[ 1d20 + [[ @{ATKMOD} + ?{Temp Modifier|0} ]] ]]}}"
-          >
+          <input class="sheet-stat-ball-color" name="attr_ATK" title="Attribute: ATK" type="number" /><br />
+          <button class="sheet-stat-roller" name="roll_attack_check" type="roll"
+            value="&{template:skill-roll} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Attack Check}} {{skill-roll=[[ 1d20 + [[ @{ATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
             <span name="attr_ATKMOD" title="Attribute: ATKMOD"></span>
           </button>
           <br />
           <p>ATK mod</p>
         </div>
-        <div class="ball def-ball">
+        <div class="sheet-ball sheet-def-ball">
           <b>Defense</b><br />
-          <input class="stat-ball-color" name="attr_DEF" title="Attribute: DEF" type="number" /><br />
-          <button
-            class="stat-roller"
-            name="roll_defense_check"
-            type="roll"
-            value="&{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Defense Check}} {{skill-roll=[[ 1d20 + [[ @{DEFMOD} + ?{Temp Modifier|0} ]] ]]}}"
-          >
+          <input class="sheet-stat-ball-color" name="attr_DEF" title="Attribute: DEF" type="number" /><br />
+          <button class="sheet-stat-roller" name="roll_defense_check" type="roll"
+            value="&{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Defense Check}} {{skill-roll=[[ 1d20 + [[ @{DEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
             <span name="attr_DEFMOD" title="Attribute: DEFMOD"></span>
           </button>
           <br />
           <p>DEF mod</p>
         </div>
-        <div class="ball spatk-ball">
+        <div class="sheet-ball sheet-spatk-ball">
           <b>Special Attack</b><br />
-          <input class="stat-ball-color" name="attr_SPATK" title="Attribute: SPATK" type="number" /><br />
-          <button
-            class="stat-roller"
-            name="roll_special-attack_check"
-            type="roll"
-            value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Attack Check}} {{skill-roll=[[ 1d20 + [[ @{SPATKMOD} + ?{Temp Modifier|0} ]] ]]}}"
-          >
+          <input class="sheet-stat-ball-color" name="attr_SPATK" title="Attribute: SPATK" type="number" /><br />
+          <button class="sheet-stat-roller" name="roll_special_attack_check" type="roll"
+            value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Attack Check}} {{skill-roll=[[ 1d20 + [[ @{SPATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
             <span name="attr_SPATKMOD" title="Attribute: SPATKMOD"></span>
           </button>
           <br />
           <p>SPATK mod</p>
         </div>
-        <div class="ball spdef-ball">
+        <div class="sheet-ball sheet-spdef-ball">
           <b>Special Defense</b><br />
-          <input class="stat-ball-color" name="attr_SPDEF" title="Attribute: SPDEF" type="number" /><br />
-          <button
-            class="stat-roller"
-            name="roll_special-defense_check"
-            type="roll"
-            value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Defense Check}} {{skill-roll=[[ 1d20 + [[ @{SPDEFMOD} + ?{Temp Modifier|0} ]] ]]}}"
-          >
+          <input class="sheet-stat-ball-color" name="attr_SPDEF" title="Attribute: SPDEF" type="number" /><br />
+          <button class="sheet-stat-roller" name="roll_special_defense_check" type="roll"
+            value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Defense Check}} {{skill-roll=[[ 1d20 + [[ @{SPDEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
             <span name="attr_SPDEFMOD" title="Attribute: SPDEFMOD"></span>
           </button>
           <br />
           <p>SPDEF mod</p>
         </div>
-        <div class="ball spd-ball">
+        <div class="sheet-ball sheet-spd-ball">
           <b>Speed</b><br />
-          <input class="stat-ball-color" name="attr_SPD" title="Attribute: SPD" type="number" /><br />
-          <button
-            class="stat-roller"
-            name="roll_speed_check"
-            type="roll"
-            value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Speed Check}} {{skill-roll=[[ 1d20 + [[ @{SPDMOD} + ?{Temp Modifier|0} ]] ]]}}"
-          >
+          <input class="sheet-stat-ball-color" name="attr_SPD" title="Attribute: SPD" type="number" /><br />
+          <button class="sheet-stat-roller" name="roll_speed_check" type="roll"
+            value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Speed Check}} {{skill-roll=[[ 1d20 + [[ @{SPDMOD} + ?{Temp Modifier|0} ]] ]]}}">
             <span name="attr_SPDMOD" title="Attribute: SPDMOD"></span>
           </button>
           <br />
@@ -311,59 +291,47 @@
       </div>
     </div>
 
-    <div class="tab-pokemon">
-      <div class="character-stat-grid">
-        <div class="ball hp-ball">
+    <div class="sheet-tab-pokemon">
+      <div class="sheet-character-stat-grid">
+        <div class="sheet-ball sheet-hp-ball">
           <b>Current HP</b><br />
-          <input class="stat-ball-color" name="attr_HP" title="Attribute: HP" type="number" /><br />
-          <input class="stat-ball-color" name="attr_HP_max" title="Attribute: HP_max" type="number" /><br />
+          <input class="sheet-stat-ball-color" name="attr_HP" title="Attribute: HP" type="number" /><br />
+          <input class="sheet-stat-ball-color" name="attr_HP_max" title="Attribute: HP_max" type="number" /><br />
           <p>Max HP</p>
         </div>
-        <div class="ball atk-ball">
+        <div class="sheet-ball sheet-atk-ball">
           <b>Attack</b><br />
-          <input class="stat-ball-color" name="attr_ATK" title="Attribute: ATK" type="number" /><br />
-          <button
-            class="stat-roller"
-            name="roll_attack_check"
-            type="roll"
-            value="&{template:skill-roll} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Attack Check}} {{skill-roll=[[ 1d20 + [[ @{ATKMOD} + ?{Temp Modifier|0} ]] ]]}}"
-          >
+          <input class="sheet-stat-ball-color" name="attr_ATK" title="Attribute: ATK" type="number" /><br />
+          <button class="sheet-stat-roller" name="roll_attack_check" type="roll"
+            value="&{template:skill-roll} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Attack Check}} {{skill-roll=[[ 1d20 + [[ @{ATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
             <span name="attr_ATKMOD" title="Attribute: ATKMOD"></span>
           </button>
           <br />
           <p>ATK mod</p>
         </div>
-        <div class="ball def-ball">
+        <div class="sheet-ball sheet-def-ball">
           <b>Defense</b><br />
-          <input class="stat-ball-color" name="attr_DEF" title="Attribute: DEF" type="number" /><br />
+          <input class="sheet-stat-ball-color" name="attr_DEF" title="Attribute: DEF" type="number" /><br />
         </div>
-        <div class="ball spatk-ball">
+        <div class="sheet-ball sheet-spatk-ball">
           <b>Special Attack</b><br />
-          <input class="stat-ball-color" name="attr_SPATK" title="Attribute: SPATK" type="number" /><br />
-          <button
-            class="stat-roller"
-            name="roll_special-attack_check"
-            type="roll"
-            value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Attack Check}} {{skill-roll=[[ 1d20 + [[ @{SPATKMOD} + ?{Temp Modifier|0} ]] ]]}}"
-          >
+          <input class="sheet-stat-ball-color" name="attr_SPATK" title="Attribute: SPATK" type="number" /><br />
+          <button class="sheet-stat-roller" name="roll_special_attack_check" type="roll"
+            value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Attack Check}} {{skill-roll=[[ 1d20 + [[ @{SPATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
             <span name="attr_SPATKMOD" title="Attribute: SPATKMOD"></span>
           </button>
           <br />
           <p>SPATK mod</p>
         </div>
-        <div class="ball spdef-ball">
+        <div class="sheet-ball sheet-spdef-ball">
           <b>Special Defense</b><br />
-          <input class="stat-ball-color" name="attr_SPDEF" title="Attribute: SPDEF" type="number" /><br />
+          <input class="sheet-stat-ball-color" name="attr_SPDEF" title="Attribute: SPDEF" type="number" /><br />
         </div>
-        <div class="ball spd-ball">
+        <div class="sheet-ball sheet-spd-ball">
           <b>Speed</b><br />
-          <input class="stat-ball-color" name="attr_SPD" title="Attribute: SPD" type="number" /><br />
-          <button
-            class="stat-roller"
-            name="roll_speed_check"
-            type="roll"
-            value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Speed Check}} {{skill-roll=[[ 1d20 + [[ @{SPDMOD} + ?{Temp Modifier|0} ]] ]]}}"
-          >
+          <input class="sheet-stat-ball-color" name="attr_SPD" title="Attribute: SPD" type="number" /><br />
+          <button class="sheet-stat-roller" name="roll_speed_check" type="roll"
+            value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Speed Check}} {{skill-roll=[[ 1d20 + [[ @{SPDMOD} + ?{Temp Modifier|0} ]] ]]}}">
             <span name="attr_SPDMOD" title="Attribute: SPDMOD"></span>
           </button>
           <br />
@@ -372,15 +340,15 @@
       </div>
     </div>
 
-    <div class="tab-pokemon tab-hybrid">
-      <div class="pokemon-extra-stats-grid">
+    <div class="sheet-tab-pokemon sheet-tab-hybrid">
+      <div class="sheet-pokemon-extra-stats-grid">
         <p></p>
         <p></p>
         <p></p>
         <p></p>
         <b>Movement</b>
         <span>
-          <input class="speed-read-color" name="attr_movement" readonly title="Attribute: movement" type="number" />
+          <input class="sheet-speed-read-color" name="attr_movement" readonly title="Attribute: movement" type="number" />
           <b>ft</b>
         </span>
         <b>Temporary Bonuses</b>
@@ -390,11 +358,11 @@
         <b>Special Defense</b>
         <b>Speed</b>
         <b></b>
-        <input class="attack-color" name="attr_atkbonus" title="Attribute: atkbonus" type="number" />
-        <input class="defense-color" name="attr_defbonus" title="Attribute: defbonus" type="number" />
-        <input class="spatk-color" name="attr_spatkbonus" title="Attribute: spatkbonus" type="number" />
-        <input class="spdef-color" name="attr_spdefbonus" title="Attribute: spdefbonus" type="number" />
-        <input class="speed-color" name="attr_spdbonus" title="Attribute: spdbonus" type="number" />
+        <input class="sheet-attack-color" name="attr_atkbonus" title="Attribute: atkbonus" type="number" />
+        <input class="sheet-defense-color" name="attr_defbonus" title="Attribute: defbonus" type="number" />
+        <input class="sheet-spatk-color" name="attr_spatkbonus" title="Attribute: spatkbonus" type="number" />
+        <input class="sheet-spdef-color" name="attr_spdefbonus" title="Attribute: spdefbonus" type="number" />
+        <input class="sheet-speed-color" name="attr_spdbonus" title="Attribute: spdbonus" type="number" />
         <b>Contest Stats</b>
         <b>Cool</b>
         <b>Tough</b>
@@ -402,18 +370,18 @@
         <b>Clever</b>
         <b>Cute</b>
         <b></b>
-        <input class="attack-color" name="attr_cool" title="Attribute: cool" type="number" />
-        <input class="defense-color" name="attr_tough" title="Attribute: tough" type="number" />
-        <input class="spatk-color" name="attr_beauty" title="Attribute: beauty" type="number" />
-        <input class="spdef-color" name="attr_clever" title="Attribute: clever" type="number" />
-        <input class="speed-color" name="attr_cute" title="Attribute: cute" type="number" />
+        <input class="sheet-attack-color" name="attr_cool" title="Attribute: cool" type="number" />
+        <input class="sheet-defense-color" name="attr_tough" title="Attribute: tough" type="number" />
+        <input class="sheet-spatk-color" name="attr_beauty" title="Attribute: beauty" type="number" />
+        <input class="sheet-spdef-color" name="attr_clever" title="Attribute: clever" type="number" />
+        <input class="sheet-speed-color" name="attr_cute" title="Attribute: cute" type="number" />
       </div>
     </div>
 
-    <div class="tab-trainer tab-hybrid">
+    <div class="sheet-tab-trainer sheet-tab-hybrid">
       <br />
 
-      <div class="character-skill-labels">
+      <div class="sheet-character-skill-labels">
         <b>Total</b>
         <b>Skill Name</b>
         <b>Talent</b>
@@ -421,17 +389,13 @@
         <b>Inventory</b>
       </div>
 
-      <div class="2col-centered">
+      <div class="sheet-2col-centered">
         <div>
-          <div class="character-skills">
+          <div class="sheet-character-skills">
             <input class="sheet-skill-color-setting" name="attr_acrobatics_ability_mod" type="hidden" value="SPD" />
             <input class="sheet-skill-total" name="attr_acrobatics_total" readonly title="Attribute: acrobatics_total" type="number" />
-            <button
-              class="skill-roller"
-              name="roll_acrobaticscheck"
-              type="roll"
-              value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Acrobatics}} {{skill-roll=[[ 1d20!kh2 + [[ @{acrobatics_total} + ?{Temporary Bonus|0} ]] ]]}}"
-            >
+            <button class="sheet-skill-roller" name="roll_acrobaticscheck" type="roll"
+              value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Acrobatics}} {{skill-roll=[[ 1d20!kh2 + [[ @{acrobatics_total} + ?{Temporary Bonus|0} ]] ]]}}">
               Acrobatics (<span name="attr_acrobatics_ability_mod"></span>)
             </button>
             <input name="attr_acrobaticstalent1" value="2" title="Attribute: acrobaticstalent1" type="checkbox" />
@@ -440,12 +404,8 @@
 
             <input class="sheet-skill-color-setting" name="attr_athletics_ability_mod" type="hidden" value="ATK" />
             <input class="sheet-skill-total" name="attr_athletics_total" readonly title="Attribute: athletics_total" type="number" />
-            <button
-              class="skill-roller"
-              name="roll_athleticscheck"
-              type="roll"
-              value="&{template:skill-roll} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Athletics}} {{skill-roll=[[ 1d20!kh2 + [[ @{athletics_total} + ?{Temporary Bonus|0} ]] ]]}}"
-            >
+            <button class="sheet-skill-roller" name="roll_athleticscheck" type="roll"
+              value="&{template:skill-roll} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Athletics}} {{skill-roll=[[ 1d20!kh2 + [[ @{athletics_total} + ?{Temporary Bonus|0} ]] ]]}}">
               Athletics (<span name="attr_athletics_ability_mod"></span>)
             </button>
             <input name="attr_athleticstalent1" value="2" title="Attribute: athleticstalent1" type="checkbox" />
@@ -454,12 +414,8 @@
 
             <input class="sheet-skill-color-setting" name="attr_bluff_ability_mod" type="hidden" value="SPDEF" />
             <input class="sheet-skill-total" name="attr_bluff_total" readonly title="Attribute: bluff_total" type="number" />
-            <button
-              class="skill-roller"
-              name="roll_bluffcheck"
-              type="roll"
-              value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Bluff/Deception}} {{skill-roll=[[ 1d20!kh2 + [[ @{bluff_total} + ?{Temporary Bonus|0} ]] ]]}}"
-            >
+            <button class="sheet-skill-roller" name="roll_bluffcheck" type="roll"
+              value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Bluff/Deception}} {{skill-roll=[[ 1d20!kh2 + [[ @{bluff_total} + ?{Temporary Bonus|0} ]] ]]}}">
               Bluff/Deception (<span name="attr_bluff_ability_mod"></span>)
             </button>
             <input name="attr_blufftalent1" value="2" title="Attribute: blufftalent1" type="checkbox" />
@@ -468,12 +424,8 @@
 
             <input class="sheet-skill-color-setting" name="attr_concentration_ability_mod" type="hidden" value="DEF" />
             <input class="sheet-skill-total" name="attr_concentration_total" readonly title="Attribute: concentration_total" type="number" />
-            <button
-              class="skill-roller"
-              name="roll_concentrationcheck"
-              type="roll"
-              value="&{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Concentration}} {{skill-roll=[[ 1d20!kh2 + [[ @{concentration_total} + ?{Temporary Bonus|0} ]] ]]}}"
-            >
+            <button class="sheet-skill-roller" name="roll_concentrationcheck" type="roll"
+              value="&{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Concentration}} {{skill-roll=[[ 1d20!kh2 + [[ @{concentration_total} + ?{Temporary Bonus|0} ]] ]]}}">
               Concentration (<span name="attr_concentration_ability_mod"></span>)
             </button>
             <input name="attr_concentrationtalent1" value="2" title="Attribute: concentrationtalent1" type="checkbox" />
@@ -482,12 +434,8 @@
 
             <input class="sheet-skill-color-setting" name="attr_constitution_ability_mod" type="hidden" value="DEF" />
             <input class="sheet-skill-total" name="attr_constitution_total" readonly title="Attribute: constitution_total" type="number" />
-            <button
-              class="skill-roller"
-              name="roll_constitutioncheck"
-              type="roll"
-              value="&{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Constitution}} {{skill-roll=[[ 1d20!kh2 + [[ @{constitution_total} + ?{Temporary Bonus|0} ]] ]]}}"
-            >
+            <button class="sheet-skill-roller" name="roll_constitutioncheck" type="roll"
+              value="&{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Constitution}} {{skill-roll=[[ 1d20!kh2 + [[ @{constitution_total} + ?{Temporary Bonus|0} ]] ]]}}">
               Constitution (<span name="attr_constitution_ability_mod"></span>)
             </button>
             <input name="attr_constitutiontalent1" value="2" title="Attribute: constitutiontalent1" type="checkbox" />
@@ -496,12 +444,8 @@
 
             <input class="sheet-skill-color-setting" name="attr_diplomacy_ability_mod" type="hidden" value="SPDEF" />
             <input class="sheet-skill-total" name="attr_diplomacy_total" readonly title="Attribute: diplomacy_total" type="number" />
-            <button
-              class="skill-roller"
-              name="roll_diplomacycheck"
-              type="roll"
-              value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Diplomacy/Persuasion}} {{skill-roll=[[ 1d20!kh2 + [[ @{diplomacy_total} + ?{Temporary Bonus|0} ]] ]]}}"
-            >
+            <button class="sheet-skill-roller" name="roll_diplomacycheck" type="roll"
+              value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Diplomacy/Persuasion}} {{skill-roll=[[ 1d20!kh2 + [[ @{diplomacy_total} + ?{Temporary Bonus|0} ]] ]]}}">
               Diplomacy/Persuasion (<span name="attr_diplomacy_ability_mod"></span>)
             </button>
             <input name="attr_diplomacytalent1" value="2" title="Attribute: diplomacytalent1" type="checkbox" />
@@ -510,12 +454,8 @@
 
             <input class="sheet-skill-color-setting" name="attr_engineering_ability_mod" type="hidden" value="SPATK" />
             <input class="sheet-skill-total" name="attr_engineering_total" readonly title="Attribute: engineering_total" type="number" />
-            <button
-              class="skill-roller"
-              name="roll_engineeringcheck"
-              type="roll"
-              value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Engineering/Operation}} {{skill-roll=[[ 1d20!kh2 + [[ @{engineering_total} + ?{Temporary Bonus|0} ]] ]]}}"
-            >
+            <button class="sheet-skill-roller" name="roll_engineeringcheck" type="roll"
+              value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Engineering/Operation}} {{skill-roll=[[ 1d20!kh2 + [[ @{engineering_total} + ?{Temporary Bonus|0} ]] ]]}}">
               Engineering/Operation (<span name="attr_engineering_ability_mod"></span>)
             </button>
             <input name="attr_engineeringtalent1" value="2" title="Attribute: engineeringtalent1" type="checkbox" />
@@ -524,12 +464,8 @@
 
             <input class="sheet-skill-color-setting" name="attr_history_ability_mod" type="hidden" value="SPATK" />
             <input class="sheet-skill-total" name="attr_history_total" readonly title="Attribute: history_total" type="number" />
-            <button
-              class="skill-roller"
-              name="roll_historycheck"
-              type="roll"
-              value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=History}} {{skill-roll=[[ 1d20!kh2 + [[ @{history_total} + ?{Temporary Bonus|0} ]] ]]}}"
-            >
+            <button class="sheet-skill-roller" name="roll_historycheck" type="roll"
+              value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=History}} {{skill-roll=[[ 1d20!kh2 + [[ @{history_total} + ?{Temporary Bonus|0} ]] ]]}}">
               History (<span name="attr_history_ability_mod"></span>)
             </button>
             <input name="attr_historytalent1" value="2" title="Attribute: historytalent1" type="checkbox" />
@@ -538,12 +474,8 @@
 
             <input class="sheet-skill-color-setting" name="attr_insight_ability_mod" type="hidden" value="SPDEF" />
             <input class="sheet-skill-total" name="attr_insight_total" readonly title="Attribute: insight_total" type="number" />
-            <button
-              class="skill-roller"
-              name="roll_insightcheck"
-              type="roll"
-              value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Insight}} {{skill-roll=[[ 1d20!kh2 + [[ @{insight_total} + ?{Temporary Bonus|0} ]] ]]}}"
-            >
+            <button class="sheet-skill-roller" name="roll_insightcheck" type="roll"
+              value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Insight}} {{skill-roll=[[ 1d20!kh2 + [[ @{insight_total} + ?{Temporary Bonus|0} ]] ]]}}">
               Insight (<span name="attr_insight_ability_mod"></span>)
             </button>
             <input name="attr_insighttalent1" value="2" title="Attribute: insighttalent1" type="checkbox" />
@@ -552,12 +484,8 @@
 
             <input class="sheet-skill-color-setting" name="attr_investigate_ability_mod" type="hidden" value="SPATK" />
             <input class="sheet-skill-total" name="attr_investigate_total" readonly title="Attribute: investigate_total" type="number" />
-            <button
-              class="skill-roller"
-              name="roll_investigatecheck"
-              type="roll"
-              value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Investigate}} {{skill-roll=[[ 1d20!kh2 + [[ @{investigate_total} + ?{Temporary Bonus|0} ]] ]]}}"
-            >
+            <button class="sheet-skill-roller" name="roll_investigatecheck" type="roll"
+              value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Investigate}} {{skill-roll=[[ 1d20!kh2 + [[ @{investigate_total} + ?{Temporary Bonus|0} ]] ]]}}">
               Investigate (<span name="attr_investigate_ability_mod"></span>)
             </button>
             <input name="attr_investigatetalent1" value="2" title="Attribute: investigatetalent1" type="checkbox" />
@@ -566,12 +494,8 @@
 
             <input class="sheet-skill-color-setting" name="attr_medicine_ability_mod" type="hidden" value="SPATK" />
             <input class="sheet-skill-total" name="attr_medicine_total" readonly title="Attribute: medicine_total" type="number" />
-            <button
-              class="skill-roller"
-              name="roll_medicinecheck"
-              type="roll"
-              value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Medicine}} {{skill-roll=[[ 1d20!kh2 + [[ @{medicine_total} + ?{Temporary Bonus|0} ]] ]]}}"
-            >
+            <button class="sheet-skill-roller" name="roll_medicinecheck" type="roll"
+              value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Medicine}} {{skill-roll=[[ 1d20!kh2 + [[ @{medicine_total} + ?{Temporary Bonus|0} ]] ]]}}">
               Medicine (<span name="attr_medicine_ability_mod"></span>)
             </button>
             <input name="attr_medicinetalent1" value="2" title="Attribute: medicinetalent1" type="checkbox" />
@@ -580,12 +504,8 @@
 
             <input class="sheet-skill-color-setting" name="attr_nature_ability_mod" type="hidden" value="SPATK" />
             <input class="sheet-skill-total" name="attr_nature_total" readonly title="Attribute: nature_total" type="number" />
-            <button
-              class="skill-roller"
-              name="roll_naturecheck"
-              type="roll"
-              value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Nature}} {{skill-roll=[[ 1d20!kh2 + [[ @{nature_total} + ?{Temporary Bonus|0} ]] ]]}}"
-            >
+            <button class="sheet-skill-roller" name="roll_naturecheck" type="roll"
+              value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Nature}} {{skill-roll=[[ 1d20!kh2 + [[ @{nature_total} + ?{Temporary Bonus|0} ]] ]]}}">
               Nature (<span name="attr_nature_ability_mod"></span>)
             </button>
             <input name="attr_naturetalent1" value="2" title="Attribute: naturetalent1" type="checkbox" />
@@ -594,12 +514,8 @@
 
             <input class="sheet-skill-color-setting" name="attr_perception_ability_mod" type="hidden" value="SPDEF" />
             <input class="sheet-skill-total" name="attr_perception_total" readonly title="Attribute: perception_total" type="number" />
-            <button
-              class="skill-roller"
-              name="roll_perceptioncheck"
-              type="roll"
-              value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perception}} {{skill-roll=[[ 1d20!kh2 + [[ @{perception_total} + ?{Temporary Bonus|0} ]] ]]}}"
-            >
+            <button class="sheet-skill-roller" name="roll_perceptioncheck" type="roll"
+              value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perception}} {{skill-roll=[[ 1d20!kh2 + [[ @{perception_total} + ?{Temporary Bonus|0} ]] ]]}}">
               Perception (<span name="attr_perception_ability_mod"></span>)
             </button>
             <input name="attr_perceptiontalent1" value="2" title="Attribute: perceptiontalent1" type="checkbox" />
@@ -608,12 +524,8 @@
 
             <input class="sheet-skill-color-setting" name="attr_perform_ability_mod" type="hidden" value="SPDEF" />
             <input class="sheet-skill-total" name="attr_perform_total" readonly title="Attribute: perform_total" type="number" />
-            <button
-              class="skill-roller"
-              name="roll_performcheck"
-              type="roll"
-              value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perform}} {{skill-roll=[[ 1d20!kh2 + [[ @{perform_total} + ?{Temporary Bonus|0} ]] ]]}}"
-            >
+            <button class="sheet-skill-roller" name="roll_performcheck" type="roll"
+              value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perform}} {{skill-roll=[[ 1d20!kh2 + [[ @{perform_total} + ?{Temporary Bonus|0} ]] ]]}}">
               Perform (<span name="attr_perform_ability_mod"></span>)
             </button>
             <input name="attr_performtalent1" value="2" title="Attribute: performtalent1" type="checkbox" />
@@ -622,12 +534,8 @@
 
             <input class="sheet-skill-color-setting" name="attr_handling_ability_mod" type="hidden" value="SPDEF" />
             <input class="sheet-skill-total" name="attr_handling_total" readonly title="Attribute: handling_total" type="number" />
-            <button
-              class="skill-roller"
-              name="roll_handlingcheck"
-              type="roll"
-              value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Pokemon Handling}} {{skill-roll=[[ 1d20!kh2 + [[ @{handling_total} + ?{Temporary Bonus|0} ]] ]]}}"
-            >
+            <button class="sheet-skill-roller" name="roll_handlingcheck" type="roll"
+              value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Pokemon Handling}} {{skill-roll=[[ 1d20!kh2 + [[ @{handling_total} + ?{Temporary Bonus|0} ]] ]]}}">
               Pokémon Handling (<span name="attr_handling_ability_mod"></span>)
             </button>
             <input name="attr_handlingtalent1" value="2" title="Attribute: handlingtalent1" type="checkbox" />
@@ -636,12 +544,7 @@
 
             <input class="sheet-skill-color-setting" name="attr_programming_ability_mod" type="hidden" value="SPATK" />
             <input class="sheet-skill-total" name="attr_programming_total" readonly title="Attribute: programming_total" type="number" />
-            <button
-              class="skill-roller"
-              name="roll_programmingcheck"
-              type="roll"
-              value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Programming}} {{skill-roll=[[ 1d20!kh2 + [[ @{programming_total} + ?{Temporary Bonus|0} ]] ]]}}"
-            >
+            <button class="sheet-skill-roller" name="roll_programmingcheck" type="roll" value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Programming}} {{skill-roll=[[ 1d20!kh2 + [[ @{programming_total} + ?{Temporary Bonus|0} ]] ]]}}">
               Programming (<span name="attr_programming_ability_mod"></span>)
             </button>
             <input name="attr_programmingtalent1" value="2" title="Attribute: programmingtalent1" type="checkbox" />
@@ -650,12 +553,8 @@
 
             <input class="sheet-skill-color-setting" name="attr_sleight_ability_mod" type="hidden" value="SPD" />
             <input class="sheet-skill-total" name="attr_sleightofhand_total" readonly title="Attribute: sleightofhand_total" type="number" />
-            <button
-              class="skill-roller"
-              name="roll_sleightofhandcheck"
-              type="roll"
-              value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Sleight of Hand}} {{skill-roll=[[ 1d20!kh2 + [[ @{sleightofhand_total} + ?{Temporary Bonus|0} ]] ]]}}"
-            >
+            <button class="sheet-skill-roller" name="roll_sleightofhandcheck" type="roll"
+              value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Sleight of Hand}} {{skill-roll=[[ 1d20!kh2 + [[ @{sleightofhand_total} + ?{Temporary Bonus|0} ]] ]]}}">
               Sleight of Hand (<span name="attr_sleight_ability_mod"></span>)
             </button>
             <input name="attr_sleightofhandtalent1" value="2" title="Attribute: sleightofhandtalent1" type="checkbox" />
@@ -664,28 +563,20 @@
 
             <input class="sheet-skill-color-setting" name="attr_stealth_ability_mod" type="hidden" value="SPD" />
             <input class="sheet-skill-total" name="attr_stealth_total" readonly title="Attribute: stealth_total" type="number" />
-            <button
-              class="skill-roller"
-              name="roll_stealthcheck"
-              type="roll"
-              value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Stealth}} {{skill-roll=[[ 1d20!kh2 + [[ @{stealth_total} + ?{Temporary Bonus|0} ]] ]]}}"
-            >
+            <button class="sheet-skill-roller" name="roll_stealthcheck" type="roll"
+              value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Stealth}} {{skill-roll=[[ 1d20!kh2 + [[ @{stealth_total} + ?{Temporary Bonus|0} ]] ]]}}">
               Stealth (<span name="attr_stealth_ability_mod"></span>)
             </button>
             <input name="attr_stealthtalent1" value="2" title="Attribute: stealthtalent1" type="checkbox" />
             <input name="attr_stealthtalent2" value="2" title="Attribute: stealthtalent2" type="checkbox" />
             <input name="attr_stealth" value="0" title="Attribute: stealth" type="number" />
           </div>
-          <hr class="skill-separator" />
-          <div class="capture-pokemon-skill tab-trainer">
+          <hr class="sheet-skill-separator" />
+          <div class="sheet-capture-pokemon-skill sheet-tab-trainer">
             <input class="sheet-skill-color-setting" name="attr_capture_ability_mod" type="hidden" value="SPD" />
             <input class="sheet-skill-total" name="attr_capture_total" readonly title="Attribute: capture_total" type="number" />
-            <button
-              class="skill-roller"
-              name="roll_capturecheck"
-              type="roll"
-              value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Capture Pokémon}} {{skill-roll=[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 + @{ball_capture_modifier} ]] }}"
-            >
+            <button class="sheet-skill-roller" name="roll_capturecheck" type="roll"
+              value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Capture Pokémon}} {{skill-roll=[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 + @{ball_capture_modifier} ]] }}">
               Capture Pokémon (<span name="attr_capture_ability_mod"></span>)
             </button>
             <select class="sheet-ball-picker sheet-no-dropdown" name="attr_ball_capture_modifier" title="Attribute: ball_capture_modifier">
@@ -722,121 +613,84 @@
             </select>
           </div>
         </div>
-        <textarea
-          class="inventory"
-          name="attr_inventory"
-          placeholder="Pokéballs, Berries, Medicine, Accessories, etc."
-          spellcheck="false"
-          title="Attribute: inventory"
-        ></textarea>
+        <textarea class="sheet-inventory" name="attr_inventory" placeholder="Pokéballs, Berries, Medicine, Accessories, etc." spellcheck="false" title="Attribute: inventory"></textarea>
       </div>
 
       <br />
 
       <b>Origin Feature</b>
       <div>
-        <div class="pokemon-move-info-header">
-          <input type="text" spellcheck="false" name="attr_originfeaturename" placeholder="Feature Name" />
-          <span
-            ><b>Feature Usage</b>
-            <input type="number" name="attr_origin_usage" value="0" />
+        <div class="sheet-pokemon-move-info-header">
+          <input name="attr_originfeaturename" placeholder="Feature Name" spellcheck="false" type="text" />
+          <span>
+            <b>Feature Usage</b>
+            <input name="attr_origin_usage" type="number" value="0" />
             <button name="act_incrementoriginusage" type="action">+</button>
             <button name="act_resetoriginusage" type="action">Reset</button>
           </span>
         </div>
 
-        <textarea spellcheck="false" name="attr_originfeaturedesc" class="3row-textarea" placeholder="Feature Description"></textarea>
+        <textarea class="sheet-3row-textarea" name="attr_originfeaturedesc" placeholder="Feature Description" spellcheck="false"></textarea>
       </div>
 
       <b>Class Features</b>
       <fieldset class="repeating_features">
-        <div class="pokemon-move-info-header">
-          <input type="text" spellcheck="false" name="attr_classfeaturename" placeholder="Feature Name" />
-          <span
-            ><b>Feature Usage</b>
-            <input type="number" name="attr_feature_usage" value="0" />
+        <div class="sheet-pokemon-move-info-header">
+          <input name="attr_classfeaturename" placeholder="Feature Name" spellcheck="false" type="text" />
+          <span>
+            <b>Feature Usage</b>
+            <input name="attr_feature_usage" type="number" value="0" />
             <button name="act_incrementfeatureusage" type="action">+</button>
             <button name="act_resetfeatureusage" type="action">Reset</button>
           </span>
         </div>
 
-        <textarea spellcheck="false" name="attr_classfeaturedesc" class="3row-textarea" placeholder="Feature Description"></textarea>
+        <textarea class="sheet-3row-textarea" name="attr_classfeaturedesc" placeholder="Feature Description" spellcheck="false"></textarea>
       </fieldset>
 
       <b>Honors</b>
       <textarea spellcheck="false" name="attr_honors" placeholder="Gym Badges, Contest Ribbons, Recognitions, etc."></textarea>
     </div>
 
-    <div class="tab-trainer">
+    <div class="sheet-tab-trainer">
       <b>Owned Pokémon</b>
       <textarea name="attr_ownedpokemon" placeholder="All Pokémon owned by this Trainer" spellcheck="false" title="Attribute: ownedpokemon"></textarea>
     </div>
 
-    <div class="tab-pokemon tab-hybrid">
+    <div class="sheet-tab-hybrid sheet-tab-pokemon">
       <b>Skills</b>
-      <textarea
-        class="3row-textarea"
-        name="attr_pokemonskills"
-        placeholder="Capabilities to be used both in and out of battle, such as Firestarter, Invisibility, and Telekinetic"
-        spellcheck="false"
-        title="Attribute: pokemonskills"
-      ></textarea>
+      <textarea class="sheet-3row-textarea" name="attr_pokemonskills" placeholder="Capabilities to be used both in and out of battle, such as Firestarter, Invisibility, and Telekinetic" spellcheck="false" title="Attribute: pokemonskills"></textarea>
 
       <b>Stat Passives</b>
-      <textarea
-        class="3row-textarea"
-        name="attr_statpassives"
-        placeholder="Passives that affect Pokémon stats, such as Nasty Plot and Play Nice"
-        spellcheck="false"
-        title="Attribute: statpassives"
-      ></textarea>
+      <textarea class="sheet-3row-textarea" name="attr_statpassives" placeholder="Passives that affect Pokémon stats, such as Nasty Plot and Play Nice" spellcheck="false" title="Attribute: statpassives"></textarea>
 
       <b>Other Passives</b>
-      <textarea
-        class="4row-textarea"
-        name="attr_otherpassives"
-        placeholder="Passives that do not affect stats, such as Cute Charm and Static"
-        spellcheck="false"
-        title="Attribute: otherpassives"
-      ></textarea>
+      <textarea class="sheet-4row-textarea" name="attr_otherpassives" placeholder="Passives that do not affect stats, such as Cute Charm and Static" spellcheck="false" title="Attribute: otherpassives"></textarea>
     </div>
 
     <b>Moves</b>
     <fieldset class="repeating_moves">
       <input name="attr_move_category_defense" type="hidden" />
       <input class="sheet-color-setting-move" name="attr_move_type" type="hidden" value="normal" />
-      <div class="pokemon-move">
+      <div class="sheet-pokemon-move">
         <input checked class="sheet-options-flag" name="attr_options_flag" type="checkbox" />
         <span name="attr_flag">-</span>
         <div class="sheet-display">
-          <div class="pokemon-move-info-header">
+          <div class="sheet-pokemon-move-info-header">
             <span class="sheet-fill-space">
-              <button
-                class="sheet-skill-roller sheet-inline-roller"
-                name="roll-movetemplate"
-                title="Click this to roll this attack with the option of choosing temporary modifiers or effectiveness."
-                type="roll"
-                value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} ]]}} {{damage-2=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-3=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-4=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-5=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}}"
-              >
+              <button class="sheet-inline-roller sheet-skill-roller" name="roll-movetemplate" title="Click this to roll this attack with the option of choosing temporary modifiers or effectiveness." type="roll"
+                value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} ]]}} {{damage-2=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-3=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-4=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-5=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}}">
                 <span name="attr_move_name"></span>
               </button>
               <b class="sheet-info-tooltip" title="Click this to roll this attack with the option of choosing temporary modifiers or effectiveness.">ℹ</b>
             </span>
 
             <span class="sheet-fill-space">
-              <button
-                class="sheet-skill-roller sheet-inline-roller"
-                name="roll-quick-move"
-                title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers."
-                type="roll"
-                value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} {{damage-2=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-3=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-4=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-5=[[ @{move_dicenumber}d@{damage_dice} ]]}}"
-              >
+              <button class="sheet-inline-roller sheet-skill-roller" name="roll-quick-move" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers." type="roll"
+                value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} {{damage-2=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-3=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-4=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-5=[[ @{move_dicenumber}d@{damage_dice} ]]}}">
                 Quick Roll
               </button>
-              <b
-                class="sheet-info-tooltip"
-                title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers."
-                >ℹ</b
+              <b class="sheet-info-tooltip" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers.">ℹ</b
               >
             </span>
 
@@ -850,24 +704,15 @@
         </div>
 
         <div class="sheet-options">
-          <div class="pokemon-move-info-header">
+          <div class="sheet-pokemon-move-info-header">
             <input name="attr_move_name" placeholder="Move" spellcheck="false" title="Attribute: move_name" type="text" />
 
             <span class="sheet-fill-space">
-              <button
-                class="skill-roller inline-roller"
-                name="roll-quick-move"
-                title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers."
-                type="roll"
-                value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} {{damage-2=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-3=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-4=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-5=[[ @{move_dicenumber}d@{damage_dice} ]]}}"
-              >
+              <button class="sheet-inline-roller sheet-skill-roller" name="roll-quick-move" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers." type="roll"
+                value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} {{damage-2=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-3=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-4=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-5=[[ @{move_dicenumber}d@{damage_dice} ]]}}">
                 Quick Roll
               </button>
-              <b
-                class="sheet-info-tooltip"
-                title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers."
-                >ℹ</b
-              >
+              <b class="sheet-info-tooltip" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers.">ℹ</b>
             </span>
 
             <span>
@@ -878,9 +723,9 @@
             </span>
           </div>
 
-          <div class="pokemon-move-info-grid-1">
-            <input class="move-text" name="attr_move_range" placeholder="Range" spellcheck="false" title="Attribute: move_range" type="text" />
-            <select class="move-text sheet-no-dropdown" name="attr_move_type" title="Attribute: move_type">
+          <div class="sheet-pokemon-move-info-grid-1">
+            <input class="sheet-move-text" name="attr_move_range" placeholder="Range" spellcheck="false" title="Attribute: move_range" type="text" />
+            <select class="sheet-move-text sheet-no-dropdown" name="attr_move_type" title="Attribute: move_type">
               <option value="bug">Bug</option>
               <option value="dark">Dark</option>
               <option value="dragon">Dragon</option>
@@ -900,13 +745,13 @@
               <option value="steel">Steel</option>
               <option value="water">Water</option>
             </select>
-            <select class="move-text sheet-no-dropdown" name="attr_move_category" title="Attribute: move_category">
+            <select class="sheet-move-text sheet-no-dropdown" name="attr_move_category" title="Attribute: move_category">
               <option value="0">Category</option>
               <option value="1">Attack</option>
               <option value="2">Special Attack</option>
               <option value="3">Effect</option>
             </select>
-            <select class="move-text sheet-no-dropdown" name="attr_move_frequency" title="Attribute: move_frequency">
+            <select class="sheet-move-text sheet-no-dropdown" name="attr_move_frequency" title="Attribute: move_frequency">
               <option value="">Frequency</option>
               <option value="atwill">At-Will</option>
               <!-- 1day and 3day are switched, I know, but if we fix it we mess up existing sheets -->
@@ -917,8 +762,8 @@
 
             <span>
               <b>Damage</b>
-              <input class="top-information damage-dice-count" name="attr_move_dicenumber" title="Attribute: move_dicenumber" type="number" value="0" />
-              <select name="attr_damage_dice" class="damage-dice">
+              <input class="sheet-damage-dice-count sheet-top-information" name="attr_move_dicenumber" title="Attribute: move_dicenumber" type="number" value="0" />
+              <select class="sheet-damage-dice" name="attr_damage_dice">
                 <option value="4">d4</option>
                 <option value="6">d6</option>
                 <option value="8">d8</option>
@@ -928,75 +773,42 @@
               </select>
             </span>
           </div>
-          <div class="pokemon-move-info-grid-2">
+          <div class="sheet-pokemon-move-info-grid-2">
             <span>
               <b>Accuracy Modifier</b>
-              <input class="top-information thin-number" name="attr_move_acmod" title="Attribute: move_acmod" type="number" value="0" />
+              <input class="sheet-top-information sheet-thin-number" name="attr_move_acmod" title="Attribute: move_acmod" type="number" value="0" />
             </span>
 
             <span>
-              <b title="Modify to change critical hits based on the dice roll, as per Focus Energy and Super Luck. For moves like Slash, see Effect Threshold"
-                >Critical Threshold</b
-              >
-              <b
-                class="sheet-info-tooltip"
-                title="Modify to change critical hits based on the dice roll, as per Focus Energy and Super Luck. For moves like Slash, see Effect Threshold"
-                >ℹ</b
-              >
-              <input
-                class="top-information thin-number"
-                max="20"
-                min="1"
-                name="attr_move_critthreshold"
-                title="Attribute: move_critthreshold"
-                type="number"
-                value="20"
-              />
+              <b title="Modify to change critical hits based on the dice roll, as per Focus Energy and Super Luck. For moves like Slash, see Effect Threshold">Critical Threshold</b>
+              <b class="sheet-info-tooltip" title="Modify to change critical hits based on the dice roll, as per Focus Energy and Super Luck. For moves like Slash, see Effect Threshold">ℹ</b>
+              <input class="sheet-top-information sheet-thin-number" max="20" min="1" name="attr_move_critthreshold" title="Attribute: move_critthreshold" type="number" value="20" />
             </span>
 
             <span>
               <b>STAB</b>
-              <input class="top-information thin-number" name="attr_move_stabbonus" title="Attribute: move_stabbonus" type="number" value="0" />
+              <input class="sheet-top-information sheet-thin-number" name="attr_move_stabbonus" title="Attribute: move_stabbonus" type="number" value="0" />
             </span>
 
             <span>
               <b>Extra Damage</b>
-              <input class="top-information thin-number" name="attr_move_damagebonus" title="Attribute: move_damagebonus" type="number" value="0" />
+              <input class="sheet-top-information sheet-thin-number" name="attr_move_damagebonus" title="Attribute: move_damagebonus" type="number" value="0" />
             </span>
 
-            <span class="readonly-field">
+            <span class="sheet-readonly-field">
               <b>Damage Roll:</b>
               <input name="attr_move_totaldamage" type="hidden" />
-              <input
-                class="top-information total-display"
-                name="attr_move_totaldamage_display"
-                readonly
-                title="Attribute: move_totaldamage_display (move_totaldamage for only the numerical bonus)"
-                type="text"
-                value=""
-              />
+              <input class="sheet-top-information sheet-total-display" name="attr_move_totaldamage_display" readonly title="Attribute: move_totaldamage_display (move_totaldamage for only the numerical bonus)" type="text" value="" />
             </span>
 
             <span>
               <b title="Enter the value shown in the move notes for effects like Burned, Poisoned, and Stunned">Effect Threshold</b>
               <b class="sheet-info-tooltip" title="Enter the value shown in the move notes for effects like Burned, Poisoned, and Stunned">ℹ</b>
-              <input
-                class="top-information thin-number"
-                max="20"
-                min="0"
-                name="attr_move_effect1_threshold"
-                title="Attribute: move_effect1_threshold"
-                type="number"
-                value="0"
-              />
+              <input class="sheet-top-information sheet-thin-number" max="20" min="0" name="attr_move_effect1_threshold" title="Attribute: move_effect1_threshold" type="number" value="0" />
             </span>
 
             <span>
-              <select
-                class="move-text"
-                name="attr_move_effect1"
-                title="Attribute: move_effect1_name (move_effect1 for the numerical value used in calculations)"
-              >
+              <select class="sheet-move-text" name="attr_move_effect1" title="Attribute: move_effect1_name (move_effect1 for the numerical value used in calculations)">
                 <option value="98" selected>None</option>
                 <option value="99">Critical Hit</option>
                 <option value="1">Asleep</option>
@@ -1012,31 +824,17 @@
                 <option value="11">Other</option>
               </select>
               <input type="hidden" name="attr_move_effect1_name" />
-              <b class="sheet-info-tooltip" title="Choose Critical Hit for moves where a high accuracy check scores a critical hit, like Slash and Karate Chop"
-                >ℹ</b
-              >
+              <b class="sheet-info-tooltip" title="Choose Critical Hit for moves where a high accuracy check scores a critical hit, like Slash and Karate Chop">ℹ</b>
             </span>
 
             <span>
               <b>Effect Threshold</b>
-              <input
-                class="top-information thin-number"
-                max="20"
-                min="0"
-                name="attr_move_effect2_threshold"
-                title="Attribute: move_effect2_threshold"
-                type="number"
-                value="0"
-              />
+              <input class="sheet-top-information sheet-thin-number" max="20" min="0" name="attr_move_effect2_threshold" title="Attribute: move_effect2_threshold" type="number" value="0" />
             </span>
 
             <span>
               <input name="attr_move_effect2_name" type="hidden" />
-              <select
-                class="move-text"
-                name="attr_move_effect2"
-                title="Attribute: move_effect2_name (move_effect2 for the numerical value used in calculations)"
-              >
+              <select class="sheet-move-text" name="attr_move_effect2" title="Attribute: move_effect2_name (move_effect2 for the numerical value used in calculations)">
                 <option value="98" selected>None</option>
                 <option value="1">Asleep</option>
                 <option value="2">Burned</option>
@@ -1052,27 +850,18 @@
               </select>
             </span>
 
-            <span class="readonly-field">
+            <span class="sheet-readonly-field">
               <b>Accuracy Roll:</b>
               <input name="attr_move_totalaccuracy" type="hidden" />
-              <input
-                class="top-information total-display"
-                name="attr_move_totalaccuracy_display"
-                readonly
-                title="Attribute: move_totalaccuracy_display (move_totalaccuracy for only the numerical bonus)"
-                type="text"
-                value="d20 + 0"
-              />
+              <input class="sheet-top-information sheet-total-display" name="attr_move_totalaccuracy_display" readonly title="Attribute: move_totalaccuracy_display (move_totalaccuracy for only the numerical bonus)" type="text" value="d20 + 0" />
             </span>
 
             <span>
               <b>Scatter</b>
-              <b class="sheet-info-tooltip" title="Choose the Scatter type of the attack. This will effect which roll template is used for the chat log output."
-                >ℹ</b
-              >
+              <b class="sheet-info-tooltip" title="Choose the Scatter type of the attack. This will effect which roll template is used for the chat log output.">ℹ</b>
             </span>
             <span>
-              <select class="move-text" name="attr_move_template" title="Attribute: move_template">
+              <select class="sheet-move-text" name="attr_move_template" title="Attribute: move_template">
                 <option value="move-roll" selected>None</option>
                 <option value="dual-hit-move-roll">Dual Hit</option>
                 <option value="multi-hit-move-roll">Multi Hit</option>
@@ -1081,20 +870,10 @@
             </span>
           </div>
 
-          <div class="move-notes-roller">
-            <textarea
-              class="3row-textarea"
-              name="attr_move_effect"
-              placeholder="Additional Effect Notes"
-              spellcheck="false"
-              title="Attribute: move_effect"
-            ></textarea>
-            <button
-              class="move-roller"
-              name="roll-movetemplate"
-              type="roll"
-              value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} ]]}} {{damage-2=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-3=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-4=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-5=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}}"
-            >
+          <div class="sheet-move-notes-roller">
+            <textarea class="sheet-3row-textarea" name="attr_move_effect" placeholder="Additional Effect Notes" spellcheck="false" title="Attribute: move_effect"></textarea>
+            <button class="sheet-move-roller" name="roll-movetemplate" type="roll"
+              value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} ]]}} {{damage-2=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-3=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-4=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-5=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}}">
               T
             </button>
           </div>
@@ -2000,19 +1779,19 @@
   </rolltemplate>
 
   <rolltemplate class="sheet-rolltemplate-skill-roll">
-    <div class="container sheet-rolltemplate-color-setting-{{base-attribute}}-skill">
-      <table class="skill-template">
+    <div class="sheet-container sheet-rolltemplate-color-setting-{{base-attribute}}-skill">
+      <table class="sheet-skill-template">
         <tr>
           <th colspan="2">{{skill-name}}</th>
         </tr>
         <tr>
-          <td colspan="2" class="subhead">[{{character-name}}](https://journal.roll20.net/character/{{character-id}}" name="name-link")</td>
+          <td colspan="2" class="sheet-subhead">[{{character-name}}](https://journal.roll20.net/character/{{character-id}}" name="name-link")</td>
         </tr>
 
         <!-- Skill Check -->
         <tr>
           <td class="sheet-label"><span>Skill Check:</span></td>
-          <td class="skill-roll">{{skill-roll}}</td>
+          <td class="sheet-skill-roll">{{skill-roll}}</td>
         </tr>
       </table>
     </div>


### PR DESCRIPTION
## Changes / Comments

- Ensures `sheet-` is prepended to every class name in the HTML file, in preparation for the sanitisation changes currently on the dev server.
  - Ensures that when the Roll20 changes go live, the CSS continues to style the sheet properly
- Makes some of the elements that were previously split into many lines less cumbersome to read
