### PR TITLE
[PokemonTabletopAdventures_v3] A new Type Option

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -54,6 +54,9 @@
   --poke-steel: #d1d1e0;
   --poke-steel-background: #ffffff80;
   --poke-steel-shaded: #8d8d9c;
+  --poke-typeless: #9dc1b7;
+  --poke-typeless-background:#e1f5fb;
+  --poke-typeless-shaded: #597d73;
   --poke-water: #9db7f5;
   --poke-water-background: #e1fbff80;
   --poke-water-shaded: #5973b1;
@@ -228,6 +231,13 @@ input.sheet-color-setting-move[value="steel"] ~ div.sheet-pokemon-move {
   --background-color: var(--poke-steel);
   --foreground-color: var(--poke-steel-shaded);
   --text-background-color: var(--poke-steel-background);
+}
+
+input.sheet-color-setting[value="typeless"] ~ div.sheet-wrapper,
+input.sheet-color-setting-move[value="typeless"] ~ div.sheet-pokemon-move {
+  --background-color: var(--poke-typeless);
+  --foreground-color: var(--poke-typeless-shaded);
+  --text-background-color: var(--poke-typeless-background);
 }
 
 input.sheet-color-setting[value="water"] ~ div.sheet-wrapper,
@@ -872,6 +882,12 @@ button[type="roll"].sheet-stat-roller:hover {
   --border-color: var(--poke-steel-shaded);
   --box-bg: linear-gradient(var(--header-bg), var(--border-color));
   --header-bg: var(--poke-steel);
+}
+
+.sheet-rolltemplate-color-setting-typeless-move {
+  --border-color: var(--poke-typeless-shaded);
+  --box-bg: linear-gradient(var(--header-bg), var(--border-color));
+  --header-bg: var(--poke-typeless);
 }
 
 .sheet-rolltemplate-color-setting-water-move {

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -1,5 +1,5 @@
 <!-- Background coloring strategy inspired by the GURPS sheet -->
-<input class="sheet-color-setting" name="attr_type1" type="hidden" value="normal" />
+<input class="sheet-color-setting" name="attr_type1" type="hidden" value="typeless" />
 <div class="sheet-wrapper sheet-color-background">
   <div class="sheet-page-selection">
     <button class="sheet-page-selection-option" name="act_character-page" type="action">Character</button>
@@ -76,6 +76,7 @@
               <option value="psychic">Psychic</option>
               <option value="rock">Rock</option>
               <option value="steel">Steel</option>
+              <option value="typeless">Typeless</option>
               <option value="water">Water</option>
             </select>
             <select class="sheet-half-text sheet-no-dropdown" name="attr_type2" title="Attribute: type2">
@@ -97,6 +98,7 @@
               <option value="psychic">Psychic</option>
               <option value="rock">Rock</option>
               <option value="steel">Steel</option>
+              <option value="typeless">Typeless</option>
               <option value="water">Water</option>
             </select>
           </span>
@@ -187,6 +189,7 @@
               <option value="psychic">Psychic</option>
               <option value="rock">Rock</option>
               <option value="steel">Steel</option>
+              <option value="typeless">Typeless</option>
               <option value="water">Water</option>
             </select>
             <select class="sheet-half-text sheet-no-dropdown" name="attr_type2" title="type2">
@@ -208,6 +211,7 @@
               <option value="psychic">Psychic</option>
               <option value="rock">Rock</option>
               <option value="steel">Steel</option>
+              <option value="typeless">Typeless</option>
               <option value="water">Water</option>
             </select>
           </span>
@@ -743,6 +747,7 @@
               <option value="psychic">Psychic</option>
               <option value="rock">Rock</option>
               <option value="steel">Steel</option>
+              <option value="typeless">Typeless</option>
               <option value="water">Water</option>
             </select>
             <select class="sheet-move-text sheet-no-dropdown" name="attr_move_category" title="Attribute: move_category">
@@ -933,6 +938,7 @@
           <option value="psychic">Psychic</option>
           <option value="rock">Rock</option>
           <option value="steel">Steel</option>
+          <option value="typeless">Typeless</option>
           <option value="water">Water</option>
         </select>
         <p class="sheet-dark-text">


### PR DESCRIPTION

## Changes / Comments
- Adds an option for character/pokémon type that is intended to represent the many type-less artefacts in-game
- Updates the default type selection for new characters to be typeless

## Roll20 Requests

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
