### PR TITLE
[PokemonTabletopAdventures_v3] Minor Sheet Worker Bugfix

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -2331,7 +2331,7 @@
 
   // Move Collapsing
   on("change:repeating_moves:options_flag", function (eventInfo) {
-    const flag = eventInfo.newValue == 1 ? "-" : "+";
+    const flag = eventInfo.newValue == "on" ? "-" : "+";
     setAttrs({ repeating_moves_flag: flag });
   });
 

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -23,6 +23,15 @@ Things we want to add to the character sheet, presented in no particular order o
 
 ## Changelog
 
+### Feb 11th, 2021
+
+- Resolved a small issue with the move repeating section where the button to collapse the fields would show a `+` instead of a `-`
+
+### Feb 10th, 2021
+
+- Add a new type option to the sheet, intended to represent neutral or unknown types - "Typeless"
+  - This uses the color scheme for the ??? type from the Pokémon video games
+
 ### Feb 6th, 2021
 
 - Resolved CSS bug introduced in previous update


### PR DESCRIPTION

## Changes / Comments
- Updates Changelog with the previous addition
- Corrects the move field open/close button display value based on the field state





## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
