### PR TITLE
Update skill improvement in compliance with the 3rd printing.

### DIFF
--- a/Delta Green 2/deltagreen.html
+++ b/Delta Green 2/deltagreen.html
@@ -1057,7 +1057,7 @@
           </fieldset>
         </div>
       </div>
-      <div class="section-directions center"> <span data-i18n="Check a box when you attempt to use a skill and fail. After the session, add 1d4-1 to each checked skill and erase all checks.">Check a box when you attempt to use a skill and fail. After the session, add 1d4-1 to each checked skill and erase all checks.</span>
+      <div class="section-directions center"> <span data-i18n="Check a box when you attempt to use a skill and fail. After the session, add 1d4 to each checked skill and erase all checks.">Check a box when you attempt to use a skill and fail. After the session, add 1d4 to each checked skill and erase all checks.</span>
         <button name="act_levelup" type="action">
           <h3 class="aligned-center" data-i18n="Update" data-i18n-title="Update"></h3>
         </button>
@@ -3650,7 +3650,7 @@ on("clicked:levelup", () =>{
     let len=copyarray.length;         // length of the original copyarray
     let getarray=[];                  // used only to update the values
     let summary={};                   // information in the log for the users
-    let var_rnd=0;                    // random variable of 1d4-1
+    let var_rnd=0;                    // random variable of 1d4
     //console.dir(copyarray);
     //getSectionIDs('repeating_skills', (idarray) => {
     //    for (i=0;i<idarray.length;i++){
@@ -3667,7 +3667,7 @@ on("clicked:levelup", () =>{
                 //console.log(val[`${sk}_fail`]);
                 //    console.log(`${sk}`);
                 if (val[`${sk}_fail`]=='on'){                    //if the checkbox is checked
-                    var_rnd=Math.floor(Math.random() * 4);       // generate a random number for each checked value (less number generated)
+                    var_rnd=Math.floor(Math.random() * (4-1) + 1);       // generate a random number for each checked value (less number generated)
                     //console.log(`${idx}`);
                     summary[`${sk}`]=var_rnd;                    // how much the skill has changed 0-3
                     update[`${sk}`]=(parseInt(val[`${sk}`])||0)+var_rnd;  // new value of the skill


### PR DESCRIPTION
In the 3rd printing, checked skills improve by 1D4, instead of 1D4-1 in previous printings. This change updates the improvement to the 3rd printing.

## Changes / Comments






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
