### PR TITLE
MERP: Add Races and Autocalcs

### DIFF
--- a/MERP/merp_2nd_ed_sheet.css
+++ b/MERP/merp_2nd_ed_sheet.css
@@ -122,6 +122,14 @@ select::-ms-expand {
     text-align: right;
 }
 
+.sheet-main input[type=number].sheet-bodydev {
+    text-align: center;
+    border-width: 1px 1px 1px 1px;
+    font-size: 0.6em;
+    width: 14px;
+    height: 15px;
+}
+
 .sheet-main .sheet-stat-label {
     font-weight: normal;
 }

--- a/MERP/merp_2nd_ed_sheet.css
+++ b/MERP/merp_2nd_ed_sheet.css
@@ -418,6 +418,10 @@ select::-ms-expand {
     font-size: 1.5em;
 }
 
+.sheet-main .sheet-text-field-race {
+    width: 80px;
+}
+
 .sheet-main .sheet-text-field-profession {
     width: 80px;
 }

--- a/MERP/merp_2nd_ed_sheet.html
+++ b/MERP/merp_2nd_ed_sheet.html
@@ -32,6 +32,7 @@
                         </div>
                         <div class="table-cell">
                             <input size="30" type="text" name="attr_character_name" />
+
                         </div>
                     </div>
                     <div class="table-row">
@@ -39,7 +40,50 @@
                             <label>Culture/Race:</label>
                         </div>
                         <div class="table-cell">
-                            <input type="text" name="attr_race" spellcheck="false"/>
+                            <select name="attr_race" class="text-field-race">
+                                <option value="">-Select One-</option>
+                                <optgroup label="Dwarvish Races">
+                                    <option value="Dwarf">Dwarf</option>
+                                    <option value="Umli">Umli</option>
+                                </optgroup>
+                                <optgroup label="Elvish Races">
+                                    <option value="Half-Elf">Half-Elf</option>
+                                    <option value="Noldo Elf">Noldo Elf</option>
+                                    <option value="Sindar Elf">Sindar Elf</option>
+                                    <option value="Silvan Elf">Silvan Elf</option>
+                                </optgroup>
+                                <optgroup label="Hobbits">
+                                    <option value="Hobbit">Hobbit</option>
+                                </optgroup>
+                                <optgroup label="Men">
+                                    <option value="Beorning">Beorning</option>
+                                    <option value="Black Numenorean">Black Numenorean</option>
+                                    <option value="Corsair">Corsair</option>
+                                    <option value="Dorwinrim">Dorwinrim</option>
+                                    <option value="Dunedain">Dunedain</option>
+                                    <option value="Dunlending">Dunlending</option>
+                                    <option value="Easterling">Easterling</option>
+                                    <option value="Eriadoran">Eriadoran</option>
+                                    <option value="Gondorian">Gondorian</option>
+                                    <option value="Haradrim">Haradrim</option>
+                                    <option value="Lossoth">Lossoth</option>
+                                    <option value="Rohirrim">Rohirrim</option>
+                                    <option value="Variag">Variag</option>
+                                    <option value="Woodman">Woodman</option>
+                                    <option value="Wose">Wose</option>
+                                </optgroup>
+                                <optgroup label="Orcish Races">
+                                    <option value="Orc">Orc</option>
+                                    <option value="Uruk-Hai">Uruk-Hai</option>
+                                    <option value="Half-Orc">Half-Orc</option>
+                                </optgroup>
+                                <optgroup label="Trollish Races">
+                                    <option value="Troll">Troll</option>
+                                    <option value="Olog-Hai">Olog-Hai</option>
+                                    <option value="Half-Troll">Half-Troll</option>
+                                </optgroup>
+                            </select>
+
                         </div>
                     </div>
                     <div class="table-row">
@@ -51,6 +95,7 @@
                                 <div class="table-row">
                                     <div class="table-cell">
                                         <select name="attr_profession" class="text-field-profession">                
+                                            <option value="">-Select One-</option>
                                             <option value="animist">Animist</option>
                                             <option value="bard">Bard</option>
                                             <option value="mage">Mage</option>
@@ -126,8 +171,9 @@
                                     </div>
                                     <div class="table-cell">
                                         <select name="attr_realm" class="text-field-medium"> 
-                                            <option value="channeling">Channeling</option>
-                                            <option value="essence">Essence</option>
+                                            <option value="">None</option>
+                                            <option value="Channeling">Channeling</option>
+                                            <option value="Essence">Essence</option>
                                         </select>
                                     </div>
                                 </div>
@@ -235,8 +281,8 @@
                     <tr>
                         <td class="skill-label">Defensive Bonus</td>
                         <td class="skill-label sheet-table-stat-label">AG</td>
-                        <td><input class="autocalc-stat" type="number" name="attr_defensive_stat_bonus" value="@{stat_ag_total_bonus}" disabled /></td>
-                        <td><input type="number" name="attr_defensive_race_bonus" value="0"/></td>
+                        <td><input class="autocalc-stat-right" type="number" name="attr_defensive_stat_bonus" value="@{stat_ag_total_bonus}" disabled /></td>
+                        <td><input class="autocalc-stat-right" type="number" name="attr_defensive_race_bonus" value="0" disabled /></td>
                         <td><input type="number" name="attr_defensive_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_defensive_spec1_bonus" value="0"/></td>
                         <td><input type="number" class="autocalc-bonus" name="attr_defensive_spec2_bonus" value="@{shield_bonus}" disabled></td>
@@ -249,8 +295,11 @@
                     <tr>
                         <td class="skill-label">Essence RR</td>
                         <td class="skill-label sheet-table-stat-label">IG</td>
-                        <td><input class="autocalc-stat" type="number" name="attr_essence_stat_bonus" value="@{stat_ig_total_bonus}" disabled /></td>
-                        <td><input type="number" name="attr_essence_race_bonus" value="0"/></td>
+                        <td><input class="autocalc-stat-right" type="number" name="attr_essence_stat_bonus" value="@{stat_ig_total_bonus}" disabled /></td>
+                        <td>
+                            <input class="autocalc-stat-right" type="number" name="attr_essence_display_race_bonus" value="@{essence_race_bonus}" disabled>
+                            <input type="hidden" name="attr_essence_race_bonus" value="0"/>
+                        </td>
                         <td><input type="number" name="attr_essence_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_essence_spec1_bonus" value="0"/></td>
                         <td><input type="number" name="attr_essence_spec2_bonus" value="0"/></td>
@@ -266,8 +315,11 @@
                     <tr>
                         <td class="skill-label">Channeling RR</td>
                         <td class="skill-label sheet-table-stat-label">IT</td>
-                        <td><input class="autocalc-stat" type="number" name="attr_channeling_stat_bonus" value="@{stat_it_total_bonus}" disabled /></td>
-                        <td><input type="number" name="attr_channeling_race_bonus" value="0"/></td>
+                        <td><input class="autocalc-stat-right" type="number" name="attr_channeling_stat_bonus" value="@{stat_it_total_bonus}" disabled /></td>
+                        <td>
+                            <input class="autocalc-stat-right" type="number" name="attr_channeling_display_race_bonus" value="@{channeling_race_bonus}" disabled>
+                            <input type="hidden" name="attr_channeling_race_bonus" value="0"/>
+                        </td>
                         <td><input type="number" name="attr_channeling_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_channeling_spec1_bonus" value="0"/></td>
                         <td><input type="number" name="attr_channeling_spec2_bonus" value="0"/></td>
@@ -283,8 +335,11 @@
                     <tr>
                         <td class="skill-label">Poison RR</td>
                         <td class="skill-label sheet-table-stat-label">CO</td>
-                        <td><input class="autocalc-stat" type="number" name="attr_poison_stat_bonus" value="@{stat_co_total_bonus}" disabled /></td>
-                        <td><input type="number" name="attr_poison_race_bonus" value="0"/></td>                        
+                        <td><input class="autocalc-stat-right" type="number" name="attr_poison_stat_bonus" value="@{stat_co_total_bonus}" disabled /></td>
+                        <td>
+                            <input class="autocalc-stat-right" type="number" name="attr_poison_display_race_bonus" value="@{poison_race_bonus}" disabled>
+                            <input type="hidden" name="attr_poison_race_bonus" value="0"/>
+                        </td>
                         <td><input type="number" name="attr_poison_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_poison_spec1_bonus" value="0"/></td>
                         <td><input type="number" name="attr_poison_spec2_bonus" value="0"/></td>
@@ -300,8 +355,11 @@
                     <tr>
                         <td class="skill-label">Disease RR</td>
                         <td class="skill-label sheet-table-stat-label">CO</td>
-                        <td><input class="autocalc-stat" type="number" name="attr_disease_stat_bonus" value="@{stat_co_total_bonus}" disabled /></td>
-                        <td><input type="number" name="attr_disease_race_bonus" value="0"/></td>                                                
+                        <td><input class="autocalc-stat-right" type="number" name="attr_disease_stat_bonus" value="@{stat_co_total_bonus}" disabled /></td>
+                        <td>
+                            <input class="autocalc-stat-right" type="number" name="attr_disease_display_race_bonus" value="@{disease_race_bonus}" disabled>
+                            <input type="hidden" name="attr_disease_race_bonus" value="0"/>
+                        </td>
                         <td><input type="number" name="attr_disease_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_disease_spec1_bonus" value="0"/></td>
                         <td><input type="number" name="attr_disease_spec2_bonus" value="0"/></td>
@@ -405,7 +463,7 @@
                                         <table class="point-indicator">
                                             <tr class="point-indicator-header">
                                                 <td><span class="point-indicator-header-text">Hit Points</span></td>
-                                                <td>[<input type="number" class="point-indicator-header-score" class="autocalc-stat" name="attr_total_hit_points" value="@{skill_bodydev_total_bonus}" disabled>]</td>
+                                                <td>[<input type="number" class="point-indicator-header-score" class="autocalc-stat-right" name="attr_total_hit_points" value="@{skill_bodydev_total_bonus}" disabled>]</td>
                                             </tr>
                                             <tr>
                                                 <td colspan="2" class="align-center">
@@ -515,85 +573,103 @@
                             <th class="stats-table-head">Total</th>
                         </tr>
                         <tr>
-                            <td class="stat-label">Strength</td>
+                            <td class="stat-label" title="A character's capabilities in melee, carrying loads, and other activities requiring strength.">Strength</td>
                             <td class="stat-label">(ST)</td>
                             <td><input type="number" name="attr_stat_st_value" min="0" value="50"/></td>
                             <td>
-                                <input type="number" name="attr_stat_st_norm_bonus" value="@{stat_st_stat_bonus}" disabled>
+                                <input class="autocalc-stat-right" type="number" name="attr_stat_st_norm_bonus" value="@{stat_st_stat_bonus}" disabled>
                                 <input type="hidden" name="attr_stat_st_stat_bonus" value="0"/>
                             </td>
-                            <td><input type="number" name="attr_stat_st_race_bonus" value="0"/></td>
+                            <td>
+                                <input class="autocalc-stat-right" type="number" name="attr_stat_st_display_race_bonus" value="@{stat_st_race_bonus}" disabled>
+                                <input type="hidden" name="attr_stat_st_race_bonus" value="0"/>
+                            </td>
                             <td><input type="number" name="attr_stat_st_misc_bonus" value="0"/></td>
                             <td><input type="number" class="autocalc-total" name="attr_stat_st_total_bonus" value="(@{stat_st_norm_bonus}+@{stat_st_race_bonus}+@{stat_st_misc_bonus})" disabled></td>
                         </tr>
                         <tr>
-                            <td class="stat-label">Agility</td>
+                            <td class="stat-label" title="A character's manual dexterity, litheness, quickness, reaction time, and speed.">Agility</td>
                             <td class="stat-label">(AG)</td>
                             <td><input type="number" name="attr_stat_ag_value" min="0" value="50"/></td>
                             <td>
-                                <input type="number" name="attr_stat_ag_norm_bonus" value="@{stat_ag_stat_bonus}" disabled>
+                                <input class="autocalc-stat-right" type="number" name="attr_stat_ag_norm_bonus" value="@{stat_ag_stat_bonus}" disabled>
                                 <input type="hidden" name="attr_stat_ag_stat_bonus" value="0"/>
                             </td>
-                            <td><input type="number" name="attr_stat_ag_race_bonus" value="0"/></td>
+                            <td>
+                                <input class="autocalc-stat-right" type="number" name="attr_stat_ag_display_race_bonus" value="@{stat_ag_race_bonus}" disabled>
+                                <input type="hidden" name="attr_stat_ag_race_bonus" value="0"/>
+                            </td>
                             <td><input type="number" name="attr_stat_ag_misc_bonus" value="0"/></td>
                             <td><input type="number" class="autocalc-total" name="attr_stat_ag_total_bonus" value="(@{stat_ag_norm_bonus}+@{stat_ag_race_bonus}+@{stat_ag_misc_bonus})" disabled></td>
                         </tr>
                         <tr>
-                            <td class="stat-label">Constitution</td>
+                            <td class="stat-label" title="A character's general health and well-being.">Constitution</td>
                             <td class="stat-label">(CO)</td>
                             <td><input type="number" name="attr_stat_co_value" min="0" value="50"/></td>
                             <td>
-                                <input type="number" name="attr_stat_co_norm_bonus" value="@{stat_co_stat_bonus}" disabled>
+                                <input class="autocalc-stat-right" type="number" name="attr_stat_co_norm_bonus" value="@{stat_co_stat_bonus}" disabled>
                                 <input type="hidden" name="attr_stat_co_stat_bonus" value="0"/>
                             </td>
-                            <td><input type="number" name="attr_stat_co_race_bonus" value="0"/></td>
+                            <td>
+                                <input class="autocalc-stat-right" type="number" name="attr_stat_co_display_race_bonus" value="@{stat_co_race_bonus}" disabled>
+                                <input type="hidden" name="attr_stat_co_race_bonus" value="0"/>
+                            </td>
                             <td><input type="number" name="attr_stat_co_misc_bonus" value="0"/></td>
                             <td><input type="number" class="autocalc-total" name="attr_stat_co_total_bonus" value="(@{stat_co_norm_bonus}+@{stat_co_race_bonus}+@{stat_co_misc_bonus})" disabled></td>
                         </tr>
                         <tr>
-                            <td class="stat-label">Intelligence</td>
+                            <td class="stat-label" title="A character's reasoning, memory, and common sense.">Intelligence</td>
                             <td class="stat-label">(IG)</td>
                             <td><input type="number" name="attr_stat_ig_value" min="0" value="50"/></td>
                             <td>
-                                <input type="number" name="attr_stat_ig_norm_bonus" value="@{stat_ig_stat_bonus}" disabled>
+                                <input class="autocalc-stat-right" type="number" name="attr_stat_ig_norm_bonus" value="@{stat_ig_stat_bonus}" disabled>
                                 <input type="hidden" name="attr_stat_ig_stat_bonus" value="0"/>
                             </td>
-                            <td><input type="number" name="attr_stat_ig_race_bonus" value="0"/></td>
+                            <td>
+                                <input class="autocalc-stat-right" type="number" name="attr_stat_ig_display_race_bonus" value="@{stat_ig_race_bonus}" disabled>
+                                <input type="hidden" name="attr_stat_ig_race_bonus" value="0"/>
+                            </td>
                             <td><input type="number" name="attr_stat_ig_misc_bonus" value="0"/></td>
                             <td><input type="number" class="autocalc-total" name="attr_stat_ig_total_bonus" value="(@{stat_ig_norm_bonus}+@{stat_ig_race_bonus}+@{stat_ig_misc_bonus})" disabled></td>
                         </tr>
                         <tr>
-                            <td class="stat-label">Intuition</td>
+                            <td class="stat-label" title="A character's wisdom, luck, and genius.">Intuition</td>
                             <td class="stat-label">(IT)</td>
                             <td><input type="number" name="attr_stat_it_value" min="0" value="50"/></td>
                             <td>
-                                <input type="number" name="attr_stat_it_norm_bonus" value="@{stat_it_stat_bonus}" disabled>
+                                <input class="autocalc-stat-right" type="number" name="attr_stat_it_norm_bonus" value="@{stat_it_stat_bonus}" disabled>
                                 <input type="hidden" name="attr_stat_it_stat_bonus" value="0"/>
                             </td>
-                            <td><input type="number" name="attr_stat_it_race_bonus" value="0"/></td>
+                            <td>
+                                <input class="autocalc-stat-right" type="number" name="attr_stat_it_display_race_bonus" value="@{stat_it_race_bonus}" disabled>
+                                <input type="hidden" name="attr_stat_it_race_bonus" value="0"/>
+                            </td>
                             <td><input type="number" name="attr_stat_it_misc_bonus" value="0"/></td>
                             <td><input type="number" class="autocalc-total" name="attr_stat_it_total_bonus" value="(@{stat_it_norm_bonus}+@{stat_it_race_bonus}+@{stat_it_misc_bonus})" disabled></td>
                         </tr>
                         <tr>
-                            <td class="stat-label">Presence</td>
+                            <td class="stat-label" title="A character's self-discipline, courage, bearing, self esteem, and charisma.">Presence</td>
                             <td class="stat-label">(PR)</td>
                             <td><input type="number" name="attr_stat_pr_value" min="0" value="50"/></td>
                             <td>
-                                <input type="number" name="attr_stat_pr_norm_bonus" value="@{stat_pr_stat_bonus}" disabled>
+                                <input class="autocalc-stat-right" type="number" name="attr_stat_pr_norm_bonus" value="@{stat_pr_stat_bonus}" disabled>
                                 <input type="hidden" name="attr_stat_pr_stat_bonus" value="0"/>
                             </td>
-                            <td><input type="number" name="attr_stat_pr_race_bonus" value="0"/></td>
+                            <td>
+                                <input class="autocalc-stat-right" type="number" name="attr_stat_pr_display_race_bonus" value="@{stat_pr_race_bonus}" disabled>
+                                <input type="hidden" name="attr_stat_pr_race_bonus" value="0"/>
+                            </td>
                             <td><input type="number" name="attr_stat_pr_misc_bonus" value="0"/></td>
                             <td><input type="number" class="autocalc-total" name="attr_stat_pr_total_bonus" value="(@{stat_pr_norm_bonus}+@{stat_pr_race_bonus}+@{stat_pr_misc_bonus})" disabled></td>
                         </tr>
                         <tr>
-                            <td class="stat-label">Appearance</td>
+                            <td class="stat-label" title="How well your character is perceived by others.">Appearance</td>
                             <td class="stat-label">(AP)</td>
                             <td><input type="number" name="attr_stat_ap_value" min="0" value="50"/></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
+                            <td>+</td>
+                            <td>PR</td>
+                            <td>=</td>
+                            <td><input type="number" class="autocalc-total" name="attr_stat_ap_total_value" value="(@{stat_ap_value}+@{stat_pr_total_bonus})" disabled></td>
                         </tr>
                     </table>
                 </div>    
@@ -608,11 +684,22 @@
                     </fieldset>
                 </div>
                 <div class="col sheet-border-box sheet-languages-box">
-                    <h3>Languages</h3>
-                    <fieldset class="repeating_languages">            
-                        <input type="text" name="attr_language" class="text-field-language" spellcheck="false"/> 
-                        <input type="number" name="attr_language_rank" />
-                    </fieldset>
+                    <h3>Languages
+                        <input type="number" name="attr_language_display_profession_development" value="@{language_profession_development}" disabled title="Number of ranks earned per level">
+                        <input type="hidden" name="attr_language_profession_development" value="0"/><span class="stat-label">/LEVEL</span>
+                    </h3>
+                    <div class="tablelike">
+                        <div class="table-heading fields-rowlike">
+                            <div class="table-cell">Language</div>
+                            <div class="table-cell" title="Proficiency in Language: 1 - Simple Phrases / No Literacy; 2 - Simple Sentences / Basic Reading; 3 - Fluency (with Accent) / 5th Grade Literacy; 4 - Fluency (with Accent) / 9th Grade Literacy; 5 - Fluency  Total Literacy">Rank</div>
+                        </div>
+                        <fieldset class="repeating_languages">            
+                            <div class="table-cell"><input type="text" name="attr_language" class="text-field-language" spellcheck="false"/></div>
+                            <div class="table-cell"><input type="number" name="attr_language_rank" /></div>
+                        </fieldset>
+                    </div>
+
+
                 </div>
             </div>
         </div>
@@ -661,6 +748,11 @@
                     <tr>
                         <td colspan="12">
                             <span class="skill-heading">Movement and Maneuver</span>
+                            <span class="skill-label">
+                                <input class="autocalc-stat-right" type="number" name="attr_movingmaneuver_display_profession_development" value="@{movingmaneuver_profession_development}" disabled title="Number of rank points per level.  To raise a skill 1 rank = 1 point, 2 ranks = 3 points">
+                                <input type="hidden" name="attr_movingmaneuver_profession_development" value="0"/>
+                                /LEVEL
+                            </span>
                         </td>
                     </tr>
                     <!-- Movement and maneuver -->
@@ -675,7 +767,7 @@
                         </td>
                         <td></td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_noarmor_rank_bonus" value="@{skill_noarmor_sum_ranks}" disabled></td>
-                        <td>AG<input type="number" class="autocalc-stat" name="attr_skill_noarmor_stat_bonus" value="(@{stat_ag_total_bonus})" disabled></td>
+                        <td>AG<input type="number" class="autocalc-stat-right" name="attr_skill_noarmor_stat_bonus" value="(@{stat_ag_total_bonus})" disabled></td>
                         <td class="table-cell-center"> xx </td>
                         <td><input type="number" name="attr_skill_noarmor_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_noarmor_spec1_bonus" value="0"/></td>
@@ -698,7 +790,7 @@
                         </td>
                         <td></td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_softleather_rank_bonus" value="@{skill_softleather_sum_ranks}" disabled></td>
-                        <td>AG<input type="number" class="autocalc-stat" name="attr_skill_softleather_stat_bonus" value="(@{stat_ag_total_bonus})" disabled></td>
+                        <td>AG<input type="number" class="autocalc-stat-right" name="attr_skill_softleather_stat_bonus" value="(@{stat_ag_total_bonus})" disabled></td>
                         <td class="table-cell-center"> xx </td>
                         <td><input type="number" name="attr_skill_softleather_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_softleather_spec1_bonus" value="0"/></td>
@@ -723,7 +815,7 @@
                         </td>
                         <td></td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_rigidleather_rank_bonus" value="@{skill_rigidleather_sum_ranks}" disabled></td>
-                        <td>AG<input type="number" class="autocalc-stat" name="attr_skill_rigidleather_stat_bonus" value="(@{stat_ag_total_bonus})" disabled></td>
+                        <td>AG<input type="number" class="autocalc-stat-right" name="attr_skill_rigidleather_stat_bonus" value="(@{stat_ag_total_bonus})" disabled></td>
                         <td class="table-cell-center"> xx </td>
                         <td><input type="number" name="attr_skill_rigidleather_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_rigidleather_spec1_bonus" value="0"/></td>
@@ -750,7 +842,7 @@
                         </td>
                         <td></td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_chain_rank_bonus" value="@{skill_chain_sum_ranks}" disabled></td>
-                        <td>ST<input type="number" class="autocalc-stat" name="attr_skill_chain_stat_bonus" value="(@{stat_st_total_bonus})" disabled></td>
+                        <td>ST<input type="number" class="autocalc-stat-right" name="attr_skill_chain_stat_bonus" value="(@{stat_st_total_bonus})" disabled></td>
                         <td class="table-cell-center"> xx </td>
                         <td><input type="number" name="attr_skill_chain_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_chain_spec1_bonus" value="0"/></td>
@@ -779,7 +871,7 @@
                         </td>
                         <td></td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_plate_rank_bonus" value="@{skill_plate_sum_ranks}" disabled></td>
-                        <td>ST<input type="number" class="autocalc-stat" name="attr_skill_plate_stat_bonus" value="(@{stat_st_total_bonus})" disabled></td>
+                        <td>ST<input type="number" class="autocalc-stat-right" name="attr_skill_plate_stat_bonus" value="(@{stat_st_total_bonus})" disabled></td>
                         <td class="table-cell-center"> xx </td>
                         <td><input type="number" name="attr_skill_plate_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_plate_spec1_bonus" value="0"/></td>
@@ -794,6 +886,11 @@
                     <tr>
                         <td colspan="12">
                             <span class="skill-heading">Weapon Skills</span>
+                            <span class="skill-label">
+                                <input class="autocalc-stat-right" type="number" name="attr_weapon_display_profession_development" value="@{weapon_profession_development}" disabled title="Number of rank points per level.  To raise a skill 1 rank = 1 point, 2 ranks = 3 points">
+                                <input type="hidden" name="attr_weapon_profession_development" value="0"/>
+                                /LEVEL
+                            </span>
                         </td>
                     </tr>
 
@@ -822,7 +919,7 @@
                             <input type="hidden" name="attr_skill_1hedged_2sum_ranks" value="(@{skill_1hedged_2rank1} + @{skill_1hedged_2rank2} + @{skill_1hedged_2rank3} + @{skill_1hedged_2rank4} + @{skill_1hedged_2rank5})"/>
                         </td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_1hedged_rank_bonus" value="(@{skill_1hedged_5sum_ranks} + @{skill_1hedged_2sum_ranks})" disabled></td>
-                        <td>ST<input type="number" class="autocalc-stat" name="attr_skill_1hedged_stat_bonus" value="(@{stat_st_total_bonus})" disabled></td>
+                        <td>ST<input type="number" class="autocalc-stat-right" name="attr_skill_1hedged_stat_bonus" value="(@{stat_st_total_bonus})" disabled></td>
                         <td><input type="number" name="attr_skill_1hedged_prof_bonus" value="(@{weapon_skill_profession_bonus})" disabled></td>
                         <td><input type="number" name="attr_skill_1hedged_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_1hedged_spec1_bonus" value="0"/></td>
@@ -862,7 +959,7 @@
                             <input type="hidden" name="attr_skill_1hconc_2sum_ranks" value="(@{skill_1hconc_2rank1} + @{skill_1hconc_2rank2} + @{skill_1hconc_2rank3} + @{skill_1hconc_2rank4} + @{skill_1hconc_2rank5})"/>
                         </td>
                         <td><input type="number"class="autocalc-stat-right" name="attr_skill_1hconc_rank_bonus" value="(@{skill_1hconc_5sum_ranks} + @{skill_1hconc_2sum_ranks})" disabled></td>
-                        <td>ST<input type="number" class="autocalc-stat" name="attr_skill_1hconc_stat_bonus" value="(@{stat_st_total_bonus})" disabled></td>
+                        <td>ST<input type="number" class="autocalc-stat-right" name="attr_skill_1hconc_stat_bonus" value="(@{stat_st_total_bonus})" disabled></td>
                         <td><input type="number" name="attr_skill_1hconc_prof_bonus" value="(@{weapon_skill_profession_bonus})" disabled></td>
                         <td><input type="number" name="attr_skill_1hconc_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_1hconc_spec1_bonus" value="0"/></td>
@@ -899,7 +996,7 @@
                             <input type="hidden" name="attr_skill_2handed_2sum_ranks" value="(@{skill_2handed_2rank1} + @{skill_2handed_2rank2} + @{skill_2handed_2rank3} + @{skill_2handed_2rank4} + @{skill_2handed_2rank5})"/>
                         </td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_2handed_rank_bonus" value="(@{skill_2handed_5sum_ranks} + @{skill_2handed_2sum_ranks})" disabled></td>
-                        <td>ST<input type="number" class="autocalc-stat" name="attr_skill_2handed_stat_bonus" value="(@{stat_st_total_bonus})" disabled></td>
+                        <td>ST<input type="number" class="autocalc-stat-right" name="attr_skill_2handed_stat_bonus" value="(@{stat_st_total_bonus})" disabled></td>
                         <td><input type="number" name="attr_skill_2handed_prof_bonus" value="(@{weapon_skill_profession_bonus})" disabled></td>
                         <td><input type="number" name="attr_skill_2handed_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_2handed_spec1_bonus" value="0"/></td>
@@ -938,7 +1035,7 @@
                             <input type="hidden" name="attr_skill_thrown_2sum_ranks" value="(@{skill_thrown_2rank1} + @{skill_thrown_2rank2} + @{skill_thrown_2rank3} + @{skill_thrown_2rank4} + @{skill_thrown_2rank5})"/>
                         </td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_thrown_rank_bonus" value="(@{skill_thrown_5sum_ranks} + @{skill_thrown_2sum_ranks})" disabled></td>
-                        <td>AG<input type="number" class="autocalc-stat" name="attr_skill_thrown_stat_bonus" value="(@{stat_ag_total_bonus})" disabled></td>
+                        <td>AG<input type="number" class="autocalc-stat-right" name="attr_skill_thrown_stat_bonus" value="(@{stat_ag_total_bonus})" disabled></td>
                         <td><input type="number" name="attr_skill_thrown_prof_bonus" value="(@{weapon_skill_profession_bonus})" disabled></td>
                         <td><input type="number" name="attr_skill_thrown_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_thrown_spec1_bonus" value="0"/></td>
@@ -977,7 +1074,7 @@
                             <input type="hidden" name="attr_skill_missile_2sum_ranks" value="(@{skill_missile_2rank1} + @{skill_missile_2rank2} + @{skill_missile_2rank3} + @{skill_missile_2rank4} + @{skill_missile_2rank5})"/>
                         </td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_missile_rank_bonus" value="(@{skill_missile_5sum_ranks} + @{skill_missile_2sum_ranks})" disabled></td>
-                        <td>AG<input type="number" class="autocalc-stat" name="attr_skill_missile_stat_bonus" value="(@{stat_ag_total_bonus})" disabled></td>
+                        <td>AG<input type="number" class="autocalc-stat-right" name="attr_skill_missile_stat_bonus" value="(@{stat_ag_total_bonus})" disabled></td>
                         <td><input type="number" name="attr_skill_missile_prof_bonus" value="(@{weapon_skill_profession_bonus})" disabled></td>
                         <td><input type="number" name="attr_skill_missile_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_missile_spec1_bonus" value="0"/></td>
@@ -1016,7 +1113,7 @@
                             <input type="hidden" name="attr_skill_polearm_2sum_ranks" value="(@{skill_polearm_2rank1} + @{skill_polearm_2rank2} + @{skill_polearm_2rank3} + @{skill_polearm_2rank4} + @{skill_polearm_2rank5})"/>
                         </td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_polearm_rank_bonus" value="(@{skill_polearm_5sum_ranks} + @{skill_polearm_2sum_ranks})" disabled></td>
-                        <td>ST<input type="number" class="autocalc-stat" name="attr_skill_polearm_stat_bonus" value="(@{stat_st_total_bonus})" disabled></td>
+                        <td>ST<input type="number" class="autocalc-stat-right" name="attr_skill_polearm_stat_bonus" value="(@{stat_st_total_bonus})" disabled></td>
                         <td><input type="number" name="attr_skill_polearm_prof_bonus" value="(@{weapon_skill_profession_bonus})" disabled></td>
                         <td><input type="number" name="attr_skill_polearm_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_polearm_spec1_bonus" value="0"/></td>
@@ -1031,6 +1128,11 @@
                     <tr>
                         <td colspan="12">
                             <span class="skill-heading">General Skills</span>
+                            <span class="skill-label">
+                                <input class="autocalc-stat-right" type="number" name="attr_general_display_profession_development" value="@{general_profession_development}" disabled title="Number of rank points per level.  To raise a skill 1 rank = 1 point, 2 ranks = 3 points">
+                                <input type="hidden" name="attr_general_profession_development" value="0"/>
+                                /LEVEL
+                            </span>
                         </td>
                     </tr>
 
@@ -1061,7 +1163,7 @@
                             <input type="hidden" name="attr_skill_climb_2sum_ranks" value="(@{skill_climb_2rank1} + @{skill_climb_2rank2} + @{skill_climb_2rank3} + @{skill_climb_2rank4} + @{skill_climb_2rank5})"/>
                         </td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_climb_rank_bonus" disabled value="(@{skill_climb_5sum_ranks} + @{skill_climb_2sum_ranks})"/></td>
-                        <td>AG<input type="number" class="autocalc-stat" name="attr_skill_climb_stat_bonus" disabled value="(@{stat_ag_total_bonus})"/></td>
+                        <td>AG<input type="number" class="autocalc-stat-right" name="attr_skill_climb_stat_bonus" disabled value="(@{stat_ag_total_bonus})"/></td>
                         <td><input type="number" name="attr_skill_climb_prof_bonus" disabled value="(@{general_skill_profession_bonus})"/></td>
                         <td><input type="number" name="attr_skill_climb_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_climb_spec1_bonus" value="0"/></td>
@@ -1100,7 +1202,7 @@
                             <input type="hidden" name="attr_skill_ride_2sum_ranks" value="(@{skill_ride_2rank1} + @{skill_ride_2rank2} + @{skill_ride_2rank3} + @{skill_ride_2rank4} + @{skill_ride_2rank5})"/>
                         </td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_ride_rank_bonus" disabled value="(@{skill_ride_5sum_ranks} + @{skill_ride_2sum_ranks})"/></td>
-                        <td>IT<input type="number" class="autocalc-stat" name="attr_skill_ride_stat_bonus" disabled value="(@{stat_it_total_bonus})"/></td>
+                        <td>IT<input type="number" class="autocalc-stat-right" name="attr_skill_ride_stat_bonus" disabled value="(@{stat_it_total_bonus})"/></td>
                         <td><input type="number" name="attr_skill_ride_prof_bonus" disabled value="@{general_skill_profession_bonus}"/></td>
                         <td><input type="number" name="attr_skill_ride_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_ride_spec1_bonus" value="0"/></td>
@@ -1139,7 +1241,7 @@
                             <input type="hidden" name="attr_skill_swim_2sum_ranks" value="(@{skill_swim_2rank1} + @{skill_swim_2rank2} + @{skill_swim_2rank3} + @{skill_swim_2rank4} + @{skill_swim_2rank5})"/>
                         </td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_swim_rank_bonus" disabled value="(@{skill_swim_5sum_ranks} + @{skill_swim_2sum_ranks})"/></td>
-                        <td>AG<input type="number" class="autocalc-stat" name="attr_skill_swim_stat_bonus" disabled value="(@{stat_ag_total_bonus})"/></td>
+                        <td>AG<input type="number" class="autocalc-stat-right" name="attr_skill_swim_stat_bonus" disabled value="(@{stat_ag_total_bonus})"/></td>
                         <td><input type="number" name="attr_skill_swim_prof_bonus" disabled value="@{general_skill_profession_bonus}"/></td>
                         <td><input type="number" name="attr_skill_swim_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_swim_spec1_bonus" value="0"/></td>
@@ -1178,7 +1280,7 @@
                             <input type="hidden" name="attr_skill_track_2sum_ranks" value="(@{skill_track_2rank1} + @{skill_track_2rank2} + @{skill_track_2rank3} + @{skill_track_2rank4} + @{skill_track_2rank5})"/>
                         </td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_track_rank_bonus" disabled value="(@{skill_track_5sum_ranks} + @{skill_track_2sum_ranks})"/></td>
-                        <td>IG<input type="number" class="autocalc-stat" name="attr_skill_track_stat_bonus" disabled value="(@{stat_ig_total_bonus})"/></td>
+                        <td>IG<input type="number" class="autocalc-stat-right" name="attr_skill_track_stat_bonus" disabled value="(@{stat_ig_total_bonus})"/></td>
                         <td><input type="number" name="attr_skill_track_prof_bonus" disabled value="@{general_skill_profession_bonus}"/></td>
                         <td><input type="number" name="attr_skill_track_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_track_spec1_bonus" value="0"/></td>
@@ -1193,6 +1295,11 @@
                     <tr>
                         <td colspan="12">
                             <span class="skill-heading">Subterfuge Skills</span>
+                            <span class="skill-label">
+                                <input class="autocalc-stat-right" type="number" name="attr_subterfuge_display_profession_development" value="@{subterfuge_profession_development}" disabled title="Number of rank points per level.  To raise a skill 1 rank = 1 point, 2 ranks = 3 points">
+                                <input type="hidden" name="attr_subterfuge_profession_development" value="0"/>
+                                /LEVEL
+                            </span>
                         </td>
                     </tr>
 
@@ -1258,7 +1365,7 @@
                             <input type="hidden" name="attr_skill_stalkhide_2sum_ranks" value="(@{skill_stalkhide_2rank1} + @{skill_stalkhide_2rank2} + @{skill_stalkhide_2rank3} + @{skill_stalkhide_2rank4} + @{skill_stalkhide_2rank5})"/>
                         </td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_stalkhide_rank_bonus" disabled value="(@{skill_stalkhide_5sum_ranks} + @{skill_stalkhide_2sum_ranks})"/></td>
-                        <td>PR<input type="number" class="autocalc-stat" name="attr_skill_stalkhide_stat_bonus" disabled value="(@{stat_pr_total_bonus})"/></td>
+                        <td>PR<input type="number" class="autocalc-stat-right" name="attr_skill_stalkhide_stat_bonus" disabled value="(@{stat_pr_total_bonus})"/></td>
                         <td><input type="number" name="attr_skill_stalkhide_prof_bonus" disabled value="(@{stalkhide_skill_profession_bonus})"/></td>
                         <td><input type="number" name="attr_skill_stalkhide_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_stalkhide_spec1_bonus" value="0"/></td>
@@ -1297,7 +1404,7 @@
                             <input type="hidden" name="attr_skill_picklock_2sum_ranks" value="(@{skill_picklock_2rank1} + @{skill_picklock_2rank2} + @{skill_picklock_2rank3} + @{skill_picklock_2rank4} + @{skill_picklock_2rank5})"/>
                         </td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_picklock_rank_bonus" disabled value="(@{skill_picklock_5sum_ranks} + @{skill_picklock_2sum_ranks})"/></td>
-                        <td>IG<input type="number" class="autocalc-stat" name="attr_skill_picklock_stat_bonus" disabled value="(@{stat_ig_total_bonus})"/></td>
+                        <td>IG<input type="number" class="autocalc-stat-right" name="attr_skill_picklock_stat_bonus" disabled value="(@{stat_ig_total_bonus})"/></td>
                         <td><input type="number" name="attr_skill_picklock_prof_bonus" disabled value="(@{subterfuge_skill_profession_bonus})"/></td>
                         <td><input type="number" name="attr_skill_picklock_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_picklock_spec1_bonus" value="0"/></td>
@@ -1336,7 +1443,7 @@
                             <input type="hidden" name="attr_skill_disarmtrap_2sum_ranks" value="(@{skill_disarmtrap_2rank1} + @{skill_disarmtrap_2rank2} + @{skill_disarmtrap_2rank3} + @{skill_disarmtrap_2rank4} + @{skill_disarmtrap_2rank5})"/>
                         </td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_disarmtrap_rank_bonus" disabled value="(@{skill_disarmtrap_5sum_ranks} + @{skill_disarmtrap_2sum_ranks})"/></td>
-                        <td>IT<input type="number" class="autocalc-stat" name="attr_skill_disarmtrap_stat_bonus" disabled value="(@{stat_it_total_bonus})"/></td>
+                        <td>IT<input type="number" class="autocalc-stat-right" name="attr_skill_disarmtrap_stat_bonus" disabled value="(@{stat_it_total_bonus})"/></td>
                         <td><input type="number" name="attr_skill_disarmtrap_prof_bonus" disabled value="(@{subterfuge_skill_profession_bonus})"/></td>
                         <td><input type="number" name="attr_skill_disarmtrap_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_disarmtrap_spec1_bonus" value="0"/></td>
@@ -1352,6 +1459,11 @@
                     <tr>
                         <td colspan="12">
                             <span class="skill-heading">Magical Skills</span>
+                            <span class="skill-label">
+                                <input class="autocalc-stat-right" type="number" name="attr_magical_display_profession_development" value="@{magical_profession_development}" disabled title="Number of rank points per level.  To raise a skill 1 rank = 1 point, 2 ranks = 3 points">
+                                <input type="hidden" name="attr_magical_profession_development" value="0"/>
+                                /LEVEL
+                            </span>
                         </td>
                     </tr>
 
@@ -1382,7 +1494,7 @@
                             <input type="hidden" name="attr_skill_readrunes_2sum_ranks" value="(@{skill_readrunes_2rank1} + @{skill_readrunes_2rank2} + @{skill_readrunes_2rank3} + @{skill_readrunes_2rank4} + @{skill_readrunes_2rank5})"/>
                         </td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_readrunes_rank_bonus" disabled value="(@{skill_readrunes_5sum_ranks} + @{skill_readrunes_2sum_ranks})"/></td>
-                        <td>IG<input type="number" class="autocalc-stat" name="attr_skill_readrunes_stat_bonus" disabled value="(@{stat_ig_total_bonus})"/> </td>
+                        <td>IG<input type="number" class="autocalc-stat-right" name="attr_skill_readrunes_stat_bonus" disabled value="(@{stat_ig_total_bonus})"/> </td>
                         <td><input type="number" name="attr_skill_readrunes_prof_bonus" disabled value="(@{magical_skill_profession_bonus})"/> </td>
                         <td><input type="number" name="attr_skill_readrunes_item_bonus" value="0"/> </td>
                         <td><input type="number" name="attr_skill_readrunes_spec1_bonus" value="0"/></td>
@@ -1421,7 +1533,7 @@
                             <input type="hidden" name="attr_skill_useitems_2sum_ranks" value="(@{skill_useitems_2rank1} + @{skill_useitems_2rank2} + @{skill_useitems_2rank3} + @{skill_useitems_2rank4} + @{skill_useitems_2rank5})"/>
                         </td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_useitems_rank_bonus" disabled value="(@{skill_useitems_5sum_ranks} + @{skill_useitems_2sum_ranks})"/></td>
-                        <td>IT<input type="number" class="autocalc-stat" name="attr_skill_useitems_stat_bonus" disabled value="(@{stat_it_total_bonus})"/></td>
+                        <td>IT<input type="number" class="autocalc-stat-right" name="attr_skill_useitems_stat_bonus" disabled value="(@{stat_it_total_bonus})"/></td>
                         <td><input type="number" name="attr_skill_useitems_prof_bonus" disabled value="(@{magical_skill_profession_bonus})"/></td>
                         <td><input type="number" name="attr_skill_useitems_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_useitems_spec1_bonus" value="0"/></td>
@@ -1460,7 +1572,7 @@
                             <input type="hidden" name="attr_skill_directedspells_2sum_ranks" value="(@{skill_directedspells_2rank1} + @{skill_directedspells_2rank2} + @{skill_directedspells_2rank3} + @{skill_directedspells_2rank4} + @{skill_directedspells_2rank5})"/>
                         </td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_directedspells_rank_bonus" disabled value="(@{skill_directedspells_5sum_ranks} + @{skill_directedspells_2sum_ranks})"/></td>
-                        <td>AG<input type="number" class="autocalc-stat" name="attr_skill_directedspells_stat_bonus" disabled value="(@{stat_ag_total_bonus})"/></td>
+                        <td>AG<input type="number" class="autocalc-stat-right" name="attr_skill_directedspells_stat_bonus" disabled value="(@{stat_ag_total_bonus})"/></td>
                         <td><input type="number" name="attr_skill_directedspells_prof_bonus" disabled value="( @{directedspell_skill_profession_bonus})"/></td>
                         <td><input type="number" name="attr_skill_directedspells_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_directedspells_spec1_bonus" value="0"/></td>
@@ -1505,7 +1617,7 @@
                             <input type="hidden" name="attr_skill_perception_2sum_ranks" value="(@{skill_perception_2rank1} + @{skill_perception_2rank2} + @{skill_perception_2rank3} + @{skill_perception_2rank4} + @{skill_perception_2rank5})"/>
                         </td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_perception_rank_bonus" disabled value="(@{skill_perception_5sum_ranks} + @{skill_perception_2sum_ranks})"/></td>
-                        <td>IT<input type="number" class="autocalc-stat" name="attr_skill_perception_stat_bonus" disabled value="(@{stat_it_total_bonus})"/> </td>
+                        <td>IT<input type="number" class="autocalc-stat-right" name="attr_skill_perception_stat_bonus" disabled value="(@{stat_it_total_bonus})"/> </td>
                         <td><input type="number" name="attr_skill_perception_prof_bonus" disabled value="(@{perception_skill_profession_bonus})"/> </td>
                         <td><input type="number" name="attr_skill_perception_item_bonus" value="0"/> </td>
                         <td><input type="number" name="attr_skill_perception_spec1_bonus" value="0"/></td>
@@ -1520,7 +1632,13 @@
 
                     <!-- Body Development -->
                     <tr>
-                        <td class="skill-label">Body Devel.</td>
+                        <td class="skill-label">Body Dev.
+                            <span class="skill-label">
+                                <input class="autocalc-stat-right" type="number" name="attr_body_display_profession_development" value="@{body_profession_development}" disabled title="Number of rank points per level.  To raise a skill 1 rank = 1 point, 2 ranks = 3 points">
+                                <input type="hidden" name="attr_body_profession_development" value="0"/>
+                                /LEVEL
+                            </span>
+                        </td>
                         <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_bodydev_5rank1" value="1" />
                             <input class="rank-box" type="checkbox" name="attr_skill_bodydev_5rank2" value="1" />
@@ -1541,7 +1659,7 @@
                             <input class="rank-box" type="checkbox" name="attr_skill_bodydev_2rank5" value="1" />
                         </td>
                         <td><input type="number" class="autocalc-stat-right" name="attr_skill_bodydev_rank_bonus" value="0"/></td>
-                        <td>CO<input type="number" class="autocalc-stat" name="attr_skill_bodydev_stat_bonus" disabled value="(@{stat_co_total_bonus})"/></td>
+                        <td>CO<input type="number" class="autocalc-stat-right" name="attr_skill_bodydev_stat_bonus" disabled value="(@{stat_co_total_bonus})"/></td>
 
                         <td><input type="number" name="attr_skill_bodydev_prof_bonus" disabled value="(@{bodydev_skill_profession_bonus})"/></td>
                         <td><input type="number" name="attr_skill_bodydev_item_bonus" value="0"/></td>
@@ -1576,7 +1694,7 @@
                         <td></td>
                         <td></td>
                         <td class="table-cell-center"> xx </td>
-                        <td>PR<input type="number" class="autocalc-stat" name="attr_skill_leadership_stat_bonus" value="@{stat_pr_total_bonus}" disabled /></td>
+                        <td>PR<input type="number" class="autocalc-stat-right" name="attr_skill_leadership_stat_bonus" value="@{stat_pr_total_bonus}" disabled /></td>
                         <td class="table-cell-center"> xx </td>
                         <td><input type="number" name="attr_skill_leadership_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_skill_leadership_spec1_bonus" value="0"/></td>
@@ -1643,7 +1761,7 @@
                                     <option value="@{stat_it_total_bonus}">IT</option>
                                     <option value="@{stat_pr_total_bonus}">PR</option>
                                 </select>
-                                <input type="number" class="autocalc-stat" name="attr_skill_secondaryskill_stat_bonus" disabled value="(@{skill_secondaryskill_stat})" /> 
+                                <input type="number" class="autocalc-stat-right" name="attr_skill_secondaryskill_stat_bonus" disabled value="(@{skill_secondaryskill_stat})" /> 
                             </div>
                             <div class="table-cell sheet-secondaryskill-cell">xx</div>
                             <div class="table-cell sheet-secondaryskill-cell"><input type="number" name="attr_skill_secondaryskill_item_bonus" value="0" /></div>
@@ -1706,7 +1824,13 @@
         </div>
 
         <div class="1colrow">
-            <h3>Spell Lists</h3>
+            <h3>Spell Lists
+                <span class="skill-label">
+                    <input class="autocalc-stat-right" type="number" name="attr_spell_display_profession_development" value="@{spell_profession_development}" disabled title="Number of rank points per level.  For each point spend learning a spell list, your chance to learn that list increases by 20%">
+                    <input type="hidden" name="attr_spell_profession_development" value="0"/>
+                    /LEVEL
+                </span>
+            </h3>
 
             <div class="col sheet-border-box">
                 <fieldset class="repeating_spellists">  
@@ -2277,13 +2401,13 @@
                     <tr>
                         <td class="skill-label">Defensive Bonus</td>
                         <td class="skill-label sheet-table-stat-label">AG</td>
-                        <td><input class="autocalc-stat" type="number" name="attr_defensive_stat_bonus" value="@{stat_ag_total_bonus}" disabled /></td>
-                        <td><input type="number" name="attr_defensive_race_bonus" value="0"/></td>
+                        <td><input class="autocalc-stat-right" type="number" name="attr_defensive_stat_bonus" value="@{stat_ag_total_bonus}" disabled /></td>
+                        <td></td>
                         <td><input type="number" name="attr_defensive_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_defensive_spec1_bonus" value="0"/></td>
                         <td><input type="number" class="autocalc-bonus" name="attr_defensive_spec2_bonus" value="@{shield_bonus}" disabled></td>
                         <td><input type="number" class="autocalc-bonus sheet-autocalc-total" name="attr_defensive_total_bonus" disabled 
-                            value="(@{defensive_stat_bonus}+@{defensive_race_bonus}+@{defensive_item_bonus}+@{defensive_spec1_bonus}+@{defensive_spec2_bonus})"/><span class="action-type-label" title="Defensive bonus">DB</span>
+                            value="(@{defensive_stat_bonus}+@{defensive_item_bonus}+@{defensive_spec1_bonus}+@{defensive_spec2_bonus})"/><span class="action-type-label" title="Defensive bonus">DB</span>
                         </td>
                         <td>
                         </td>
@@ -2291,7 +2415,7 @@
                     <tr>
                         <td class="skill-label">Essence RR</td>
                         <td class="skill-label sheet-table-stat-label">IG</td>
-                        <td><input class="autocalc-stat" type="number" name="attr_essence_stat_bonus" value="@{stat_ig_total_bonus}" disabled /></td>
+                        <td><input class="autocalc-stat-right" type="number" name="attr_essence_stat_bonus" value="@{stat_ig_total_bonus}" disabled /></td>
                         <td><input type="number" name="attr_essence_race_bonus" value="0"/></td>
                         <td><input type="number" name="attr_essence_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_essence_spec1_bonus" value="0"/></td>
@@ -2308,7 +2432,7 @@
                     <tr>
                         <td class="skill-label">Channeling RR</td>
                         <td class="skill-label sheet-table-stat-label">IT</td>
-                        <td><input class="autocalc-stat" type="number" name="attr_channeling_stat_bonus" value="@{stat_it_total_bonus}" disabled /></td>
+                        <td><input class="autocalc-stat-right" type="number" name="attr_channeling_stat_bonus" value="@{stat_it_total_bonus}" disabled /></td>
                         <td><input type="number" name="attr_channeling_race_bonus" value="0"/></td>
                         <td><input type="number" name="attr_channeling_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_channeling_spec1_bonus" value="0"/></td>
@@ -2325,7 +2449,7 @@
                     <tr>
                         <td class="skill-label">Poison RR</td>
                         <td class="skill-label sheet-table-stat-label">CO</td>
-                        <td><input class="autocalc-stat" type="number" name="attr_poison_stat_bonus" value="@{stat_co_total_bonus}" disabled /></td>
+                        <td><input class="autocalc-stat-right" type="number" name="attr_poison_stat_bonus" value="@{stat_co_total_bonus}" disabled /></td>
                         <td><input type="number" name="attr_poison_race_bonus" value="0"/></td>                        
                         <td><input type="number" name="attr_poison_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_poison_spec1_bonus" value="0"/></td>
@@ -2342,7 +2466,7 @@
                     <tr>
                         <td class="skill-label">Disease RR</td>
                         <td class="skill-label sheet-table-stat-label">CO</td>
-                        <td><input class="autocalc-stat" type="number" name="attr_disease_stat_bonus" value="@{stat_co_total_bonus}" disabled /></td>
+                        <td><input class="autocalc-stat-right" type="number" name="attr_disease_stat_bonus" value="@{stat_co_total_bonus}" disabled /></td>
                         <td><input type="number" name="attr_disease_race_bonus" value="0"/></td>                                                
                         <td><input type="number" name="attr_disease_item_bonus" value="0"/></td>
                         <td><input type="number" name="attr_disease_spec1_bonus" value="0"/></td>
@@ -2456,7 +2580,7 @@
                                         <table class="point-indicator">
                                             <tr class="point-indicator-header">
                                                 <td><span class="point-indicator-header-text">Hit Points</span></td>
-                                                <td>[<input type="number" class="point-indicator-header-score" class="autocalc-stat" name="attr_creature_total_hit_points" value="0">]</td>
+                                                <td>[<input type="number" class="point-indicator-header-score" class="autocalc-stat-right" name="attr_creature_total_hit_points" value="0">]</td>
                                             </tr>
                                             <tr>
                                                 <td colspan="2" class="align-center">
@@ -2793,8 +2917,8 @@
 var TAS = TAS || (function(){
     'use strict';
 
-    var version = '0.2.5',
-    lastUpdate = 1504710542,
+    var version = '0.3.0',
+    lastUpdate = 1613447936,
 
     loggingSettings = {
         debug: {
@@ -3418,7 +3542,7 @@ repeatingSimpleSum = function(section, field, destination){
 };
 
 /* eslint-disable no-console */
-console.log('%c•.¸¸.•*´¨`*•.¸¸.•*´¨`*•.¸  The Aaron Sheet  v'+version+'  ¸.•*´¨`*•.¸¸.•*´¨`*•.¸¸.•','background: linear-gradient(to right,green,white,white,green); color:black;text-shadow: 0 0 8px white;');
+console.log('%c•.¸¸.•*´¨`*•.¸¸.•*´¨`*•.¸  MERP Sheet  v'+version+'  ¸.•*´¨`*•.¸¸.•*´¨`*•.¸¸.•','background: linear-gradient(to right,green,white,white,green); color:black;text-shadow: 0 0 8px white;');
 console.log('%c•.¸¸.•*´¨`*•.¸¸.•*´¨`*•.¸  Last update: '+(new Date(lastUpdate*1000))+'  ¸.•*´¨`*•.¸¸.•*´¨`*•.¸¸.•','background: linear-gradient(to right,green,white,white,green); color:black;text-shadow: 0 0 8px white;');
 /* eslint-enable no-console */
 
@@ -3463,8 +3587,6 @@ return {
         pp = 2;
     } else if (stat <= 101) {
         pp = 3;
-    } else if (stat <= 102){
-        pp = 4;
     } else {
         pp = 4;
     }
@@ -3498,8 +3620,6 @@ function statBonus(stat) {
         bonus = 25;
     } else if (stat <= 101) {
         bonus = 30;
-    } else if (stat <= 102){
-        bonus = 35;
     } else {
         bonus = 35;
     }
@@ -3731,6 +3851,376 @@ on("sheet:opened change:armorworn change:skill_noarmor_total_bonus change:skill_
 });
 
 
+on("sheet:opened change:race", function(eventInfo) {
+    getAttrs(["race"], function(values) {
+        TAS.log("Race  bonus  " + eventInfo.previousValue + " to " +  eventInfo.newValue)
+        let race = values["race"];
+
+        let bonuses = raceBonuses(race);
+        TAS.log("Strength skill bonus for race:" +  race + " is " + bonuses["attr_stat_st_race_bonus"]);
+
+        setAttrs({
+            "stat_st_race_bonus": bonuses["stat_st_race_bonus"] || 0,
+            "stat_ag_race_bonus": bonuses["stat_ag_race_bonus"] || 0,
+            "stat_co_race_bonus": bonuses["stat_co_race_bonus"] || 0,
+            "stat_ig_race_bonus": bonuses["stat_ig_race_bonus"] || 0,
+            "stat_it_race_bonus": bonuses["stat_it_race_bonus"] || 0,
+            "stat_pr_race_bonus": bonuses["stat_pr_race_bonus"] || 0,
+            "essence_race_bonus": bonuses["essence_race_bonus"] || 0,
+            "channeling_race_bonus": bonuses["channeling_race_bonus"] || 0,
+            "poison_race_bonus": bonuses["poison_race_bonus"] || 0,
+            "disease_race_bonus": bonuses["disease_race_bonus"] || 0
+        });
+    });
+});
+
+function raceBonuses(race) {
+    var bonuses = {};
+
+    switch(race) {
+        case "Dwarf":
+        bonuses["stat_st_race_bonus"] = 5;
+        bonuses["stat_ag_race_bonus"] = -5;
+        bonuses["stat_co_race_bonus"] = 15;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = -5;
+        bonuses["stat_pr_race_bonus"] = -5;
+        bonuses["essence_race_bonus"] = 40;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 10;
+        bonuses["disease_race_bonus"] = 10;
+        break;    
+        case "Umli":
+        bonuses["stat_st_race_bonus"] = 5;
+        bonuses["stat_ag_race_bonus"] = 0;
+        bonuses["stat_co_race_bonus"] = 10;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = -5;
+        bonuses["stat_pr_race_bonus"] = -5;
+        bonuses["essence_race_bonus"] = 20;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 5;
+        bonuses["disease_race_bonus"] = 5;
+        break;    
+        case "Noldo Elf":
+        bonuses["stat_st_race_bonus"] = 0;
+        bonuses["stat_ag_race_bonus"] = 15;
+        bonuses["stat_co_race_bonus"] = 10;
+        bonuses["stat_ig_race_bonus"] = 5;
+        bonuses["stat_it_race_bonus"] = 5;
+        bonuses["stat_pr_race_bonus"] = 15;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 10;
+        bonuses["disease_race_bonus"] = 100;
+        break;    
+        case "Sindar Elf":
+        bonuses["stat_st_race_bonus"] = 0;
+        bonuses["stat_ag_race_bonus"] = 10;
+        bonuses["stat_co_race_bonus"] = 5;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = 5;
+        bonuses["stat_pr_race_bonus"] = 10;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 10;
+        bonuses["disease_race_bonus"] = 100;
+        break;    
+        case "Silvan Elf":
+        bonuses["stat_st_race_bonus"] = 0;
+        bonuses["stat_ag_race_bonus"] = 10;
+        bonuses["stat_co_race_bonus"] = 0;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = 5;
+        bonuses["stat_pr_race_bonus"] = 5;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 10;
+        bonuses["disease_race_bonus"] = 100;
+        break;    
+        case "Half-Elf":
+        bonuses["stat_st_race_bonus"] = 5;
+        bonuses["stat_ag_race_bonus"] = 5;
+        bonuses["stat_co_race_bonus"] = 5;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = 0;
+        bonuses["stat_pr_race_bonus"] = 5;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 5;
+        bonuses["disease_race_bonus"] = 50;
+        break;    
+        case "Hobbit":
+        bonuses["stat_st_race_bonus"] = -10;
+        bonuses["stat_ag_race_bonus"] = 15;
+        bonuses["stat_co_race_bonus"] = 15;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = -5;
+        bonuses["stat_pr_race_bonus"] = -5;
+        bonuses["essence_race_bonus"] = 50;
+        bonuses["channeling_race_bonus"] = 20; 
+        bonuses["poison_race_bonus"] = 30;
+        bonuses["disease_race_bonus"] = 15;
+        break;    
+        case "Beorning":
+        bonuses["stat_st_race_bonus"] = 5;
+        bonuses["stat_ag_race_bonus"] = 0;
+        bonuses["stat_co_race_bonus"] = 0;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = 0;
+        bonuses["stat_pr_race_bonus"] = 0;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 0;
+        bonuses["disease_race_bonus"] = 0;
+        break;    
+        case "Black Numenorean":
+        bonuses["stat_st_race_bonus"] = 5;
+        bonuses["stat_ag_race_bonus"] = 0;
+        bonuses["stat_co_race_bonus"] = 0;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = 0;
+        bonuses["stat_pr_race_bonus"] = 0;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 0;
+        bonuses["disease_race_bonus"] = 0;
+        break;    
+        case "Corsair":
+        bonuses["stat_st_race_bonus"] = 5;
+        bonuses["stat_ag_race_bonus"] = 0;
+        bonuses["stat_co_race_bonus"] = 0;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = 0;
+        bonuses["stat_pr_race_bonus"] = 0;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 0;
+        bonuses["disease_race_bonus"] = 0;
+        break;    
+        case "Dorwinrim":
+        bonuses["stat_st_race_bonus"] = 5;
+        bonuses["stat_ag_race_bonus"] = 0;
+        bonuses["stat_co_race_bonus"] = 0;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = 0;
+        bonuses["stat_pr_race_bonus"] = 0;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 0;
+        bonuses["disease_race_bonus"] = 0;
+        break;    
+        case "Dunedain":
+        bonuses["stat_st_race_bonus"] = 5;
+        bonuses["stat_ag_race_bonus"] = 0;
+        bonuses["stat_co_race_bonus"] = 10;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = 0;
+        bonuses["stat_pr_race_bonus"] = 5;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 5;
+        bonuses["disease_race_bonus"] = 5;
+        break;    
+        case "Dunlending":
+        bonuses["stat_st_race_bonus"] = 5;
+        bonuses["stat_ag_race_bonus"] = 0;
+        bonuses["stat_co_race_bonus"] = 0;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = 0;
+        bonuses["stat_pr_race_bonus"] = 0;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 0;
+        bonuses["disease_race_bonus"] = 0;
+        break;    
+        case "Easterling":
+        bonuses["stat_st_race_bonus"] = 5;
+        bonuses["stat_ag_race_bonus"] = 0;
+        bonuses["stat_co_race_bonus"] = 0;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = 0;
+        bonuses["stat_pr_race_bonus"] = 0;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 0;
+        bonuses["disease_race_bonus"] = 0;
+        break;    
+        case "Eriadoran":
+        bonuses["stat_st_race_bonus"] = 5;
+        bonuses["stat_ag_race_bonus"] = 0;
+        bonuses["stat_co_race_bonus"] = 0;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = 0;
+        bonuses["stat_pr_race_bonus"] = 0;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 0;
+        bonuses["disease_race_bonus"] = 0;
+        break;    
+        case "Gondorian":
+        bonuses["stat_st_race_bonus"] = 5;
+        bonuses["stat_ag_race_bonus"] = 0;
+        bonuses["stat_co_race_bonus"] = 0;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = 0;
+        bonuses["stat_pr_race_bonus"] = 0;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 0;
+        bonuses["disease_race_bonus"] = 0;
+        break;    
+        case "Haradrim":
+        bonuses["stat_st_race_bonus"] = 5;
+        bonuses["stat_ag_race_bonus"] = 0;
+        bonuses["stat_co_race_bonus"] = 0;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = 0;
+        bonuses["stat_pr_race_bonus"] = 0;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 0;
+        bonuses["disease_race_bonus"] = 0;
+        break;    
+        case "Lossoth":
+        bonuses["stat_st_race_bonus"] = 5;
+        bonuses["stat_ag_race_bonus"] = 0;
+        bonuses["stat_co_race_bonus"] = 0;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = 0;
+        bonuses["stat_pr_race_bonus"] = 0;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 0;
+        bonuses["disease_race_bonus"] = 0;
+        break;    
+        case "Rohirrim":
+        bonuses["stat_st_race_bonus"] = 5;
+        bonuses["stat_ag_race_bonus"] = 0;
+        bonuses["stat_co_race_bonus"] = 0;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = 0;
+        bonuses["stat_pr_race_bonus"] = 0;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 0;
+        bonuses["disease_race_bonus"] = 0;
+        break;    
+        case "Variag":
+        bonuses["stat_st_race_bonus"] = 5;
+        bonuses["stat_ag_race_bonus"] = 0;
+        bonuses["stat_co_race_bonus"] = 0;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = 0;
+        bonuses["stat_pr_race_bonus"] = 0;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 0;
+        bonuses["disease_race_bonus"] = 0;
+        break;    
+        case "Woodman":
+        bonuses["stat_st_race_bonus"] = 5;
+        bonuses["stat_ag_race_bonus"] = 0;
+        bonuses["stat_co_race_bonus"] = 0;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = 0;
+        bonuses["stat_pr_race_bonus"] = 0;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 0;
+        bonuses["disease_race_bonus"] = 0;
+        break;    
+        case "Wose":
+        bonuses["stat_st_race_bonus"] = 0;
+        bonuses["stat_ag_race_bonus"] = 0;
+        bonuses["stat_co_race_bonus"] = 5;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = 0;
+        bonuses["stat_pr_race_bonus"] = -5;
+        bonuses["essence_race_bonus"] = 20;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 0;
+        bonuses["disease_race_bonus"] = 0;
+        break;    
+        case "Orc":
+        bonuses["stat_st_race_bonus"] = 5;
+        bonuses["stat_ag_race_bonus"] = -5;
+        bonuses["stat_co_race_bonus"] = 15;
+        bonuses["stat_ig_race_bonus"] = -10;
+        bonuses["stat_it_race_bonus"] = -10;
+        bonuses["stat_pr_race_bonus"] = -10;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 20;
+        bonuses["disease_race_bonus"] = 5;
+        break;    
+        case "Uruk-Hai":
+        bonuses["stat_st_race_bonus"] = 10;
+        bonuses["stat_ag_race_bonus"] = 0;
+        bonuses["stat_co_race_bonus"] = 20;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = -5;
+        bonuses["stat_pr_race_bonus"] = -10;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 20;
+        bonuses["disease_race_bonus"] = 5;
+        break;    
+        case "Half-Orc":
+        bonuses["stat_st_race_bonus"] = 5;
+        bonuses["stat_ag_race_bonus"] = 0;
+        bonuses["stat_co_race_bonus"] = 5;
+        bonuses["stat_ig_race_bonus"] = 0;
+        bonuses["stat_it_race_bonus"] = 0;
+        bonuses["stat_pr_race_bonus"] = -5;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 10;
+        bonuses["disease_race_bonus"] = 0;
+        break;    
+        case "Troll":
+        bonuses["stat_st_race_bonus"] = 15;
+        bonuses["stat_ag_race_bonus"] = -10;
+        bonuses["stat_co_race_bonus"] = 15;
+        bonuses["stat_ig_race_bonus"] = -15;
+        bonuses["stat_it_race_bonus"] = -15;
+        bonuses["stat_pr_race_bonus"] = -10;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 30;
+        bonuses["disease_race_bonus"] = 10;
+        break;    
+        case "Olog-Hai":
+        bonuses["stat_st_race_bonus"] = 20;
+        bonuses["stat_ag_race_bonus"] = -5;
+        bonuses["stat_co_race_bonus"] = 15;
+        bonuses["stat_ig_race_bonus"] = -5;
+        bonuses["stat_it_race_bonus"] = -10;
+        bonuses["stat_pr_race_bonus"] = -10;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 20;
+        bonuses["disease_race_bonus"] = 10;
+        break;    
+        case "Half-Troll":
+        bonuses["stat_st_race_bonus"] = 10;
+        bonuses["stat_ag_race_bonus"] = -5;
+        bonuses["stat_co_race_bonus"] = 10;
+        bonuses["stat_ig_race_bonus"] = -5;
+        bonuses["stat_it_race_bonus"] = -5;
+        bonuses["stat_pr_race_bonus"] = -5;
+        bonuses["essence_race_bonus"] = 0;
+        bonuses["channeling_race_bonus"] = 0; 
+        bonuses["poison_race_bonus"] = 15;
+        bonuses["disease_race_bonus"] = 5;
+        break;    
+        default:
+        break;
+    }
+    return bonuses;
+}
+
+
 on("sheet:opened change:level change:profession", function(eventInfo) {
     getAttrs(["level", "profession"], function(values) {
         TAS.log("Profession skill bonus  " + eventInfo.previousValue + " to " +  eventInfo.newValue)
@@ -3741,6 +4231,7 @@ on("sheet:opened change:level change:profession", function(eventInfo) {
         TAS.log("Weapon skill bonus level:" + intLevel + " and profession:" +  profession + " is " + bonuses["weapon_skill_profession_bonus"])
 
         setAttrs({
+            "realm": bonuses["realm"] || "",
             "weapon_skill_profession_bonus": bonuses["weapon_skill_profession_bonus"] * intLevel || 0,
             "general_skill_profession_bonus": bonuses["general_skill_profession_bonus"] * intLevel || 0,
             "subterfuge_skill_profession_bonus": bonuses["subterfuge_skill_profession_bonus"] * intLevel || 0,
@@ -3749,7 +4240,15 @@ on("sheet:opened change:level change:profession", function(eventInfo) {
             "directedspell_skill_profession_bonus": bonuses["directedspell_skill_profession_bonus"] * intLevel || 0,
             "perception_skill_profession_bonus": bonuses["perception_skill_profession_bonus"] * intLevel || 0,
             "basespell_skill_profession_bonus": bonuses["basespell_skill_profession_bonus"] * intLevel || 0,
-            "bodydev_skill_profession_bonus": bonuses["bodydev_skill_profession_bonus"] * intLevel || 0
+            "bodydev_skill_profession_bonus": bonuses["bodydev_skill_profession_bonus"] * intLevel || 0,
+            "movingmaneuver_profession_development": bonuses["movingmaneuver_profession_development"] || 0,
+            "weapon_profession_development": bonuses["weapon_profession_development"] || 0,
+            "general_profession_development": bonuses["general_profession_development"] || 0,
+            "subterfuge_profession_development": bonuses["subterfuge_profession_development"] || 0,
+            "magical_profession_development": bonuses["magical_profession_development"] || 0,
+            "body_profession_development": bonuses["body_profession_development"] || 0,
+            "language_profession_development": bonuses["language_profession_development"] || 0,
+            "spell_profession_development": bonuses["spell_profession_development"] || 0
         });
     });
 });
@@ -3764,6 +4263,15 @@ function profBonuses(profession) {
         bonuses["perception_skill_profession_bonus"] = 1;
         bonuses["directedspell_skill_profession_bonus"] = 2;
         bonuses["basespell_skill_profession_bonus"] = 2;
+        bonuses["movingmaneuver_profession_development"] = 1;
+        bonuses["weapon_profession_development"] = 1;
+        bonuses["general_profession_development"] = 2;
+        bonuses["subterfuge_profession_development"] = 1;
+        bonuses["magical_profession_development"] = 2;
+        bonuses["body_profession_development"] = 1;
+        bonuses["language_profession_development"] = 2;
+        bonuses["spell_profession_development"] = 5;
+        bonuses["realm"] = "Channeling";
         break;    
         case "bard":
         bonuses["weapon_skill_profession_bonus"] = 1; 
@@ -3774,17 +4282,44 @@ function profBonuses(profession) {
         bonuses["directedspell_skill_profession_bonus"] = 1;
         bonuses["perception_skill_profession_bonus"] = 1;
         bonuses["basespell_skill_profession_bonus"] = 1;
+        bonuses["movingmaneuver_profession_development"] = 0;
+        bonuses["weapon_profession_development"] = 2;
+        bonuses["general_profession_development"] = 2;
+        bonuses["subterfuge_profession_development"] = 2;
+        bonuses["magical_profession_development"] = 3;
+        bonuses["body_profession_development"] = 1;
+        bonuses["language_profession_development"] = 3;
+        bonuses["spell_profession_development"] = 2;
+        bonuses["realm"] = "Essence";
         break;   
         case "mage":
         bonuses["magical_skill_profession_bonus"] = 2; 
         bonuses["directedspell_skill_profession_bonus"] = 3;
         bonuses["basespell_skill_profession_bonus"] = 2;
+        bonuses["movingmaneuver_profession_development"] = 0;
+        bonuses["weapon_profession_development"] = 0;
+        bonuses["general_profession_development"] = 2;
+        bonuses["subterfuge_profession_development"] = 0;
+        bonuses["magical_profession_development"] = 5;
+        bonuses["body_profession_development"] = 1;
+        bonuses["language_profession_development"] = 2;
+        bonuses["spell_profession_development"] = 5;
+        bonuses["realm"] = "Essence";
         break;     
         case "ranger":
         bonuses["weapon_skill_profession_bonus"] = 2; 
         bonuses["general_skill_profession_bonus"] = 3;
         bonuses["perception_skill_profession_bonus"] = 2;
         bonuses["stalkhide_skill_profession_bonus"] = 2;
+        bonuses["movingmaneuver_profession_development"] = 2;
+        bonuses["weapon_profession_development"] = 3;
+        bonuses["general_profession_development"] = 4;
+        bonuses["subterfuge_profession_development"] = 2;
+        bonuses["magical_profession_development"] = 0;
+        bonuses["body_profession_development"] = 2;
+        bonuses["language_profession_development"] = 1;
+        bonuses["spell_profession_development"] = 1;
+        bonuses["realm"] = "Channeling";
         break;    
         case "scout":
         bonuses["weapon_skill_profession_bonus"] = 1; 
@@ -3792,11 +4327,27 @@ function profBonuses(profession) {
         bonuses["subterfuge_skill_profession_bonus"] = 2;
         bonuses["stalkhide_skill_profession_bonus"] = 2;
         bonuses["perception_skill_profession_bonus"] = 3;
+        bonuses["movingmaneuver_profession_development"] = 1;
+        bonuses["weapon_profession_development"] = 3;
+        bonuses["general_profession_development"] = 3;
+        bonuses["subterfuge_profession_development"] = 5;
+        bonuses["magical_profession_development"] = 0;
+        bonuses["body_profession_development"] = 2;
+        bonuses["language_profession_development"] = 1;
+        bonuses["spell_profession_development"] = 0;
         break;    
         case "warrior":
         bonuses["weapon_skill_profession_bonus"] = 3; 
         bonuses["general_skill_profession_bonus"] = 1;
         bonuses["bodydev_skill_profession_bonus"] = 2;
+        bonuses["movingmaneuver_profession_development"] = 3;
+        bonuses["weapon_profession_development"] = 5;
+        bonuses["general_profession_development"] = 2;
+        bonuses["subterfuge_profession_development"] = 2;
+        bonuses["magical_profession_development"] = 0;
+        bonuses["body_profession_development"] = 3;
+        bonuses["language_profession_development"] = 0;
+        bonuses["spell_profession_development"] = 0;
         break;
         default:
         break;

--- a/MERP/merp_2nd_ed_sheet.html
+++ b/MERP/merp_2nd_ed_sheet.html
@@ -565,7 +565,6 @@
 
                         <tr class="stats-table-heading">
                             <th class="stats-table-head">Stats</th>
-                            <th class="stats-table-head">Abbr</th>
                             <th class="stats-table-head">Value</th>
                             <th class="stats-table-head">Norm</th>
                             <th class="stats-table-head">Race</th>
@@ -573,8 +572,7 @@
                             <th class="stats-table-head">Total</th>
                         </tr>
                         <tr>
-                            <td class="stat-label" title="A character's capabilities in melee, carrying loads, and other activities requiring strength.">Strength</td>
-                            <td class="stat-label">(ST)</td>
+                            <td class="stat-label" title="A character's capabilities in melee, carrying loads, and other activities requiring strength.">Strength (ST)</td>
                             <td><input type="number" name="attr_stat_st_value" min="0" value="50"/></td>
                             <td>
                                 <input class="autocalc-stat-right" type="number" name="attr_stat_st_norm_bonus" value="@{stat_st_stat_bonus}" disabled>
@@ -588,8 +586,7 @@
                             <td><input type="number" class="autocalc-total" name="attr_stat_st_total_bonus" value="(@{stat_st_norm_bonus}+@{stat_st_race_bonus}+@{stat_st_misc_bonus})" disabled></td>
                         </tr>
                         <tr>
-                            <td class="stat-label" title="A character's manual dexterity, litheness, quickness, reaction time, and speed.">Agility</td>
-                            <td class="stat-label">(AG)</td>
+                            <td class="stat-label" title="A character's manual dexterity, litheness, quickness, reaction time, and speed.">Agility (AG)</td>
                             <td><input type="number" name="attr_stat_ag_value" min="0" value="50"/></td>
                             <td>
                                 <input class="autocalc-stat-right" type="number" name="attr_stat_ag_norm_bonus" value="@{stat_ag_stat_bonus}" disabled>
@@ -603,8 +600,7 @@
                             <td><input type="number" class="autocalc-total" name="attr_stat_ag_total_bonus" value="(@{stat_ag_norm_bonus}+@{stat_ag_race_bonus}+@{stat_ag_misc_bonus})" disabled></td>
                         </tr>
                         <tr>
-                            <td class="stat-label" title="A character's general health and well-being.">Constitution</td>
-                            <td class="stat-label">(CO)</td>
+                            <td class="stat-label" title="A character's general health and well-being.">Constitution (CO)</td>
                             <td><input type="number" name="attr_stat_co_value" min="0" value="50"/></td>
                             <td>
                                 <input class="autocalc-stat-right" type="number" name="attr_stat_co_norm_bonus" value="@{stat_co_stat_bonus}" disabled>
@@ -618,8 +614,7 @@
                             <td><input type="number" class="autocalc-total" name="attr_stat_co_total_bonus" value="(@{stat_co_norm_bonus}+@{stat_co_race_bonus}+@{stat_co_misc_bonus})" disabled></td>
                         </tr>
                         <tr>
-                            <td class="stat-label" title="A character's reasoning, memory, and common sense.">Intelligence</td>
-                            <td class="stat-label">(IG)</td>
+                            <td class="stat-label" title="A character's reasoning, memory, and common sense.">Intelligence (IG)</td>
                             <td><input type="number" name="attr_stat_ig_value" min="0" value="50"/></td>
                             <td>
                                 <input class="autocalc-stat-right" type="number" name="attr_stat_ig_norm_bonus" value="@{stat_ig_stat_bonus}" disabled>
@@ -633,8 +628,7 @@
                             <td><input type="number" class="autocalc-total" name="attr_stat_ig_total_bonus" value="(@{stat_ig_norm_bonus}+@{stat_ig_race_bonus}+@{stat_ig_misc_bonus})" disabled></td>
                         </tr>
                         <tr>
-                            <td class="stat-label" title="A character's wisdom, luck, and genius.">Intuition</td>
-                            <td class="stat-label">(IT)</td>
+                            <td class="stat-label" title="A character's wisdom, luck, and genius.">Intuition (IT)</td>
                             <td><input type="number" name="attr_stat_it_value" min="0" value="50"/></td>
                             <td>
                                 <input class="autocalc-stat-right" type="number" name="attr_stat_it_norm_bonus" value="@{stat_it_stat_bonus}" disabled>
@@ -648,8 +642,7 @@
                             <td><input type="number" class="autocalc-total" name="attr_stat_it_total_bonus" value="(@{stat_it_norm_bonus}+@{stat_it_race_bonus}+@{stat_it_misc_bonus})" disabled></td>
                         </tr>
                         <tr>
-                            <td class="stat-label" title="A character's self-discipline, courage, bearing, self esteem, and charisma.">Presence</td>
-                            <td class="stat-label">(PR)</td>
+                            <td class="stat-label" title="A character's self-discipline, courage, bearing, self esteem, and charisma.">Presence (PR)</td>
                             <td><input type="number" name="attr_stat_pr_value" min="0" value="50"/></td>
                             <td>
                                 <input class="autocalc-stat-right" type="number" name="attr_stat_pr_norm_bonus" value="@{stat_pr_stat_bonus}" disabled>
@@ -663,8 +656,7 @@
                             <td><input type="number" class="autocalc-total" name="attr_stat_pr_total_bonus" value="(@{stat_pr_norm_bonus}+@{stat_pr_race_bonus}+@{stat_pr_misc_bonus})" disabled></td>
                         </tr>
                         <tr>
-                            <td class="stat-label" title="How well your character is perceived by others.">Appearance</td>
-                            <td class="stat-label">(AP)</td>
+                            <td class="stat-label" title="How well your character is perceived by others.">Appearance (AP)</td>
                             <td><input type="number" name="attr_stat_ap_value" min="0" value="50"/></td>
                             <td>+</td>
                             <td>PR</td>
@@ -678,23 +670,301 @@
             <div class="col">
 
                 <div class="col sheet-border-box sheet-abilities-box">
+                    <h3>Background Opts (<input class="autocalc-total" type="number" name="attr_race_display_bg_options" value="@{race_bg_options}" disabled title="Number of background options available for your race."><input type="hidden" name="attr_race_bg_options" value="0"/>)</h3>
+                    <fieldset class="repeating_backgroundoptions">            
+                        <select name="attr_background_options">
+                            <optgroup label="Primary Skill Hobbies (2 Ranks)">
+                                <option value="Hobby No Armor">No Armor Hobby</option>
+                                <option value="Hobby Soft Leather">Soft Leather Hobby</option>
+                                <option value="Hobby Rigid Leather">Rigid Leather Hobby</option>
+                                <option value="Hobby Chain Mail">Chain Mail Hobby</option>
+                                <option value="Hobby Plate Mail">Plate Mail Hobby</option>
+                                <option value="Hobby 1H Edged">1H Edged Hobby</option>
+                                <option value="Hobby 1H Concussion">1H Concussion Hobby</option>
+                                <option value="Hobby 2 Handed">2 Handed Hobby</option>
+                                <option value="Hobby Pole Arms">Pole Arms Hobby</option>
+                                <option value="Hobby Missile">Missile Hobby</option>
+                                <option value="Hobby Thrown">Thrown Hobby</option>
+                                <option value="Hobby Climb">Climb Hobby</option>
+                                <option value="Hobby Ride">Ride Hobby</option>
+                                <option value="Hobby Swim">Swim Hobby</option>
+                                <option value="Hobby Track">Track Hobby</option>
+                                <option value="Hobby Stalk Hide">Stalk/Hide Hobby</option>
+                                <option value="Hobby Pick Lock">Pick Lock Hobby</option>
+                                <option value="Hobby Disarm Trap">Disarm Trap Hobby</option>
+                                <option value="Hobby Read Rune">Read Rune Hobby</option>
+                                <option value="Hobby Use Item">Use Item Hobby</option>
+                                <option value="Hobby Directed Spells">Directed Spells Hobby</option>
+                                <option value="Hobby Perception">Perception Hobby</option>
+                                <option value="Hobby Body Development">Body Development Hobby</option>
+                            </optgroup>
+                            <optgroup label="Secondary Skill Hobbies (5 Ranks)">
+                                <option value="Hobby Acrobatics">Acrobatics Hobby</option>
+                                <option value="Hobby Acting">Acting Hobby</option>
+                                <option value="Hobby Animal Handling">Animal Handling Hobby</option>
+                                <option value="Hobby Appraisal">Appraisal Hobby</option>
+                                <option value="Hobby Boat Handling">Boat Handling Hobby</option>
+                                <option value="Hobby Caving">Caving Hobby</option>
+                                <option value="Hobby Contortions">Contortions Hobby</option>
+                                <option value="Hobby Cookery">Cookery Hobby</option>
+                                <option value="Hobby First Aid">First Aid Hobby</option>
+                                <option value="Hobby Foraging">Foraging Hobby</option>
+                                <option value="Hobby Gambling">Gambling Hobby</option>
+                                <option value="Hobby Meditation">Meditation Hobby</option>
+                                <option value="Hobby Rope-Mastery">Rope-Mastery Hobby</option>
+                                <option value="Hobby Signaling">Signaling Hobby</option>
+                                <option value="Hobby Sky-Watching">Sky-Watching Hobby</option>
+                                <option value="Hobby Trickery">Trickery Hobby</option>
+                                <option value="Hobby Dance">Dance Hobby</option>
+                                <option value="Hobby Music">Music Hobby</option>
+                                <option value="Hobby Painting">Painting Hobby</option>
+                                <option value="Hobby Poetry">Poetry Hobby</option>
+                                <option value="Hobby Sculpting">Sculpting Hobby</option>
+                                <option value="Hobby Singing">Singing Hobby</option>
+                                <option value="Hobby Tale Telling">Tale Telling Hobby</option>
+                                <option value="Hobby Juggling">Juggling Hobby</option>
+                                <option value="Hobby Jumping">Jumping Hobby</option>
+                                <option value="Hobby Pole Vaulting">Pole Vaulting Hobby</option>
+                                <option value="Hobby Rappelling">Rappelling Hobby</option>
+                                <option value="Hobby Skiing">Skiing Hobby</option>
+                                <option value="Hobby Skating">Skating Hobby</option>
+                                <option value="Hobby Sprinting">Sprinting Hobby</option>
+                                <option value="Hobby Stilt Walking">Stilt Walking Hobby</option>
+                                <option value="Hobby Surfing">Surfing Hobby</option>
+                                <option value="Hobby Tight Rope Walking">Tight Rope Walking Hobby</option>
+                                <option value="Hobby Fletching">Fletching Hobby</option>
+                                <option value="Hobby Leather Crafting">Leather Crafting Hobby</option>
+                                <option value="Hobby Metal Crafting">Metal Crafting Hobby</option>
+                                <option value="Hobby Stone Crafting">Stone Crafting Hobby</option>
+                                <option value="Hobby Trap Making">Trap Making Hobby</option>
+                                <option value="Hobby Wood Crafting">Wood Crafting Hobby</option>
+                                <option value="Hobby Bribery">Bribery Hobby</option>
+                                <option value="Hobby Bureacracy">Bureacracy Hobby</option>
+                                <option value="Hobby Diplomacy">Diplomacy Hobby</option>
+                                <option value="Hobby Interrogation">Interrogation Hobby</option>
+                                <option value="Hobby Leadership">Leadership Hobby</option>
+                                <option value="Hobby Public Speaking">Public Speaking Hobby</option>
+                                <option value="Hobby Seduction">Seduction Hobby</option>
+                                <option value="Hobby Trading">Trading Hobby</option>
+                                <option value="Hobby Animal Lore">Animal Lore Hobby</option>
+                                <option value="Hobby Culture">Culture Hobby</option>
+                                <option value="Hobby Geography">Geography Hobby</option>
+                                <option value="Hobby History">History Hobby</option>
+                                <option value="Hobby Mathematics">Mathematics Hobby</option>
+                                <option value="Hobby Physics">Physics Hobby</option>
+                                <option value="Hobby Plant Lore">Plant Lore Hobby</option>
+                                <option value="Hobby Religion">Religion Hobby</option>
+                                <option value="Hobby Special Creature Lore">Special Creature Lore Hobby</option>
+                                <option value="Hobby Tactics">Tactics Hobby</option>
+                                <option value="Hobby 2 Weapon Fighting">2 Weapon Fighting Hobby</option>
+                                <option value="Hobby Shield Bash">Shield Bash Hobby</option>
+                            </optgroup>
+                            <optgroup label="Stat Increases">
+                                <option value="ST 2">Strength by 2</option>
+                                <option value="AG 2">Agility by 2</option>
+                                <option value="CO 2">Constitution by 2</option>
+                                <option value="IG 2">Intelligence by 2</option>
+                                <option value="IT 2">Intuition by 2</option>
+                                <option value="PR 2">Presence by 2</option>
+                                <option value="ST AG CO">Strengh/Agility/Constitution by 1</option>
+                                <option value="ST AG IG">Strengh/Agility/Intelligence by 1</option>
+                                <option value="ST AG IT">Strengh/Agility/Intuition by 1</option>
+                                <option value="ST AG PR">Strengh/Agility/Presence by 1</option>
+                                <option value="ST CO IG">Strengh/Constitution/Intelligence by 1</option>
+                                <option value="ST CO IT">Strengh/Constitution/Intuition by 1</option>
+                                <option value="ST CO PR">Strengh/Constitution/Presence by 1</option>
+                                <option value="ST IG IT">Strengh/Intelligence/Intuition by 1</option>
+                                <option value="ST IG PR">Strengh/Intelligence/Presence by 1</option>
+                                <option value="ST IT PR">Strengh/Intuition/Presence by 1</option>
+                                <option value="AG CO IG">Agility/Constitution/Intelligence by 1</option>
+                                <option value="AG CO IT">Agility/Constitution/Intuition by 1</option>
+                                <option value="AG CO PR">Agility/Constitution/Presence by 1</option>
+                                <option value="AG IG IT">Agility/Intelligence/Intuition by 1</option>
+                                <option value="AG IG PR">Agility/Intelligence/Presence by 1</option>
+                                <option value="AG IT PR">Agility/Intuition/Presence by 1</option>
+                                <option value="CO IG IT">Constitution/Intelligence/Intuition by 1</option>
+                                <option value="CO IG PR">Constitution/Intelligence/Presence by 1</option>
+                                <option value="CO IT PR">Constitution/Intuition/Presence by 1</option>
+                                <option value="IG IT PR">Intelligence/Intuition/Presence by 1</option>
+                            </optgroup>
+                            <optgroup label="Extra Languages (5 Ranks)">
+                                <option value="Adunaic">Adunaic</option>
+                                <option value="Apysaic">Apysaic</option>
+                                <option value="Atliduk">Atliduk</option>
+                                <option value="Bethteur">Bethteur</option>
+                                <option value="Black Speech">Black Speech</option>
+                                <option value="Dunael">Dunael</option>
+                                <option value="Haradaic">Haradaic</option>
+                                <option value="Khuzdul">Khuzdul</option>
+                                <option value="Kuduk">Kuduk</option>
+                                <option value="Labba">Labba</option>
+                                <option value="Logathig">Logathig</option>
+                                <option value="Nahaiduk">Nahaiduk</option>
+                                <option value="Orkish">Orkish</option>
+                                <option value="Pukael">Pukael</option>
+                                <option value="Quenya">Quenya</option>
+                                <option value="Rohirric">Rohirric</option>
+                                <option value="Sindarin">Sindarin</option>
+                                <option value="Umitic">Umitic</option>
+                                <option value="Varadja">Varadja</option>
+                                <option value="Waildyth">Waildyth</option>
+                                <option value="Westron">Westron</option>
+                            </optgroup>
+                            <optgroup label="Primary Skills (+5 Bonus)">
+                                <option value="Bonus No Armor">No Armor Bonus</option>
+                                <option value="Bonus Soft Leather">Soft Leather Bonus</option>
+                                <option value="Bonus Rigid Leather">Rigid Leather Bonus</option>
+                                <option value="Bonus Chain Mail">Chain Mail Bonus</option>
+                                <option value="Bonus Plate Mail">Plate Mail Bonus</option>
+                                <option value="Bonus 1H Edged">1H Edged Bonus</option>
+                                <option value="Bonus 1H Concussion">1H Concussion Bonus</option>
+                                <option value="Bonus 2 Handed">2 Handed Bonus</option>
+                                <option value="Bonus Pole Arms">Pole Arms Bonus</option>
+                                <option value="Bonus Missile">Missile Bonus</option>
+                                <option value="Bonus Thrown">Thrown Bonus</option>
+                                <option value="Bonus Climb">Climb Bonus</option>
+                                <option value="Bonus Ride">Ride Bonus</option>
+                                <option value="Bonus Swim">Swim Bonus</option>
+                                <option value="Bonus Track">Track Bonus</option>
+                                <option value="Bonus Stalk Hide">Stalk/Hide Bonus</option>
+                                <option value="Bonus Pick Lock">Pick Lock Bonus</option>
+                                <option value="Bonus Disarm Trap">Disarm Trap Bonus</option>
+                                <option value="Bonus Read Rune">Read Rune Bonus</option>
+                                <option value="Bonus Use Item">Use Item Bonus</option>
+                                <option value="Bonus Directed Spells">Directed Spells Bonus</option>
+                                <option value="Bonus Perception">Perception Bonus</option>
+                                <option value="Bonus Body Development">Body Development Bonus</option>
+                                <option value="Bonus Base Spell OB">Base Spell OB Bonus</option>
+                            </optgroup>
+                            <optgroup label="Secondary Skills (+15 Bonus)">
+                                <option value="Bonus Acrobatics">Acrobatics Bonus</option>
+                                <!--TODO Finish Secondary Skills-->
+                            </optgroup>
+                            <optgroup label="Animal Empathy">
+                                <option value="Animal Empathy">Animal Empathy</option>
+                            </optgroup>
+                            <optgroup label="Resistances (+10)">
+                                <option value="Resist Essence">Essence Resistance</option>
+                                <option value="Resist Channeling">Channeling Resistance</option>
+                                <option value="Resist Poison">Poison Resistance</option>
+                                <option value="Resist Disease">Disease Resistance</option>
+                                <option value="Resist Cold">Cold Resistance</option>
+                                <option value="Resist Heat">Heat Resistance</option>
+                            </optgroup>
+                            <optgroup label="Proficient with Essence Spells">
+                                <option value="Essence Hand">Essence Hand</option>
+                                <option value="Essence Perception">Essence Perception</option>
+                                <option value="Essence Ways">Essence Ways</option>
+                                <option value="Illusions">Illusions</option>
+                                <option value="Physical Enhancement">Physical Enhancement</option>
+                                <option value="Spell Ways">Spell Ways</option>
+                                <option value="Spirit Mastery">Spirit Mastery</option>
+                                <option value="Unbarring Ways">Unbarring Ways</option>
+                            </optgroup>
+                            <optgroup label="Proficient with Mage Spells">
+                                <option value="Fire Law">Fire Law</option>
+                                <option value="Ice Law">Ice Law</option>
+                                <option value="Earth Law">Earth Law</option>
+                                <option value="Light Law">Light Law</option>
+                                <option value="Wind Law">Wind Law</option>
+                                <option value="Water Law">Water Law</option>
+                                <option value="Lofty Bridge">Lofty Bridge</option>
+                                <option value="Living Change">Living Change</option>
+                            </optgroup>
+                            <optgroup label="Proficient with Bard Spells">
+                                <option value="Lore">Lore</option>
+                                <option value="Controlling Songs">Controlling Songs</option>
+                                <option value="Sound Control">Sound Control</option>
+                                <option value="Item Lore">Item Lore</option>
+                            </optgroup>
+                            <optgroup label="Proficient with Channeling Spells">
+                                <option value="Natures Lore">Natures Lore</option>
+                                <option value="Natures Movement">Natures Movement</option>
+                                <option value="Spell Defense">Spell Defense</option>
+                                <option value="Suface Ways">Suface Ways</option>
+                                <option value="Protections">Protections</option>
+                                <option value="Detection Mastery">Detection Mastery</option>
+                                <option value="Sound Light Ways">Sound-Light Ways</option>
+                                <option value="Calm Spirits">Calm Spirits</option>
+                            </optgroup>
+                            <optgroup label="Proficient with Animist Spells">
+                                <option value="Direct Channeling">Direct Channeling</option>
+                                <option value="Blood Ways">Blood Ways</option>
+                                <option value="Bone Muscle Ways">Bone-Muscle Ways</option>
+                                <option value="Organ Ways">Organ Ways</option>
+                                <option value="Animal Mastery">Animal Mastery</option>
+                                <option value="Plant Mastery">Plant Mastery</option>
+                                <option value="Purifications">Purifications</option>
+                                <option value="Creations">Creations</option>
+                            </optgroup>
+                            <optgroup label="Proficient with Ranger Spells">
+                                <option value="Path Mastery">Path Mastery</option>
+                                <option value="Moving Ways">Moving Ways</option>
+                                <option value="Natures Guises">Natures Guises</option>
+                                <option value="Natures Ways">Natures Ways</option>
+                            </optgroup>
+                            <optgroup label="Special Abilities">
+                                <option value="Infravision">Infravision</option>
+                                <option value="Adept at Moving">Adept at Moving</option>
+                                <option value="Very Observant">Very Observant</option>
+                                <option value="Lightning Reactions">Lightning Reactions</option>
+                                <option value="Charismatic">Charismatic</option>
+                                <option value="Resistant to Pain">Resistant to Pain</option>
+                            </optgroup>
+                            <optgroup label="Special Items">
+                                <option value="+10 Magic Item">+10 Magic Item</option>
+                                <option value="+15 Magic Item">+15 Magic Item</option>
+                                <option value="+1 Spell Adder">+1 Spell Adder</option>
+                                <option value="+2 Spell Adder">+2 Spell Adder</option>
+                                <option value="Daily Spell Item">Daily Spell Item</option>
+                            </optgroup>
+                            <optgroup label="Money">
+                                <option value="Extra Gold">Extra Gold</option>
+                            </optgroup>
+                        </select>
+                    </fieldset>
                     <h3>Special Abilities</h3>
                     <fieldset class="repeating_special">            
                         <input type="text" name="attr_special" spellcheck="false"/> 
                     </fieldset>
                 </div>
                 <div class="col sheet-border-box sheet-languages-box">
-                    <h3>Languages
-                        <input type="number" name="attr_language_display_profession_development" value="@{language_profession_development}" disabled title="Number of ranks earned per level">
-                        <input type="hidden" name="attr_language_profession_development" value="0"/><span class="stat-label">/LEVEL</span>
-                    </h3>
+                    <h3>Languages <input type="number" name="attr_language_display_profession_development" value="@{language_profession_development}" disabled title="Number of ranks earned per level"><input type="hidden" name="attr_language_profession_development" value="0"/>/LVL</h3>
                     <div class="tablelike">
+                        <div class="table-heading fields-rowlike">
+                            <div class="table-cell">Adolescent Ranks:<input type="number" name="attr_language_display_ad_ranks" value="@{race_language_ad_ranks}" disabled title="Number of ranks learned during adolescence."><input type="hidden" name="attr_race_language_ad_ranks" value="0"/>;
+                            </div>
+                        </div>
                         <div class="table-heading fields-rowlike">
                             <div class="table-cell">Language</div>
                             <div class="table-cell" title="Proficiency in Language: 1 - Simple Phrases / No Literacy; 2 - Simple Sentences / Basic Reading; 3 - Fluency (with Accent) / 5th Grade Literacy; 4 - Fluency (with Accent) / 9th Grade Literacy; 5 - Fluency  Total Literacy">Rank</div>
                         </div>
                         <fieldset class="repeating_languages">            
-                            <div class="table-cell"><input type="text" name="attr_language" class="text-field-language" spellcheck="false"/></div>
+                            <div class="table-cell">
+                                <select name="attr_language" class="text-field-language">
+                                    <option value="Adunaic">Adunaic</option>
+                                    <option value="Apysaic">Apysaic</option>
+                                    <option value="Atliduk">Atliduk</option>
+                                    <option value="Bethteur">Bethteur</option>
+                                    <option value="Black Speech">Black Speech</option>
+                                    <option value="Dunael">Dunael</option>
+                                    <option value="Haradaic">Haradaic</option>
+                                    <option value="Khuzdul">Khuzdul</option>
+                                    <option value="Kuduk">Kuduk</option>
+                                    <option value="Labba">Labba</option>
+                                    <option value="Logathig">Logathig</option>
+                                    <option value="Nahaiduk">Nahaiduk</option>
+                                    <option value="Orkish">Orkish</option>
+                                    <option value="Pukael">Pukael</option>
+                                    <option value="Quenya">Quenya</option>
+                                    <option value="Rohirric">Rohirric</option>
+                                    <option value="Sindarin">Sindarin</option>
+                                    <option value="Umitic">Umitic</option>
+                                    <option value="Varadja">Varadja</option>
+                                    <option value="Waildyth">Waildyth</option>
+                                    <option value="Westron">Westron</option>
+                                </select>
+                            </div>
                             <div class="table-cell"><input type="number" name="attr_language_rank" /></div>
                         </fieldset>
                     </div>
@@ -727,12 +997,13 @@
                 <table class="skills-table">
 
                     <tr class="skills-table-row sheet-skills-table-head">
-                        <th class="skills-table-head sheet-skill-heading" colspan="3">Skill Ranks</th>
+                        <th class="skills-table-head sheet-skill-heading" colspan="4">Skill Ranks</th>
                         <th class="skills-table-head sheet-skill-heading" colspan="9">Skill Bonuses</th>
                     </tr>
 
                     <tr class="skills-table-row sheet-skills-table-head">
                         <th class="skills-table-head">Skills</th>
+                        <th class="skills-table-head">AD/BG<br/>Ranks</th>
                         <th class="skills-table-head">5% Rank</th>
                         <th class="skills-table-head">2% Rank</th>
                         <th class="skills-table-head" title="The total bonus from skill ranks">Rank</th>
@@ -746,7 +1017,7 @@
                     </tr>
 
                     <tr>
-                        <td colspan="12">
+                        <td colspan="13">
                             <span class="skill-heading">Movement and Maneuver</span>
                             <span class="skill-label">
                                 <input class="autocalc-stat-right" type="number" name="attr_movingmaneuver_display_profession_development" value="@{movingmaneuver_profession_development}" disabled title="Number of rank points per level.  To raise a skill 1 rank = 1 point, 2 ranks = 3 points">
@@ -760,6 +1031,10 @@
                     <!-- No armor -->
                     <tr class="table-section-shaded">
                         <td class="skill-label">No Armor</td>
+                        <td>
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_noarmor_display_ad_ranks" value="@{skill_noarmor_ad_ranks}" disabled><input type="hidden" name="attr_skill_noarmor_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_noarmor_display_bg_ranks" value="@{skill_noarmor_bg_ranks}" disabled><input type="hidden" name="attr_skill_noarmor_bg_ranks" value="0">
+                        </td>
                         <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_noarmor_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_noarmor_5rank2" value="5" />
@@ -783,6 +1058,10 @@
                     <tr class="table-section-shaded">
                         <td class="skill-label">Soft Leather</td>
                         <td>
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_softleather_display_ad_ranks" value="@{skill_softleather_ad_ranks}" disabled><input type="hidden" name="attr_skill_softleather_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_softleather_display_bg_ranks" value="@{skill_softleather_bg_ranks}" disabled><input type="hidden" name="attr_skill_softleather_bg_ranks" value="0">
+                        </td>
+                        <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_softleather_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_softleather_5rank2" value="5" />
                             <input class="rank-box" type="checkbox" name="attr_skill_softleather_5rank3" value="5" />
@@ -805,6 +1084,10 @@
                     <!-- Rigid leather -->
                     <tr class="table-section-shaded">
                         <td class="skill-label">Rigid Leather</td>
+                        <td>
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_rigidleather_display_ad_ranks" value="@{skill_rigidleather_ad_ranks}" disabled><input type="hidden" name="attr_skill_rigidleather_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_rigidleather_display_bg_ranks" value="@{skill_rigidleather_bg_ranks}" disabled><input type="hidden" name="attr_skill_rigidleather_bg_ranks" value="0">
+                        </td>
                         <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_rigidleather_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_rigidleather_5rank2" value="5" />
@@ -830,6 +1113,10 @@
                     <!-- Chain -->
                     <tr class="table-section-shaded">
                         <td class="skill-label">Chain</td>
+                        <td>
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_chain_display_ad_ranks" value="@{skill_chain_ad_ranks}" disabled><input type="hidden" name="attr_skill_chain_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_chain_display_bg_ranks" value="@{skill_chain_bg_ranks}" disabled><input type="hidden" name="attr_skill_chain_bg_ranks" value="0">
+                        </td>
                         <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_chain_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_chain_5rank2" value="5" />
@@ -858,6 +1145,8 @@
                     <tr class="table-section-shaded">
                         <td class="skill-label">Plate</td>
                         <td>
+                        </td>
+                        <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_plate_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_plate_5rank2" value="5" />
                             <input class="rank-box" type="checkbox" name="attr_skill_plate_5rank3" value="5" />
@@ -884,7 +1173,7 @@
                     </tr>
 
                     <tr>
-                        <td colspan="12">
+                        <td colspan="13">
                             <span class="skill-heading">Weapon Skills</span>
                             <span class="skill-label">
                                 <input class="autocalc-stat-right" type="number" name="attr_weapon_display_profession_development" value="@{weapon_profession_development}" disabled title="Number of rank points per level.  To raise a skill 1 rank = 1 point, 2 ranks = 3 points">
@@ -897,6 +1186,10 @@
                     <!-- 1H-Edged -->
                     <tr>
                         <td class="skill-label">1-H Edged</td>
+                        <td>
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_1hedged_display_ad_ranks" value="@{skill_1hedged_ad_ranks}" disabled><input type="hidden" name="attr_skill_1hedged_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_1hedged_display_bg_ranks" value="@{skill_1hedged_bg_ranks}" disabled><input type="hidden" name="attr_skill_1hedged_bg_ranks" value="0">
+                        </td>
                         <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_1hedged_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_1hedged_5rank2" value="5" />
@@ -937,6 +1230,10 @@
                     <tr>
                         <td class="skill-label">1-H Concussion</td>
                         <td>
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_1hconc_display_ad_ranks" value="@{skill_1hconc_ad_ranks}" disabled><input type="hidden" name="attr_skill_1hconc_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_1hconc_display_bg_ranks" value="@{skill_1hconc_bg_ranks}" disabled><input type="hidden" name="attr_skill_1hconc_bg_ranks" value="0">
+                        </td>
+                        <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_1hconc_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_1hconc_5rank2" value="5" />
                             <input class="rank-box" type="checkbox" name="attr_skill_1hconc_5rank3" value="5" />
@@ -975,6 +1272,10 @@
                     <tr>
                         <td class="skill-label">2-Handed</td>
                         <td>
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_2handed_display_ad_ranks" value="@{skill_2handed_ad_ranks}" disabled><input type="hidden" name="attr_skill_2handed_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_2handed_display_bg_ranks" value="@{skill_2handed_bg_ranks}" disabled><input type="hidden" name="attr_skill_2handed_bg_ranks" value="0">
+                        </td>
+                        <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_2handed_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_2handed_5rank2" value="5" />
                             <input class="rank-box" type="checkbox" name="attr_skill_2handed_5rank3" value="5" />
@@ -1011,6 +1312,10 @@
                     <!-- Thrown -->
                     <tr>
                         <td class="skill-label">Thrown</td>
+                        <td>
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_thrown_display_ad_ranks" value="@{skill_thrown_ad_ranks}" disabled><input type="hidden" name="attr_skill_thrown_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_thrown_display_bg_ranks" value="@{skill_thrown_bg_ranks}" disabled><input type="hidden" name="attr_skill_thrown_bg_ranks" value="0">
+                        </td>
                         <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_thrown_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_thrown_5rank2" value="5" />
@@ -1051,6 +1356,10 @@
                     <tr>
                         <td class="skill-label">Missile</td>
                         <td>
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_missile_display_ad_ranks" value="@{skill_missile_ad_ranks}" disabled><input type="hidden" name="attr_skill_missile_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_missile_display_bg_ranks" value="@{skill_missile_bg_ranks}" disabled><input type="hidden" name="attr_skill_missile_bg_ranks" value="0">
+                        </td>
+                        <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_missile_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_missile_5rank2" value="5" />
                             <input class="rank-box" type="checkbox" name="attr_skill_missile_5rank3" value="5" />
@@ -1090,6 +1399,10 @@
                     <tr>
                         <td class="skill-label">Pole-arms</td>
                         <td>
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_polearm_display_ad_ranks" value="@{skill_polearm_ad_ranks}" disabled><input type="hidden" name="attr_skill_polearm_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_polearm_display_bg_ranks" value="@{skill_polearm_bg_ranks}" disabled><input type="hidden" name="attr_skill_polearm_bg_ranks" value="0">
+                        </td>
+                        <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_polearm_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_polearm_5rank2" value="5" />
                             <input class="rank-box" type="checkbox" name="attr_skill_polearm_5rank3" value="5" />
@@ -1126,7 +1439,7 @@
                     </tr>
 
                     <tr>
-                        <td colspan="12">
+                        <td colspan="13">
                             <span class="skill-heading">General Skills</span>
                             <span class="skill-label">
                                 <input class="autocalc-stat-right" type="number" name="attr_general_display_profession_development" value="@{general_profession_development}" disabled title="Number of rank points per level.  To raise a skill 1 rank = 1 point, 2 ranks = 3 points">
@@ -1139,6 +1452,10 @@
                     <!-- Climb -->
                     <tr class="table-section-shaded">
                         <td class="skill-label">Climb</td>
+                        <td>
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_climb_display_ad_ranks" value="@{skill_climb_ad_ranks}" disabled><input type="hidden" name="attr_skill_climb_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_climb_display_bg_ranks" value="@{skill_climb_bg_ranks}" disabled><input type="hidden" name="attr_skill_climb_bg_ranks" value="0">
+                        </td>
                         <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_climb_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_climb_5rank2" value="5" />
@@ -1179,6 +1496,10 @@
                     <tr class="table-section-shaded">
                         <td class="skill-label">Ride</td>
                         <td>
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_ride_display_ad_ranks" value="@{skill_ride_ad_ranks}" disabled><input type="hidden" name="attr_skill_ride_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_ride_display_bg_ranks" value="@{skill_ride_bg_ranks}" disabled><input type="hidden" name="attr_skill_ride_bg_ranks" value="0">
+                        </td>
+                        <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_ride_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_ride_5rank2" value="5" />
                             <input class="rank-box" type="checkbox" name="attr_skill_ride_5rank3" value="5" />
@@ -1217,6 +1538,10 @@
                     <!-- Swim -->
                     <tr class="table-section-shaded">
                         <td class="skill-label">Swim</td>
+                        <td>
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_swim_display_ad_ranks" value="@{skill_swim_ad_ranks}" disabled><input type="hidden" name="attr_skill_swim_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_swim_display_bg_ranks" value="@{skill_swim_bg_ranks}" disabled><input type="hidden" name="attr_skill_swim_bg_ranks" value="0">
+                        </td>
                         <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_swim_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_swim_5rank2" value="5" />
@@ -1257,6 +1582,8 @@
                     <tr class="table-section-shaded">
                         <td class="skill-label">Track</td>
                         <td>
+                        </td>
+                        <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_track_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_track_5rank2" value="5" />
                             <input class="rank-box" type="checkbox" name="attr_skill_track_5rank3" value="5" />
@@ -1293,7 +1620,7 @@
                     </tr>
 
                     <tr>
-                        <td colspan="12">
+                        <td colspan="13">
                             <span class="skill-heading">Subterfuge Skills</span>
                             <span class="skill-label">
                                 <input class="autocalc-stat-right" type="number" name="attr_subterfuge_display_profession_development" value="@{subterfuge_profession_development}" disabled title="Number of rank points per level.  To raise a skill 1 rank = 1 point, 2 ranks = 3 points">
@@ -1306,6 +1633,10 @@
                     <!-- Ambush -->
                     <tr>
                         <td class="skill-label">Ambush</td>
+                        <td>
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_ambush_display_ad_ranks" value="@{skill_ambush_ad_ranks}" disabled><input type="hidden" name="attr_skill_ambush_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_ambush_display_bg_ranks" value="@{skill_ambush_bg_ranks}" disabled><input type="hidden" name="attr_skill_ambush_bg_ranks" value="0">
+                        </td>
                         <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_ambush_5rank1" value="1" />
                             <input class="rank-box" type="checkbox" name="attr_skill_ambush_5rank2" value="1" />
@@ -1341,6 +1672,10 @@
                     <!-- Stalk/Hide -->
                     <tr>
                         <td class="skill-label">Stalk/Hide</td>
+                        <td>
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_stalkhide_display_ad_ranks" value="@{skill_stalkhide_ad_ranks}" disabled><input type="hidden" name="attr_skill_stalkhide_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_stalkhide_display_bg_ranks" value="@{skill_stalkhide_bg_ranks}" disabled><input type="hidden" name="attr_skill_stalkhide_bg_ranks" value="0">
+                        </td>
                         <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_stalkhide_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_stalkhide_5rank2" value="5" />
@@ -1381,6 +1716,10 @@
                     <tr>
                         <td class="skill-label">Pick Lock</td>
                         <td>
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_picklock_display_ad_ranks" value="@{skill_picklock_ad_ranks}" disabled><input type="hidden" name="attr_skill_picklock_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_picklock_display_bg_ranks" value="@{skill_picklock_bg_ranks}" disabled><input type="hidden" name="attr_skill_picklock_bg_ranks" value="0">
+                        </td>
+                        <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_picklock_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_picklock_5rank2" value="5" />
                             <input class="rank-box" type="checkbox" name="attr_skill_picklock_5rank3" value="5" />
@@ -1420,6 +1759,10 @@
                     <tr>
                         <td class="skill-label">Disarm Trap</td>
                         <td>
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_disarmtrap_display_ad_ranks" value="@{skill_disarmtrap_ad_ranks}" disabled><input type="hidden" name="attr_skill_disarmtrap_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_disarmtrap_display_bg_ranks" value="@{skill_disarmtrap_bg_ranks}" disabled><input type="hidden" name="attr_skill_disarmtrap_bg_ranks" value="0">
+                        </td>
+                        <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_disarmtrap_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_disarmtrap_5rank2" value="5" />
                             <input class="rank-box" type="checkbox" name="attr_skill_disarmtrap_5rank3" value="5" />
@@ -1457,7 +1800,7 @@
 
 
                     <tr>
-                        <td colspan="12">
+                        <td colspan="13">
                             <span class="skill-heading">Magical Skills</span>
                             <span class="skill-label">
                                 <input class="autocalc-stat-right" type="number" name="attr_magical_display_profession_development" value="@{magical_profession_development}" disabled title="Number of rank points per level.  To raise a skill 1 rank = 1 point, 2 ranks = 3 points">
@@ -1470,6 +1813,10 @@
                     <!-- Read Runes -->
                     <tr class="table-section-shaded">
                         <td class="skill-label">Read Runes</td>
+                        <td>
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_readrunes_display_ad_ranks" value="@{skill_readrunes_ad_ranks}" disabled><input type="hidden" name="attr_skill_readrunes_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_readrunes_display_bg_ranks" value="@{skill_readrunes_bg_ranks}" disabled><input type="hidden" name="attr_skill_readrunes_bg_ranks" value="0">
+                        </td>
                         <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_readrunes_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_readrunes_5rank2" value="5" />
@@ -1510,6 +1857,10 @@
                     <tr class="table-section-shaded">
                         <td class="skill-label">Use Items</td>
                         <td>
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_useitems_display_ad_ranks" value="@{skill_useitems_ad_ranks}" disabled><input type="hidden" name="attr_skill_useitems_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_useitems_display_bg_ranks" value="@{skill_useitems_bg_ranks}" disabled><input type="hidden" name="attr_skill_useitems_bg_ranks" value="0">
+                        </td>
+                        <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_useitems_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_useitems_5rank2" value="5" />
                             <input class="rank-box" type="checkbox" name="attr_skill_useitems_5rank3" value="5" />
@@ -1549,6 +1900,8 @@
                     <tr class="table-section-shaded">
                         <td class="skill-label">Directed Spells</td>
                         <td>
+                        </td>
+                        <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_directedspells_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_directedspells_5rank2" value="5" />
                             <input class="rank-box" type="checkbox" name="attr_skill_directedspells_5rank3" value="5" />
@@ -1585,7 +1938,7 @@
                     </tr>
 
                     <tr>
-                        <td colspan="12">
+                        <td colspan="13">
                             <span class="skill-heading">Misc. Skills and Bonuses</span>
                         </td>
                     </tr>
@@ -1593,6 +1946,10 @@
                     <!-- Perception -->
                     <tr>
                         <td class="skill-label">Perception</td>
+                        <td>
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_perception_display_ad_ranks" value="@{skill_perception_ad_ranks}" disabled><input type="hidden" name="attr_skill_perception_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_perception_display_bg_ranks" value="@{skill_perception_bg_ranks}" disabled><input type="hidden" name="attr_skill_perception_bg_ranks" value="0">
+                        </td>
                         <td>
                             <input class="rank-box" type="checkbox" name="attr_skill_perception_5rank1" value="30" />
                             <input class="rank-box" type="checkbox" name="attr_skill_perception_5rank2" value="5" />
@@ -1634,31 +1991,35 @@
                     <tr>
                         <td class="skill-label">Body Dev.
                             <span class="skill-label">
-                                <input class="autocalc-stat-right" type="number" name="attr_body_display_profession_development" value="@{body_profession_development}" disabled title="Number of rank points per level.  To raise a skill 1 rank = 1 point, 2 ranks = 3 points">
-                                <input type="hidden" name="attr_body_profession_development" value="0"/>
+                                <input class="autocalc-stat-right" type="number" name="attr_body_display_profession_development" value="@{bodydev_profession_development}" disabled title="Number of rank points per level.  To raise a skill 1 rank = 1 point, 2 ranks = 3 points">
+                                <input type="hidden" name="attr_bodydev_profession_development" value="0"/>
                                 /LEVEL
                             </span>
                         </td>
                         <td>
-                            <input class="rank-box" type="checkbox" name="attr_skill_bodydev_5rank1" value="1" />
-                            <input class="rank-box" type="checkbox" name="attr_skill_bodydev_5rank2" value="1" />
-                            <input class="rank-box" type="checkbox" name="attr_skill_bodydev_5rank3" value="1" />
-                            <input class="rank-box" type="checkbox" name="attr_skill_bodydev_5rank4" value="1" />
-                            <input class="rank-box" type="checkbox" name="attr_skill_bodydev_5rank5" value="1" />
-                            <input class="rank-box" type="checkbox" name="attr_skill_bodydev_5rank6" value="1" />
-                            <input class="rank-box" type="checkbox" name="attr_skill_bodydev_5rank7" value="1" />
-                            <input class="rank-box" type="checkbox" name="attr_skill_bodydev_5rank8" value="1" />
-                            <input class="rank-box" type="checkbox" name="attr_skill_bodydev_5rank9" value="1" />
-                            <input class="rank-box" type="checkbox" name="attr_skill_bodydev_5rank10" value="1" />
+                            <input type="number" class="autocalc-stat-right" name="attr_skill_bodydev_display_ad_ranks" value="@{skill_bodydev_ad_ranks}" disabled><input type="hidden" name="attr_skill_bodydev_ad_ranks" value="0">/
+                            <input type="number" class="autocalc-stat" name="attr_skill_bodydev_display_bg_ranks" value="@{skill_bodydev_bg_ranks}" disabled><input type="hidden" name="attr_skill_bodydev_bg_ranks" value="0">
                         </td>
                         <td>
-                            <input class="rank-box" type="checkbox" name="attr_skill_bodydev_2rank1" value="1" />
-                            <input class="rank-box" type="checkbox" name="attr_skill_bodydev_2rank2" value="1" />
-                            <input class="rank-box" type="checkbox" name="attr_skill_bodydev_2rank3" value="1" />
-                            <input class="rank-box" type="checkbox" name="attr_skill_bodydev_2rank4" value="1" />
-                            <input class="rank-box" type="checkbox" name="attr_skill_bodydev_2rank5" value="1" />
+                            <input type="number" class="bodydev" name="attr_skill_bodydev_5rank1" min="0" max="10" value="0" />
+                            <input type="number" class="bodydev" name="attr_skill_bodydev_5rank2" min="0" max="10" value="0" />
+                            <input type="number" class="bodydev" name="attr_skill_bodydev_5rank3" min="0" max="10" value="0" />
+                            <input type="number" class="bodydev" name="attr_skill_bodydev_5rank4" min="0" max="10" value="0" />
+                            <input type="number" class="bodydev" name="attr_skill_bodydev_5rank5" min="0" max="10" value="0" />
+                            <input type="number" class="bodydev" name="attr_skill_bodydev_5rank6" min="0" max="10" value="0" />
+                            <input type="number" class="bodydev" name="attr_skill_bodydev_5rank7" min="0" max="10" value="0" />
+                            <input type="number" class="bodydev" name="attr_skill_bodydev_5rank8" min="0" max="10" value="0" />
+                            <input type="number" class="bodydev" name="attr_skill_bodydev_5rank9" min="0" max="10" value="0" />
+                            <input type="number" class="bodydev" name="attr_skill_bodydev_5rank10" min="0" max="10" value="0" />
                         </td>
-                        <td><input type="number" class="autocalc-stat-right" name="attr_skill_bodydev_rank_bonus" value="0"/></td>
+                        <td>
+                            <input type="number" class="bodydev" name="attr_skill_bodydev_2rank1" min="0" max="10" value="0" />
+                            <input type="number" class="bodydev" name="attr_skill_bodydev_2rank2" min="0" max="10" value="0" />
+                            <input type="number" class="bodydev" name="attr_skill_bodydev_2rank3" min="0" max="10" value="0" />
+                            <input type="number" class="bodydev" name="attr_skill_bodydev_2rank4" min="0" max="10" value="0" />
+                            <input type="number" class="bodydev" name="attr_skill_bodydev_2rank5" min="0" max="10" value="0" />
+                        </td>
+                        <td><input type="number" class="autocalc-stat-right" name="attr_skill_bodydev_rank_bonus" disabled value="(@{skill_bodydev_5rank1} + @{skill_bodydev_5rank2} + @{skill_bodydev_5rank3} + @{skill_bodydev_5rank4} + @{skill_bodydev_5rank5} + @{skill_bodydev_5rank6} + @{skill_bodydev_5rank7} + @{skill_bodydev_5rank8} + @{skill_bodydev_5rank9} + @{skill_bodydev_5rank10} + @{skill_bodydev_2rank1} + @{skill_bodydev_2rank2} + @{skill_bodydev_2rank3} + @{skill_bodydev_2rank4} + @{skill_bodydev_2rank5})"/></td>
                         <td>CO<input type="number" class="autocalc-stat-right" name="attr_skill_bodydev_stat_bonus" disabled value="(@{stat_co_total_bonus})"/></td>
 
                         <td><input type="number" name="attr_skill_bodydev_prof_bonus" disabled value="(@{bodydev_skill_profession_bonus})"/></td>
@@ -1672,6 +2033,7 @@
 
                     <tr class="table-section-shaded">
                         <td class="skill-label">Base Spells</td>
+                        <td></td>
                         <td></td>
                         <td></td>
                         <td class="table-cell-center"> xx </td>
@@ -1691,6 +2053,7 @@
                     </tr>
                     <tr class="table-section-shaded">
                         <td class="skill-label">Leadership and Influence</td>
+                        <td></td>
                         <td></td>
                         <td></td>
                         <td class="table-cell-center"> xx </td>
@@ -1713,7 +2076,7 @@
 
                 <table class="stats-table full-width">
                     <tr>
-                        <td colspan="12">
+                        <td colspan="13">
                             <span class="skill-heading">Secondary Skills</span>
                         </td>
                     </tr>
@@ -1726,6 +2089,7 @@
                             <div class="table-cell sheet-secondaryskill-cell sheet-secondaryskill-name">
                                 <input class="skill-label sheet-secondaryskill-label" type="text" name="attr_skill_secondaryskill_name"/>
                             </div>
+                            <div class="table-cell sheet-secondaryskill-cell">&nbsp;</div>
                             <div class="table-cell sheet-secondaryskill-cell sheet-secondaryskill-5ranks">
                                 <input class="rank-box" type="checkbox" name="attr_skill_secondaryskill_5rank1" value="30" />
                                 <input class="rank-box" type="checkbox" name="attr_skill_secondaryskill_5rank2" value="5" />
@@ -1824,13 +2188,13 @@
         </div>
 
         <div class="1colrow">
-            <h3>Spell Lists
-                <span class="skill-label">
-                    <input class="autocalc-stat-right" type="number" name="attr_spell_display_profession_development" value="@{spell_profession_development}" disabled title="Number of rank points per level.  For each point spend learning a spell list, your chance to learn that list increases by 20%">
-                    <input type="hidden" name="attr_spell_profession_development" value="0"/>
-                    /LEVEL
-                </span>
-            </h3>
+            <span class="skill-heading">Spell Lists</span>
+            <input class="autocalc-stat-right" type="number" name="attr_spell_display_profession_development" value="@{spell_profession_development}" disabled title="Number of rank points per level.  For each point spend learning a spell list, your chance to learn that list increases by 20%">
+            <input type="hidden" name="attr_spell_profession_development" value="0"/>
+            <span class="skill-label">Ranks/LEVEL; Adolescent Chance:</span>
+            <input class="autocalc-stat-right" type="number" name="attr_race_spell_display_ad_ranks" value="@{race_spell_ad_ranks}" disabled title="Percent chance you have at learning a spell list during adolescence.">
+            <input type="hidden" name="attr_race_spell_ad_ranks" value="0"/>
+            <span class="skill-label">%</span>
 
             <div class="col sheet-border-box">
                 <fieldset class="repeating_spellists">  
@@ -2620,7 +2984,7 @@
                                         <span class="skill-label" title="Encumbrance penalty applies to all movement and moving maneuvers. Negated by ST bonus.">Enc. Penalty:</span>
                                     </div>
                                     <div class="table-cell">
-                                        <input type="hidden" name="attr_creature_enc_plus_st" value="(@{creature_encumbrance_penalty} + @{creature_stat_st_total_bonus})" disabled />
+                                        <input type="hidden" name="attr_creature_enc_plus_st" value="(@{creature_encumbrance_penalty} + @{stat_st_total_bonus})" disabled />
                                         <input type="hidden" name="attr_creature_abs_enc_penalty" value="(((@{creature_enc_plus_st}) - abs(@{creature_enc_plus_st}))/2)" disabled />
 
                                         <input type="number" class="autocalc-bonus" name="attr_creature_total_enc_penalty" value="@{creature_abs_enc_penalty}" disabled />
@@ -3792,10 +4156,10 @@ on("sheet:opened change:stat_it_value change:stat_ig_value change:realm", functi
     getAttrs(["stat_it_value", "stat_ig_value", "realm"], function(values) {
         let powerPoints = 0
         switch (values["realm"]) {
-            case "channeling":
+            case "Channeling":
             powerPoints = powerPointBase(parseInt(values["stat_it_value"], 10) || 0)
             break;
-            case "essence":
+            case "Essence":
             powerPoints = powerPointBase(parseInt(values["stat_ig_value"], 10) || 0)
             break;   
             default:
@@ -3869,7 +4233,31 @@ on("sheet:opened change:race", function(eventInfo) {
             "essence_race_bonus": bonuses["essence_race_bonus"] || 0,
             "channeling_race_bonus": bonuses["channeling_race_bonus"] || 0,
             "poison_race_bonus": bonuses["poison_race_bonus"] || 0,
-            "disease_race_bonus": bonuses["disease_race_bonus"] || 0
+            "disease_race_bonus": bonuses["disease_race_bonus"] || 0,
+            "skill_noarmor_ad_ranks": bonuses["skill_noarmor_ad_ranks"] || 0,
+            "skill_softleather_ad_ranks": bonuses["skill_softleather_ad_ranks"] || 0,
+            "skill_rigidleather_ad_ranks": bonuses["skill_rigidleather_ad_ranks"] || 0,
+            "skill_chain_ad_ranks": bonuses["skill_chain_ad_ranks"] || 0,
+            "skill_1hedged_ad_ranks": bonuses["skill_1hedged_ad_ranks"] || 0,
+            "skill_1hconc_ad_ranks": bonuses["skill_1conc_ad_ranks"] || 0,
+            "skill_2handed_ad_ranks": bonuses["skill_2handed_ad_ranks"] || 0,
+            "skill_thrown_ad_ranks": bonuses["skill_thrown_ad_ranks"] || 0,
+            "skill_missile_ad_ranks": bonuses["skill_missile_ad_ranks"] || 0,
+            "skill_polearm_ad_ranks": bonuses["skill_polearm_ad_ranks"] || 0,
+            "skill_climb_ad_ranks": bonuses["skill_climb_ad_ranks"] || 0,
+            "skill_ride_ad_ranks": bonuses["skill_ride_ad_ranks"] || 0,
+            "skill_swim_ad_ranks": bonuses["skill_swim_ad_ranks"] || 0,
+            "skill_ambush_ad_ranks": bonuses["skill_ambush_ad_ranks"] || 0,
+            "skill_stalkhide_ad_ranks": bonuses["skill_stalkhide_ad_ranks"] || 0,
+            "skill_picklock_ad_ranks": bonuses["skill_picklock_ad_ranks"] || 0,
+            "skill_disarmtrap_ad_ranks": bonuses["skill_disarmtrap_ad_ranks"] || 0,
+            "skill_readrunes_ad_ranks": bonuses["skill_readrunes_ad_ranks"] || 0,
+            "skill_useitems_ad_ranks": bonuses["skill_useitems_ad_ranks"] || 0,
+            "skill_perception_ad_ranks": bonuses["skill_perception_ad_ranks"] || 0,
+            "skill_bodydev_ad_ranks": bonuses["skill_bodydev_ad_ranks"] || 0,
+            "race_spell_ad_ranks": bonuses["race_spell_ad_ranks"] || 0,
+            "race_language_ad_ranks": bonuses["race_language_ad_ranks"] || 0,
+            "race_bg_options": bonuses["race_bg_options"] || 0
         });
     });
 });
@@ -3889,6 +4277,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 10;
         bonuses["disease_race_bonus"] = 10;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 0;
+        bonuses["skill_rigidleather_ad_ranks"] = 1;
+        bonuses["skill_chain_ad_ranks"] = 3;
+        bonuses["skill_1hedged_ad_ranks"] = 0;
+        bonuses["skill_1conc_ad_ranks"] = 4;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 1;
+        bonuses["skill_missile_ad_ranks"] = 0;
+        bonuses["skill_polearm_ad_ranks"] = 0;
+        bonuses["skill_climb_ad_ranks"] = 1;
+        bonuses["skill_ride_ad_ranks"] = 0;
+        bonuses["skill_swim_ad_ranks"] = 0;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 0;
+        bonuses["skill_picklock_ad_ranks"] = 1;
+        bonuses["skill_disarmtrap_ad_ranks"] = 1;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 2;
+        bonuses["skill_bodydev_ad_ranks"] = 3;
+        bonuses["race_spell_ad_ranks"] = 3;
+        bonuses["race_language_ad_ranks"] = 4;
+        bonuses["race_bg_options"] = 4;
         break;    
         case "Umli":
         bonuses["stat_st_race_bonus"] = 5;
@@ -3901,6 +4313,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 5;
         bonuses["disease_race_bonus"] = 5;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 3;
+        bonuses["skill_rigidleather_ad_ranks"] = 3;
+        bonuses["skill_chain_ad_ranks"] = 0;
+        bonuses["skill_1hedged_ad_ranks"] = 0;
+        bonuses["skill_1conc_ad_ranks"] = 3;
+        bonuses["skill_2handed_ad_ranks"] = 1;
+        bonuses["skill_thrown_ad_ranks"] = 1;
+        bonuses["skill_missile_ad_ranks"] = 0;
+        bonuses["skill_polearm_ad_ranks"] = 0;
+        bonuses["skill_climb_ad_ranks"] = 0;
+        bonuses["skill_ride_ad_ranks"] = 0;
+        bonuses["skill_swim_ad_ranks"] = 1;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 1;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 1;
+        bonuses["skill_bodydev_ad_ranks"] = 2;
+        bonuses["race_spell_ad_ranks"] = 5;
+        bonuses["race_language_ad_ranks"] = 3;
+        bonuses["race_bg_options"] = 4;
         break;    
         case "Noldo Elf":
         bonuses["stat_st_race_bonus"] = 0;
@@ -3913,6 +4349,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 10;
         bonuses["disease_race_bonus"] = 100;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 0;
+        bonuses["skill_rigidleather_ad_ranks"] = 0;
+        bonuses["skill_chain_ad_ranks"] = 0;
+        bonuses["skill_1hedged_ad_ranks"] = 1;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 0;
+        bonuses["skill_missile_ad_ranks"] = 1;
+        bonuses["skill_polearm_ad_ranks"] = 0;
+        bonuses["skill_climb_ad_ranks"] = 0;
+        bonuses["skill_ride_ad_ranks"] = 1;
+        bonuses["skill_swim_ad_ranks"] = 2;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 2;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 2;
+        bonuses["skill_useitems_ad_ranks"] = 1;
+        bonuses["skill_perception_ad_ranks"] = 3;
+        bonuses["skill_bodydev_ad_ranks"] = 1;
+        bonuses["race_spell_ad_ranks"] = 40;
+        bonuses["race_language_ad_ranks"] = 10;
+        bonuses["race_bg_options"] = 2;
         break;    
         case "Sindar Elf":
         bonuses["stat_st_race_bonus"] = 0;
@@ -3925,6 +4385,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 10;
         bonuses["disease_race_bonus"] = 100;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 0;
+        bonuses["skill_rigidleather_ad_ranks"] = 0;
+        bonuses["skill_chain_ad_ranks"] = 0;
+        bonuses["skill_1hedged_ad_ranks"] = 1;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 0;
+        bonuses["skill_missile_ad_ranks"] = 2;
+        bonuses["skill_polearm_ad_ranks"] = 0;
+        bonuses["skill_climb_ad_ranks"] = 1;
+        bonuses["skill_ride_ad_ranks"] = 1;
+        bonuses["skill_swim_ad_ranks"] = 2;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 3;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 1;
+        bonuses["skill_useitems_ad_ranks"] = 1;
+        bonuses["skill_perception_ad_ranks"] = 3;
+        bonuses["skill_bodydev_ad_ranks"] = 1;
+        bonuses["race_spell_ad_ranks"] = 30;
+        bonuses["race_language_ad_ranks"] = 8;
+        bonuses["race_bg_options"] = 3;
         break;    
         case "Silvan Elf":
         bonuses["stat_st_race_bonus"] = 0;
@@ -3937,6 +4421,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 10;
         bonuses["disease_race_bonus"] = 100;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 0;
+        bonuses["skill_rigidleather_ad_ranks"] = 0;
+        bonuses["skill_chain_ad_ranks"] = 0;
+        bonuses["skill_1hedged_ad_ranks"] = 1;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 0;
+        bonuses["skill_missile_ad_ranks"] = 3;
+        bonuses["skill_polearm_ad_ranks"] = 0;
+        bonuses["skill_climb_ad_ranks"] = 2;
+        bonuses["skill_ride_ad_ranks"] = 1;
+        bonuses["skill_swim_ad_ranks"] = 3;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 4;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 1;
+        bonuses["skill_useitems_ad_ranks"] = 1;
+        bonuses["skill_perception_ad_ranks"] = 3;
+        bonuses["skill_bodydev_ad_ranks"] = 1;
+        bonuses["race_spell_ad_ranks"] = 20;
+        bonuses["race_language_ad_ranks"] = 6;
+        bonuses["race_bg_options"] = 4;
         break;    
         case "Half-Elf":
         bonuses["stat_st_race_bonus"] = 5;
@@ -3949,6 +4457,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 5;
         bonuses["disease_race_bonus"] = 50;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 0;
+        bonuses["skill_rigidleather_ad_ranks"] = 1;
+        bonuses["skill_chain_ad_ranks"] = 1;
+        bonuses["skill_1hedged_ad_ranks"] = 1;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 0;
+        bonuses["skill_missile_ad_ranks"] = 2;
+        bonuses["skill_polearm_ad_ranks"] = 0;
+        bonuses["skill_climb_ad_ranks"] = 1;
+        bonuses["skill_ride_ad_ranks"] = 1;
+        bonuses["skill_swim_ad_ranks"] = 1;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 2;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 1;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 1;
+        bonuses["skill_bodydev_ad_ranks"] = 1;
+        bonuses["race_spell_ad_ranks"] = 10;
+        bonuses["race_language_ad_ranks"] = 4;
+        bonuses["race_bg_options"] = 3;
         break;    
         case "Hobbit":
         bonuses["stat_st_race_bonus"] = -10;
@@ -3961,6 +4493,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 20; 
         bonuses["poison_race_bonus"] = 30;
         bonuses["disease_race_bonus"] = 15;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 0;
+        bonuses["skill_rigidleather_ad_ranks"] = 0;
+        bonuses["skill_chain_ad_ranks"] = 0;
+        bonuses["skill_1hedged_ad_ranks"] = 0;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 2;
+        bonuses["skill_missile_ad_ranks"] = 2;
+        bonuses["skill_polearm_ad_ranks"] = 0;
+        bonuses["skill_climb_ad_ranks"] = 2;
+        bonuses["skill_ride_ad_ranks"] = 0;
+        bonuses["skill_swim_ad_ranks"] = 0;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 5;
+        bonuses["skill_picklock_ad_ranks"] = 1;
+        bonuses["skill_disarmtrap_ad_ranks"] = 1;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 4;
+        bonuses["skill_bodydev_ad_ranks"] = 2;
+        bonuses["race_spell_ad_ranks"] = 0;
+        bonuses["race_language_ad_ranks"] = 3;
+        bonuses["race_bg_options"] = 3;
         break;    
         case "Beorning":
         bonuses["stat_st_race_bonus"] = 5;
@@ -3973,6 +4529,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 0;
         bonuses["disease_race_bonus"] = 0;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 0;
+        bonuses["skill_rigidleather_ad_ranks"] = 0;
+        bonuses["skill_chain_ad_ranks"] = 0;
+        bonuses["skill_1hedged_ad_ranks"] = 0;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 1;
+        bonuses["skill_thrown_ad_ranks"] = 1;
+        bonuses["skill_missile_ad_ranks"] = 0;
+        bonuses["skill_polearm_ad_ranks"] = 2;
+        bonuses["skill_climb_ad_ranks"] = 2;
+        bonuses["skill_ride_ad_ranks"] = 0;
+        bonuses["skill_swim_ad_ranks"] = 2;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 4;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 1;
+        bonuses["skill_bodydev_ad_ranks"] = 3;
+        bonuses["race_spell_ad_ranks"] = 3;
+        bonuses["race_language_ad_ranks"] = 3;
+        bonuses["race_bg_options"] = 5;
         break;    
         case "Black Numenorean":
         bonuses["stat_st_race_bonus"] = 5;
@@ -3985,6 +4565,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 0;
         bonuses["disease_race_bonus"] = 0;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 0;
+        bonuses["skill_rigidleather_ad_ranks"] = 0;
+        bonuses["skill_chain_ad_ranks"] = 2;
+        bonuses["skill_1hedged_ad_ranks"] = 1;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 1;
+        bonuses["skill_missile_ad_ranks"] = 1;
+        bonuses["skill_polearm_ad_ranks"] = 0;
+        bonuses["skill_climb_ad_ranks"] = 0;
+        bonuses["skill_ride_ad_ranks"] = 1;
+        bonuses["skill_swim_ad_ranks"] = 3;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 0;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 1;
+        bonuses["skill_useitems_ad_ranks"] = 1;
+        bonuses["skill_perception_ad_ranks"] = 0;
+        bonuses["skill_bodydev_ad_ranks"] = 2;
+        bonuses["race_spell_ad_ranks"] = 10;
+        bonuses["race_language_ad_ranks"] = 6;
+        bonuses["race_bg_options"] = 3;
         break;    
         case "Corsair":
         bonuses["stat_st_race_bonus"] = 5;
@@ -3997,6 +4601,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 0;
         bonuses["disease_race_bonus"] = 0;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 0;
+        bonuses["skill_rigidleather_ad_ranks"] = 2;
+        bonuses["skill_chain_ad_ranks"] = 0;
+        bonuses["skill_1hedged_ad_ranks"] = 2;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 1;
+        bonuses["skill_missile_ad_ranks"] = 1;
+        bonuses["skill_polearm_ad_ranks"] = 0;
+        bonuses["skill_climb_ad_ranks"] = 0;
+        bonuses["skill_ride_ad_ranks"] = 0;
+        bonuses["skill_swim_ad_ranks"] = 5;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 0;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 0;
+        bonuses["skill_bodydev_ad_ranks"] = 2;
+        bonuses["race_spell_ad_ranks"] = 5;
+        bonuses["race_language_ad_ranks"] = 5;
+        bonuses["race_bg_options"] = 5;
         break;    
         case "Dorwinrim":
         bonuses["stat_st_race_bonus"] = 5;
@@ -4009,6 +4637,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 0;
         bonuses["disease_race_bonus"] = 0;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 0;
+        bonuses["skill_rigidleather_ad_ranks"] = 1;
+        bonuses["skill_chain_ad_ranks"] = 0;
+        bonuses["skill_1hedged_ad_ranks"] = 0;
+        bonuses["skill_1conc_ad_ranks"] = 1;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 1;
+        bonuses["skill_missile_ad_ranks"] = 1;
+        bonuses["skill_polearm_ad_ranks"] = 1;
+        bonuses["skill_climb_ad_ranks"] = 0;
+        bonuses["skill_ride_ad_ranks"] = 2;
+        bonuses["skill_swim_ad_ranks"] = 1;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 0;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 0;
+        bonuses["skill_bodydev_ad_ranks"] = 1;
+        bonuses["race_spell_ad_ranks"] = 10;
+        bonuses["race_language_ad_ranks"] = 5;
+        bonuses["race_bg_options"] = 5;
         break;    
         case "Dunedain":
         bonuses["stat_st_race_bonus"] = 5;
@@ -4021,6 +4673,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 5;
         bonuses["disease_race_bonus"] = 5;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 0;
+        bonuses["skill_rigidleather_ad_ranks"] = 1;
+        bonuses["skill_chain_ad_ranks"] = 2;
+        bonuses["skill_1hedged_ad_ranks"] = 2;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 1;
+        bonuses["skill_thrown_ad_ranks"] = 0;
+        bonuses["skill_missile_ad_ranks"] = 1;
+        bonuses["skill_polearm_ad_ranks"] = 1;
+        bonuses["skill_climb_ad_ranks"] = 0;
+        bonuses["skill_ride_ad_ranks"] = 1;
+        bonuses["skill_swim_ad_ranks"] = 1;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 0;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 1;
+        bonuses["skill_useitems_ad_ranks"] = 1;
+        bonuses["skill_perception_ad_ranks"] = 0;
+        bonuses["skill_bodydev_ad_ranks"] = 3;
+        bonuses["race_spell_ad_ranks"] = 10;
+        bonuses["race_language_ad_ranks"] = 6;
+        bonuses["race_bg_options"] = 3;
         break;    
         case "Dunlending":
         bonuses["stat_st_race_bonus"] = 5;
@@ -4033,6 +4709,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 0;
         bonuses["disease_race_bonus"] = 0;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 0;
+        bonuses["skill_rigidleather_ad_ranks"] = 1;
+        bonuses["skill_chain_ad_ranks"] = 0;
+        bonuses["skill_1hedged_ad_ranks"] = 0;
+        bonuses["skill_1conc_ad_ranks"] = 1;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 2;
+        bonuses["skill_missile_ad_ranks"] = 1;
+        bonuses["skill_polearm_ad_ranks"] = 2;
+        bonuses["skill_climb_ad_ranks"] = 5;
+        bonuses["skill_ride_ad_ranks"] = 0;
+        bonuses["skill_swim_ad_ranks"] = 1;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 0;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 1;
+        bonuses["skill_bodydev_ad_ranks"] = 2;
+        bonuses["race_spell_ad_ranks"] = 2;
+        bonuses["race_language_ad_ranks"] = 2;
+        bonuses["race_bg_options"] = 4;
         break;    
         case "Easterling":
         bonuses["stat_st_race_bonus"] = 5;
@@ -4045,6 +4745,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 0;
         bonuses["disease_race_bonus"] = 0;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 0;
+        bonuses["skill_rigidleather_ad_ranks"] = 0;
+        bonuses["skill_chain_ad_ranks"] = 0;
+        bonuses["skill_1hedged_ad_ranks"] = 1;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 1;
+        bonuses["skill_missile_ad_ranks"] = 2;
+        bonuses["skill_polearm_ad_ranks"] = 2;
+        bonuses["skill_climb_ad_ranks"] = 0;
+        bonuses["skill_ride_ad_ranks"] = 5;
+        bonuses["skill_swim_ad_ranks"] = 0;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 0;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 1;
+        bonuses["skill_bodydev_ad_ranks"] = 2;
+        bonuses["race_spell_ad_ranks"] = 2;
+        bonuses["race_language_ad_ranks"] = 2;
+        bonuses["race_bg_options"] = 4;
         break;    
         case "Eriadoran":
         bonuses["stat_st_race_bonus"] = 5;
@@ -4057,6 +4781,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 0;
         bonuses["disease_race_bonus"] = 0;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 1;
+        bonuses["skill_rigidleather_ad_ranks"] = 1;
+        bonuses["skill_chain_ad_ranks"] = 1;
+        bonuses["skill_1hedged_ad_ranks"] = 1;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 1;
+        bonuses["skill_missile_ad_ranks"] = 1;
+        bonuses["skill_polearm_ad_ranks"] = 1;
+        bonuses["skill_climb_ad_ranks"] = 0;
+        bonuses["skill_ride_ad_ranks"] = 1;
+        bonuses["skill_swim_ad_ranks"] = 1;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 1;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 1;
+        bonuses["skill_bodydev_ad_ranks"] = 2;
+        bonuses["race_spell_ad_ranks"] = 3;
+        bonuses["race_language_ad_ranks"] = 4;
+        bonuses["race_bg_options"] = 5;
         break;    
         case "Gondorian":
         bonuses["stat_st_race_bonus"] = 5;
@@ -4069,6 +4817,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 0;
         bonuses["disease_race_bonus"] = 0;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 0;
+        bonuses["skill_rigidleather_ad_ranks"] = 0;
+        bonuses["skill_chain_ad_ranks"] = 0;
+        bonuses["skill_1hedged_ad_ranks"] = 1;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 0;
+        bonuses["skill_missile_ad_ranks"] = 1;
+        bonuses["skill_polearm_ad_ranks"] = 0;
+        bonuses["skill_climb_ad_ranks"] = 0;
+        bonuses["skill_ride_ad_ranks"] = 0;
+        bonuses["skill_swim_ad_ranks"] = 1;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 0;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 1;
+        bonuses["skill_useitems_ad_ranks"] = 1;
+        bonuses["skill_perception_ad_ranks"] = 1;
+        bonuses["skill_bodydev_ad_ranks"] = 1;
+        bonuses["race_spell_ad_ranks"] = 15;
+        bonuses["race_language_ad_ranks"] = 5;
+        bonuses["race_bg_options"] = 5;
         break;    
         case "Haradrim":
         bonuses["stat_st_race_bonus"] = 5;
@@ -4081,6 +4853,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 0;
         bonuses["disease_race_bonus"] = 0;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 1;
+        bonuses["skill_rigidleather_ad_ranks"] = 0;
+        bonuses["skill_chain_ad_ranks"] = 0;
+        bonuses["skill_1hedged_ad_ranks"] = 1;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 1;
+        bonuses["skill_missile_ad_ranks"] = 0;
+        bonuses["skill_polearm_ad_ranks"] = 2;
+        bonuses["skill_climb_ad_ranks"] = 0;
+        bonuses["skill_ride_ad_ranks"] = 7;
+        bonuses["skill_swim_ad_ranks"] = 0;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 0;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 1;
+        bonuses["skill_bodydev_ad_ranks"] = 2;
+        bonuses["race_spell_ad_ranks"] = 2;
+        bonuses["race_language_ad_ranks"] = 3;
+        bonuses["race_bg_options"] = 5;
         break;    
         case "Lossoth":
         bonuses["stat_st_race_bonus"] = 5;
@@ -4093,6 +4889,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 0;
         bonuses["disease_race_bonus"] = 0;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 3;
+        bonuses["skill_rigidleather_ad_ranks"] = 0;
+        bonuses["skill_chain_ad_ranks"] = 0;
+        bonuses["skill_1hedged_ad_ranks"] = 0;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 3;
+        bonuses["skill_missile_ad_ranks"] = 0;
+        bonuses["skill_polearm_ad_ranks"] = 2;
+        bonuses["skill_climb_ad_ranks"] = 0;
+        bonuses["skill_ride_ad_ranks"] = 0;
+        bonuses["skill_swim_ad_ranks"] = 2;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 4;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 1;
+        bonuses["skill_bodydev_ad_ranks"] = 3;
+        bonuses["race_spell_ad_ranks"] = 5;
+        bonuses["race_language_ad_ranks"] = 1;
+        bonuses["race_bg_options"] = 4;
         break;    
         case "Rohirrim":
         bonuses["stat_st_race_bonus"] = 5;
@@ -4105,6 +4925,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 0;
         bonuses["disease_race_bonus"] = 0;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 0;
+        bonuses["skill_rigidleather_ad_ranks"] = 1;
+        bonuses["skill_chain_ad_ranks"] = 2;
+        bonuses["skill_1hedged_ad_ranks"] = 2;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 0;
+        bonuses["skill_missile_ad_ranks"] = 1;
+        bonuses["skill_polearm_ad_ranks"] = 1;
+        bonuses["skill_climb_ad_ranks"] = 0;
+        bonuses["skill_ride_ad_ranks"] = 8;
+        bonuses["skill_swim_ad_ranks"] = 1;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 0;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 1;
+        bonuses["skill_bodydev_ad_ranks"] = 2;
+        bonuses["race_spell_ad_ranks"] = 3;
+        bonuses["race_language_ad_ranks"] = 4;
+        bonuses["race_bg_options"] = 5;
         break;    
         case "Variag":
         bonuses["stat_st_race_bonus"] = 5;
@@ -4117,6 +4961,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 0;
         bonuses["disease_race_bonus"] = 0;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 1;
+        bonuses["skill_rigidleather_ad_ranks"] = 0;
+        bonuses["skill_chain_ad_ranks"] = 0;
+        bonuses["skill_1hedged_ad_ranks"] = 2;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 1;
+        bonuses["skill_missile_ad_ranks"] = 1;
+        bonuses["skill_polearm_ad_ranks"] = 1;
+        bonuses["skill_climb_ad_ranks"] = 0;
+        bonuses["skill_ride_ad_ranks"] = 4;
+        bonuses["skill_swim_ad_ranks"] = 0;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 1;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 1;
+        bonuses["skill_bodydev_ad_ranks"] = 2;
+        bonuses["race_spell_ad_ranks"] = 5;
+        bonuses["race_language_ad_ranks"] = 3;
+        bonuses["race_bg_options"] = 4;
         break;    
         case "Woodman":
         bonuses["stat_st_race_bonus"] = 5;
@@ -4129,6 +4997,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 0;
         bonuses["disease_race_bonus"] = 0;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 1;
+        bonuses["skill_rigidleather_ad_ranks"] = 0;
+        bonuses["skill_chain_ad_ranks"] = 0;
+        bonuses["skill_1hedged_ad_ranks"] = 1;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 1;
+        bonuses["skill_missile_ad_ranks"] = 1;
+        bonuses["skill_polearm_ad_ranks"] = 1;
+        bonuses["skill_climb_ad_ranks"] = 3;
+        bonuses["skill_ride_ad_ranks"] = 0;
+        bonuses["skill_swim_ad_ranks"] = 1;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 4;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 1;
+        bonuses["skill_bodydev_ad_ranks"] = 3;
+        bonuses["race_spell_ad_ranks"] = 3;
+        bonuses["race_language_ad_ranks"] = 2;
+        bonuses["race_bg_options"] = 5;
         break;    
         case "Wose":
         bonuses["stat_st_race_bonus"] = 0;
@@ -4141,6 +5033,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 0;
         bonuses["disease_race_bonus"] = 0;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 3;
+        bonuses["skill_rigidleather_ad_ranks"] = 0;
+        bonuses["skill_chain_ad_ranks"] = 0;
+        bonuses["skill_1hedged_ad_ranks"] = 2;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 4;
+        bonuses["skill_missile_ad_ranks"] = 0;
+        bonuses["skill_polearm_ad_ranks"] = 1;
+        bonuses["skill_climb_ad_ranks"] = 3;
+        bonuses["skill_ride_ad_ranks"] = 0;
+        bonuses["skill_swim_ad_ranks"] = 2;
+        bonuses["skill_ambush_ad_ranks"] = 2;
+        bonuses["skill_stalkhide_ad_ranks"] = 4;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 1;
+        bonuses["skill_bodydev_ad_ranks"] = 3;
+        bonuses["race_spell_ad_ranks"] = 5;
+        bonuses["race_language_ad_ranks"] = 2;
+        bonuses["race_bg_options"] = 5;
         break;    
         case "Orc":
         bonuses["stat_st_race_bonus"] = 5;
@@ -4153,6 +5069,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 20;
         bonuses["disease_race_bonus"] = 5;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 1;
+        bonuses["skill_rigidleather_ad_ranks"] = 3;
+        bonuses["skill_chain_ad_ranks"] = 2;
+        bonuses["skill_1hedged_ad_ranks"] = 0;
+        bonuses["skill_1conc_ad_ranks"] = 3;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 1;
+        bonuses["skill_missile_ad_ranks"] = 0;
+        bonuses["skill_polearm_ad_ranks"] = 1;
+        bonuses["skill_climb_ad_ranks"] = 1;
+        bonuses["skill_ride_ad_ranks"] = 0;
+        bonuses["skill_swim_ad_ranks"] = 0;
+        bonuses["skill_ambush_ad_ranks"] = 1;
+        bonuses["skill_stalkhide_ad_ranks"] = 0;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 0;
+        bonuses["skill_bodydev_ad_ranks"] = 2;
+        bonuses["race_spell_ad_ranks"] = 0;
+        bonuses["race_language_ad_ranks"] = 2;
+        bonuses["race_bg_options"] = 2;
         break;    
         case "Uruk-Hai":
         bonuses["stat_st_race_bonus"] = 10;
@@ -4165,6 +5105,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 20;
         bonuses["disease_race_bonus"] = 5;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 1;
+        bonuses["skill_rigidleather_ad_ranks"] = 3;
+        bonuses["skill_chain_ad_ranks"] = 3;
+        bonuses["skill_1hedged_ad_ranks"] = 4;
+        bonuses["skill_1conc_ad_ranks"] = 1;
+        bonuses["skill_2handed_ad_ranks"] = 1;
+        bonuses["skill_thrown_ad_ranks"] = 1;
+        bonuses["skill_missile_ad_ranks"] = 1;
+        bonuses["skill_polearm_ad_ranks"] = 1;
+        bonuses["skill_climb_ad_ranks"] = 1;
+        bonuses["skill_ride_ad_ranks"] = 1;
+        bonuses["skill_swim_ad_ranks"] = 0;
+        bonuses["skill_ambush_ad_ranks"] = 1;
+        bonuses["skill_stalkhide_ad_ranks"] = 0;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 1;
+        bonuses["skill_bodydev_ad_ranks"] = 3;
+        bonuses["race_spell_ad_ranks"] = 0;
+        bonuses["race_language_ad_ranks"] = 2;
+        bonuses["race_bg_options"] = 2;
         break;    
         case "Half-Orc":
         bonuses["stat_st_race_bonus"] = 5;
@@ -4177,6 +5141,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 10;
         bonuses["disease_race_bonus"] = 0;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 1;
+        bonuses["skill_rigidleather_ad_ranks"] = 3;
+        bonuses["skill_chain_ad_ranks"] = 1;
+        bonuses["skill_1hedged_ad_ranks"] = 0;
+        bonuses["skill_1conc_ad_ranks"] = 3;
+        bonuses["skill_2handed_ad_ranks"] = 0;
+        bonuses["skill_thrown_ad_ranks"] = 1;
+        bonuses["skill_missile_ad_ranks"] = 1;
+        bonuses["skill_polearm_ad_ranks"] = 0;
+        bonuses["skill_climb_ad_ranks"] = 1;
+        bonuses["skill_ride_ad_ranks"] = 0;
+        bonuses["skill_swim_ad_ranks"] = 0;
+        bonuses["skill_ambush_ad_ranks"] = 1;
+        bonuses["skill_stalkhide_ad_ranks"] = 0;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 0;
+        bonuses["skill_bodydev_ad_ranks"] = 2;
+        bonuses["race_spell_ad_ranks"] = 0;
+        bonuses["race_language_ad_ranks"] = 2;
+        bonuses["race_bg_options"] = 3;
         break;    
         case "Troll":
         bonuses["stat_st_race_bonus"] = 15;
@@ -4189,6 +5177,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 30;
         bonuses["disease_race_bonus"] = 10;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 0;
+        bonuses["skill_rigidleather_ad_ranks"] = 0;
+        bonuses["skill_chain_ad_ranks"] = 0;
+        bonuses["skill_1hedged_ad_ranks"] = 0;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 3;
+        bonuses["skill_thrown_ad_ranks"] = 1;
+        bonuses["skill_missile_ad_ranks"] = 0;
+        bonuses["skill_polearm_ad_ranks"] = 0;
+        bonuses["skill_climb_ad_ranks"] = 1;
+        bonuses["skill_ride_ad_ranks"] = 0;
+        bonuses["skill_swim_ad_ranks"] = 0;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 0;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 0;
+        bonuses["skill_bodydev_ad_ranks"] = 5;
+        bonuses["race_spell_ad_ranks"] = 0;
+        bonuses["race_language_ad_ranks"] = 2;
+        bonuses["race_bg_options"] = 1;
         break;    
         case "Olog-Hai":
         bonuses["stat_st_race_bonus"] = 20;
@@ -4201,6 +5213,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 20;
         bonuses["disease_race_bonus"] = 10;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 0;
+        bonuses["skill_rigidleather_ad_ranks"] = 0;
+        bonuses["skill_chain_ad_ranks"] = 0;
+        bonuses["skill_1hedged_ad_ranks"] = 0;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 5;
+        bonuses["skill_thrown_ad_ranks"] = 2;
+        bonuses["skill_missile_ad_ranks"] = 0;
+        bonuses["skill_polearm_ad_ranks"] = 0;
+        bonuses["skill_climb_ad_ranks"] = 1;
+        bonuses["skill_ride_ad_ranks"] = 0;
+        bonuses["skill_swim_ad_ranks"] = 0;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 0;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 1;
+        bonuses["skill_bodydev_ad_ranks"] = 5;
+        bonuses["race_spell_ad_ranks"] = 0;
+        bonuses["race_language_ad_ranks"] = 2;
+        bonuses["race_bg_options"] = 1;
         break;    
         case "Half-Troll":
         bonuses["stat_st_race_bonus"] = 10;
@@ -4213,6 +5249,30 @@ function raceBonuses(race) {
         bonuses["channeling_race_bonus"] = 0; 
         bonuses["poison_race_bonus"] = 15;
         bonuses["disease_race_bonus"] = 5;
+        bonuses["skill_noarmor_ad_ranks"] = 1;
+        bonuses["skill_softleather_ad_ranks"] = 1;
+        bonuses["skill_rigidleather_ad_ranks"] = 2;
+        bonuses["skill_chain_ad_ranks"] = 3;
+        bonuses["skill_1hedged_ad_ranks"] = 0;
+        bonuses["skill_1conc_ad_ranks"] = 0;
+        bonuses["skill_2handed_ad_ranks"] = 4;
+        bonuses["skill_thrown_ad_ranks"] = 2;
+        bonuses["skill_missile_ad_ranks"] = 0;
+        bonuses["skill_polearm_ad_ranks"] = 0;
+        bonuses["skill_climb_ad_ranks"] = 1;
+        bonuses["skill_ride_ad_ranks"] = 0;
+        bonuses["skill_swim_ad_ranks"] = 0;
+        bonuses["skill_ambush_ad_ranks"] = 0;
+        bonuses["skill_stalkhide_ad_ranks"] = 0;
+        bonuses["skill_picklock_ad_ranks"] = 0;
+        bonuses["skill_disarmtrap_ad_ranks"] = 0;
+        bonuses["skill_readrunes_ad_ranks"] = 0;
+        bonuses["skill_useitems_ad_ranks"] = 0;
+        bonuses["skill_perception_ad_ranks"] = 0;
+        bonuses["skill_bodydev_ad_ranks"] = 4;
+        bonuses["race_spell_ad_ranks"] = 0;
+        bonuses["race_language_ad_ranks"] = 2;
+        bonuses["race_bg_options"] = 2;
         break;    
         default:
         break;
@@ -4246,7 +5306,7 @@ on("sheet:opened change:level change:profession", function(eventInfo) {
             "general_profession_development": bonuses["general_profession_development"] || 0,
             "subterfuge_profession_development": bonuses["subterfuge_profession_development"] || 0,
             "magical_profession_development": bonuses["magical_profession_development"] || 0,
-            "body_profession_development": bonuses["body_profession_development"] || 0,
+            "bodydev_profession_development": bonuses["bodydev_profession_development"] || 0,
             "language_profession_development": bonuses["language_profession_development"] || 0,
             "spell_profession_development": bonuses["spell_profession_development"] || 0
         });
@@ -4268,7 +5328,7 @@ function profBonuses(profession) {
         bonuses["general_profession_development"] = 2;
         bonuses["subterfuge_profession_development"] = 1;
         bonuses["magical_profession_development"] = 2;
-        bonuses["body_profession_development"] = 1;
+        bonuses["bodydev_profession_development"] = 1;
         bonuses["language_profession_development"] = 2;
         bonuses["spell_profession_development"] = 5;
         bonuses["realm"] = "Channeling";
@@ -4287,7 +5347,7 @@ function profBonuses(profession) {
         bonuses["general_profession_development"] = 2;
         bonuses["subterfuge_profession_development"] = 2;
         bonuses["magical_profession_development"] = 3;
-        bonuses["body_profession_development"] = 1;
+        bonuses["bodydev_profession_development"] = 1;
         bonuses["language_profession_development"] = 3;
         bonuses["spell_profession_development"] = 2;
         bonuses["realm"] = "Essence";
@@ -4301,7 +5361,7 @@ function profBonuses(profession) {
         bonuses["general_profession_development"] = 2;
         bonuses["subterfuge_profession_development"] = 0;
         bonuses["magical_profession_development"] = 5;
-        bonuses["body_profession_development"] = 1;
+        bonuses["bodydev_profession_development"] = 1;
         bonuses["language_profession_development"] = 2;
         bonuses["spell_profession_development"] = 5;
         bonuses["realm"] = "Essence";
@@ -4316,7 +5376,7 @@ function profBonuses(profession) {
         bonuses["general_profession_development"] = 4;
         bonuses["subterfuge_profession_development"] = 2;
         bonuses["magical_profession_development"] = 0;
-        bonuses["body_profession_development"] = 2;
+        bonuses["bodydev_profession_development"] = 2;
         bonuses["language_profession_development"] = 1;
         bonuses["spell_profession_development"] = 1;
         bonuses["realm"] = "Channeling";
@@ -4332,7 +5392,7 @@ function profBonuses(profession) {
         bonuses["general_profession_development"] = 3;
         bonuses["subterfuge_profession_development"] = 5;
         bonuses["magical_profession_development"] = 0;
-        bonuses["body_profession_development"] = 2;
+        bonuses["bodydev_profession_development"] = 2;
         bonuses["language_profession_development"] = 1;
         bonuses["spell_profession_development"] = 0;
         break;    
@@ -4345,7 +5405,7 @@ function profBonuses(profession) {
         bonuses["general_profession_development"] = 2;
         bonuses["subterfuge_profession_development"] = 2;
         bonuses["magical_profession_development"] = 0;
-        bonuses["body_profession_development"] = 3;
+        bonuses["bodydev_profession_development"] = 3;
         bonuses["language_profession_development"] = 0;
         bonuses["spell_profession_development"] = 0;
         break;


### PR DESCRIPTION
## Changes / Comments
**New Features**
- Added all playable races
- Added stat autocalcs for races
- Added defense autocalcs for races
- Added development point fields for leveling
- Autoselect realm based on profession
- Body Development now is calculatable!
- Added a section for background options
- Added a language dropdown
- Added adolescent ranks to all appropriate sections

**Enhancements/Bug Fixes**
- Fixed Language Headers
- Fixed Spell School Capitalization
- Fixed Appearance (AP) Calculation
- Added some tooltips
- Improved some field alignments
- Condensed stat section
- Fixed NPC strength bug
- Fixed power point calculation bug

**Breaking Changes**
- No variable names were changed so existing sheets should still work.  
- Race stat bonuses were overridden to be auto-calculated and protected, so any keyed bonuses will be replaced by the auto-calcs.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [X] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.

