### PR TITLE
Mongoose_Traveller2e sheet update, to add default skill characteristics

### DIFF
--- a/Mongoose_Traveller2e/MongooseTraveller.html
+++ b/Mongoose_Traveller2e/MongooseTraveller.html
@@ -383,7 +383,7 @@
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
-                                <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
+                                <option value="@{mod-Education}" selected data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
                             <th style="width:50px;"><input type="number" class="sheet-input" style="width:45px;" name="attr_skillDM-Admin" value="@{skillCharacteristicDM-Admin}" disabled="true"/></th>
@@ -417,7 +417,7 @@
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
-                                <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
+                                <option value="@{mod-Education}" selected data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
                             <th><input type="number" class="sheet-input" name="attr_skillDM-Advocate" value="@{skillCharacteristicDM-Advocate}" disabled="true"/></th>
@@ -447,7 +447,7 @@
                             <th><button name="roll_Animals" type="roll" value='&{template:skill-general} {{skill= Animals }} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-Animals}]] @{ro_default_mod}]] }} ' ><div class="sheet-button_header">Animals</div></button></th>
                             <th><select type="text" class="sheet-input" name="attr_skillCharacteristicDM-Animals" value="0" style="width:95px" />
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
-                                <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
+                                <option value="@{mod-Dexterity}" selected data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
@@ -503,7 +503,7 @@
                             <th><button name="roll_Athletics" type="roll" value='&{template:skill-general} {{skill= Athletics }} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-Athletics}]] @{ro_default_mod}]] }} ' ><div class="sheet-button_header">Athletics</div></button></th>
                             <th><select type="text" class="sheet-input" name="attr_skillCharacteristicDM-Athletics" value="0" style="width:95px" />
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
-                                <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
+                                <option value="@{mod-Dexterity}" selected data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
@@ -562,7 +562,7 @@
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
-                                <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
+                                <option value="@{mod-Intellect}" selected data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
@@ -619,7 +619,7 @@
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
-                                <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
+                                <option value="@{mod-Education}" selected data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
                             <th><input type="number" class="sheet-input" name="attr_skillDM-Astrogation" value="@{skillCharacteristicDM-Astrogation}" disabled="true"/></th>
@@ -651,7 +651,7 @@
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
-                                <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
+                                <option value="@{mod-Intellect}" selected data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
@@ -686,7 +686,7 @@
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
-                                <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
+                                <option value="@{mod-Social}" selected data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
                             <th><input type="number" class="sheet-input" name="attr_skillDM-Carouse" value="@{skillCharacteristicDM-Carouse}" disabled="true"/></th>
                             <th><input type="number" class="sheet-input" name="attr_skilllevel-Carouse" value="0" /></th>
@@ -717,7 +717,7 @@
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
-                                <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
+                                <option value="@{mod-Intellect}" selected data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
@@ -752,7 +752,7 @@
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
-                                <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
+                                <option value="@{mod-Social}" selected data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
                             <th><input type="number" class="sheet-input" name="attr_skillDM-Diplomat" value="@{skillCharacteristicDM-Diplomat}" disabled="true"/></th>
                             <th><input type="number" class="sheet-input" name="attr_skilllevel-Diplomat" value="0" /></th>
@@ -781,7 +781,7 @@
                             <th><button name="roll_Drive" type="roll" value='&{template:skill-general} {{skill= Drive }} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-Drive}]] @{ro_default_mod}]] }} ' ><div class="sheet-button_header">Drive</div></button></th>
                             <th><select type="text" class="sheet-input" name="attr_skillCharacteristicDM-Drive" value="0" style="width:95px" />
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
-                                <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
+                                <option value="@{mod-Dexterity}" selected data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
@@ -840,7 +840,7 @@
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
-                                <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
+                                <option value="@{mod-Education}" selected data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
                             <th><input type="number" class="sheet-input" name="attr_skillDM-Electronics" value="@{skillCharacteristicDM-Electronics}" disabled="true"/></th>
@@ -896,7 +896,7 @@
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
-                                <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
+                                <option value="@{mod-Education}" selected data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
                             <th><input type="number" class="sheet-input" name="attr_skillDM-Engineer" value="@{skillCharacteristicDM-Engineer}" disabled="true"/></th>
@@ -952,7 +952,7 @@
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
-                                <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
+                                <option value="@{mod-Education}" selected data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
                             <th><input type="number" class="sheet-input" name="attr_skillDM-Explosives" value="@{skillCharacteristicDM-Explosives}" disabled="true"/></th>
@@ -982,7 +982,7 @@
                             <th><button name="roll_Flyer" type="roll" value='&{template:skill-general} {{skill= Flyer }} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-Flyer}]] @{ro_default_mod}]] }} ' ><div class="sheet-button_header">Flyer</div></button></th>
                             <th><select type="text" class="sheet-input" name="attr_skillCharacteristicDM-Flyer" value="0" style="width:95px" />
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
-                                <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
+                                <option value="@{mod-Dexterity}" selected data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
@@ -1040,7 +1040,7 @@
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
-                                <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
+                                <option value="@{mod-Intellect}" selected data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
@@ -1073,7 +1073,7 @@
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
-                                <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
+                                <option value="@{mod-Intellect}" selected data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
@@ -1127,7 +1127,7 @@
                             <th><button name="roll_GunCombat" type="roll" value='&{template:skill-general} {{skill= Gun Combat }} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-GunCombat}]] @{ro_default_mod}]] }} ' ><div class="sheet-button_header">Gun Combat</div></button></th>
                             <th><select type="text" class="sheet-input" name="attr_skillCharacteristicDM-GunCombat" value="0" style="width:95px" />
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
-                                <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
+                                <option value="@{mod-Dexterity}" selected data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
@@ -1183,7 +1183,7 @@
                             <th><button name="roll_HeavyWeapons" type="roll" value='&{template:skill-general} {{skill= Heavy Weapons }} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-HeavyWeapons}]] @{ro_default_mod}]] }} ' ><div class="sheet-button_header">Heavy Weapons</div></button></th>
                             <th><select type="text" class="sheet-input" name="attr_skillCharacteristicDM-HeavyWeapons" value="0" style="width:95px" />
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
-                                <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
+                                <option value="@{mod-Dexterity}" selected data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
@@ -1241,7 +1241,7 @@
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
-                                <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
+                                <option value="@{mod-Intellect}" selected data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
@@ -1274,7 +1274,7 @@
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
-                                <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
+                                <option value="@{mod-Intellect}" selected data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
@@ -1308,7 +1308,7 @@
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
-                                <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
+                                <option value="@{mod-Education}" selected data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
                             <th><input type="number" class="sheet-input" name="attr_skillDM-Language" value="@{skillCharacteristicDM-Language}" disabled="true"/></th>
@@ -1365,7 +1365,7 @@
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
-                                <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
+                                <option value="@{mod-Social}" selected data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
                             <th><input type="number" class="sheet-input" name="attr_skillDM-Leadership" value="@{skillCharacteristicDM-Leadership}" disabled="true"/></th>
                             <th><input type="number" class="sheet-input" name="attr_skilllevel-Leadership" value="0" /></th>
@@ -1397,7 +1397,7 @@
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
-                                <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
+                                <option value="@{mod-Education}" selected data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
                             <th><input type="number" class="sheet-input" name="attr_skillDM-Mechanic" value="@{skillCharacteristicDM-Mechanic}" disabled="true"/></th>
@@ -1430,7 +1430,7 @@
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
-                                <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
+                                <option value="@{mod-Education}" selected data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
                             <th><input type="number" class="sheet-input" name="attr_skillDM-Medic" value="@{skillCharacteristicDM-Medic}" disabled="true"/></th>
@@ -1460,7 +1460,7 @@
                             <th><button name="roll_Melee" type="roll" value='&{template:skill-general} {{skill= Melee }} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-Melee}]] @{ro_default_mod}]] }} ' ><div class="sheet-button_header">Melee</div></button></th>
                             <th><select type="text" class="sheet-input" name="attr_skillCharacteristicDM-Melee" value="0" style="width:95px" />
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
-                                <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
+                                <option value="@{mod-Dexterity}" selected data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
@@ -1519,7 +1519,7 @@
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
-                                <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
+                                <option value="@{mod-Education}" selected data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
                             <th><input type="number" class="sheet-input" name="attr_skillDM-Navigation" value="@{skillCharacteristicDM-Navigation}" disabled="true"/></th>
@@ -1551,7 +1551,7 @@
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
-                                <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
+                                <option value="@{mod-Intellect}" selected data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
@@ -1582,7 +1582,7 @@
                             <th><button name="roll_Pilot" type="roll" value='&{template:skill-general} {{skill= Pilot }} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-Pilot}]] @{ro_default_mod}]] }} ' ><div class="sheet-button_header">Pilot</div></button></th>
                             <th><select type="text" class="sheet-input" name="attr_skillCharacteristicDM-Pilot" value="0" style="width:95px" />
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
-                                <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
+                                <option value="@{mod-Dexterity}" selected data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
@@ -1641,7 +1641,7 @@
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
-                                <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
+                                <option value="@{mod-Education}" selected data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
                             <th><input type="number" class="sheet-input" name="attr_skillDM-Profession" value="@{skillCharacteristicDM-Profession}" disabled="true"/></th>
@@ -1696,7 +1696,7 @@
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
-                                <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
+                                <option value="@{mod-Intellect}" selected data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
@@ -1730,7 +1730,7 @@
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
-                                <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
+                                <option value="@{mod-Education}" selected data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
                             <th><input type="number" class="sheet-input" name="attr_skillDM-Science" value="@{skillCharacteristicDM-Science}" disabled="true"/></th>
@@ -1786,7 +1786,7 @@
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
-                                <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
+                                <option value="@{mod-Education}" selected data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
                             <th><input type="number" class="sheet-input" name="attr_skillDM-Seafarer" value="@{skillCharacteristicDM-Seafarer}" disabled="true"/></th>
@@ -1839,7 +1839,7 @@
                             <th><button name="roll_Stealth" type="roll" value='&{template:skill-general} {{skill= Stealth }} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-Stealth}]] @{ro_default_mod}]] }} ' ><div class="sheet-button_header">Stealth</div></button></th>
                             <th><select type="text" class="sheet-input" name="attr_skillCharacteristicDM-Stealth" value="0" style="width:95px" />
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
-                                <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
+                                <option value="@{mod-Dexterity}" selected data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
@@ -1874,7 +1874,7 @@
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
-                                <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
+                                <option value="@{mod-Intellect}" selected data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
@@ -1907,7 +1907,7 @@
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
-                                <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
+                                <option value="@{mod-Intellect}" selected data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
@@ -1940,7 +1940,7 @@
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
-                                <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
+                                <option value="@{mod-Intellect}" selected data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
@@ -1973,7 +1973,7 @@
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                                 <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
-                                <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
+                                <option value="@{mod-Intellect}" selected data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
                                 <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
                                 </select></th>
@@ -2027,7 +2027,7 @@
                             <th><button name="roll_VaccSuit" type="roll" value='&{template:skill-general} {{skill= Vacc Suit }} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-VaccSuit}]] @{ro_default_mod}]] }} ' ><div class="sheet-button_header">Vacc Suit</div></button></th>
                             <th><select type="text" class="sheet-input" name="attr_skillCharacteristicDM-VaccSuit" value="0" style="width:95px" />
                                 <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
-                                <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
+                                <option value="@{mod-Dexterity}" selected data-i18n="skilldexterityoption-u">Dexterity</option>
                                 <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
                                 <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
                                 <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>


### PR DESCRIPTION
Rather than have each skill default to Strength when it is added, it will default to a more likely characteristic
(such as DEX or INT).  Characteristics can still be changed, it only changes what they initially default to.

## Changes / Comments

Added selected option to tags in drop down menus.




## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ Y ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ N ] Is this a bug fix?
- [ Y ] Does this add functional enhancements (new features or extending existing features) ?
- [ N ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ N ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ N ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
