### PR TITLE
[PokemonTabletopAdventures_v3] Adds capture roll modifiers

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -287,6 +287,7 @@ div.sheet-character-stat-grid p {
 
 .sheet-configuration-grid {
   align-items: start;
+  column-gap: 10px;
   display: grid;
   grid-template-columns: 1fr 1fr;
   padding: 6px;
@@ -454,9 +455,21 @@ div.sheet-skill-selection .sheet-no-dropdown {
 }
 
 .sheet-capture-pokemon-skill {
-  display: grid;
-  grid-template-columns: 2fr 10fr 4fr;
   align-items: center;
+  display: grid;
+  grid-template-columns: 2fr 3fr 7fr 2fr 2fr;
+}
+
+div.sheet-capture-pokemon-skill input[type="text"] {
+  margin-left: -1px;
+}
+
+div.sheet-capture-pokemon-skill .sheet-skill-roller {
+  grid-column: 2 / end;
+}
+
+div.sheet-capture-pokemon-skill select.sheet-ball-picker {
+  grid-column: 1 / span 2;
 }
 
 select.sheet-ball-picker {
@@ -668,10 +681,15 @@ input.sheet-skill-color-setting[value="SPD"] + .sheet-skill-total + button[type=
   background-color: var(--stat-ro-spd);
 }
 
-input[type="number"].sheet-skill-total {
+input.sheet-skill-total {
   border: none;
   font-style: italic;
   font-weight: bold;
+  width: 3.5em;
+}
+
+input[type="text"].sheet-skill-total {
+  text-align: center;
 }
 
 .sheet-stat-ball-color[type="number"] {

--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -462,6 +462,7 @@ div.sheet-skill-selection .sheet-no-dropdown {
 
 div.sheet-capture-pokemon-skill input[type="text"] {
   margin-left: -1px;
+  width: 65% !important;
 }
 
 div.sheet-capture-pokemon-skill .sheet-skill-roller {
@@ -472,8 +473,11 @@ div.sheet-capture-pokemon-skill select.sheet-ball-picker {
   grid-column: 1 / span 2;
 }
 
+div.sheet-capture-pokemon-skill > span {
+  padding-left: 10px;
+}
+
 select.sheet-ball-picker {
-  border: none;
   width: auto;
 }
 

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -580,12 +580,13 @@
             <input class="sheet-skill-color-setting" name="attr_capture_ability_mod" type="hidden" value="SPD" />
             <input class="sheet-skill-total" name="attr_capture_total" readonly title="Attribute: capture_total" type="number" />
             <button class="sheet-skill-roller" name="roll_capturecheck" type="roll"
-              value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Capture Pokémon}} {{skill-roll=[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 + @{ball_capture_modifier} ]] }}">
+              value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Capture Pokémon}} {{skill-roll=[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 @{ball_capture_modifier} + @{capture_roll_bonus} - @{capture_roll_feature_bonus} ]] }}">
               Capture Pokémon (<span name="attr_capture_ability_mod"></span>)
             </button>
-            <select class="sheet-ball-picker sheet-no-dropdown" name="attr_ball_capture_modifier" title="Attribute: ball_capture_modifier">
-              <option value="5" selected>Basic Ball</option>
-              <option value="0">Great Ball</option>
+            <input name="attr_capture_default_custom_modifier" type="hidden" value="0" />
+            <select class="sheet-ball-picker" name="attr_ball_capture_modifier" title="Attribute: ball_capture_modifier">
+              <option value="+5" selected>Basic Ball</option>
+              <option value="+0">Great Ball</option>
               <option value="-5">Ultra Ball</option>
               <option value="-20">Park Ball</option>
               <option value="-20">Safari Ball</option>
@@ -601,8 +602,8 @@
               <option value="-10">Repeat Ball</option>
               <option value="-10">1m Timer Ball</option>
               <option value="-25">2m Timer Ball</option>
-              <option value="0">Friend Ball</option>
-              <option value="0">Heal Ball</option>
+              <option value="+0">Friend Ball</option>
+              <option value="+0">Heal Ball</option>
               <option value="-10">Dream Ball</option>
               <option value="-15">Heavy Ball</option>
               <option value="-10">Level Ball</option>
@@ -613,8 +614,12 @@
               <option value="-12">Terrain Ball</option>
               <option value="-10">Save Ball</option>
               <option value="-100">Master Ball</option>
-              <option value="?{Custom Ball Modifier|0}">Custom Ball</option>
+              <option value="+ ?{Custom Ball Modifier|@{capture_default_custom_modifier}}">Custom Ball</option>
             </select>
+            <input name="attr_capture_display" readonly title="Attribute: capture_display" type="text" />
+            <input name="attr_capture_roll_bonus" type="number" value="0" />
+            <input class="sheet-skill-total" name="attr_capture_roll_total" readonly type="text" />
+            <input name="attr_capture_roll_feature_bonus" type="hidden" />
           </div>
         </div>
         <textarea class="sheet-inventory" name="attr_inventory" placeholder="Pokéballs, Berries, Medicine, Accessories, etc." spellcheck="false" title="Attribute: inventory"></textarea>
@@ -933,12 +938,12 @@
           <option value="grass">Grass</option>
           <option value="ground">Ground</option>
           <option value="ice">Ice</option>
-          <option value="normal" selected>Normal</option>
+          <option value="normal">Normal</option>
           <option value="poison">Poison</option>
           <option value="psychic">Psychic</option>
           <option value="rock">Rock</option>
           <option value="steel">Steel</option>
-          <option value="typeless">Typeless</option>
+          <option value="typeless" selected>Typeless</option>
           <option value="water">Water</option>
         </select>
         <p class="sheet-dark-text">
@@ -982,6 +987,22 @@
         <p class="sheet-dark-text">
           This setting area allows you to change the base ability modifier added to each skill total. Select the skill you want to modify with the left
           selector, and then assign the stat you want to use with the right selector.
+        </p>
+      </div>
+      <div class="sheet-custom-ball-default-selecton">
+        <b title="Default value: 0">Custom Ball Default:</b>
+        <b class="sheet-info-tooltip" title="Default value: 0"> ℹ </b>
+        <input name="attr_capture_default_custom_modifier" title="Attribute: capture_default_custom_modifier" type="text" value="0" /><br />
+        <p class="sheet-dark-text">
+          This setting allows you to specify a default modifier to be used for the Custom Ball when capturing pokémon. You can use an attribute for this value.
+        </p>
+      </div>
+      <div class="sheet-capture-roll-feature-bonus">
+        <b title="Default value: 0">Feature Bonus to Capture:</b>
+        <b class="sheet-info-tooltip" title="Default value: 0"> ℹ </b>
+        <input name="attr_capture_roll_feature_bonus" title="Attribute: capture_roll_feature_bonus" type="text" value="0" /><br />
+        <p class="sheet-dark-text">
+          This setting allows you to define a numerical bonus to your capture rolls. This value will be subtracted from your capture rolls.
         </p>
       </div>
     </div>
@@ -2299,7 +2320,7 @@
   });
 
   // Capture
-  on("change:SPDMOD change:capture sheet:opened", function () {
+  on("change:SPDMOD sheet:opened", function () {
     getAttrs([`SPDMOD`, `capture_total`], function (values) {
       const stat = parseInt(values.SPDMOD) || 0;
       const total = parseInt(values.capture_total) || -1;
@@ -2307,6 +2328,51 @@
       assignSkillTotal("capture_total", stat, 0, 0, total, 0);
     });
   });
+
+  on("change:ball_capture_modifier change:capture_roll_bonus change:capture_roll_feature_bonus sheet:opened", function () {
+    getAttrs(["ball_capture_modifier", "capture_default_custom_modifier", "capture_roll_bonus", "capture_roll_feature_bonus"], function (values) {
+
+      const ball = values.ball_capture_modifier;
+      const bonus = parseInt(values.capture_roll_bonus) || 0;
+
+      var display;
+      var showAsterisk = false;
+      if (ball.includes("Custom")) {
+        display = values.capture_default_custom_modifier;
+        showAsterisk = true;
+      } else {
+         display = ball;
+      }
+      
+      
+      const feature = values.capture_roll_feature_bonus;
+      if (feature.includes("@{")) {
+        const stripped = feature.replace('@{', '').replace('}', '');
+
+        getAttrs([stripped], function (innerValue) {
+          const value = innerValue[`${stripped}`];
+          assignCaptureAttributesWith(bonus, value, display, showAsterisk);
+        });
+      } else {
+        const intFeature = parseInt(feature) || 0;
+        assignCaptureAttributesWith(bonus, intFeature, display, showAsterisk);
+      }
+    });
+  })
+
+  function assignCaptureAttributesWith(bonus, feature, display, isCustomPokeball) {
+    var total = bonus - feature;
+    if (isCustomPokeball) {
+      total = `${total}*`;
+    } else {
+      total += parseInt(display) || 0;
+    }
+  
+    setAttrs({
+      "capture_display"   : display,
+      "capture_roll_total": total
+    });
+  }
 
   function getSkillAttributes(statLabel, talent1Label, talent2Label, userBonusLabel, totalLabel) {
     getAttrs([statLabel, talent1Label, talent2Label, totalLabel, userBonusLabel], function (attributes) {

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -578,13 +578,15 @@
           <hr class="sheet-skill-separator" />
           <div class="sheet-capture-pokemon-skill sheet-tab-trainer">
             <input class="sheet-skill-color-setting" name="attr_capture_ability_mod" type="hidden" value="SPD" />
-            <input class="sheet-skill-total" name="attr_capture_total" readonly title="Attribute: capture_total" type="number" />
+            <input class="sheet-skill-total" name="attr_capture_total" readonly title="The value added to your skill check to hit a Pokémon with a Pokéball. Note - this can be ignored if the target Pokémon is at or below half of their max HP.
+            Attribute: capture_total" type="number" />
             <button class="sheet-skill-roller" name="roll_capturecheck" type="roll"
-              value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Capture Pokémon}} {{skill-roll=[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 @{ball_capture_modifier} + @{capture_roll_bonus} - @{capture_roll_feature_bonus} ]] }}">
+              value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Capture Pokémon}} {{skill-roll=[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 @{ball_capture_modifier} + @{capture_roll_bonus} ]] }}">
               Capture Pokémon (<span name="attr_capture_ability_mod"></span>)
             </button>
             <input name="attr_capture_default_custom_modifier" type="hidden" value="0" />
-            <select class="sheet-ball-picker" name="attr_ball_capture_modifier" title="Attribute: ball_capture_modifier">
+            <select class="sheet-ball-picker" name="attr_ball_capture_modifier" title="Select which Pokéball you want to use - this presumes the benefit is applied for conditional balls such as Quick Ball.
+            Attribute: ball_capture_modifier">
               <option value="+5" selected>Basic Ball</option>
               <option value="+0">Great Ball</option>
               <option value="-5">Ultra Ball</option>
@@ -616,10 +618,15 @@
               <option value="-100">Master Ball</option>
               <option value="+ ?{Custom Ball Modifier|@{capture_default_custom_modifier}}">Custom Ball</option>
             </select>
-            <input name="attr_capture_display" readonly title="Attribute: capture_display" type="text" />
-            <input name="attr_capture_roll_bonus" type="number" value="0" />
-            <input class="sheet-skill-total" name="attr_capture_roll_total" readonly type="text" />
-            <input name="attr_capture_roll_feature_bonus" type="hidden" />
+            <span title="The modifier applied to your capture rolls because of your selected Pokéball. This value can be configured for custom balls in the Configuration page.
+            Attribute: capture_display">
+              <b>Ball Mod:</b>
+              <input class="sheet-total-display" name="attr_capture_display" readonly type="text" />
+            </span>
+            <input name="attr_capture_roll_bonus" title="Use this field to assign a static modifier to your capture rolls - things like a Capture Specialist's Capture Point feature.
+            Attribute: capture_roll_bonus" type="number" value="0" />
+            <input class="sheet-skill-total sheet-total-display" name="attr_capture_roll_total" readonly title="The total modifier applied to your d100 capture rolls. If an asterisk * is shown, that means you've selected a custom ball.
+            Attribute: capture_roll_total" type="text" />
           </div>
         </div>
         <textarea class="sheet-inventory" name="attr_inventory" placeholder="Pokéballs, Berries, Medicine, Accessories, etc." spellcheck="false" title="Attribute: inventory"></textarea>
@@ -995,14 +1002,6 @@
         <input name="attr_capture_default_custom_modifier" title="Attribute: capture_default_custom_modifier" type="text" value="0" /><br />
         <p class="sheet-dark-text">
           This setting allows you to specify a default modifier to be used for the Custom Ball when capturing pokémon. You can use an attribute for this value.
-        </p>
-      </div>
-      <div class="sheet-capture-roll-feature-bonus">
-        <b title="Default value: 0">Feature Bonus to Capture:</b>
-        <b class="sheet-info-tooltip" title="Default value: 0"> ℹ </b>
-        <input name="attr_capture_roll_feature_bonus" title="Attribute: capture_roll_feature_bonus" type="text" value="0" /><br />
-        <p class="sheet-dark-text">
-          This setting allows you to define a numerical bonus to your capture rolls. This value will be subtracted from your capture rolls.
         </p>
       </div>
     </div>
@@ -2329,50 +2328,34 @@
     });
   });
 
-  on("change:ball_capture_modifier change:capture_roll_bonus change:capture_roll_feature_bonus sheet:opened", function () {
-    getAttrs(["ball_capture_modifier", "capture_default_custom_modifier", "capture_roll_bonus", "capture_roll_feature_bonus"], function (values) {
+  on("change:ball_capture_modifier change:capture_roll_bonus sheet:opened", function () {
+    getAttrs(["ball_capture_modifier", "capture_default_custom_modifier", "capture_roll_bonus"], function (values) {
 
       const ball = values.ball_capture_modifier;
       const bonus = parseInt(values.capture_roll_bonus) || 0;
 
       var display;
-      var showAsterisk = false;
+      var isCustomPokeball = false;
       if (ball.includes("Custom")) {
         display = values.capture_default_custom_modifier;
-        showAsterisk = true;
+        isCustomPokeball = true;
       } else {
          display = ball;
       }
       
-      
-      const feature = values.capture_roll_feature_bonus;
-      if (feature.includes("@{")) {
-        const stripped = feature.replace('@{', '').replace('}', '');
-
-        getAttrs([stripped], function (innerValue) {
-          const value = innerValue[`${stripped}`];
-          assignCaptureAttributesWith(bonus, value, display, showAsterisk);
-        });
+      var total = bonus;
+      if (isCustomPokeball) {
+        total = `${total}*`;
       } else {
-        const intFeature = parseInt(feature) || 0;
-        assignCaptureAttributesWith(bonus, intFeature, display, showAsterisk);
+        total += parseInt(display) || 0;
       }
+    
+      setAttrs({
+        "capture_display": display,
+        "capture_roll_total": total
+      });
     });
-  })
-
-  function assignCaptureAttributesWith(bonus, feature, display, isCustomPokeball) {
-    var total = bonus - feature;
-    if (isCustomPokeball) {
-      total = `${total}*`;
-    } else {
-      total += parseInt(display) || 0;
-    }
-  
-    setAttrs({
-      "capture_display"   : display,
-      "capture_roll_total": total
-    });
-  }
+  });
 
   function getSkillAttributes(statLabel, talent1Label, talent2Label, userBonusLabel, totalLabel) {
     getAttrs([statLabel, talent1Label, talent2Label, totalLabel, userBonusLabel], function (attributes) {

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -23,6 +23,13 @@ Things we want to add to the character sheet, presented in no particular order o
 
 ## Changelog
 
+### Feb 18th, 2021
+
+- Expanded the Capture Pokémon skill, allowing modifiers such as Capture Point to be applied
+- Improved the display of the Pokéball selection, and added a display of the effect that each has on the capture roll
+- Added a display of the total modifier to capture rolls
+- Added the option of configuring the default value for Custom Pokéballs
+
 ### Feb 11th, 2021
 
 - Resolved a small issue with the move repeating section where the button to collapse the fields would show a `+` instead of a `-`


### PR DESCRIPTION
## Changes / Comments
- refactors the capture pokemon skill section to allow for more information and more extensive modifiers
- adds two new options to the configuration page to further modify the capture pokemon skill

## Roll20 Requests

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Does this add functional enhancements (new features or extending existing features)?
- [x] Does this add or change functional aesthetics (such as layout or color scheme)?
