### PR TITLE
[Call_of_Cthulhu_7th_Ed] De-dupe "Roll" text in Drive Auto skill use output

### DIFF
--- a/Call_of_Cthulhu_7th_Ed/coc_7th_ed.html
+++ b/Call_of_Cthulhu_7th_Ed/coc_7th_ed.html
@@ -2224,8 +2224,8 @@
                     <td><input type="checkbox" name="attr_drive_auto_checkbox"></td>
                     <td class="skill-label" data-i18n="driveauto-u">Drive Auto(20%)</td>
                     <td><input class="skill-input" type="text" name="attr_drive_auto" value="20"/></td>
-                    <td><button class='old-roll' type='roll' value='&{template:coc} {{name=@{driveauto_txt} Roll}} {{success=[[@{drive_auto}]]}} {{hard=[[floor(@{drive_auto}/2)]]}} {{extreme=[[floor(@{drive_auto}/5)]]}} {{roll1=[[1d100]]}} {{roll2=[[1d100]]}} {{roll3=[[1d100]]}}' name='roll_drive_auto_check' /></td>
-					<td><button class='new-roll' type='roll' value='&{template:coc-1} {{name=@{driveauto_txt} Roll}} {{success=[[@{drive_auto}]]}} {{hard=[[floor(@{drive_auto}/2)]]}} {{extreme=[[floor(@{drive_auto}/5)]]}} {{roll1=[[1d100]]}}' name='roll_drive_auto_check' /></td>
+                    <td><button class='old-roll' type='roll' value='&{template:coc} {{name=@{driveauto_txt}}} {{success=[[@{drive_auto}]]}} {{hard=[[floor(@{drive_auto}/2)]]}} {{extreme=[[floor(@{drive_auto}/5)]]}} {{roll1=[[1d100]]}} {{roll2=[[1d100]]}} {{roll3=[[1d100]]}}' name='roll_drive_auto_check' /></td>
+					<td><button class='new-roll' type='roll' value='&{template:coc-1} {{name=@{driveauto_txt}}} {{success=[[@{drive_auto}]]}} {{hard=[[floor(@{drive_auto}/2)]]}} {{extreme=[[floor(@{drive_auto}/5)]]}} {{roll1=[[1d100]]}}' name='roll_drive_auto_check' /></td>
                 </tr>
                 <tr>
                     <td><input type="checkbox" name="attr_elec_repair_checkbox"></td>


### PR DESCRIPTION
## Changes / Comments

The Drive Auto skill would produce the `name` text "Drive Auto Roll Roll" in the chat window output templates.  This was caused by the explicit inclusion of the text "Roll" in the HTML in addition to the translation data.  This change removes the extra "Roll" from the HTML and the output.

roll20userid: 16813

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name. **YES**
- [x] Is this a bug fix? **YES**
- [ ] Does this add functional enhancements (new features or extending existing features) ? **NO**
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ?  **NO**
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ? **NOT APPLICABLE**
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards (https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ? **NOT APPLICABLE**

If you do not know English. Please leave a comment in your native language.
