### PR TITLE
[Warhammer 4e Character Sheet] Channel label change

### DIFF
--- a/Warhammer 4e Character Sheet/README.md
+++ b/Warhammer 4e Character Sheet/README.md
@@ -28,7 +28,7 @@ My optional Custom WFRP4e token marker set 2.0 is available @ https://github.com
 
 - Intergated SL results for all rolls, which aids in the manual calculation for opposed rolls (due underlying limits with Roll20 full Opposed SL resolution is not a straight forward matter for now, i have chosen the visual self calcualted approach while providing the maximum possible information.)
 
-- Full combat Advantage & Condition Tracking, per core rules.
+- Full combat Advantage & Condition Tracking, per core rules. Additionally advantage can be disabled for spells in the settings tab, allowing for seemless integration the Unoffical Grimoire rules (@ http://www.lahiette.com/leratierbretonnien/wp-content/uploads/2020/09/WFRP4-Unofficial-Grimoire-2.02-PDF.pdf).
 
 - Inventory: Full Encumbrance Management system, with automatic Overencumbrance modifiers (-move/agi), and Container & Vehicle Management section (TEW compatible) .
 
@@ -74,10 +74,12 @@ Note conditions are not inteneded for out of combat situations, GM simply makes 
 
 ///// ============ Change Log ============ ///// 
 
+
 February 1st 2021 v1.34
 
 - Added coin converters buttons on the inventory page.
 - Various Qualities text fields now align to the left.
+- Changed spellbook Channel button label from "Cast" to "Channel".
 
 
 January 18th 2021 v1.33

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -11866,34 +11866,15 @@
 					<!-- LANGUAGE SKILLS SECTION -->					
 					<div class="sheet-row sheet-area-border">
 						<div class="sheet-col-1-19 sheet-center sheet-pad-r-sm sheet-vert-middle"><span>&nbsp;</span></div>
-              <label class="sheet-col-1-14 sheet-left talsetshow-check" style="width: 15px">
-		<input class="talsetshow-check__hide" type="hidden" name="attr_Language_settings_hide" value="0"/>		
-		<input class="talsetshow-check__hide" type="checkbox" name="attr_Language_settings_hide" value="1"/><span class="talsetshow-check__span" checked="unchecked">y</span>
+              <label class="sheet-col-1-14 sheet-left" style="width: 15px">
               </label>
 						<div class="sheet-col-1-7 sheet-vert-middle">
 							<span data-i18n="LANGUAGE" class="sheet-italic">Language</span>
 						</div>
-		
-				<input type="checkbox" name="attr_Language_settings_hide" class="sheet-hidden sheet-hider" value="1" />	
-		<div class="talsetshow">
-									
-
-						<div class="sheet-col-1-2 sheet-center" style="padding-left: 20px">
-						<div class="sheet-row">	
-							<div class="sheet-col-2-3 sheet-left">	
-								<span data-i18n="LANG-MAGICK" class="sheet-italic sheet-nowrap">Language (Magick)</span>
-							</div>
-							<div class="sheet-col-1-3 sheet-center">			
-						<input class="meleeshow-check" type="checkbox" name="attr_LanguageMagick_hide" value="1"/>
-							</div>
-						</div>
-						</div>
-							<span class="sheet-spacer"></span>		
-						</div>						
+				
 
 						
 						<!-- Language (Magick) -->
-				<input type="checkbox" name="attr_LanguageMagick_hide" class="sheet-hidden sheet-hider" value="1" />	
 						<div class="sheet-row">
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<input type="checkbox" name="attr_LangMagickCareer" value="1">

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -16473,7 +16473,7 @@
 							
 							<div class="sheet-col-1-12 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<button type="roll" class="sheet-roll" name="roll_ExtChannellingLoreRoll" value="@{Whisper} &amp&{template:whfrp2e} {{modvalue=[[?{Channeling Roll Modifier|@{ChanMod}}]]}} {{title=@{spellname}}} {{title=^{EXTENDED-CHANNELLING-TEST}}} {{skill=^{ADVANCED-SKILL}}}} {{unconscious=[[@{UnconsciousMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[@{DeafenedMod}]]}} {{character_name=@{character_name}}} {{target=[[([[{[[@{ConditionMod}]],[[@{ConditionMoveMod}]],[[@{ConditionSeeMod}]],[[@{ConditionHearMod}]]}kl1]]) [COND] + @{ExtChannellingLore} [SKILL] + ?{Channeling Roll Modifier|0} [MOD] ]]}} {{skilltest=true}} {{test=[[@{roll_rule}]]}} {{accuchanexlsl=[[?{Accumulated Extended Channelling SL (Start at 0)|@{spellchannelsl}}}} {{SLmod=[[?{SL Modifier|0}]]]]}} {{spellcastingnumber=[[@{spellcastingnumber}]]}} {{SLmod=[[?{SL Modifier|0}]]}} {{rolltype=[[9]]}} {{mod1type=[[@{ExtChannellingLoreRoll_modtype1}]]}} {{mod1=@{ExtChannellingLoreRoll_mod1}}} {{mod2type=[[@{ExtChannellingLoreRoll_modtype2}]]}} {{mod2=@{ExtChannellingLoreRoll_mod2}}} {{mod3type=[[@{ExtChannellingLoreRoll_modtype3}]]}} {{mod3=@{ExtChannellingLoreRoll_mod3}}} {{NPC=[[0]]}} {{RTminor=@{RT-minor}}} {{RTmajor=@{RT-major}}} {{reroll=@{RR-rep}ExtChannellingLoreRoll)}} {{sptal1=[[@{spelltalent1}]]}}">
-									<span data-i18n="CAST">Cast</span>
+									<span data-i18n="CHANNEL">Channel</span>
 								</button>
 							</div>
 
@@ -25951,10 +25951,6 @@ on('change:repeating_advancements', function(){
         })
         .execute(); 
 });
-
-
-
-
 
 		on("sheet:opened", function(eventInfo){
 		setAttrs({

--- a/Warhammer 4e Character Sheet/translation.json
+++ b/Warhammer 4e Character Sheet/translation.json
@@ -1058,6 +1058,7 @@
 	"CRITICAL-ROLL": "Critical Roll",
 	"CRITICAL-CAST": "Critical Cast",
 	"CRITICAL-CHANNEL": "Critical Channel",
+	"CHANNEL": "Channel",
 	"CRITICAL": "Critical Hit",
 	"IMPALE-CRITICAL": "Critical Hit (Impaled)",
 	"CRITICAL-SUCCESS": "Auto Success",


### PR DESCRIPTION
## Changes / Comments

- Changed spellbook Channel button label from "Cast" to "Channel". 
- Language Magick is now always shown

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
