### PR TITLE
ShadowrunAnarchy: Fix French Karma boxes

### DIFF
--- a/ShadowrunAnarchy/ShadowrunAnarchy.css
+++ b/ShadowrunAnarchy/ShadowrunAnarchy.css
@@ -2142,10 +2142,6 @@ input.sheet-radio-header-physical:hover + h2
 
 /* FRENCH adjustments */
 
-.charsheet.lang-fr .sheet-karma-bubbles input[type="number"] {
-	margin-top: -2em;
-}
-
 .charsheet.lang-fr .sheet-cuerow input[type="checkbox"] {
 	left: 55%;
 	top: -25px;}


### PR DESCRIPTION
## Changes / Comments
- Sheet: ShadowrunAnarchy
- It is a bug fix
- It doe not add functional enhancements or anything, only fix a margin issue in the french version of the sheet

I removed the margin-top: -2em that was hiding the Karma boxes labels, like this:
![image](https://user-images.githubusercontent.com/5885505/108792673-d0bf5b80-754f-11eb-9896-9151c4f41b43.png)

With this fix, the boxes look like this:
![image](https://user-images.githubusercontent.com/5885505/108792690-dc128700-754f-11eb-8445-58c240ca0c90.png)

