### PR TITLE
[Awakening_RPG]fixed attribute name to exclude duplicates

### DIFF
--- a/Awakening_RPG/awakening.html
+++ b/Awakening_RPG/awakening.html
@@ -171,7 +171,7 @@
         </button>
     </div>
     <div class="sheet-tln-lbl"><label>Талоны</label></div>
-    <div class="sheet-tal-val"><input type="number" name="attr_ac"
+    <div class="sheet-tal-val"><input type="number" name="attr_tal"
                                       class="sheet-input-number-no-roll"/></div>
     <div class="sheet-ahc-header"><label class="sheet-center-align">Административно-хозяйственная часть</label></div>
     <div class="sheet-flair-adv">


### PR DESCRIPTION
## Changes / Comments
There was a duplicate in character list - two different attributes have same name in input field. This updated aimed to remove this duplication in order to have two separate fields: attr_ac and attr_tal.
You can find rule book on the DriveThru: https://www.drivethrurpg.com/product/318336/

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? **Yes**.
- [x] Is this a bug fix? **Yes**.
- [ ] Does this add functional enhancements (new features or extending existing features) ? **No**.
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? **No**.
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ? **Unfortunately there are no way to preserve player's data because two different attributes now have one field to store them. That means that in fact now all players have only one value from two. But as far as I know there are no active games on roll20 with his character sheet.**
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards] **This is not a new sheet**. 

If you do not know English. Please leave a comment in your native language.
