### PR TITLE
[PokemonTabletopAdventures_v3] Allows Collapsing of Origin and Class Features

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -55,7 +55,7 @@
   --poke-steel-background: #ffffff80;
   --poke-steel-shaded: #8d8d9c;
   --poke-typeless: #9dc1b7;
-  --poke-typeless-background:#e1f5fb;
+  --poke-typeless-background:#e1f5fb80;
   --poke-typeless-shaded: #597d73;
   --poke-water: #9db7f5;
   --poke-water-background: #e1fbff80;
@@ -462,7 +462,7 @@ div.sheet-skill-selection .sheet-no-dropdown {
 
 div.sheet-capture-pokemon-skill input[type="text"] {
   margin-left: -1px;
-  width: 65% !important;
+  width: 60% !important;
 }
 
 div.sheet-capture-pokemon-skill .sheet-skill-roller {

--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -400,7 +400,7 @@ div.sheet-skill-selection .sheet-no-dropdown {
 
 .sheet-top-information[type="number"],
 .sheet-top-information[type="text"] {
-  background-color: rgba(255, 153, 153, 0);
+  background-color: transparent;
   border: 2px var(--foreground-color);
   border-style: none none solid none;
   font-weight: bold;
@@ -549,8 +549,9 @@ input[type="checkbox"] {
 
 input[type="number"] {
   -moz-appearance: textfield;
+  background-color: var(--text-background-color);
+  font-weight: bold;
   text-align: center;
-  background-color: rgba(255, 255, 255, 0.6);
 }
 
 input[type="number"]::placeholder,
@@ -582,7 +583,7 @@ input[type="text"].sheet-caps {
 }
 
 textarea {
-  background-color: rgba(255, 255, 255, 0.3);
+  background-color: var(--text-background-color);
   box-sizing: border-box;
   font-weight: bold;
 }
@@ -1224,10 +1225,6 @@ button[type="roll"].sheet-inline-roller {
 .sheet-pokemon-move-info-header input[type="text"] {
   margin-left: 4px;
   width: 30%;
-}
-
-.charsheet div {
-  position: relative;
 }
 
 .sheet-collapsible-feature .sheet-options-flag,

--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -2,7 +2,8 @@
 .sheet-rolltemplate-move-roll,
 .sheet-rolltemplate-dual-hit-move-roll,
 .sheet-rolltemplate-multi-hit-move-roll,
-.sheet-rolltemplate-triple-hit-move-roll {
+.sheet-rolltemplate-triple-hit-move-roll,
+.sheet-rolltemplate-feature-output {
   --poke-bug: #c6d16e;
   --poke-bug-background: #ffffb280;
   --poke-bug-shaded: #828d2a;
@@ -272,7 +273,8 @@ div.sheet-pokemon-move span.sheet-readonly-field input[type="number"] {
 }
 
 div.sheet-wrapper,
-div.sheet-pokemon-move {
+div.sheet-pokemon-move,
+div.sheet-collapsible-feature {
   background-color: var(--background-color);
   border-color: var(--foreground-color);
 }
@@ -585,11 +587,11 @@ textarea {
   font-weight: bold;
 }
 
+.sheet-collapsible-feature,
 .sheet-pokemon-move {
   margin: 2px;
   padding: 2px;
   border: 1px solid;
-  background-color: rgba(204, 204, 204, 0.5);
 }
 
 /* Changing Pages */
@@ -741,6 +743,10 @@ button[type="roll"].sheet-skill-roller {
   text-shadow: 0 0 transparent;
 }
 
+button[type="roll"].sheet-skill-roller:hover {
+  color: #555555;
+}
+
 button[type="roll"].sheet-stat-roller {
   align-items: center;
   background: #00000000;
@@ -785,7 +791,8 @@ button[type="roll"].sheet-stat-roller:hover {
 .sheet-rolltemplate-move-roll,
 .sheet-rolltemplate-dual-hit-move-roll,
 .sheet-rolltemplate-multi-hit-move-roll,
-.sheet-rolltemplate-triple-hit-move-roll {
+.sheet-rolltemplate-triple-hit-move-roll,
+.sheet-rolltemplate-feature-output {
   --header-text: white;
 }
 
@@ -797,7 +804,8 @@ button[type="roll"].sheet-stat-roller:hover {
 .sheet-rolltemplate-dual-hit-move-roll,
 .sheet-rolltemplate-multi-hit-move-roll,
 .sheet-rolltemplate-triple-hit-move-roll,
-.sheet-rolltemplate-skill-roll {
+.sheet-rolltemplate-skill-roll,
+.sheet-rolltemplate-feature-output {
   --main-text: black;
   --odd-row-bg: #d9d9d6;
   --row-bg: #e9e9e9;
@@ -952,7 +960,8 @@ button[type="roll"].sheet-stat-roller:hover {
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container hr.sheet-border,
 .sheet-rolltemplate-multi-hit-move-roll .sheet-container hr.sheet-border,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container hr.sheet-border,
-.sheet-rolltemplate-skill-roll .sheet-container hr.sheet-border {
+.sheet-rolltemplate-skill-roll .sheet-container hr.sheet-border,
+.sheet-rolltemplate-feature-output .sheet-container hr.sheet-border {
   margin: 5px 0 5px 0;
   border-top: 1px solid var(--border-color);
 }
@@ -961,7 +970,8 @@ button[type="roll"].sheet-stat-roller:hover {
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template,
 .sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template,
-.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template {
+.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template,
+.sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template {
   border: 1px solid;
   border-color: var(--border-color);
   color: var(--main-text);
@@ -983,7 +993,12 @@ button[type="roll"].sheet-stat-roller:hover {
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
 .sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
-.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template .sheet-skill-roll .inlinerollresult {
+.sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-notes-text .inlinerollresult,
+.sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-notes-text .inlinerollresult,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-notes-text .inlinerollresult,
+.sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .sheet-notes-text .inlinerollresult,
+.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template .sheet-skill-roll .inlinerollresult,
+.sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template .sheet-notes-text .inlinerollresult {
   background: #000000;
   border: 2px solid #000000;
   color: #ffffff;
@@ -1084,7 +1099,8 @@ button[type="roll"].sheet-stat-roller:hover {
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template a,
 .sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template a,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template a,
-.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template a {
+.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template a,
+.sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template a {
   color: var(--header-text);
   padding: 3px;
   font-style: italic;
@@ -1097,7 +1113,8 @@ button[type="roll"].sheet-stat-roller:hover {
   padding: 4px 2px;
 }
 
-.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template td {
+.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template td,
+.sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template td {
   padding: 8px 2px;
 }
 
@@ -1129,7 +1146,8 @@ button[type="roll"].sheet-stat-roller:hover {
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
 .sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
-.sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text {
+.sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
+.sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template td.sheet-notes-text {
   font-size: 12px;
   line-height: 12px;
   padding: 8px;
@@ -1140,7 +1158,8 @@ button[type="roll"].sheet-stat-roller:hover {
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
 .sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
-.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template td.sheet-subhead {
+.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template td.sheet-subhead,
+.sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template td.sheet-subhead {
   padding: 4px;
   background: var(--box-bg);
   font-size: 12px;
@@ -1151,7 +1170,8 @@ button[type="roll"].sheet-stat-roller:hover {
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template th,
 .sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template th,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template th,
-.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template th {
+.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template th,
+.sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template th {
   color: var(--header-text);
   padding: 6px;
   font-size: 14px;
@@ -1163,7 +1183,8 @@ button[type="roll"].sheet-stat-roller:hover {
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(odd),
 .sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(odd),
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(odd),
-.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template tr:nth-child(odd) {
+.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template tr:nth-child(odd),
+.sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template tr:nth-child(odd) {
   background: var(--odd-row-bg);
 }
 
@@ -1171,7 +1192,8 @@ button[type="roll"].sheet-stat-roller:hover {
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
 .sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
-.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template tr:nth-child(even) {
+.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template tr:nth-child(even),
+.sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template tr:nth-child(even) {
   background: var(--row-bg);
 }
 
@@ -1185,30 +1207,47 @@ button[type="roll"].sheet-stat-roller:hover {
   display: none;
 }
 
-.sheet-pokemon-move button[type="roll"].sheet-inline-roller:hover {
+button[type="roll"].sheet-inline-roller:hover {
   background-color: var(--text-background-color);
   color: #555555;
 }
 
-.sheet-pokemon-move button[type="roll"].sheet-inline-roller {
+button[type="roll"].sheet-inline-roller {
   border: none;
   min-width: 85%;
 }
 
-.sheet-pokemon-move .sheet-fill-space {
+.sheet-fill-space {
   width: 30%;
 }
 
 .sheet-pokemon-move-info-header input[type="text"] {
+  margin-left: 4px;
   width: 30%;
 }
 
+.charsheet div {
+  position: relative;
+}
+
+.sheet-collapsible-feature .sheet-options-flag,
+.sheet-collapsible-feature .sheet-options-flag + span,
+.sheet-pokemon-move .sheet-options-flag,
+.sheet-pokemon-move .sheet-options-flag + span {
+  top: 10px;
+}
+
+.sheet-collapsible-feature .sheet-options-flag:checked,
+.sheet-collapsible-feature .sheet-options-flag:checked + span,
+.sheet-pokemon-move .sheet-options-flag:checked,
+.sheet-pokemon-move .sheet-options-flag:checked + span {
+  top: 13px;
+}
+
 .sheet-options-flag {
+  height: 18px;
   opacity: 0;
   position: absolute;
-  top: 13px;
-  left: 4px;
-  height: 18px;
   width: 18px;
   z-index: 2;
 }
@@ -1217,18 +1256,16 @@ button[type="roll"].sheet-stat-roller:hover {
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  position: absolute;
-  top: 13px;
-  left: 4px;
-  white-space: nowrap;
-  height: 18px;
-  width: 18px;
-  font-size: 20px;
-  font-family: pictos;
   color: var(--foreground-color);
   cursor: pointer;
-  margin-top: 0px;
   display: none;
+  font-size: 20px;
+  font-family: pictos;
+  height: 18px;
+  margin-top: 0px;
+  position: absolute;
+  white-space: nowrap;
+  width: 18px;
 }
 
 .sheet-options-flag:hover + span {
@@ -1242,6 +1279,7 @@ button[type="roll"].sheet-stat-roller:hover {
   display: flex;
 }
 
+.sheet-collapsible-feature:hover .sheet-options-flag + span,
 .sheet-pokemon-move:hover .sheet-options-flag + span {
   display: -webkit-box;
   display: -ms-flexbox;

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -2450,6 +2450,11 @@
   }
 
   // Collapsing Blocks
+  on("change:repeating_features:options_flag", function (eventInfo) {
+    const flag = eventInfo.newValue == "on" ? "-" : "+";
+    setAttrs({ repeating_features_flag: flag });
+  });
+
   on("change:repeating_moves:options_flag", function (eventInfo) {
     const flag = eventInfo.newValue == "on" ? "-" : "+";
     setAttrs({ repeating_moves_flag: flag });

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -633,22 +633,52 @@
       </div>
 
       <br />
+    </div>
 
+    <div class="sheet-tab-trainer sheet-tab-hybrid">
       <b>Origin Feature</b>
-      <div>
-        <div class="sheet-pokemon-move-info-header">
-          <input name="attr_originfeaturename" placeholder="Feature Name" spellcheck="false" type="text" />
-          <span>
-            <b>Feature Usage</b>
-            <input name="attr_origin_usage" type="number" value="0" />
-            <button name="act_incrementoriginusage" type="action">+</button>
-            <button name="act_resetoriginusage" type="action">Reset</button>
-          </span>
+      <div class="sheet-collapsible-feature">
+        <input checked class="sheet-options-flag" name="attr_origin_options_flag" type="checkbox" />
+        <span name="attr_origin_flag">-</span>
+        <div class="sheet-display">
+          <div class="sheet-pokemon-move-info-header">
+            <span class="sheet-fill-space">
+              <button class="sheet-inline-roller sheet-skill-roller" name="roll-origin-feature-output" title="Click this to send this feature to the chat log. Click the Plus to allow editing the information. Roll Name: -roll-origin-feature-output" type="roll"
+              value="&{template:feature-output} {{type-color=@{type1}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{feature-name=@{originfeaturename}}} {{feature-text=@{originfeaturedesc}}}">
+                  <span name="attr_originfeaturename"></span>
+              </button>
+              <b class="sheet-info-tooltip" title="Click this to send this feature to the chat log. Click the Plus to allow editing the information. Roll Name: -roll-origin-feature-output">ℹ</b>
+            </span>
+            <span>
+              <b>Feature Usage</b>
+              <input name="attr_origin_usage" type="number" value="0" />
+              <button name="act_incrementoriginusage" type="action">+</button>
+              <button name="act_resetoriginusage" type="action">Reset</button>
+            </span>
+          </div>
         </div>
-
-        <textarea class="sheet-3row-textarea" name="attr_originfeaturedesc" placeholder="Feature Description" spellcheck="false"></textarea>
+        <div class="sheet-options">
+          <div class="sheet-pokemon-move-info-header">
+            <input name="attr_originfeaturename" placeholder="Feature Name" spellcheck="false" type="text" />
+            <span class="sheet-fill-space">
+              <button class="sheet-inline-roller sheet-skill-roller" name="roll-origin-feature-output" title="Click this to send this feature to the chat log. Roll Name: -roll-origin-feature-output" type="roll"
+              value="&{template:feature-output} {{type-color=@{type1}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{feature-name=@{originfeaturename}}} {{feature-text=@{originfeaturedesc}}}">
+                  Send to Chat
+                </button>
+                <b class="sheet-info-tooltip" title="Click this to send this feature to the chat log. Roll Name: -roll-origin-feature-output">ℹ</b>
+            </span>
+            <span>
+              <b>Feature Usage</b>
+              <input name="attr_origin_usage" type="number" value="0" />
+              <button name="act_incrementoriginusage" type="action">+</button>
+              <button name="act_resetoriginusage" type="action">Reset</button>
+            </span>
+          </div>
+          <textarea name="attr_originfeaturedesc" placeholder="Feature Description" spellcheck="false"></textarea>
+        </div>
       </div>
 
+      <br />
       <b>Class Features</b>
       <fieldset class="repeating_features">
         <div class="sheet-pokemon-move-info-header">
@@ -706,8 +736,7 @@
                 value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} {{damage-2=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-3=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-4=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-5=[[ @{move_dicenumber}d@{damage_dice} ]]}}">
                 Quick Roll
               </button>
-              <b class="sheet-info-tooltip" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers.">ℹ</b
-              >
+              <b class="sheet-info-tooltip" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers.">ℹ</b>
             </span>
 
             <span>
@@ -1822,6 +1851,18 @@
       </table>
     </div>
   </rolltemplate>
+
+  <rolltemplate class="sheet-rolltemplate-feature-output">
+    <div class="sheet-container sheet-rolltemplate-color-setting-{{type-color}}-move">
+      <table class="sheet-feature-template">
+        <tr><th>{{feature-name}}</th></tr>
+        <tr><td class="sheet-subhead">[{{character-name}}](https://journal.roll20.net/character/{{character-id}}" name="name-link")</td></tr>
+        <tr>
+          <td class="sheet-notes-text"><span>{{feature-text}}</span></td>
+        </tr>
+      </table>
+    </div>
+  </rolltemplate>
 </div>
 
 <!-- SCRIPTS -->
@@ -2378,10 +2419,15 @@
     if (newBonus != oldTotal) setAttrs(attrs);
   }
 
-  // Move Collapsing
+  // Collapsing Blocks
   on("change:repeating_moves:options_flag", function (eventInfo) {
     const flag = eventInfo.newValue == "on" ? "-" : "+";
     setAttrs({ repeating_moves_flag: flag });
+  });
+
+  on("change:origin_options_flag", function (eventInfo) {
+    const flag = eventInfo.newValue == "on" ? "-" : "+";
+    setAttrs({ origin_flag: flag });
   });
 
   // Changing Skill Ability Modifiers

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -637,17 +637,17 @@
 
     <div class="sheet-tab-trainer sheet-tab-hybrid">
       <b>Origin Feature</b>
-      <div class="sheet-collapsible-feature">
+      <div class="sheet-collapsible-feature" style="position: relative;">
         <input checked class="sheet-options-flag" name="attr_origin_options_flag" type="checkbox" />
         <span name="attr_origin_flag">-</span>
         <div class="sheet-display">
           <div class="sheet-pokemon-move-info-header">
             <span class="sheet-fill-space">
-              <button class="sheet-inline-roller sheet-skill-roller" name="roll-origin-feature-output" title="Click this to send this feature to the chat log. Click the Plus to allow editing the information. Roll Name: -roll-origin-feature-output" type="roll"
+              <button class="sheet-inline-roller sheet-skill-roller" name="roll-origin-feature-output" title="Click this to send this feature to the chat log. Click the Plus to allow editing the information." type="roll"
               value="&{template:feature-output} {{type-color=@{type1}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{feature-name=@{originfeaturename}}} {{feature-text=@{originfeaturedesc}}}">
-                  <span name="attr_originfeaturename"></span>
+                <span name="attr_originfeaturename"></span>
               </button>
-              <b class="sheet-info-tooltip" title="Click this to send this feature to the chat log. Click the Plus to allow editing the information. Roll Name: -roll-origin-feature-output">ℹ</b>
+              <b class="sheet-info-tooltip" title="Click this to send this feature to the chat log. Click the Plus to allow editing the information.">ℹ</b>
             </span>
             <span>
               <b>Feature Usage</b>
@@ -661,11 +661,11 @@
           <div class="sheet-pokemon-move-info-header">
             <input name="attr_originfeaturename" placeholder="Feature Name" spellcheck="false" type="text" />
             <span class="sheet-fill-space">
-              <button class="sheet-inline-roller sheet-skill-roller" name="roll-origin-feature-output" title="Click this to send this feature to the chat log. Roll Name: -roll-origin-feature-output" type="roll"
+              <button class="sheet-inline-roller sheet-skill-roller" name="roll-origin-feature-output" title="Click this to send this feature to the chat log." type="roll"
               value="&{template:feature-output} {{type-color=@{type1}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{feature-name=@{originfeaturename}}} {{feature-text=@{originfeaturedesc}}}">
                   Send to Chat
                 </button>
-                <b class="sheet-info-tooltip" title="Click this to send this feature to the chat log. Roll Name: -roll-origin-feature-output">ℹ</b>
+                <b class="sheet-info-tooltip" title="Click this to send this feature to the chat log.">ℹ</b>
             </span>
             <span>
               <b>Feature Usage</b>
@@ -681,19 +681,49 @@
       <br />
       <b>Class Features</b>
       <fieldset class="repeating_features">
-        <div class="sheet-pokemon-move-info-header">
-          <input name="attr_classfeaturename" placeholder="Feature Name" spellcheck="false" type="text" />
-          <span>
-            <b>Feature Usage</b>
-            <input name="attr_feature_usage" type="number" value="0" />
-            <button name="act_incrementfeatureusage" type="action">+</button>
-            <button name="act_resetfeatureusage" type="action">Reset</button>
-          </span>
+        <div class="sheet-collapsible-feature">
+          <input checked class="sheet-options-flag" name="attr_options_flag" type="checkbox" />
+          <span name="attr_flag">-</span>
+          <div class="sheet-display">
+            <div class="sheet-pokemon-move-info-header">
+              <span class="sheet-fill-space">
+                <button class="sheet-inline-roller sheet-skill-roller" name="roll-class-feature-output" title="Click this to send this feature to the chat log. Click the Plus to allow editing the information." type="roll"
+                value="&{template:feature-output} {{type-color=@{type1}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{feature-name=@{classfeaturename}}} {{feature-text=@{classfeaturedesc}}}">
+                  <span name="attr_classfeaturename"></span>
+                </button>
+                <b class="sheet-info-tooltip" title="Click this to send this feature to the chat log. Click the Plus to allow editing the information.">ℹ</b>
+              </span>
+              <span>
+                <b>Feature Usage</b>
+                <input name="attr_feature_usage" type="number" value="0" />
+                <button name="act_incrementfeatureusage" type="action">+</button>
+                <button name="act_resetfeatureusage" type="action">Reset</button>
+              </span>
+            </div>
+          </div>
+          <div class="sheet-options">
+            <div class="sheet-pokemon-move-info-header">
+              <input name="attr_classfeaturename" placeholder="Feature Name" spellcheck="false" type="text" />
+              <span class="sheet-fill-space">
+                <button class="sheet-inline-roller sheet-skill-roller" name="roll-class-feature-output" title="Click this to send this feature to the chat log." type="roll"
+                value="&{template:feature-output} {{type-color=@{type1}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{feature-name=@{classfeaturename}}} {{feature-text=@{classfeaturedesc}}}">
+                    Send to Chat
+                  </button>
+                  <b class="sheet-info-tooltip" title="Click this to send this feature to the chat log.">ℹ</b>
+                </span>
+              <span>
+                <b>Feature Usage</b>
+                <input name="attr_feature_usage" type="number" value="0" />
+                <button name="act_incrementfeatureusage" type="action">+</button>
+                <button name="act_resetfeatureusage" type="action">Reset</button>
+              </span>
+            </div>
+            <textarea name="attr_classfeaturedesc" placeholder="Feature Description" spellcheck="false"></textarea>
+          </div>
         </div>
-
-        <textarea class="sheet-3row-textarea" name="attr_classfeaturedesc" placeholder="Feature Description" spellcheck="false"></textarea>
       </fieldset>
 
+      <br />
       <b>Honors</b>
       <textarea spellcheck="false" name="attr_honors" placeholder="Gym Badges, Contest Ribbons, Recognitions, etc."></textarea>
     </div>

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -23,6 +23,11 @@ Things we want to add to the character sheet, presented in no particular order o
 
 ## Changelog
 
+### Feb 23rd, 2021
+
+- Added collapsing to the Origin Feature
+- Added a send to chat button for the Origin Feature to output the name and description in the chat log in a nice and easily readable format
+
 ### Feb 18th, 2021
 
 - Expanded the Capture Pokémon skill, allowing modifiers such as Capture Point to be applied

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -25,8 +25,10 @@ Things we want to add to the character sheet, presented in no particular order o
 
 ### Feb 23rd, 2021
 
-- Added collapsing to the Origin Feature
-- Added a send to chat button for the Origin Feature to output the name and description in the chat log in a nice and easily readable format
+- Unifies background colours for text areas and number inputs
+- Added collapsing to the Origin Feature and all Class Features
+- Added a send to chat button for the Origin Feature and Class Features to output the name and description in the chat log in a nice and easily readable format
+  - Made the name of the features into the same button when collapsed to improve consistency of design vis-a-vis the moves section
 
 ### Feb 18th, 2021
 

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -19,6 +19,9 @@ Things we want to add to the character sheet, presented in no particular order o
 - [ ] Allow modifications to movement (maybe just an extra box)
 - [ ] Display the adjusted stat score when temporary stat changes are provided
 - [ ] Display the skills section for Pokémon characters
+- [ ] Moves deserve a section for "bonuses that apply to all moves." Things that should go here include:
+  - [ ] A spot for Attack and Special Attack bonuses, for things like Ace Trainer
+  - [ ] The critical hit range for the moves, as this is used for passives, items, etc.
 - [ ] Refactor the sheet workers to remove the cascading change observation; each `setAttrs` call takes way too long, so we want to capitalise on making them as low as possible
 
 ## Changelog


### PR DESCRIPTION
## Changes / Comments

- fix: Small CSS fix for the ball modifier section
  - improves appearance at the standard width of character sheets
  - ensures transparency is correctly set for text background colours
- feature: Collapsing origin feature
  - Added the capability to collapse the Origin Feature to save scroll time
  - Added the capability to send the Origin Feature to the chat log in a neat and colour-coded format
- feature: Makes class features collapsible
  - Updates text area and number input backgrounds to use the type-variable text background colour
  - Updates number inputs to use bold font-weight for consistency across the character sheet
  - Adds collapsing to class features
  - Corrects the assignment of relative position for the origin feature div
- chore: Adding more to-do entries
  - Adds missing sheet-worker script for repeating features options flag management

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
_Yes._
- [x] Is this a bug fix?
_Not primarily, although there are some small fixes included._
- [x] Does this add functional enhancements (new features or extending existing features)?
_Technically yes, although it's a secondary purpose._
- [x] Does this add or change functional aesthetics (such as layout or color scheme)?
_Yes - the ability to collapse features_
