### PR TITLE
[AD&D 2E] - GM_Monster-sheet_update

### DIFF
--- a/AD&D 2E Revised/2ESheet.html
+++ b/AD&D 2E Revised/2ESheet.html
@@ -10,15 +10,8 @@
         <br/>
         <div class="sheet-announce-items">
             <ul style="font-style:italic">
-                <li>Fixed Weapon-type vs. Armor-type. Now actually works for repeating rows!</li>
-                <li><ul><li>Many attributes has been removed / changed / added. Please see the forum for the fill list</li></ul></li>
-                <li>Change all references to "Blunt" weapons into "Bludgeoning" as it is the correct term</li>
-                <li>Added new spell section for wizard spells level 3 to 15. Spell auto fill coming later. Suggested by Jonathan</li>
-                <li>Added new spell section for priest spells level 3 to 7 and Quest. Spell auto fill coming later. Suggested by Jonathan</li>
-                <li>Added spell auto fill for Wizard spells level 3</li>
-                <li>Added spell auto fill for Priest spells level 3</li>
-                <li>Added a field for a characters base ThAC0. Field is accessible by @{thac0-base}. Suggested by Richard @ Damery and BilBo 2</li>
-                <li>Made Worn Equipment section collapsable. Suggested by Chronische</li>
+                <li>Monster Sheet: Added more fine grained unput fields for Monster Hit Dice, as well as a roll button to roll monster Hit Points</li>
+                <li>Monster Sheet: Added Public / To GM toggle for Hit and Damage for monster rolls. Default is Public which was also the previous value before this change</li>
             </ul>
             <hr>
             <p>
@@ -4089,15 +4082,15 @@
                                     <option value="Hold Undead">Hold Undead</option>
                                     <option value="Illusionary Script">Illusionary Script</option>
                                     <option value="Infravision">Infravision</option>
-                                    <option value="Invisibility, 10\' Radius">Invisibility, 10\' Radius</option>
+                                    <option value="Invisibility, 10' Radius">Invisibility, 10' Radius</option>
                                     <option value="Item">Item</option>
-                                    <option value="Leomund\'s Tiny Hut">Leomund\'s Tiny Hut</option>
+                                    <option value="Leomund's Tiny Hut">Leomund's Tiny Hut</option>
                                     <option value="Lightning Bolt">Lightning Bolt</option>
-                                    <option value="Melf\'s Minute Meteors">Melf\'s Minute Meteors</option>
+                                    <option value="Melf's Minute Meteors">Melf's Minute Meteors</option>
                                     <option value="Monster Summoning I">Monster Summoning I</option>
                                     <option value="Nondetection">Nondetection</option>
                                     <option value="Phantom Steed">Phantom Steed</option>
-                                    <option value="Protection from Evil, 10\' Radius">Protection from Evil, 10\' Radius</option>
+                                    <option value="Protection from Evil, 10' Radius">Protection from Evil, 10' Radius</option>
                                     <option value="Protection From Normal Missiles">Protection From Normal Missiles</option>
                                     <option value="Secret Page">Secret Page</option>
                                     <option value="Sepia Snake Sigil">Sepia Snake Sigil</option>
@@ -16594,175 +16587,383 @@
 </div>
 
 <div class="sheet-tab-content sheet-section-monster-page">
-<h2><b>Monster Info</b></h2><br>
-<h4><b>Name:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b></h4><input type="text" name="attr_character_name" title="@{character_name}">&nbsp;&nbsp;&nbsp;<button type="roll" name="roll_surprisemon" title="@{surprisemon}" value="/gmroll [[{([[1d10]]+(?{Misc Modifier?|+0})), 1}kh1]] [Surprise roll for @{character_name}]">Surprise</button>&nbsp;&nbsp;&nbsp;<button type="roll" name="roll_monmorale" title="@{monmorale}" value="/gmroll [[{([[1d20]]+(?{Misc. Modifier?|+0})), 1}kh1]]&le;@{monstermorale}">Morale</button>
-    
-    <div class="body">
-    <div class='sheet-3colrow'>
-    <div class='sheet-col'>
-<table><tr>
-<td><h4><b>Climate/Terrain:</b></h4></td><td><input type="text" name="attr_climateterrain" title="@{climateterrain}"></td></tr>
-<tr><td><h4><b>Frequency:</b></h4></td><td><input type="text" name="attr_frequency" title="@{frequency}"></td></tr>
-<tr><td><h4><b>Organization:</b></h4></td><td><input type="text" name="attr_organization" title="@{organization}"></td></tr>
-<tr><td><h4><b>Activity Cycle:</b></h4></td><td><input type="text" name="attr_cycle" title="@{cycle}"></td></tr>
-<tr><td><h4><b>Diet:</b></h4></td><td><input type="text" name="attr_diet" title="@{diet}"></td></tr>
-<tr><td><h4><b>Intelligence:</b></h4></td><td><input type="text" name="attr_monsterintelligence" title="@{monsterintelligence}"></td></tr>
-<tr><td><h4><b>Treasure:</b></h4></td><td><input type="text" name="attr_treasure" title="@{treasure}"></td></tr>
-<tr><td><h4><b>Alignment:</b></h4></td><td><input type="text" name="attr_monsteralignment" title="@{monsteralignment}"></td>
-</tr></table>
-</div>
-    <div class='sheet-col'>
-        <table><tr>
-<tr><td><h4><b>Armor Class:</b></h4></td><td><input type="text" name="attr_monsterarmor" title="@{monsterarmor}" class="short"></td></tr>
-<tr><td><h4><b>Movement:</b></h4></td><td><input type="text" name="attr_movement" title="@{movement}" class="medium"></td></tr>
-<tr><td><h4><b>Hit Dice:</b></h4></td><td><input type="text" name="attr_hitdice" title="@{hitdice}" class="short"></td></tr>
-<tr><td><h4><b>THAC0:</b></h4></td><td><input type="text" name="attr_monsterthac0" title="@{monsterthac0}" class="short"></td></tr>
-<tr><td><h4><b># of Attacks:</b></h4></td><td><input type="text" name="attr_monsteratknum" title="@{monsteratknum}" class="sheet-small"></td></tr>
-<tr><td><h4><b>Attack 1:</b></h4></td><td><input type="text" name="attr_monsterdmg" title="@{monsterdmg}"></td></tr>
-<tr><td><h4><b>Attack 2:</b></h4></td><td><input type="text" name="attr_monsterdmg2" title="@{monsterdmg2}"></td></tr>
-<tr><td><h4><b>Attack 3:</b></h4></td><td><input type="text" name="attr_monsterdmg3" title="@{monsterdmg3}"></td>
-</tr></table>
-    </div>
-    <div class='sheet-col'>
-<table>
-<tr><td><h4><b>No. Appearing:</b></h4></td><td><input type="text" name="attr_appearing" title="@{appearing}" class="short"></td></tr>
-<tr><td><h4><b>Special Attacks:</b></h4></td><td><input type="text" name="attr_monsterspecattacks" title="@{monsterspecattacks}"></td></tr>
-<tr><td><h4><b>Special Defenses:</b></h4></td><td><input type="text" name="attr_monsterspecdefenses" title="@{monsterspecdefenses}"></td></tr>
-<tr><td><h4><b>Magic Resistance:</b></h4></td><td><input type="text" name="attr_monstermagicresist" title="@{monstermagicresist}" class="short"><h4><b>%</b></h4><button type="roll" name="roll_monstermagicresist" title="%{monstermagicresist}" value="/gmroll [[1d100+(?{Modifier?|0})]]<[[@{monstermagicresist}]]">Roll</button></td></tr>
-<tr><td><h4><b>Size:</b></h4></td><td><input type="text" name="attr_monstersize" title="@{monstersize}" class="tiny"></td></tr>
-<tr><td><h4><b>Morale:</b></h4></td><td><input type="text" name="attr_monstermorale" title="@{monstermorale}"></td></tr>
-<tr><td><h4><b>XP Value:</b></h4></td><td><input type="text" name="attr_monsterxp" title="@{monsterxp}"></td></tr>
-</table>
-    </div>
-</div>
-<tr>
-            <td><button type="roll" name="roll_monthac0" title="%{monthac0}" value="/em strikes AC [[(@{monsterthac0})-(1d20+(?{Modifier?|0}))]]">ThAC0</button></td>&nbsp;
-            <td><button type="roll" name="roll_mondmg" title="%{mondmg}" value="/em inflicts [[@{monsterdmg}]] damage!">Attack 1</button></td>&nbsp;
-            <td><button type="roll" name="roll_mondmg2" title="%{mondmg2}" value="/em inflicts [[@{monsterdmg2}]] damage!">Attack 2</button></td>&nbsp;
-            <td><button type="roll" name="roll_mondmg3" title="%{mondmg3}" value="/em inflicts [[@{monsterdmg3}]] damage!">Attack 3</button></td>&nbsp;
-            <td><button type="roll" name="roll_spcatk" title="%{spcatk}" value="/em @{monsterspecattacks}">Special Attack</button></td>&nbsp;
-            <td><input type="text" name="attr_monsterini" title="@{monsterini}" class="sheet-short">&nbsp;<button type="roll" name="roll_monini" title="%{monini}" value="/gmroll [[{([[1d10]]+@{monsterini}-(?{Misc. bonus|+0})), 1}kh1]] [Initiative (@{character_name})]&{tracker}">Initiative</button></td>
-</tr><br>
-
-<table style="width: 100%;">
-<tr>
-            <td><button type="roll" name="roll_monparsave" title="%{monparsave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monpartar}]] [Save versus Paralyzation]"><br>Para<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monpoisave" title="%{monpoisave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monpoitar}]] [Save versus Poison]"><br>Pois<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_mondeasave" title="%{mondeasave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{mondeatar}]] [Save versus Death]"><br>Death<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monrodsave" title="%{monrodsave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monrodtar}]] [Save versus Rod]"><br>Rod<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monstasave" title="%{monstasave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monstatar}]] [Save versus Staff]"><br>Staff<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monwansave" title="%{monwansave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monwantar}]] [Save versus Wand]"><br>Wand<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monpetsave" title="%{monpetsave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monpettar}]] [Save versus Petrification]"><br>Pet<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monpolsave" title="%{monpolsave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monpoltar}]] [Save versus Polymorph]"><br>Poly<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monbresave" title="%{monbresave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monbretar}]] [Save versus Breath]"><br>Breath<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monspesave" title="%{monspesave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monspetar}]] [Save versus Spell]"><br>Spell<br>Save</button></td>
-</tr>
-<tr>
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monpartar" title="@{monpartar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monpoitar" title="@{monpoitar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;&nbsp;<input type="text" name="attr_mondeatar" title="@{mondeatar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monrodtar" title="@{monrodtar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monstatar" title="@{monstatar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monwantar" title="@{monwantar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monpettar" title="@{monpettar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monpoltar" title="@{monpoltar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monbretar" title="@{monbretar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monspetar" title="@{monspetar}" class="sheet-small"></td>
-</tr></table><br>
-
-<h4><b>Description</b></h4><br><textarea name="attr_monsterdesc" title="@{monsterdesc}" placeholder="Description"></textarea><br>
-<h4><b>Combat</b></h4><textarea name="attr_monstercombat" title="@{monstercombat}"></textarea><br>
-<h4><b>Habitat/Society</b></h4><textarea name="attr_monsterhabitat" title="@{monsterhabitat}"></textarea><br>
-<h4><b>Ecology</b></h4><textarea name="attr_monsterecology" title="@{monsterecology}"></textarea><br><br>
-</div>
-
-<h3><b>Variants</b></h3>
-<fieldset class="repeating_monstervariants" name="monstervariants" title="@{monstervariants}">  
-    
-    <div class="body">
-    <div class='sheet-3colrow'>
-    <div class='sheet-col'>
-        <tr>
-            <td><button type="roll" name="roll_surprisemon" title="%{repeating_monstervariants_$X_surprisemon}" value="/gmroll [[{([[1d10]]+(?{Misc Modifier?|+0})), 1}kh1]] [Surprise roll for @{character_name}]">Surprise</button></td>
-            <td><button type="roll" name="roll_monmorale" title="%{repeating_monstervariants_$X_monmorale}" value="/gmroll [[{([[1d20]]+(?{Misc. Modifier?|+0})), 1}kh1]]&le;@{monstermorale}">Morale</button></td>
+    <h2><b>Monster Info</b></h2>
+    <br>
+    <table>
+        <tr class="sheet-collapse">
+            <td><h4><b>Climate/Terrain:</b></h4></td>
         </tr>
-<table><tr>
-<td><h4><b>Climate/Terrain:</b></h4></td><td><input type="text" name="attr_climateterrain" title="@{repeating_monstervariants_$X_climateterrain}"></td></tr>
-<tr><td><h4><b>Frequency:</b></h4></td><td><input type="text" name="attr_frequency" title="@{repeating_monstervariants_$X_frequency}"></td></tr>
-<tr><td><h4><b>Organization:</b></h4></td><td><input type="text" name="attr_organization" title="@{repeating_monstervariants_$X_organization}"></td></tr>
-<tr><td><h4><b>Activity Cycle:</b></h4></td><td><input type="text" name="attr_cycle" title="@{repeating_monstervariants_$X_cycle}"></td></tr>
-<tr><td><h4><b>Diet:</b></h4></td><td><input type="text" name="attr_diet" title="@{repeating_monstervariants_$X_diet}"></td></tr>
-<tr><td><h4><b>Intelligence:</b></h4></td><td><input type="text" name="attr_monsterintelligence" title="@{repeating_monstervariants_$X_monsterintelligence}"></td></tr>
-<tr><td><h4><b>Treasure:</b></h4></td><td><input type="text" name="attr_treasure" title="@{repeating_monstervariants_$X_treasure}"></td></tr>
-<tr><td><h4><b>Alignment:</b></h4></td><td><input type="text" name="attr_monsteralignment" title="@{repeating_monstervariants_$X_monsteralignment}"></td>
-</tr></table>
-</div>
-    <div class='sheet-col'>
-        <table><tr>
-<tr><td><h4><b>Armor Class:</b></h4></td><td><input type="text" name="attr_monsterarmor" title="@{repeating_monstervariants_$X_monsterarmor}" class="short"></td></tr>
-<tr><td><h4><b>Movement:</b></h4></td><td><input type="text" name="attr_movement" title="@{repeating_monstervariants_$X_movement}" class="medium"></td></tr>
-<tr><td><h4><b>Hit Dice:</b></h4></td><td><input type="text" name="attr_hitdice" title="@{repeating_monstervariants_$X_hitdice}" class="short"></td></tr>
-<tr><td><h4><b>THAC0:</b></h4></td><td><input type="text" name="attr_monsterthac0" title="@{repeating_monstervariants_$X_monsterthac0}" class="short"></td></tr>
-<tr><td><h4><b># of Attacks:</b></h4></td><td><input type="text" name="attr_monsteratknum" title="@{repeating_monstervariants_$X_monsteratknum}" class="sheet-small"></td></tr>
-<tr><td><h4><b>Attack 1:</b></h4></td><td><input type="text" name="attr_monsterdmg" title="@{repeating_monstervariants_$X_monsterdmg}"></td></tr>
-<tr><td><h4><b>Attack 2:</b></h4></td><td><input type="text" name="attr_monsterdmg2" title="@{repeating_monstervariants_$X_monsterdmg2}"></td></tr>
-<tr><td><h4><b>Attack 3:</b></h4></td><td><input type="text" name="attr_monsterdmg3" title="@{repeating_monstervariants_$X_monsterdmg3}"></td>
-</tr></table>
-    </div>
-    <div class='sheet-col'>
-<table><tr>
-<td><h4><b>No. Appearing:</b></h4></td><td><input type="text" name="attr_appearing" title="@{repeating_monstervariants_$X_appearing}" class="short"></td></tr>
-<tr><td><h4><b>Special Attacks:</b></h4></td><td><input type="text" name="attr_monsterspecattacks" title="@{repeating_monstervariants_$X_monsterspecattacks}"></td></tr>
-<tr><td><h4><b>Special Defenses:</b></h4></td><td><input type="text" name="attr_monsterspecdefenses" title="@{repeating_monstervariants_$X_monsterspecdefenses}"></td></tr>
-<tr><td><h4><b>Magic Resistance:</b></h4></td><td><input type="text" name="attr_monstermagicresist" title="@{repeating_monstervariants_$X_monstermagicresist}" class="short"><h4><b>%</b></h4><button type="roll" name="roll_monstermagicresist" title="%{repeating_monstervariants_$X_monstermagicresist}" value="/gmroll [[1d100+(?{Modifier?|0})]]<[[@{monstermagicresist}]]">Roll</button></td></tr>
-<tr><td><h4><b>Size:</b></h4></td><td><input type="text" name="attr_monstersize" title="@{repeating_monstervariants_$X_monstersize}" class="tiny"></td></tr>
-<tr><td><h4><b>Morale:</b></h4></td><td><input type="text" name="attr_monstermorale" title="@{repeating_monstervariants_$X_monstermorale}"></td></tr>
-<tr><td><h4><b>XP Value:</b></h4></td><td><input type="text" name="attr_monsterxp" title="@{repeating_monstervariants_$X_monsterxp}"></td></tr>
-</table>
-    </div>
-</div>
-<tr>
-            <td><button type="roll" name="roll_monthac0" title="%{repeating_monstervariants_$X_monthac0}" value="/em strikes AC [[(@{monsterthac0})-(1d20+(?{Modifier?|0}))]]">ThAC0</button></td>&nbsp;
-            <td><button type="roll" name="roll_mondmg" title="%{repeating_monstervariants_$X_mondmg}" value="/em inflicts [[@{monsterdmg}]] damage!">Attack 1</button></td>&nbsp;
-            <td><button type="roll" name="roll_mondmg2" title="%{repeating_monstervariants_$X_mondmg2}" value="/em inflicts [[@{monsterdmg2}]] damage!">Attack 2</button></td>&nbsp;
-            <td><button type="roll" name="roll_mondmg3" title="%{repeating_monstervariants_$X_mondmg3}" value="/em inflicts [[@{monsterdmg3}]] damage!">Attack 3</button></td>&nbsp;
-            <td><button type="roll" name="roll_spcatk" title="%{repeating_monstervariants_$X_spcatk}" value="/em @{monsterspecattacks}">Special Attack</button></td>&nbsp;
-            <td><input type="text" name="attr_monsterini" title="@{repeating_monstervariants_$X_monsterini}" class="sheet-short">&nbsp;<button type="roll" name="roll_monini" title="%{repeating_monstervariants_$X_monini}" value="/gmroll [[{([[1d10]]+@{monsterini}-(?{Misc. bonus|+0})), 1}kh1]] [Initiative (@{character_name})]&{tracker}">Initiative</button></td>
-</tr><br>
+        <tr>
+            <td><h4><b>Name:</b></h4></td>
+            <td class="sheet-padding-right"><input type="text" name="attr_character_name" title="@{character_name}"></td>
+            <td class="sheet-padding-right"><button type="roll" name="roll_surprisemon" title="@{surprisemon}" value="/gmroll {1d10+(?{Misc Modifier?|0})}>3 [Surprise roll for @{character_name}]">Surprise</button></td>
+            <td><button type="roll" name="roll_monmorale" title="@{monmorale}" value="/gmroll {1d20+(?{Misc. Modifier?|0})}<@{monstermorale} [Morale roll for @{character_name}]">Morale</button></td>
+        </tr>
+    </table>
 
-<table style="width: 100%;">
-<tr>
-            <td><button type="roll" name="roll_monparsave" title="%{monparsave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monpartar}]] [Save versus Paralyzation]"><br>Para<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monpoisave" title="%{monpoisave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monpoitar}]] [Save versus Poison]"><br>Pois<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_mondeasave" title="%{mondeasave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{mondeatar}]] [Save versus Death]"><br>Death<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monrodsave" title="%{monrodsave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monrodtar}]] [Save versus Rod]"><br>Rod<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monstasave" title="%{monstasave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monstatar}]] [Save versus Staff]"><br>Staff<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monwansave" title="%{monwansave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monwantar}]] [Save versus Wand]"><br>Wand<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monpetsave" title="%{monpetsave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monpettar}]] [Save versus Petrification]"><br>Pet<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monpolsave" title="%{monpolsave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monpoltar}]] [Save versus Polymorph]"><br>Poly<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monbresave" title="%{monbresave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monbretar}]] [Save versus Breath]"><br>Breath<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monspesave" title="%{monspesave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monspetar}]] [Save versus Spell]"><br>Spell<br>Save</button></td>
-</tr>
-<tr>
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monpartar" title="@{monpartar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monpoitar" title="@{monpoitar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;&nbsp;<input type="text" name="attr_mondeatar" title="@{mondeatar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monrodtar" title="@{monrodtar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monstatar" title="@{monstatar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monwantar" title="@{monwantar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monpettar" title="@{monpettar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monpoltar" title="@{monpoltar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monbretar" title="@{monbretar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monspetar" title="@{monspetar}" class="sheet-small"></td>
-</tr></table><br>
+    <div class="body">
+        <div class='sheet-3colrow'>
+            <div class='sheet-col'>
+                <table>
+                    <tr>
+                        <td><h4><b>Climate/Terrain:</b></h4></td>
+                        <td><input type="text" name="attr_climateterrain" title="@{climateterrain}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Frequency:</b></h4></td>
+                        <td><input type="text" name="attr_frequency" title="@{frequency}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Organization:</b></h4></td>
+                        <td><input type="text" name="attr_organization" title="@{organization}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Activity Cycle:</b></h4></td>
+                        <td><input type="text" name="attr_cycle" title="@{cycle}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Diet:</b></h4></td>
+                        <td><input type="text" name="attr_diet" title="@{diet}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Intelligence:</b></h4></td>
+                        <td><input type="text" name="attr_monsterintelligence" title="@{monsterintelligence}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Treasure:</b></h4></td>
+                        <td><input type="text" name="attr_treasure" title="@{treasure}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Alignment:</b></h4></td>
+                        <td><input type="text" name="attr_monsteralignment" title="@{monsteralignment}"></td>
+                    </tr>
+                </table>
+            </div>
+            <div class='sheet-col'>
+                <table>
+                    <tr>
+                        <td><h4><b>No. Appearing:</b></h4></td>
+                        <td><input type="text" name="attr_appearing" title="@{appearing}" class="sheet-short"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Armor Class:</b></h4></td>
+                        <td><input type="text" name="attr_monsterarmor" title="@{monsterarmor}" class="sheet-short"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Movement:</b></h4></td>
+                        <td><input type="text" name="attr_movement" title="@{movement}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Hit Dice:</b></h4></td>
+                        <td>
+                            <input type="number" name="attr_hitdice" title="@{hitdice}" class="sheet-short">&plusmn;<input type="number" name="attr_monsterhpextra" title="@{monsterhpextra}" class="sheet-minish" value="0">
+                            |
+                            <input type="number" name="attr_monsterhitdice-reroll" title="@{hitdice-reroll}" class="sheet-min" value="0">
+                            <button type="roll" name="roll_monsterhitpoints" title="%{monsterhitpoints}" value="/gmroll [@{character_name} Hit Points] (@{hitdice}d8r<@{monsterhitdice-reroll}) + (@{monsterhpextra})"></button>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Hit Points:</b></h4></td>
+                        <td>
+                            <input type="number" name="attr_HP" title="@{HP}" class="sheet-short" placeholder="Current">
+                            /
+                            <input type="number" name="attr_HP_max" title="@{HP|max}" class="sheet-short" placeholder="Max">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>THAC0:</b></h4></td>
+                        <td><input type="text" name="attr_monsterthac0" title="@{monsterthac0}" class="sheet-short"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b># of Attacks:</b></h4></td>
+                        <td><input type="text" name="attr_monsteratknum" title="@{monsteratknum}" class="sheet-small"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Attack 1:</b></h4></td>
+                        <td><input type="text" name="attr_monsterdmg" title="@{monsterdmg}"></td>
+                    </tr>
+                </table>
+            </div>
+            <div class='sheet-col'>
+                <table>
+                    <tr>
+                        <td><h4><b>Attack 2:</b></h4></td>
+                        <td><input type="text" name="attr_monsterdmg2" title="@{monsterdmg2}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Attack 3:</b></h4></td>
+                        <td><input type="text" name="attr_monsterdmg3" title="@{monsterdmg3}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Special Attacks:</b></h4></td>
+                        <td><input type="text" name="attr_monsterspecattacks" title="@{monsterspecattacks}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Special Defenses:</b></h4></td>
+                        <td><input type="text" name="attr_monsterspecdefenses" title="@{monsterspecdefenses}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Magic Resistance:</b></h4></td>
+                        <td>
+                            <input type="text" name="attr_monstermagicresist" title="@{monstermagicresist}" class="sheet-short"><h4><b>%</b></h4>
+                            <button type="roll" name="roll_monstermagicresist" title="%{monstermagicresist}" value="/gmroll {1d100+(?{Modifier?|0})}<@{monstermagicresist} [@{character_name} Save with Magic resistance]">Roll</button>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Size:</b></h4></td>
+                        <td><input type="text" name="attr_monstersize" title="@{monstersize}" class="sheet-tiny"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Morale:</b></h4></td>
+                        <td><input type="text" name="attr_monstermorale" title="@{monstermorale}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>XP Value:</b></h4></td>
+                        <td><input type="text" name="attr_monsterxp" title="@{monsterxp}"></td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        <label>Should ThAC0 and Attack rolls be public or private?</label>
+        <br>
+        <label><input type="radio" name="attr_wtype" title="@{wtype}" value="/em" checked><span>Public</span></label>
+        <label><input type="radio" name="attr_wtype" title="@{wtype}" value="/w gm @{character_name}"><span>To GM</span></label>
+        <table>
+            <tr>
+                <td class="sheet-padding-right"><button type="roll" name="roll_monthac0" title="%{monthac0}" value="@{wtype} strikes AC [[(@{monsterthac0})-(1d20+(?{Modifier?|0}))]]">ThAC0</button></td>
+                <td class="sheet-padding-right"><button type="roll" name="roll_mondmg" title="%{mondmg}" value="@{wtype} inflicts [[@{monsterdmg}]] damage!">Attack 1</button></td>
+                <td class="sheet-padding-right"><button type="roll" name="roll_mondmg2" title="%{mondmg2}" value="@{wtype} inflicts [[@{monsterdmg2}]] damage!">Attack 2</button></td>
+                <td class="sheet-padding-right"><button type="roll" name="roll_mondmg3" title="%{mondmg3}" value="@{wtype} inflicts [[@{monsterdmg3}]] damage!">Attack 3</button></td>
+                <td class="sheet-padding-right"><button type="roll" name="roll_spcatk" title="%{spcatk}" value="@{wtype} @{monsterspecattacks}">Special Attack</button></td>
+                <td><input type="text" name="attr_monsterini" title="@{monsterini}" class="sheet-short"></td>
+                <td><button type="roll" name="roll_monini" title="%{monini}" value="/gmroll [[{([[1d10]]+@{monsterini}-(?{Misc. bonus|+0})), 1}kh1]] [Initiative (@{character_name})]&{tracker}">Initiative</button></td>
+            </tr>
+        </table>
+        <br>
 
-<h4><b>Description</b></h4><br><textarea name="attr_monsterdesc" title="@{repeating_monstervariants_$X_monsterdesc}" placeholder="Description"></textarea><br>
-<h4><b>Combat</b></h4><textarea name="attr_monstercombat" title="@{repeating_monstervariants_$X_monstercombat}"></textarea><br>
-<h4><b>Habitat/Society</b></h4><textarea name="attr_monsterhabitat" title="@{repeating_monstervariants_$X_monsterhabitat}"></textarea><br>
-<h4><b>Ecology</b></h4><textarea name="attr_monsterecology" title="@{repeating_monstervariants_$X_monsterecology}"></textarea><br><br>
-    
+        <table class="sheet-centering" style="width: 100%;">
+            <tr>
+                <td><button type="roll" name="roll_monparsave" title="%{monparsave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monpartar} [@{character_name} Save versus Paralyzation]"><br>Para<br>Save</button></td>
+                <td><button type="roll" name="roll_monpoisave" title="%{monpoisave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monpoitar} [@{character_name} Save versus Poison]"><br>Pois<br>Save</button></td>
+                <td><button type="roll" name="roll_mondeasave" title="%{mondeasave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{mondeatar} [@{character_name} Save versus Death]"><br>Death<br>Save</button></td>
+                <td><button type="roll" name="roll_monrodsave" title="%{monrodsave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monrodtar} [@{character_name} Save versus Rod]"><br>Rod<br>Save</button></td>
+                <td><button type="roll" name="roll_monstasave" title="%{monstasave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monstatar} [@{character_name} Save versus Staff]"><br>Staff<br>Save</button></td>
+                <td><button type="roll" name="roll_monwansave" title="%{monwansave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monwantar} [@{character_name} Save versus Wand]"><br>Wand<br>Save</button></td>
+                <td><button type="roll" name="roll_monpetsave" title="%{monpetsave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monpettar} [@{character_name} Save versus Petrification]"><br>Pet<br>Save</button></td>
+                <td><button type="roll" name="roll_monpolsave" title="%{monpolsave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monpoltar} [@{character_name} Save versus Polymorph]"><br>Poly<br>Save</button></td>
+                <td><button type="roll" name="roll_monbresave" title="%{monbresave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monbretar} [@{character_name} Save versus Breath]"><br>Breath<br>Save</button></td>
+                <td><button type="roll" name="roll_monspesave" title="%{monspesave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monspetar} [@{character_name} Save versus Spell]"><br>Spell<br>Save</button></td>
+            </tr>
+            <tr>
+                <td><input type="text" name="attr_monpartar" title="@{monpartar}" class="sheet-small"></td>
+                <td><input type="text" name="attr_monpoitar" title="@{monpoitar}" class="sheet-small"></td>
+                <td><input type="text" name="attr_mondeatar" title="@{mondeatar}" class="sheet-small"></td>
+                <td><input type="text" name="attr_monrodtar" title="@{monrodtar}" class="sheet-small"></td>
+                <td><input type="text" name="attr_monstatar" title="@{monstatar}" class="sheet-small"></td>
+                <td><input type="text" name="attr_monwantar" title="@{monwantar}" class="sheet-small"></td>
+                <td><input type="text" name="attr_monpettar" title="@{monpettar}" class="sheet-small"></td>
+                <td><input type="text" name="attr_monpoltar" title="@{monpoltar}" class="sheet-small"></td>
+                <td><input type="text" name="attr_monbretar" title="@{monbretar}" class="sheet-small"></td>
+                <td><input type="text" name="attr_monspetar" title="@{monspetar}" class="sheet-small"></td>
+            </tr>
+        </table>
+        <br>
+
+        <h4><b>Description</b></h4><br><textarea name="attr_monsterdesc" title="@{monsterdesc}" placeholder="Description"></textarea>
+        <br>
+        <h4><b>Combat</b></h4><textarea name="attr_monstercombat" title="@{monstercombat}"></textarea>
+        <br>
+        <h4><b>Habitat/Society</b></h4><textarea name="attr_monsterhabitat" title="@{monsterhabitat}"></textarea>
+        <br>
+        <h4><b>Ecology</b></h4><textarea name="attr_monsterecology" title="@{monsterecology}"></textarea>
+        <br>
+        <br>
 </div>
-</fieldset>
+
+    <h3><b>Variants</b></h3>
+    <fieldset class="repeating_monstervariants" name="monstervariants" title="@{monstervariants}">
+
+        <table>
+            <tr>
+                <td class="sheet-padding-right"><button type="roll" name="roll_surprisemon" title="@{repeating_monstervariants_$X_surprisemon}" value="/gmroll {1d10+(?{Misc Modifier?|0})}>3 [Surprise roll for @{character_name}]">Surprise</button></td>
+                <td><button type="roll" name="roll_monmorale" title="@{repeating_monstervariants_$X_monmorale}" value="/gmroll {1d20+(?{Misc. Modifier?|0})}<@{monstermorale} [Morale roll for @{character_name}]">Morale</button></td>
+            </tr>
+        </table>
+
+        <div class="body">
+            <div class='sheet-3colrow'>
+                <div class='sheet-col'>
+                    <table>
+                        <tr>
+                            <td><h4><b>Climate/Terrain:</b></h4></td>
+                            <td><input type="text" name="attr_climateterrain" title="@{repeating_monstervariants_$X_climateterrain}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Frequency:</b></h4></td>
+                            <td><input type="text" name="attr_frequency" title="@{repeating_monstervariants_$X_frequency}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Organization:</b></h4></td>
+                            <td><input type="text" name="attr_organization" title="@{repeating_monstervariants_$X_organization}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Activity Cycle:</b></h4></td>
+                            <td><input type="text" name="attr_cycle" title="@{repeating_monstervariants_$X_cycle}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Diet:</b></h4></td>
+                            <td><input type="text" name="attr_diet" title="@{repeating_monstervariants_$X_diet}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Intelligence:</b></h4></td>
+                            <td><input type="text" name="attr_monsterintelligence" title="@{repeating_monstervariants_$X_monsterintelligence}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Treasure:</b></h4></td>
+                            <td><input type="text" name="attr_treasure" title="@{repeating_monstervariants_$X_treasure}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Alignment:</b></h4></td>
+                            <td><input type="text" name="attr_monsteralignment" title="@{repeating_monstervariants_$X_monsteralignment}"></td>
+                        </tr>
+                    </table>
+                </div>
+                <div class='sheet-col'>
+                    <table>
+                        <tr>
+                            <td><h4><b>No. Appearing:</b></h4></td>
+                            <td><input type="text" name="attr_appearing" title="@{repeating_monstervariants_$X_appearing}" class="sheet-short"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Armor Class:</b></h4></td>
+                            <td><input type="text" name="attr_monsterarmor" title="@{repeating_monstervariants_$X_monsterarmor}" class="sheet-short"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Movement:</b></h4></td>
+                            <td><input type="text" name="attr_movement" title="@{repeating_monstervariants_$X_movement}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Hit Dice:</b></h4></td>
+                            <td>
+                                <input type="number" name="attr_hitdice" title="@{repeating_monstervariants_$X_hitdice}" class="sheet-short">&plusmn;<input type="number" name="attr_monsterhpextra" title="@{repeating_monstervariants_$X_monsterhpextra}" class="sheet-minish" value="0">
+                                |
+                                <input type="number" name="attr_monsterhitdice-reroll" title="@{repeating_monstervariants_$X_hitdice-reroll}" class="sheet-min" value="0">
+                                <button type="roll" name="roll_monsterhitpoints" title="%{repeating_monstervariants_$X_monsterhitpoints}" value="/gmroll [@{character_name} Hit Points] (@{hitdice}d8r<@{monsterhitdice-reroll}) + (@{monsterhpextra})"></button>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Hit Points:</b></h4></td>
+                            <td>
+                                <input type="number" name="attr_HP" title="@{repeating_monstervariants_$X_HP}" class="sheet-short" placeholder="Current">
+                                /
+                                <input type="number" name="attr_HP_max" title="@{repeating_monstervariants_$X_HP|max}" class="sheet-short" placeholder="Max">
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>THAC0:</b></h4></td>
+                            <td><input type="text" name="attr_monsterthac0" title="@{repeating_monstervariants_$X_monsterthac0}" class="sheet-short"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b># of Attacks:</b></h4></td>
+                            <td><input type="text" name="attr_monsteratknum" title="@{repeating_monstervariants_$X_monsteratknum}" class="sheet-small"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Attack 1:</b></h4></td>
+                            <td><input type="text" name="attr_monsterdmg" title="@{repeating_monstervariants_$X_monsterdmg}"></td>
+                        </tr>
+                    </table>
+                </div>
+                <div class='sheet-col'>
+                    <table>
+                        <tr>
+                            <td><h4><b>Attack 2:</b></h4></td>
+                            <td><input type="text" name="attr_monsterdmg2" title="@{repeating_monstervariants_$X_monsterdmg2}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Attack 3:</b></h4></td>
+                            <td><input type="text" name="attr_monsterdmg3" title="@{repeating_monstervariants_$X_monsterdmg3}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Special Attacks:</b></h4></td>
+                            <td><input type="text" name="attr_monsterspecattacks" title="@{repeating_monstervariants_$X_monsterspecattacks}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Special Defenses:</b></h4></td>
+                            <td><input type="text" name="attr_monsterspecdefenses" title="@{repeating_monstervariants_$X_monsterspecdefenses}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Magic Resistance:</b></h4></td>
+                            <td><input type="text" name="attr_monstermagicresist" title="@{repeating_monstervariants_$X_monstermagicresist}" class="sheet-short"><h4><b>%</b></h4>
+                                <button type="roll" name="roll_monstermagicresist" title="%{repeating_monstervariants_$X_monstermagicresist}" value="/gmroll {1d100+(?{Modifier?|0})}<@{monstermagicresist} [@{character_name} Save with Magic resistance]">Roll</button>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Size:</b></h4></td>
+                            <td><input type="text" name="attr_monstersize" title="@{repeating_monstervariants_$X_monstersize}" class="sheet-tiny"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Morale:</b></h4></td>
+                            <td><input type="text" name="attr_monstermorale" title="@{repeating_monstervariants_$X_monstermorale}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>XP Value:</b></h4></td>
+                            <td><input type="text" name="attr_monsterxp" title="@{repeating_monstervariants_$X_monsterxp}"></td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+            <table>
+                <tr>
+                    <td class="sheet-padding-right"><button type="roll" name="roll_monthac0" title="%{repeating_monstervariants_$X_monthac0}" value="@{wtype} strikes AC [[(@{monsterthac0})-(1d20+(?{Modifier?|0}))]]">ThAC0</button></td>
+                    <td class="sheet-padding-right"><button type="roll" name="roll_mondmg" title="%{repeating_monstervariants_$X_mondmg}" value="@{wtype} inflicts [[@{monsterdmg}]] damage!">Attack 1</button></td>
+                    <td class="sheet-padding-right"><button type="roll" name="roll_mondmg2" title="%{repeating_monstervariants_$X_mondmg2}" value="@{wtype} inflicts [[@{monsterdmg2}]] damage!">Attack 2</button></td>
+                    <td class="sheet-padding-right"><button type="roll" name="roll_mondmg3" title="%{repeating_monstervariants_$X_mondmg3}" value="@{wtype} inflicts [[@{monsterdmg3}]] damage!">Attack 3</button></td>
+                    <td class="sheet-padding-right"><button type="roll" name="roll_spcatk" title="%{repeating_monstervariants_$X_spcatk}" value="@{wtype} @{monsterspecattacks}">Special Attack</button></td>
+                    <td><input type="text" name="attr_monsterini" title="@{repeating_monstervariants_$X_monsterini}" class="sheet-short"></td>
+                    <td><button type="roll" name="roll_monini" title="%{repeating_monstervariants_$X_monini}" value="/gmroll [[{([[1d10]]+@{monsterini}-(?{Misc. bonus|+0})), 1}kh1]] [Initiative (@{character_name})]&{tracker}">Initiative</button></td>
+                </tr>
+            </table>
+            <br>
+            <table class="sheet-centering" style="width: 100%;">
+                <tr>
+                    <td><button type="roll" name="roll_monparsave" title="%{monparsave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monpartar} [@{character_name} Save versus Paralyzation]"><br>Para<br>Save</button></td>
+                    <td><button type="roll" name="roll_monpoisave" title="%{monpoisave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monpoitar} [@{character_name} Save versus Poison]"><br>Pois<br>Save</button></td>
+                    <td><button type="roll" name="roll_mondeasave" title="%{mondeasave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{mondeatar} [@{character_name} Save versus Death]"><br>Death<br>Save</button></td>
+                    <td><button type="roll" name="roll_monrodsave" title="%{monrodsave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monrodtar} [@{character_name} Save versus Rod]"><br>Rod<br>Save</button></td>
+                    <td><button type="roll" name="roll_monstasave" title="%{monstasave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monstatar} [@{character_name} Save versus Staff]"><br>Staff<br>Save</button></td>
+                    <td><button type="roll" name="roll_monwansave" title="%{monwansave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monwantar} [@{character_name} Save versus Wand]"><br>Wand<br>Save</button></td>
+                    <td><button type="roll" name="roll_monpetsave" title="%{monpetsave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monpettar} [@{character_name} Save versus Petrification]"><br>Pet<br>Save</button></td>
+                    <td><button type="roll" name="roll_monpolsave" title="%{monpolsave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monpoltar} [@{character_name} Save versus Polymorph]"><br>Poly<br>Save</button></td>
+                    <td><button type="roll" name="roll_monbresave" title="%{monbresave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monbretar} [@{character_name} Save versus Breath]"><br>Breath<br>Save</button></td>
+                    <td><button type="roll" name="roll_monspesave" title="%{monspesave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monspetar} [@{character_name} Save versus Spell]"><br>Spell<br>Save</button></td>
+                </tr>
+                <tr>
+                    <td><input type="text" name="attr_monpartar" title="@{monpartar}" class="sheet-small"></td>
+                    <td><input type="text" name="attr_monpoitar" title="@{monpoitar}" class="sheet-small"></td>
+                    <td><input type="text" name="attr_mondeatar" title="@{mondeatar}" class="sheet-small"></td>
+                    <td><input type="text" name="attr_monrodtar" title="@{monrodtar}" class="sheet-small"></td>
+                    <td><input type="text" name="attr_monstatar" title="@{monstatar}" class="sheet-small"></td>
+                    <td><input type="text" name="attr_monwantar" title="@{monwantar}" class="sheet-small"></td>
+                    <td><input type="text" name="attr_monpettar" title="@{monpettar}" class="sheet-small"></td>
+                    <td><input type="text" name="attr_monpoltar" title="@{monpoltar}" class="sheet-small"></td>
+                    <td><input type="text" name="attr_monbretar" title="@{monbretar}" class="sheet-small"></td>
+                    <td><input type="text" name="attr_monspetar" title="@{monspetar}" class="sheet-small"></td>
+                </tr>
+            </table>
+            <br>
+
+            <h4><b>Description</b></h4><br><textarea name="attr_monsterdesc" title="@{repeating_monstervariants_$X_monsterdesc}" placeholder="Description"></textarea>
+            <br>
+            <h4><b>Combat</b></h4><textarea name="attr_monstercombat" title="@{repeating_monstervariants_$X_monstercombat}"></textarea>
+            <br>
+            <h4><b>Habitat/Society</b></h4><textarea name="attr_monsterhabitat" title="@{repeating_monstervariants_$X_monsterhabitat}"></textarea>
+            <br>
+            <h4><b>Ecology</b></h4><textarea name="attr_monsterecology" title="@{repeating_monstervariants_$X_monsterecology}"></textarea>
+            <br>
+            <br>
+
+        </div>
+    </fieldset>
 </div>
 
 
@@ -18778,7 +18979,7 @@ wiz2['Choke'] = {
     'damage': '[[1d4]]',
     'damage-type': '',
     'healing': '',
-    'effect': 'By means of *choke*, the caster causes a pair of ghostly hands to appear around the throat of a single victim. The victim must be a human, demihuman, or humanoid, and must be within 30 yards of the caster. The hands will choke and strangle the affected victim for the duration of the spell; each round, the victim suffers 1-4 hit points of damage from the choking hands. If the victim makes a successful saving throw, he suffers half- damage each round.\\n&emsp;*Choke* can be negated by *dispel magic* or a similar spell; the victim makes all attack rolls at a -2 penalty while affected by *choke*.'
+    'effect': 'By means of *choke*, the caster causes a pair of ghostly hands to appear around the throat of a single victim. The victim must be a human, demihuman, or humanoid, and must be within 30 yards of the caster. The hands will choke and strangle the affected victim for the duration of the spell; each round, the victim suffers 1-4 hit points of damage from the choking hands. If the victim makes a successful saving throw, he suffers half- damage each round.\n&emsp;*Choke* can be negated by *dispel magic* or a similar spell; the victim makes all attack rolls at a -2 penalty while affected by *choke*.'
 }
 // End
 
@@ -22456,7 +22657,7 @@ gemSections.forEach(i => {
 // --- Version change start --- //
 
 const sheetName = 'AD&D 2E Revised';
-const sheetVersion = '3.4.0';
+const sheetVersion = '3.4.1';
 
 function moveStaticToRepeating(section, fieldsToMove) {
     getAttrs(fieldsToMove, function (values) {

--- a/AD&D 2E Revised/2EStyle.css
+++ b/AD&D 2E Revised/2EStyle.css
@@ -88,8 +88,14 @@
     width: 400px;
 }
 .charsheet select.sheet-min,
+.charsheet .sheet-body input.sheet-min,
 .charsheet input.sheet-min {
     width: 2.5em;
+}
+.charsheet select.sheet-minish,
+.charsheet .sheet-body input.sheet-minish,
+.charsheet input.sheet-minish {
+    width: 3em;
 }
 .charsheet select.sheet-short,
 .charsheet input.sheet-short {

--- a/AD&D 2E Revised/javascript/version.js
+++ b/AD&D 2E Revised/javascript/version.js
@@ -1,7 +1,7 @@
 // --- Version change start --- //
 
 const sheetName = 'AD&D 2E Revised';
-const sheetVersion = '3.4.0';
+const sheetVersion = '3.4.1';
 
 function moveStaticToRepeating(section, fieldsToMove) {
     getAttrs(fieldsToMove, function (values) {

--- a/AD&D 2E Revised/javascript/wizardSpells.js
+++ b/AD&D 2E Revised/javascript/wizardSpells.js
@@ -896,7 +896,7 @@ wiz2['Choke'] = {
     'damage': '[[1d4]]',
     'damage-type': '',
     'healing': '',
-    'effect': 'By means of *choke*, the caster causes a pair of ghostly hands to appear around the throat of a single victim. The victim must be a human, demihuman, or humanoid, and must be within 30 yards of the caster. The hands will choke and strangle the affected victim for the duration of the spell; each round, the victim suffers 1-4 hit points of damage from the choking hands. If the victim makes a successful saving throw, he suffers half- damage each round.\\n&emsp;*Choke* can be negated by *dispel magic* or a similar spell; the victim makes all attack rolls at a -2 penalty while affected by *choke*.'
+    'effect': 'By means of *choke*, the caster causes a pair of ghostly hands to appear around the throat of a single victim. The victim must be a human, demihuman, or humanoid, and must be within 30 yards of the caster. The hands will choke and strangle the affected victim for the duration of the spell; each round, the victim suffers 1-4 hit points of damage from the choking hands. If the victim makes a successful saving throw, he suffers half- damage each round.\n&emsp;*Choke* can be negated by *dispel magic* or a similar spell; the victim makes all attack rolls at a -2 penalty while affected by *choke*.'
 }
 // End
 

--- a/AD&D 2E Revised/raw/2ESheet-raw.html
+++ b/AD&D 2E Revised/raw/2ESheet-raw.html
@@ -10,15 +10,8 @@
         <br/>
         <div class="sheet-announce-items">
             <ul style="font-style:italic">
-                <li>Fixed Weapon-type vs. Armor-type. Now actually works for repeating rows!</li>
-                <li><ul><li>Many attributes has been removed / changed / added. Please see the forum for the fill list</li></ul></li>
-                <li>Change all references to "Blunt" weapons into "Bludgeoning" as it is the correct term</li>
-                <li>Added new spell section for wizard spells level 3 to 15. Spell auto fill coming later. Suggested by Jonathan</li>
-                <li>Added new spell section for priest spells level 3 to 7 and Quest. Spell auto fill coming later. Suggested by Jonathan</li>
-                <li>Added spell auto fill for Wizard spells level 3</li>
-                <li>Added spell auto fill for Priest spells level 3</li>
-                <li>Added a field for a characters base ThAC0. Field is accessible by @{thac0-base}. Suggested by Richard @ Damery and BilBo 2</li>
-                <li>Made Worn Equipment section collapsable. Suggested by Chronische</li>
+                <li>Monster Sheet: Added more fine grained unput fields for Monster Hit Dice, as well as a roll button to roll monster Hit Points</li>
+                <li>Monster Sheet: Added Public / To GM toggle for Hit and Damage for monster rolls. Default is Public which was also the previous value before this change</li>
             </ul>
             <hr>
             <p>
@@ -4089,15 +4082,15 @@
                                     <option value="Hold Undead">Hold Undead</option>
                                     <option value="Illusionary Script">Illusionary Script</option>
                                     <option value="Infravision">Infravision</option>
-                                    <option value="Invisibility, 10\' Radius">Invisibility, 10\' Radius</option>
+                                    <option value="Invisibility, 10' Radius">Invisibility, 10' Radius</option>
                                     <option value="Item">Item</option>
-                                    <option value="Leomund\'s Tiny Hut">Leomund\'s Tiny Hut</option>
+                                    <option value="Leomund's Tiny Hut">Leomund's Tiny Hut</option>
                                     <option value="Lightning Bolt">Lightning Bolt</option>
-                                    <option value="Melf\'s Minute Meteors">Melf\'s Minute Meteors</option>
+                                    <option value="Melf's Minute Meteors">Melf's Minute Meteors</option>
                                     <option value="Monster Summoning I">Monster Summoning I</option>
                                     <option value="Nondetection">Nondetection</option>
                                     <option value="Phantom Steed">Phantom Steed</option>
-                                    <option value="Protection from Evil, 10\' Radius">Protection from Evil, 10\' Radius</option>
+                                    <option value="Protection from Evil, 10' Radius">Protection from Evil, 10' Radius</option>
                                     <option value="Protection From Normal Missiles">Protection From Normal Missiles</option>
                                     <option value="Secret Page">Secret Page</option>
                                     <option value="Sepia Snake Sigil">Sepia Snake Sigil</option>
@@ -16594,175 +16587,383 @@
 </div>
 
 <div class="sheet-tab-content sheet-section-monster-page">
-<h2><b>Monster Info</b></h2><br>
-<h4><b>Name:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b></h4><input type="text" name="attr_character_name" title="@{character_name}">&nbsp;&nbsp;&nbsp;<button type="roll" name="roll_surprisemon" title="@{surprisemon}" value="/gmroll [[{([[1d10]]+(?{Misc Modifier?|+0})), 1}kh1]] [Surprise roll for @{character_name}]">Surprise</button>&nbsp;&nbsp;&nbsp;<button type="roll" name="roll_monmorale" title="@{monmorale}" value="/gmroll [[{([[1d20]]+(?{Misc. Modifier?|+0})), 1}kh1]]&le;@{monstermorale}">Morale</button>
-    
-    <div class="body">
-    <div class='sheet-3colrow'>
-    <div class='sheet-col'>
-<table><tr>
-<td><h4><b>Climate/Terrain:</b></h4></td><td><input type="text" name="attr_climateterrain" title="@{climateterrain}"></td></tr>
-<tr><td><h4><b>Frequency:</b></h4></td><td><input type="text" name="attr_frequency" title="@{frequency}"></td></tr>
-<tr><td><h4><b>Organization:</b></h4></td><td><input type="text" name="attr_organization" title="@{organization}"></td></tr>
-<tr><td><h4><b>Activity Cycle:</b></h4></td><td><input type="text" name="attr_cycle" title="@{cycle}"></td></tr>
-<tr><td><h4><b>Diet:</b></h4></td><td><input type="text" name="attr_diet" title="@{diet}"></td></tr>
-<tr><td><h4><b>Intelligence:</b></h4></td><td><input type="text" name="attr_monsterintelligence" title="@{monsterintelligence}"></td></tr>
-<tr><td><h4><b>Treasure:</b></h4></td><td><input type="text" name="attr_treasure" title="@{treasure}"></td></tr>
-<tr><td><h4><b>Alignment:</b></h4></td><td><input type="text" name="attr_monsteralignment" title="@{monsteralignment}"></td>
-</tr></table>
-</div>
-    <div class='sheet-col'>
-        <table><tr>
-<tr><td><h4><b>Armor Class:</b></h4></td><td><input type="text" name="attr_monsterarmor" title="@{monsterarmor}" class="short"></td></tr>
-<tr><td><h4><b>Movement:</b></h4></td><td><input type="text" name="attr_movement" title="@{movement}" class="medium"></td></tr>
-<tr><td><h4><b>Hit Dice:</b></h4></td><td><input type="text" name="attr_hitdice" title="@{hitdice}" class="short"></td></tr>
-<tr><td><h4><b>THAC0:</b></h4></td><td><input type="text" name="attr_monsterthac0" title="@{monsterthac0}" class="short"></td></tr>
-<tr><td><h4><b># of Attacks:</b></h4></td><td><input type="text" name="attr_monsteratknum" title="@{monsteratknum}" class="sheet-small"></td></tr>
-<tr><td><h4><b>Attack 1:</b></h4></td><td><input type="text" name="attr_monsterdmg" title="@{monsterdmg}"></td></tr>
-<tr><td><h4><b>Attack 2:</b></h4></td><td><input type="text" name="attr_monsterdmg2" title="@{monsterdmg2}"></td></tr>
-<tr><td><h4><b>Attack 3:</b></h4></td><td><input type="text" name="attr_monsterdmg3" title="@{monsterdmg3}"></td>
-</tr></table>
-    </div>
-    <div class='sheet-col'>
-<table>
-<tr><td><h4><b>No. Appearing:</b></h4></td><td><input type="text" name="attr_appearing" title="@{appearing}" class="short"></td></tr>
-<tr><td><h4><b>Special Attacks:</b></h4></td><td><input type="text" name="attr_monsterspecattacks" title="@{monsterspecattacks}"></td></tr>
-<tr><td><h4><b>Special Defenses:</b></h4></td><td><input type="text" name="attr_monsterspecdefenses" title="@{monsterspecdefenses}"></td></tr>
-<tr><td><h4><b>Magic Resistance:</b></h4></td><td><input type="text" name="attr_monstermagicresist" title="@{monstermagicresist}" class="short"><h4><b>%</b></h4><button type="roll" name="roll_monstermagicresist" title="%{monstermagicresist}" value="/gmroll [[1d100+(?{Modifier?|0})]]<[[@{monstermagicresist}]]">Roll</button></td></tr>
-<tr><td><h4><b>Size:</b></h4></td><td><input type="text" name="attr_monstersize" title="@{monstersize}" class="tiny"></td></tr>
-<tr><td><h4><b>Morale:</b></h4></td><td><input type="text" name="attr_monstermorale" title="@{monstermorale}"></td></tr>
-<tr><td><h4><b>XP Value:</b></h4></td><td><input type="text" name="attr_monsterxp" title="@{monsterxp}"></td></tr>
-</table>
-    </div>
-</div>
-<tr>
-            <td><button type="roll" name="roll_monthac0" title="%{monthac0}" value="/em strikes AC [[(@{monsterthac0})-(1d20+(?{Modifier?|0}))]]">ThAC0</button></td>&nbsp;
-            <td><button type="roll" name="roll_mondmg" title="%{mondmg}" value="/em inflicts [[@{monsterdmg}]] damage!">Attack 1</button></td>&nbsp;
-            <td><button type="roll" name="roll_mondmg2" title="%{mondmg2}" value="/em inflicts [[@{monsterdmg2}]] damage!">Attack 2</button></td>&nbsp;
-            <td><button type="roll" name="roll_mondmg3" title="%{mondmg3}" value="/em inflicts [[@{monsterdmg3}]] damage!">Attack 3</button></td>&nbsp;
-            <td><button type="roll" name="roll_spcatk" title="%{spcatk}" value="/em @{monsterspecattacks}">Special Attack</button></td>&nbsp;
-            <td><input type="text" name="attr_monsterini" title="@{monsterini}" class="sheet-short">&nbsp;<button type="roll" name="roll_monini" title="%{monini}" value="/gmroll [[{([[1d10]]+@{monsterini}-(?{Misc. bonus|+0})), 1}kh1]] [Initiative (@{character_name})]&{tracker}">Initiative</button></td>
-</tr><br>
-
-<table style="width: 100%;">
-<tr>
-            <td><button type="roll" name="roll_monparsave" title="%{monparsave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monpartar}]] [Save versus Paralyzation]"><br>Para<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monpoisave" title="%{monpoisave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monpoitar}]] [Save versus Poison]"><br>Pois<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_mondeasave" title="%{mondeasave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{mondeatar}]] [Save versus Death]"><br>Death<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monrodsave" title="%{monrodsave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monrodtar}]] [Save versus Rod]"><br>Rod<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monstasave" title="%{monstasave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monstatar}]] [Save versus Staff]"><br>Staff<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monwansave" title="%{monwansave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monwantar}]] [Save versus Wand]"><br>Wand<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monpetsave" title="%{monpetsave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monpettar}]] [Save versus Petrification]"><br>Pet<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monpolsave" title="%{monpolsave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monpoltar}]] [Save versus Polymorph]"><br>Poly<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monbresave" title="%{monbresave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monbretar}]] [Save versus Breath]"><br>Breath<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monspesave" title="%{monspesave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monspetar}]] [Save versus Spell]"><br>Spell<br>Save</button></td>
-</tr>
-<tr>
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monpartar" title="@{monpartar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monpoitar" title="@{monpoitar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;&nbsp;<input type="text" name="attr_mondeatar" title="@{mondeatar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monrodtar" title="@{monrodtar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monstatar" title="@{monstatar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monwantar" title="@{monwantar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monpettar" title="@{monpettar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monpoltar" title="@{monpoltar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monbretar" title="@{monbretar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monspetar" title="@{monspetar}" class="sheet-small"></td>
-</tr></table><br>
-
-<h4><b>Description</b></h4><br><textarea name="attr_monsterdesc" title="@{monsterdesc}" placeholder="Description"></textarea><br>
-<h4><b>Combat</b></h4><textarea name="attr_monstercombat" title="@{monstercombat}"></textarea><br>
-<h4><b>Habitat/Society</b></h4><textarea name="attr_monsterhabitat" title="@{monsterhabitat}"></textarea><br>
-<h4><b>Ecology</b></h4><textarea name="attr_monsterecology" title="@{monsterecology}"></textarea><br><br>
-</div>
-
-<h3><b>Variants</b></h3>
-<fieldset class="repeating_monstervariants" name="monstervariants" title="@{monstervariants}">  
-    
-    <div class="body">
-    <div class='sheet-3colrow'>
-    <div class='sheet-col'>
-        <tr>
-            <td><button type="roll" name="roll_surprisemon" title="%{repeating_monstervariants_$X_surprisemon}" value="/gmroll [[{([[1d10]]+(?{Misc Modifier?|+0})), 1}kh1]] [Surprise roll for @{character_name}]">Surprise</button></td>
-            <td><button type="roll" name="roll_monmorale" title="%{repeating_monstervariants_$X_monmorale}" value="/gmroll [[{([[1d20]]+(?{Misc. Modifier?|+0})), 1}kh1]]&le;@{monstermorale}">Morale</button></td>
+    <h2><b>Monster Info</b></h2>
+    <br>
+    <table>
+        <tr class="sheet-collapse">
+            <td><h4><b>Climate/Terrain:</b></h4></td>
         </tr>
-<table><tr>
-<td><h4><b>Climate/Terrain:</b></h4></td><td><input type="text" name="attr_climateterrain" title="@{repeating_monstervariants_$X_climateterrain}"></td></tr>
-<tr><td><h4><b>Frequency:</b></h4></td><td><input type="text" name="attr_frequency" title="@{repeating_monstervariants_$X_frequency}"></td></tr>
-<tr><td><h4><b>Organization:</b></h4></td><td><input type="text" name="attr_organization" title="@{repeating_monstervariants_$X_organization}"></td></tr>
-<tr><td><h4><b>Activity Cycle:</b></h4></td><td><input type="text" name="attr_cycle" title="@{repeating_monstervariants_$X_cycle}"></td></tr>
-<tr><td><h4><b>Diet:</b></h4></td><td><input type="text" name="attr_diet" title="@{repeating_monstervariants_$X_diet}"></td></tr>
-<tr><td><h4><b>Intelligence:</b></h4></td><td><input type="text" name="attr_monsterintelligence" title="@{repeating_monstervariants_$X_monsterintelligence}"></td></tr>
-<tr><td><h4><b>Treasure:</b></h4></td><td><input type="text" name="attr_treasure" title="@{repeating_monstervariants_$X_treasure}"></td></tr>
-<tr><td><h4><b>Alignment:</b></h4></td><td><input type="text" name="attr_monsteralignment" title="@{repeating_monstervariants_$X_monsteralignment}"></td>
-</tr></table>
-</div>
-    <div class='sheet-col'>
-        <table><tr>
-<tr><td><h4><b>Armor Class:</b></h4></td><td><input type="text" name="attr_monsterarmor" title="@{repeating_monstervariants_$X_monsterarmor}" class="short"></td></tr>
-<tr><td><h4><b>Movement:</b></h4></td><td><input type="text" name="attr_movement" title="@{repeating_monstervariants_$X_movement}" class="medium"></td></tr>
-<tr><td><h4><b>Hit Dice:</b></h4></td><td><input type="text" name="attr_hitdice" title="@{repeating_monstervariants_$X_hitdice}" class="short"></td></tr>
-<tr><td><h4><b>THAC0:</b></h4></td><td><input type="text" name="attr_monsterthac0" title="@{repeating_monstervariants_$X_monsterthac0}" class="short"></td></tr>
-<tr><td><h4><b># of Attacks:</b></h4></td><td><input type="text" name="attr_monsteratknum" title="@{repeating_monstervariants_$X_monsteratknum}" class="sheet-small"></td></tr>
-<tr><td><h4><b>Attack 1:</b></h4></td><td><input type="text" name="attr_monsterdmg" title="@{repeating_monstervariants_$X_monsterdmg}"></td></tr>
-<tr><td><h4><b>Attack 2:</b></h4></td><td><input type="text" name="attr_monsterdmg2" title="@{repeating_monstervariants_$X_monsterdmg2}"></td></tr>
-<tr><td><h4><b>Attack 3:</b></h4></td><td><input type="text" name="attr_monsterdmg3" title="@{repeating_monstervariants_$X_monsterdmg3}"></td>
-</tr></table>
-    </div>
-    <div class='sheet-col'>
-<table><tr>
-<td><h4><b>No. Appearing:</b></h4></td><td><input type="text" name="attr_appearing" title="@{repeating_monstervariants_$X_appearing}" class="short"></td></tr>
-<tr><td><h4><b>Special Attacks:</b></h4></td><td><input type="text" name="attr_monsterspecattacks" title="@{repeating_monstervariants_$X_monsterspecattacks}"></td></tr>
-<tr><td><h4><b>Special Defenses:</b></h4></td><td><input type="text" name="attr_monsterspecdefenses" title="@{repeating_monstervariants_$X_monsterspecdefenses}"></td></tr>
-<tr><td><h4><b>Magic Resistance:</b></h4></td><td><input type="text" name="attr_monstermagicresist" title="@{repeating_monstervariants_$X_monstermagicresist}" class="short"><h4><b>%</b></h4><button type="roll" name="roll_monstermagicresist" title="%{repeating_monstervariants_$X_monstermagicresist}" value="/gmroll [[1d100+(?{Modifier?|0})]]<[[@{monstermagicresist}]]">Roll</button></td></tr>
-<tr><td><h4><b>Size:</b></h4></td><td><input type="text" name="attr_monstersize" title="@{repeating_monstervariants_$X_monstersize}" class="tiny"></td></tr>
-<tr><td><h4><b>Morale:</b></h4></td><td><input type="text" name="attr_monstermorale" title="@{repeating_monstervariants_$X_monstermorale}"></td></tr>
-<tr><td><h4><b>XP Value:</b></h4></td><td><input type="text" name="attr_monsterxp" title="@{repeating_monstervariants_$X_monsterxp}"></td></tr>
-</table>
-    </div>
-</div>
-<tr>
-            <td><button type="roll" name="roll_monthac0" title="%{repeating_monstervariants_$X_monthac0}" value="/em strikes AC [[(@{monsterthac0})-(1d20+(?{Modifier?|0}))]]">ThAC0</button></td>&nbsp;
-            <td><button type="roll" name="roll_mondmg" title="%{repeating_monstervariants_$X_mondmg}" value="/em inflicts [[@{monsterdmg}]] damage!">Attack 1</button></td>&nbsp;
-            <td><button type="roll" name="roll_mondmg2" title="%{repeating_monstervariants_$X_mondmg2}" value="/em inflicts [[@{monsterdmg2}]] damage!">Attack 2</button></td>&nbsp;
-            <td><button type="roll" name="roll_mondmg3" title="%{repeating_monstervariants_$X_mondmg3}" value="/em inflicts [[@{monsterdmg3}]] damage!">Attack 3</button></td>&nbsp;
-            <td><button type="roll" name="roll_spcatk" title="%{repeating_monstervariants_$X_spcatk}" value="/em @{monsterspecattacks}">Special Attack</button></td>&nbsp;
-            <td><input type="text" name="attr_monsterini" title="@{repeating_monstervariants_$X_monsterini}" class="sheet-short">&nbsp;<button type="roll" name="roll_monini" title="%{repeating_monstervariants_$X_monini}" value="/gmroll [[{([[1d10]]+@{monsterini}-(?{Misc. bonus|+0})), 1}kh1]] [Initiative (@{character_name})]&{tracker}">Initiative</button></td>
-</tr><br>
+        <tr>
+            <td><h4><b>Name:</b></h4></td>
+            <td class="sheet-padding-right"><input type="text" name="attr_character_name" title="@{character_name}"></td>
+            <td class="sheet-padding-right"><button type="roll" name="roll_surprisemon" title="@{surprisemon}" value="/gmroll {1d10+(?{Misc Modifier?|0})}>3 [Surprise roll for @{character_name}]">Surprise</button></td>
+            <td><button type="roll" name="roll_monmorale" title="@{monmorale}" value="/gmroll {1d20+(?{Misc. Modifier?|0})}<@{monstermorale} [Morale roll for @{character_name}]">Morale</button></td>
+        </tr>
+    </table>
 
-<table style="width: 100%;">
-<tr>
-            <td><button type="roll" name="roll_monparsave" title="%{monparsave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monpartar}]] [Save versus Paralyzation]"><br>Para<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monpoisave" title="%{monpoisave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monpoitar}]] [Save versus Poison]"><br>Pois<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_mondeasave" title="%{mondeasave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{mondeatar}]] [Save versus Death]"><br>Death<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monrodsave" title="%{monrodsave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monrodtar}]] [Save versus Rod]"><br>Rod<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monstasave" title="%{monstasave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monstatar}]] [Save versus Staff]"><br>Staff<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monwansave" title="%{monwansave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monwantar}]] [Save versus Wand]"><br>Wand<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monpetsave" title="%{monpetsave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monpettar}]] [Save versus Petrification]"><br>Pet<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monpolsave" title="%{monpolsave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monpoltar}]] [Save versus Polymorph]"><br>Poly<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monbresave" title="%{monbresave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monbretar}]] [Save versus Breath]"><br>Breath<br>Save</button></td>&nbsp;
-            <td><button type="roll" name="roll_monspesave" title="%{monspesave}" value="/gmroll [[d20+?{Misc Modifier?|0}]] &GreaterEqual; [[@{monspetar}]] [Save versus Spell]"><br>Spell<br>Save</button></td>
-</tr>
-<tr>
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monpartar" title="@{monpartar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monpoitar" title="@{monpoitar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;&nbsp;<input type="text" name="attr_mondeatar" title="@{mondeatar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monrodtar" title="@{monrodtar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monstatar" title="@{monstatar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monwantar" title="@{monwantar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monpettar" title="@{monpettar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monpoltar" title="@{monpoltar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monbretar" title="@{monbretar}" class="sheet-small"></td>&nbsp;
-            <td>&nbsp;&nbsp;&nbsp;<input type="text" name="attr_monspetar" title="@{monspetar}" class="sheet-small"></td>
-</tr></table><br>
+    <div class="body">
+        <div class='sheet-3colrow'>
+            <div class='sheet-col'>
+                <table>
+                    <tr>
+                        <td><h4><b>Climate/Terrain:</b></h4></td>
+                        <td><input type="text" name="attr_climateterrain" title="@{climateterrain}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Frequency:</b></h4></td>
+                        <td><input type="text" name="attr_frequency" title="@{frequency}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Organization:</b></h4></td>
+                        <td><input type="text" name="attr_organization" title="@{organization}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Activity Cycle:</b></h4></td>
+                        <td><input type="text" name="attr_cycle" title="@{cycle}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Diet:</b></h4></td>
+                        <td><input type="text" name="attr_diet" title="@{diet}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Intelligence:</b></h4></td>
+                        <td><input type="text" name="attr_monsterintelligence" title="@{monsterintelligence}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Treasure:</b></h4></td>
+                        <td><input type="text" name="attr_treasure" title="@{treasure}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Alignment:</b></h4></td>
+                        <td><input type="text" name="attr_monsteralignment" title="@{monsteralignment}"></td>
+                    </tr>
+                </table>
+            </div>
+            <div class='sheet-col'>
+                <table>
+                    <tr>
+                        <td><h4><b>No. Appearing:</b></h4></td>
+                        <td><input type="text" name="attr_appearing" title="@{appearing}" class="sheet-short"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Armor Class:</b></h4></td>
+                        <td><input type="text" name="attr_monsterarmor" title="@{monsterarmor}" class="sheet-short"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Movement:</b></h4></td>
+                        <td><input type="text" name="attr_movement" title="@{movement}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Hit Dice:</b></h4></td>
+                        <td>
+                            <input type="number" name="attr_hitdice" title="@{hitdice}" class="sheet-short">&plusmn;<input type="number" name="attr_monsterhpextra" title="@{monsterhpextra}" class="sheet-minish" value="0">
+                            |
+                            <input type="number" name="attr_monsterhitdice-reroll" title="@{hitdice-reroll}" class="sheet-min" value="0">
+                            <button type="roll" name="roll_monsterhitpoints" title="%{monsterhitpoints}" value="/gmroll [@{character_name} Hit Points] (@{hitdice}d8r<@{monsterhitdice-reroll}) + (@{monsterhpextra})"></button>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Hit Points:</b></h4></td>
+                        <td>
+                            <input type="number" name="attr_HP" title="@{HP}" class="sheet-short" placeholder="Current">
+                            /
+                            <input type="number" name="attr_HP_max" title="@{HP|max}" class="sheet-short" placeholder="Max">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>THAC0:</b></h4></td>
+                        <td><input type="text" name="attr_monsterthac0" title="@{monsterthac0}" class="sheet-short"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b># of Attacks:</b></h4></td>
+                        <td><input type="text" name="attr_monsteratknum" title="@{monsteratknum}" class="sheet-small"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Attack 1:</b></h4></td>
+                        <td><input type="text" name="attr_monsterdmg" title="@{monsterdmg}"></td>
+                    </tr>
+                </table>
+            </div>
+            <div class='sheet-col'>
+                <table>
+                    <tr>
+                        <td><h4><b>Attack 2:</b></h4></td>
+                        <td><input type="text" name="attr_monsterdmg2" title="@{monsterdmg2}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Attack 3:</b></h4></td>
+                        <td><input type="text" name="attr_monsterdmg3" title="@{monsterdmg3}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Special Attacks:</b></h4></td>
+                        <td><input type="text" name="attr_monsterspecattacks" title="@{monsterspecattacks}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Special Defenses:</b></h4></td>
+                        <td><input type="text" name="attr_monsterspecdefenses" title="@{monsterspecdefenses}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Magic Resistance:</b></h4></td>
+                        <td>
+                            <input type="text" name="attr_monstermagicresist" title="@{monstermagicresist}" class="sheet-short"><h4><b>%</b></h4>
+                            <button type="roll" name="roll_monstermagicresist" title="%{monstermagicresist}" value="/gmroll {1d100+(?{Modifier?|0})}<@{monstermagicresist} [@{character_name} Save with Magic resistance]">Roll</button>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Size:</b></h4></td>
+                        <td><input type="text" name="attr_monstersize" title="@{monstersize}" class="sheet-tiny"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>Morale:</b></h4></td>
+                        <td><input type="text" name="attr_monstermorale" title="@{monstermorale}"></td>
+                    </tr>
+                    <tr>
+                        <td><h4><b>XP Value:</b></h4></td>
+                        <td><input type="text" name="attr_monsterxp" title="@{monsterxp}"></td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        <label>Should ThAC0 and Attack rolls be public or private?</label>
+        <br>
+        <label><input type="radio" name="attr_wtype" title="@{wtype}" value="/em" checked><span>Public</span></label>
+        <label><input type="radio" name="attr_wtype" title="@{wtype}" value="/w gm @{character_name}"><span>To GM</span></label>
+        <table>
+            <tr>
+                <td class="sheet-padding-right"><button type="roll" name="roll_monthac0" title="%{monthac0}" value="@{wtype} strikes AC [[(@{monsterthac0})-(1d20+(?{Modifier?|0}))]]">ThAC0</button></td>
+                <td class="sheet-padding-right"><button type="roll" name="roll_mondmg" title="%{mondmg}" value="@{wtype} inflicts [[@{monsterdmg}]] damage!">Attack 1</button></td>
+                <td class="sheet-padding-right"><button type="roll" name="roll_mondmg2" title="%{mondmg2}" value="@{wtype} inflicts [[@{monsterdmg2}]] damage!">Attack 2</button></td>
+                <td class="sheet-padding-right"><button type="roll" name="roll_mondmg3" title="%{mondmg3}" value="@{wtype} inflicts [[@{monsterdmg3}]] damage!">Attack 3</button></td>
+                <td class="sheet-padding-right"><button type="roll" name="roll_spcatk" title="%{spcatk}" value="@{wtype} @{monsterspecattacks}">Special Attack</button></td>
+                <td><input type="text" name="attr_monsterini" title="@{monsterini}" class="sheet-short"></td>
+                <td><button type="roll" name="roll_monini" title="%{monini}" value="/gmroll [[{([[1d10]]+@{monsterini}-(?{Misc. bonus|+0})), 1}kh1]] [Initiative (@{character_name})]&{tracker}">Initiative</button></td>
+            </tr>
+        </table>
+        <br>
 
-<h4><b>Description</b></h4><br><textarea name="attr_monsterdesc" title="@{repeating_monstervariants_$X_monsterdesc}" placeholder="Description"></textarea><br>
-<h4><b>Combat</b></h4><textarea name="attr_monstercombat" title="@{repeating_monstervariants_$X_monstercombat}"></textarea><br>
-<h4><b>Habitat/Society</b></h4><textarea name="attr_monsterhabitat" title="@{repeating_monstervariants_$X_monsterhabitat}"></textarea><br>
-<h4><b>Ecology</b></h4><textarea name="attr_monsterecology" title="@{repeating_monstervariants_$X_monsterecology}"></textarea><br><br>
-    
+        <table class="sheet-centering" style="width: 100%;">
+            <tr>
+                <td><button type="roll" name="roll_monparsave" title="%{monparsave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monpartar} [@{character_name} Save versus Paralyzation]"><br>Para<br>Save</button></td>
+                <td><button type="roll" name="roll_monpoisave" title="%{monpoisave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monpoitar} [@{character_name} Save versus Poison]"><br>Pois<br>Save</button></td>
+                <td><button type="roll" name="roll_mondeasave" title="%{mondeasave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{mondeatar} [@{character_name} Save versus Death]"><br>Death<br>Save</button></td>
+                <td><button type="roll" name="roll_monrodsave" title="%{monrodsave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monrodtar} [@{character_name} Save versus Rod]"><br>Rod<br>Save</button></td>
+                <td><button type="roll" name="roll_monstasave" title="%{monstasave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monstatar} [@{character_name} Save versus Staff]"><br>Staff<br>Save</button></td>
+                <td><button type="roll" name="roll_monwansave" title="%{monwansave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monwantar} [@{character_name} Save versus Wand]"><br>Wand<br>Save</button></td>
+                <td><button type="roll" name="roll_monpetsave" title="%{monpetsave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monpettar} [@{character_name} Save versus Petrification]"><br>Pet<br>Save</button></td>
+                <td><button type="roll" name="roll_monpolsave" title="%{monpolsave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monpoltar} [@{character_name} Save versus Polymorph]"><br>Poly<br>Save</button></td>
+                <td><button type="roll" name="roll_monbresave" title="%{monbresave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monbretar} [@{character_name} Save versus Breath]"><br>Breath<br>Save</button></td>
+                <td><button type="roll" name="roll_monspesave" title="%{monspesave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monspetar} [@{character_name} Save versus Spell]"><br>Spell<br>Save</button></td>
+            </tr>
+            <tr>
+                <td><input type="text" name="attr_monpartar" title="@{monpartar}" class="sheet-small"></td>
+                <td><input type="text" name="attr_monpoitar" title="@{monpoitar}" class="sheet-small"></td>
+                <td><input type="text" name="attr_mondeatar" title="@{mondeatar}" class="sheet-small"></td>
+                <td><input type="text" name="attr_monrodtar" title="@{monrodtar}" class="sheet-small"></td>
+                <td><input type="text" name="attr_monstatar" title="@{monstatar}" class="sheet-small"></td>
+                <td><input type="text" name="attr_monwantar" title="@{monwantar}" class="sheet-small"></td>
+                <td><input type="text" name="attr_monpettar" title="@{monpettar}" class="sheet-small"></td>
+                <td><input type="text" name="attr_monpoltar" title="@{monpoltar}" class="sheet-small"></td>
+                <td><input type="text" name="attr_monbretar" title="@{monbretar}" class="sheet-small"></td>
+                <td><input type="text" name="attr_monspetar" title="@{monspetar}" class="sheet-small"></td>
+            </tr>
+        </table>
+        <br>
+
+        <h4><b>Description</b></h4><br><textarea name="attr_monsterdesc" title="@{monsterdesc}" placeholder="Description"></textarea>
+        <br>
+        <h4><b>Combat</b></h4><textarea name="attr_monstercombat" title="@{monstercombat}"></textarea>
+        <br>
+        <h4><b>Habitat/Society</b></h4><textarea name="attr_monsterhabitat" title="@{monsterhabitat}"></textarea>
+        <br>
+        <h4><b>Ecology</b></h4><textarea name="attr_monsterecology" title="@{monsterecology}"></textarea>
+        <br>
+        <br>
 </div>
-</fieldset>
+
+    <h3><b>Variants</b></h3>
+    <fieldset class="repeating_monstervariants" name="monstervariants" title="@{monstervariants}">
+
+        <table>
+            <tr>
+                <td class="sheet-padding-right"><button type="roll" name="roll_surprisemon" title="@{repeating_monstervariants_$X_surprisemon}" value="/gmroll {1d10+(?{Misc Modifier?|0})}>3 [Surprise roll for @{character_name}]">Surprise</button></td>
+                <td><button type="roll" name="roll_monmorale" title="@{repeating_monstervariants_$X_monmorale}" value="/gmroll {1d20+(?{Misc. Modifier?|0})}<@{monstermorale} [Morale roll for @{character_name}]">Morale</button></td>
+            </tr>
+        </table>
+
+        <div class="body">
+            <div class='sheet-3colrow'>
+                <div class='sheet-col'>
+                    <table>
+                        <tr>
+                            <td><h4><b>Climate/Terrain:</b></h4></td>
+                            <td><input type="text" name="attr_climateterrain" title="@{repeating_monstervariants_$X_climateterrain}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Frequency:</b></h4></td>
+                            <td><input type="text" name="attr_frequency" title="@{repeating_monstervariants_$X_frequency}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Organization:</b></h4></td>
+                            <td><input type="text" name="attr_organization" title="@{repeating_monstervariants_$X_organization}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Activity Cycle:</b></h4></td>
+                            <td><input type="text" name="attr_cycle" title="@{repeating_monstervariants_$X_cycle}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Diet:</b></h4></td>
+                            <td><input type="text" name="attr_diet" title="@{repeating_monstervariants_$X_diet}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Intelligence:</b></h4></td>
+                            <td><input type="text" name="attr_monsterintelligence" title="@{repeating_monstervariants_$X_monsterintelligence}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Treasure:</b></h4></td>
+                            <td><input type="text" name="attr_treasure" title="@{repeating_monstervariants_$X_treasure}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Alignment:</b></h4></td>
+                            <td><input type="text" name="attr_monsteralignment" title="@{repeating_monstervariants_$X_monsteralignment}"></td>
+                        </tr>
+                    </table>
+                </div>
+                <div class='sheet-col'>
+                    <table>
+                        <tr>
+                            <td><h4><b>No. Appearing:</b></h4></td>
+                            <td><input type="text" name="attr_appearing" title="@{repeating_monstervariants_$X_appearing}" class="sheet-short"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Armor Class:</b></h4></td>
+                            <td><input type="text" name="attr_monsterarmor" title="@{repeating_monstervariants_$X_monsterarmor}" class="sheet-short"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Movement:</b></h4></td>
+                            <td><input type="text" name="attr_movement" title="@{repeating_monstervariants_$X_movement}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Hit Dice:</b></h4></td>
+                            <td>
+                                <input type="number" name="attr_hitdice" title="@{repeating_monstervariants_$X_hitdice}" class="sheet-short">&plusmn;<input type="number" name="attr_monsterhpextra" title="@{repeating_monstervariants_$X_monsterhpextra}" class="sheet-minish" value="0">
+                                |
+                                <input type="number" name="attr_monsterhitdice-reroll" title="@{repeating_monstervariants_$X_hitdice-reroll}" class="sheet-min" value="0">
+                                <button type="roll" name="roll_monsterhitpoints" title="%{repeating_monstervariants_$X_monsterhitpoints}" value="/gmroll [@{character_name} Hit Points] (@{hitdice}d8r<@{monsterhitdice-reroll}) + (@{monsterhpextra})"></button>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Hit Points:</b></h4></td>
+                            <td>
+                                <input type="number" name="attr_HP" title="@{repeating_monstervariants_$X_HP}" class="sheet-short" placeholder="Current">
+                                /
+                                <input type="number" name="attr_HP_max" title="@{repeating_monstervariants_$X_HP|max}" class="sheet-short" placeholder="Max">
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>THAC0:</b></h4></td>
+                            <td><input type="text" name="attr_monsterthac0" title="@{repeating_monstervariants_$X_monsterthac0}" class="sheet-short"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b># of Attacks:</b></h4></td>
+                            <td><input type="text" name="attr_monsteratknum" title="@{repeating_monstervariants_$X_monsteratknum}" class="sheet-small"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Attack 1:</b></h4></td>
+                            <td><input type="text" name="attr_monsterdmg" title="@{repeating_monstervariants_$X_monsterdmg}"></td>
+                        </tr>
+                    </table>
+                </div>
+                <div class='sheet-col'>
+                    <table>
+                        <tr>
+                            <td><h4><b>Attack 2:</b></h4></td>
+                            <td><input type="text" name="attr_monsterdmg2" title="@{repeating_monstervariants_$X_monsterdmg2}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Attack 3:</b></h4></td>
+                            <td><input type="text" name="attr_monsterdmg3" title="@{repeating_monstervariants_$X_monsterdmg3}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Special Attacks:</b></h4></td>
+                            <td><input type="text" name="attr_monsterspecattacks" title="@{repeating_monstervariants_$X_monsterspecattacks}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Special Defenses:</b></h4></td>
+                            <td><input type="text" name="attr_monsterspecdefenses" title="@{repeating_monstervariants_$X_monsterspecdefenses}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Magic Resistance:</b></h4></td>
+                            <td><input type="text" name="attr_monstermagicresist" title="@{repeating_monstervariants_$X_monstermagicresist}" class="sheet-short"><h4><b>%</b></h4>
+                                <button type="roll" name="roll_monstermagicresist" title="%{repeating_monstervariants_$X_monstermagicresist}" value="/gmroll {1d100+(?{Modifier?|0})}<@{monstermagicresist} [@{character_name} Save with Magic resistance]">Roll</button>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Size:</b></h4></td>
+                            <td><input type="text" name="attr_monstersize" title="@{repeating_monstervariants_$X_monstersize}" class="sheet-tiny"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>Morale:</b></h4></td>
+                            <td><input type="text" name="attr_monstermorale" title="@{repeating_monstervariants_$X_monstermorale}"></td>
+                        </tr>
+                        <tr>
+                            <td><h4><b>XP Value:</b></h4></td>
+                            <td><input type="text" name="attr_monsterxp" title="@{repeating_monstervariants_$X_monsterxp}"></td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+            <table>
+                <tr>
+                    <td class="sheet-padding-right"><button type="roll" name="roll_monthac0" title="%{repeating_monstervariants_$X_monthac0}" value="@{wtype} strikes AC [[(@{monsterthac0})-(1d20+(?{Modifier?|0}))]]">ThAC0</button></td>
+                    <td class="sheet-padding-right"><button type="roll" name="roll_mondmg" title="%{repeating_monstervariants_$X_mondmg}" value="@{wtype} inflicts [[@{monsterdmg}]] damage!">Attack 1</button></td>
+                    <td class="sheet-padding-right"><button type="roll" name="roll_mondmg2" title="%{repeating_monstervariants_$X_mondmg2}" value="@{wtype} inflicts [[@{monsterdmg2}]] damage!">Attack 2</button></td>
+                    <td class="sheet-padding-right"><button type="roll" name="roll_mondmg3" title="%{repeating_monstervariants_$X_mondmg3}" value="@{wtype} inflicts [[@{monsterdmg3}]] damage!">Attack 3</button></td>
+                    <td class="sheet-padding-right"><button type="roll" name="roll_spcatk" title="%{repeating_monstervariants_$X_spcatk}" value="@{wtype} @{monsterspecattacks}">Special Attack</button></td>
+                    <td><input type="text" name="attr_monsterini" title="@{repeating_monstervariants_$X_monsterini}" class="sheet-short"></td>
+                    <td><button type="roll" name="roll_monini" title="%{repeating_monstervariants_$X_monini}" value="/gmroll [[{([[1d10]]+@{monsterini}-(?{Misc. bonus|+0})), 1}kh1]] [Initiative (@{character_name})]&{tracker}">Initiative</button></td>
+                </tr>
+            </table>
+            <br>
+            <table class="sheet-centering" style="width: 100%;">
+                <tr>
+                    <td><button type="roll" name="roll_monparsave" title="%{monparsave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monpartar} [@{character_name} Save versus Paralyzation]"><br>Para<br>Save</button></td>
+                    <td><button type="roll" name="roll_monpoisave" title="%{monpoisave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monpoitar} [@{character_name} Save versus Poison]"><br>Pois<br>Save</button></td>
+                    <td><button type="roll" name="roll_mondeasave" title="%{mondeasave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{mondeatar} [@{character_name} Save versus Death]"><br>Death<br>Save</button></td>
+                    <td><button type="roll" name="roll_monrodsave" title="%{monrodsave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monrodtar} [@{character_name} Save versus Rod]"><br>Rod<br>Save</button></td>
+                    <td><button type="roll" name="roll_monstasave" title="%{monstasave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monstatar} [@{character_name} Save versus Staff]"><br>Staff<br>Save</button></td>
+                    <td><button type="roll" name="roll_monwansave" title="%{monwansave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monwantar} [@{character_name} Save versus Wand]"><br>Wand<br>Save</button></td>
+                    <td><button type="roll" name="roll_monpetsave" title="%{monpetsave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monpettar} [@{character_name} Save versus Petrification]"><br>Pet<br>Save</button></td>
+                    <td><button type="roll" name="roll_monpolsave" title="%{monpolsave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monpoltar} [@{character_name} Save versus Polymorph]"><br>Poly<br>Save</button></td>
+                    <td><button type="roll" name="roll_monbresave" title="%{monbresave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monbretar} [@{character_name} Save versus Breath]"><br>Breath<br>Save</button></td>
+                    <td><button type="roll" name="roll_monspesave" title="%{monspesave}" value="/gmroll {d20+(?{Misc Modifier?|0})}>@{monspetar} [@{character_name} Save versus Spell]"><br>Spell<br>Save</button></td>
+                </tr>
+                <tr>
+                    <td><input type="text" name="attr_monpartar" title="@{monpartar}" class="sheet-small"></td>
+                    <td><input type="text" name="attr_monpoitar" title="@{monpoitar}" class="sheet-small"></td>
+                    <td><input type="text" name="attr_mondeatar" title="@{mondeatar}" class="sheet-small"></td>
+                    <td><input type="text" name="attr_monrodtar" title="@{monrodtar}" class="sheet-small"></td>
+                    <td><input type="text" name="attr_monstatar" title="@{monstatar}" class="sheet-small"></td>
+                    <td><input type="text" name="attr_monwantar" title="@{monwantar}" class="sheet-small"></td>
+                    <td><input type="text" name="attr_monpettar" title="@{monpettar}" class="sheet-small"></td>
+                    <td><input type="text" name="attr_monpoltar" title="@{monpoltar}" class="sheet-small"></td>
+                    <td><input type="text" name="attr_monbretar" title="@{monbretar}" class="sheet-small"></td>
+                    <td><input type="text" name="attr_monspetar" title="@{monspetar}" class="sheet-small"></td>
+                </tr>
+            </table>
+            <br>
+
+            <h4><b>Description</b></h4><br><textarea name="attr_monsterdesc" title="@{repeating_monstervariants_$X_monsterdesc}" placeholder="Description"></textarea>
+            <br>
+            <h4><b>Combat</b></h4><textarea name="attr_monstercombat" title="@{repeating_monstervariants_$X_monstercombat}"></textarea>
+            <br>
+            <h4><b>Habitat/Society</b></h4><textarea name="attr_monsterhabitat" title="@{repeating_monstervariants_$X_monsterhabitat}"></textarea>
+            <br>
+            <h4><b>Ecology</b></h4><textarea name="attr_monsterecology" title="@{repeating_monstervariants_$X_monsterecology}"></textarea>
+            <br>
+            <br>
+
+        </div>
+    </fieldset>
 </div>
 
 


### PR DESCRIPTION
- Added toggle for Public / GM only thac0 and attack
- Fixed newline in Choke wizard spell
- Fixed backslashes in level three wizard spells
- Updated changelog
- Bumped version

## Changes / Comments

Changes can be seen here: https://app.roll20.net/forum/permalink/9844117/

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [X] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
