### PR TITLE
Update Deadlands Classic (html)

### DIFF
--- a/Deadlands Classic/deadlandsclassic.html
+++ b/Deadlands Classic/deadlandsclassic.html
@@ -307,6 +307,18 @@
             <button type="roll" name="roll_GutsGrit" value="@{gmtoggle}&{template:simple}  {{rollname=Guts+Grit}} {{dice=[[@{gutslvl}@{spidtype}!!k1@{gutsmod}+@{grit}]]}}"></button>
           </div>
         </div>
+        <div class="sheet-col">
+          <div class="sheet-item sheet-xxxlarge"><label><b>Initiative</b></label></div>
+          <div class="sheet-item sheet-small">
+            <button type="roll" name="roll_Initiative" value="@{gmtoggle}&{template:simple}  {{rollname=Initiative}} {{dice=[[@{quilvl}@{quidtype}!!k1]]}}"></button>
+          </div>
+        </div>
+        <div class="sheet-col">
+          <div class="sheet-item sheet-xxxlarge"><label><b>Perception</b></label></div>
+          <div class="sheet-item sheet-small">
+            <button type="roll" name="roll_Perception" value="@{gmtoggle}&{template:simple}  {{rollname=Perception}} {{dice=[[@{coglvl}@{cogdtype}!!k1+@{scrutinizelvl}+@{searchlvl}+@{trackinlvl}]]}}"></button>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -886,7 +898,7 @@
             <div class="sheet-row">
               <div class="sheet-item sheet-xhuge"><label><b>Professional</b></label></div>
             </div>
-            <fieldset class="repeating_language">
+            <fieldset class="repeating_professional">
               <div class="sheet-row">
                 <div class="sheet-item sheet-large">&nbsp;</div>
                 <div class="sheet-item sheet-third"><input type="text" name="attr_professionalname" placeholder="Professional"></div>
@@ -904,7 +916,7 @@
             <div class="sheet-row">
               <div class="sheet-item sheet-xhuge"><label><b>Science</b></label></div>
             </div>
-            <fieldset class="repeating_language">
+            <fieldset class="repeating_science">
               <div class="sheet-row">
                 <div class="sheet-item sheet-large">&nbsp;</div>
                 <div class="sheet-item sheet-third"><input type="text" name="attr_sciencename" placeholder="Chemistry"></div>
@@ -922,7 +934,7 @@
             <div class="sheet-row">
               <div class="sheet-item sheet-xhuge"><label><b>Trade</b></label></div>
             </div>
-            <fieldset class="repeating_language">
+            <fieldset class="repeating_trade">
               <div class="sheet-row">
                 <div class="sheet-item sheet-large">&nbsp;</div>
                 <div class="sheet-item sheet-third"><input type="text" name="attr_tradename" placeholder="Blacksmithing"></div>
@@ -1033,7 +1045,7 @@
               <div class="sheet-item sheet-tiny">&nbsp;</div>
               <div class="sheet-item sheet-large"><input type="text" name="attr_survivalconcmod" placeholder="Mod"></div>
               <div class="sheet-itemright sheet-small">
-                <button type="roll" name="roll_Performin" value="@{gmtoggle}&{template:simple}  {{rollname=Survival @{survivalconname}}} {{dice=[[@{survivallvl}@{spidtype}!!k1+@{survivalconcmod}]]}}"></button>
+                <button type="roll" name="roll_Survival" value="@{gmtoggle}&{template:simple}  {{rollname=Survival @{survivalconname}}} {{dice=[[@{survivallvl}@{spidtype}!!k1+@{survivalconcmod}]]}}"></button>
               </div>
             </fieldset>
           </div>
@@ -1123,7 +1135,7 @@
             <fieldset class="repeating_fightin">
               <div class="sheet-row">
                 <div class="sheet-item sheet-large">&nbsp;</div>
-                <div class="sheet-item sheet-third"><input type="text" name="attr_fightinname" placeholder="Brawlin’"></div>
+                <div class="sheet-item sheet-third"><input type="text" name="attr_fightinname" placeholder="Brawlin'"></div>
                 <div class="sheet-item sheet-large"><input type="number" name="attr_fightinlvl" placeholder="Level"></div>
                 <div class="sheet-item sheet-tiny">+</div>
                 <div class="sheet-item sheet-large"><input type="text" name="attr_fightinmod" placeholder="Mod"></div>
@@ -1504,7 +1516,7 @@
       <div class="sheet-item sheet-small"><label><b>Range</b></label></div>
       <div class="sheet-item sheet-small"><label><b>Trait</b></label></div>
       <div class="sheet-item sheet-small"><label><b>TN</b></label></div>
-      <div class="sheet-item sheet-small"><label><b>Trait</b></label></div>
+      <div class="sheet-item sheet-small"><label><b>Hand</b></label></div>
       <div class="sheet-item sheet-large"><label><b>Notes</b></label></div>
 	</div>
       <fieldset class="repeating_spells" style="display: none;">
@@ -1513,9 +1525,9 @@
         <div class="sheet-item sheet-small"><input type="number" name="attr_spellspeed" placeholder="2"></div>
         <div class="sheet-item sheet-large"><input type="text" name="attr_spelldur" placeholder="Concentration"></div>
         <div class="sheet-item sheet-small"><input type="text" name="attr_spellran" placeholder="Self"></div>
-        <div class="sheet-item sheet-small"><input type="text" name="attr_spelltrait" placeholder="Smarts">
-        </div>
-        <div class="sheet-item sheet-small"><input type="text" name="attr_spelltn" placeholder="Target #"></div>>
+        <div class="sheet-item sheet-small"><input type="text" name="attr_spelltrait" placeholder="Smarts"></div>
+        <div class="sheet-item sheet-small"><input type="text" name="attr_spelltn" placeholder="Target #"></div>
+        <div class="sheet-item sheet-small"><input type="text" name="attr_spellhand" placeholder="2 pr"></div>
         <div class="sheet-item sheet-huge" style="width: 390px;">
           <textarea name="attr_spellnotes" class="sheet-shorttextarea" placeholder="Notes"></textarea>
         </div>
@@ -1532,7 +1544,7 @@
         <div class="sheet-col">
           <div class="sheet-row borderdiv">
             <h2>Edges</h2>
-          
+
           <fieldset class="repeating_edges">
             <div class="sheet-row sheet-textarea">
               <input type="text" name="attr_edgename" placeholder="Edge name"><br>
@@ -1544,7 +1556,7 @@
         <div class="sheet-col">
           <div class="sheet-row borderdiv">
             <h2>Hindrances</h2>
-          
+
           <fieldset class="repeating_hinds">
             <div class="sheet-row sheet-textarea">
               <input type="text" name="attr_hindname" placeholder="Hindrance name"><br>
@@ -1558,7 +1570,7 @@
         <div class="sheet-col">
           <div class="sheet-row borderdiv">
             <h2>Equipment</h2>
-          
+
           <div class="sheet-row sheet-textarea">
             <textarea name="attr_equipment" class="sheet-textarea" placeholder="Equipment"></textarea>
           </div>
@@ -1567,7 +1579,7 @@
         <div class="sheet-col">
           <div class="sheet-row borderdiv">
           <h2>Money</h2>
-          
+
           <div class="sheet-row sheet-textarea">
             <textarea name="attr_money" class="sheet-textarea" placeholder="Money"></textarea>
           </div>
@@ -1578,7 +1590,7 @@
         <div class="sheet-col">
           <div class="sheet-row borderdiv">
             <h2>Your Worst Nightmare</h2>
-          
+
           <div class="sheet-row sheet-textarea">
             <textarea name="attr_nightmare" class="sheet-textarea" placeholder="Elm Street"></textarea>
           </div>
@@ -1587,7 +1599,7 @@
         <div class="sheet-col">
           <div class="sheet-row borderdiv">
             <h2>Character Notes</h2>
-          
+
           <div class="sheet-row sheet-textarea">
             <textarea name="attr_notes" class="sheet-textarea" placeholder="Notes"></textarea>
           </div>


### PR DESCRIPTION
Added two common rolls (initiative and perception) to the Core tab.
Updated a few of the skills with concentrations to have their concentrations be separate classes rather than all linked with the same name (language) so they can be added/deleted separately.
Fixed roll name for survival (was performin).
Changed placeholder in Fightin to use (') rather than (`) like the rest of the sheet.
Replaced second instance of TN in arcane abilities with Hand.

## Changes / Comments






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
