### PR TITLE
[StarWars5e] Fix to encumbered not displaying on StarWars5e

### DIFF
--- a/StarWars5E/StarWars5E_HTML.html
+++ b/StarWars5E/StarWars5E_HTML.html
@@ -10072,9 +10072,6 @@
         getSectionIDs("repeating_inventory", function(idarray) {
             update_inventory_from_weight_change("repeating_inventory_", idarray, "weighttotal");
         });
-        getSectionIDs("repeating_hiddeninventory", function(idarray) {
-            update_inventory_from_weight_change("repeating_hiddeninventory_", idarray, "hiddenweighttotal");
-        });
     };
 
     var update_inventory_from_weight_change = function (inventory, idarray, weightAttrToUpdate){


### PR DESCRIPTION
Removed the attempt to calculate the weight for the ships cargo inventory, it does solve the error and allow the encumbered message to display, but now a ship will not be warned when it is over capacity
Though, the calculation for a ship being overcapacity is wrong, as it before used the same method as the pc sheet when it should rely on fixed values dependant on it's size
https://sw5e.com/rules/sotg/equipment#cargo-capacity
The ship sheet also doesn't have the text display fields for the encumbered message, so it shouldn't matter anyway

Fixes #8413

## Changes / Comments






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
