### PR TITLE
Serenity: Page breaks, print backgrounds, advancement points

### DIFF
--- a/Serenity/serenity.css
+++ b/Serenity/serenity.css
@@ -18,7 +18,7 @@
     margin: 0;
     font-family: "Papyrus", serif;
     border-collapse: separate;
-    line-height: normal;
+    line-height: 1.42857143;
     vertical-align: middle;
 }
 
@@ -57,7 +57,7 @@
     top: -15px;
     left: 10px;
     padding: 0 5px;
-    background-color: white;
+    background-color: white !important;
     text-align: left;
     font-weight: bold;
     font-size: 125%;
@@ -78,6 +78,12 @@
     clear: both;
     display: block;
     margin-bottom: 15px;
+}
+
+@media print {
+    .sheet-serenity-charactersheet .sheet-serenity-float-group {
+        page-break-inside: avoid;
+    }
 }
 
 .sheet-serenity-charactersheet .sheet-serenity-asset-specialization,
@@ -206,20 +212,20 @@
 
 .sheet-serenity-charactersheet .sheet-character-life-points .sheet-serenity-stuns-taken {
     border-radius: 30px 0 0 0;
-    background-color: #e8af20;
-    background-image: linear-gradient(left, #e8af20, #c93f00);
+    background-color: #e8af20 !important;
+    background-image: linear-gradient(left, #e8af20, #c93f00) !important;
 }
 
 .sheet-serenity-charactersheet .sheet-character-life-points .sheet-serenity-wounds-taken {
     border-radius: 0 0 30px 0;
-    background-color: #c93f00;
-    background-image: linear-gradient(left, #c93f00, #e8af20);
+    background-color: #c93f00 !important;
+    background-image: linear-gradient(left, #c93f00, #e8af20) !important;
 }
 
 .sheet-serenity-charactersheet .sheet-character-life-points .sheet-serenity-shocks-taken {
     border-radius: 0 0 30px 30px;
-    background-color: #cedce7;
-    background-image: linear-gradient(to right, #cedce7, #596a72);
+    background-color: #cedce7 !important;
+    background-image: linear-gradient(to right, #cedce7, #596a72) !important;
     display: flex;
     width: 475px;
     padding-left: 15px;
@@ -526,7 +532,7 @@
     bottom: 0;
     right: 0;
     cursor: pointer;
-    background-color: lightgrey;
+    background-color: lightgrey !important;
     box-shadow: 1px 1px 2px #333;
     font-size: 150%;
     font-weight: bold;
@@ -537,7 +543,7 @@
     border: none;
     box-shadow: none;
     content: 'S';
-    background: #e8af20;
+    background: #e8af20 !important;
 }
 
 .sheet-serenity-charactersheet .sheet-character-life-points .sheet-serenity-stuns-taken input+span:before {
@@ -555,7 +561,7 @@
     bottom: 0;
     right: 0;
     cursor: pointer;
-    background-color: lightgrey;
+    background-color: lightgrey !important;
     box-shadow: 1px 1px 2px #333;
 }
 
@@ -578,7 +584,7 @@
 
 .sheet-serenity-charactersheet .sheet-character-life-points input[type="radio"]:checked:not(.sheet-serenity-stun0).sheet-serenity-stun+span:before,
 .sheet-serenity-charactersheet .sheet-character-life-points input[type="radio"]:checked.sheet-serenity-stun~input:not(.sheet-serenity-stun0).sheet-serenity-stun+span:before {
-    background-color: red;
+    background-color: red !important;
 }
 
 .sheet-serenity-charactersheet .sheet-character-life-points .sheet-serenity-wound0 {
@@ -881,7 +887,7 @@
     bottom: 0;
     right: 0;
     cursor: pointer;
-    background-color: lightgrey;
+    background-color: lightgrey !important;
     box-shadow: 1px 1px 2px #333;
     font-size: 150%;
     font-weight: bold;
@@ -892,7 +898,7 @@
     border: none;
     box-shadow: none;
     content: 'W';
-    background: #e8af20;
+    background: #e8af20 !important;
 }
 
 .sheet-serenity-charactersheet .sheet-character-life-points .sheet-serenity-wounds-taken input+span:before {
@@ -910,7 +916,7 @@
     bottom: 0;
     right: 0;
     cursor: pointer;
-    background-color: lightgrey;
+    background-color: lightgrey !important;
     box-shadow: 1px 1px 2px #333;
 }
 
@@ -933,7 +939,7 @@
 
 .sheet-serenity-charactersheet .sheet-character-life-points input[type="radio"]:checked:not(.sheet-serenity-wound0).sheet-serenity-wound+span:before,
 .sheet-serenity-charactersheet .sheet-character-life-points input[type="radio"]:checked.sheet-serenity-wound~input:not(.sheet-serenity-wound0).sheet-serenity-wound+span:before {
-    background-color: red;
+    background-color: red !important;
 }
 
 .sheet-serenity-charactersheet .sheet-character-life-points .sheet-serenity-shock0 {
@@ -1113,7 +1119,7 @@
     bottom: 0;
     right: 0;
     cursor: pointer;
-    background-color: lightgrey;
+    background-color: lightgrey !important;
     box-shadow: 1px 1px 2px #333;
     width: 24px;
     height: 24px;
@@ -1126,8 +1132,8 @@
     border: none;
     box-shadow: none;
     content: 'Shock';
-    background-color: #cedce7;
-    background-image: linear-gradient(to right, #cedce7, #c0ccd6);
+    background-color: #cedce7 !important;
+    background-image: linear-gradient(to right, #cedce7, #c0ccd6) !important;
     font-size: 100%;
     top: 0;
     right: 25px;
@@ -1146,7 +1152,7 @@
     bottom: 0;
     right: 0;
     cursor: pointer;
-    background-color: lightgrey;
+    background-color: lightgrey !important;
     box-shadow: 1px 1px 2px #333;
     width: 24px;
     height: 24px;
@@ -1171,7 +1177,7 @@
 
 .sheet-serenity-charactersheet .sheet-character-life-points input[type="radio"]:checked:not(.sheet-serenity-shock0).sheet-serenity-shock+span:before,
 .sheet-serenity-charactersheet .sheet-character-life-points input[type="radio"]:checked.sheet-serenity-shock~input:not(.sheet-serenity-shock0).sheet-serenity-shock+span:before {
-    background-color: red;
+    background-color: red !important;
 }
 
 .sheet-serenity-charactersheet .sheet-character-life-points input[type="radio"].sheet-serenity-shock0 {
@@ -1223,11 +1229,27 @@
     font-size: 60%;
 }
 
+.sheet-serenity-charactersheet .sheet-serenity-advancement-points {
+    height: 55px;
+    width: 330px;
+    float: right;
+    margin-top: 15px;
+}
+
+.sheet-serenity-charactersheet .sheet-serenity-advancement-points input {
+    width: 100%;
+}
+
 .sheet-serenity-charactersheet .sheet-serenity-plot-points {
-    height: 230px;
+    height: 160px;
     width: 330px;
     position: relative;
     float: right;
+}
+
+.sheet-serenity-charactersheet .sheet-serenity-plot-points .sheet-serenity-plot-points-notes {
+    font-size: small;
+    padding: 10px;
 }
 
 .sheet-serenity-charactersheet .sheet-serenity-plot-points .sheet-serenity-plot-points-input {
@@ -1405,7 +1427,7 @@
     bottom: 0;
     right: 0;
     cursor: pointer;
-    background-color: lightgrey;
+    background-color: lightgrey !important;
     box-shadow: 1px 1px 2px #333;
     font-family: "Papyrus", serif;
     font-weight: bold;
@@ -1426,7 +1448,7 @@
     bottom: 0;
     right: 0;
     cursor: pointer;
-    background-color: lightgrey;
+    background-color: lightgrey !important;
     box-shadow: 1px 1px 2px #333;
 }
 
@@ -1448,34 +1470,15 @@
 
 .sheet-serenity-charactersheet .sheet-serenity-plot-points input[type="radio"]:checked:not(.sheet-serenity-plotpoint0).sheet-serenity-plotpoint+span:before,
 .sheet-serenity-charactersheet .sheet-serenity-plot-points input[type="radio"]:checked.sheet-serenity-plotpoint~input:not(.sheet-serenity-plotpoint0).sheet-serenity-plotpoint+span:before {
-    background-color: #e8af20;
+    background-color: #e8af20 !important;
 }
 
 .sheet-serenity-charactersheet .sheet-serenity-plot-points .sheet-serenity-plotpoint0:checked+span:before {
-    background-color: darkgrey;
+    background-color: darkgrey !important;
 }
 
 .sheet-serenity-charactersheet .sheet-serenity-plot-points .sheet-serenity-plotpoint0:active+span:before {
     border: 2px inset grey;
-}
-
-.sheet-serenity-charactersheet .sheet-serenity-plot-points table {
-    font-size: 10pt;
-    white-space: nowrap;
-    bottom: 0;
-    position: absolute;
-}
-
-.sheet-serenity-charactersheet .sheet-serenity-plot-points td:first-child {
-    border-right: 1px solid grey;
-    padding-right: 5px;
-    padding-bottom: 5px;
-    text-align: right;
-}
-
-.sheet-serenity-charactersheet .sheet-serenity-plot-points td:last-child {
-    padding-left: 2px;
-    text-align: left;
 }
 
 .sheet-serenity-charactersheet .sheet-character-skills {
@@ -1709,6 +1712,7 @@
     z-index: 1;
     text-align: left;
     font-size: 12pt;
+    font-weight: normal;
     /* vertically center */
     top: 50%;
     -webkit-transform: translateY(-50%);
@@ -1717,7 +1721,7 @@
     width: 400px;
     padding: 10px;
     border-radius: 10px;
-    background: #111111;
+    background: #111111 !important;
     color: #CCC;
     opacity: 0;
     transition: 0.3s opacity;
@@ -1730,7 +1734,7 @@
 
 .sheet-serenity-charactersheet .sheet-serenity-tooltip .sheet-serenity-tooltip-text table {
     color: inherit;
-    margin: 5px;
+    margin: 5px auto;
     border-spacing: 0;
 }
 
@@ -1744,6 +1748,7 @@
 
 .sheet-serenity-charactersheet .sheet-serenity-tooltip .sheet-serenity-tooltip-text table th {
     text-align: center;
+    padding: 0 8px;
 }
 
 .sheet-serenity-charactersheet .sheet-serenity-tooltip .sheet-serenity-tooltip-text table tr:first-child td {

--- a/Serenity/serenity.html
+++ b/Serenity/serenity.html
@@ -936,7 +936,35 @@
         </div>
         <!-- PLOT POINTS -->
         <div class="sheet-serenity-fieldset sheet-serenity-plot-points">
-          <span class="sheet-serenity-fieldset-title">Plot Points</span>
+          <span class="sheet-serenity-tooltip sheet-serenity-fieldset-title">
+            Plot Points
+            <span class="sheet-serenity-tooltip-text">
+              Plot Points are a way for major characters in the game to add a
+              little drama to the story. Plot Points can be used to improve the
+              odds for important actions, prevent someone from getting killed or
+              badly injured, or even used to alter the story.
+              <table>
+                <tbody>
+                  <tr>
+                    <td>Reduce Damage</td>
+                    <td>+1 Step per Point / +1 LP after</td>
+                  </tr>
+                  <tr>
+                    <td>Add to Rolls</td>
+                    <td>+1 Step per Point / +1 to roll after</td>
+                  </tr>
+                  <tr>
+                    <td>Utilize Assets</td>
+                    <td>See Asset description, 1-6 Points</td>
+                  </tr>
+                  <tr>
+                    <td>Affect Plot</td>
+                    <td>GM discretion, can use 1-12 Points</td>
+                  </tr>
+                </tbody>
+              </table>
+            </span>
+          </span>
 
           <div class="sheet-serenity-plot-points-input">
             <input
@@ -1032,26 +1060,74 @@
               name="attr_plotpoints"
             /><span></span>
           </div>
-          <table border="0" cellspacing="0" cellpadding="0">
-            <tbody>
-              <tr>
-                <td>Reduce Damage</td>
-                <td>+1 Step per Point / +1 LP after</td>
-              </tr>
-              <tr>
-                <td>Add to Rolls</td>
-                <td>+1 Step per Point / +1 to roll after</td>
-              </tr>
-              <tr>
-                <td>Utilize Assets</td>
-                <td>See Asset description, 1-6 Points</td>
-              </tr>
-              <tr>
-                <td>Affect Plot</td>
-                <td>GM discretion, can use 1-12 Points</td>
-              </tr>
-            </tbody>
-          </table>
+
+          <div class="sheet-serenity-plot-points-notes">
+            Plot points above 6 are converted to Advancement points at the end
+            of each session.
+          </div>
+        </div>
+        <!-- ADVANCEMENT POINTS -->
+        <div class="sheet-serenity-fieldset sheet-serenity-advancement-points">
+          <span class="sheet-serenity-tooltip sheet-serenity-fieldset-title">
+            Advancement Points
+            <span class="sheet-serenity-tooltip-text">
+              Advancement Points represent the accumulation of experience and
+              are the building blocks for improvement.
+              <table class="sheet-serenity-tooltip-table-center">
+                <tbody>
+                  <tr>
+                    <th>Die</th>
+                    <th>Skill cost</th>
+                    <th>Attribute cost</th>
+                  </tr>
+                  <tr>
+                    <td>d2</td>
+                    <td>2</td>
+                    <td>–</td>
+                  </tr>
+                  <tr>
+                    <td>d4</td>
+                    <td>4</td>
+                    <td>–</td>
+                  </tr>
+                  <tr>
+                    <td>d6</td>
+                    <td>6</td>
+                    <td>24</td>
+                  </tr>
+                  <tr>
+                    <td>d8</td>
+                    <td>8</td>
+                    <td>32</td>
+                  </tr>
+                  <tr>
+                    <td>d10</td>
+                    <td>10</td>
+                    <td>40</td>
+                  </tr>
+                  <tr>
+                    <td>d12</td>
+                    <td>12</td>
+                    <td>48</td>
+                  </tr>
+                  <tr>
+                    <td>d12 + d2</td>
+                    <td>14</td>
+                    <td>56</td>
+                  </tr>
+                  <tr>
+                    <td>d12 + d4</td>
+                    <td>16</td>
+                    <td>64</td>
+                  </tr>
+                </tbody>
+              </table>
+            </span>
+          </span>
+
+          <div class="sheet-serenity-advancement-points-input">
+            <input type="number" name="attr_advancement_points" />
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Changes / Comments
* Prevent printing from putting page breaks inside float groups
* Maintain needed backgrounds while printing
* Add advancement point attribute
* Fix line-spacing bug in some browsers

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
  - New Attribute, player data not impacted
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
