### PR TITLE
Twilight 2000 4th Edition | Additional vehicle weapons

### DIFF
--- a/T2K 4e/twilight-2k-4e.css
+++ b/T2K 4e/twilight-2k-4e.css
@@ -551,27 +551,32 @@ textarea {
     margin-top: 16px;
     padding-top: 8px;
 }
-.sheet-custom-roll.sheet-die-roll {
+.sheet-custom-roll-base-attributes-info {
     grid-row: 1;
+    grid-column: 1/15;
+    padding-bottom: 12px;
+}
+.sheet-custom-roll.sheet-die-roll {
+    grid-row: 2;
     grid-column: 1;
 }
 .sheet-custom-roll.sheet-die-one {
-    grid-row: 1;
+    grid-row: 2;
     grid-column: 2/4;
 }
 .sheet-custom-roll.sheet-die-two {
-    grid-row: 1;
+    grid-row: 2;
     grid-column: 4/6;
 }
 .sheet-custom-roll.sheet-die-ammo {
-    grid-row: 1;
+    grid-row: 2;
     grid-column: 6/11;
 }
 .sheet-custom-roll-select.sheet-short {
-    width: 3em;
+    width: 4.5em;
 }
 .sheet-coolness-under-fire {
-    grid-row: 1;
+    grid-row: 2;
     grid-column: 12/14;
     display: grid;
     margin-top: -10px;

--- a/T2K 4e/twilight-2k-4e.css
+++ b/T2K 4e/twilight-2k-4e.css
@@ -1237,11 +1237,14 @@ input[type=number].sheet-number-input.sheet-gear-weight {
 .sheet-vehicle-armor-front {
     grid-column: 2;
 }
-.sheet-vehicle-armor-side {
+.sheet-vehicle-armor-left {
     grid-column: 3;
 }
-.sheet-vehicle-armor-rear {
+.sheet-vehicle-armor-right {
     grid-column: 4;
+}
+.sheet-vehicle-armor-rear {
+    grid-column: 5;
 }
 .sheet-vehicle-fuel {
     grid-column: 6;

--- a/T2K 4e/twilight-2k-4e.html
+++ b/T2K 4e/twilight-2k-4e.html
@@ -1207,7 +1207,8 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=Coolnes
         <!-- ROW THREE -->
         <span class="vehicle-header input-label vehicle-armor">Armor</span>
         <span class="vehicle-header minor vehicle-armor-front">Front</span>
-        <span class="vehicle-header minor vehicle-armor-side">Side</span>
+        <span class="vehicle-header minor vehicle-armor-left">left</span>
+        <span class="vehicle-header minor vehicle-armor-right">right</span>
         <span class="vehicle-header minor vehicle-armor-rear">Rear</span>
 
         <span class="vehicle-header input-label vehicle-fuel">Fuel</span>
@@ -1218,7 +1219,8 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=Coolnes
 
         <!-- ROW FOUR -->
         <input type="number" name="attr_vehicle_one_armor_front" class="number-input no-spin-input vehicle-one vehicle-armor-front" />
-        <input type="number" name="attr_vehicle_one_armor_side" class="number-input no-spin-input vehicle-one vehicle-armor-side" />
+        <input type="number" name="attr_vehicle_one_armor_left" class="number-input no-spin-input vehicle-one vehicle-armor-left" />
+        <input type="number" name="attr_vehicle_one_armor_right" class="number-input no-spin-input vehicle-one vehicle-armor-right" />
         <input type="number" name="attr_vehicle_one_armor_rear" class="number-input no-spin-input vehicle-one vehicle-armor-rear" />
         <select name='attr_vehicle_one_fuel_type' class="vehicle-one vehicle-fuel-type short">
             <option value=''> - </option>
@@ -1371,7 +1373,8 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=Coolnes
         <!-- ROW THREE -->
         <span class="vehicle-header input-label vehicle-armor">Armor</span>
         <span class="vehicle-header minor vehicle-armor-front">Front</span>
-        <span class="vehicle-header minor vehicle-armor-side">Side</span>
+        <span class="vehicle-header minor vehicle-armor-left">Left</span>
+        <span class="vehicle-header minor vehicle-armor-right">Right</span>
         <span class="vehicle-header minor vehicle-armor-rear">Rear</span>
 
         <span class="vehicle-header input-label vehicle-fuel">Fuel</span>
@@ -1382,7 +1385,8 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=Coolnes
     
         <!-- ROW FOUR -->
         <input type="number" name="attr_vehicle_two_armor_front" class="number-input no-spin-input vehicle-one vehicle-armor-front" />
-        <input type="number" name="attr_vehicle_two_armor_side" class="number-input no-spin-input vehicle-one vehicle-armor-side" />
+        <input type="number" name="attr_vehicle_two_armor_left" class="number-input no-spin-input vehicle-one vehicle-armor-left" />
+        <input type="number" name="attr_vehicle_two_armor_right" class="number-input no-spin-input vehicle-one vehicle-armor-right" />
         <input type="number" name="attr_vehicle_two_armor_rear" class="number-input no-spin-input vehicle-one vehicle-armor-rear" />
         <select name='attr_vehicle_two_fuel_type' class="vehicle-one vehicle-fuel-type short">
             <option value=''> - </option>
@@ -1535,7 +1539,8 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=Coolnes
         <!-- ROW THREE -->
         <span class="vehicle-header input-label vehicle-armor">Armor</span>
         <span class="vehicle-header minor vehicle-armor-front">Front</span>
-        <span class="vehicle-header minor vehicle-armor-side">Side</span>
+        <span class="vehicle-header minor vehicle-armor-left">Left</span>
+        <span class="vehicle-header minor vehicle-armor-right">Right</span>
         <span class="vehicle-header minor vehicle-armor-rear">Rear</span>
 
         <span class="vehicle-header input-label vehicle-fuel">Fuel</span>
@@ -1546,7 +1551,8 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=Coolnes
     
         <!-- ROW FOUR -->
         <input type="number" name="attr_vehicle_three_armor_front" class="number-input no-spin-input vehicle-one vehicle-armor-front" />
-        <input type="number" name="attr_vehicle_three_armor_side" class="number-input no-spin-input vehicle-one vehicle-armor-side" />
+        <input type="number" name="attr_vehicle_three_armor_left" class="number-input no-spin-input vehicle-one vehicle-armor-left" />
+        <input type="number" name="attr_vehicle_three_armor_right" class="number-input no-spin-input vehicle-one vehicle-armor-right" />
         <input type="number" name="attr_vehicle_three_armor_rear" class="number-input no-spin-input vehicle-one vehicle-armor-rear" />
         <select name='attr_vehicle_three_fuel_type' class="vehicle-one vehicle-fuel-type short">
             <option value=''> - </option>

--- a/T2K 4e/twilight-2k-4e.html
+++ b/T2K 4e/twilight-2k-4e.html
@@ -166,7 +166,7 @@
             <!-- ROW TWO: HEAVY WEAPONS -->
             <span class="heavy-weapons-skill minor attribute-label">Heavy Weapons</span>
             <select name='attr_heavyweapons' class="heavy-weapons-skill short attribute-select">
-                <option value=''> - </option>
+                <option value='-'> - </option>
                 <option value='A'>A</option>
                 <option value='B'>B</option>
                 <option value='C'>C</option>
@@ -177,7 +177,7 @@
             <!-- ROW THREE: CLOSE COMBAT -->
             <span class="close-combat-skill minor attribute-label">Close Combat</span>
             <select name='attr_closecombat' class="close-combat-skill short attribute-select">
-                <option value=''> - </option>
+                <option value='-'> - </option>
                 <option value='A'>A</option>
                 <option value='B'>B</option>
                 <option value='C'>C</option>
@@ -188,7 +188,7 @@
             <!-- ROW FOUR: STAMINA -->
             <span class="stamina-skill minor attribute-label">Stamina</span>
             <select name='attr_stamina' class="stamina-skill short attribute-select">
-                <option value=''> - </option>
+                <option value='-'> - </option>
                 <option value='A'>A</option>
                 <option value='B'>B</option>
                 <option value='C'>C</option>
@@ -211,7 +211,7 @@
             <!-- ROW TWO: DRIVING -->
             <span class="driving-skill minor attribute-label">Driving</span>
             <select name='attr_driving' class="driving-skill short attribute-select">
-                <option value=''> - </option>
+                <option value='-'> - </option>
                 <option value='A'>A</option>
                 <option value='B'>B</option>
                 <option value='C'>C</option>
@@ -222,7 +222,7 @@
             <!-- ROW THREE: MOBILITY -->
             <span class="mobility-skill minor attribute-label">Mobility</span>
             <select name='attr_mobility' class="mobility-skill short attribute-select">
-                <option value=''> - </option>
+                <option value='-'> - </option>
                 <option value='A'>A</option>
                 <option value='B'>B</option>
                 <option value='C'>C</option>
@@ -233,7 +233,7 @@
             <!-- ROW TWO: RANGED COMBAT -->
             <span class="ranged-combat-skill minor attribute-label">Ranged Combat</span>
             <select name='attr_rangedcombat' class="ranged-combat-skill short attribute-select">
-                <option value=''> - </option>
+                <option value='-'> - </option>
                 <option value='A'>A</option>
                 <option value='B'>B</option>
                 <option value='C'>C</option>
@@ -257,7 +257,7 @@
             <!-- ROW TWO: RECON -->
             <span class="recon-skill minor attribute-label">Recon</span>
             <select name='attr_recon' class="recon-skill short attribute-select">
-                <option value=''> - </option>
+                <option value='-'> - </option>
                 <option value='A'>A</option>
                 <option value='B'>B</option>
                 <option value='C'>C</option>
@@ -268,7 +268,7 @@
             <!-- ROW THREE: SURVIVAL -->
             <span class="survival-skill minor attribute-label">Survival</span>
             <select name='attr_survival' class="survival-skill short attribute-select">
-                <option value=''> - </option>
+                <option value='-'> - </option>
                 <option value='A'>A</option>
                 <option value='B'>B</option>
                 <option value='C'>C</option>
@@ -279,7 +279,7 @@
             <!-- ROW TWO: TECH -->
             <span class="tech-skill minor attribute-label">Tech</span>
             <select name='attr_tech' class="tech-skill short attribute-select">
-                <option value=''> - </option>
+                <option value='-'> - </option>
                 <option value='A'>A</option>
                 <option value='B'>B</option>
                 <option value='C'>C</option>
@@ -303,7 +303,7 @@
             <!-- ROW TWO: COMMAND -->
             <span class="command-skill minor attribute-label">Command</span>
             <select name='attr_command' class="command-skill short attribute-select">
-                <option value=''> - </option>
+                <option value='-'> - </option>
                 <option value='A'>A</option>
                 <option value='B'>B</option>
                 <option value='C'>C</option>
@@ -314,7 +314,7 @@
             <!-- ROW THREE: MANIPULATION -->
             <span class="manipulation-skill minor attribute-label">Manipulation</span>
             <select name='attr_manipulation' class="manipulation-skill short attribute-select">
-                <option value=''> - </option>
+                <option value='-'> - </option>
                 <option value='A'>A</option>
                 <option value='B'>B</option>
                 <option value='C'>C</option>
@@ -325,7 +325,7 @@
             <!-- ROW TWO: MEDICAL AID -->
             <span class="medical-aid-skill minor attribute-label">Medical Aid</span>
             <select name='attr_medical-aid' class="medical-aid-skill short attribute-select">
-                <option value=''> - </option>
+                <option value='-'> - </option>
                 <option value='A'>A</option>
                 <option value='B'>B</option>
                 <option value='C'>C</option>
@@ -442,10 +442,10 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=General
         <div class="custom-roll die-one">
             <span class="input-label attribute-label">Die 1</span>
             <select name='attr_rawdie1' class="custom-roll-select short">
-                <option value='12'>d12</option>
-                <option value='10'>d10</option>
-                <option value='8' selected="selected">d8</option>
-                <option value='6'>d6</option>
+                <option value='12'>A: d12</option>
+                <option value='10'>B: d10</option>
+                <option value='8' selected="selected">C: d8</option>
+                <option value='6'>D: d6</option>
             </select>
         </div>
 
@@ -453,10 +453,10 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=General
             <span class="input-label attribute-label">Die 2</span>
             <select name='attr_rawdie2' class="custom-roll-select short">
                 <option value='0'> - </option>
-                <option value='12'>d12</option>
-                <option value='10'>d10</option>
-                <option value='8' selected="selected">d8</option>
-                <option value='6'>d6</option>
+                <option value='12'>A: d12</option>
+                <option value='10'>B: d10</option>
+                <option value='8' selected="selected">C: d8</option>
+                <option value='6'>D: d6</option>
             </select>
         </div>
 
@@ -480,9 +480,17 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=General
     <input type="hidden" class="tab-weapons" name="attr_tab_weapon" value="tab_weapon_one"/>
     <div class="weapons-section">
         <button type="action" name="act_tab_weapon_one" class="action-tab weapons-header weapon-button-one">Weapons I-V</button>
-        <button type="action" name="act_tab_weapon_two" class="action-tab weapons-header weapon-button-two">Weapons VI-X</button>    
+        <button type="action" name="act_tab_weapon_two" class="action-tab weapons-header weapon-button-two">Weapons VI-X</button>
 
         <div class="custom-rolls-section weapons-rolls-section">
+            <div class="custom-roll-base-attributes-info">
+                <span class="input-label attribute-label">Strength: <span name="attr_strength"></span>&emsp;</span>
+                <span class="input-label attribute-label">Agility: <span name="attr_agility"></span>&emsp;</span>
+                <span class="input-label attribute-label">Heavy Weapons: <span name="attr_heavyweapons"></span>&emsp;</span>
+                <span class="input-label attribute-label">Close Combat: <span name="attr_closecombat"></span>&emsp;</span>
+                <span class="input-label attribute-label">Ranged Combat: <span name="attr_rangedcombat"></span>&emsp;</span>
+            </div>
+
             <div class="custom-roll die-roll">
                 <button type="roll" name="roll_rawdice" class="custom-roll attribute-button"
     value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=General Dice Roll}} {{roll-die-one=[[1d@{rawdie1}]] }} {{roll-die-two=[[1d@{rawdie2}]] }} {{roll-one-type=[[@{rawdie1}]]}} {{roll-two-type=[[@{rawdie2}]]}} {{ammo-dice=[[@{rawammo}]] }} {{ammo-roll-one=[[1d6]] }} {{ammo-roll-two=[[1d6]] }} {{ammo-roll-three=[[1d6]] }} {{ammo-roll-four=[[1d6]] }} {{ammo-roll-five=[[1d6]] }} {{ammo-roll-six=[[1d6]] }}"></button>
@@ -491,10 +499,10 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=General
             <div class="custom-roll die-one">
                 <span class="input-label attribute-label">Attr</span>
                 <select name='attr_rawdie1' class="custom-roll-select short">
-                    <option value='12'>d12</option>
-                    <option value='10'>d10</option>
-                    <option value='8' selected="selected">d8</option>
-                    <option value='6'>d6</option>
+                    <option value='12'>A: d12</option>
+                    <option value='10'>B: d10</option>
+                    <option value='8' selected="selected">C: d8</option>
+                    <option value='6'>D: d6</option>
                 </select>
             </div>
     
@@ -502,10 +510,10 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=General
                 <span class="input-label attribute-label">Skill</span>
                 <select name='attr_rawdie2' class="custom-roll-select short">
                     <option value='0'> - </option>
-                    <option value='12'>d12</option>
-                    <option value='10'>d10</option>
-                    <option value='8' selected="selected">d8</option>
-                    <option value='6'>d6</option>
+                    <option value='12'>A: d12</option>
+                    <option value='10'>B: d10</option>
+                    <option value='8' selected="selected">C: d8</option>
+                    <option value='6'>D: d6</option>
                 </select>
             </div>
     
@@ -1118,10 +1126,10 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=General
         <div class="custom-roll die-one">
             <span class="input-label attribute-label">Attr</span>
             <select name='attr_rawdie1' class="custom-roll-select short">
-                <option value='12'>d12</option>
-                <option value='10'>d10</option>
-                <option value='8' selected="selected">d8</option>
-                <option value='6'>d6</option>
+                <option value='12'>A: d12</option>
+                <option value='10'>B: d10</option>
+                <option value='8' selected="selected">C: d8</option>
+                <option value='6'>D: d6</option>
             </select>
         </div>
 
@@ -1129,10 +1137,10 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=General
             <span class="input-label attribute-label">Skill</span>
             <select name='attr_rawdie2' class="custom-roll-select short">
                 <option value='0'> - </option>
-                <option value='12'>d12</option>
-                <option value='10'>d10</option>
-                <option value='8' selected="selected">d8</option>
-                <option value='6'>d6</option>
+                <option value='12'>A: d12</option>
+                <option value='10'>B: d10</option>
+                <option value='8' selected="selected">C: d8</option>
+                <option value='6'>D: d6</option>
             </select>
         </div>
 
@@ -1236,7 +1244,6 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=Coolnes
             <span class="weapons-header minor weapon-range">Range</span>
             <span class="weapons-header minor weapon-mag">Mag</span>
             <span class="weapons-header minor weapon-armor">Armor</span>
-            <span class="weapons-header minor weapon-weight">Weight</span>
             <span class="weapons-header minor weapon-spent">Spent</span>
 
             <!-- ROW TWO -->
@@ -1266,7 +1273,6 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=Coolnes
             <input type="number" name="attr_vehicle_one_weapon_one_range" class="number-input no-spin-input weapons-one weapon-range" />
             <input type="number" name="attr_vehicle_one_weapon_one_mag" class="number-input no-spin-input weapons-one weapon-mag" />
             <input type="number" name="attr_vehicle_one_weapon_one_armor" class="number-input no-spin-input weapons-one weapon-armor" />
-            <input type="number" name="attr_vehicle_one_weapon_one_weight" class="number-input no-spin-input weapons-one weapon-weight" />
             <input type="number" name="attr_vehicle_one_weapon_one_spent_ammo" class="number-input no-spin-input weapons-one weapon-spent" />
 
             <!-- ROW THREE -->
@@ -1296,8 +1302,36 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=Coolnes
             <input type="number" name="attr_vehicle_one_weapon_two_range" class="number-input no-spin-input weapons-two weapon-range" />
             <input type="number" name="attr_vehicle_one_weapon_two_mag" class="number-input no-spin-input weapons-two weapon-mag" />
             <input type="number" name="attr_vehicle_one_weapon_two_armor" class="number-input no-spin-input weapons-two weapon-armor" />
-            <input type="number" name="attr_vehicle_one_weapon_two_weight" class="number-input no-spin-input weapons-two weapon-weight" />
             <input type="number" name="attr_vehicle_one_weapon_two_spent_ammo" class="number-input no-spin-input weapons-two weapon-spent" />
+
+            <!-- ROW FOUR -->
+            <div class="weapons-three weapon-attack">
+                <button type="roll" name="roll_rawdice" class="custom-roll attribute-button"
+                value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=@{vehicle_one_weapon_three_name} }} {{roll-die-one=[[1d@{rawdie1}]] }} {{roll-die-three=[[1d@{rawdie2}]] }} {{roll-one-type=[[@{rawdie1}]]}} {{roll-three-type=[[@{rawdie2}]]}} {{ammo-dice=[[@{rawammo}]] }} {{ammo-roll-one=[[1d6]] }} {{ammo-roll-three=[[1d6]] }} {{ammo-roll-three=[[1d6]] }} {{ammo-roll-four=[[1d6]] }} {{ammo-roll-five=[[1d6]] }} {{ammo-roll-six=[[1d6]] }} {{current-crit=@{vehicle_one_weapon_three_crit} }} {{current-damage=@{vehicle_one_weapon_three_damage} }} {{current-range=@{vehicle_one_weapon_three_range} }}"></button>
+            </div>
+            <input type="text" name="attr_vehicle_one_weapon_three_name" class="input-text weapons-three weapon-name" />
+            <input type="text" name="attr_vehicle_one_weapon_three_type" class="input-text weapons-three weapon-type" />
+            <input type="text" name="attr_vehicle_one_weapon_three_ammotype" class="input-text weapons-three weapon-ammo short-input" />
+            <select name='attr_vehicle_one_weapon_three_reliability' class="weapons-three weapon-rel short">
+                <option value='A'>A</option>
+                <option value='B'>B</option>
+                <option value='C'>C</option>
+                <option value='D'>D</option>
+            </select>
+            <input type="number" name="attr_vehicle_one_weapon_three_rof" class="number-input no-spin-input weapons-three weapon-rof" />
+            <input type="number" name="attr_vehicle_one_weapon_three_damage" class="number-input no-spin-input weapons-three weapon-dam" />
+            <input type="number" name="attr_vehicle_one_weapon_three_crit" class="number-input no-spin-input weapons-three weapon-crit" />
+            <select name='attr_vehicle_one_weapon_three_blast' class="weapons-three weapon-blast short">
+                <option value=''> - </option>
+                <option value='A'>A</option>
+                <option value='B'>B</option>
+                <option value='C'>C</option>
+                <option value='D'>D</option>
+            </select>
+            <input type="number" name="attr_vehicle_one_weapon_three_range" class="number-input no-spin-input weapons-three weapon-range" />
+            <input type="number" name="attr_vehicle_one_weapon_three_mag" class="number-input no-spin-input weapons-three weapon-mag" />
+            <input type="number" name="attr_vehicle_one_weapon_three_armor" class="number-input no-spin-input weapons-three weapon-armor" />
+            <input type="number" name="attr_vehicle_one_weapon_three_spent_ammo" class="number-input no-spin-input weapons-three weapon-spent" />
         </div>
 
         <div class="vehicle-one vehicle-inventory-details">
@@ -1374,7 +1408,6 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=Coolnes
             <span class="weapons-header minor weapon-range">Range</span>
             <span class="weapons-header minor weapon-mag">Mag</span>
             <span class="weapons-header minor weapon-armor">Armor</span>
-            <span class="weapons-header minor weapon-weight">Weight</span>
             <span class="weapons-header minor weapon-spent">Spent</span>
 
             <!-- ROW TWO -->
@@ -1404,7 +1437,6 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=Coolnes
             <input type="number" name="attr_vehicle_weapon_two_one_range" class="number-input no-spin-input weapons-one weapon-range" />
             <input type="number" name="attr_vehicle_weapon_two_one_mag" class="number-input no-spin-input weapons-one weapon-mag" />
             <input type="number" name="attr_vehicle_weapon_two_one_armor" class="number-input no-spin-input weapons-one weapon-armor" />
-            <input type="number" name="attr_vehicle_weapon_two_one_weight" class="number-input no-spin-input weapons-one weapon-weight" />
             <input type="number" name="attr_vehicle_weapon_two_one_spent_ammo" class="number-input no-spin-input weapons-one weapon-spent" />
 
             <!-- ROW THREE -->
@@ -1434,8 +1466,36 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=Coolnes
             <input type="number" name="attr_vehicle_weapon_two_two_range" class="number-input no-spin-input weapons-two weapon-range" />
             <input type="number" name="attr_vehicle_weapon_two_two_mag" class="number-input no-spin-input weapons-two weapon-mag" />
             <input type="number" name="attr_vehicle_weapon_two_two_armor" class="number-input no-spin-input weapons-two weapon-armor" />
-            <input type="number" name="attr_vehicle_weapon_two_two_weight" class="number-input no-spin-input weapons-two weapon-weight" />
             <input type="number" name="attr_vehicle_weapon_two_two_spent_ammo" class="number-input no-spin-input weapons-two weapon-spent" />
+
+            <!-- ROW FOUR -->
+            <div class="weapons-three weapon-attack">
+                <button type="roll" name="roll_rawdice" class="custom-roll attribute-button"
+                value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=@{vehicle_two_weapon_three_name} }} {{roll-die-one=[[1d@{rawdie1}]] }} {{roll-die-three=[[1d@{rawdie2}]] }} {{roll-one-type=[[@{rawdie1}]]}} {{roll-three-type=[[@{rawdie2}]]}} {{ammo-dice=[[@{rawammo}]] }} {{ammo-roll-one=[[1d6]] }} {{ammo-roll-three=[[1d6]] }} {{ammo-roll-three=[[1d6]] }} {{ammo-roll-four=[[1d6]] }} {{ammo-roll-five=[[1d6]] }} {{ammo-roll-six=[[1d6]] }} {{current-crit=@{vehicle_two_weapon_three_crit} }} {{current-damage=@{vehicle_two_weapon_three_damage} }} {{current-range=@{vehicle_two_weapon_three_range} }}"></button>
+            </div>
+            <input type="text" name="attr_vehicle_two_weapon_three_name" class="input-text weapons-three weapon-name" />
+            <input type="text" name="attr_vehicle_two_weapon_three_type" class="input-text weapons-three weapon-type" />
+            <input type="text" name="attr_vehicle_two_weapon_three_ammotype" class="input-text weapons-three weapon-ammo short-input" />
+            <select name='attr_vehicle_two_weapon_three_reliability' class="weapons-three weapon-rel short">
+                <option value='A'>A</option>
+                <option value='B'>B</option>
+                <option value='C'>C</option>
+                <option value='D'>D</option>
+            </select>
+            <input type="number" name="attr_vehicle_two_weapon_three_rof" class="number-input no-spin-input weapons-three weapon-rof" />
+            <input type="number" name="attr_vehicle_two_weapon_three_damage" class="number-input no-spin-input weapons-three weapon-dam" />
+            <input type="number" name="attr_vehicle_two_weapon_three_crit" class="number-input no-spin-input weapons-three weapon-crit" />
+            <select name='attr_vehicle_two_weapon_three_blast' class="weapons-three weapon-blast short">
+                <option value=''> - </option>
+                <option value='A'>A</option>
+                <option value='B'>B</option>
+                <option value='C'>C</option>
+                <option value='D'>D</option>
+            </select>
+            <input type="number" name="attr_vehicle_two_weapon_three_range" class="number-input no-spin-input weapons-three weapon-range" />
+            <input type="number" name="attr_vehicle_two_weapon_three_mag" class="number-input no-spin-input weapons-three weapon-mag" />
+            <input type="number" name="attr_vehicle_two_weapon_three_armor" class="number-input no-spin-input weapons-three weapon-armor" />
+            <input type="number" name="attr_vehicle_two_weapon_three_spent_ammo" class="number-input no-spin-input weapons-three weapon-spent" />
         </div>
 
         <div class="vehicle-one vehicle-inventory-details">
@@ -1513,7 +1573,6 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=Coolnes
             <span class="weapons-header minor weapon-range">Range</span>
             <span class="weapons-header minor weapon-mag">Mag</span>
             <span class="weapons-header minor weapon-armor">Armor</span>
-            <span class="weapons-header minor weapon-weight">Weight</span>
             <span class="weapons-header minor weapon-spent">Spent</span>
 
             <!-- ROW TWO -->
@@ -1543,7 +1602,6 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=Coolnes
             <input type="number" name="attr_vehicle_three_weapon_one_range" class="number-input no-spin-input weapons-one weapon-range" />
             <input type="number" name="attr_vehicle_three_weapon_one_mag" class="number-input no-spin-input weapons-one weapon-mag" />
             <input type="number" name="attr_vehicle_three_weapon_one_armor" class="number-input no-spin-input weapons-one weapon-armor" />
-            <input type="number" name="attr_vehicle_three_weapon_one_weight" class="number-input no-spin-input weapons-one weapon-weight" />
             <input type="number" name="attr_vehicle_three_weapon_one_spent_ammo" class="number-input no-spin-input weapons-one weapon-spent" />
 
             <!-- ROW THREE -->
@@ -1573,8 +1631,36 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=Coolnes
             <input type="number" name="attr_vehicle_three_weapon_two_range" class="number-input no-spin-input weapons-two weapon-range" />
             <input type="number" name="attr_vehicle_three_weapon_two_mag" class="number-input no-spin-input weapons-two weapon-mag" />
             <input type="number" name="attr_vehicle_three_weapon_two_armor" class="number-input no-spin-input weapons-two weapon-armor" />
-            <input type="number" name="attr_vehicle_three_weapon_two_weight" class="number-input no-spin-input weapons-two weapon-weight" />
             <input type="number" name="attr_vehicle_three_weapon_two_spent_ammo" class="number-input no-spin-input weapons-two weapon-spent" />
+
+            <!-- ROW FOUR -->
+            <div class="weapons-three weapon-attack">
+                <button type="roll" name="roll_rawdice" class="custom-roll attribute-button"
+                value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=@{vehicle_three_weapon_three_name} }} {{roll-die-one=[[1d@{rawdie1}]] }} {{roll-die-three=[[1d@{rawdie2}]] }} {{roll-one-type=[[@{rawdie1}]]}} {{roll-three-type=[[@{rawdie2}]]}} {{ammo-dice=[[@{rawammo}]] }} {{ammo-roll-one=[[1d6]] }} {{ammo-roll-three=[[1d6]] }} {{ammo-roll-three=[[1d6]] }} {{ammo-roll-four=[[1d6]] }} {{ammo-roll-five=[[1d6]] }} {{ammo-roll-six=[[1d6]] }} {{current-crit=@{vehicle_three_weapon_three_crit} }} {{current-damage=@{vehicle_three_weapon_three_damage} }} {{current-range=@{vehicle_three_weapon_three_range} }}"></button>
+            </div>
+            <input type="text" name="attr_vehicle_three_weapon_three_name" class="input-text weapons-three weapon-name" />
+            <input type="text" name="attr_vehicle_three_weapon_three_type" class="input-text weapons-three weapon-type" />
+            <input type="text" name="attr_vehicle_three_weapon_three_ammotype" class="input-text weapons-three weapon-ammo short-input" />
+            <select name='attr_vehicle_three_weapon_three_reliability' class="weapons-three weapon-rel short">
+                <option value='A'>A</option>
+                <option value='B'>B</option>
+                <option value='C'>C</option>
+                <option value='D'>D</option>
+            </select>
+            <input type="number" name="attr_vehicle_three_weapon_three_rof" class="number-input no-spin-input weapons-three weapon-rof" />
+            <input type="number" name="attr_vehicle_three_weapon_three_damage" class="number-input no-spin-input weapons-three weapon-dam" />
+            <input type="number" name="attr_vehicle_three_weapon_three_crit" class="number-input no-spin-input weapons-three weapon-crit" />
+            <select name='attr_vehicle_three_weapon_three_blast' class="weapons-three weapon-blast short">
+                <option value=''> - </option>
+                <option value='A'>A</option>
+                <option value='B'>B</option>
+                <option value='C'>C</option>
+                <option value='D'>D</option>
+            </select>
+            <input type="number" name="attr_vehicle_three_weapon_three_range" class="number-input no-spin-input weapons-three weapon-range" />
+            <input type="number" name="attr_vehicle_three_weapon_three_mag" class="number-input no-spin-input weapons-three weapon-mag" />
+            <input type="number" name="attr_vehicle_three_weapon_three_armor" class="number-input no-spin-input weapons-three weapon-armor" />
+            <input type="number" name="attr_vehicle_three_weapon_three_spent_ammo" class="number-input no-spin-input weapons-three weapon-spent" />
         </div>
 
         <div class="vehicle-one vehicle-inventory-details">
@@ -1832,7 +1918,7 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=Coolnes
                         <span>Range: </span>{{current-range}}
                     </div>
                 {{/current-range}}
-
+                
             </div>
         </div>
     </div>

--- a/T2K 4e/twilight-2k-4e.html
+++ b/T2K 4e/twilight-2k-4e.html
@@ -1207,8 +1207,8 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=Coolnes
         <!-- ROW THREE -->
         <span class="vehicle-header input-label vehicle-armor">Armor</span>
         <span class="vehicle-header minor vehicle-armor-front">Front</span>
-        <span class="vehicle-header minor vehicle-armor-left">left</span>
-        <span class="vehicle-header minor vehicle-armor-right">right</span>
+        <span class="vehicle-header minor vehicle-armor-left">Left</span>
+        <span class="vehicle-header minor vehicle-armor-right">Right</span>
         <span class="vehicle-header minor vehicle-armor-rear">Rear</span>
 
         <span class="vehicle-header input-label vehicle-fuel">Fuel</span>


### PR DESCRIPTION
## Changes / Comments

- Added 3rd weapons slot for Vehicles
- Added attributes and skills listed above dice roller for quick reference

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- Yes: Twilight 2000 4th Edition
- [x] Is this a bug fix?
- This is not a bug fix
- [x] Does this add functional enhancements (new features or extending existing features) ?
- Yes, adds additional weapons slot to vehicle and displays some quick reference information about dice rolls in the Combat Section
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- Yes, adds additional weapons slot to vehicle and displays some quick reference information about dice rolls in the Combat Section
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- Not Applicable
- [x] If this is a new sheet, did you follow [Building Character Sheets standards]
- Not Applicable
(https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
