### PR TITLE
Serenity: Fix gradients, move new tooltips to left, move adv points right

### DIFF
--- a/Serenity/serenity.css
+++ b/Serenity/serenity.css
@@ -71,6 +71,8 @@
 .sheet-serenity-charactersheet .sheet-serenity-float-group {
     max-width: 930px;
     margin: auto;
+    background: white !important;
+    page-break-inside: avoid;
 }
 
 .sheet-serenity-charactersheet .sheet-serenity-float-group:after {
@@ -78,12 +80,6 @@
     clear: both;
     display: block;
     margin-bottom: 15px;
-}
-
-@media print {
-    .sheet-serenity-charactersheet .sheet-serenity-float-group {
-        page-break-inside: avoid;
-    }
 }
 
 .sheet-serenity-charactersheet .sheet-serenity-asset-specialization,
@@ -213,13 +209,13 @@
 .sheet-serenity-charactersheet .sheet-character-life-points .sheet-serenity-stuns-taken {
     border-radius: 30px 0 0 0;
     background-color: #e8af20 !important;
-    background-image: linear-gradient(left, #e8af20, #c93f00) !important;
+    background-image: linear-gradient(to right, #e8af20, #c93f00) !important;
 }
 
 .sheet-serenity-charactersheet .sheet-character-life-points .sheet-serenity-wounds-taken {
     border-radius: 0 0 30px 0;
     background-color: #c93f00 !important;
-    background-image: linear-gradient(left, #c93f00, #e8af20) !important;
+    background-image: linear-gradient(to right, #c93f00, #e8af20) !important;
 }
 
 .sheet-serenity-charactersheet .sheet-character-life-points .sheet-serenity-shocks-taken {
@@ -1238,6 +1234,7 @@
 
 .sheet-serenity-charactersheet .sheet-serenity-advancement-points input {
     width: 100%;
+    text-align: right;
 }
 
 .sheet-serenity-charactersheet .sheet-serenity-plot-points {

--- a/Serenity/serenity.html
+++ b/Serenity/serenity.html
@@ -938,7 +938,9 @@
         <div class="sheet-serenity-fieldset sheet-serenity-plot-points">
           <span class="sheet-serenity-tooltip sheet-serenity-fieldset-title">
             Plot Points
-            <span class="sheet-serenity-tooltip-text">
+            <span
+              class="sheet-serenity-tooltip-text sheet-serenity-tooltip-text-left"
+            >
               Plot Points are a way for major characters in the game to add a
               little drama to the story. Plot Points can be used to improve the
               odds for important actions, prevent someone from getting killed or
@@ -1070,7 +1072,9 @@
         <div class="sheet-serenity-fieldset sheet-serenity-advancement-points">
           <span class="sheet-serenity-tooltip sheet-serenity-fieldset-title">
             Advancement Points
-            <span class="sheet-serenity-tooltip-text">
+            <span
+              class="sheet-serenity-tooltip-text sheet-serenity-tooltip-text-left"
+            >
               Advancement Points represent the accumulation of experience and
               are the building blocks for improvement.
               <table class="sheet-serenity-tooltip-table-center">


### PR DESCRIPTION
## Changes / Comments
* Fix gradients
* Tooltips for plot/adv points point left
* Right align adv points
* Remove media query for print
* Make float groups have white background

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
