### PR TITLE
Twilight 2000 4th Edition | Fix medical aid roll bug

### DIFF
--- a/T2K 4e/sheet.json
+++ b/T2K 4e/sheet.json
@@ -4,6 +4,6 @@
     "authors": "/u/NocFenix(3266353)",
     "roll20userid": "3266353",
     "preview": "twilight-2k-4e.png",
-    "instructions": "You can click on the Attribute names to roll against your attributes.",
+    "instructions": "Character Sheet for 4th Edition release of Twilight 2000 by Free League. \r\nSetup with different tabs for grouped information and allows the user to make rolls for various Skills and weapons attacks.",
     "legacy": true
   }

--- a/T2K 4e/twilight-2k-4e.html
+++ b/T2K 4e/twilight-2k-4e.html
@@ -324,7 +324,7 @@
 
             <!-- ROW TWO: MEDICAL AID -->
             <span class="medical-aid-skill minor attribute-label">Medical Aid</span>
-            <select name='attr_medical-aid' class="medical-aid-skill short attribute-select">
+            <select name='attr_medicalaid' class="medical-aid-skill short attribute-select">
                 <option value='-'> - </option>
                 <option value='A'>A</option>
                 <option value='B'>B</option>


### PR DESCRIPTION
## Changes / Comments

Necessary fix to Medical Aid resolving a typo on the attribute.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- This fixes an issue with a typo in the Medical Aid attribute so that the roller works as expected
- [x] Does this add functional enhancements (new features or extending existing features) ?
- This does not add new or enhanced features
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- This change does not
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- Will not preserve data as the previous medical aid attribute had a typo in it
- [x] If this is a new sheet, did you follow [Building Character Sheets standards]
- This is not a new sheet
(https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
