### PR TITLE
[Call of Cthulhu 5e/Spanish] corrected some i18n

### DIFF
--- a/Call_of_Cthulhu_Spanish/Call_of_Cthulhu.html
+++ b/Call_of_Cthulhu_Spanish/Call_of_Cthulhu.html
@@ -45,7 +45,12 @@ on("sheet:opened", function(eventInfo){
     setAttrs({
         treatmentquery: getTranslationByKey("treatment-u"),
         emergencymedicine: getTranslationByKey("emergency-u"),
-        weeklymedicine: getTranslationByKey("weekly-u")
+        weeklymedicine: getTranslationByKey("weekly-u"),
+        objectivegrapple: getTranslationByKey("objective-u"),
+        immobilisegrapple: getTranslationByKey("immobilise-u"),
+        knockdowngrapple: getTranslationByKey("knock-down-u"),
+        knockoutgrapple: getTranslationByKey("knock-out-u"),
+        disarmgrapple: getTranslationByKey("disarm-u")
     });     
     
 });
@@ -943,7 +948,7 @@ on("sheet:opened", function(eventInfo){
                 <td><input type="number" name="attr_Grapple-ApR" /></td>
                 <td><input type="text" name="attr_Grapple-HP" style="width: 50px" /></td>
                 <td><button type="roll" name="roll_Grapple" value="&{template:default} {{name=^{grapple-u}}} {{^{attack-u}=[[1d100<@{Grapple}]]}}" /></td>
-				<td><button type="roll" name="roll_wgm-Grapple" value="/w gm &{template:default} {{name=^{grapple-u}}} {{^{attack-u}=[[1d100<@{Grapple}]]}} {{^{damage-u}= ?{^{objective-u}|Inmovilizar, [[1d100<((5*(@{STR}-@{target|STR})))+50]]|Derribar, [[1]]|Noquear, [[1]]|Desarmar, [[1d100<@{Grapple}]]}}}" /></td>
+				<td><button type="roll" name="roll_wgm-Grapple" value="/w gm &{template:default} {{name=^{grapple-u}}} {{^{attack-u}=[[1d100<@{Grapple}]]}} {{^{damage-u}= ?{@{objectivegrapple}|@{immobilisegrapple}, [[1d100<((5*(@{STR}-@{target|STR})))+50]]|@{knockdowngrapple}, [[1]]|@{knockoutgrapple}, [[1]]|@{disarmgrapple}, [[1d100<@{Grapple}]]}}}" /></td>
             </tr>
         </tbody>
     </table>

--- a/Call_of_Cthulhu_Spanish/Call_of_Cthulhu.html
+++ b/Call_of_Cthulhu_Spanish/Call_of_Cthulhu.html
@@ -39,6 +39,16 @@ on("change:FUE change:TAM", function() {
 	setAttrs({ "Damage-Bonus": damage_bonus});
   });
 });
+
+on("sheet:opened", function(eventInfo){
+    
+    setAttrs({
+        treatmentquery: getTranslationByKey("treatment-u"),
+        emergencymedicine: getTranslationByKey("emergency-u"),
+        weeklymedicine: getTranslationByKey("weekly-u")
+    });     
+    
+});
 </script>
 
 <div class='sheet-2colrow'>
@@ -670,7 +680,7 @@ on("change:FUE change:TAM", function() {
                     <td><input type="checkbox" name="attr_Success-Medicine"  /></td>
                     <td data-i18n="medicine-u">Medicina (05%)</td>
                     <td><input type="number" name="attr_Medicine" value="5"  /></td>
-                    <td><button type="roll" name="roll_Medicine" value="&{template:default} {{name=^{medicine-u}}} {{^{roll-u}=[[1d100<@{Medicine}]]}} {{^{heal-u}=[[?{Tratamiento|Urgencia, 1d3|Semanal, 2d3}]]}}" /></td>
+                    <td><button type="roll" name="roll_Medicine" value="&{template:default} {{name=^{medicine-u}}} {{^{roll-u}=[[1d100<@{Medicine}]]}} {{^{heal-u}=[[?{@{treatmentquery}|@{emergencymedicine}, 1d3|@{weeklymedicine}, 2d3}]]}}" /></td>
                 </tr>
                 <tr data-i18n-list-item="cthulhu-mythos">
                     <td></td>
@@ -946,7 +956,7 @@ on("change:FUE change:TAM", function() {
                <td><input type="text" name="attr_Damage" style="width: 110px" /></td>
                <td><input type="number" name="attr_Attacks-Round" /></td>
                <td><input type="text" name="attr_HP" style="width: 50px" /></td>
-               <td><button type="roll" name="roll_Attack-Weapon" value="&{template:default} {{name=@{Attack-Weapon}}} {{^{attack-u}=[[1d100<@{Score}]]}} {{daño=[[@{Damage}+@{Damage-Bonus}]]}}" /></td>
+               <td><button type="roll" name="roll_Attack-Weapon" value="&{template:default} {{name=@{Attack-Weapon}}} {{^{attack-u}=[[1d100<@{Score}]]}} {{^{damage-u}=[[@{Damage}+@{Damage-Bonus}]]}}" /></td>
 			   <td><button type="roll" name="roll_wgm-Attack-Weapon" value="/w gm &{template:default} {{name=@{Attack-Weapon}}} {{^{attack-u}=[[1d100<@{Score}]]}} {{^{damage-u}=[[@{Damage}+@{Damage-Bonus}]]}}" /></td>
             </tr>
         </table>
@@ -979,8 +989,8 @@ on("change:FUE change:TAM", function() {
                 <td><input type="number" name="attr_Shots-in-Gun" /></td>
                 <td><input type="number" name="attr_Malfunc-Num" /></td>
                 <td><input type="text" name="attr_HP" style="width: 50px" /></td>
-				<td><button type="roll" name="roll_Firearm" value="&{template:default} {{name=@{Firearm}}} {{ataque=[[1d100<@{Score}]]}} {{daño=[[@{Damage}]]}}" /></td>
-				<td><button type="roll" name="roll_wgm-Firearm" value="/w gm &{template:default} {{name=@{Firearm}}} {{ataque=[[1d100<@{Score}]]}} {{daño=[[@{Damage}]]}}" /></td>
+				<td><button type="roll" name="roll_Firearm" value="&{template:default} {{name=@{Firearm}}} {{^{attack-u}=[[1d100<@{Score}]]}} {{^{damage-u}=[[@{Damage}]]}}" /></td>
+				<td><button type="roll" name="roll_wgm-Firearm" value="/w gm &{template:default} {{name=@{Firearm}}} {{^{attack-u}=[[1d100<@{Score}]]}} {{^{damage-u}=[[@{Damage}]]}}" /></td>
             </tr>
         </table>
     </fieldset>

--- a/Call_of_Cthulhu_Spanish/translation.json
+++ b/Call_of_Cthulhu_Spanish/translation.json
@@ -141,5 +141,9 @@
 	"edition-u":"Game edition",
 	"edition-info":"Choose between editions. If you are playing the 6e french edition, please, use the especific sheet, this isn't the one you're looking for. If you convert a game between editions, you will need to change the skills manually.",
 	"treatment-u": "Treatment",
-	"emergency-u": "Emergency"
+	"emergency-u": "Emergency",
+	"immobilise-u": "Immobilise",
+	"knock-down-u": "Knock down",
+	"knock-out-u": "Knock out",
+	"disarm-u": "Disarm"
 }

--- a/Call_of_Cthulhu_Spanish/translation.json
+++ b/Call_of_Cthulhu_Spanish/translation.json
@@ -139,5 +139,7 @@
 	"weekly-u":"Weekly",
 	"objective-u":"Objective",
 	"edition-u":"Game edition",
-	"edition-info":"Choose between editions. If you are playing the 6e french edition, please, use the especific sheet, this isn't the one you're looking for. If you convert a game between editions, you will need to change the skills manually."
+	"edition-info":"Choose between editions. If you are playing the 6e french edition, please, use the especific sheet, this isn't the one you're looking for. If you convert a game between editions, you will need to change the skills manually.",
+	"treatment-u": "Treatment",
+	"emergency-u": "Emergency"
 }

--- a/Call_of_Cthulhu_Spanish/translations/en.json
+++ b/Call_of_Cthulhu_Spanish/translations/en.json
@@ -139,5 +139,5 @@
 	"weekly-u": "Weekly",
 	"objective-u": "Objective",
 	"edition-u": "Game edition",
-	"edition-info": "Choose between editions. If you are playing the 6e french edition, please, use the especific sheet, this isn't the one you're looking for. If you convert a game between editions, you will need to change the skills manually."
+	"edition-info": "Choose between editions. If you are playing the 6e french edition, please, use the specific sheet, this isn't the one you're looking for. If you convert a game between editions, you will need to change the skills manually."
 }

--- a/Call_of_Cthulhu_Spanish/translations/es.json
+++ b/Call_of_Cthulhu_Spanish/translations/es.json
@@ -139,5 +139,7 @@
 	"weekly-u": "Semanal",
 	"objective-u": "Objetivo",
 	"edition-u": "Edici&oacute;n",
-	"edition-info": "Elije entre ediciones. Si estás jugando la edición francesa, por favor, usa su ficha específica, esta no es la ficha que estás buscando. Si conviertes fichas entre ediciones, tendrás que cambiar las habilidades a mano."
+	"edition-info": "Elije entre ediciones. Si estás jugando la edición francesa, por favor, usa su ficha específica, esta no es la ficha que estás buscando. Si conviertes fichas entre ediciones, tendrás que cambiar las habilidades a mano.",
+	"treatment-u": "Tratamiento",
+	"emergency-u": "Urgencia"
 }


### PR DESCRIPTION
I changed the Call_of_Cthulhu_Spanish sheet. Added i18n to the firearms area, the grapple attack and the Medicine roll.

## Changes / Comments

The 5th edition sheet in my campaign seems to use the internationalised Spanish version (English being the language we use). However, some of the text wasn't translated into English (see image below).

![2021-03-10 21_37_52-Cthulhu_ The Edge of Darkness Copy _ Roll20](https://user-images.githubusercontent.com/135422/110701452-15eabb00-81e9-11eb-9947-f3c69ac1cd98.png)

I put existing i18n attributes into the firearms roll template. I added some JavaScript attributes to insert i18n text into the grapple attack and the Medicine roll template.



## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
