### PR TITLE
[Ironsworn] Resource and Custom Asset Fix

### DIFF
--- a/Ironsworn/Ironsworn.html
+++ b/Ironsworn/Ironsworn.html
@@ -46,7 +46,7 @@
             <div class="resource">
               <label class="roll-resource-label">
                 <button class="hide" type="roll" title="@{rollhealth}" name="rollhealth" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=roll +health}} {{action=[[d6+@{health}+(?{Modifier|0})]]}} {{negate1=[[1+@{health}+(?{Modifier|0})]]}} {{negate2=[[2+@{health}+(?{Modifier|0})]]}} {{negate3=[[3+@{health}+(?{Modifier|0})]]}} {{negate4=[[4+@{health}+(?{Modifier|0})]]}} {{negate5=[[5+@{health}+(?{Modifier|0})]]}} {{negate6=[[6+@{health}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[@{health}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[@{health}]]}}"></button>
-                <div data-i18n="resource-health"></div>
+                <div data-i18n="resource-health">HEALTH</div>
               </label>
               <select class="resource-value" name="attr_health">
                   <option value="5">+5</option>
@@ -60,7 +60,7 @@
             <div class="resource">
               <label class="roll-resource-label">
                 <button class="hide" type="roll" title="@{rollspirit}" name="rollspirit" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=roll +spirit}} {{action=[[d6+@{spirit}+(?{Modifier|0})]]}} {{negate1=[[1+@{spirit}+(?{Modifier|0})]]}} {{negate2=[[2+@{spirit}+(?{Modifier|0})]]}} {{negate3=[[3+@{spirit}+(?{Modifier|0})]]}} {{negate4=[[4+@{spirit}+(?{Modifier|0})]]}} {{negate5=[[5+@{spirit}+(?{Modifier|0})]]}} {{negate6=[[6+@{spirit}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[@{spirit}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[@{spirit}]]}}"></button>
-                <div data-i18n="resource-spirit"></div>
+                <div data-i18n="resource-spirit">SPIRIT</div>
               </label>
               <select class="resource-value" name="attr_spirit">
                   <option value="5">+5</option>
@@ -74,7 +74,7 @@
             <div class="resource">
               <label class="roll-resource-label">
                 <button class="hide" type="roll" title="@{rollsupply}" name="rollsupply" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=roll +supply}} {{action=[[d6+@{supply}+(?{Modifier|0})]]}} {{negate1=[[1+@{supply}+(?{Modifier|0})]]}} {{negate2=[[2+@{supply}+(?{Modifier|0})]]}} {{negate3=[[3+@{supply}+(?{Modifier|0})]]}} {{negate4=[[4+@{supply}+(?{Modifier|0})]]}} {{negate5=[[5+@{supply}+(?{Modifier|0})]]}} {{negate6=[[6+@{supply}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[@{supply}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[@{supply}]]}}"></button>
-                <div data-i18n="resource-supply"></div>
+                <div data-i18n="resource-supply">SUPPLY</div>
               </label>
               <select class="resource-value" name="attr_supply">
                   <option value="5">+5</option>
@@ -9697,7 +9697,7 @@
             <div class="resource">
               <label class="roll-resource-label">
                 <button class="hide" type="roll" title="@{rollsupply}" name="rollsupply" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=roll +supply}} {{action=[[d6+@{supply}+(?{Modifier|0})]]}} {{negate1=[[1+@{supply}+(?{Modifier|0})]]}} {{negate2=[[2+@{supply}+(?{Modifier|0})]]}} {{negate3=[[3+@{supply}+(?{Modifier|0})]]}} {{negate4=[[4+@{supply}+(?{Modifier|0})]]}} {{negate5=[[5+@{supply}+(?{Modifier|0})]]}} {{negate6=[[6+@{supply}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[@{supply}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[@{supply}]]}}"></button>
-                <div data-i18n="resource-supply"></div>
+                <div data-i18n="resource-supply">SUPPLY</div>
               </label>
               <select class="resource-value" name="attr_supply">
                   <option value="5">+5</option>

--- a/Ironsworn/Ironsworn.html
+++ b/Ironsworn/Ironsworn.html
@@ -44,8 +44,9 @@
             </div>
           </div>
             <div class="resource">
-              <label class="roll-resource-label" data-i18n="resource-health">
+              <label class="roll-resource-label">
                 <button class="hide" type="roll" title="@{rollhealth}" name="rollhealth" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=roll +health}} {{action=[[d6+@{health}+(?{Modifier|0})]]}} {{negate1=[[1+@{health}+(?{Modifier|0})]]}} {{negate2=[[2+@{health}+(?{Modifier|0})]]}} {{negate3=[[3+@{health}+(?{Modifier|0})]]}} {{negate4=[[4+@{health}+(?{Modifier|0})]]}} {{negate5=[[5+@{health}+(?{Modifier|0})]]}} {{negate6=[[6+@{health}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[@{health}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[@{health}]]}}"></button>
+                <div data-i18n="resource-health"></div>
               </label>
               <select class="resource-value" name="attr_health">
                   <option value="5">+5</option>
@@ -57,8 +58,9 @@
               </select>
             </div>
             <div class="resource">
-              <label class="roll-resource-label" data-i18n="resource-spirit">
+              <label class="roll-resource-label">
                 <button class="hide" type="roll" title="@{rollspirit}" name="rollspirit" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=roll +spirit}} {{action=[[d6+@{spirit}+(?{Modifier|0})]]}} {{negate1=[[1+@{spirit}+(?{Modifier|0})]]}} {{negate2=[[2+@{spirit}+(?{Modifier|0})]]}} {{negate3=[[3+@{spirit}+(?{Modifier|0})]]}} {{negate4=[[4+@{spirit}+(?{Modifier|0})]]}} {{negate5=[[5+@{spirit}+(?{Modifier|0})]]}} {{negate6=[[6+@{spirit}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[@{spirit}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[@{spirit}]]}}"></button>
+                <div data-i18n="resource-spirit"></div>
               </label>
               <select class="resource-value" name="attr_spirit">
                   <option value="5">+5</option>
@@ -70,8 +72,9 @@
               </select>
             </div>
             <div class="resource">
-              <label class="roll-resource-label" data-i18n="resource-supply">
+              <label class="roll-resource-label">
                 <button class="hide" type="roll" title="@{rollsupply}" name="rollsupply" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=roll +supply}} {{action=[[d6+@{supply}+(?{Modifier|0})]]}} {{negate1=[[1+@{supply}+(?{Modifier|0})]]}} {{negate2=[[2+@{supply}+(?{Modifier|0})]]}} {{negate3=[[3+@{supply}+(?{Modifier|0})]]}} {{negate4=[[4+@{supply}+(?{Modifier|0})]]}} {{negate5=[[5+@{supply}+(?{Modifier|0})]]}} {{negate6=[[6+@{supply}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[@{supply}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[@{supply}]]}}"></button>
+                <div data-i18n="resource-supply"></div>
               </label>
               <select class="resource-value" name="attr_supply">
                   <option value="5">+5</option>
@@ -4018,7 +4021,7 @@
                               <input class="custom-asset-ability" type="checkbox" name="attr_assetcheckbox_builder-ability-2"/>
                               <div class="asset-ability"><span class="no-border ability-text" name="attr_builder-ability-2-text-area"></span></div>
                             </div>
-                            <input class="builder-ability-2-text-input hide" type="checkbox" name="attr_builder-ability-1-text-input"/>
+                            <input class="builder-ability-2-text-input hide" type="checkbox" name="attr_builder-ability-2-text-input"/>
                             <div class="builder-ability-2-text-input hide">
                               <input class="custom-asset-ability" type="checkbox" name="attr_assetcheckbox_builder-ability-2"/>
                               <div class="asset-ability"><span class="no-border ability-text" name="attr_builder-ability-2-text-area"></span>
@@ -4032,7 +4035,7 @@
                               <input class="custom-asset-ability" type="checkbox" name="attr_assetcheckbox_builder-ability-3"/>
                               <div class="asset-ability"><span class="no-border ability-text" name="attr_builder-ability-3-text-area"></span></div>
                             </div>
-                            <input class="builder-ability-3-text-input hide" type="checkbox" name="attr_builder-ability-1-text-input"/>
+                            <input class="builder-ability-3-text-input hide" type="checkbox" name="attr_builder-ability-3-text-input"/>
                             <div class="builder-ability-3-text-input hide">
                               <input class="custom-asset-ability" type="checkbox" name="attr_assetcheckbox_builder-ability-3"/>
                               <div class="asset-ability"><span class="no-border ability-text" name="attr_builder-ability-3-text-area"></span>
@@ -9692,8 +9695,9 @@
   <div class="header">
         <div class="resources">
             <div class="resource">
-              <label class="roll-resource-label" data-i18n="resource-supply">
+              <label class="roll-resource-label">
                 <button class="hide" type="roll" title="@{rollsupply}" name="rollsupply" value="&{template:ironsworn_moves} {{header=@{character_name}}} {{name=roll +supply}} {{action=[[d6+@{supply}+(?{Modifier|0})]]}} {{negate1=[[1+@{supply}+(?{Modifier|0})]]}} {{negate2=[[2+@{supply}+(?{Modifier|0})]]}} {{negate3=[[3+@{supply}+(?{Modifier|0})]]}} {{negate4=[[4+@{supply}+(?{Modifier|0})]]}} {{negate5=[[5+@{supply}+(?{Modifier|0})]]}} {{negate6=[[6+@{supply}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[@{supply}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[@{supply}]]}}"></button>
+                <div data-i18n="resource-supply"></div>
               </label>
               <select class="resource-value" name="attr_supply">
                   <option value="5">+5</option>

--- a/Ironsworn/src/components/assets/asset-custom.pug
+++ b/Ironsworn/src/components/assets/asset-custom.pug
@@ -26,7 +26,7 @@ mixin abilityView(value)
     )
     .asset-ability
       span.no-border.ability-text(name=`attr_builder-ability-${value}-text-area`)
-  input(class=`builder-ability-${value}-text-input hide` type='checkbox' name='attr_builder-ability-1-text-input')
+  input(class=`builder-ability-${value}-text-input hide` type='checkbox' name=`attr_builder-ability-${value}-text-input`)
   div(class=`builder-ability-${value}-text-input hide`)
     input.custom-asset-ability(type='checkbox' name=`attr_assetcheckbox_builder-ability-${value}`)
     .asset-ability

--- a/Ironsworn/src/components/resources/resources.pug
+++ b/Ironsworn/src/components/resources/resources.pug
@@ -19,7 +19,7 @@ mixin dropdowns(resource)
         name=`roll${resource}`
         value!=`&{template:ironsworn_moves} {{header=@{character_name}}} {{name=roll +${resource}}} {{action=[[d6+@{${resource}}+(?{Modifier|0})]]}} {{negate1=[[1+@{${resource}}+(?{Modifier|0})]]}} {{negate2=[[2+@{${resource}}+(?{Modifier|0})]]}} {{negate3=[[3+@{${resource}}+(?{Modifier|0})]]}} {{negate4=[[4+@{${resource}}+(?{Modifier|0})]]}} {{negate5=[[5+@{${resource}}+(?{Modifier|0})]]}} {{negate6=[[6+@{${resource}}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[@{${resource}}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[@{${resource}}]]}}`
       )
-      div(data-i18n=`resource-${resource}`)=translations[resource]
+      div(data-i18n=`resource-${resource}`)=translations[`resource-${resource}`]
     select(class="resource-value" name=`attr_${resource}`)
       if resource == 'wealth'
         - var trackValues = inverse

--- a/Ironsworn/src/components/resources/resources.pug
+++ b/Ironsworn/src/components/resources/resources.pug
@@ -11,7 +11,7 @@ mixin options(trackValues)
 
 mixin dropdowns(resource)
   div.resource
-    label.roll-resource-label(data-i18n=`resource-${resource}`)=translations[resource]
+    label.roll-resource-label
       button(
         type="roll"
         title=`@{roll${resource}}`
@@ -19,6 +19,7 @@ mixin dropdowns(resource)
         name=`roll${resource}`
         value!=`&{template:ironsworn_moves} {{header=@{character_name}}} {{name=roll +${resource}}} {{action=[[d6+@{${resource}}+(?{Modifier|0})]]}} {{negate1=[[1+@{${resource}}+(?{Modifier|0})]]}} {{negate2=[[2+@{${resource}}+(?{Modifier|0})]]}} {{negate3=[[3+@{${resource}}+(?{Modifier|0})]]}} {{negate4=[[4+@{${resource}}+(?{Modifier|0})]]}} {{negate5=[[5+@{${resource}}+(?{Modifier|0})]]}} {{negate6=[[6+@{${resource}}+(?{Modifier|0})]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}} {{momentum=[[@{momentum}]]}} {{modifiers=[[@{${resource}}+(?{Modifier|0})]]}} {{add=[[(?{Modifier|0})]]}} {{stat=[[@{${resource}}]]}}`
       )
+      div(data-i18n=`resource-${resource}`)=translations[resource]
     select(class="resource-value" name=`attr_${resource}`)
       if resource == 'wealth'
         - var trackValues = inverse


### PR DESCRIPTION
## Changes / Comments
Fixes https://github.com/Roll20/roll20-character-sheets/issues/8452

### Custom Assets Fix
Missed setting one of the input fields to Dynamic for the custom assets:
```
input(class=`builder-ability-${value}-text-input hide` type='checkbox' name='attr_builder-ability-1-text-input')
```

### Resource Fix
The resources translation was replacing the contained button. Added a separate div within the label to fix this.


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
