### PR TITLE
[Ironsworn] Modify Custom Asset CSS

### DIFF
--- a/Ironsworn/src/components/assets/assets.styl
+++ b/Ironsworn/src/components/assets/assets.styl
@@ -126,6 +126,11 @@ div.sheet-builder-titles-3
 
 .sheet-asset-custom
   padding 0.2em
+  background: linear-gradient(to bottom,#ccc 2em,white 2em, white)
+  > input[type=radio]
+    margin-left: 4px
+  div[class|=sheet-builder-ability]
+    align-items: flex-start 
 
 div.sheet-asset-view,
 div.sheet-asset-builder


### PR DESCRIPTION
## Changes / Comments

CSS fix for alignment of checkboxes beside custom asset abilities, and add a grey highlight behind the builder/view radio buttons to distinguish them from the asset title.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [X] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
