### PR TITLE
The Expanse RPG (AGE System) - Dex/Tough and Other Bug fixes Feb/Mar 2021

### DIFF
--- a/The Expanse RPG (AGE System)/sheet.json
+++ b/The Expanse RPG (AGE System)/sheet.json
@@ -1,8 +1,8 @@
 {
   "html": "the-expanse-rpg-age-system.html",
   "css": "the-expanse-rpg-age-system.css",
-  "authors": "Green Ronin (Evan Sass)",
-  "roll20userid": "6360493",
+  "authors": "Green Ronin (Evan Sass), Elminster(Duncan)",
+  "roll20userid": "6360493, 5752003",
   "preview": "the-expanse-rpg-age-system.png",
   "instructions": "The Green Ronin-official Roll20 character sheet for The Expanse RPG. Based on the AGE System sheet by Olivier L.-L. and Zach Hall.\n\nUtilizes the API script 'TotalRolled for AGE' to total rolls and calculate stunt points.\n**Note:** When adding a new character, ability focuses need to be added from the 'Focuses' tab, and you must enter a number under Focus Bonus in order for the focus rolls to perform correctly.\n\nSheet version 1.0.0 (last modified 27 July 2020). Starting from v.1.20.1 of the AGE System sheet, The Expanse sheet now only shows options available in The Expanse RPG (no magic options), includes a Conditions tracker, and tracks Income and Fortune as used in The Expanse RPG.\n\nThe Expanse RPG is Â©2019 Green Ronin Publishing, LLC. The Expanse is Â© 2011-2020 Daniel Abraham and Ty Franck.",
   "useroptions": [

--- a/The Expanse RPG (AGE System)/the-expanse-rpg-age-system.css
+++ b/The Expanse RPG (AGE System)/the-expanse-rpg-age-system.css
@@ -492,19 +492,28 @@ input {
 	/* Right column */
 .sheet-sectionfourth {
 		width: calc(25% - 6px);
-		height: 92px;
+		height: 125px;
 }
 .sheet-sectionthreefourths {
         width: calc(75% - 4px);
-        height: 92px;
+        height: 125px;
 }
 .sheet-shieldbonus-armorpenalty {
-    	width:  calc(50% - 3.79px);
+    	width:  calc(20% - 3.79px);
+		padding-top: 0.75em;
     	text-align: right;
     	float: left;
 }
-
-
+.sheet-shieldbonus-armorpenalty2 {
+	width:  calc(23% - 3.79px);
+	padding-left: 1.1em;
+}
+.sheet-shieldbonus-armorpenalty2 .sheet-maximum-input span {
+	text-align: center;
+}
+.sheet-shieldbonus-armorpenalty2 .sheet-maximum-input input {
+	margin-right: 0.75em;
+}
 .sheet-sectiononethird {
 		width:  calc(33.3% - 3.79px);
 	/*	height: 92px;  */
@@ -555,6 +564,7 @@ input {
 		-webkit-appearance: none;
 		-moz-appearance: none;
 		-webkit-border-radius: 0px;
+		border-radius: 0px;
 		border: none;
 		color: black;
 		padding: none;
@@ -696,7 +706,7 @@ input {
 }
 
 .sheet-speed-defense-armor-container {
-		height: 92px;
+		height: 125px;
 }
 
 .sheet-speed-defense-armor-container .sheet-col {
@@ -740,6 +750,7 @@ input {
 }
 
 .sheet-speed-defense-armor-container .sheet-maximum-input span { 
+		height: 20px;
 		margin-left: 5px;;
 }
 
@@ -2304,3 +2315,349 @@ input.sheet-ammo-col-checkbox:checked ~ .sheet-page .sheet-attack-container .she
     border: 1px solid #333;
     background: #eee;
 }
+
+/* ROLL TEMPLATES */
+
+.sheet-rolltemplate-default table {
+	border: 1px solid black;
+}
+
+.sheet-rolltemplate-default caption {
+	background-color: black;
+	font-weight: bold;
+	border-top: 1px solid black;
+	border-bottom: 0px;
+	border-left: 1px solid black;
+	border-right: 1px solid black;
+}
+
+.sheet-rolltemplate-default td:first-child {
+	text-align: left;
+}
+
+.sheet-rolltemplate-default td:nth-child(2) {
+	text-align: right;
+}
+
+.sheet-rolltemplate-age-roller .sheet-age-roller-title.sheet-age-roller-color-red,
+input.sheet-red-color-checkbox:checked ~ .sheet-tab-button:checked + span,
+input.sheet-red-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span,
+input.sheet-red-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span + span,
+input.sheet-red-color-checkbox:checked ~ .sheet-page .sheet-section-name  { 
+		background-color: #810206;
+}
+
+.sheet-rolltemplate-age-roller .sheet-age-roller-title.sheet-age-roller-color-teal1,
+input.sheet-teal1-color-checkbox:checked ~ .sheet-tab-button:checked + span,
+input.sheet-teal1-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span,
+input.sheet-teal1-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span + span,
+input.sheet-teal1-color-checkbox:checked ~ .sheet-page .sheet-section-name  { 
+		background-color: #00576B;
+}
+
+.sheet-rolltemplate-age-roller .sheet-age-roller-title.sheet-age-roller-color-teal2,
+input.sheet-teal2-color-checkbox:checked ~ .sheet-tab-button:checked + span,
+input.sheet-teal2-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span,
+input.sheet-teal2-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span + span,
+input.sheet-teal2-color-checkbox:checked ~ .sheet-page .sheet-section-name  {
+		background-color: #1f7b92;
+}
+
+.sheet-rolltemplate-age-roller .sheet-age-roller-title.sheet-age-roller-color-blue1,
+input.sheet-blue1-color-checkbox:checked ~ .sheet-tab-button:checked + span,
+input.sheet-blue1-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span,
+input.sheet-blue1-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span + span,
+input.sheet-blue1-color-checkbox:checked ~ .sheet-page .sheet-section-name  { 
+		background-color: #007ab8;
+}
+
+.sheet-rolltemplate-age-roller .sheet-age-roller-title.sheet-age-roller-color-blue2,
+input.sheet-blue2-color-checkbox:checked ~ .sheet-tab-button:checked + span,
+input.sheet-blue2-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span,
+input.sheet-blue2-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span + span,
+input.sheet-blue2-color-checkbox:checked ~ .sheet-page .sheet-section-name { 
+		background-color: #006496;
+}
+
+.sheet-rolltemplate-age-roller .sheet-age-roller-title.sheet-age-roller-color-orange,
+input.sheet-orange-color-checkbox:checked ~ .sheet-tab-button:checked + span,
+input.sheet-orange-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span,
+input.sheet-orange-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span + span,
+input.sheet-orange-color-checkbox:checked ~ .sheet-page .sheet-section-name  { 
+                background-image: radial-gradient(ellipse at top, #bc610e, #431c00);
+}
+
+.sheet-rolltemplate-age-roller .sheet-age-roller-title.sheet-age-roller-color-threefold,
+input.sheet-threefold-color-checkbox:checked ~ .sheet-tab-button:checked + span,
+input.sheet-threefold-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span,
+input.sheet-threefold-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span + span,
+input.sheet-threefold-color-checkbox:checked ~ .sheet-page .sheet-section-name  { 
+                background-image: linear-gradient(135deg, #00658D, #2A828E, #87641B, #c79846, #851c07);
+}
+
+.sheet-rolltemplate-age-roller .sheet-age-roller-title.sheet-age-roller-color-rainbow,
+input.sheet-rainbow-color-checkbox:checked ~ .sheet-tab-button:checked + span,
+input.sheet-rainbow-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span,
+input.sheet-rainbow-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span + span,
+input.sheet-rainbow-color-checkbox:checked ~ .sheet-page .sheet-section-name  { 
+                background-image: radial-gradient(circle at bottom left, mediumvioletred, firebrick, darkorange, darkkhaki, forestgreen, blue, darkviolet);
+}
+
+.sheet-rolltemplate-age-roller .sheet-age-roller-title.sheet-age-roller-color-green,
+input.sheet-green-color-checkbox:checked ~ .sheet-tab-button:checked + span,
+input.sheet-green-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span,
+input.sheet-green-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span + span,
+input.sheet-green-color-checkbox:checked ~ .sheet-page .sheet-section-name  { 
+                background-image: radial-gradient(circle at center, #1d8514, #1d8514, black);
+}
+
+/* dragonscale texture from https://www.myfreetextures.com/four-dragon-scale-background-textures/ */
+.sheet-rolltemplate-age-roller .sheet-age-roller-title.sheet-age-roller-color-dragon,
+input.sheet-dragon-color-checkbox:checked ~ .sheet-tab-button:checked + span,
+input.sheet-dragon-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span,
+input.sheet-dragon-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span + span,
+input.sheet-dragon-color-checkbox:checked ~ .sheet-page .sheet-section-name  { 
+                background-image: url("https://i.imgur.com/ZiUOVSE.jpg");
+}
+
+.sheet-rolltemplate-age-roller .sheet-age-roller-title.sheet-age-roller-color-lazarus,
+input.sheet-lazarus-color-checkbox:checked ~ .sheet-tab-button:checked + span,
+input.sheet-lazarus-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span,
+input.sheet-lazarus-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span + span,
+input.sheet-lazarus-color-checkbox:checked ~ .sheet-page .sheet-section-name  { 
+                background-image: radial-gradient(circle at center, #3A8BCC, #124179);
+}
+
+.sheet-rolltemplate-age-roller .sheet-age-roller-title.sheet-age-roller-color-stars,
+input.sheet-stars-color-checkbox:checked ~ .sheet-tab-button:checked + span,
+input.sheet-stars-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span,
+input.sheet-stars-color-checkbox:checked ~ .sheet-tab-button.sheet-tab5:checked + span + span + span,
+input.sheet-stars-color-checkbox:checked ~ .sheet-page .sheet-section-name  { 
+                background-image: url("http://i.imgur.com/Xsnnevo.png");
+}
+
+input.sheet-stars-color-checkbox:checked ~ .sheet-tab4 .sheet-ability-strength .sheet-section-name, 
+input.sheet-stars-color-checkbox:checked ~ .sheet-tab4 .sheet-ability-intelligence .sheet-section-name, 
+input.sheet-stars-color-checkbox:checked ~ .sheet-tab4 .sheet-ability-accuracy .sheet-section-name,
+input.sheet-stars-color-checkbox:checked ~ .sheet-tab1 .sheet-ability-strength .sheet-section-name, 
+input.sheet-stars-color-checkbox:checked ~ .sheet-tab1 .sheet-ability-fighting .sheet-section-name, 
+input.sheet-stars-color-checkbox:checked ~ .sheet-tab1 .sheet-ability-communication .sheet-section-name, 
+input.sheet-stars-color-checkbox:checked ~ .sheet-page .sheet-section:nth-child(odd) .sheet-section-name  { 
+                background-image: url("http://i.imgur.com/CEij2yw.png");
+}
+input.sheet-stars-color-checkbox:checked ~ .sheet-tab4 .sheet-ability-willpower .sheet-section-name,
+input.sheet-stars-color-checkbox:checked ~ .sheet-tab4 .sheet-ability-dexterity .sheet-section-name,
+input.sheet-stars-color-checkbox:checked ~ .sheet-tab4 .sheet-ability-communication .sheet-section-name, 
+input.sheet-stars-color-checkbox:checked ~ .sheet-tab1 .sheet-ability-constitution .sheet-section-name, 
+input.sheet-stars-color-checkbox:checked ~ .sheet-tab1 .sheet-ability-intelligence .sheet-section-name, 
+input.sheet-stars-color-checkbox:checked ~ .sheet-tab1 .sheet-ability-willpower .sheet-section-name { 
+                background-image: url("https://i.imgur.com/aRp1Jdz.png");
+}
+
+.sheet-rolltemplate-age-roller .sheet-die-face-drama.sheet-color-red,
+input.sheet-red-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_edit:after,
+input.sheet-red-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_add:before,
+input.sheet-red-color-checkbox:checked ~ button[type=roll].sheet-floating-dice-roller::before,
+input.sheet-red-color-checkbox:checked ~ .sheet-page .sheet-attack-container button[type=roll]::before,
+input.sheet-red-color-checkbox:checked ~ .sheet-page .sheet-spell-short-container button[type=roll]::before,
+input.sheet-red-color-checkbox:checked ~ .sheet-page .sheet-focus-container button[type=roll]::before,
+input.sheet-red-color-checkbox:checked ~ .sheet-page .sheet-spell-container button[type=roll]::before {
+		color: #810206;
+}
+
+.sheet-rolltemplate-age-roller .sheet-die-face-drama.sheet-color-teal1,
+input.sheet-teal1-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_edit:after,
+input.sheet-teal1-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_add:before,
+input.sheet-teal1-color-checkbox:checked ~ button[type=roll].sheet-floating-dice-roller::before,
+input.sheet-teal1-color-checkbox:checked ~ .sheet-page .sheet-attack-container button[type=roll]::before,
+input.sheet-teal1-color-checkbox:checked ~ .sheet-page .sheet-spell-short-container button[type=roll]::before,
+input.sheet-teal1-color-checkbox:checked ~ .sheet-page .sheet-focus-container button[type=roll]::before,
+input.sheet-teal1-color-checkbox:checked ~ .sheet-page .sheet-spell-container button[type=roll]::before {
+		color: #00576B;
+}
+
+.sheet-rolltemplate-age-roller .sheet-die-face-drama.sheet-color-teal2,
+input.sheet-teal2-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_edit:after,
+input.sheet-teal2-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_add:before,
+input.sheet-teal2-color-checkbox:checked ~ button[type=roll].sheet-floating-dice-roller::before,
+input.sheet-teal2-color-checkbox:checked ~ .sheet-page .sheet-attack-container button[type=roll]::before,
+input.sheet-teal2-color-checkbox:checked ~ .sheet-page .sheet-spell-short-container button[type=roll]::before,
+input.sheet-teal2-color-checkbox:checked ~ .sheet-page .sheet-focus-container button[type=roll]::before,
+input.sheet-teal2-color-checkbox:checked ~ .sheet-page .sheet-spell-container button[type=roll]::before { 
+		color: #1f7b92;
+}
+
+.sheet-rolltemplate-age-roller .sheet-die-face-drama.sheet-color-blue1,
+input.sheet-blue1-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_edit:after,
+input.sheet-blue1-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_add:before,
+input.sheet-blue1-color-checkbox:checked ~ button[type=roll].sheet-floating-dice-roller::before,
+input.sheet-blue1-color-checkbox:checked ~ .sheet-page .sheet-attack-container button[type=roll]::before,
+input.sheet-blue1-color-checkbox:checked ~ .sheet-page .sheet-spell-short-container button[type=roll]::before,
+input.sheet-blue1-color-checkbox:checked ~ .sheet-page .sheet-focus-container button[type=roll]::before,
+input.sheet-blue1-color-checkbox:checked ~ .sheet-page .sheet-spell-container button[type=roll]::before {
+		color: #007ab8;
+}
+
+.sheet-rolltemplate-age-roller .sheet-die-face-drama.sheet-color-blue2,
+input.sheet-blue2-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_edit:after,
+input.sheet-blue2-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_add:before,
+input.sheet-blue2-color-checkbox:checked ~ button[type=roll].sheet-floating-dice-roller::before,
+input.sheet-blue2-color-checkbox:checked ~ .sheet-page .sheet-attack-container button[type=roll]::before,
+input.sheet-blue2-color-checkbox:checked ~ .sheet-page .sheet-spell-short-container button[type=roll]::before,
+input.sheet-blue2-color-checkbox:checked ~ .sheet-page .sheet-focus-container button[type=roll]::before,
+input.sheet-blue2-color-checkbox:checked ~ .sheet-page .sheet-spell-container button[type=roll]::before {
+		color: #006496;
+}
+
+.sheet-rolltemplate-age-roller .sheet-die-face-drama.sheet-color-orange,
+input.sheet-orange-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_edit:after,
+input.sheet-orange-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_add:before,
+input.sheet-orange-color-checkbox:checked ~ button[type=roll].sheet-floating-dice-roller::before,
+input.sheet-orange-color-checkbox:checked ~ .sheet-page .sheet-attack-container button[type=roll]::before,
+input.sheet-orange-color-checkbox:checked ~ .sheet-page .sheet-spell-short-container button[type=roll]::before,
+input.sheet-orange-color-checkbox:checked ~ .sheet-page .sheet-focus-container button[type=roll]::before,
+input.sheet-orange-color-checkbox:checked ~ .sheet-page .sheet-spell-container button[type=roll]::before {
+		color: #BC610E;
+}
+
+.sheet-rolltemplate-age-roller .sheet-die-face-drama.sheet-color-stars,
+input.sheet-stars-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_edit:after,
+input.sheet-stars-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_add:before,
+input.sheet-stars-color-checkbox:checked ~ button[type=roll].sheet-floating-dice-roller::before,
+input.sheet-stars-color-checkbox:checked ~ .sheet-page .sheet-attack-container button[type=roll]::before,
+input.sheet-stars-color-checkbox:checked ~ .sheet-page .sheet-spell-short-container button[type=roll]::before,
+input.sheet-stars-color-checkbox:checked ~ .sheet-page .sheet-focus-container button[type=roll]::before,
+input.sheet-stars-color-checkbox:checked ~ .sheet-page .sheet-spell-container button[type=roll]::before {
+		color: black;
+}
+
+.sheet-rolltemplate-age-roller .sheet-die-face-drama.sheet-color-threefold,
+input.sheet-threefold-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_edit:after,
+input.sheet-threefold-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_add:before,
+input.sheet-threefold-color-checkbox:checked ~ button[type=roll].sheet-floating-dice-roller::before,
+input.sheet-threefold-color-checkbox:checked ~ .sheet-page .sheet-attack-container button[type=roll]::before,
+input.sheet-threefold-color-checkbox:checked ~ .sheet-page .sheet-spell-short-container button[type=roll]::before,
+input.sheet-threefold-color-checkbox:checked ~ .sheet-page .sheet-focus-container button[type=roll]::before,
+input.sheet-threefold-color-checkbox:checked ~ .sheet-page .sheet-spell-container button[type=roll]::before {
+		color: #1f7b92;
+}
+
+.sheet-rolltemplate-age-roller .sheet-die-face-drama.sheet-color-lazarus,
+input.sheet-lazarus-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_edit:after,
+input.sheet-lazarus-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_add:before,
+input.sheet-lazarus-color-checkbox:checked ~ button[type=roll].sheet-floating-dice-roller::before,
+input.sheet-lazarus-color-checkbox:checked ~ .sheet-page .sheet-attack-container button[type=roll]::before,
+input.sheet-lazarus-color-checkbox:checked ~ .sheet-page .sheet-spell-short-container button[type=roll]::before,
+input.sheet-lazarus-color-checkbox:checked ~ .sheet-page .sheet-focus-container button[type=roll]::before,
+input.sheet-lazarus-color-checkbox:checked ~ .sheet-page .sheet-spell-container button[type=roll]::before {
+		color: #007ab8;
+}
+
+.sheet-rolltemplate-age-roller .sheet-die-face-drama.sheet-color-green,
+input.sheet-green-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_edit:after,
+input.sheet-green-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_add:before,
+input.sheet-green-color-checkbox:checked ~ button[type=roll].sheet-floating-dice-roller::before,
+input.sheet-green-color-checkbox:checked ~ .sheet-page .sheet-attack-container button[type=roll]::before,
+input.sheet-green-color-checkbox:checked ~ .sheet-page .sheet-spell-short-container button[type=roll]::before,
+input.sheet-green-color-checkbox:checked ~ .sheet-page .sheet-focus-container button[type=roll]::before,
+input.sheet-green-color-checkbox:checked ~ .sheet-page .sheet-spell-container button[type=roll]::before {
+                color: #1D8514;
+}
+
+.sheet-rolltemplate-age-roller .sheet-die-face-drama.sheet-color-rainbow,
+input.sheet-rainbow-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_edit:after,
+input.sheet-rainbow-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_add:before,
+input.sheet-rainbow-color-checkbox:checked ~ button[type=roll].sheet-floating-dice-roller::before,
+input.sheet-rainbow-color-checkbox:checked ~ .sheet-page .sheet-attack-container button[type=roll]::before,
+input.sheet-rainbow-color-checkbox:checked ~ .sheet-page .sheet-spell-short-container button[type=roll]::before,
+input.sheet-rainbow-color-checkbox:checked ~ .sheet-page .sheet-focus-container button[type=roll]::before,
+input.sheet-rainbow-color-checkbox:checked ~ .sheet-page .sheet-spell-container button[type=roll]::before {
+                color: blueviolet;
+}
+
+.sheet-rolltemplate-age-roller .sheet-die-face-drama.sheet-color-dragon,
+input.sheet-dragon-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_edit:after,
+input.sheet-dragon-color-checkbox:checked ~ .sheet-page .repcontrol .repcontrol_add:before,
+input.sheet-dragon-color-checkbox:checked ~ button[type=roll].sheet-floating-dice-roller::before,
+input.sheet-dragon-color-checkbox:checked ~ .sheet-page .sheet-attack-container button[type=roll]::before,
+input.sheet-dragon-color-checkbox:checked ~ .sheet-page .sheet-spell-short-container button[type=roll]::before,
+input.sheet-dragon-color-checkbox:checked ~ .sheet-page .sheet-focus-container button[type=roll]::before,
+input.sheet-dragon-color-checkbox:checked ~ .sheet-page .sheet-spell-container button[type=roll]::before {
+                color: darkred;
+}
+
+
+input.sheet-dragon-age-button:checked       ~ .sheet-page .sheet-no-dragon-age-selected,
+input.sheet-fantasy-age-button:checked      ~ .sheet-page .sheet-no-fantasy-age-selected,
+input.sheet-titansgrave-button:checked      ~ .sheet-page .sheet-no-titansgrave-selected,
+input.sheet-blue-rose-button:checked        ~ .sheet-page .sheet-no-blue-rose-selected,
+input.sheet-the-expanse-button:checked      ~ .sheet-page .sheet-no-the-expanse-selected,
+input.sheet-modern-age-button:checked       ~ .sheet-page .sheet-no-modern-age-selected,
+input.sheet-threefold-button:checked        ~ .sheet-page .sheet-no-threefold-selected,
+input.sheet-world-of-lazarus-button:checked ~ .sheet-page .sheet-no-world-of-lazarus-selected {
+  display: none;
+}
+
+.sheet-mod-selected { display: none; }
+
+/* specific games */
+input.sheet-dragon-age-button:checked       ~ .sheet-page .sheet-dragon-age-selected,
+input.sheet-fantasy-age-button:checked      ~ .sheet-page .sheet-fantasy-age-selected,
+input.sheet-titansgrave-button:checked      ~ .sheet-page .sheet-titansgrave-selected,
+input.sheet-blue-rose-button:checked        ~ .sheet-page .sheet-blue-rose-selected,
+input.sheet-the-expanse-button:checked      ~ .sheet-page .sheet-the-expanse-selected,
+input.sheet-modern-age-button:checked       ~ .sheet-page .sheet-modern-age-selected,
+input.sheet-threefold-button:checked        ~ .sheet-page .sheet-threefold-selected,
+input.sheet-world-of-lazarus-button:checked ~ .sheet-page .sheet-world-of-lazarus-selected,
+input.sheet-dragon-age-button:checked       ~ .sheet-page .sheet-age-selected,
+input.sheet-fantasy-age-button:checked      ~ .sheet-page .sheet-age-selected,
+input.sheet-titansgrave-button:checked      ~ .sheet-page .sheet-age-selected,
+input.sheet-modern-age-button:checked       ~ .sheet-page .sheet-mod-selected,
+input.sheet-threefold-button:checked        ~ .sheet-page .sheet-mod-selected,
+input.sheet-world-of-lazarus-button:checked ~ .sheet-page .sheet-mod-selected,
+input.sheet-fantasy-age-button:checked      ~ .sheet-page .sheet-second-gen-selected,
+input.sheet-titansgrave-button:checked      ~ .sheet-page .sheet-second-gen-selected,
+input.sheet-blue-rose-button:checked        ~ .sheet-page .sheet-second-gen-selected { 
+		display: inline-block;
+}
+
+input.sheet-modern-age-button:checked ~ .sheet-page .sheet-no-mod-selected,
+input.sheet-threefold-button:checked ~ .sheet-page .sheet-no-mod-selected,
+input.sheet-world-of-lazarus-button:checked ~ .sheet-page .sheet-no-mod-selected {
+display: none;
+}
+
+input.sheet-dragon-age-button:checked ~ .sheet-page .sheet-blue-rose-selected,
+input.sheet-fantasy-age-button:checked ~ .sheet-page .sheet-blue-rose-selected,
+input.sheet-titansgrave-button:checked ~ .sheet-page .sheet-blue-rose-selected,
+input.sheet-blue-rose-button:checked ~ .sheet-page .sheet-age-selected,
+input.sheet-the-expanse-button:checked ~ .sheet-page .sheet-blue-rose-selected { 
+		display: none;
+}
+
+sheet-rolltemplate-default td:first-child {
+	text-align: left;
+}
+
+.sheet-rolltemplate-default td:nth-child(2) {
+	text-align: right;
+}
+
+.sheet-rolltemplate-age-roller .sheet-age-roller-container { width: 225px; border: 1px solid black; padding: 0; margin: 0; background-color: white; }
+.sheet-rolltemplate-age-roller .sheet-age-roller-result { width: 100%; padding-top: 10px; text-align: center; border-bottom: 1px solid black;padding-bottom: 5px; }
+.sheet-rolltemplate-age-roller .sheet-die-face { font-size: 48px; font-weight: bold; font-family: "dicefontd6"; color: #333333; }
+.sheet-rolltemplate-age-roller .sheet-die-face-drama { text-transform: uppercase; }
+.sheet-rolltemplate-age-roller .sheet-age-roller-stunt + .sheet-age-roller-stunt { display: none; }
+.sheet-rolltemplate-age-roller .sheet-age-roller-line { padding-top: 2px; padding-bottom: 2px; text-align: top; }
+.sheet-rolltemplate-age-roller .sheet-age-roller-stunt { border-top: 1px solid black; color: green; font-weight: bold; }
+.sheet-rolltemplate-age-roller .sheet-age-roller-col1 { display: inline-block; width: 165px; text-align: left; margin-left: 5px; margin-right: 5px; }
+.sheet-rolltemplate-age-roller .sheet-age-roller-col2 { display: inline-block; width: 36px;  text-align: right; margin-left: 5px; margin-right: 5px; }
+.sheet-rolltemplate-age-roller .sheet-age-roller-title { background-color: black; color: white; font-weight: bold; padding-left: 5px; padding-right: 5px; padding-bottom: 2px; padding-top: 2px; margin-bottom: 3px; }
+.sheet-rolltemplate-age-roller .sheet-age-roller-total { border-top: 1px solid black; }
+.sheet-rolltemplate-age-roller .sheet-age-roller-total .sheet-age-roller-col1 { font-weight: bold; }
+.sheet-rolltemplate-age-roller .sheet-age-roller-tn { border-top: 1px solid black; font-style: italic; }
+
+.sheet-rolltemplate-age-roller .sheet-age-roller-col2 .inlinerollresult { background-color: transparent; border: none; padding: 0; margin: 0; text-align: right; }
+.sheet-rolltemplate-age-roller .sheet-age-roller-col2 .inlinerollresult.fullfail,
+.sheet-rolltemplate-age-roller .sheet-age-roller-col2 .inlinerollresult.fullcrit,
+.sheet-rolltemplate-age-roller .sheet-age-roller-col2 .inlinerollresult.importantroll { border: none; }

--- a/The Expanse RPG (AGE System)/the-expanse-rpg-age-system.html
+++ b/The Expanse RPG (AGE System)/the-expanse-rpg-age-system.html
@@ -1,5 +1,6 @@
 <!-- PLAYER CHARACTER SHEET -->
 <div class="container pc">
+<input type="hidden" value="1.1.0 [Last Modified 26 Feb 2021]" name="attr_version-name">
 
 <input class="hiddencheckbox the-expanse-button" type="checkbox" name="attr_game" value="the-expanse" checked="checked">    
 <input class="hiddencheckbox dragon-age-button" type="checkbox" name="attr_game" value="dragon-age">
@@ -109,7 +110,7 @@
 					<div class="col left-ability-container">
 						<div class="section-name focuses-section">
 							<div class="col ability-name">
-								<button class="abilities-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Accuracy}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{accuracy}]]}}" name="roll_accuracy_check" data-i18n="accuracy-u">ACCURACY</button>
+								<button class="abilities-buttons" name="roll_accuracy_check" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{accuracy} ]] {{mod=@{accuracy}}} {{ability=Accuracy}} {{desc=Accuracy}} {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}" data-i18n="accuracy-u">ACCURACY</button>
 							</div>
 							<div class="col primary-checkbox">
 								<input type="checkbox" name="attr_primary_accuracy"/><span></span>
@@ -120,7 +121,7 @@
 								<input type="hidden" name="attr_focusname">
 								<input type="hidden" name="attr_focusbonus">
 								<input type="hidden" name="attr_focusdescription">
-							    <button class="focus-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Accuracy (@{focusname})}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{accuracy}]]}}{{Focus=+ [[@{focusbonus}]]}}" name="roll_accuracy_focus"><span name="attr_focusname"></span><span> (</span><span name="attr_focusbonus"></span><span>)</span></button><span class="focus-comma">,</span>
+								<button class="focus-buttons" name="roll_accuracy_focus" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{accuracy} + @{focusbonus} ]] {{mod=@{accuracy}}} {{ability=Accuracy}} {{desc=Accuracy (@{focusname})}} {{extramod1=@{focusbonus}}} {{extramod1-name=@{focusname} Focus}}  {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"><span name="attr_focusname"></span><span> (</span><span name="attr_focusbonus"></span><span>)</span></button><span class="focus-comma">,</span>
 							</fieldset>
 						</div>
 					</div>
@@ -133,7 +134,7 @@
 					<div class="col left-ability-container">
 						<div class="section-name focuses-section">
 							<div class="col ability-name">
-								<button class="abilities-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Communication}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{communication}]]}}" name="roll_communication_check" data-i18n="communication-u">COMMUNICATION</button>
+								<button class="abilities-buttons" name="roll_communication_check" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{communication} ]] {{mod=@{communication}}} {{ability=Communication}} {{desc=Communication}}  {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}" data-i18n="communication-u">COMMUNICATION</button>
 							</div>
 							<div class="col primary-checkbox">
 								<input type="checkbox" name="attr_primary_communication"/><span></span>
@@ -144,7 +145,7 @@
 								<input type="hidden" name="attr_focusname">
 								<input type="hidden" name="attr_focusbonus">
 								<input type="hidden" name="attr_focusdescription">
-							    <button class="focus-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Communication (@{focusname})}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{communication}]]}}{{Focus=+ [[@{focusbonus}]]}}" name="roll_communication_focus"><span name="attr_focusname"></span><span> (</span><span name="attr_focusbonus"></span><span>)</span></button><span class="focus-comma">,</span>
+								<button class="focus-buttons" name="roll_communication_focus" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{communication} + @{focusbonus} ]] {{mod=@{communication}}} {{ability=Communication}} {{desc=Communication (@{focusname})}} {{extramod1=@{focusbonus}}} {{extramod1-name=@{focusname} Focus}} {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"><span name="attr_focusname"></span><span> (</span><span name="attr_focusbonus"></span><span>)</span></button><span class="focus-comma">,</span>
 							</fieldset>
 						</div>
 					</div>
@@ -157,7 +158,7 @@
 					<div class="col left-ability-container">
 						<div class="section-name focuses-section">
 							<div class="col ability-name">
-								<button class="abilities-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Constitution}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{constitution}]]}}" name="roll_constitution_check" data-i18n="constitution-u">CONSTITUTION</button>
+								<button class="abilities-buttons" name="roll_constitution_check" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{constitution} ]] {{mod=@{constitution}}} {{ability=Constitution}} {{desc=Constitution}} {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}" data-i18n="constitution-u">CONSTITUTION</button>
 							</div>
 							<div class="col primary-checkbox">
 								<input type="checkbox" name="attr_primary_constitution"/><span></span>
@@ -168,8 +169,7 @@
 								<input type="hidden" name="attr_focusname">
 								<input type="hidden" name="attr_focusbonus">
 								<input type="hidden" name="attr_focusdescription">
-						<!--	<button class="focus-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Constitution (@{focusname})}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{constitution}]]}}{{Focus=+ [[@{focusbonus}]]}}" name="roll_constitution_focus"><span name="attr_focusname"></span><span> (</span><span name="attr_focusbonus"></span><span>)</span></button><span class="focus-comma">,</span> -->
-								<button class="focus-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Constitution (@{focusname})}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{constitution}]]}}{{Focus=+ [[@{focusbonus}]]}}" name="roll_constitution_focus"><span name="attr_focusname"></span><span> (</span><span name="attr_focusbonus"></span><span>)</span></button><span class="focus-comma">,</span>
+								<button class="focus-buttons" name="roll_constitution_focus" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{constitution} + @{focusbonus} ]] {{mod=@{constitution}}} {{ability=Constitution}} {{desc=Constitution (@{focusname})}} {{extramod1=@{focusbonus}}} {{extramod1-name=@{focusname} Focus}}  {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"><span name="attr_focusname"></span><span> (</span><span name="attr_focusbonus"></span><span>)</span></button><span class="focus-comma">,</span>
 							</fieldset>
 						</div>
 					</div>
@@ -182,7 +182,7 @@
 					<div class="col left-ability-container">
 						<div class="section-name focuses-section">
 							<div class="col ability-name">
-								<button class="abilities-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Dexterity}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{dexterity}]]}}" data-i18n="dexterity-u">DEXTERITY</button>
+									<button class="abilities-buttons" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{dexterity} + @{armor-penalty-for-dex} ]] {{mod=@{dexterity}}} {{ability=Dexterity}} {{extramod1=[[@{armor-penalty-for-dex}]]}} {{extramod1-name=Armor Penalty}} {{desc=Dexterity}} {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}" data-i18n="dexterity-u">DEXTERITY</button> 
 							</div>
 							<div class="col primary-checkbox">
 								<input type="checkbox" name="attr_primary_dexterity"/><span></span>
@@ -193,7 +193,7 @@
 								<input type="hidden" name="attr_focusname">
 								<input type="hidden" name="attr_focusbonus">
 								<input type="hidden" name="attr_focusdescription">
-								<button class="focus-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Dexterity (@{focusname})}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{dexterity}]]}}{{Focus=+ [[@{focusbonus}]]}}" name="roll_dexterity_focus"><span name="attr_focusname"></span><span> (</span><span name="attr_focusbonus"></span><span>)</span></button><span class="focus-comma">,</span>
+								<button class="focus-buttons" name="roll_dexterity_focus" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{dexterity} + @{focusbonus} + @{armor-penalty-for-dex} ]] {{mod=@{dexterity}}} {{ability=Dexterity}} {{desc=Dexterity (@{focusname})}} {{extramod1=@{focusbonus}}} {{extramod1-name=@{focusname} Focus}} {{extramod2=[[@{armor-penalty-for-dex}]]}} {{extramod2-name=Armor Penalty}} {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"><span name="attr_focusname"></span><span> (</span><span name="attr_focusbonus"></span><span>)</span></button><span class="focus-comma">,</span>
 							</fieldset>
 						</div>
 					</div>
@@ -206,7 +206,7 @@
 					<div class="col left-ability-container">
 						<div class="section-name focuses-section">
 							<div class="col ability-name">
-								<button class="abilities-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Fighting}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{fighting}]]}}" name="roll_fighting_check" data-i18n="fighting-u">FIGHTING</button>
+								<button class="abilities-buttons" name="roll_fighting_check" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{fighting} ]] {{mod=@{fighting}}} {{ability=Fighting}} {{desc=Fighting}}   {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}" data-i18n="fighting-u">FIGHTING</button>
 							</div>
 							<div class="col primary-checkbox">
 								<input type="checkbox" name="attr_primary_fighting"/><span></span>
@@ -217,7 +217,7 @@
 								<input type="hidden" name="attr_focusname">
 								<input type="hidden" name="attr_focusbonus">
 								<input type="hidden" name="attr_focusdescription">
-								<button class="focus-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Fighting (@{focusname})}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{fighting}]]}}{{Focus=+ [[@{focusbonus}]]}}" name="roll_fighting_focus"><span name="attr_focusname"></span><span> (</span><span name="attr_focusbonus"></span><span>)</span></button><span class="focus-comma">,</span>
+								<button class="focus-buttons" name="roll_fighting_focus" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{fighting} + @{focusbonus} ]] {{mod=@{fighting}}} {{ability=Fighting}} {{desc=Fighting (@{focusname})}} {{extramod1=@{focusbonus}}} {{extramod1-name=@{focusname} Focus}}  {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"><span name="attr_focusname"></span><span> (</span><span name="attr_focusbonus"></span><span>)</span></button><span class="focus-comma">,</span>
 							</fieldset>
 						</div>
 					</div>
@@ -230,7 +230,7 @@
 					<div class="col left-ability-container">
 						<div class="section-name focuses-section">
 							<div class="col ability-name">
-								<button class="abilities-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Intelligence}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{Intelligence}]]}}" name="roll_intelligence_check" data-i18n="intelligence-u">INTELLIGENCE</button>
+								<button class="abilities-buttons" name="roll_intelligence_check" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{intelligence} ]] {{mod=@{intelligence}}} {{ability=Intelligence}} {{desc=Intelligence}}  {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}" data-i18n="intelligence-u">INTELLIGENCE</button>
 							</div>
 							<div class="col primary-checkbox">
 								<input type="checkbox" name="attr_primary_intelligence"/><span></span>
@@ -241,7 +241,7 @@
 								<input type="hidden" name="attr_focusname">
 								<input type="hidden" name="attr_focusbonus">
 								<input type="hidden" name="attr_focusdescription">
-								<button class="focus-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Intelligence (@{focusname})}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{intelligence}]]}}{{Focus=+ [[@{focusbonus}]]}}" name="roll_intelligence_focus"><span name="attr_focusname"></span><span> (</span><span name="attr_focusbonus"></span><span>)</span></button><span class="focus-comma">,</span>
+								<button class="focus-buttons" name="roll_intelligence_focus" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{intelligence} + @{focusbonus} ]] {{mod=@{intelligence}}} {{ability=Intelligence}} {{desc=Intelligence (@{focusname})}} {{extramod1=@{focusbonus}}} {{extramod1-name=@{focusname} Focus}} {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"><span name="attr_focusname"></span><span> (</span><span name="attr_focusbonus"></span><span>)</span></button><span class="focus-comma">,</span>
 							</fieldset>
 						</div>
 					</div>
@@ -254,7 +254,7 @@
 					<div class="col left-ability-container">
 						<div class="section-name focuses-section">
 							<div class="col ability-name">
-								<button class="abilities-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Perception}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{perception}]]}}" name="roll_perception_check" data-i18n="perception-u">PERCEPTION</button>
+								<button class="abilities-buttons" name="roll_perception_check" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{perception} ]] {{mod=@{perception}}} {{ability=Perception}} {{desc=Perception}}  {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}" data-i18n="perception-u">PERCEPTION</button>
 							</div>
 							<div class="col primary-checkbox">
 								<input type="checkbox" name="attr_primary_perception"/><span></span>
@@ -265,7 +265,7 @@
 								<input type="hidden" name="attr_focusname">
 								<input type="hidden" name="attr_focusbonus">
 								<input type="hidden" name="attr_focusdescription">
-								<button class="focus-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Perception (@{focusname})}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{perception}]]}}{{Focus=+ [[@{focusbonus}]]}}" name="roll_perception_focus"><span name="attr_focusname"></span><span> (</span><span name="attr_focusbonus"></span><span>)</span></button><span class="focus-comma">,</span>
+								<button class="focus-buttons" name="roll_perception_focus" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{perception} + @{focusbonus} ]] {{mod=@{perception}}} {{ability=Perception}} {{desc=Perception (@{focusname})}} {{extramod1=@{focusbonus}}} {{extramod1-name=@{focusname} Focus}} {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"><span name="attr_focusname"></span><span> (</span><span name="attr_focusbonus"></span><span>)</span></button><span class="focus-comma">,</span>
 							</fieldset>
 						</div>
 					</div>
@@ -278,7 +278,7 @@
 					<div class="col left-ability-container">
 						<div class="section-name focuses-section">
 							<div class="col ability-name">
-								<button class="abilities-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Strength}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{strength}]]}}" name="roll_strength_check" data-i18n="strength-u">STRENGTH</button>
+								<button class="abilities-buttons" name="roll_strength_check" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{strength} ]] {{mod=@{strength}}} {{ability=Strength}} {{desc=Strength}} {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}" data-i18n="strength-u">STRENGTH</button>
 							</div>
 							<div class="col primary-checkbox">
 								<input type="checkbox" name="attr_primary_strength"/><span></span>
@@ -289,7 +289,7 @@
 								<input type="hidden" name="attr_focusname">
 								<input type="hidden" name="attr_focusbonus">
 								<input type="hidden" name="attr_focusdescription">
-								<button class="focus-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Strength (@{focusname})}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{strength}]]}}{{Focus=+ [[@{focusbonus}]]}}" name="roll_strength_focus"><span name="attr_focusname"></span><span> (</span><span name="attr_focusbonus"></span><span>)</span></button><span class="focus-comma">,</span>
+								<button class="focus-buttons" name="roll_strength_focus" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{strength} + @{focusbonus} ]] {{mod=@{strength}}} {{ability=Strength}} {{desc=Strength (@{focusname})}} {{extramod1=@{focusbonus}}} {{extramod1-name=@{focusname} Focus}} {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"><span name="attr_focusname"></span><span> (</span><span name="attr_focusbonus"></span><span>)</span></button><span class="focus-comma">,</span>
 							</fieldset>
 						</div>
 					</div>
@@ -302,7 +302,7 @@
 					<div class="col left-ability-container">
 						<div class="section-name focuses-section">
 							<div class="col ability-name">
-								<button class="abilities-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Willpower}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{willpower}]]}}" name="roll_willpower_check" data-i18n="willpower-u">WILLPOWER</button>
+								<button class="abilities-buttons" name="roll_willpower_check" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{willpower} ]] {{mod=@{willpower}}} {{ability=Willpower}} {{desc=Willpower}} {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}" data-i18n="willpower-u">WILLPOWER</button>
 							</div>
 							<div class="col primary-checkbox">
 								<input type="checkbox" name="attr_primary_willpower"/><span></span>
@@ -313,7 +313,7 @@
 								<input type="hidden" name="attr_focusname">
 								<input type="hidden" name="attr_focusbonus">
 								<input type="hidden" name="attr_focusdescription">
-								<button class="focus-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Willpower (@{focusname})}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{willpower}]]}}{{Focus=+ [[@{focusbonus}]]}}" name="roll_willpower_focus"><span name="attr_focusname"></span><span> (</span><span name="attr_focusbonus"></span><span>)</span></button><span class="focus-comma">,</span>
+								<button class="focus-buttons" name="roll_willpower_focus" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{willpower} + @{focusbonus} ]] {{mod=@{willpower}}} {{ability=Willpower}} {{desc=Willpower (@{focusname})}} {{extramod1=@{focusbonus}}} {{extramod1-name=@{focusname} Focus}} {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"><span name="attr_focusname"></span><span> (</span><span name="attr_focusbonus"></span><span>)</span></button><span class="focus-comma">,</span>
 							</fieldset>
 						</div>
 					</div>
@@ -360,12 +360,12 @@
 						</div>
 						<div class="col">
 							<div class="speed-defense-score">
-								<input type="number" name="attr_defense" value="10+(@{dexterity}+@{shield-bonus})" disabled="true">
+								<input type="number" name="attr_defense" value="10+(@{dexterity}+@{shield-bonus}+@{defense-bonus})" disabled="true">
 							</div>
 						</div>
 						<div class="col">
 							<div class="speed-defense-score">
-								<input type="number" name="attr_toughness" value="(@{constitution}+@{armor})" disabled="true">
+								<input type="number" name="attr_toughness" value="(@{constitution}+@{armor}+@{tough-bonus})" disabled="true">
 							</div>
 						</div>						
 						<div class="col">
@@ -379,7 +379,19 @@
 								<input type="number" name="attr_shield-bonus" value="0">
 							</div>
 						</div>
-						<div class="shieldbonus-armorpenalty">
+						<div class="shieldbonus-armorpenalty shieldbonus-armorpenalty2">
+							<div class="maximum-input">
+								<span data-i18n="Defense">Defense Bonus</span>
+								<input type="number" name="attr_defense-bonus" value="0">
+							</div>
+						</div>
+						<div class="shieldbonus-armorpenalty shieldbonus-armorpenalty2">
+						    <div class="maximum-input">
+								<span data-i18n="Tough">Tough Bonus</span>
+								<input type="number" name="attr_tough-bonus" value="0">
+							</div>
+						</div>
+						<div class="shieldbonus-armorpenalty shieldbonus-armorpenalty2">
 							<div class="maximum-input">
 								<span data-i18n="Penalty">Armor Penalty</span>
 								<input type="number" name="attr_armor-penalty" value="0">
@@ -446,12 +458,12 @@
 						</div>
 						<div class="col repeatingcol col-attackdice">
 							<input type="text" placeholder="1" name="attr_attackroll">
-							<button type="roll" class="attackroll-noaim" value="@{wtype}&{template:default} {{name=@{char-name-option}@{attack-name}}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Bonus=[[@{attackroll}]]}}{{Range (+0/-2)=@{range}}} }" name="roll_attackdice"></button>
-							<button type="roll" class="attackroll-withprompt" value="@{wtype}&{template:default} {{name=@{char-name-option}@{attack-name}}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Bonus=[[@{attackroll}]]}}{{Aim=[[@{aim-select}]]}}{{Range (+0/-2)=@{range}}}}" name="roll_attackdice"></button>
+							<button class="attackroll-noaim" name="roll_attackdice" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{attackroll}]] {{mod=@{attackroll}}} {{ability=Attack Bonus}} {{desc=@{attack-name} (Range @{range})}}  {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"></button>
+							<button class="attackroll-withprompt" name="roll_attackdice" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{attackroll} + @{aim-select} ]] {{mod=@{attackroll}}} {{ability=Attack Bonus}} {{extramod1=[[@{aim-select}]]}} {{extramod1-name=Aim}}  {{desc=@{attack-name} (Range @{range})}}  {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"></button>
 						</div>
 						<div class="col repeatingcol col-attack-damage">
 							<input type="text" placeholder="2d6+1" name="attr_attack-damage">
-							<button type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}@{attack-name}}}{{Damage=[[@{attack-damage}]]}}" name="roll_weapondamage"></button>
+							<button type="roll" name="roll_weapondamage" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} {{damage=[[@{attack-damage}]]}} {{desc=@{attack-name}}} {{player=@{char-name-option}}} {{simple}}"></button>
 						</div>
 					</fieldset>
 					<div class="col-weapon-groups">
@@ -489,7 +501,8 @@
 				<!-- INCOME -->
 					<div class="money-section">
 						<div class="col repeatingcol money">
-							<span class="money-label">Income:</span> <input class="money-score" type="number" name="attr_income" placeholder="0" title="Income"><button class="" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option} Income Test}} {{roll=[[ 3d6cs>7cf<0 +@{income} ]]}}" name="roll_income_test"></button>
+							<span class="money-label">Income:</span> <input class="money-score" type="number" name="attr_income" placeholder="0" title="Income">
+								<button class="abilities-buttons" name="roll_income_check" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{income}]] {{mod=@{income}}} {{ability=Income}} {{desc=Income}} {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"></button>
 						</div>
 					</div>
 				</div>
@@ -739,7 +752,7 @@
 							<span data-i18n="focus:-u">FOCUS:</span>
 							<input type="text" title="Focus name"  name="attr_focusname">
 							<input type="number" placeholder="2" title="Focus bonus: MUST include a number or the roll will not work." name="attr_focusbonus" min="2" max="5">
-							<button class="focus-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Accuracy (@{focusname})}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{accuracy}]]}}{{Focus=+ [[@{focusbonus}]]}}" name="roll_accuracy_focus"></button>
+							<button class="focus-buttons" name="roll_accuracy_focus" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{accuracy} + @{focusbonus} ]] {{mod=@{accuracy}}} {{ability=Accuracy}} {{desc=Accuracy (@{focusname})}} {{extramod1=@{focusbonus}}} {{extramod1-name=@{focusname} Focus}} {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"></button>
 						</div>
 						<div class="row">
 							<textarea name="attr_focusdescription" placeholder="Description" title="Description"></textarea>
@@ -757,7 +770,7 @@
 							<span data-i18n="focus:-u">FOCUS:</span>
 							<input type="text" title="Focus name"  name="attr_focusname">
 							<input type="number" placeholder="2" title="Focus bonus: MUST include a number or the roll will not work." name="attr_focusbonus" min="2" max="5">
-							<button class="focus-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Communication (@{focusname})}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{communication}]]}}{{Focus=+ [[@{focusbonus}]]}}" name="roll_communication_focus"></button>
+							<button class="focus-buttons" name="roll_communication_focus" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{communication} + @{focusbonus} ]] {{mod=@{communication}}} {{ability=Communication}} {{desc=Communication (@{focusname})}} {{extramod1=@{focusbonus}}} {{extramod1-name=@{focusname} Focus}} {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"></button>
 						</div>
 						<div class="row">
 							<textarea name="attr_focusdescription" placeholder="Description" title="Description"></textarea>
@@ -775,7 +788,7 @@
 							<span data-i18n="focus:-u">FOCUS:</span>
 							<input type="text" title="Focus name"  name="attr_focusname">
 							<input type="number" placeholder="2" title="Focus bonus: MUST include a number or the roll will not work."  name="attr_focusbonus" min="2" max="5">
-							<button class="focus-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Constitution (@{focusname})}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{constitution}]]}}{{Focus=+ [[@{focusbonus}]]}}" name="roll_constitution_focus"></button>
+							<button class="focus-buttons" name="roll_constitution_focus" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{constitution} + @{focusbonus} ]] {{mod=@{constitution}}} {{ability=Constitution}} {{desc=Constitution (@{focusname})}} {{extramod1=@{focusbonus}}} {{extramod1-name=@{focusname} Focus}} {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"></button>
 						</div>
 						<div class="row">
 							<textarea name="attr_focusdescription" placeholder="Description" title="Description"></textarea>
@@ -796,7 +809,7 @@
 							<span data-i18n="focus:-u">FOCUS:</span>
 							<input type="text" title="Focus name"  name="attr_focusname">
 							<input type="number" placeholder="2" title="Focus bonus: MUST include a number or the roll will not work."  name="attr_focusbonus" min="2" max="5">
-							<button class="focus-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Dexterity (@{focusname})}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{dexterity}]]}}{{Focus=+ [[@{focusbonus}]]}}" name="roll_dexterity_focus"></button>
+							<button class="focus-buttons" name="roll_dexterity_focus" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{dexterity} + @{focusbonus} + @{armor-penalty-for-dex} ]] {{mod=@{dexterity}}} {{ability=Dexterity}} {{desc=Dexterity (@{focusname})}} {{extramod1=@{focusbonus}}} {{extramod1-name=@{focusname} Focus}} {{extramod2=[[@{armor-penalty-for-dex}]]}} {{extramod2-name=Armor Penalty}} {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"></button>
 						</div>
 						<div class="row">
 							<textarea name="attr_focusdescription" placeholder="Description" title="Description"></textarea>
@@ -814,7 +827,7 @@
 							<span data-i18n="focus:-u">FOCUS:</span>
 							<input type="text" title="Focus name"  name="attr_focusname">
 							<input type="number" placeholder="2" title="Focus bonus: MUST include a number or the roll will not work." name="attr_focusbonus" min="2" max="5">
-							<button class="focus-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Fighting (@{focusname})}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{fighting}]]}}{{Focus=+ [[@{focusbonus}]]}}" name="roll_fighting_focus"></button>
+							<button class="focus-buttons" name="roll_fighting_focus" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{fighting} + @{focusbonus} ]] {{mod=@{fighting}}} {{ability=Fighting}} {{desc=Fighting (@{focusname})}} {{extramod1=@{focusbonus}}} {{extramod1-name=@{focusname} Focus}} {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"></button>
 						</div>
 						<div class="row">
 							<textarea name="attr_focusdescription" placeholder="Description" title="Description"></textarea>
@@ -832,7 +845,7 @@
 							<span data-i18n="focus:-u">FOCUS:</span>
 							<input type="text" title="Focus name"  name="attr_focusname">
 							<input type="number" placeholder="2" title="Focus bonus: MUST include a number or the roll will not work." name="attr_focusbonus" min="2" max="5">
-							<button class="focus-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Intelligence (@{focusname})}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{intelligence}]]}}{{Focus=+ [[@{focusbonus}]]}}" name="roll_intelligence_focus"></button>
+							<button class="focus-buttons" name="roll_intelligence_focus" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{intelligence} + @{focusbonus} ]] {{mod=@{intelligence}}} {{ability=Intelligence}} {{desc=Intelligence (@{focusname})}} {{extramod1=@{focusbonus}}} {{extramod1-name=@{focusname} Focus}}  {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"></button>
 						</div>
 						<div class="row">
 							<textarea name="attr_focusdescription" placeholder="Description" title="Description"></textarea>
@@ -853,7 +866,7 @@
 							<span data-i18n="focus:-u">FOCUS:</span>
 							<input type="text" title="Focus name"  name="attr_focusname">
 							<input type="number" placeholder="2" title="Focus bonus: MUST include a number or the roll will not work." name="attr_focusbonus" min="2" max="5">
-							<button class="focus-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Perception (@{focusname})}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{perception}]]}}{{Focus=+ [[@{focusbonus}]]}}" name="roll_perception_focus"></button>
+							<button class="focus-buttons" name="roll_perception_focus" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{perception} + @{focusbonus} ]] {{mod=@{perception}}} {{ability=Perception}} {{desc=Perception (@{focusname})}} {{extramod1=@{focusbonus}}} {{extramod1-name=@{focusname} Focus}}  {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"></button>
 						</div>
 						<div class="row">
 							<textarea name="attr_focusdescription" placeholder="Description" title="Description"></textarea>
@@ -871,7 +884,7 @@
 							<span data-i18n="focus:-u">FOCUS:</span>
 							<input type="text" title="Focus name"  name="attr_focusname">
 							<input type="number" placeholder="2" title="Focus bonus: MUST include a number or the roll will not work." name="attr_focusbonus" min="2" max="5">
-							<button class="focus-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Strength (@{focusname})}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{strength}]]}}{{Focus=+ [[@{focusbonus}]]}}" name="roll_strength_focus"></button>
+							<button class="focus-buttons" name="roll_strength_focus" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{strength} + @{focusbonus} ]] {{mod=@{strength}}} {{ability=Strength}} {{desc=Strength (@{focusname})}} {{extramod1=@{focusbonus}}} {{extramod1-name=@{focusname} Focus}}  {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"></button>
 						</div>
 						<div class="row">
 							<textarea name="attr_focusdescription" placeholder="Description" title="Description"></textarea>
@@ -889,7 +902,7 @@
 							<span data-i18n="focus:-u">FOCUS:</span>
 							<input type="text" title="Focus name"  name="attr_focusname">
 							<input type="number" placeholder="2" title="Focus bonus: MUST include a number or the roll will not work." name="attr_focusbonus" min="2" max="5">
-							<button class="focus-buttons" type="roll" value="@{wtype}&{template:default} {{name=@{char-name-option}Willpower (@{focusname})}}{{Roll=[[1d6cs>7cf<0]] [[1d6cs>7cf<0]] [[1d6cs>1cf<6]]}}{{Ability=+ [[@{willpower}]]}}{{Focus=+ [[@{focusbonus}]]}}" name="roll_willpower_focus"></button>
+							<button class="focus-buttons" name="roll_willpower_focus" type="roll" value="@{wtype}&{template:age-roller} {{color-@{color}=1}} [[ [[1d6]] + [[1d6]] + [[1d6]] + @{willpower} + @{focusbonus} ]] {{mod=@{willpower}}} {{ability=Willpower}} {{desc=Willpower (@{focusname})}} {{extramod1=@{focusbonus}}} {{extramod1-name=@{focusname} Focus}} {{player=@{char-name-option}}} {{die1=$[[0]]}} {{die2=$[[1]]}} {{drama=$[[2]]}} {{total=$[[3]]}}"></button>
 						</div>
 						<div class="row">
 							<textarea name="attr_focusdescription" placeholder="Description" title="Description"></textarea>
@@ -952,7 +965,7 @@
 						<span data-i18n="specialization2-u">SPECIALIZATION 2</span>
 				</div>
 				<div class="info-container">
-						<input type="text" name="attr_specialization1-degree" style="width: 97px;">
+						<input type="text" name="attr_specialization2-degree" style="width: 97px;">
 						<span data-i18n="specialization1-degree-u">DEGREE</span>
 				</div>
 			</div>
@@ -1029,9 +1042,18 @@
 						<span data-i18n="aim-value-a-value-must-be-entered-here">Aim value (a number MUST be entered here)</span>
 					</div>
 					<div class="col aim-value-field">
-						<input type="number" name="attr_aim-value" placeholder="*">
+						<input type="number" name="attr_aim-value" placeholder="*" value="1">
 					</div>
 				</div>
+				<div class="row">
+					<div class="col select-text">
+						<span data-i18n="apply-armor-penalty-to-dexterity-rolls">Apply Armor Penalty to Dexterity rolls</span>
+					</div>
+                    <select name="attr_armor-penalty-for-dex">
+                        <option value="0" data-i18n="no">No</option>
+                        <option value="@{armor-penalty}" data-i18n="yes">Yes</option>
+                    </select>
+                </div>
 			</div>
 		</div>
 		<div class="col col-options">
@@ -1045,7 +1067,11 @@
 			        the TotalRolled for AGE API script by Joshua Casserino and Olivier L.-L., 
 			        with much appreciation from Green Ronin.</p>
 			        <p>The Expanse RPG is ©2019 Green Ronin Publishing, LLC. The Expanse is © 2011-2020 Daniel Abraham and Ty Franck.</p>
-			        <span class="version-name">Version 1.0.0 [Last Modified 20 July 2020]</span>
+			       <!-- <span class="version-name">Version 1.0.0 [Last Modified 20 July 2020]</span> -->
+					<span class="version-name">
+						<span data-i18n="version">Version</span>
+						<span name="attr_version-name"></span>
+				  </span>
 			    </div>
 			</div>
 		</div>
@@ -1054,3 +1080,264 @@
 
 </div>
 <!-- END OF PC SHEET -->
+
+<rolltemplate class="sheet-rolltemplate-age-roller">
+	<div class="sheet-age-roller-container">
+	 
+		   {{#color-black}} <div class="sheet-age-roller-title sheet-age-roller-color-black">{{#player}}{{player}}{{/player}}{{#desc}}{{desc}}{{/desc}} </div> {{/color-black}}
+		   {{#color-red}} <div class="sheet-age-roller-title sheet-age-roller-color-red">{{#player}}{{player}}{{/player}}{{#desc}}{{desc}}{{/desc}} </div> {{/color-red}}
+		   {{#color-blue1}} <div class="sheet-age-roller-title sheet-age-roller-color-blue1">{{#player}}{{player}}{{/player}}{{#desc}}{{desc}}{{/desc}} </div> {{/color-blue1}}
+		   {{#color-blue2}} <div class="sheet-age-roller-title sheet-age-roller-color-blue2">{{#player}}{{player}}{{/player}}{{#desc}}{{desc}}{{/desc}} </div> {{/color-blue2}}
+		   {{#color-teal1}} <div class="sheet-age-roller-title sheet-age-roller-color-teal1">{{#player}}{{player}}{{/player}}{{#desc}}{{desc}}{{/desc}} </div> {{/color-teal1}}
+		   {{#color-teal2}} <div class="sheet-age-roller-title sheet-age-roller-color-teal2">{{#player}}{{player}}{{/player}}{{#desc}}{{desc}}{{/desc}} </div> {{/color-teal2}}
+		   {{#color-green}} <div class="sheet-age-roller-title sheet-age-roller-color-green">{{#player}}{{player}}{{/player}}{{#desc}}{{desc}}{{/desc}} </div> {{/color-green}}
+		   {{#color-orange}} <div class="sheet-age-roller-title sheet-age-roller-color-orange">{{#player}}{{player}}{{/player}}{{#desc}}{{desc}}{{/desc}} </div> {{/color-orange}}
+		   {{#color-stars}}<div class="sheet-age-roller-title sheet-age-roller-color-stars">{{#player}}{{player}}{{/player}}{{#desc}}{{desc}}{{/desc}} </div>{{/color-stars}}
+		   {{#color-threefold}}<div class="sheet-age-roller-title sheet-age-roller-color-threefold">{{#player}}{{player}}{{/player}}{{#desc}}{{desc}}{{/desc}} </div>{{/color-threefold}}
+		   {{#color-lazarus}}<div class="sheet-age-roller-title sheet-age-roller-color-lazarus">{{#player}}{{player}}{{/player}}{{#desc}}{{desc}}{{/desc}} </div>{{/color-lazarus}}
+		   {{#color-rainbow}}<div class="sheet-age-roller-title sheet-age-roller-color-rainbow">{{#player}}{{player}}{{/player}}{{#desc}}{{desc}}{{/desc}} </div>{{/color-rainbow}}
+		   {{#color-dragon}}<div class="sheet-age-roller-title sheet-age-roller-color-dragon">{{#player}}{{player}}{{/player}}{{#desc}}{{desc}}{{/desc}} </div>{{/color-dragon}}
+
+		   {{#total}}
+				   <div class="sheet-age-roller-result">
+						  <span class="sheet-die-face">
+								  {{#rollTotal() die1 1}}a{{/rollTotal() die1 1}}
+								  {{#rollTotal() die1 2}}b{{/rollTotal() die1 2}}
+								  {{#rollTotal() die1 3}}c{{/rollTotal() die1 3}}
+								  {{#rollTotal() die1 4}}d{{/rollTotal() die1 4}}
+								  {{#rollTotal() die1 5}}e{{/rollTotal() die1 5}}
+								  {{#rollTotal() die1 6}}f{{/rollTotal() die1 6}}
+						  </span>
+						  <span class="sheet-die-face">
+								  {{#rollTotal() die2 1}}a{{/rollTotal() die2 1}}
+								  {{#rollTotal() die2 2}}b{{/rollTotal() die2 2}}
+								  {{#rollTotal() die2 3}}c{{/rollTotal() die2 3}}
+								  {{#rollTotal() die2 4}}d{{/rollTotal() die2 4}}
+								  {{#rollTotal() die2 5}}e{{/rollTotal() die2 5}}
+								  {{#rollTotal() die2 6}}f{{/rollTotal() die2 6}}
+						   </span>
+						   {{#color-black}} <span class="sheet-die-face sheet-die-face-drama sheet-color-black"> {{/color-black}}
+						   {{#color-red}} <span class="sheet-die-face sheet-die-face-drama sheet-color-red"> {{/color-red}}
+						   {{#color-blue1}} <span class="sheet-die-face sheet-die-face-drama sheet-color-blue1"> {{/color-blue1}}
+						   {{#color-blue2}} <span class="sheet-die-face sheet-die-face-drama sheet-color-blue2"> {{/color-blue2}}
+						   {{#color-teal1}} <span class="sheet-die-face sheet-die-face-drama sheet-color-teal1"> {{/color-teal1}}
+						   {{#color-teal2}} <span class="sheet-die-face sheet-die-face-drama sheet-color-teal2"> {{/color-teal2}}
+						   {{#color-orange}} <span class="sheet-die-face sheet-die-face-drama sheet-color-orange"> {{/color-orange}}
+						   {{#color-green}} <span class="sheet-die-face sheet-die-face-drama sheet-color-green"> {{/color-green}}
+						   {{#color-threefold}} <span class="sheet-die-face sheet-die-face-drama sheet-color-threefold"> {{/color-threefold}}
+						   {{#color-lazarus}} <span class="sheet-die-face sheet-die-face-drama sheet-color-lazarus"> {{/color-lazarus}}
+						   {{#color-stars}} <span class="sheet-die-face sheet-die-face-drama sheet-color-stars"> {{/color-stars}}
+						   {{#color-rainbow}} <span class="sheet-die-face sheet-die-face-drama sheet-color-rainbow"> {{/color-rainbow}}
+						   {{#color-dragon}} <span class="sheet-die-face sheet-die-face-drama sheet-color-dragon"> {{/color-dragon}}
+
+								  {{#rollTotal() drama 1}}a{{/rollTotal() drama 1}}
+								  {{#rollTotal() drama 2}}b{{/rollTotal() drama 2}}
+								  {{#rollTotal() drama 3}}c{{/rollTotal() drama 3}}
+								  {{#rollTotal() drama 4}}d{{/rollTotal() drama 4}}
+								  {{#rollTotal() drama 5}}e{{/rollTotal() drama 5}}
+								  {{#rollTotal() drama 6}}f{{/rollTotal() drama 6}}
+							</span>
+				   </div>
+		   {{/total}}
+
+		   {{#mod}}
+				   <div class="sheet-age-roller-line">
+						   <div class="sheet-age-roller-col1 sheet-age-roller-ability">
+								  {{#ability}}{{ability}}{{/ability}}
+						   </div>
+						   <div class="sheet-age-roller-col2 sheet-age-roller-mod">
+								  {{#mod}}
+										  {{#rollGreater() mod 0}}+{{/rollGreater() mod 0}}{{mod}}
+								  {{/mod}}
+						   </div>
+				   </div>
+		   {{/mod}}
+
+		   {{#damage}}
+				   <div class="sheet-age-roller-line">
+						   <div class="sheet-age-roller-col1">
+								  Damage
+						   </div>
+						   <div class="sheet-age-roller-col2">
+								  {{damage}}
+						   </div>
+				   </div>
+		   {{/damage}}
+
+		   {{#extramod1}}
+				   <div class="sheet-age-roller-line">
+						   <div class="sheet-age-roller-col1">
+								  {{#extramod1-name}}{{extramod1-name}}{{/extramod1-name}}
+						   </div>
+						   <div class="sheet-age-roller-col2">
+								  {{#extramod1}}
+										  {{#rollGreater() extramod1 0}}+{{/rollGreater() extramod1 0}}{{extramod1}}
+								  {{/extramod1}}
+						   </div>
+				   </div>
+		   {{/extramod1}}
+
+		   {{#extramod2}}
+				   {{#^rollTotal() extramod2 0}}
+						   <div class="sheet-age-roller-line">
+								   <div class="sheet-age-roller-col1">
+										  {{#extramod2-name}}{{extramod2-name}}{{/extramod2-name}}
+								   </div>
+								   <div class="sheet-age-roller-col2">
+										  {{#extramod2}}
+												  {{#rollGreater() extramod2 0}}+{{/rollGreater() extramod2 0}}{{extramod2}}
+										  {{/extramod2}}
+								   </div>
+						   </div>
+				   {{/^rollTotal() extramod2 0}}
+		   {{/extramod2}}
+
+		   {{#extramod3}}
+				   {{#^rollTotal() extramod3 0}}
+						   <div class="sheet-age-roller-line">
+								   <div class="sheet-age-roller-col1">
+										  {{#extramod3-name}}{{extramod3-name}}{{/extramod3-name}}
+								   </div>
+								   <div class="sheet-age-roller-col2">
+										  {{#extramod3}}
+												  {{#rollGreater() extramod3 0}}+{{/rollGreater() extramod3 0}}{{extramod3}}
+										  {{/extramod3}}
+								   </div>
+						   </div>
+				   {{/^rollTotal() extramod3 0}}
+		   {{/extramod3}}
+
+		   {{#extramod4}}
+				   {{#^rollTotal() extramod4 0}}
+						   <div class="sheet-age-roller-line">
+								   <div class="sheet-age-roller-col1">
+										  {{#extramod4-name}}{{extramod4-name}}{{/extramod4-name}}
+								   </div>
+								   <div class="sheet-age-roller-col2">
+										  {{#extramod4}}
+												  {{#rollGreater() extramod4 0}}+{{/rollGreater() extramod4 0}}{{extramod4}}
+										  {{/extramod4}}
+								   </div>
+						   </div>
+				   {{/^rollTotal() extramod4 0}}
+		   {{/extramod4}}
+
+		   {{#rollGreater() fatigue 0}}
+						   <div class="sheet-age-roller-line">
+								   <div class="sheet-age-roller-col1">
+										  Fatigue
+								   </div>
+								   <div class="sheet-age-roller-col2">
+										  {{#fatigue}}
+												  -{{fatigue}}
+										  {{/fatigue}}
+								   </div>
+						   </div>
+		   {{/rollGreater() fatigue 0}}
+
+		   {{#total}}
+				   <div class="sheet-age-roller-total sheet-age-roller-line">
+							<span class="sheet-age-roller-col1">Total</span>
+							<span class="sheet-age-roller-col2">{{total}}</span>
+				   </div>
+		   {{/total}}
+
+		   {{#tn}} 
+				   <div class="sheet-age-roller-line sheet-age-roller-tn">
+						   <span class="sheet-age-roller-col1">
+								   Target Number
+						   </span>
+						   <span class="sheet-age-roller-col2">
+								   {{tn}}
+						   </span>
+	  
+				   </div> 
+		   {{/tn}}
+
+		   {{#note1}} 
+				   <div class="sheet-age-roller-line sheet-age-roller-tn">
+						   <span class="sheet-age-roller-col1">
+								   {{note1-name}}
+						   </span>
+						   <span class="sheet-age-roller-col2">
+								   {{note1}}
+						   </span>
+	  
+				   </div> 
+		   {{/note1}}
+
+		   {{#note2}} 
+				   <div class="sheet-age-roller-line sheet-age-roller-tn">
+						   <span class="sheet-age-roller-col1">
+								   {{note2-name}}
+						   </span>
+						   <span class="sheet-age-roller-col2">
+								   {{note2}}
+						   </span>
+				   </div> 
+		   {{/note2}}
+
+		   {{#note3}} 
+				   <div class="sheet-age-roller-line sheet-age-roller-tn">
+						   <span class="sheet-age-roller-col1">
+								   {{note3-name}}
+						   </span>
+						   <span class="sheet-age-roller-col2">
+								   {{note3}}
+						   </span>
+				   </div> 
+		   {{/note3}}
+
+		   {{#note4}} 
+				   <div class="sheet-age-roller-line sheet-age-roller-tn">
+						   <span class="sheet-age-roller-col1">
+								   {{note4-name}}
+						   </span>
+						   <span class="sheet-age-roller-col2">
+								   {{note4}}
+						   </span>
+				   </div> 
+		   {{/note4}}
+
+		   {{#note5}} 
+				   <div class="sheet-age-roller-line sheet-age-roller-tn">
+						   <span class="sheet-age-roller-col1">
+								  {{note5-name}}
+						   </span>
+						   <span class="sheet-age-roller-col2">
+								   {{note5}}
+						   </span>
+				   </div> 
+		   {{/note5}}
+
+		   {{#note6}} 
+				   <div class="sheet-age-roller-line sheet-age-roller-tn">
+						   <span class="sheet-age-roller-col1">
+								  {{note6-name}}
+						   </span>
+						   <span class="sheet-age-roller-col2">
+								   {{note6}}
+						   </span>
+				   </div> 
+		   {{/note6}}
+
+		   {{#rollTotal() die1 die2}}
+					<div class="sheet-age-roller-line sheet-age-roller-stunt">
+						   <span class="sheet-age-roller-stunt-dice-label sheet-age-roller-col1">Stunt Points</span><span class="sheet-age-roller-stunt-dice sheet-age-roller-col2">{{drama}}</span>        
+					</div>
+		   {{/rollTotal() die1 die2}}
+
+		   {{#rollTotal() die1 drama}}
+					<div class="sheet-age-roller-line sheet-age-roller-stunt">
+						   <span class="sheet-age-roller-stunt-dice-label sheet-age-roller-col1">Stunt Points</span><span class="sheet-age-roller-stunt-dice sheet-age-roller-col2">{{drama}}</span>        
+					</div>
+		   {{/rollTotal() die1 drama}}
+
+		   {{#rollTotal() die2 drama}}
+					<div class="sheet-age-roller-line sheet-age-roller-stunt">
+						   <span class="sheet-age-roller-stunt-dice-label sheet-age-roller-col1">Stunt Points</span><span class="sheet-age-roller-stunt-dice sheet-age-roller-col2">{{drama}}</span>        
+					</div>
+		   {{/rollTotal() die2 drama}}
+
+   </div>
+</rolltemplate>

--- a/The Expanse RPG (AGE System)/translation.json
+++ b/The Expanse RPG (AGE System)/translation.json
@@ -58,6 +58,8 @@
 	"base": "Base",
 	"Shield": "Shield Bonus",
 	"Penalty": "Armor Penalty",
+	"Defense": "Defence Lvl Bonus",
+	"Tough": "Tough Lvl Bonus",
 	"attack-u": "WEAPON TYPE",
 	"range-u": "RANGE",
 	"reload-u": "RELOAD",
@@ -178,5 +180,10 @@
 	"unconscious": "UNCONSCIOUS",
 	"wounded": "WOUNDED",
 	"about-u": "ABOUT",
-	"DEGREE:-u": "DEGREE:"
+	"DEGREE:-u": "DEGREE:",
+	"version":"Version",
+	"no":"No",
+   	"yes":"Yes",
+	"income-u":"INCOME",
+	"apply-armor-penalty-to-dexterity-rolls":"Apply Armor Penalty to Dexterity rolls"
 }


### PR DESCRIPTION

## Changes / Comments

Update for The Expanse RPG sheet
Bug Fixes:
• DEX/Toughness increase now possible with ever 4 character levels, using new widgets.
• Fixed Level for specialisation  2, was a duplicate of specialisation 1 level parameter attribute
• Added Dex penalty dropdown option for armour (backported from AGE System All in One Sheet)

Extra Functionality:
◇ Custom dice roller backported from AGE sheet so that TotalrollAGE API no longer required to show stunts points

Attributes added but not removed.
 Layout changed slightly on main screen for the extra two widgets labelled 'Tough Lvl bonus' and 'Defence Lvl Bonus'
 Layout changed slightly on 'Cog' screen for 'Apply Armor Penalty to Dexterity rolls' dropdown





## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
