### PR TITLE
[Pathfinder_Cazra] add tracker for Turn Order on "initiative" button

### DIFF
--- a/Pathfinder_Cazra/sheet.html
+++ b/Pathfinder_Cazra/sheet.html
@@ -355,7 +355,7 @@
                 <div class="blackBox">
                   <div class="rollButton">
                     <div class="shortname" data-i18n="initiative">Initiative</div>
-                    <button type="roll" value="&amp;{template:pf} {{charName=@{character_name}}} {{attr=init}} {{result=[[1d20 + @{init}]]}}{{isNotAttack=true}}{{notes=@{init_notes}}}"></button>
+                    <button type="roll" value="&amp;{template:pf} {{charName=@{character_name}}} {{attr=init}} {{result=[[1d20 + @{init} &amp;{tracker}]]}}{{isNotAttack=true}}{{notes=@{init_notes}}}"></button>
                   </div>
                 </div>
                 <div class="labelledUnderlined">


### PR DESCRIPTION
## Changes / Comments

the "&{tracker}" code was missing on the "Initiative" button ; this code will add the selected token to the "Turn Order" table.




## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
