### PR TITLE
PokemonTabletopAdventures_v3 - Autoinitiative, status boxes, and more

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -111,7 +111,8 @@
 
 /* Fancy colors */
 
-input.sheet-hidden-setting {
+input.sheet-hidden-setting,
+button.sheet-hidden-setting {
   display: none;
 }
 
@@ -326,6 +327,12 @@ p {
   margin-bottom: 0px;
 }
 
+label {
+  margin-bottom: 0px;
+  font-size: 1em;
+  color: var(--foreground-color);
+}
+
 .sheet-ball {
   display: block;
   text-align: center;
@@ -380,6 +387,27 @@ p {
   grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
 }
 
+.sheet-below-stats {
+  display: grid;
+  justify-items: stretch;
+  text-align: left;
+  grid-template-columns: 2.6fr 1fr;
+  padding-left: 25px;
+}
+
+.sheet-afflictions-grid {
+  display: grid;
+  justify-items: left;
+  text-align: left;
+  grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+}
+
+.sheet-afflictions-text {
+  justify-items: left;
+  text-align: left;
+  padding-left: 25px;
+}
+
 .sheet-half-text {
   width: 105px;
 }
@@ -429,6 +457,13 @@ p {
   color: var(--foreground-color);
   vertical-align: revert;
   width: 70px !important;
+}
+
+.sheet-affliction-display[type="text"] {
+  border: none;
+  color: var(--foreground-color);
+  font-weight: bold;
+  width: auto !important;
 }
 
 .sheet-damage-dice-count[type="number"] {

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -320,15 +320,6 @@
           <br />
           <p>SPD mod</p>
         </div>
-        <p></p>
-        <p></p>
-        <p></p>
-        <p></p>
-        <b>Movement</b>
-        <span>
-          <input class="sheet-speed-read-color" name="attr_movement" readonly title="Attribute: movement" type="number" />
-          <b>ft</b>
-        </span>
       </div>
     </div>
 
@@ -337,6 +328,14 @@
         <input checked class="sheet-options-flag" name="attr_options_stat_flag" type="checkbox" />
         <span name="attr_stat_flag">-</span>
         <div class="sheet-display">
+          <div class="sheet-below-stats">
+            <input class="sheet-affliction-display" name="attr_afflictions_text" readonly type="text" value="" />
+            <span>
+              <b>Movement: </b>
+              <input class="sheet-speed-read-color" name="attr_movement" readonly title="Attribute: movement" type="number" />
+              <b>ft</b>
+            </span>
+          </div>
           <div class="sheet-pokemon-extra-stats-grid">
             <b>Temp Stat Changes</b>
             <input class="sheet-attack-color" name="attr_atkbonus" title="Attribute: atkbonus" type="number" />
@@ -347,6 +346,26 @@
           </div>
         </div>
         <div class="sheet-options">
+          <div class="sheet-below-stats">
+            <div class="sheet-afflictions-grid">
+              <p><label><input name="attr_Asleep" value="1" title="Attribute: Asleep" type="checkbox" /> Asleep</label></p>
+              <p><label><input name="attr_Burned" value="1" title="Attribute: Burned" type="checkbox" /> Burned</label></p>
+              <p><label><input name="attr_Confused" value="1" title="Attribute: Confused" type="checkbox" /> Confused</label></p>
+              <p><label><input name="attr_Cursed" value="1" title="Attribute: Cursed" type="checkbox" /> Cursed</label></p>
+              <p><label><input name="attr_Frozen" value="1" title="Attribute: Frozen" type="checkbox" /> Frozen</label></p>
+              <p><label><input name="attr_Infatuated" value="1" title="Attribute: Infatuated" type="checkbox" /> Infatuated</label></p>
+              <p><label><input name="attr_Paralyzed" value="1" title="Attribute: Paralyzed" type="checkbox" /> Paralyzed</label></p>
+              <p><label><input name="attr_Poisoned" value="1" title="Attribute: Poisoned" type="checkbox" /> Poisoned</label></p>
+              <p><label><input name="attr_Toxified" value="1" title="Attribute: Toxified" type="checkbox" /> Toxified</label></p>
+              <p><label><input name="attr_Stunned" value="1" title="Attribute: Stunned" type="checkbox" /> Stunned</label></p>
+            </div>
+            <div class="sheet-2col-centered">
+              <b>Movement</b>
+              <b>Bonus</b>
+              <span><input class="sheet-speed-read-color" name="attr_movement" readonly title="Attribute: movement" type="number" /><b>ft</b></span>
+              <span><input name="attr_movebonus" title="Attribute: movebonus" type="number" /><b>ft</b></span>
+            </div>
+          </div>
           <div class="sheet-pokemon-extra-stats-grid">
             <p></p>
             <b>Attack</b>
@@ -376,6 +395,14 @@
         <input checked class="sheet-options-flag" name="attr_options_stat_flag" type="checkbox" />
         <span name="attr_stat_flag">-</span>
         <div class="sheet-display">
+          <div class="sheet-below-stats">
+            <input class="sheet-affliction-display" name="attr_afflictions_text" readonly type="text" value="" />
+            <span>
+              <b>Movement: </b>
+              <input class="sheet-speed-read-color" name="attr_movement" readonly title="Attribute: movement" type="number" />
+              <b>ft</b>
+            </span>
+          </div>
           <div class="sheet-pokemon-extra-stats-grid">
             <b>Temp Stat Changes</b>
             <input class="sheet-attack-color" name="attr_atkbonus" title="Attribute: atkbonus" type="number" />
@@ -386,6 +413,26 @@
           </div>
         </div>
         <div class="sheet-options">
+          <div class="sheet-below-stats">
+            <div class="sheet-afflictions-grid">
+              <p><label><input name="attr_Asleep" value="1" title="Attribute: Asleep" type="checkbox" /> Asleep</label></p>
+              <p><label><input name="attr_Burned" value="1" title="Attribute: Burned" type="checkbox" /> Burned</label></p>
+              <p><label><input name="attr_Confused" value="1" title="Attribute: Confused" type="checkbox" /> Confused</label></p>
+              <p><label><input name="attr_Cursed" value="1" title="Attribute: Cursed" type="checkbox" /> Cursed</label></p>
+              <p><label><input name="attr_Frozen" value="1" title="Attribute: Frozen" type="checkbox" /> Frozen</label></p>
+              <p><label><input name="attr_Infatuated" value="1" title="Attribute: Infatuated" type="checkbox" /> Infatuated</label></p>
+              <p><label><input name="attr_Paralyzed" value="1" title="Attribute: Paralyzed" type="checkbox" /> Paralyzed</label></p>
+              <p><label><input name="attr_Poisoned" value="1" title="Attribute: Poisoned" type="checkbox" /> Poisoned</label></p>
+              <p><label><input name="attr_Toxified" value="1" title="Attribute: Toxified" type="checkbox" /> Toxified</label></p>
+              <p><label><input name="attr_Stunned" value="1" title="Attribute: Stunned" type="checkbox" /> Stunned</label></p>
+            </div>
+            <div class="sheet-2col-centered">
+              <b>Movement</b>
+              <b>Bonus</b>
+              <span><input class="sheet-speed-read-color" name="attr_movement" readonly title="Attribute: movement" type="number" /><b>ft</b></span>
+              <span><input name="attr_movebonus" title="Attribute: movebonus" type="number" /><b>ft</b></span>
+            </div>
+          </div>
           <div class="sheet-pokemon-extra-stats-grid">
             <p></p>
             <b>Attack</b>
@@ -411,7 +458,7 @@
             <input class="sheet-spatk-color" name="attr_spatkbonus" title="Attribute: spatkbonus" type="number" />
             <input class="sheet-spdef-color" name="attr_spdefbonus" title="Attribute: spdefbonus" type="number" />
             <input class="sheet-speed-color" name="attr_spdbonus" title="Attribute: spdbonus" type="number" />
-            <b></b>
+            <p></p>
             <b>Cool</b>
             <b>Tough</b>
             <b>Beauty</b>
@@ -785,12 +832,12 @@
           <input class="sheet-top-information sheet-thin-number" max="20" min="1" name="attr_move_critthreshold" title="Attribute: move_critthreshold" type="number" value="20" />
         </span>
         <span>
-          <b title="Additional damage for moves that use the Attack stat, such as for Ace Trainer">Attack Bonus</b>
+          <b title="Additional damage for moves that use the Attack stat, such as for Ace Trainer">Attack Damage Bonus</b>
           <b class="sheet-info-tooltip" title="Additional damage for moves that use the Attack stat, such as for Ace Trainer">ℹ</b>
           <input class="sheet-top-information sheet-thin-number" name="attr_move_bonusattack" title="Attribute: move_bonusattack" type="number" value="0" />
         </span>
         <span>
-          <b title="Additional damage for moves that use the Special Attack stat, such as for Ace Trainer">Special Attack Bonus</b>
+          <b title="Additional damage for moves that use the Special Attack stat, such as for Ace Trainer">Special Attack Damage Bonus</b>
           <b class="sheet-info-tooltip" title="Additional damage for moves that use the Special Attack stat, such as for Ace Trainer">ℹ</b>
           <input class="sheet-top-information sheet-thin-number" name="attr_move_bonusspecialattack" title="Attribute: move_bonusspecialattack" type="number" value="0" />
         </span>
@@ -1038,16 +1085,6 @@
           suited to custom classes.
         </p>
       </div>
-      <div class="sheet-initiative-breaker">
-        <b title="Default value: [[d20]]">Initiative Tie Breaker:</b>
-        <b class="sheet-info-tooltip" title="Default value: [[d20]]"> ℹ </b>
-        <input name="attr_initiative-tie-breaker" title="Attribute: initiative-tie-breaker" type="text" value="[[d20]]" /><br />
-        <p class="sheet-dark-text">
-          This setting is not used by the character sheet, but is incldued so that you can, if you wish, add it to the character's speed when determining their
-          initiative order. (Note this isn't an official rule, but it's helpful when characters have the same speed!)
-          <br />For best results, leave this as something you can add to a die-roll.
-        </p>
-      </div>
       <div class="sheet-type-color-selection">
         <b title="Default value: Normal">Type & Background Color:</b>
         <b class="sheet-info-tooltip" title="Default value: Normal"> ℹ </b>
@@ -1074,6 +1111,29 @@
         </select>
         <p class="sheet-dark-text">
           This setting will update the first type for Pokémon-type characters, and also change the character sheet color theme for all types of characters.
+        </p>
+      </div>
+      <div class="sheet-initiative-macro">
+        <b title="Default value: @{SPD}+(@{initiative-tie-breaker}/100)">Initiative Macro:</b>
+        <b class="sheet-info-tooltip" title="Default value: @{SPD}+(@{initiative-tie-breaker}/100)"> ℹ </b>
+        <input name="attr_initiative-macro" title="Attribute: initiative-macro" type="text" value="@{SPD}+(@{initiative-tie-breaker}/100)" /><br />
+        <p class="sheet-dark-text">
+          If a Token is associated with a character, they will automatically gain an 'initiative' token action. By clicking the token action on the top
+          left of the screen, the token will automatically roll the macro above, and add the token to the turn order. By default, it will use the character's
+          speed stat, plus 1/100th of the initiative tie breaker, which defaults to 1d20.
+        </p>
+        <!-- This is super not supported so be warned that it might break one day -->
+        <button class="tokenaction sheet-hidden-setting" type="roll" name="attr_Initiative" title="Initiative"
+          value="@{character_name}'s Initiative: [[@{initiative-macro}&{tracker}]]"></button>
+      </div>
+      <div class="sheet-initiative-breaker">
+        <b title="Default value: [[d20]]">Initiative Tie Breaker:</b>
+        <b class="sheet-info-tooltip" title="Default value: [[d20]]"> ℹ </b>
+        <input name="attr_initiative-tie-breaker" title="Attribute: initiative-tie-breaker" type="text" value="[[d20]]" /><br />
+        <p class="sheet-dark-text">
+          This setting is not used by the character sheet, but is included so that you can, if you wish, add it to the character's speed when determining their
+          initiative order. (Note this isn't an official rule, but it's helpful when characters have the same speed!)
+          <br />For best results, leave this as something you can add to a die-roll.
         </p>
       </div>
       <div class="sheet-skill-modifier-selection">
@@ -2004,7 +2064,7 @@
   });
 
   // Handling Stat Changes
-  on("change:atkbase change:atknature change:atkbonus sheet:opened", function () {
+  on("change:atkbase change:atknature change:atkbonus change:Burned sheet:opened", function () {
     recalculateStat("atk");
   });
 
@@ -2012,7 +2072,7 @@
     recalculateStat("def");
   });
 
-  on("change:spatkbase change:spatknature change:spatkbonus sheet:opened", function () {
+  on("change:spatkbase change:spatknature change:spatkbonus change:Poisoned change:Toxified sheet:opened", function () {
     recalculateStat("spatk");
   });
 
@@ -2020,7 +2080,7 @@
     recalculateStat("spdef");
   });
 
-  on("change:spdbase change:spdnature change:spdbonus sheet:opened", function () {
+  on("change:spdbase change:spdnature change:spdbonus change:movebonus change:Paralyzed sheet:opened", function () {
     recalculateStat("spd");
   });
 
@@ -2029,26 +2089,42 @@
     const baseStat = `${abilityPrefix}base`;
     const natureStat = `${abilityPrefix}nature`;
     const bonusStat = `${abilityPrefix}bonus`;
-    getAttrs([ability, baseStat, natureStat, bonusStat, "character-type"], function(values) {
+    getAttrs([ability, baseStat, natureStat, bonusStat, "character-type", "movebonus", "Burned", "Poisoned", "Toxified", "Paralyzed"], function(values) {
       let baseValue = parseInt(values[baseStat]) || 0;
       if(baseValue == 0) return; // Needed to avoid wiping out old data too quickly
       let natureValue = parseInt(values[natureStat]) || 0;
       let bonusValue = parseInt(values[bonusStat]) || 0;
       let totalValue = baseValue + natureValue + bonusValue;
+      if(ability == "ATK" && values["Burned"] == 1) totalValue = totalValue - 2;
+      if(ability == "SPATK" && (values["Poisoned"] == 1 || values["Toxified"] == 1)) totalValue = totalValue - 2;
+      if(ability == "SPD" && values["Paralyzed"] == 1) totalValue = totalValue - 2;
       const attrs = {
         [ability] : totalValue,
         [`${ability}MOD`] : Math.floor(totalValue / 2)
       };
       if(ability == "SPD"){
         if(values["character-type"] == "trainer"){
-          attrs["movement"] = 30;
+          attrs["movement"] = 30 + (parseInt(values["movebonus"]) || 0);
         } else {
-          attrs["movement"] = totalValue * 5;
+          attrs["movement"] = totalValue * 5 + (parseInt(values["movebonus"]) || 0);
         }
       }
       setAttrs(attrs);
     });
   }
+
+  on("sheet:opened change:Asleep change:Burned change:Confused change:Cursed change:Frozen change:Infatuated change:Paralyzed change:Poisoned change:Toxified change:Stunned", function () {
+    const afflictionList = ["Asleep", "Burned", "Confused", "Cursed", "Frozen", "Infatuated", "Paralyzed", "Poisoned", "Toxified", "Stunned"];
+    getAttrs(afflictionList, function(values) {
+      const activeAfflicts = afflictionList.filter(afflict => values[afflict] == 1);
+      let afflictionsText = activeAfflicts.join(", ");
+      if (afflictionsText != "") afflictionsText = "Afflictions: " + afflictionsText;
+      const attrs = {
+        "afflictions_text" : afflictionsText
+      };
+      setAttrs(attrs);
+    });
+  });
 
   // Handling Targeted Defense Changes
   defenses = ["", "Defense", "Special Defense", "Speed"];
@@ -2206,11 +2282,11 @@
           const extra = parseInt(values[rowName + "_move_damagebonus"]) || 0;
           const dice = parseInt(values[rowName + "_move_dicenumber"]) || 0;
           const points = parseInt(values[rowName + "_damage_dice"]) || 0;
+          const movetype = values[rowName + "_move_type"];
           let stab = 0;
-          console.log("Character type: " + values["character-type"]);
           if(values["character-type"] != "trainer" &&
              (category == 1 || category == 2) &&
-             (values[rowName + "_move_type"] == values.type1 || values[rowName + "_move_type"] == values.type2)) stab = 4;
+             (movetype == values.type1 || movetype == values.type2)) stab = 4;
 
           const categoryModifier = parseInt(values[`${categoryDamageModifiers[category]}`]) || 0;
           const categoryBonus = parseInt(values[`${categoryDamageBonuses[category]}`]) || 0;
@@ -2581,6 +2657,11 @@
   on("change:options_stat_flag", function (eventInfo) {
     const flag = eventInfo.newValue == "on" ? "-" : "+";
     setAttrs({ stat_flag: flag });
+  });
+
+  on("change:options_afflictions_flag", function (eventInfo) {
+    const flag = eventInfo.newValue == "on" ? "-" : "+";
+    setAttrs({ afflictions_flag: flag });
   });
 
   // Changing Skill Ability Modifiers

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -12,13 +12,10 @@ Things we want to add to the character sheet, presented in no particular order o
 
 - [ ] Allow a second ability score to apply to skill checks
 - [ ] Allow formula calculations for the extra damage fields
-- [ ] Allow modifications to movement (maybe just an extra box)
 - [ ] Refactor the sheet workers to remove the cascading change observation; each `setAttrs` call takes way too long, so we want to capitalise on making them as low as possible
 - [ ] JSON import and export of sheet data, to support the Pokelicious Sheets and also migrating/copying characters
 - [ ] Add Struggle to the move lists automatically
-- [ ] Add status effects that you can click
-  - [ ] Burn, Poison/Toxified, and Paralyzed should modify stats automatically
-- [ ] Somehow make it easier to get tokens into initiative. No idea how to accomplish this.
+- [X] ~~Somehow make it easier to get tokens into initiative. No idea how to accomplish this.~~
 - [x] ~~Display the full bonus to skill checks~~
 - [x] ~~Handle temporary stat changes somehow, this may be a lot of work~~
 - [x] ~~Prevent critical range from going below 0 or above 20, maybe do similar to other fields~~
@@ -28,8 +25,20 @@ Things we want to add to the character sheet, presented in no particular order o
 - [X] ~~Moves deserve a section for "bonuses that apply to all moves." Things that should go here include:~~
   - [X] ~~A spot for Attack and Special Attack bonuses, for things like Ace Trainer~~
   - [X] ~~The critical hit range for the moves, as this is used for passives, items, etc.~~
+- [X] ~~Allow modifications to movement (maybe just an extra box)~~
+- [X] ~~Add status effects that you can click~~
+  - [X] ~~Burn, Poison/Toxified, and Paralyzed should modify stats automatically~~
 
 ## Changelog
+
+### Mar 21st, 2021
+- You can now set Afflictions in the character sheet, and they modify stats accordingly!
+  - Not everyone will use these, so they can be mostly hidden with just a click
+- Automatic initiative macro - if you have a token associated with a character sheet, you get a free token action
+- Add bonus movement field
+- Rename Attack Damage Bonus and Special Attack Damage Bonus for clarity
+- Fix typo in config page
+- Remove leftover debug logging
 
 ### Mar 7th, 2021
 


### PR DESCRIPTION
## Changes / Comments

- You can now set Afflictions in the character sheet, and they modify stats accordingly!
  - Not everyone will use these, so they can be mostly hidden with just a click
- Automatic initiative macro - if you have a token associated with a character sheet, you get a free token action
- Add bonus movement field
- Rename Attack Damage Bonus and Special Attack Damage Bonus for clarity
- Fix typo in config page
- Remove leftover debug logging

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [X] Does this add functional enhancements (new features or extending existing features) ?
- [X] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
