### PR TITLE
[Mothership Official] Add modifier prompt and correct dice type

### DIFF
--- a/Mothership Official/mothership.html
+++ b/Mothership Official/mothership.html
@@ -75,28 +75,28 @@
         <div class="ms-stats__main">
           <div class="ms-mainstat">
             <div class="ms-mainstat__label">
-              <button data-i18n="strength" type="roll" value="&amp;{template:ms} {{name=strength}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=@{strength}}}"></button><span class="ms-tooltip">
+              <button data-i18n="strength" type="roll" value="&amp;{template:ms} {{name=strength}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[@{strength}+?{Modifier?|0}]]}}"></button><span class="ms-tooltip">
                 <p><span data-i18n="How able-bodied you are. Lifting, pushing, hitting things hard, etc."></span></p></span>
             </div>
             <input class="ms-mainstat__input" name="attr_strength" type="number"/>
           </div>
           <div class="ms-mainstat">
             <div class="ms-mainstat__label">
-              <button data-i18n="speed" type="roll" value="&amp;{template:ms} {{name=speed}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=@{speed}}}"></button><span class="ms-tooltip">
+              <button data-i18n="speed" type="roll" value="&amp;{template:ms} {{name=speed}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[@{speed}+?{Modifier?|0}]]}}"></button><span class="ms-tooltip">
                 <p><span data-i18n="How quickly you can act and react under pressure."></span></p></span>
             </div>
             <input class="ms-mainstat__input" name="attr_speed" type="number"/>
           </div>
           <div class="ms-mainstat">
             <div class="ms-mainstat__label">
-              <button data-i18n="intellect" type="roll" value="&amp;{template:ms} {{name=intellect}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=@{intellect}}}"></button><span class="ms-tooltip">
+              <button data-i18n="intellect" type="roll" value="&amp;{template:ms} {{name=intellect}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[@{intellect}+?{Modifier?|0}]]}}"></button><span class="ms-tooltip">
                 <p><span data-i18n="How knowledgeable and experienced you are."></span></p></span>
             </div>
             <input class="ms-mainstat__input" name="attr_intellect" type="number"/>
           </div>
           <div class="ms-mainstat">
             <div class="ms-mainstat__label">
-              <button data-i18n="combat" type="roll" value="&amp;{template:ms} {{name=combat}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=@{combat}}}"></button><span class="ms-tooltip">
+              <button data-i18n="combat" type="roll" value="&amp;{template:ms} {{name=combat}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[@{combat}+?{Modifier?|0}]]}}"></button><span class="ms-tooltip">
                 <p><span data-i18n="How good you are at fighting."></span></p></span>
             </div>
             <input class="ms-mainstat__input" name="attr_combat" type="number"/>
@@ -112,22 +112,22 @@
       <div class="ms-saves">
         <div class="ms-saves__col--left">
           <div class="ms-saves__label">
-            <button class="ms-saves__name" data-i18n="sanity" type="roll" value="&amp;{template:ms} {{name=sanity}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=@{sanity}}}"></button><span class="ms-tooltip">
+            <button class="ms-saves__name" data-i18n="sanity" type="roll" value="&amp;{template:ms} {{name=sanity}} {{character_name=@{character_name}}} {{roll=[[(1d100-1)cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[@{sanity}+?{Modifier?|0}]]}}"></button><span class="ms-tooltip">
               <p><span data-i18n="Sanity is your ability to explain away logical inconsistencies in the universe, rationalize and make sense out of chaos, detect illusions and mimicry and think quickly under pressure."></span></p></span>
             <div class="ms-saves__subtext" data-i18n="rationalization, logic"></div>
           </div>
           <div class="ms-saves__label">
-            <button class="ms-saves__name" data-i18n="fear" type="roll" value="&amp;{template:ms} {{name=fear}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=@{fear}}}"></button><span class="ms-tooltip">
+            <button class="ms-saves__name" data-i18n="fear" type="roll" value="&amp;{template:ms} {{name=fear}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[@{fear}+?{Modifier?|0}]]}}"></button><span class="ms-tooltip">
               <p><span data-i18n="Fear is how well you can cope with emotional trauma, and covers not only fear, but also loneliness, depression or any other emotional surge."></span></p></span>
             <div class="ms-saves__subtext" data-i18n="surprise, loneliness"></div>
           </div>
           <div class="ms-saves__label">
-            <button class="ms-saves__name" data-i18n="body" type="roll" value="&amp;{template:ms} {{name=body}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=@{body}}}"></button><span class="ms-tooltip">
+            <button class="ms-saves__name" data-i18n="body" type="roll" value="&amp;{template:ms} {{name=body}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[@{body}+?{Modifier?|0}]]}}"></button><span class="ms-tooltip">
               <p><span data-i18n="Body is your reflexes, and how well you can resist hunger, disease or any other organism that might attempt to invade your insides."></span></p></span>
             <div class="ms-saves__subtext" data-i18n="hunger, disease, infection"></div>
           </div>
           <div class="ms-saves__label">
-            <button class="ms-saves__name" data-i18n="armor" type="roll" value="&amp;{template:ms} {{name=armor}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=@{armor}}}"></button><span class="ms-tooltip">
+            <button class="ms-saves__name" data-i18n="armor" type="roll" value="&amp;{template:ms} {{name=armor}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[@{armor}+?{Modifier?|0}]]}}"></button><span class="ms-tooltip">
               <p><span data-i18n="Armor is how resistant you ae to damage sustained during combat, whether that be through bullets, claws, teeth, etc."></span></p></span>
             <div class="ms-saves__subtext" data-i18n="physical damage"></div>
           </div>
@@ -177,12 +177,12 @@
               <input name="attr_linguistics" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="linguistics" type="roll" value="&amp;{template:ms} {{name=linguistics}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"></button>
+              <button data-i18n="linguistics" type="roll" value="&amp;{template:ms} {{name=linguistics}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_linguistics_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_linguistics_notes" type="text"/>
@@ -198,12 +198,12 @@
               <input name="attr_biology" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="biology" type="roll" value="&amp;{template:ms} {{name=biology}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"></button>
+              <button data-i18n="biology" type="roll" value="&amp;{template:ms} {{name=biology}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_biology_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_biology_notes" type="text"/>
@@ -219,12 +219,12 @@
               <input name="attr_first_aid" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="first aid" type="roll" value="&amp;{template:ms} {{name=first aid}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"></button>
+              <button data-i18n="first aid" type="roll" value="&amp;{template:ms} {{name=first aid}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_first_aid_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_first_aid_notes" type="text"/>
@@ -240,12 +240,12 @@
               <input name="attr_hydroponics" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="hydroponics" type="roll" value="&amp;{template:ms} {{name=hydroponics}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"></button>
+              <button data-i18n="hydroponics" type="roll" value="&amp;{template:ms} {{name=hydroponics}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_hydroponics_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_hydroponics_notes" type="text"/>
@@ -261,12 +261,12 @@
               <input name="attr_geology" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="geology" type="roll" value="&amp;{template:ms} {{name=geology}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"></button>
+              <button data-i18n="geology" type="roll" value="&amp;{template:ms} {{name=geology}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_geology_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_geology_notes" type="text"/>
@@ -282,12 +282,12 @@
               <input name="attr_zero-g" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="zero-g" type="roll" value="&amp;{template:ms} {{name=zero-g}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"></button>
+              <button data-i18n="zero-g" type="roll" value="&amp;{template:ms} {{name=zero-g}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_zero-g_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_zero-g_notes" type="text"/>
@@ -303,12 +303,12 @@
               <input name="attr_scavenging" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="scavenging" type="roll" value="&amp;{template:ms} {{name=scavenging}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"></button>
+              <button data-i18n="scavenging" type="roll" value="&amp;{template:ms} {{name=scavenging}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_scavenging_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_scavenging_notes" type="text"/>
@@ -324,12 +324,12 @@
               <input name="attr_heavy_machinery" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="heavy machinery" type="roll" value="&amp;{template:ms} {{name=heavy machinery}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"></button>
+              <button data-i18n="heavy machinery" type="roll" value="&amp;{template:ms} {{name=heavy machinery}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_heavy_machinery_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_heavy_machinery_notes" type="text"/>
@@ -345,12 +345,12 @@
               <input name="attr_computers" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="computers" type="roll" value="&amp;{template:ms} {{name=computers}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"></button>
+              <button data-i18n="computers" type="roll" value="&amp;{template:ms} {{name=computers}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_computers_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_computers_notes" type="text"/>
@@ -366,12 +366,12 @@
               <input name="attr_mechanical_repair" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="mechanical repair" type="roll" value="&amp;{template:ms} {{name=mechanical repair}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"></button>
+              <button data-i18n="mechanical repair" type="roll" value="&amp;{template:ms} {{name=mechanical repair}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_mechanical_repair_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_mechanical_repair_notes" type="text"/>
@@ -387,12 +387,12 @@
               <input name="attr_driving" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="driving" type="roll" value="&amp;{template:ms} {{name=driving}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"></button>
+              <button data-i18n="driving" type="roll" value="&amp;{template:ms} {{name=driving}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_driving_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_driving_notes" type="text"/>
@@ -408,12 +408,12 @@
               <input name="attr_piloting" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="piloting" type="roll" value="&amp;{template:ms} {{name=piloting}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"></button>
+              <button data-i18n="piloting" type="roll" value="&amp;{template:ms} {{name=piloting}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_piloting_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_piloting_notes" type="text"/>
@@ -429,12 +429,12 @@
               <input name="attr_mathematics" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="mathematics" type="roll" value="&amp;{template:ms} {{name=mathematics}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"></button>
+              <button data-i18n="mathematics" type="roll" value="&amp;{template:ms} {{name=mathematics}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_mathematics_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_mathematics_notes" type="text"/>
@@ -450,12 +450,12 @@
               <input name="attr_art" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="art" type="roll" value="&amp;{template:ms} {{name=art}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"></button>
+              <button data-i18n="art" type="roll" value="&amp;{template:ms} {{name=art}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_art_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_art_notes" type="text"/>
@@ -471,12 +471,12 @@
               <input name="attr_archaeology" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="archaeology" type="roll" value="&amp;{template:ms} {{name=archaeology}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"></button>
+              <button data-i18n="archaeology" type="roll" value="&amp;{template:ms} {{name=archaeology}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_archaeology_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_archaeology_notes" type="text"/>
@@ -492,12 +492,12 @@
               <input name="attr_theology" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="theology" type="roll" value="&amp;{template:ms} {{name=theology}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"></button>
+              <button data-i18n="theology" type="roll" value="&amp;{template:ms} {{name=theology}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_theology_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_theology_notes" type="text"/>
@@ -513,12 +513,12 @@
               <input name="attr_military_training" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="military training" type="roll" value="&amp;{template:ms} {{name=military training}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"></button>
+              <button data-i18n="military training" type="roll" value="&amp;{template:ms} {{name=military training}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_military_training_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_military_training_notes" type="text"/>
@@ -534,12 +534,12 @@
               <input name="attr_rimwise" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="rimwise" type="roll" value="&amp;{template:ms} {{name=rimwise}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"></button>
+              <button data-i18n="rimwise" type="roll" value="&amp;{template:ms} {{name=rimwise}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_rimwise_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_rimwise_notes" type="text"/>
@@ -555,12 +555,12 @@
               <input name="attr_athletics" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="athletics" type="roll" value="&amp;{template:ms} {{name=athletics}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"></button>
+              <button data-i18n="athletics" type="roll" value="&amp;{template:ms} {{name=athletics}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_athletics_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_athletics_notes" type="text"/>
@@ -576,12 +576,12 @@
               <input name="attr_chemistry" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="chemistry" type="roll" value="&amp;{template:ms} {{name=chemistry}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"></button>
+              <button data-i18n="chemistry" type="roll" value="&amp;{template:ms} {{name=chemistry}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_chemistry_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_chemistry_notes" type="text"/>
@@ -598,12 +598,12 @@
                 <input name="attr_skill_trained" type="checkbox"/><span></span>
               </label>
               <div class="ms-skill__button">
-                <button class="edit-hide" type="roll" value="&amp;{template:ms} {{name=@{skill_name}}}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10]]}}"><span name="attr_skill_name"></span></button>
+                <button class="edit-hide" type="roll" value="&amp;{template:ms} {{name=@{skill_name}}}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+10+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
               </div>
               <label class="ms-skill__cog">
                 <input name="attr_skill_settings" type="checkbox"/><span>y</span>
               </label>
-              <div class="ms-skill__settings"> 
+              <div class="ms-skill__settings">
                 <div class="ms-skill__settingsrow">
                   <div class="ms-skill__settingstitle" data-i18n="name"></div>
                   <input class="ms-skill__settingsinput" data-i18n-title="custom skill" name="attr_skill_name" type="text"/>
@@ -629,12 +629,12 @@
               <input name="attr_psychology" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="psychology" type="roll" value="&amp;{template:ms} {{name=psychology}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15]]}}"><span name="attr_skill_name"></span></button>
+              <button data-i18n="psychology" type="roll" value="&amp;{template:ms} {{name=psychology}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_psychology_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_psychology_notes" type="text"/>
@@ -653,12 +653,12 @@
               <input name="attr_genetics" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="genetics" type="roll" value="&amp;{template:ms} {{name=genetics}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15]]}}"><span name="attr_skill_name"></span></button>
+              <button data-i18n="genetics" type="roll" value="&amp;{template:ms} {{name=genetics}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_genetics_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_genetics_notes" type="text"/>
@@ -677,12 +677,12 @@
               <input name="attr_pathology" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="pathology" type="roll" value="&amp;{template:ms} {{name=pathology}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15]]}}"><span name="attr_skill_name"></span></button>
+              <button data-i18n="pathology" type="roll" value="&amp;{template:ms} {{name=pathology}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_pathology_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_pathology_notes" type="text"/>
@@ -701,12 +701,12 @@
               <input name="attr_botany" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="botany" type="roll" value="&amp;{template:ms} {{name=botany}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15]]}}"><span name="attr_skill_name"></span></button>
+              <button data-i18n="botany" type="roll" value="&amp;{template:ms} {{name=botany}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_botany_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_botany_notes" type="text"/>
@@ -725,12 +725,12 @@
               <input name="attr_planetology" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="planetology" type="roll" value="&amp;{template:ms} {{name=planetology}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15]]}}"><span name="attr_skill_name"></span></button>
+              <button data-i18n="planetology" type="roll" value="&amp;{template:ms} {{name=planetology}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_planetology_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_planetology_notes" type="text"/>
@@ -749,12 +749,12 @@
               <input name="attr_asteroid_mining" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="asteroid mining" type="roll" value="&amp;{template:ms} {{name=asteroid mining}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15]]}}"><span name="attr_skill_name"></span></button>
+              <button data-i18n="asteroid mining" type="roll" value="&amp;{template:ms} {{name=asteroid mining}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_asteroid_mining_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_asteroid_mining_notes" type="text"/>
@@ -773,12 +773,12 @@
               <input name="attr_jury_rigging" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="jury rigging" type="roll" value="&amp;{template:ms} {{name=jury rigging}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15]]}}"><span name="attr_skill_name"></span></button>
+              <button data-i18n="jury rigging" type="roll" value="&amp;{template:ms} {{name=jury rigging}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_jury_rigging_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_jury_rigging_notes" type="text"/>
@@ -797,12 +797,12 @@
               <input name="attr_engineering" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="engineering" type="roll" value="&amp;{template:ms} {{name=engineering}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15]]}}"><span name="attr_skill_name"></span></button>
+              <button data-i18n="engineering" type="roll" value="&amp;{template:ms} {{name=engineering}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_engineering_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_engineering_notes" type="text"/>
@@ -821,12 +821,12 @@
               <input name="attr_hacking" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="hacking" type="roll" value="&amp;{template:ms} {{name=hacking}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15]]}}"><span name="attr_skill_name"></span></button>
+              <button data-i18n="hacking" type="roll" value="&amp;{template:ms} {{name=hacking}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_hacking_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_hacking_notes" type="text"/>
@@ -845,12 +845,12 @@
               <input name="attr_vehicle_specialization" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="vehicle specialization" type="roll" value="&amp;{template:ms} {{name=vehicle specialization}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15]]}}"><span name="attr_skill_name"></span></button>
+              <button data-i18n="vehicle specialization" type="roll" value="&amp;{template:ms} {{name=vehicle specialization}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_vehicle_specialization_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_vehicle_specialization_notes" type="text"/>
@@ -869,12 +869,12 @@
               <input name="attr_astrogation" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="astrogation" type="roll" value="&amp;{template:ms} {{name=astrogation}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15]]}}"><span name="attr_skill_name"></span></button>
+              <button data-i18n="astrogation" type="roll" value="&amp;{template:ms} {{name=astrogation}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_astrogation_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_astrogation_notes" type="text"/>
@@ -893,12 +893,12 @@
               <input name="attr_physics" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="physics" type="roll" value="&amp;{template:ms} {{name=physics}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15]]}}"><span name="attr_skill_name"></span></button>
+              <button data-i18n="physics" type="roll" value="&amp;{template:ms} {{name=physics}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_physics_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_physics_notes" type="text"/>
@@ -917,12 +917,12 @@
               <input name="attr_mysticism" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="mysticism" type="roll" value="&amp;{template:ms} {{name=mysticism}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15]]}}"><span name="attr_skill_name"></span></button>
+              <button data-i18n="mysticism" type="roll" value="&amp;{template:ms} {{name=mysticism}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_mysticism_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_mysticism_notes" type="text"/>
@@ -941,12 +941,12 @@
               <input name="attr_tactics" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="tactics" type="roll" value="&amp;{template:ms} {{name=tactics}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15]]}}"><span name="attr_skill_name"></span></button>
+              <button data-i18n="tactics" type="roll" value="&amp;{template:ms} {{name=tactics}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_tactics_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_tactics_notes" type="text"/>
@@ -965,12 +965,12 @@
               <input name="attr_gunnery" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="gunnery" type="roll" value="&amp;{template:ms} {{name=gunnery}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15]]}}"><span name="attr_skill_name"></span></button>
+              <button data-i18n="gunnery" type="roll" value="&amp;{template:ms} {{name=gunnery}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_gunnery_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_gunnery_notes" type="text"/>
@@ -989,12 +989,12 @@
               <input name="attr_firearms" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="firearms" type="roll" value="&amp;{template:ms} {{name=firearms}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15]]}}"><span name="attr_skill_name"></span></button>
+              <button data-i18n="firearms" type="roll" value="&amp;{template:ms} {{name=firearms}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_firearms_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_firearms_notes" type="text"/>
@@ -1013,12 +1013,12 @@
               <input name="attr_close-quarters_combat" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="close-quarters combat" type="roll" value="&amp;{template:ms} {{name=close-quarters combat}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15]]}}"><span name="attr_skill_name"></span></button>
+              <button data-i18n="close-quarters combat" type="roll" value="&amp;{template:ms} {{name=close-quarters combat}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_close-quarters_combat_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_close-quarters_combat_notes" type="text"/>
@@ -1037,12 +1037,12 @@
               <input name="attr_explosives" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="explosives" type="roll" value="&amp;{template:ms} {{name=explosives}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15]]}}"><span name="attr_skill_name"></span></button>
+              <button data-i18n="explosives" type="roll" value="&amp;{template:ms} {{name=explosives}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+15+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_explosives_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_explosives_notes" type="text"/>
@@ -1062,12 +1062,12 @@
                 <input name="attr_skill_trained" type="checkbox"/><span></span>
               </label>
               <div class="ms-skill__button">
-                <button class="edit-hide" type="roll" value="&amp;{template:ms} {{name=@{skill_name}}}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20]]}}"><span name="attr_skill_name"></span></button>
+                <button class="edit-hide" type="roll" value="&amp;{template:ms} {{name=@{skill_name}}}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
               </div>
               <label class="ms-skill__cog">
                 <input name="attr_skill_settings" type="checkbox"/><span>y</span>
               </label>
-              <div class="ms-skill__settings"> 
+              <div class="ms-skill__settings">
                 <div class="ms-skill__settingsrow">
                   <div class="ms-skill__settingstitle" data-i18n="name"></div>
                   <input class="ms-skill__settingsinput" data-i18n-value="custom skill" name="attr_skill_name" type="text"/>
@@ -1093,12 +1093,12 @@
               <input name="attr_sophontology" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="sophontology" type="roll" value="&amp;{template:ms} {{name=sophontology}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20]]}}"></button>
+              <button data-i18n="sophontology" type="roll" value="&amp;{template:ms} {{name=sophontology}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_sophontology_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_sophontology_notes" type="text"/>
@@ -1117,12 +1117,12 @@
               <input name="attr_xenobiology" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="xenobiology" type="roll" value="&amp;{template:ms} {{name=xenobiology}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20]]}}"></button>
+              <button data-i18n="xenobiology" type="roll" value="&amp;{template:ms} {{name=xenobiology}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_xenobiology_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_xenobiology_notes" type="text"/>
@@ -1141,12 +1141,12 @@
               <input name="attr_surgery" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="surgery" type="roll" value="&amp;{template:ms} {{name=surgery}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20]]}}"></button>
+              <button data-i18n="surgery" type="roll" value="&amp;{template:ms} {{name=surgery}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_surgery_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_surgery_notes" type="text"/>
@@ -1165,12 +1165,12 @@
               <input name="attr_cybernetics" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="cybernetics" type="roll" value="&amp;{template:ms} {{name=cybernetics}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20]]}}"></button>
+              <button data-i18n="cybernetics" type="roll" value="&amp;{template:ms} {{name=cybernetics}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_cybernetics_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_cybernetics_notes" type="text"/>
@@ -1189,12 +1189,12 @@
               <input name="attr_robotics" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="robotics" type="roll" value="&amp;{template:ms} {{name=robotics}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20]]}}"></button>
+              <button data-i18n="robotics" type="roll" value="&amp;{template:ms} {{name=robotics}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_robotics_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_robotics_notes" type="text"/>
@@ -1213,12 +1213,12 @@
               <input name="attr_artificial_intelligence" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="artificial intelligence" type="roll" value="&amp;{template:ms} {{name=artificial intelligence}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20]]}}"></button>
+              <button data-i18n="artificial intelligence" type="roll" value="&amp;{template:ms} {{name=artificial intelligence}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_artificial_intelligence_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_artificial_intelligence_notes" type="text"/>
@@ -1237,12 +1237,12 @@
               <input name="attr_command" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="command" type="roll" value="&amp;{template:ms} {{name=command}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20]]}}"></button>
+              <button data-i18n="command" type="roll" value="&amp;{template:ms} {{name=command}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_command_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_command_notes" type="text"/>
@@ -1261,12 +1261,12 @@
               <input name="attr_hyperspace" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="hyperspace" type="roll" value="&amp;{template:ms} {{name=hyperspace}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20]]}}"></button>
+              <button data-i18n="hyperspace" type="roll" value="&amp;{template:ms} {{name=hyperspace}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_hyperspace_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_hyperspace_notes" type="text"/>
@@ -1285,12 +1285,12 @@
               <input name="attr_xenoesotericism" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="xenoesotericism" type="roll" value="&amp;{template:ms} {{name=xenoesotericism}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20]]}}"></button>
+              <button data-i18n="xenoesotericism" type="roll" value="&amp;{template:ms} {{name=xenoesotericism}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_xenoesotericism_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_xenoesotericism_notes" type="text"/>
@@ -1309,12 +1309,12 @@
               <input name="attr_weapon_specialization" type="checkbox"/><span></span>
             </label>
             <div class="ms-skill__button">
-              <button data-i18n="weapon specialization" type="roll" value="&amp;{template:ms} {{name=weapon specialization}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20]]}}"></button>
+              <button data-i18n="weapon specialization" type="roll" value="&amp;{template:ms} {{name=weapon specialization}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20+?{Modifier?|0}]]}}"></button>
             </div>
             <label class="ms-skill__cog">
               <input name="attr_weapon_specialization_settings" type="checkbox"/><span>y</span>
             </label>
-            <div class="ms-skill__settings"> 
+            <div class="ms-skill__settings">
               <div class="ms-skill__settingsrow">
                 <div class="ms-skill__settingstitle" data-i18n="notes"></div>
                 <input class="ms-skill__settingsinput" name="attr_weapon_specialization_notes" type="text"/>
@@ -1334,12 +1334,12 @@
                 <input name="attr_skill_trained" type="checkbox"/><span></span>
               </label>
               <div class="ms-skill__button">
-                <button class="edit-hide" type="roll" value="&amp;{template:ms} {{name=@{skill_name}}}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20]]}}"><span name="attr_skill_name"></span></button>
+                <button class="edit-hide" type="roll" value="&amp;{template:ms} {{name=@{skill_name}}}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[?{Attribute|Strength,@{strength}|Speed,@{speed}|Intellect,@{intellect}|Combat,@{combat}}+20+?{Modifier?|0}]]}}"><span name="attr_skill_name"></span></button>
               </div>
               <label class="ms-skill__cog">
                 <input name="attr_skill_settings" type="checkbox"/><span>y</span>
               </label>
-              <div class="ms-skill__settings"> 
+              <div class="ms-skill__settings">
                 <div class="ms-skill__settingsrow">
                   <div class="ms-skill__settingstitle" data-i18n="name"></div>
                   <input class="ms-skill__settingsinput" data-i18n-value="custom skill" name="attr_skill_name" type="text"/>
@@ -1354,7 +1354,7 @@
         </fieldset>
       </div>
     </div>
-    <div class="ms-gear"> 
+    <div class="ms-gear">
       <div class="ms-equipment">
         <h1 data-i18n="equipment"></h1>
         <div class="ms-equipmentrow--head">
@@ -1407,7 +1407,7 @@
           <div class="ms-attackrow">
             <input name="attr_attack_settings" type="hidden" value="on"/>
             <input name="attr_attack_linkedid" type="hidden"/>
-            <button class="ms-attackrow__name" type="roll" value="&amp;{template:ms} {{name=@{attack_name}}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[@{combat}]]}} {{ranges=@{attack_range_s}}} {{rangem=@{attack_range_m}}} {{rangel=@{attack_range_l}}} {{damage=[[@{attack_damage}]]}}"><span name="attr_attack_name" type="text"></span></button>
+            <button class="ms-attackrow__name" type="roll" value="&amp;{template:ms} {{name=@{attack_name}}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[@{combat}+?{Modifier?|0}]]}} {{ranges=@{attack_range_s}}} {{rangem=@{attack_range_m}}} {{rangel=@{attack_range_l}}} {{damage=[[@{attack_damage}]]}}"><span name="attr_attack_name" type="text"></span></button>
             <input class="ms-attackrow__skill" name="attr_attack_type" type="hidden"/>
             <select class="ms-attackrow__skill" name="attr_attack_type">
               <option data-i18n="Ranged"></option>
@@ -1433,13 +1433,13 @@
                   <div class="ms-attackrow__settingstitle" data-i18n="critical damage"></div>
                   <input class="ms-attackrow__settingsinput" data-i18n-placeholder="damage" name="attr_attack_crit_damage" type="text"/>
                 </div>
-                <div> 
+                <div>
                   <div class="ms-attackrow__settingstitle" data-i18n="critical effect"></div>
                   <input class="ms-attackrow__settingsinput" data-i18n-placeholder="effect" name="attr_attack_crit_effect" type="text"/>
                 </div>
               </div>
               <div class="ms-attackrow__settingsrow">
-                <div> 
+                <div>
                   <div class="ms-attackrow__settingstitle" data-i18n="shots"></div>
                   <input class="ms-attackrow__settingsinput" data-i18n-placeholder="shots" name="attr_attack_shots" type="text"/>
                 </div>
@@ -1468,7 +1468,7 @@
         <div class="ms-shipbuilder__title">
           <h3 data-i18n="life support"></h3>
         </div>
-        <div class="ms-shipbuilder__desc"> 
+        <div class="ms-shipbuilder__desc">
           <p data-i18n="Life support keeps the human crew alive. Each point of life support can support up to 10 humans. For every point below the required minimum, anyone not wearing a vaccsuit must make a &lt;strong&gt;Body Save&lt;/strong&gt; every hour or take 1d10 damage. This includes those in cryochambers as well, but does not include androids. Many ships include 2-3 times the required amount of life support in case of extra passengers or damage to the system."></p>
         </div>
         <div class="ms-shipbuilder__flex">
@@ -1481,7 +1481,7 @@
                 <div class="ms-shipbuilder__label" data-i18n="life support"></div>
               </div>
               <div class="ms-shipbuilder__equals">= </div>
-          <div class="ms-shipbuilder__hull">      
+          <div class="ms-shipbuilder__hull">
             <div class="ms-shipbuilder__item"><span class="ms-shipbuilder__display" name="attr_life_support_hull"></span>
               <div class="ms-shipbuilder__label" data-i18n="hull"></div>
             </div>
@@ -1492,7 +1492,7 @@
         <div class="ms-shipbuilder__title">
           <h3 data-i18n="command"></h3>
         </div>
-        <div class="ms-shipbuilder__desc"> 
+        <div class="ms-shipbuilder__desc">
           <p data-i18n="The command module is the cockpit, command center, or bridge of a ship. For every 4 officer positions, one command module is required. Officers can be captains, first mates, navigation officers, communications officers, and is largely up to the Warden and the players to decide."></p>
         </div>
         <div class="ms-shipbuilder__flex">
@@ -1505,7 +1505,7 @@
                 <div class="ms-shipbuilder__label" data-i18n="command modules"></div>
               </div>
               <div class="ms-shipbuilder__equals">= </div>
-          <div class="ms-shipbuilder__hull">      
+          <div class="ms-shipbuilder__hull">
             <div class="ms-shipbuilder__item"><span class="ms-shipbuilder__display" name="attr_command_hull"></span>
               <div class="ms-shipbuilder__label" data-i18n="hull"></div>
             </div>
@@ -1516,7 +1516,7 @@
         <div class="ms-shipbuilder__title">
           <h3 data-i18n="armor"></h3>
         </div>
-        <div class="ms-shipbuilder__desc"> 
+        <div class="ms-shipbuilder__desc">
           <p data-i18n="Armor plating protects the ship fromsmall metoerites, space dust and debris, as well as, if need be, attacks from other vessels. Every point of armor costs 3 hull, and grants the ship +10% Armor Save (Max 80)."></p>
         </div>
         <div class="ms-shipbuilder__flex">
@@ -1528,7 +1528,7 @@
               <div class="ms-shipbuilder__item"><span class="ms-shipbuilder__display" name="attr_armor"></span>
                 <div class="ms-shipbuilder__label" data-i18n="armor save"></div>
               </div>
-          <div class="ms-shipbuilder__hull">      
+          <div class="ms-shipbuilder__hull">
             <div class="ms-shipbuilder__item"><span class="ms-shipbuilder__display" name="attr_armor_hull"></span>
               <div class="ms-shipbuilder__label" data-i18n="hull"></div>
             </div>
@@ -1542,7 +1542,7 @@
         <div class="ms-shipbuilder__title">
           <h3 data-i18n="jump drives"></h3>
         </div>
-        <div class="ms-shipbuilder__desc"> 
+        <div class="ms-shipbuilder__desc">
           <p data-i18n="Jump drives enable the ship to travel through hyperspace. Every point of Jump Drive increasesthe ship’s jump capability by 1 (Max 9). The first drive costs 1 hull, the second costs 2, the third costs 3, etc."></p>
         </div>
         <div class="ms-shipbuilder__flex">
@@ -1551,7 +1551,7 @@
                 <div class="ms-shipbuilder__label" data-i18n="jump drives"></div>
               </div>
               <div class="ms-shipbuilder__modifier">...</div>
-          <div class="ms-shipbuilder__hull">                   
+          <div class="ms-shipbuilder__hull">
             <div class="ms-shipbuilder__item"><span class="ms-shipbuilder__display" name="attr_jump_drives_hull"></span>
               <div class="ms-shipbuilder__label" data-i18n="hull"></div>
             </div>
@@ -1562,7 +1562,7 @@
         <div class="ms-shipbuilder__title">
           <h3 data-i18n="computer"></h3>
         </div>
-        <div class="ms-shipbuilder__desc"> 
+        <div class="ms-shipbuilder__desc">
           <p data-i18n="The ship’s computer is a powerful artificial intelligence that helps with astrogation, combat, and anumber of other autonomous tasks. A ship’s Intellect is equal to the number of computer modules x10 +30%. It’s Combat is equal to the number of computer modules x10 +10%. A computer module is required for each jumpdrive. Additionally, each computer module equipped allows the computer to take more actions during combat."></p>
         </div>
         <div class="ms-shipbuilder__flex">
@@ -1571,7 +1571,7 @@
                 <div class="ms-shipbuilder__label" data-i18n="computer modules"></div>
               </div>
               <div class="ms-shipbuilder__equals">= </div>
-          <div class="ms-shipbuilder__hull">                   
+          <div class="ms-shipbuilder__hull">
             <div class="ms-shipbuilder__item"><span class="ms-shipbuilder__display" name="attr_computer_hull"></span>
               <div class="ms-shipbuilder__label" data-i18n="hull"></div>
             </div>
@@ -1582,7 +1582,7 @@
         <div class="ms-shipbuilder__title">
           <h3 data-i18n="galley"></h3>
         </div>
-        <div class="ms-shipbuilder__desc"> 
+        <div class="ms-shipbuilder__desc">
           <p data-i18n="Galleys contain a kitchen, restrooms, and a common area on a ship. Any ships making trips longer than 1 day must have 1 galley for every 2 life support modules or else the crew must take &lt;strong&gt;Body Saves&lt;/strong&gt; once/day. Failure means 2d10 damage and 1d10 Stress. Galleys must be re-stocked once a month and extra stores take up 1 Cargo."></p>
         </div>
         <div class="ms-shipbuilder__flex">
@@ -1591,7 +1591,7 @@
                 <div class="ms-shipbuilder__label" data-i18n="galleys"></div>
               </div>
               <div class="ms-shipbuilder__equals">= </div>
-          <div class="ms-shipbuilder__hull">                   
+          <div class="ms-shipbuilder__hull">
             <div class="ms-shipbuilder__item"><span class="ms-shipbuilder__display" name="attr_galley_hull"></span>
               <div class="ms-shipbuilder__label" data-i18n="hull"></div>
             </div>
@@ -1602,7 +1602,7 @@
         <div class="ms-shipbuilder__title">
           <h3 data-i18n="weapon mount"></h3>
         </div>
-        <div class="ms-shipbuilder__desc"> 
+        <div class="ms-shipbuilder__desc">
           <p data-i18n="For every weapon your ship has you must have 1 mount for it. You can find the list of ship weapons in &lt;em&gt;The Player's Survival Guide&lt;/em&gt;"></p>
         </div>
         <div class="ms-shipbuilder__flex">
@@ -1615,7 +1615,7 @@
                 <div class="ms-shipbuilder__label" data-i18n="weapon mounts"></div>
               </div>
               <div class="ms-shipbuilder__equals">= </div>
-          <div class="ms-shipbuilder__hull">                   
+          <div class="ms-shipbuilder__hull">
             <div class="ms-shipbuilder__item"><span class="ms-shipbuilder__display" name="attr_weapon_mount_hull"></span>
               <div class="ms-shipbuilder__label" data-i18n="hull"></div>
             </div>
@@ -1626,7 +1626,7 @@
         <div class="ms-shipbuilder__title">
           <h3 data-i18n="medical bay"></h3>
         </div>
-        <div class="ms-shipbuilder__desc"> 
+        <div class="ms-shipbuilder__desc">
           <p data-i18n="Medical bays allow scientists, doctors, and other researchers to heal crew members and perform various procedures (biopsies, autopsies, surgery). Each connected medbay on the ship grants +5% to the Intellect of the Scientists or Androids using them. Medical bays also grant advantage on &lt;strong&gt;Body Saves&lt;/strong&gt; made for healing."></p>
         </div>
         <div class="ms-shipbuilder__flex">
@@ -1638,7 +1638,7 @@
               <div class="ms-shipbuilder__item"><span class="ms-shipbuilder__display" name="attr_ship_medint_bonus"></span>
                 <div class="ms-shipbuilder__label" data-i18n="medical intellect bonus"></div>
               </div>
-          <div class="ms-shipbuilder__hull">                   
+          <div class="ms-shipbuilder__hull">
             <div class="ms-shipbuilder__item"><span class="ms-shipbuilder__display" name="attr_medical_bay_hull"></span>
               <div class="ms-shipbuilder__label" data-i18n="hull"></div>
             </div>
@@ -1649,7 +1649,7 @@
         <div class="ms-shipbuilder__title">
           <h3 data-i18n="cryochamber"></h3>
         </div>
-        <div class="ms-shipbuilder__desc"> 
+        <div class="ms-shipbuilder__desc">
           <p data-i18n="Cryochambers allow humans to sleep during long trips, particularly through hyperspace.  Androids do not require them. Each point of hull spent on cryochambers accomodates up to 4 cryosleep pods.  Individuals who don’t go into cryosleep during hyperspace jumps often have strange and terrifying experiences."></p>
         </div>
         <div class="ms-shipbuilder__flex">
@@ -1662,7 +1662,7 @@
                 <div class="ms-shipbuilder__label" data-i18n="cryo-chambers"></div>
               </div>
               <div class="ms-shipbuilder__equals">= </div>
-          <div class="ms-shipbuilder__hull">                   
+          <div class="ms-shipbuilder__hull">
             <div class="ms-shipbuilder__item"><span class="ms-shipbuilder__display" name="attr_cryochamber_hull"></span>
               <div class="ms-shipbuilder__label" data-i18n="hull"></div>
             </div>
@@ -1673,7 +1673,7 @@
         <div class="ms-shipbuilder__title">
           <h3 data-i18n="living quarters"></h3>
         </div>
-        <div class="ms-shipbuilder__desc"> 
+        <div class="ms-shipbuilder__desc">
           <p data-i18n="Generally, if a ship is to travel through normal space for at least a week, then living quarters or “staterooms” are provided for each of the ship’s officers, or other important crew members."></p>
         </div>
         <div class="ms-shipbuilder__flex">
@@ -1686,7 +1686,7 @@
                 <div class="ms-shipbuilder__label" data-i18n="living quarters"></div>
               </div>
               <div class="ms-shipbuilder__equals">= </div>
-          <div class="ms-shipbuilder__hull">                   
+          <div class="ms-shipbuilder__hull">
             <div class="ms-shipbuilder__item"><span class="ms-shipbuilder__display" name="attr_living_quarters_hull"></span>
               <div class="ms-shipbuilder__label" data-i18n="hull"></div>
             </div>
@@ -1697,7 +1697,7 @@
         <div class="ms-shipbuilder__title">
           <h3 data-i18n="barracks"></h3>
         </div>
-        <div class="ms-shipbuilder__desc"> 
+        <div class="ms-shipbuilder__desc">
           <p data-i18n="The same as living quarters, except they are non-private and house up to twelve crew members.  Like living quarters, they are not-essential rooms, but ships that need them, but don’t have them, give their crew +1 Stress per journey or month of travel."></p>
         </div>
         <div class="ms-shipbuilder__flex">
@@ -1710,7 +1710,7 @@
                 <div class="ms-shipbuilder__label" data-i18n="barracks"></div>
               </div>
               <div class="ms-shipbuilder__equals">= </div>
-          <div class="ms-shipbuilder__hull">                   
+          <div class="ms-shipbuilder__hull">
             <div class="ms-shipbuilder__item"><span class="ms-shipbuilder__display" name="attr_barracks_hull"></span>
               <div class="ms-shipbuilder__label" data-i18n="hull"></div>
             </div>
@@ -1721,7 +1721,7 @@
         <div class="ms-shipbuilder__title">
           <h3 data-i18n="cargo hold"></h3>
         </div>
-        <div class="ms-shipbuilder__desc"> 
+        <div class="ms-shipbuilder__desc">
           <p data-i18n="Cargo holds are essentially 20x20m rooms used for storage. Each cargo hold can hold up to 10 cargo units (each cargo is roughly the size of a large pallet). Cargo holds can also be used for any other basic room not provided for on this list (brigs, secret compartments, mining equipment, training facilities, hangars, armories, etc.)."></p>
         </div>
         <div class="ms-shipbuilder__flex">
@@ -1734,7 +1734,7 @@
                 <div class="ms-shipbuilder__label" data-i18n="cargo holds"></div>
               </div>
               <div class="ms-shipbuilder__equals">= </div>
-          <div class="ms-shipbuilder__hull">                   
+          <div class="ms-shipbuilder__hull">
             <div class="ms-shipbuilder__item"><span class="ms-shipbuilder__display" name="attr_cargo_hold_hull"></span>
               <div class="ms-shipbuilder__label" data-i18n="hull"></div>
             </div>
@@ -1745,7 +1745,7 @@
         <div class="ms-shipbuilder__title">
           <h3 data-i18n="science lab"></h3>
         </div>
-        <div class="ms-shipbuilder__desc"> 
+        <div class="ms-shipbuilder__desc">
           <p data-i18n="Similar to the medical bay, the science lab allows for detailed research. Each connected sciencelab grants +5% Intellect to Scientists and Androids using them to conduct research or experiments. Additionally, they can be designated as repair shops and used by Teamsters to repair electronics, machines, or even Androids."></p>
         </div>
         <div class="ms-shipbuilder__flex">
@@ -1757,7 +1757,7 @@
               <div class="ms-shipbuilder__item"><span class="ms-shipbuilder__display" name="attr_ship_resint_bonus"></span>
                 <div class="ms-shipbuilder__label" data-i18n="research intellect bonus"></div>
               </div>
-          <div class="ms-shipbuilder__hull">                   
+          <div class="ms-shipbuilder__hull">
             <div class="ms-shipbuilder__item"><span class="ms-shipbuilder__display" name="attr_science_lab_hull"></span>
               <div class="ms-shipbuilder__label" data-i18n="hull"></div>
             </div>
@@ -1771,7 +1771,7 @@
         <div class="ms-shipbuilder__title">
           <h3 data-i18n="thrusters"></h3>
         </div>
-        <div class="ms-shipbuilder__desc"> 
+        <div class="ms-shipbuilder__desc">
           <p data-i18n="Without thrusters, the ship cannot move. Every thruster module equipped increases the speed ofthe ship by +10% (to a maximum of 80). Additionally, thrusters cost an extra 1 hull for every 10 base hull."></p>
         </div>
         <div class="ms-shipbuilder__flex">
@@ -1784,7 +1784,7 @@
                 <div class="ms-shipbuilder__label" data-i18n="thrusters"></div>
               </div>
               <div class="ms-shipbuilder__equals">= </div>
-          <div class="ms-shipbuilder__hull">                       
+          <div class="ms-shipbuilder__hull">
             <div class="ms-shipbuilder__item"><span class="ms-shipbuilder__display" name="attr_thrusters_hull"></span>
               <div class="ms-shipbuilder__label" data-i18n="hull"></div>
             </div>
@@ -1795,7 +1795,7 @@
         <div class="ms-shipbuilder__title">
           <h3 data-i18n="engine"></h3>
         </div>
-        <div class="ms-shipbuilder__desc"> 
+        <div class="ms-shipbuilder__desc">
           <p data-i18n="Without the engine, the entire ship ceases to operate and becomes a ruin. You must have 1 engine module for every jump drive, plus 1 for every 4 thrusters, plus 1 for every 20 points of base hull."></p>
         </div>
         <div class="ms-shipbuilder__flex">
@@ -1815,7 +1815,7 @@
                 <div class="ms-shipbuilder__label" data-i18n="engine"></div>
               </div>
               <div class="ms-shipbuilder__equals">= </div>
-          <div class="ms-shipbuilder__hull">                       
+          <div class="ms-shipbuilder__hull">
             <div class="ms-shipbuilder__item"><span class="ms-shipbuilder__display" name="attr_engine_hull"></span>
               <div class="ms-shipbuilder__label" data-i18n="hull"></div>
             </div>
@@ -1826,7 +1826,7 @@
         <div class="ms-shipbuilder__title">
           <h3 data-i18n="fuel"></h3>
         </div>
-        <div class="ms-shipbuilder__desc"> 
+        <div class="ms-shipbuilder__desc">
           <p data-i18n="The engine needs fuel to run on. Every jump requires double the fuel of the jump (Jump 2 = 4 fuel) and thrusters burn 1 unit of fuel per day. The engine requires at least 3 fuel for every point of engine plus any extra fuel capacity you want to add. More fuel can be stored in Cargo Holds at 1 Fuel per 10 Cargo."></p>
         </div>
         <div class="ms-shipbuilder__flex">
@@ -1839,7 +1839,7 @@
                 <div class="ms-shipbuilder__label" data-i18n="extra fuel"></div>
               </div>
               <div class="ms-shipbuilder__equals">= </div>
-          <div class="ms-shipbuilder__hull">                       
+          <div class="ms-shipbuilder__hull">
             <div class="ms-shipbuilder__item"><span class="ms-shipbuilder__display" name="attr_fuel_hull"></span>
               <div class="ms-shipbuilder__label" data-i18n="hull"></div>
             </div>
@@ -1850,7 +1850,7 @@
         <div class="ms-shipbuilder__title">
           <h3 data-i18n="frame"></h3>
         </div>
-        <div class="ms-shipbuilder__desc"> 
+        <div class="ms-shipbuilder__desc">
           <p data-i18n="Frame covers the miscellaneous parts of a ship, docking gear, airlocks, ventillation, corridors, comms relays, everything else a ship generally uses. Frame is 1 point per 10 points of base hull."></p>
         </div>
         <div class="ms-shipbuilder__flex">
@@ -1858,7 +1858,7 @@
                 <div class="ms-shipbuilder__label" data-i18n="frame"></div>
               </div>
               <div class="ms-shipbuilder__equals">= </div>
-          <div class="ms-shipbuilder__hull">                       
+          <div class="ms-shipbuilder__hull">
             <div class="ms-shipbuilder__item"><span class="ms-shipbuilder__display" name="attr_frame_hull"></span>
               <div class="ms-shipbuilder__label" data-i18n="hull"></div>
             </div>
@@ -1913,28 +1913,28 @@
       <div class="ms-shipstats">
         <div class="ms-mainstat">
           <div class="ms-mainstat__label">
-            <button data-i18n="armor" type="roll" value="&amp;{template:ms} {{name=armor}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=@{armor}}}"></button><span class="ms-tooltip">
+            <button data-i18n="armor" type="roll" value="&amp;{template:ms} {{name=armor}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[@{armor}+?{Modifier?|0}]]}}"></button><span class="ms-tooltip">
               <p><span data-i18n="The value the ship must roll under to avoid taking Damage. Generally the captain or acting captain of the ship rolls the Armor Save."></span></p></span>
           </div>
           <input class="ms-mainstat__input" name="attr_armor" type="number"/>
         </div>
         <div class="ms-mainstat">
           <div class="ms-mainstat__label">
-            <button data-i18n="combat" type="roll" value="&amp;{template:ms} {{name=combat}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=@{combat}}}"></button><span class="ms-tooltip">
+            <button data-i18n="combat" type="roll" value="&amp;{template:ms} {{name=combat}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[@{combat}+?{Modifier?|0}]]}}"></button><span class="ms-tooltip">
               <p><span data-i18n="Used during Combat Checks. You can use whichever is higher: your own Combat Stat or the ship's."></span></p></span>
           </div>
           <input class="ms-mainstat__input" name="attr_combat" type="number"/>
         </div>
         <div class="ms-mainstat">
           <div class="ms-mainstat__label">
-            <button data-i18n="intellect" type="roll" value="&amp;{template:ms} {{name=intellect}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=@{intellect}}}"></button><span class="ms-tooltip">
+            <button data-i18n="intellect" type="roll" value="&amp;{template:ms} {{name=intellect}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[@{intellect}+?{Modifier?|0}]]}}"></button><span class="ms-tooltip">
               <p><span data-i18n="Used as both a stat and a Sanity Save, should the need arise."></span></p></span>
           </div>
           <input class="ms-mainstat__input" name="attr_intellect" type="number"/>
         </div>
         <div class="ms-mainstat">
           <div class="ms-mainstat__label">
-            <button data-i18n="speed" type="roll" value="&amp;{template:ms} {{name=speed}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=@{speed}}}"></button><span class="ms-tooltip">
+            <button data-i18n="speed" type="roll" value="&amp;{template:ms} {{name=speed}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[@{speed}+?{Modifier?|0}]]}}"></button><span class="ms-tooltip">
               <p><span data-i18n="Often used to see if the ship can dodge asteroids or escape explosions from collapsing stars."></span></p></span>
           </div>
           <input class="ms-mainstat__input" name="attr_speed" type="number"/>
@@ -1982,7 +1982,7 @@
           <div class="ms-topstat__label--small" data-i18n="current"></div>
         </div>
       </div>
-      <div class="ms-shipweapons"> 
+      <div class="ms-shipweapons">
         <h1 data-i18n="weapons"></h1>
         <div class="ms-shipweaponrow--head">
           <div class="ms-shipweaponrow__name--head" data-i18n="weapon"></div>
@@ -1991,7 +1991,7 @@
         <fieldset class="repeating_shipweapon">
           <div class="ms-shipweaponrow">
             <input name="attr_shipweapon_settings" type="hidden" value="on"/>
-            <button class="ms-shipweaponrow__name" type="roll" value="&amp;{template:ms} {{name=@{shipweapon_name}}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[@{combat}]]}} {{damage=[[@{shipweapon_damage}]]}}"><span name="attr_shipweapon_name" type="text"></span></button><span class="ms-shipweaponrow__damage" name="attr_shipweapon_damage" type="text"></span>
+            <button class="ms-shipweaponrow__name" type="roll" value="&amp;{template:ms} {{name=@{shipweapon_name}}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[@{combat}+?{Modifier?|0}]]}} {{damage=[[@{shipweapon_damage}]]}}"><span name="attr_shipweapon_name" type="text"></span></button><span class="ms-shipweaponrow__damage" name="attr_shipweapon_damage" type="text"></span>
             <label class="ms-shipweaponrow__cog">
               <input name="attr_shipweapon_settings" type="checkbox" checked="checked"/><span>y</span>
             </label>
@@ -2053,7 +2053,7 @@
             <input class="ms-shipcargorow__name" name="attr_shipcrew_number" type="text"/>
           </div>
         </fieldset>
-        <div class="ms-cargowrap">      
+        <div class="ms-cargowrap">
           <div class="ms-cargo">
             <div class="ms-credits__label" data-i18n="total cargo"></div>
             <input class="ms-credits__input ms-rounded" name="attr_cargo" type="text"/>
@@ -2139,21 +2139,21 @@
       <div class="ms-npcstats">
         <div class="ms-mainstat">
           <div class="ms-mainstat__label">
-            <button data-i18n="Combat" type="roll" value="&amp;{template:ms},{{name=Combat}},{{character_name=@{character_name}}},{{roll=[[1d100cs1cf100]]}},{{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}},{{target=@{combat}}}"></button><span class="ms-tooltip">
+            <button data-i18n="Combat" type="roll" value="&amp;{template:ms},{{name=Combat}},{{character_name=@{character_name}}},{{roll=[[1d100-1cs0cf99]]}},{{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}},{{target=[[@{combat}+?{Modifier?|0}]]}}"></button><span class="ms-tooltip">
               <p><span data-i18n="This works exactly like the PC's combat stat, except it doubles as an armor save."></span></p></span>
           </div>
           <input class="ms-mainstat__input" name="attr_combat" type="number" placeholder="20"/>
         </div>
         <div class="ms-mainstat">
           <div class="ms-mainstat__label">
-            <button data-i18n="Speed" type="roll" value="&amp;{template:ms},{{name=Speed}},{{character_name=@{character_name}}},{{roll=[[1d100cs1cf100]]}},{{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}},{{target=@{speed}}}"></button><span class="ms-tooltip">
+            <button data-i18n="Speed" type="roll" value="&amp;{template:ms},{{name=Speed}},{{character_name=@{character_name}}},{{roll=[[1d100-1cs0cf99]]}},{{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}},{{target=[[@{speed}+?{Modifier?|0}]]}}"></button><span class="ms-tooltip">
               <p><span data-i18n="This works exactly like the PC's speed stat."></span></p></span>
           </div>
           <input class="ms-mainstat__input" name="attr_speed" type="number" placeholder="20"/>
         </div>
         <div class="ms-mainstat">
           <div class="ms-mainstat__label">
-            <button data-i18n="Instinct" type="roll" value="&amp;{template:ms},{{name=Instinct}},{{character_name=@{character_name}}},{{roll=[[1d100cs1cf100]]}},{{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}},{{target=@{instinct}}}"></button><span class="ms-tooltip">
+            <button data-i18n="Instinct" type="roll" value="&amp;{template:ms},{{name=Instinct}},{{character_name=@{character_name}}},{{roll=[[1d100-1cs0cf99]]}},{{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}},{{target=[[@{instinct}+?{Modifier?|0}]]}}"></button><span class="ms-tooltip">
               <p><span data-i18n="This is a catchall for Fear, Sanity, Body, Intellect and everything else."></span></p></span>
           </div>
           <input class="ms-mainstat__input" name="attr_instinct" type="number" placeholder="20"/>
@@ -2174,7 +2174,7 @@
           <fieldset class="repeating_attacks">
             <div class="ms-npcattackrow">
               <input name="attr_attack_settings" type="hidden" value="on"/><span class="ms-npcattackrow__arrow">]</span>
-              <button class="ms-npcattackrow__name" type="roll" value="&amp;{template:ms} {{name=@{attack_name}}} {{character_name=@{character_name}}} {{roll=[[1d100cs1cf100]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100cs1cf100}]]}} {{target=[[@{combat}]]}} {{damage=[[@{attack_damage}]]}}"><span name="attr_attack_name" type="text"></span></button><span class="ms-npcattackrow__damage" name="attr_attack_damage" type="text"></span>
+              <button class="ms-npcattackrow__name" type="roll" value="&amp;{template:ms} {{name=@{attack_name}}} {{character_name=@{character_name}}} {{roll=[[1d100-1cs0cf99]]}} {{roll2=[[?{Advantage/Disadvantage|Normal,0|Advantage/Disadvantage,1d100-1cs0cf99}]]}} {{target=[[@{combat}+?{Modifier?|0}]]}} {{damage=[[@{attack_damage}]]}}"><span name="attr_attack_name" type="text"></span></button><span class="ms-npcattackrow__damage" name="attr_attack_damage" type="text"></span>
               <label class="ms-npcattackrow__cog">
                 <input name="attr_attack_settings" type="checkbox" checked="checked"/><span>y</span>
               </label>
@@ -2205,7 +2205,7 @@
         <div class="ms-npcgrid">
           <h3 data-i18n="Special Abilities"></h3>
           <fieldset class="repeating_abilities">
-            <div class="ms-npcabilityrow"> 
+            <div class="ms-npcabilityrow">
               <input name="attr_ability_settings" type="hidden" value="on"/>
               <button class="ms-npcabilityrow__name" type="roll" value="&amp;{template:ms} {{name=@{ability_name}}} {{character_name=@{character_name}}} {{notes=@{ability_text}}}"><span name="attr_ability_name" type="text"></span></button>
               <label class="ms-npcabilityrow__cog">
@@ -2406,7 +2406,7 @@ const toggleSkill = (source, newValue) => {
         const unlocks = skillList[source].unlocks || [];
 
         let updateAttr = "";
-    
+
         if (newValue === "0") {
 
             unlocks.forEach(item => valueList.splice(valueList.indexOf(item), 1));
@@ -2414,16 +2414,16 @@ const toggleSkill = (source, newValue) => {
             updateAttr = valueList.join(" ");
 
         } else if (newValue === "on") {
-    
+
             updateAttr = existingValue + " ";
-    
+
             if (unlocks === []) return;
-            
+
             unlocks.forEach(unlock => updateAttr += `${unlock} `);
 
         }
-            
-        setAttrs({sheet_skill_toggles:updateAttr}); 
+
+        setAttrs({sheet_skill_toggles:updateAttr});
     });
 
 }
@@ -2527,7 +2527,7 @@ const toggleClass = (new_class, previous_class, source_type) => {
             update["skill_points"] = 3;
             update["stress_panic"] = getTranslationByKey(["Whenever a Marine Panics, every friendly player nearby must make a Fear Save."]);
             break;
-        default: 
+        default:
             return;
     }
 
@@ -2615,8 +2615,8 @@ const calculateRow = (row, new_value) => {
             const thrusters = parseInt(values["ship_thrusters"]) || 0;
             setAttrs({thrusters_hull : hullreq + thrusters, ship_engine_thrusterreq: thrusters});
         });
-    } 
-    if (row === "fuel") { 
+    }
+    if (row === "fuel") {
         getAttrs(["ship_fuel_min","ship_fuel_extra"], values => {
             const min_fuel = parseInt(values["ship_fuel_min"]) || 0;
             const extra_fuel = parseInt(values["ship_fuel_extra"]) || 0;
@@ -2631,7 +2631,7 @@ const calculateRow = (row, new_value) => {
             const jumpdrive = parseInt(values["ship_jumpdrive_modules"]) || 0;
 
             setAttrs({ship_engine:hullreq + thrustreq + jumpdrive, engine_hull: hullreq + thrustreq + jumpdrive, ship_fuel_min: (hullreq + thrustreq + jumpdrive) * 3})
-        }); 
+        });
     }
     if (row === "frame") setAttrs({frame_hull:int_value});
 
@@ -2654,7 +2654,7 @@ const recalculateBaseHull = () => {
         "cargo_hold_hull",
         "science_lab_hull"
     ];
-    
+
     getAttrs(base_hull_array, values => {
         const base_hull_int = Object.values(values).map(value => parseInt(value) || 0);
 
@@ -2666,10 +2666,10 @@ const recalculateBaseHull = () => {
 
 const recalculateTotalHull = () => {
     const total_hull_array = [
-        "ship_base_hull", 
-        "thrusters_hull", 
-        "engine_hull", 
-        "fuel_hull", 
+        "ship_base_hull",
+        "thrusters_hull",
+        "engine_hull",
+        "fuel_hull",
         "frame_hull"
     ];
 
@@ -2723,10 +2723,10 @@ const checkFuelValue = (new_value) => {
 
         let hull_toggle = "";
 
-        if (value <= hull_75) hull_toggle = 75; 
-        else if (value <= hull_50) hull_toggle = 50; 
+        if (value <= hull_75) hull_toggle = 75;
+        else if (value <= hull_50) hull_toggle = 50;
         else if (value <= hull_25) hull_toggle = 25;
-        
+
         setAttrs({hull_toggle: hull_toggle});
     });
 }
@@ -2734,11 +2734,11 @@ const checkFuelValue = (new_value) => {
 const calculateHullValues = () => {
     getAttrs(["hull_max"], values => {
         const value = parseInt(values["hull_max"]) || 0;
-    
+
         const n25 = Math.floor(value * 0.75);
         const n50 = Math.floor(value * 0.5);
         const n75 = Math.floor(value * 0.25);
-        
+
         setAttrs({
             hull_25: n25,
             hull_50: n50,
@@ -2757,19 +2757,19 @@ const dropHandler = (values) => {
     if (name === ""|| typeof data === "" || typeof category === "") return console.warn("No drag and drop data found.");
 
     switch (category) {
-        case "Classes": 
+        case "Classes":
             handleClassDrop(name, data);
             break;
         case "Items":
             handleItemDrop(name, data);
             break;
-        case "Mercenaries": 
+        case "Mercenaries":
             handleMercenaryDrop(name, data);
             break;
         case "Ships":
             handleShipDrop(name, data);
             break;
-        case "Ship Weapons": 
+        case "Ship Weapons":
             handleShipWeaponDrop(name, data);
             break;
         default:
@@ -2780,7 +2780,7 @@ const dropHandler = (values) => {
 }
 
 const handleItemDrop = (name, data) => {
-    const id = generateRowID();        
+    const id = generateRowID();
     const address = `repeating_equipment_${id}_equipment`;
 
     let updateAttrs = {};
@@ -2794,7 +2794,7 @@ const handleItemDrop = (name, data) => {
 
         updateAttrs[`${address}_type`] = "Weapon";
         updateAttrs[`${address}_linkedid`] = attack_id;
-        
+
         updateAttrs[`${attack_address}_linkedid`] = id;
         updateAttrs[`${attack_address}_name`] = name;
         updateAttrs[`${attack_address}_damage`] = data.Damage;
@@ -2819,7 +2819,7 @@ const handleItemDrop = (name, data) => {
             updateAttrs[`${attack_address}_range_l`] = range.Long || "-";
 
         } else {
-            updateAttrs[`${attack_address}_type`] = "Melee";      
+            updateAttrs[`${attack_address}_type`] = "Melee";
         }
     } else if (data["Armor Save"]) {
         updateAttrs[`${address}_type`] = "Armor";
@@ -2871,9 +2871,9 @@ const handleShipDrop = (name, data) => {
     updateAttrs["ship_sciencelabs"] = modules_parsed.science_lab || 0;
     updateAttrs["ship_thrusters"] = modules_parsed.thrusters || 0;
     updateAttrs["ship_engine"] = modules_parsed.engine || 0;
-    
+
     console.log(updateAttrs);
-    setAttrs(updateAttrs);    
+    setAttrs(updateAttrs);
 }
 
 const handleShipWeaponDrop = () => {
@@ -2899,9 +2899,9 @@ on(`change:ship_medbays`, eventInfo => calculateRow("medbays", eventInfo.newValu
 on(`change:ship_cryopods`, eventInfo => calculateRow("cryochamber", eventInfo.newValue));
 on(`change:ship_livingquarters`, eventInfo => calculateRow("livingquarters", eventInfo.newValue));
 on(`change:ship_crew`, eventInfo => calculateRow("barracks", eventInfo.newValue));
-on(`change:ship_cargo`, eventInfo => calculateRow("cargoholds", eventInfo.newValue)); 
-on(`change:ship_sciencelabs`, eventInfo => calculateRow("sciencelabs", eventInfo.newValue)); 
-on(`change:ship_thrusters change:ship_thruster_hullreq`, eventInfo => calculateRow("thrusters", eventInfo.newValue)); 
+on(`change:ship_cargo`, eventInfo => calculateRow("cargoholds", eventInfo.newValue));
+on(`change:ship_sciencelabs`, eventInfo => calculateRow("sciencelabs", eventInfo.newValue));
+on(`change:ship_thrusters change:ship_thruster_hullreq`, eventInfo => calculateRow("thrusters", eventInfo.newValue));
 on(`change:ship_fuel_extra change:ship_fuel_min`, eventInfo => calculateRow("fuel", eventInfo.newValue));
 on(`change:ship_engine_hullreq change:ship_engine_thrusterreq change:ship_jumpdrive_modules`, eventInfo => calculateRow("engine", eventInfo.newValue));
 on(`change:ship_frame`, eventInfo => calculateRow("frame", eventInfo.newValue));


### PR DESCRIPTION
## Changes / Comments
Three changes have been made to rolls in this sheet. First, modifier prompts are now on all rolls, allowing users to input modifiers for the roll's Target. Second, the dice type has been corrected. Initially it was a d100 (range of 1 to 100), however Mothership uses a d% (range of 0 to 99). This correction manifested as replacing instances of 1d100 with 1d100-1 to get the proper range of values. Finally, the critical successes and critical failures have been updated to reflect the new dice range. CS is now 0 instead of 1, and CF is now 99 instead of 100.

I would also like to apologize for the additional differences due to whitespace changes.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
