### PR TITLE
Ironsworn: Scene Challenges

### DIFF
--- a/Ironsworn/src/components/progress/progress.pug
+++ b/Ironsworn/src/components/progress/progress.pug
@@ -1,11 +1,17 @@
 - var track = [ 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten' ]
+- var challenge = [ 'one', 'two', 'three', 'four' ]
 include ../../data/difficulties
 include ./mixins/box
+include ../../data/translations
 
 fieldset.repeating_progress
   div
     br
-    input.progress-name(type='text' name='attr_name')
+    .sheet-progress-holder
+      input.progress-name(type='text' name='attr_name')
+      label.challenge-show
+        input(type='checkbox' class='hide challenge-show-button' name='attr_challenge-show-button')
+        .challenge-show-back(data-i18n='progress-challenge')=translations['progress-challenge']
     .progress-header
       each difficulty, index in difficulties
         label.difficulty
@@ -15,19 +21,30 @@ fieldset.repeating_progress
             input(type="radio" class="hide" name="attr_rank" value=index)
           h5=difficulty.text
     .progress
-      div
-        label.btn MARK
-          input(class="mark-vow hide" type="checkbox" name="attr_mark_progress")
-        label.btn CLEAR
-          input(class="clear-vow hide" type="checkbox" name="attr_clear_progress")
+      div.progress-row
+        div
+          label.btn MARK
+            input(class="mark-vow hide" type="checkbox" name="attr_mark_progress")
+          label.btn CLEAR
+            input(class="clear-vow hide" type="checkbox" name="attr_clear_progress")
         each index in track
           select(name=`attr_progress_${index}` class="progress-input")
             +progressBox
-        label.btn CONCLUDE 
-          button(
-            type="roll"
-            class='hide'
-            name="rollProgress"
-            value='&{template:ironsworn_progress} {{header=@{character_name} Conclude Your Progress}} {{progress_name=@{name}}} {{progress=[[@{progress-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}'
-          )    
+        div
+          label.btn CONCLUDE 
+            button(
+              type="roll"
+              class='hide'
+              name="rollProgress"
+              value='&{template:ironsworn_progress} {{header=@{character_name} Conclude Your Progress}} {{progress_name=@{name}}} {{progress=[[@{progress-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}'
+            )    
         input.hide(type='text' name='attr_progress-filled' value='floor((@{progress_one}+@{progress_two}+@{progress_three}+@{progress_four}+@{progress_five}+@{progress_six}+@{progress_seven}+@{progress_eight}+@{progress_nine}+@{progress_ten})/4)' disabled='true')
+    .progress
+      input(type='checkbox' class='hide challenge-show' name='attr_challenge-show' checked)
+      .challenge-row.showhide
+        label.challenge-label COUNTDOWN
+        each index in challenge
+          label.challenge-box
+            input.challenge.hide(type='checkbox' class='hide' name=`attr_countdown-${index}`)
+            .challenge-fill
+      

--- a/Ironsworn/src/components/progress/progress.styl
+++ b/Ironsworn/src/components/progress/progress.styl
@@ -32,7 +32,7 @@ input
   justify-content center
   align-items center
   padding 2px 0px 0px 12px
-  margin-bottom 0.4em
+  margin 0.3em 0em
   cursor pointer
   borderCommon()
   border-radius 0
@@ -43,3 +43,75 @@ input
     outline 3px solid #fd0
     outline-offset 0
     box-shadow inset 0 0 0 2px
+
+/* button to control display of countdown boxes */
+
+.sheet-progress-holder
+  display flex
+    
+input.sheet-progress-name
+  margin-bottom 0px
+
+.sheet-challenge-show
+  padding 0
+  margin 0
+  borderCommon()
+  width auto
+  height auto
+  cursor pointer
+  border-left 0
+  &:hover
+    background #ccc
+    transition 0.5s ease
+
+.sheet-challenge-show-back
+  height 100%
+  padding 0em 1em 0em 1em
+  line-height 25px
+
+input[type='checkbox'].sheet-challenge-show:checked ~ div.sheet-challenge-row
+  show-hide(0.7s)
+
+input[type='checkbox'].sheet-challenge-show-button:checked ~ div.sheet-challenge-show-back
+  background #4c4d4f
+  color white
+
+/* grid container to hold challenge boxes and countdown boxes */
+
+.sheet-challenge-row, .sheet-progress-row
+  display grid
+  grid-template-columns 151px repeat(10, 43.5px) 110px
+  align-items center
+  
+/* Individual boxes */
+
+label.sheet-challenge-label
+  padding-left 0.5em
+  display block
+  height 18px
+  margin 0px
+
+.sheet-challenge-box
+  borderCommon()
+  padding 0
+  display inline-flex
+  height 36px
+  width 36px
+  margin 0.2em 0em
+  cursor pointer
+  
+.sheet-challenge-fill
+  height 100%
+  width 100%
+  background white
+
+input[type="checkbox"].sheet-challenge:checked ~ .sheet-challenge-fill
+  background #4c4d4f
+
+input[type="checkbox"].sheet-challenge:hover ~ .sheet-challenge-fill
+  background #E6E7E8
+
+.blank-index
+  display: inline-block
+  height: 40px
+  width: 40px

--- a/Ironsworn/src/data/translations.pug
+++ b/Ironsworn/src/data/translations.pug
@@ -29,6 +29,7 @@
         "vow-threat": "Threat",
         "vow-mark":"MARK",
         "vow-fulfill":"FULFILL",
+        "progress-challenge":"CHALLENGE",
         "failures-learn": "LEARN",
         "difficulty-troublesome":"troublesome",
         "difficulty-dangerous":"dangerous",

--- a/Ironsworn/src/workers/scripts/progress.js
+++ b/Ironsworn/src/workers/scripts/progress.js
@@ -123,3 +123,9 @@ on('change:clear_misses', function() {
     'clear_misses': 'off'
   });
 });
+
+on('change:repeating_progress:challenge-show-button', function(eventinfo) {
+  setAttrs({
+    'repeating_progress_challenge-show': eventinfo.newValue  
+  });
+});


### PR DESCRIPTION
Update Ironswon sheet progress elements to also support scene challenges (from Ironsworn: Delve).

Adds a "Challenge" button which shows a parallel countdown track under the progress track, using a fixed 4-box format. Also converts the existing progress track to use css grid for the formatting. The countdown track adds six attributes to the progress repeating section — four to track the countdown boxes, and two to control visibility — but does not remove or alter any existing attributes.

![image](https://user-images.githubusercontent.com/4206142/112068139-3a3b8580-8b61-11eb-8f8d-167317b86779.png)

![image](https://user-images.githubusercontent.com/4206142/112067974-e16bed00-8b60-11eb-9fe6-bcaf2b8da694.png)