### PR TITLE
Ironsworn: Show images for progress boxes

### DIFF
--- a/Ironsworn/Ironsworn.css
+++ b/Ironsworn/Ironsworn.css
@@ -761,7 +761,7 @@ input.sheet-progress-name {
   justify-content: center;
   align-items: center;
   padding: 2px 0px 0px 12px;
-  margin: 0.3em 0em;
+  margin: 0px;
   cursor: pointer;
   border: 2px solid #4c4d4f;
   border-radius: 0;
@@ -845,6 +845,37 @@ input[type="checkbox"].sheet-challenge:hover ~ .sheet-challenge-fill {
   display: inline-block;
   height: 40px;
   width: 40px;
+}
+.sheet-progress-input-holder {
+  position: relative;
+  margin: 0.3em 0em;
+}
+.sheet-progress-input-holder input[min],
+input[min] + span {
+  display: none;
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 36px;
+  height: 36px;
+  pointer-events: none;
+  background: #fff;
+}
+.sheet-progress-input-holder input[min="1"]:valid + span {
+  display: block;
+  background-image: linear-gradient(45deg, transparent 0px, transparent calc(50% - 1px), #4c4d4f calc(50% - 1px), #4c4d4f calc(50% + 1px), transparent calc(50% + 1px));
+}
+.sheet-progress-input-holder input[min="2"]:valid + span {
+  display: block;
+  background-image: linear-gradient(45deg, transparent 0px, transparent calc(50% - 1px), #4c4d4f calc(50% - 1px), #4c4d4f calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(135deg, transparent 0px, transparent calc(50% - 1px), #4c4d4f calc(50% - 1px), #4c4d4f calc(50% + 1px), transparent calc(50% + 1px), transparent 100%);
+}
+.sheet-progress-input-holder input[min="3"]:valid + span {
+  display: block;
+  background-image: linear-gradient(45deg, transparent 0px, transparent calc(50% - 1px), #4c4d4f calc(50% - 1px), #4c4d4f calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(135deg, transparent 0px, transparent calc(50% - 1px), #4c4d4f calc(50% - 1px), #4c4d4f calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(90deg, transparent 0px, transparent calc(50% - 1px), #4c4d4f calc(50% - 1px), #4c4d4f calc(50% + 1px), transparent calc(50% + 1px), transparent 100%);
+}
+.sheet-progress-input-holder input[min="4"]:valid + span {
+  display: block;
+  background-image: linear-gradient(45deg, transparent 0px, transparent calc(50% - 1px), #4c4d4f calc(50% - 1px), #4c4d4f calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(135deg, transparent 0px, transparent calc(50% - 1px), #4c4d4f calc(50% - 1px), #4c4d4f calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(90deg, transparent 0px, transparent calc(50% - 1px), #4c4d4f calc(50% - 1px), #4c4d4f calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(0deg, transparent 0px, transparent calc(50% - 1px), #4c4d4f calc(50% - 1px), #4c4d4f calc(50% + 1px), transparent calc(50% + 1px), transparent 100%);
 }
 .sheet-nav-child {
   border: 2px solid #4c4d4f;

--- a/Ironsworn/Ironsworn.html
+++ b/Ironsworn/Ironsworn.html
@@ -516,89 +516,153 @@
               </label>
             </div>
             <div class="vow">
-              <div>
-                <label class="btn">
-                  <input class="mark-vow hide" type="checkbox" name="attr_mark_progress_1"/>
-                  <div class="btn-div" data-i18n="vow-mark">MARK</div>
-                </label>
-                <label class="btn">
-                  <input class="clear-vow hide" type="checkbox" name="attr_clear_progress_1"/>
-                  <div class="btn-div" data-i18n="clear-btn">CLEAR</div>
-                </label>
-                <select class="progress-input" name="attr_vow1-0">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow1-1">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow1-2">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow1-3">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow1-4">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow1-5">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow1-6">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow1-7">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow1-8">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow1-9">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <label class="btn">
-                  <button class="hide" type="roll" name="rollVow" value="&amp;{template:ironsworn_progress} {{progress_type=Vow}} {{header=@{character_name} &lt;em&gt;Fulfill Your Vow&lt;/em&gt; }} {{progress_name=@{vow1_name}}} {{progress=[[@{vow1-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
-                  <div class="btn-div" data-i18n="vow-fulfill">FULFILL</div>
-                </label>
+              <div class="progress-row">
+                <div>
+                  <label class="btn">
+                    <input class="mark-vow hide" type="checkbox" name="attr_mark_progress_1"/>
+                    <div class="btn-div" data-i18n="vow-mark">MARK</div>
+                  </label>
+                  <label class="btn">
+                    <input class="clear-vow hide" type="checkbox" name="attr_clear_progress_1"/>
+                    <div class="btn-div" data-i18n="clear-btn">CLEAR</div>
+                  </label>
+                </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow1-0">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow1-0" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-0" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-0" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-0" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow1-1">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow1-1" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-1" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-1" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-1" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow1-2">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow1-2" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-2" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-2" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-2" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow1-3">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow1-3" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-3" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-3" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-3" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow1-4">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow1-4" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-4" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-4" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-4" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow1-5">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow1-5" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-5" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-5" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-5" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow1-6">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow1-6" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-6" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-6" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-6" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow1-7">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow1-7" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-7" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-7" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-7" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow1-8">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow1-8" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-8" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-8" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-8" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow1-9">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow1-9" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-9" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-9" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow1-9" min="4" required="required"/><span></span>
+                      </div>
+                <div>
+                  <label class="btn">
+                    <button class="hide" type="roll" name="rollVow" value="&amp;{template:ironsworn_progress} {{progress_type=Vow}} {{header=@{character_name} &lt;em&gt;Fulfill Your Vow&lt;/em&gt; }} {{progress_name=@{vow1_name}}} {{progress=[[@{vow1-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                    <div class="btn-div" data-i18n="vow-fulfill">FULFILL</div>
+                  </label>
+                </div>
                 <input class="hide" type="text" name="attr_vow1-filled" value="floor((@{vow1-0}+@{vow1-1}+@{vow1-2}+@{vow1-3}+@{vow1-4}+@{vow1-5}+@{vow1-6}+@{vow1-7}+@{vow1-8}+@{vow1-9})/4)" disabled="disabled"/>
               </div>
             </div>
@@ -681,89 +745,153 @@
               </label>
             </div>
             <div class="vow">
-              <div>
-                <label class="btn">
-                  <input class="mark-vow hide" type="checkbox" name="attr_mark_progress_2"/>
-                  <div class="btn-div" data-i18n="vow-mark">MARK</div>
-                </label>
-                <label class="btn">
-                  <input class="clear-vow hide" type="checkbox" name="attr_clear_progress_2"/>
-                  <div class="btn-div" data-i18n="clear-btn">CLEAR</div>
-                </label>
-                <select class="progress-input" name="attr_vow2-0">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow2-1">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow2-2">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow2-3">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow2-4">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow2-5">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow2-6">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow2-7">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow2-8">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow2-9">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <label class="btn">
-                  <button class="hide" type="roll" name="rollVow" value="&amp;{template:ironsworn_progress} {{progress_type=Vow}} {{header=@{character_name} &lt;em&gt;Fulfill Your Vow&lt;/em&gt; }} {{progress_name=@{vow2_name}}} {{progress=[[@{vow2-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
-                  <div class="btn-div" data-i18n="vow-fulfill">FULFILL</div>
-                </label>
+              <div class="progress-row">
+                <div>
+                  <label class="btn">
+                    <input class="mark-vow hide" type="checkbox" name="attr_mark_progress_2"/>
+                    <div class="btn-div" data-i18n="vow-mark">MARK</div>
+                  </label>
+                  <label class="btn">
+                    <input class="clear-vow hide" type="checkbox" name="attr_clear_progress_2"/>
+                    <div class="btn-div" data-i18n="clear-btn">CLEAR</div>
+                  </label>
+                </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow2-0">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow2-0" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-0" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-0" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-0" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow2-1">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow2-1" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-1" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-1" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-1" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow2-2">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow2-2" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-2" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-2" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-2" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow2-3">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow2-3" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-3" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-3" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-3" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow2-4">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow2-4" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-4" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-4" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-4" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow2-5">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow2-5" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-5" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-5" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-5" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow2-6">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow2-6" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-6" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-6" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-6" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow2-7">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow2-7" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-7" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-7" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-7" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow2-8">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow2-8" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-8" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-8" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-8" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow2-9">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow2-9" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-9" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-9" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow2-9" min="4" required="required"/><span></span>
+                      </div>
+                <div>
+                  <label class="btn">
+                    <button class="hide" type="roll" name="rollVow" value="&amp;{template:ironsworn_progress} {{progress_type=Vow}} {{header=@{character_name} &lt;em&gt;Fulfill Your Vow&lt;/em&gt; }} {{progress_name=@{vow2_name}}} {{progress=[[@{vow2-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                    <div class="btn-div" data-i18n="vow-fulfill">FULFILL</div>
+                  </label>
+                </div>
                 <input class="hide" type="text" name="attr_vow2-filled" value="floor((@{vow2-0}+@{vow2-1}+@{vow2-2}+@{vow2-3}+@{vow2-4}+@{vow2-5}+@{vow2-6}+@{vow2-7}+@{vow2-8}+@{vow2-9})/4)" disabled="disabled"/>
               </div>
             </div>
@@ -846,89 +974,153 @@
               </label>
             </div>
             <div class="vow">
-              <div>
-                <label class="btn">
-                  <input class="mark-vow hide" type="checkbox" name="attr_mark_progress_3"/>
-                  <div class="btn-div" data-i18n="vow-mark">MARK</div>
-                </label>
-                <label class="btn">
-                  <input class="clear-vow hide" type="checkbox" name="attr_clear_progress_3"/>
-                  <div class="btn-div" data-i18n="clear-btn">CLEAR</div>
-                </label>
-                <select class="progress-input" name="attr_vow3-0">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow3-1">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow3-2">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow3-3">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow3-4">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow3-5">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow3-6">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow3-7">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow3-8">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow3-9">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <label class="btn">
-                  <button class="hide" type="roll" name="rollVow" value="&amp;{template:ironsworn_progress} {{progress_type=Vow}} {{header=@{character_name} &lt;em&gt;Fulfill Your Vow&lt;/em&gt; }} {{progress_name=@{vow3_name}}} {{progress=[[@{vow3-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
-                  <div class="btn-div" data-i18n="vow-fulfill">FULFILL</div>
-                </label>
+              <div class="progress-row">
+                <div>
+                  <label class="btn">
+                    <input class="mark-vow hide" type="checkbox" name="attr_mark_progress_3"/>
+                    <div class="btn-div" data-i18n="vow-mark">MARK</div>
+                  </label>
+                  <label class="btn">
+                    <input class="clear-vow hide" type="checkbox" name="attr_clear_progress_3"/>
+                    <div class="btn-div" data-i18n="clear-btn">CLEAR</div>
+                  </label>
+                </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow3-0">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow3-0" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-0" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-0" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-0" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow3-1">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow3-1" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-1" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-1" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-1" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow3-2">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow3-2" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-2" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-2" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-2" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow3-3">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow3-3" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-3" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-3" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-3" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow3-4">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow3-4" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-4" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-4" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-4" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow3-5">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow3-5" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-5" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-5" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-5" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow3-6">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow3-6" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-6" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-6" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-6" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow3-7">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow3-7" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-7" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-7" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-7" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow3-8">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow3-8" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-8" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-8" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-8" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow3-9">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow3-9" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-9" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-9" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow3-9" min="4" required="required"/><span></span>
+                      </div>
+                <div>
+                  <label class="btn">
+                    <button class="hide" type="roll" name="rollVow" value="&amp;{template:ironsworn_progress} {{progress_type=Vow}} {{header=@{character_name} &lt;em&gt;Fulfill Your Vow&lt;/em&gt; }} {{progress_name=@{vow3_name}}} {{progress=[[@{vow3-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                    <div class="btn-div" data-i18n="vow-fulfill">FULFILL</div>
+                  </label>
+                </div>
                 <input class="hide" type="text" name="attr_vow3-filled" value="floor((@{vow3-0}+@{vow3-1}+@{vow3-2}+@{vow3-3}+@{vow3-4}+@{vow3-5}+@{vow3-6}+@{vow3-7}+@{vow3-8}+@{vow3-9})/4)" disabled="disabled"/>
               </div>
             </div>
@@ -1011,89 +1203,153 @@
               </label>
             </div>
             <div class="vow">
-              <div>
-                <label class="btn">
-                  <input class="mark-vow hide" type="checkbox" name="attr_mark_progress_4"/>
-                  <div class="btn-div" data-i18n="vow-mark">MARK</div>
-                </label>
-                <label class="btn">
-                  <input class="clear-vow hide" type="checkbox" name="attr_clear_progress_4"/>
-                  <div class="btn-div" data-i18n="clear-btn">CLEAR</div>
-                </label>
-                <select class="progress-input" name="attr_vow4-0">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow4-1">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow4-2">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow4-3">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow4-4">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow4-5">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow4-6">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow4-7">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow4-8">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow4-9">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <label class="btn">
-                  <button class="hide" type="roll" name="rollVow" value="&amp;{template:ironsworn_progress} {{progress_type=Vow}} {{header=@{character_name} &lt;em&gt;Fulfill Your Vow&lt;/em&gt; }} {{progress_name=@{vow4_name}}} {{progress=[[@{vow4-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
-                  <div class="btn-div" data-i18n="vow-fulfill">FULFILL</div>
-                </label>
+              <div class="progress-row">
+                <div>
+                  <label class="btn">
+                    <input class="mark-vow hide" type="checkbox" name="attr_mark_progress_4"/>
+                    <div class="btn-div" data-i18n="vow-mark">MARK</div>
+                  </label>
+                  <label class="btn">
+                    <input class="clear-vow hide" type="checkbox" name="attr_clear_progress_4"/>
+                    <div class="btn-div" data-i18n="clear-btn">CLEAR</div>
+                  </label>
+                </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow4-0">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow4-0" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-0" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-0" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-0" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow4-1">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow4-1" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-1" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-1" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-1" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow4-2">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow4-2" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-2" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-2" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-2" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow4-3">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow4-3" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-3" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-3" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-3" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow4-4">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow4-4" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-4" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-4" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-4" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow4-5">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow4-5" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-5" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-5" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-5" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow4-6">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow4-6" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-6" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-6" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-6" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow4-7">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow4-7" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-7" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-7" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-7" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow4-8">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow4-8" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-8" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-8" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-8" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow4-9">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow4-9" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-9" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-9" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow4-9" min="4" required="required"/><span></span>
+                      </div>
+                <div>
+                  <label class="btn">
+                    <button class="hide" type="roll" name="rollVow" value="&amp;{template:ironsworn_progress} {{progress_type=Vow}} {{header=@{character_name} &lt;em&gt;Fulfill Your Vow&lt;/em&gt; }} {{progress_name=@{vow4_name}}} {{progress=[[@{vow4-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                    <div class="btn-div" data-i18n="vow-fulfill">FULFILL</div>
+                  </label>
+                </div>
                 <input class="hide" type="text" name="attr_vow4-filled" value="floor((@{vow4-0}+@{vow4-1}+@{vow4-2}+@{vow4-3}+@{vow4-4}+@{vow4-5}+@{vow4-6}+@{vow4-7}+@{vow4-8}+@{vow4-9})/4)" disabled="disabled"/>
               </div>
             </div>
@@ -1176,89 +1432,153 @@
               </label>
             </div>
             <div class="vow">
-              <div>
-                <label class="btn">
-                  <input class="mark-vow hide" type="checkbox" name="attr_mark_progress_5"/>
-                  <div class="btn-div" data-i18n="vow-mark">MARK</div>
-                </label>
-                <label class="btn">
-                  <input class="clear-vow hide" type="checkbox" name="attr_clear_progress_5"/>
-                  <div class="btn-div" data-i18n="clear-btn">CLEAR</div>
-                </label>
-                <select class="progress-input" name="attr_vow5-0">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow5-1">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow5-2">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow5-3">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow5-4">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow5-5">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow5-6">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow5-7">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow5-8">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_vow5-9">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <label class="btn">
-                  <button class="hide" type="roll" name="rollVow" value="&amp;{template:ironsworn_progress} {{progress_type=Vow}} {{header=@{character_name} &lt;em&gt;Fulfill Your Vow&lt;/em&gt; }} {{progress_name=@{vow5_name}}} {{progress=[[@{vow5-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
-                  <div class="btn-div" data-i18n="vow-fulfill">FULFILL</div>
-                </label>
+              <div class="progress-row">
+                <div>
+                  <label class="btn">
+                    <input class="mark-vow hide" type="checkbox" name="attr_mark_progress_5"/>
+                    <div class="btn-div" data-i18n="vow-mark">MARK</div>
+                  </label>
+                  <label class="btn">
+                    <input class="clear-vow hide" type="checkbox" name="attr_clear_progress_5"/>
+                    <div class="btn-div" data-i18n="clear-btn">CLEAR</div>
+                  </label>
+                </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow5-0">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow5-0" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-0" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-0" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-0" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow5-1">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow5-1" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-1" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-1" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-1" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow5-2">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow5-2" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-2" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-2" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-2" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow5-3">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow5-3" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-3" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-3" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-3" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow5-4">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow5-4" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-4" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-4" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-4" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow5-5">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow5-5" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-5" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-5" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-5" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow5-6">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow5-6" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-6" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-6" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-6" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow5-7">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow5-7" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-7" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-7" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-7" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow5-8">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow5-8" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-8" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-8" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-8" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_vow5-9">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_vow5-9" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-9" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-9" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_vow5-9" min="4" required="required"/><span></span>
+                      </div>
+                <div>
+                  <label class="btn">
+                    <button class="hide" type="roll" name="rollVow" value="&amp;{template:ironsworn_progress} {{progress_type=Vow}} {{header=@{character_name} &lt;em&gt;Fulfill Your Vow&lt;/em&gt; }} {{progress_name=@{vow5_name}}} {{progress=[[@{vow5-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                    <div class="btn-div" data-i18n="vow-fulfill">FULFILL</div>
+                  </label>
+                </div>
                 <input class="hide" type="text" name="attr_vow5-filled" value="floor((@{vow5-0}+@{vow5-1}+@{vow5-2}+@{vow5-3}+@{vow5-4}+@{vow5-5}+@{vow5-6}+@{vow5-7}+@{vow5-8}+@{vow5-9})/4)" disabled="disabled"/>
               </div>
             </div>
@@ -1339,89 +1659,153 @@
                 </label>
               </div>
               <div class="vow">
-                <div>
-                  <label class="btn">
-                    <input class="mark-vow hide" type="checkbox" name="attr_mark_progress"/>
-                    <div class="btn-div" data-i18n="vow-mark">MARK</div>
-                  </label>
-                  <label class="btn">
-                    <input class="clear-vow hide" type="checkbox" name="attr_clear_progress"/>
-                    <div class="btn-div" data-i18n="clear-btn">CLEAR</div>
-                  </label>
-                  <select class="progress-input" name="attr_progress_0">
-                          <option value="0" selected="selected"></option>
-                          <option value="1">-</option>
-                          <option value="2">+</option>
-                          <option value="3">*</option>
-                          <option value="4">#</option>
-                  </select>
-                  <select class="progress-input" name="attr_progress_1">
-                          <option value="0" selected="selected"></option>
-                          <option value="1">-</option>
-                          <option value="2">+</option>
-                          <option value="3">*</option>
-                          <option value="4">#</option>
-                  </select>
-                  <select class="progress-input" name="attr_progress_2">
-                          <option value="0" selected="selected"></option>
-                          <option value="1">-</option>
-                          <option value="2">+</option>
-                          <option value="3">*</option>
-                          <option value="4">#</option>
-                  </select>
-                  <select class="progress-input" name="attr_progress_3">
-                          <option value="0" selected="selected"></option>
-                          <option value="1">-</option>
-                          <option value="2">+</option>
-                          <option value="3">*</option>
-                          <option value="4">#</option>
-                  </select>
-                  <select class="progress-input" name="attr_progress_4">
-                          <option value="0" selected="selected"></option>
-                          <option value="1">-</option>
-                          <option value="2">+</option>
-                          <option value="3">*</option>
-                          <option value="4">#</option>
-                  </select>
-                  <select class="progress-input" name="attr_progress_5">
-                          <option value="0" selected="selected"></option>
-                          <option value="1">-</option>
-                          <option value="2">+</option>
-                          <option value="3">*</option>
-                          <option value="4">#</option>
-                  </select>
-                  <select class="progress-input" name="attr_progress_6">
-                          <option value="0" selected="selected"></option>
-                          <option value="1">-</option>
-                          <option value="2">+</option>
-                          <option value="3">*</option>
-                          <option value="4">#</option>
-                  </select>
-                  <select class="progress-input" name="attr_progress_7">
-                          <option value="0" selected="selected"></option>
-                          <option value="1">-</option>
-                          <option value="2">+</option>
-                          <option value="3">*</option>
-                          <option value="4">#</option>
-                  </select>
-                  <select class="progress-input" name="attr_progress_8">
-                          <option value="0" selected="selected"></option>
-                          <option value="1">-</option>
-                          <option value="2">+</option>
-                          <option value="3">*</option>
-                          <option value="4">#</option>
-                  </select>
-                  <select class="progress-input" name="attr_progress_9">
-                          <option value="0" selected="selected"></option>
-                          <option value="1">-</option>
-                          <option value="2">+</option>
-                          <option value="3">*</option>
-                          <option value="4">#</option>
-                  </select>
-                  <label class="btn">
-                    <button class="hide" type="roll" name="rollVow" value="&amp;{template:ironsworn_progress} {{progress_type=Vow}} {{header=@{character_name} &lt;em&gt;Fulfill Your Vow&lt;/em&gt; }} {{progress_name=@{vow_name}}} {{progress=[[@{vow-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
-                    <div class="btn-div" data-i18n="vow-fulfill">FULFILL</div>
-                  </label>
+                <div class="progress-row">
+                  <div>
+                    <label class="btn">
+                      <input class="mark-vow hide" type="checkbox" name="attr_mark_progress"/>
+                      <div class="btn-div" data-i18n="vow-mark">MARK</div>
+                    </label>
+                    <label class="btn">
+                      <input class="clear-vow hide" type="checkbox" name="attr_clear_progress"/>
+                      <div class="btn-div" data-i18n="clear-btn">CLEAR</div>
+                    </label>
+                  </div>
+                        <div class="progress-input-holder">
+                          <select class="progress-input" name="attr_progress_0">
+                            <option value="0" selected="selected"></option>
+                            <option value="1">-</option>
+                            <option value="2">+</option>
+                            <option value="3">*</option>
+                            <option value="4">#</option>
+                          </select>
+                          <input class="hide" type="number" name="attr_progress_0" min="1" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_0" min="2" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_0" min="3" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_0" min="4" required="required"/><span></span>
+                        </div>
+                        <div class="progress-input-holder">
+                          <select class="progress-input" name="attr_progress_1">
+                            <option value="0" selected="selected"></option>
+                            <option value="1">-</option>
+                            <option value="2">+</option>
+                            <option value="3">*</option>
+                            <option value="4">#</option>
+                          </select>
+                          <input class="hide" type="number" name="attr_progress_1" min="1" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_1" min="2" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_1" min="3" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_1" min="4" required="required"/><span></span>
+                        </div>
+                        <div class="progress-input-holder">
+                          <select class="progress-input" name="attr_progress_2">
+                            <option value="0" selected="selected"></option>
+                            <option value="1">-</option>
+                            <option value="2">+</option>
+                            <option value="3">*</option>
+                            <option value="4">#</option>
+                          </select>
+                          <input class="hide" type="number" name="attr_progress_2" min="1" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_2" min="2" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_2" min="3" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_2" min="4" required="required"/><span></span>
+                        </div>
+                        <div class="progress-input-holder">
+                          <select class="progress-input" name="attr_progress_3">
+                            <option value="0" selected="selected"></option>
+                            <option value="1">-</option>
+                            <option value="2">+</option>
+                            <option value="3">*</option>
+                            <option value="4">#</option>
+                          </select>
+                          <input class="hide" type="number" name="attr_progress_3" min="1" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_3" min="2" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_3" min="3" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_3" min="4" required="required"/><span></span>
+                        </div>
+                        <div class="progress-input-holder">
+                          <select class="progress-input" name="attr_progress_4">
+                            <option value="0" selected="selected"></option>
+                            <option value="1">-</option>
+                            <option value="2">+</option>
+                            <option value="3">*</option>
+                            <option value="4">#</option>
+                          </select>
+                          <input class="hide" type="number" name="attr_progress_4" min="1" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_4" min="2" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_4" min="3" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_4" min="4" required="required"/><span></span>
+                        </div>
+                        <div class="progress-input-holder">
+                          <select class="progress-input" name="attr_progress_5">
+                            <option value="0" selected="selected"></option>
+                            <option value="1">-</option>
+                            <option value="2">+</option>
+                            <option value="3">*</option>
+                            <option value="4">#</option>
+                          </select>
+                          <input class="hide" type="number" name="attr_progress_5" min="1" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_5" min="2" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_5" min="3" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_5" min="4" required="required"/><span></span>
+                        </div>
+                        <div class="progress-input-holder">
+                          <select class="progress-input" name="attr_progress_6">
+                            <option value="0" selected="selected"></option>
+                            <option value="1">-</option>
+                            <option value="2">+</option>
+                            <option value="3">*</option>
+                            <option value="4">#</option>
+                          </select>
+                          <input class="hide" type="number" name="attr_progress_6" min="1" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_6" min="2" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_6" min="3" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_6" min="4" required="required"/><span></span>
+                        </div>
+                        <div class="progress-input-holder">
+                          <select class="progress-input" name="attr_progress_7">
+                            <option value="0" selected="selected"></option>
+                            <option value="1">-</option>
+                            <option value="2">+</option>
+                            <option value="3">*</option>
+                            <option value="4">#</option>
+                          </select>
+                          <input class="hide" type="number" name="attr_progress_7" min="1" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_7" min="2" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_7" min="3" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_7" min="4" required="required"/><span></span>
+                        </div>
+                        <div class="progress-input-holder">
+                          <select class="progress-input" name="attr_progress_8">
+                            <option value="0" selected="selected"></option>
+                            <option value="1">-</option>
+                            <option value="2">+</option>
+                            <option value="3">*</option>
+                            <option value="4">#</option>
+                          </select>
+                          <input class="hide" type="number" name="attr_progress_8" min="1" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_8" min="2" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_8" min="3" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_8" min="4" required="required"/><span></span>
+                        </div>
+                        <div class="progress-input-holder">
+                          <select class="progress-input" name="attr_progress_9">
+                            <option value="0" selected="selected"></option>
+                            <option value="1">-</option>
+                            <option value="2">+</option>
+                            <option value="3">*</option>
+                            <option value="4">#</option>
+                          </select>
+                          <input class="hide" type="number" name="attr_progress_9" min="1" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_9" min="2" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_9" min="3" required="required"/><span></span>
+                          <input class="hide" type="number" name="attr_progress_9" min="4" required="required"/><span></span>
+                        </div>
+                  <div>
+                    <label class="btn">
+                      <button class="hide" type="roll" name="rollVow" value="&amp;{template:ironsworn_progress} {{progress_type=Vow}} {{header=@{character_name} &lt;em&gt;Fulfill Your Vow&lt;/em&gt; }}   {{progress_name=@{vow_name}}} {{progress=[[@{vow-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                      <div class="btn-div" data-i18n="vow-fulfill">FULFILL</div>
+                    </label>
+                  </div>
                   <input class="hide" type="text" name="attr_vow-filled" value="floor((@{progress_0}+@{progress_1}+@{progress_2}+@{progress_3}+@{progress_4}+@{progress_5}+@{progress_6}+@{progress_7}+@{progress_8}+@{progress_9})/4)" disabled="disabled"/>
                 </div>
               </div>
@@ -1503,77 +1887,138 @@
       <input class="bonds hide" type="radio" name="attr_character_page" value="3"/>
       <div class="bonds showhide">
           <div class="bonds-track">
-            <div>
-              <select class="progress-input" name="attr_bond-0">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-              </select>
-              <select class="progress-input" name="attr_bond-1">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-              </select>
-              <select class="progress-input" name="attr_bond-2">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-              </select>
-              <select class="progress-input" name="attr_bond-3">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-              </select>
-              <select class="progress-input" name="attr_bond-4">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-              </select>
-              <select class="progress-input" name="attr_bond-5">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-              </select>
-              <select class="progress-input" name="attr_bond-6">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-              </select>
-              <select class="progress-input" name="attr_bond-7">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-              </select>
-              <select class="progress-input" name="attr_bond-8">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-              </select>
-              <select class="progress-input" name="attr_bond-9">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-              </select>
+            <div class="progress-row">
+              <div></div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_bond-0">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_bond-0" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-0" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-0" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-0" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_bond-1">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_bond-1" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-1" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-1" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-1" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_bond-2">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_bond-2" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-2" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-2" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-2" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_bond-3">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_bond-3" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-3" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-3" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-3" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_bond-4">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_bond-4" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-4" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-4" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-4" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_bond-5">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_bond-5" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-5" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-5" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-5" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_bond-6">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_bond-6" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-6" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-6" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-6" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_bond-7">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_bond-7" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-7" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-7" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-7" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_bond-8">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_bond-8" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-8" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-8" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-8" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_bond-9">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_bond-9" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-9" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-9" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_bond-9" min="4" required="required"/><span></span>
+                    </div>
               <input class="hide" type="text" name="attr_bond-filled" value="floor((@{bond-0}+@{bond-1}+@{bond-2}+@{bond-3}+@{bond-4}+@{bond-5}+@{bond-6}+@{bond-7}+@{bond-8}+@{bond-9})/4)" disabled="true"/>
             </div>
           </div>
@@ -6137,76 +6582,136 @@
                     <input class="clear-vow hide" type="checkbox" name="attr_clear_progress"/>
                   </label>
                 </div>
-                <select class="progress-input" name="attr_progress_one">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_progress_two">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_progress_three">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_progress_four">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_progress_five">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_progress_six">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_progress_seven">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_progress_eight">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_progress_nine">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_progress_ten">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_progress_one">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_progress_one" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_one" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_one" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_one" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_progress_two">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_progress_two" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_two" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_two" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_two" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_progress_three">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_progress_three" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_three" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_three" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_three" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_progress_four">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_progress_four" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_four" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_four" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_four" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_progress_five">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_progress_five" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_five" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_five" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_five" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_progress_six">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_progress_six" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_six" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_six" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_six" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_progress_seven">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_progress_seven" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_seven" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_seven" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_seven" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_progress_eight">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_progress_eight" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_eight" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_eight" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_eight" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_progress_nine">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_progress_nine" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_nine" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_nine" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_nine" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_progress_ten">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_progress_ten" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_ten" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_ten" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_ten" min="4" required="required"/><span></span>
+                      </div>
                 <div>
                   <label class="btn">CONCLUDE 
                     <button class="hide" type="roll" name="rollProgress" value="&amp;{template:ironsworn_progress} {{header=@{character_name} Conclude Your Progress}} {{progress_name=@{name}}} {{progress=[[@{progress-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}">   </button>
@@ -8912,78 +9417,141 @@
                     </label>
                   </div>
                   <div class="progress">
-                    <div>
-                      <select class="progress-input" name="attr_progress_one"> 
-                        <option value="0" selected="selected"> </option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                      </select>
-                      <select class="progress-input" name="attr_progress_two"> 
-                        <option value="0" selected="selected"> </option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                      </select>
-                      <select class="progress-input" name="attr_progress_three"> 
-                        <option value="0" selected="selected"> </option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                      </select>
-                      <select class="progress-input" name="attr_progress_four"> 
-                        <option value="0" selected="selected"> </option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                      </select>
-                      <select class="progress-input" name="attr_progress_five"> 
-                        <option value="0" selected="selected"> </option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                      </select>
-                      <select class="progress-input" name="attr_progress_six"> 
-                        <option value="0" selected="selected"> </option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                      </select>
-                      <select class="progress-input" name="attr_progress_seven"> 
-                        <option value="0" selected="selected"> </option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                      </select>
-                      <select class="progress-input" name="attr_progress_eight"> 
-                        <option value="0" selected="selected"> </option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                      </select>
-                      <select class="progress-input" name="attr_progress_nine"> 
-                        <option value="0" selected="selected"> </option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                      </select>
-                      <select class="progress-input" name="attr_progress_ten"> 
-                        <option value="0" selected="selected"> </option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                      </select>
-                      <button type="roll" title="Conclude your progress" name="rollprogress1" value="&amp;{template:ironsworn_progress} {{header=@{character_name} Conclude Your Progress}} {{progressname=@{site-name}}} {{progress=[[@{progress-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                    <div class="progress-row">
+                      <div></div>
+                            <div class="progress-input-holder">
+                              <select class="progress-input" name="attr_progress_one">
+                                <option value="0" selected="selected"></option>
+                                <option value="1">-</option>
+                                <option value="2">+</option>
+                                <option value="3">*</option>
+                                <option value="4">#</option>
+                              </select>
+                              <input class="hide" type="number" name="attr_progress_one" min="1" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_one" min="2" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_one" min="3" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_one" min="4" required="required"/><span></span>
+                            </div>
+                            <div class="progress-input-holder">
+                              <select class="progress-input" name="attr_progress_two">
+                                <option value="0" selected="selected"></option>
+                                <option value="1">-</option>
+                                <option value="2">+</option>
+                                <option value="3">*</option>
+                                <option value="4">#</option>
+                              </select>
+                              <input class="hide" type="number" name="attr_progress_two" min="1" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_two" min="2" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_two" min="3" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_two" min="4" required="required"/><span></span>
+                            </div>
+                            <div class="progress-input-holder">
+                              <select class="progress-input" name="attr_progress_three">
+                                <option value="0" selected="selected"></option>
+                                <option value="1">-</option>
+                                <option value="2">+</option>
+                                <option value="3">*</option>
+                                <option value="4">#</option>
+                              </select>
+                              <input class="hide" type="number" name="attr_progress_three" min="1" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_three" min="2" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_three" min="3" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_three" min="4" required="required"/><span></span>
+                            </div>
+                            <div class="progress-input-holder">
+                              <select class="progress-input" name="attr_progress_four">
+                                <option value="0" selected="selected"></option>
+                                <option value="1">-</option>
+                                <option value="2">+</option>
+                                <option value="3">*</option>
+                                <option value="4">#</option>
+                              </select>
+                              <input class="hide" type="number" name="attr_progress_four" min="1" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_four" min="2" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_four" min="3" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_four" min="4" required="required"/><span></span>
+                            </div>
+                            <div class="progress-input-holder">
+                              <select class="progress-input" name="attr_progress_five">
+                                <option value="0" selected="selected"></option>
+                                <option value="1">-</option>
+                                <option value="2">+</option>
+                                <option value="3">*</option>
+                                <option value="4">#</option>
+                              </select>
+                              <input class="hide" type="number" name="attr_progress_five" min="1" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_five" min="2" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_five" min="3" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_five" min="4" required="required"/><span></span>
+                            </div>
+                            <div class="progress-input-holder">
+                              <select class="progress-input" name="attr_progress_six">
+                                <option value="0" selected="selected"></option>
+                                <option value="1">-</option>
+                                <option value="2">+</option>
+                                <option value="3">*</option>
+                                <option value="4">#</option>
+                              </select>
+                              <input class="hide" type="number" name="attr_progress_six" min="1" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_six" min="2" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_six" min="3" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_six" min="4" required="required"/><span></span>
+                            </div>
+                            <div class="progress-input-holder">
+                              <select class="progress-input" name="attr_progress_seven">
+                                <option value="0" selected="selected"></option>
+                                <option value="1">-</option>
+                                <option value="2">+</option>
+                                <option value="3">*</option>
+                                <option value="4">#</option>
+                              </select>
+                              <input class="hide" type="number" name="attr_progress_seven" min="1" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_seven" min="2" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_seven" min="3" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_seven" min="4" required="required"/><span></span>
+                            </div>
+                            <div class="progress-input-holder">
+                              <select class="progress-input" name="attr_progress_eight">
+                                <option value="0" selected="selected"></option>
+                                <option value="1">-</option>
+                                <option value="2">+</option>
+                                <option value="3">*</option>
+                                <option value="4">#</option>
+                              </select>
+                              <input class="hide" type="number" name="attr_progress_eight" min="1" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_eight" min="2" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_eight" min="3" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_eight" min="4" required="required"/><span></span>
+                            </div>
+                            <div class="progress-input-holder">
+                              <select class="progress-input" name="attr_progress_nine">
+                                <option value="0" selected="selected"></option>
+                                <option value="1">-</option>
+                                <option value="2">+</option>
+                                <option value="3">*</option>
+                                <option value="4">#</option>
+                              </select>
+                              <input class="hide" type="number" name="attr_progress_nine" min="1" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_nine" min="2" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_nine" min="3" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_nine" min="4" required="required"/><span></span>
+                            </div>
+                            <div class="progress-input-holder">
+                              <select class="progress-input" name="attr_progress_ten">
+                                <option value="0" selected="selected"></option>
+                                <option value="1">-</option>
+                                <option value="2">+</option>
+                                <option value="3">*</option>
+                                <option value="4">#</option>
+                              </select>
+                              <input class="hide" type="number" name="attr_progress_ten" min="1" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_ten" min="2" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_ten" min="3" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_ten" min="4" required="required"/><span></span>
+                            </div>
+                      <div>
+                        <button type="roll" title="Conclude your progress" name="rollprogress1" value="&amp;{template:ironsworn_progress} {{header=@{character_name} Conclude Your Progress}} {{progressname=@{site-name}}} {{progress=[[@{progress-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                      </div>
                       <input class="hide" type="text" name="attr_progress-filled" value="floor((@{progress_one}+@{progress_two}+@{progress_three}+@{progress_four}+@{progress_five}+@{progress_six}+@{progress_seven}+@{progress_eight}+@{progress_nine}+@{progress_ten})/4)" disabled="true"/>
                     </div>
                   </div>
@@ -9851,89 +10419,153 @@
                 </label>
               </div>
               <div class="vow">
-                <div>
-                  <label class="btn">
-                    <input class="mark-vow hide" type="checkbox" name="attr_mark_progress"/>
-                    <div class="btn-div" data-i18n="vow-mark">MARK</div>
-                  </label>
-                  <label class="btn">
-                    <input class="clear-vow hide" type="checkbox" name="attr_clear_progress"/>
-                    <div class="btn-div" data-i18n="clear-btn">CLEAR</div>
-                  </label>
-                  <select class="progress-input" name="attr_progress_0">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-                  </select>
-                  <select class="progress-input" name="attr_progress_1">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-                  </select>
-                  <select class="progress-input" name="attr_progress_2">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-                  </select>
-                  <select class="progress-input" name="attr_progress_3">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-                  </select>
-                  <select class="progress-input" name="attr_progress_4">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-                  </select>
-                  <select class="progress-input" name="attr_progress_5">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-                  </select>
-                  <select class="progress-input" name="attr_progress_6">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-                  </select>
-                  <select class="progress-input" name="attr_progress_7">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-                  </select>
-                  <select class="progress-input" name="attr_progress_8">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-                  </select>
-                  <select class="progress-input" name="attr_progress_9">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-                  </select>
-                  <label class="btn">
-                    <button class="hide" type="roll" name="rollVow" value="&amp;{template:ironsworn_progress} {{progress_type=Vow}} {{header=@{character_name} &lt;em&gt;Fulfill Your Vow&lt;/em&gt; }} {{progress_name=@{vow_name}}} {{progress=[[@{vow-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
-                    <div class="btn-div" data-i18n="vow-fulfill">FULFILL</div>
-                  </label>
+                <div class="progress-row">
+                  <div>
+                    <label class="btn">
+                      <input class="mark-vow hide" type="checkbox" name="attr_mark_progress"/>
+                      <div class="btn-div" data-i18n="vow-mark">MARK</div>
+                    </label>
+                    <label class="btn">
+                      <input class="clear-vow hide" type="checkbox" name="attr_clear_progress"/>
+                      <div class="btn-div" data-i18n="clear-btn">CLEAR</div>
+                    </label>
+                  </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_progress_0">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_progress_0" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_0" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_0" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_0" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_progress_1">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_progress_1" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_1" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_1" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_1" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_progress_2">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_progress_2" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_2" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_2" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_2" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_progress_3">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_progress_3" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_3" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_3" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_3" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_progress_4">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_progress_4" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_4" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_4" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_4" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_progress_5">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_progress_5" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_5" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_5" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_5" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_progress_6">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_progress_6" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_6" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_6" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_6" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_progress_7">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_progress_7" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_7" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_7" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_7" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_progress_8">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_progress_8" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_8" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_8" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_8" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_progress_9">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_progress_9" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_9" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_9" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_progress_9" min="4" required="required"/><span></span>
+                    </div>
+                  <div>
+                    <label class="btn">
+                      <button class="hide" type="roll" name="rollVow" value="&amp;{template:ironsworn_progress} {{progress_type=Vow}} {{header=@{character_name} &lt;em&gt;Fulfill Your Vow&lt;/em&gt; }}   {{progress_name=@{vow_name}}} {{progress=[[@{vow-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                      <div class="btn-div" data-i18n="vow-fulfill">FULFILL</div>
+                    </label>
+                  </div>
                   <input class="hide" type="text" name="attr_vow-filled" value="floor((@{progress_0}+@{progress_1}+@{progress_2}+@{progress_3}+@{progress_4}+@{progress_5}+@{progress_6}+@{progress_7}+@{progress_8}+@{progress_9})/4)" disabled="disabled"/>
                 </div>
               </div>
@@ -10016,76 +10648,136 @@
                     <input class="clear-vow hide" type="checkbox" name="attr_clear_progress"/>
                   </label>
                 </div>
-                <select class="progress-input" name="attr_progress_one">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_progress_two">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_progress_three">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_progress_four">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_progress_five">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_progress_six">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_progress_seven">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_progress_eight">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_progress_nine">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
-                <select class="progress-input" name="attr_progress_ten">
-                        <option value="0" selected="selected"></option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                </select>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_progress_one">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_progress_one" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_one" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_one" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_one" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_progress_two">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_progress_two" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_two" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_two" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_two" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_progress_three">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_progress_three" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_three" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_three" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_three" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_progress_four">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_progress_four" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_four" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_four" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_four" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_progress_five">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_progress_five" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_five" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_five" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_five" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_progress_six">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_progress_six" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_six" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_six" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_six" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_progress_seven">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_progress_seven" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_seven" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_seven" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_seven" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_progress_eight">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_progress_eight" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_eight" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_eight" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_eight" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_progress_nine">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_progress_nine" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_nine" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_nine" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_nine" min="4" required="required"/><span></span>
+                      </div>
+                      <div class="progress-input-holder">
+                        <select class="progress-input" name="attr_progress_ten">
+                          <option value="0" selected="selected"></option>
+                          <option value="1">-</option>
+                          <option value="2">+</option>
+                          <option value="3">*</option>
+                          <option value="4">#</option>
+                        </select>
+                        <input class="hide" type="number" name="attr_progress_ten" min="1" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_ten" min="2" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_ten" min="3" required="required"/><span></span>
+                        <input class="hide" type="number" name="attr_progress_ten" min="4" required="required"/><span></span>
+                      </div>
                 <div>
                   <label class="btn">CONCLUDE 
                     <button class="hide" type="roll" name="rollProgress" value="&amp;{template:ironsworn_progress} {{header=@{character_name} Conclude Your Progress}} {{progress_name=@{name}}} {{progress=[[@{progress-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}">   </button>
@@ -10182,78 +10874,141 @@
                     </label>
                   </div>
                   <div class="progress">
-                    <div>
-                      <select class="progress-input" name="attr_progress_one"> 
-                        <option value="0" selected="selected"> </option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                      </select>
-                      <select class="progress-input" name="attr_progress_two"> 
-                        <option value="0" selected="selected"> </option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                      </select>
-                      <select class="progress-input" name="attr_progress_three"> 
-                        <option value="0" selected="selected"> </option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                      </select>
-                      <select class="progress-input" name="attr_progress_four"> 
-                        <option value="0" selected="selected"> </option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                      </select>
-                      <select class="progress-input" name="attr_progress_five"> 
-                        <option value="0" selected="selected"> </option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                      </select>
-                      <select class="progress-input" name="attr_progress_six"> 
-                        <option value="0" selected="selected"> </option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                      </select>
-                      <select class="progress-input" name="attr_progress_seven"> 
-                        <option value="0" selected="selected"> </option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                      </select>
-                      <select class="progress-input" name="attr_progress_eight"> 
-                        <option value="0" selected="selected"> </option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                      </select>
-                      <select class="progress-input" name="attr_progress_nine"> 
-                        <option value="0" selected="selected"> </option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                      </select>
-                      <select class="progress-input" name="attr_progress_ten"> 
-                        <option value="0" selected="selected"> </option>
-                        <option value="1">-</option>
-                        <option value="2">+</option>
-                        <option value="3">*</option>
-                        <option value="4">#</option>
-                      </select>
-                      <button type="roll" title="Conclude your progress" name="rollprogress1" value="&amp;{template:ironsworn_progress} {{header=@{character_name} Conclude Your Progress}} {{progressname=@{site-name}}} {{progress=[[@{progress-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                    <div class="progress-row">
+                      <div></div>
+                            <div class="progress-input-holder">
+                              <select class="progress-input" name="attr_progress_one">
+                                <option value="0" selected="selected"></option>
+                                <option value="1">-</option>
+                                <option value="2">+</option>
+                                <option value="3">*</option>
+                                <option value="4">#</option>
+                              </select>
+                              <input class="hide" type="number" name="attr_progress_one" min="1" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_one" min="2" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_one" min="3" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_one" min="4" required="required"/><span></span>
+                            </div>
+                            <div class="progress-input-holder">
+                              <select class="progress-input" name="attr_progress_two">
+                                <option value="0" selected="selected"></option>
+                                <option value="1">-</option>
+                                <option value="2">+</option>
+                                <option value="3">*</option>
+                                <option value="4">#</option>
+                              </select>
+                              <input class="hide" type="number" name="attr_progress_two" min="1" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_two" min="2" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_two" min="3" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_two" min="4" required="required"/><span></span>
+                            </div>
+                            <div class="progress-input-holder">
+                              <select class="progress-input" name="attr_progress_three">
+                                <option value="0" selected="selected"></option>
+                                <option value="1">-</option>
+                                <option value="2">+</option>
+                                <option value="3">*</option>
+                                <option value="4">#</option>
+                              </select>
+                              <input class="hide" type="number" name="attr_progress_three" min="1" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_three" min="2" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_three" min="3" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_three" min="4" required="required"/><span></span>
+                            </div>
+                            <div class="progress-input-holder">
+                              <select class="progress-input" name="attr_progress_four">
+                                <option value="0" selected="selected"></option>
+                                <option value="1">-</option>
+                                <option value="2">+</option>
+                                <option value="3">*</option>
+                                <option value="4">#</option>
+                              </select>
+                              <input class="hide" type="number" name="attr_progress_four" min="1" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_four" min="2" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_four" min="3" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_four" min="4" required="required"/><span></span>
+                            </div>
+                            <div class="progress-input-holder">
+                              <select class="progress-input" name="attr_progress_five">
+                                <option value="0" selected="selected"></option>
+                                <option value="1">-</option>
+                                <option value="2">+</option>
+                                <option value="3">*</option>
+                                <option value="4">#</option>
+                              </select>
+                              <input class="hide" type="number" name="attr_progress_five" min="1" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_five" min="2" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_five" min="3" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_five" min="4" required="required"/><span></span>
+                            </div>
+                            <div class="progress-input-holder">
+                              <select class="progress-input" name="attr_progress_six">
+                                <option value="0" selected="selected"></option>
+                                <option value="1">-</option>
+                                <option value="2">+</option>
+                                <option value="3">*</option>
+                                <option value="4">#</option>
+                              </select>
+                              <input class="hide" type="number" name="attr_progress_six" min="1" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_six" min="2" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_six" min="3" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_six" min="4" required="required"/><span></span>
+                            </div>
+                            <div class="progress-input-holder">
+                              <select class="progress-input" name="attr_progress_seven">
+                                <option value="0" selected="selected"></option>
+                                <option value="1">-</option>
+                                <option value="2">+</option>
+                                <option value="3">*</option>
+                                <option value="4">#</option>
+                              </select>
+                              <input class="hide" type="number" name="attr_progress_seven" min="1" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_seven" min="2" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_seven" min="3" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_seven" min="4" required="required"/><span></span>
+                            </div>
+                            <div class="progress-input-holder">
+                              <select class="progress-input" name="attr_progress_eight">
+                                <option value="0" selected="selected"></option>
+                                <option value="1">-</option>
+                                <option value="2">+</option>
+                                <option value="3">*</option>
+                                <option value="4">#</option>
+                              </select>
+                              <input class="hide" type="number" name="attr_progress_eight" min="1" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_eight" min="2" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_eight" min="3" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_eight" min="4" required="required"/><span></span>
+                            </div>
+                            <div class="progress-input-holder">
+                              <select class="progress-input" name="attr_progress_nine">
+                                <option value="0" selected="selected"></option>
+                                <option value="1">-</option>
+                                <option value="2">+</option>
+                                <option value="3">*</option>
+                                <option value="4">#</option>
+                              </select>
+                              <input class="hide" type="number" name="attr_progress_nine" min="1" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_nine" min="2" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_nine" min="3" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_nine" min="4" required="required"/><span></span>
+                            </div>
+                            <div class="progress-input-holder">
+                              <select class="progress-input" name="attr_progress_ten">
+                                <option value="0" selected="selected"></option>
+                                <option value="1">-</option>
+                                <option value="2">+</option>
+                                <option value="3">*</option>
+                                <option value="4">#</option>
+                              </select>
+                              <input class="hide" type="number" name="attr_progress_ten" min="1" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_ten" min="2" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_ten" min="3" required="required"/><span></span>
+                              <input class="hide" type="number" name="attr_progress_ten" min="4" required="required"/><span></span>
+                            </div>
+                      <div>
+                        <button type="roll" title="Conclude your progress" name="rollprogress1" value="&amp;{template:ironsworn_progress} {{header=@{character_name} Conclude Your Progress}} {{progressname=@{site-name}}} {{progress=[[@{progress-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                      </div>
                       <input class="hide" type="text" name="attr_progress-filled" value="floor((@{progress_one}+@{progress_two}+@{progress_three}+@{progress_four}+@{progress_five}+@{progress_six}+@{progress_seven}+@{progress_eight}+@{progress_nine}+@{progress_ten})/4)" disabled="true"/>
                     </div>
                   </div>

--- a/Ironsworn/Ironsworn.html
+++ b/Ironsworn/Ironsworn.html
@@ -352,85 +352,149 @@
         <div class="optional-track-failures showhide">
           <h3 class="divide" data-i18n="page-summary-failures">&amp;emsp;FAILURES&amp;emsp;</h3>
           <div class="misses-track">
-            <div>
-              <label class="clear-miss">
-                <input class="clear-miss hide" type="checkbox" name="attr_clear_misses"/>
-                <div class="failure-btn-div" data-i18n="clear-btn">CLEAR</div>
-              </label>
-              <select class="progress-input miss-input" name="attr_miss-0">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-              </select>
-              <select class="progress-input miss-input" name="attr_miss-1">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-              </select>
-              <select class="progress-input miss-input" name="attr_miss-2">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-              </select>
-              <select class="progress-input miss-input" name="attr_miss-3">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-              </select>
-              <select class="progress-input miss-input" name="attr_miss-4">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-              </select>
-              <select class="progress-input miss-input" name="attr_miss-5">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-              </select>
-              <select class="progress-input miss-input" name="attr_miss-6">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-              </select>
-              <select class="progress-input miss-input" name="attr_miss-7">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-              </select>
-              <select class="progress-input miss-input" name="attr_miss-8">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-              </select>
-              <select class="progress-input miss-input" name="attr_miss-9">
-                      <option value="0" selected="selected"></option>
-                      <option value="1">-</option>
-                      <option value="2">+</option>
-                      <option value="3">*</option>
-                      <option value="4">#</option>
-              </select>
-              <label class="btn">
-                <button class="hide" type="roll" name="rollMisses" value="&amp;{template:ironsworn_progress} {{progress_type=Failures}} {{header=@{character_name} &lt;em&gt;Learn From Your Failures&lt;/em&gt; }} {{progress=[[@{misses-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
-                <div class="failure-btn-div" data-i18n="failures-learn">LEARN</div>
-              </label>
+            <div class="progress-row">
+              <div>
+                <label class="clear-miss">
+                  <input class="clear-miss hide" type="checkbox" name="attr_clear_misses"/>
+                  <div class="failure-btn-div" data-i18n="clear-btn">CLEAR</div>
+                </label>
+              </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_miss_0">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_miss_0" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_0" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_0" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_0" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_miss_1">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_miss_1" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_1" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_1" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_1" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_miss_2">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_miss_2" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_2" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_2" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_2" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_miss_3">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_miss_3" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_3" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_3" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_3" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_miss_4">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_miss_4" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_4" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_4" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_4" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_miss_5">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_miss_5" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_5" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_5" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_5" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_miss_6">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_miss_6" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_6" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_6" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_6" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_miss_7">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_miss_7" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_7" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_7" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_7" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_miss_8">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_miss_8" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_8" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_8" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_8" min="4" required="required"/><span></span>
+                    </div>
+                    <div class="progress-input-holder">
+                      <select class="progress-input" name="attr_miss_9">
+                        <option value="0" selected="selected"></option>
+                        <option value="1">-</option>
+                        <option value="2">+</option>
+                        <option value="3">*</option>
+                        <option value="4">#</option>
+                      </select>
+                      <input class="hide" type="number" name="attr_miss_9" min="1" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_9" min="2" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_9" min="3" required="required"/><span></span>
+                      <input class="hide" type="number" name="attr_miss_9" min="4" required="required"/><span></span>
+                    </div>
+              <div>
+                <label class="btn">
+                  <button class="hide" type="roll" name="rollMisses" value="&amp;{template:ironsworn_progress} {{progress_type=Failures}} {{header=@{character_name} &lt;em&gt;Learn From Your Failures&lt;/em&gt; }} {{progress=[[@{misses-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"></button>
+                  <div class="failure-btn-div" data-i18n="failures-learn">LEARN</div>
+                </label>
+              </div>
               <input class="hide" type="text" name="attr_misses-filled" value="floor((@{miss-0}+@{miss-1}+@{miss-2}+@{miss-3}+@{miss-4}+@{miss-5}+@{miss-6}+@{miss-7}+@{miss-8}+@{miss-9})/4)" disabled="true"/>
             </div>
           </div>

--- a/Ironsworn/src/components/bonds/track.pug
+++ b/Ironsworn/src/components/bonds/track.pug
@@ -2,11 +2,11 @@
 include ../progress/mixins/box
 
 mixin bondsTrack()
-  div.bonds-track
-    div
+  .bonds-track
+    .progress-row
+      div
       each index in track
-        select(name=`attr_bond-${index}` class="progress-input")
-          +progressBox
+        +progressBoxComplex(`attr_bond-${index}`)
       input(
         type="text"
         class="hide"

--- a/Ironsworn/src/components/misses/track.pug
+++ b/Ironsworn/src/components/misses/track.pug
@@ -6,21 +6,22 @@ input.optional-track-failures.hide(type='checkbox' name='attr_optional_track_fai
 div.optional-track-failures.showhide
   h3.divide(data-i18n='page-summary-failures')=translations['page-summary-failures']
   .misses-track
-    div
-      label.clear-miss
-        input(class="clear-miss hide" type="checkbox" name="attr_clear_misses")
-        div.failure-btn-div(data-i18n='clear-btn')=translations['clear-btn']
+    .progress-row
+      div
+        label.clear-miss
+          input(class="clear-miss hide" type="checkbox" name="attr_clear_misses")
+          div.failure-btn-div(data-i18n='clear-btn')=translations['clear-btn']
       each index in track
-        select(name=`attr_miss-${index}` class="progress-input miss-input")
-          +progressBox
-      label.btn
-        button(
-          type="roll"
-          class='hide'
-          name="rollMisses"
-          value="&{template:ironsworn_progress} {{progress_type=Failures}} {{header=@{character_name} <em>Learn From Your Failures</em> }} {{progress=[[@{misses-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"
-        )
-        div.failure-btn-div(data-i18n='failures-learn')=translations['failures-learn'] 
+          +progressBoxComplex(`attr_miss_${index}`)
+      div
+        label.btn
+          button(
+            type="roll"
+            class='hide'
+            name="rollMisses"
+            value="&{template:ironsworn_progress} {{progress_type=Failures}} {{header=@{character_name} <em>Learn From Your Failures</em> }} {{progress=[[@{misses-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"
+          )
+          div.failure-btn-div(data-i18n='failures-learn')=translations['failures-learn'] 
       input(
         type="text"
         class="hide"

--- a/Ironsworn/src/components/progress/mixins/box.pug
+++ b/Ironsworn/src/components/progress/mixins/box.pug
@@ -5,3 +5,19 @@ mixin progressBox
   option(value="3") *
   option(value="4") #
 
+mixin progressBoxComplex(attribute_name)
+  .progress-input-holder
+    select(name=attribute_name class="progress-input")
+      option(value="0" selected)
+      option(value="1") -
+      option(value="2") +
+      option(value="3") *
+      option(value="4") #
+    input.hide(type='number' name=attribute_name min='1' required)
+    span
+    input.hide(type='number' name=attribute_name min='2' required)
+    span
+    input.hide(type='number' name=attribute_name min='3' required)
+    span
+    input.hide(type='number' name=attribute_name min='4' required)
+    span

--- a/Ironsworn/src/components/progress/progress.pug
+++ b/Ironsworn/src/components/progress/progress.pug
@@ -28,8 +28,17 @@ fieldset.repeating_progress
           label.btn CLEAR
             input(class="clear-vow hide" type="checkbox" name="attr_clear_progress")
         each index in track
-          select(name=`attr_progress_${index}` class="progress-input")
-            +progressBox
+          .progress-input-holder
+            select(name=`attr_progress_${index}` class="progress-input")
+              +progressBox
+            input.hide(type='number' name=`attr_progress_${index}` min='1' required)
+            span
+            input.hide(type='number' name=`attr_progress_${index}` min='2' required)
+            span
+            input.hide(type='number' name=`attr_progress_${index}` min='3' required)
+            span
+            input.hide(type='number' name=`attr_progress_${index}` min='4' required)
+            span
         div
           label.btn CONCLUDE 
             button(

--- a/Ironsworn/src/components/progress/progress.pug
+++ b/Ironsworn/src/components/progress/progress.pug
@@ -21,24 +21,14 @@ fieldset.repeating_progress
             input(type="radio" class="hide" name="attr_rank" value=index)
           h5=difficulty.text
     .progress
-      div.progress-row
+      .progress-row
         div
           label.btn MARK
             input(class="mark-vow hide" type="checkbox" name="attr_mark_progress")
           label.btn CLEAR
             input(class="clear-vow hide" type="checkbox" name="attr_clear_progress")
         each index in track
-          .progress-input-holder
-            select(name=`attr_progress_${index}` class="progress-input")
-              +progressBox
-            input.hide(type='number' name=`attr_progress_${index}` min='1' required)
-            span
-            input.hide(type='number' name=`attr_progress_${index}` min='2' required)
-            span
-            input.hide(type='number' name=`attr_progress_${index}` min='3' required)
-            span
-            input.hide(type='number' name=`attr_progress_${index}` min='4' required)
-            span
+          +progressBoxComplex(`attr_progress_${index}`)
         div
           label.btn CONCLUDE 
             button(

--- a/Ironsworn/src/components/progress/progress.styl
+++ b/Ironsworn/src/components/progress/progress.styl
@@ -32,7 +32,7 @@ input
   justify-content center
   align-items center
   padding 2px 0px 0px 12px
-  margin 0.3em 0em
+  margin 0px
   cursor pointer
   borderCommon()
   border-radius 0
@@ -115,3 +115,36 @@ input[type="checkbox"].sheet-challenge:hover ~ .sheet-challenge-fill
   display: inline-block
   height: 40px
   width: 40px
+
+/* crazy stuff for svg crosses */
+
+.sheet-progress-input-holder {
+    position relative
+    margin 0.3em 0em
+}
+.sheet-progress-input-holder input[min], input[min] + span 
+    display none
+    position absolute
+    top 0px
+    left 0px
+    right 0px
+    bottom 0px
+    pointer-events none
+    background white
+
+.sheet-progress-input-holder input[min="1"]:valid + span 
+    display block
+    background-image linear-gradient(45deg, transparent 0px, transparent calc(50% - 1px), black calc(50% - 1px), black calc(50% + 1px), transparent calc(50% + 1px))
+
+.sheet-progress-input-holder input[min="2"]:valid + span
+    display block
+    background-image linear-gradient(45deg, transparent 0px, transparent calc(50% - 1px), black calc(50% - 1px), black calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(135deg, transparent 0px, transparent calc(50% - 1px), black calc(50% - 1px), black calc(50% + 1px), transparent calc(50% + 1px), transparent 100%)
+    
+.sheet-progress-input-holder input[min="3"]:valid + span
+    display block
+    background-image linear-gradient(45deg, transparent 0px, transparent calc(50% - 1px), black calc(50% - 1px), black calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(135deg, transparent 0px, transparent calc(50% - 1px), black calc(50% - 1px), black calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(90deg, transparent 0px, transparent calc(50% - 1px), black calc(50% - 1px), black calc(50% + 1px), transparent calc(50% + 1px), transparent 100%)
+    
+.sheet-progress-input-holder input[min="4"]:valid + span
+    display block
+    background-image linear-gradient(45deg, transparent 0px, transparent calc(50% - 1px), black calc(50% - 1px), black calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(135deg, transparent 0px, transparent calc(50% - 1px), black calc(50% - 1px), black calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(90deg, transparent 0px, transparent calc(50% - 1px), black calc(50% - 1px), black calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(0deg, transparent 0px, transparent calc(50% - 1px), black calc(50% - 1px), black calc(50% + 1px), transparent calc(50% + 1px), transparent 100%)
+    

--- a/Ironsworn/src/components/progress/progress.styl
+++ b/Ironsworn/src/components/progress/progress.styl
@@ -125,10 +125,10 @@ input[type="checkbox"].sheet-challenge:hover ~ .sheet-challenge-fill
 .sheet-progress-input-holder input[min], input[min] + span 
     display none
     position absolute
-    top 0px
-    left 0px
-    right 0px
-    bottom 0px
+    top 2px
+    left 2px
+    width 36px
+    height 36px
     pointer-events none
     background white
 

--- a/Ironsworn/src/components/progress/progress.styl
+++ b/Ironsworn/src/components/progress/progress.styl
@@ -134,17 +134,17 @@ input[type="checkbox"].sheet-challenge:hover ~ .sheet-challenge-fill
 
 .sheet-progress-input-holder input[min="1"]:valid + span 
     display block
-    background-image linear-gradient(45deg, transparent 0px, transparent calc(50% - 1px), black calc(50% - 1px), black calc(50% + 1px), transparent calc(50% + 1px))
+    background-image linear-gradient(45deg, transparent 0px, transparent calc(50% - 1px), #4c4d4f calc(50% - 1px), #4c4d4f calc(50% + 1px), transparent calc(50% + 1px))
 
 .sheet-progress-input-holder input[min="2"]:valid + span
     display block
-    background-image linear-gradient(45deg, transparent 0px, transparent calc(50% - 1px), black calc(50% - 1px), black calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(135deg, transparent 0px, transparent calc(50% - 1px), black calc(50% - 1px), black calc(50% + 1px), transparent calc(50% + 1px), transparent 100%)
+    background-image linear-gradient(45deg, transparent 0px, transparent calc(50% - 1px), #4c4d4f calc(50% - 1px), #4c4d4f calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(135deg, transparent 0px, transparent calc(50% - 1px), #4c4d4f calc(50% - 1px), #4c4d4f calc(50% + 1px), transparent calc(50% + 1px), transparent 100%)
     
 .sheet-progress-input-holder input[min="3"]:valid + span
     display block
-    background-image linear-gradient(45deg, transparent 0px, transparent calc(50% - 1px), black calc(50% - 1px), black calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(135deg, transparent 0px, transparent calc(50% - 1px), black calc(50% - 1px), black calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(90deg, transparent 0px, transparent calc(50% - 1px), black calc(50% - 1px), black calc(50% + 1px), transparent calc(50% + 1px), transparent 100%)
+    background-image linear-gradient(45deg, transparent 0px, transparent calc(50% - 1px), #4c4d4f calc(50% - 1px), #4c4d4f calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(135deg, transparent 0px, transparent calc(50% - 1px), #4c4d4f calc(50% - 1px), #4c4d4f calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(90deg, transparent 0px, transparent calc(50% - 1px), #4c4d4f calc(50% - 1px), #4c4d4f calc(50% + 1px), transparent calc(50% + 1px), transparent 100%)
     
 .sheet-progress-input-holder input[min="4"]:valid + span
     display block
-    background-image linear-gradient(45deg, transparent 0px, transparent calc(50% - 1px), black calc(50% - 1px), black calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(135deg, transparent 0px, transparent calc(50% - 1px), black calc(50% - 1px), black calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(90deg, transparent 0px, transparent calc(50% - 1px), black calc(50% - 1px), black calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(0deg, transparent 0px, transparent calc(50% - 1px), black calc(50% - 1px), black calc(50% + 1px), transparent calc(50% + 1px), transparent 100%)
+    background-image linear-gradient(45deg, transparent 0px, transparent calc(50% - 1px), #4c4d4f calc(50% - 1px), #4c4d4f calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(135deg, transparent 0px, transparent calc(50% - 1px), #4c4d4f calc(50% - 1px), #4c4d4f calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(90deg, transparent 0px, transparent calc(50% - 1px), #4c4d4f calc(50% - 1px), #4c4d4f calc(50% + 1px), transparent calc(50% + 1px), transparent 100%), linear-gradient(0deg, transparent 0px, transparent calc(50% - 1px), #4c4d4f calc(50% - 1px), #4c4d4f calc(50% + 1px), transparent calc(50% + 1px), transparent 100%)
     

--- a/Ironsworn/src/components/sites/sites.pug
+++ b/Ironsworn/src/components/sites/sites.pug
@@ -1,4 +1,6 @@
+- var track = [ 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten' ]
 include ../../data/difficulties
+include ../progress/mixins/box
 
 .sites-container
   fieldset.repeating_sites
@@ -37,68 +39,12 @@ include ../../data/difficulties
                   input(type="radio" class="hide" name="attr_rank" value=index)
                 h5=difficulty.text
           .progress
-            div
-              select(name="attr_progress_one" class="progress-input") 
-                option(value="0" selected) 
-                option(value="1") -
-                option(value="2") +
-                option(value="3") *
-                option(value="4") #
-              select(name="attr_progress_two" class="progress-input") 
-                option(value="0" selected) 
-                option(value="1") -
-                option(value="2") +
-                option(value="3") *
-                option(value="4") #
-              select(name="attr_progress_three" class="progress-input") 
-                option(value="0" selected) 
-                option(value="1") -
-                option(value="2") +
-                option(value="3") *
-                option(value="4") #
-              select(name="attr_progress_four" class="progress-input") 
-                option(value="0" selected) 
-                option(value="1") -
-                option(value="2") +
-                option(value="3") *
-                option(value="4") #
-              select(name="attr_progress_five" class="progress-input") 
-                option(value="0" selected) 
-                option(value="1") -
-                option(value="2") +
-                option(value="3") *
-                option(value="4") #
-              select(name="attr_progress_six" class="progress-input") 
-                option(value="0" selected) 
-                option(value="1") -
-                option(value="2") +
-                option(value="3") *
-                option(value="4") #
-              select(name="attr_progress_seven" class="progress-input") 
-                option(value="0" selected) 
-                option(value="1") -
-                option(value="2") +
-                option(value="3") *
-                option(value="4") #
-              select(name="attr_progress_eight" class="progress-input") 
-                option(value="0" selected) 
-                option(value="1") -
-                option(value="2") +
-                option(value="3") *
-                option(value="4") #
-              select(name="attr_progress_nine" class="progress-input") 
-                option(value="0" selected) 
-                option(value="1") -
-                option(value="2") +
-                option(value="3") *
-                option(value="4") #
-              select(name="attr_progress_ten" class="progress-input") 
-                option(value="0" selected) 
-                option(value="1") -
-                option(value="2") +
-                option(value="3") *
-                option(value="4") #
-              button(type="roll" title="Conclude your progress" name="rollprogress1" value="&{template:ironsworn_progress} {{header=@{character_name} Conclude Your Progress}} {{progressname=@{site-name}}} {{progress=[[@{progress-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}")
+            .progress-row
+              div
+              each index in track
+                +progressBoxComplex(`attr_progress_${index}`)
+              div
+                button(type="roll" title="Conclude your progress" name="rollprogress1" value="&{template:ironsworn_progress} {{header=@{character_name} Conclude Your Progress}} {{progressname=@{site-name}}} {{progress=[[@{progress-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}")
               input(type="text" class="hide" name="attr_progress-filled" value="floor((@{progress_one}+@{progress_two}+@{progress_three}+@{progress_four}+@{progress_five}+@{progress_six}+@{progress_seven}+@{progress_eight}+@{progress_nine}+@{progress_ten})/4)" disabled="true")
         
         .full-width

--- a/Ironsworn/src/components/vows/vow-container.pug
+++ b/Ironsworn/src/components/vows/vow-container.pug
@@ -44,24 +44,25 @@ mixin vowLegacy(number)
         h5(data-i18n=translation)=translations[translation]
 
   div.vow
-    div
-      label.btn
-        input(class="mark-vow hide" type="checkbox" name=`attr_mark_progress_${number}`)
-        div.btn-div(data-i18n='vow-mark')=translations['vow-mark']
-      label.btn
-        input(class="clear-vow hide" type="checkbox" name=`attr_clear_progress_${number}`)
-        div.btn-div(data-i18n='clear-btn')=translations['clear-btn']
+    .progress-row
+      div
+        label.btn
+          input(class="mark-vow hide" type="checkbox" name=`attr_mark_progress_${number}`)
+          div.btn-div(data-i18n='vow-mark')=translations['vow-mark']
+        label.btn
+          input(class="clear-vow hide" type="checkbox" name=`attr_clear_progress_${number}`)
+          div.btn-div(data-i18n='clear-btn')=translations['clear-btn']
       each index in track
-        select(name=`attr_vow${number}-${index}` class="progress-input")
-          +progressBox
-      label.btn
-        button(
-          type="roll"
-          class='hide'
-          name="rollVow"
-          value=`&{template:ironsworn_progress} {{progress_type=Vow}} {{header=@{character_name} <em>Fulfill Your Vow</em> }} {{progress_name=@{vow${number}_name}}} {{progress=[[@{vow${number}-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}`
-        )
-        div.btn-div(data-i18n='vow-fulfill')=translations['vow-fulfill']
+        +progressBoxComplex(`attr_vow${number}-${index}`)
+      div
+        label.btn
+          button(
+            type="roll"
+            class='hide'
+            name="rollVow"
+            value=`&{template:ironsworn_progress} {{progress_type=Vow}} {{header=@{character_name} <em>Fulfill Your Vow</em> }} {{progress_name=@{vow${number}_name}}} {{progress=[[@{vow${number}-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}`
+          )
+          div.btn-div(data-i18n='vow-fulfill')=translations['vow-fulfill']
       input(
         type="text"
         class="hide"
@@ -97,24 +98,25 @@ mixin repeatingVow()
         h5(data-i18n=translation)=translations[translation]
 
   div.vow
-    div
-      label.btn
-        input(class="mark-vow hide" type="checkbox" name="attr_mark_progress")
-        div.btn-div(data-i18n='vow-mark')=translations['vow-mark']
-      label.btn
-        input(class="clear-vow hide" type="checkbox" name="attr_clear_progress")
-        div.btn-div(data-i18n='clear-btn')=translations['clear-btn']
+    .progress-row
+      div
+        label.btn
+          input(class="mark-vow hide" type="checkbox" name="attr_mark_progress")
+          div.btn-div(data-i18n='vow-mark')=translations['vow-mark']
+        label.btn
+          input(class="clear-vow hide" type="checkbox" name="attr_clear_progress")
+          div.btn-div(data-i18n='clear-btn')=translations['clear-btn']
       each index in track
-        select(name=`attr_progress_${index}` class="progress-input")
-          +progressBox
-      label.btn
-        button(
-          type="roll"
-          class='hide'
-          name="rollVow"
-          value="&{template:ironsworn_progress} {{progress_type=Vow}} {{header=@{character_name} <em>Fulfill Your Vow</em> }} {{progress_name=@{vow_name}}} {{progress=[[@{vow-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"
-        )
-        div.btn-div(data-i18n='vow-fulfill')=translations['vow-fulfill']     
+        +progressBoxComplex(`attr_progress_${index}`)
+      div
+        label.btn
+          button(
+            type="roll"
+            class='hide'
+            name="rollVow"
+            value="&{template:ironsworn_progress} {{progress_type=Vow}} {{header=@{character_name} <em>Fulfill Your Vow</em> }}   {{progress_name=@{vow_name}}} {{progress=[[@{vow-filled}]]}} {{challenge1=[[d10]]}} {{challenge2=[[d10]]}}"
+          )
+          div.btn-div(data-i18n='vow-fulfill')=translations['vow-fulfill']     
       input(
         type="text"
         class="hide"

--- a/Ironsworn/translation.json
+++ b/Ironsworn/translation.json
@@ -26,6 +26,7 @@
   "vow-threat": "Threat",
   "vow-mark":"MARK",
   "vow-fulfill":"FULFILL",
+  "progress-challenge":"CHALLENGE",
   "failures-learn": "LEARN",
   "difficulty-troublesome":"troublesome",
   "difficulty-dangerous":"dangerous",


### PR DESCRIPTION
Changes the progress track boxes to use gradient based backgrounds to display 'tick' marks instead of just the characters - + * #

![image](https://user-images.githubusercontent.com/4206142/112233337-2e6bc400-8c32-11eb-8830-81a1bb507425.png)

Changes progress bars in: Failure track, Legacy Vows, Repeating Vows, Progress Tracks, Bonds Track, Sites Track

Does not add any new attributes or remove any attributes.
