### PR TITLE
ChroniquesOublieesContemporain Version 3.9.0

### DIFF
--- a/ChroniquesOublieesContemporain/README.md
+++ b/ChroniquesOublieesContemporain/README.md
@@ -10,9 +10,16 @@ Le jeu complet est disponible sur le site de l'éditeur [Black Book Editions](ht
 
 # Version courante
 
-3.8.1 [Screenshot](coc_v2.png)
+3.9.0 [Screenshot](coc_v2.png)
 
 # Notes de version
+
+## v3.9.0 (2021-03-30)
+
+- Ajout d'un champ titre pour chaque capacité (attributs @{voieN-tR} où N = no de voie et R = rang)
+  - Migration automatique d'une version antérieure : la première ligne de la capacité est considérée comme titre
+  - Prise en compte dans les autres fonctions (liaison d'un jet de capacité à une voie+rang, import de données de profil JSON)
+- Correction d'un bug après suppression du seul modificateur d'attaque ou de DM de la liste (le modificateur n'est plus pris en compte dans les jets d'attaque)
 
 ## v3.8.1 (2021-03-01)
 

--- a/ChroniquesOublieesContemporain/coc.css
+++ b/ChroniquesOublieesContemporain/coc.css
@@ -133,8 +133,12 @@ table.sheet-tabsep {
   padding: 2px;
 }
 
-textarea.sheet-boxability {
+input[type='text'].sheet-boxability {
   width: 92%;
+  border-style: none;
+}
+
+textarea.sheet-boxability {
   overflow-x: hidden;
 }
 
@@ -262,12 +266,17 @@ button[type='roll'].sheet-roll-d4::before {
 button.sheet-flatbtn {
   border: 0px;
   background-color: transparent;
+  background-image: none;
   font-size: 12px !important;
 }
 
-button[type='action'].sheet-iconbtn {
+button[type='roll'].sheet-iconbtn::before {
+  content: '';
+}
+
+button.sheet-iconbtn {
   font-family: pictos;
-  font-size: large;
+  font-size: large !important;
 }
 
 img.sheet-iconimg {

--- a/ChroniquesOublieesContemporain/coc.html
+++ b/ChroniquesOublieesContemporain/coc.html
@@ -1,8 +1,8 @@
 <div class="sheet-mainBg">
   <!-- FDP -->
   <!-- INPUT HIDDEN Version FdP -->
-  <input type="hidden" name="attr_VERFDP" value="3.8.1" />
-  <input type="hidden" name="attr_VERSION" value="3.8.1" />
+  <input type="hidden" name="attr_VERFDP" value="3.9.0" />
+  <input type="hidden" name="attr_VERSION" value="3.9.0" />
   <!-- INPUT HIDDEN Univers (COF, CG, COC) -->
   <input type="hidden" name="attr_UNIVERS" value="COC" />
   <input type="hidden" name="attr_coc_setting_bitume" value="0" />
@@ -82,13 +82,13 @@
     <input type="checkbox" class="block-switch" style="display: none;" name="attr_coc_setting_bitume" value="1">
     <div class="block-hidden">
       <div style="vertical-align: middle; text-align: center;">
-        <img style="width:70%; height:90%" title="Version 3.8.1 - 01/03/2021"
+        <img style="width:70%; height:90%" title="Version 3.9.0 - 30/03/2021"
           src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesOublieesContemporain/coc_logo.png" />
       </div>
     </div>
     <div class="block-show">
       <div style="vertical-align: middle; text-align: center;">
-        <img style="width:70%; height:90%" title="Version 3.8.1 - 01/03/2021"
+        <img style="width:70%; height:90%" title="Version 3.9.0 - 30/03/2021"
           src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesOublieesContemporain/coc_bitume.jpg" />
       </div>
     </div>
@@ -1138,8 +1138,8 @@
             <tr>
               <td class="sheet-textfatleft" colspan="5">
                 CAPACITÉS DU PERSONNAGE
-                <input type="checkbox" class="sheet-setup-abilities" name="attr_setup_abilities"
-                  title="Editer les capacités">
+                <span class="sheet-setup-abilities sheet-textbase">Edition&nbsp;<input type="checkbox" name="attr_setup_abilities"
+                  title="Editer les capacités"></span>
               </td>
             </tr>
             <tr>
@@ -1167,75 +1167,150 @@
               <td class="sheet-boxtitresmall">1</td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v1r1" value="1" />
-                <span name="attr_voie1-1" class="sheet-boxability" title="@{voie1-1}"></span>
+                <span name="attr_voie1-t1" class="sheet-boxability" title="@{voie1-t1}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v1r1" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie1-t1} }} {{desc=**@{voie1nom}, rang [[1]]** }} {{text=@{voie1-1} }}">w</button>
+                </span>
+                <br><span name="attr_voie1-1" class="sheet-boxability" title="@{voie1-1}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v2r1" value="1" />
-                <span name="attr_voie2-1" class="sheet-boxability" title="@{voie2-1}"></span>
+                <span name="attr_voie2-t1" class="sheet-boxability" title="@{voie2-t1}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v2r1" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie2-t1} }} {{desc=**@{voie2nom}, rang [[1]]** }} {{text=@{voie2-1} }}">w</button>
+                </span>
+                <br><span name="attr_voie2-1" class="sheet-boxability" title="@{voie2-1}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v3r1" value="1" />
-                <span name="attr_voie3-1" class="sheet-boxability" title="@{voie3-1}"></span>
+                <span name="attr_voie3-t1" class="sheet-boxability" title="@{voie3-t1}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v3r1" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie3-t1} }} {{desc=**@{voie3nom}, rang [[1]]** }} {{text=@{voie3-1} }}">w</button>
+                </span>
+                <br><span name="attr_voie3-1" class="sheet-boxability" title="@{voie3-1}"></span>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">2</td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v1r2" value="1" />
-                <span name="attr_voie1-2" class="sheet-boxability" title="@{voie1-2}"></span>
+                <span name="attr_voie1-t2" class="sheet-boxability" title="@{voie1-t2}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v1r2" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie1-t2} }} {{desc=**@{voie1nom}, rang [[2]]** }} {{text=@{voie1-2} }}">w</button>
+                </span>
+                <br><span name="attr_voie1-2" class="sheet-boxability" title="@{voie1-2}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v2r2" value="1" />
-                <span name="attr_voie2-2" class="sheet-boxability" title="@{voie2-2}"></span>
+                <span name="attr_voie2-t2" class="sheet-boxability" title="@{voie2-t2}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v2r2" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie2-t2} }} {{desc=**@{voie2nom}, rang [[2]]** }} {{text=@{voie2-2} }}">w</button>
+                </span>
+                <br><span name="attr_voie2-2" class="sheet-boxability" title="@{voie2-2}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v3r2" value="1" />
-                <span name="attr_voie3-2" class="sheet-boxability" title="@{voie3-2}"></span>
+                <span name="attr_voie3-t2" class="sheet-boxability" title="@{voie3-t2}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v3r2" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie3-t2} }} {{desc=**@{voie3nom}, rang [[2]]** }} {{text=@{voie3-2} }}">w</button>
+                </span>
+                <br><span name="attr_voie3-2" class="sheet-boxability" title="@{voie3-2}"></span>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">3</td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v1r3" value="1" />
-                <span name="attr_voie1-3" class="sheet-boxability" title="@{voie1-3}"></span>
+                <span name="attr_voie1-t3" class="sheet-boxability" title="@{voie1-t3}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v1r3" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie1-t3} }} {{desc=**@{voie1nom}, rang [[3]]** }} {{text=@{voie1-3} }}">w</button>
+                </span>
+                <br><span name="attr_voie1-3" class="sheet-boxability" title="@{voie1-3}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v2r3" value="1" />
-                <span name="attr_voie2-3" class="sheet-boxability" title="@{voie2-3}"></span>
+                <span name="attr_voie2-t3" class="sheet-boxability" title="@{voie2-t3}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v2r3" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie2-t3} }} {{desc=**@{voie2nom}, rang [[3]]** }} {{text=@{voie2-3} }}">w</button>
+                </span>
+                <br><span name="attr_voie2-3" class="sheet-boxability" title="@{voie2-3}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v3r3" value="1" />
-                <span name="attr_voie3-3" class="sheet-boxability" title="@{voie3-3}"></span>
+                <span name="attr_voie3-t3" class="sheet-boxability" title="@{voie3-t3}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v3r3" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie3-t3} }} {{desc=**@{voie3nom}, rang [[3]]** }} {{text=@{voie3-3} }}">w</button>
+                </span>
+                <br><span name="attr_voie3-3" class="sheet-boxability" title="@{voie3-3}"></span>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">4</td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v1r4" value="1" />
-                <span name="attr_voie1-4" class="sheet-boxability" title="@{voie1-4}"></span>
+                <span name="attr_voie1-t4" class="sheet-boxability" title="@{voie1-t4}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v1r4" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie1-t4} }} {{desc=**@{voie1nom}, rang [[4]]** }} {{text=@{voie1-4} }}">w</button>
+                </span>
+                <br><span name="attr_voie1-4" class="sheet-boxability" title="@{voie1-4}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v2r4" value="1" />
-                <span name="attr_voie2-4" class="sheet-boxability" title="@{voie2-4}"></span>
+                <span name="attr_voie2-t4" class="sheet-boxability" title="@{voie2-t4}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v2r4" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie2-t4} }} {{desc=**@{voie2nom}, rang [[4]]** }} {{text=@{voie2-4} }}">w</button>
+                </span>
+                <br><span name="attr_voie2-4" class="sheet-boxability" title="@{voie2-4}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v3r4" value="1" />
-                <span name="attr_voie3-4" class="sheet-boxability" title="@{voie3-4}"></span>
+                <span name="attr_voie3-t4" class="sheet-boxability" title="@{voie3-t4}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v3r4" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie3-t4} }} {{desc=**@{voie3nom}, rang [[4]]** }} {{text=@{voie3-4} }}">w</button>
+                </span>
+                <br><span name="attr_voie3-4" class="sheet-boxability" title="@{voie3-4}"></span>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">5</td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v1r5" value="1" />
-                <span name="attr_voie1-5" class="sheet-boxability" title="@{voie1-5}"></span>
+                <span name="attr_voie1-t5" class="sheet-boxability" title="@{voie1-t5}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v1r5" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie1-t5} }} {{desc=**@{voie1nom}, rang [[5]]** }} {{text=@{voie1-5} }}">w</button>
+                </span>
+                <br><span name="attr_voie1-5" class="sheet-boxability" title="@{voie1-5}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v2r5" value="1" />
-                <span name="attr_voie2-5" class="sheet-boxability" title="@{voie2-5}"></span>
+                <span name="attr_voie2-t5" class="sheet-boxability" title="@{voie2-t5}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v2r5" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie2-t5} }} {{desc=**@{voie2nom}, rang [[5]]** }} {{text=@{voie2-5} }}">w</button>
+                </span>
+                <br><span name="attr_voie2-5" class="sheet-boxability" title="@{voie2-5}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v3r5" value="1" />
-                <span name="attr_voie3-5" class="sheet-boxability" title="@{voie3-5}"></span>
+                <span name="attr_voie3-t5" class="sheet-boxability" title="@{voie3-t5}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v3r5" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie3-t5} }} {{desc=**@{voie3nom}, rang [[5]]** }} {{text=@{voie3-5} }}">w</button>
+                </span>
+                <br><span name="attr_voie3-5" class="sheet-boxability" title="@{voie3-5}"></span>
               </td>
             </tr>
           </table>
@@ -1265,75 +1340,150 @@
               <td class="sheet-boxtitresmall">1</td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v4r1" value="1" />
-                <span name="attr_voie4-1" class="sheet-boxability" title="@{voie4-1}"></span>
+                <span name="attr_voie4-t1" class="sheet-boxability" title="@{voie4-t1}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v4r1" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie4-t1} }} {{desc=**@{voie4nom}, rang [[1]]** }} {{text=@{voie4-1} }}">w</button>
+                </span>
+                <br><span name="attr_voie4-1" class="sheet-boxability" title="@{voie4-1}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v5r1" value="1" />
-                <span name="attr_voie5-1" class="sheet-boxability" title="@{voie5-1}"></span>
+                <span name="attr_voie5-t1" class="sheet-boxability" title="@{voie5-t1}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v5r1" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie5-t1} }} {{desc=**@{voie5nom}, rang [[1]]** }} {{text=@{voie5-1} }}">w</button>
+                </span>
+                <br><span name="attr_voie5-1" class="sheet-boxability" title="@{voie5-1}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v6r1" value="1" />
-                <span name="attr_voie6-1" class="sheet-boxability" title="@{voie6-1}"></span>
+                <span name="attr_voie6-t1" class="sheet-boxability" title="@{voie6-t1}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v6r1" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie6-t1} }} {{desc=**@{voie6nom}, rang [[1]]** }} {{text=@{voie6-1} }}">w</button>
+                </span>
+                <br><span name="attr_voie6-1" class="sheet-boxability" title="@{voie6-1}"></span>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">2</td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v4r2" value="1" />
-                <span name="attr_voie4-2" class="sheet-boxability" title="@{voie4-2}"></span>
+                <span name="attr_voie4-t2" class="sheet-boxability" title="@{voie4-t2}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v4r2" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie4-t2} }} {{desc=**@{voie4nom}, rang [[2]]** }} {{text=@{voie4-2} }}">w</button>
+                </span>
+                <br><span name="attr_voie4-2" class="sheet-boxability" title="@{voie4-2}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v5r2" value="1" />
-                <span name="attr_voie5-2" class="sheet-boxability" title="@{voie5-2}"></span>
+                <span name="attr_voie5-t2" class="sheet-boxability" title="@{voie5-t2}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v5r2" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie5-t2} }} {{desc=**@{voie5nom}, rang [[2]]** }} {{text=@{voie5-2} }}">w</button>
+                </span>
+                <br><span name="attr_voie5-2" class="sheet-boxability" title="@{voie5-2}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v6r2" value="1" />
-                <span name="attr_voie6-2" class="sheet-boxability" title="@{voie6-2}"></span>
+                <span name="attr_voie6-t2" class="sheet-boxability" title="@{voie6-t2}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v6r2" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie6-t2} }} {{desc=**@{voie6nom}, rang [[2]]** }} {{text=@{voie6-2} }}">w</button>
+                </span>
+                <br><span name="attr_voie6-2" class="sheet-boxability" title="@{voie6-2}"></span>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">3</td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v4r3" value="1" />
-                <span name="attr_voie4-3" class="sheet-boxability" title="@{voie4-3}"></span>
+                <span name="attr_voie4-t3" class="sheet-boxability" title="@{voie4-t3}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v4r3" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie4-t3} }} {{desc=**@{voie4nom}, rang [[3]]** }} {{text=@{voie4-3} }}">w</button>
+                </span>
+                <br><span name="attr_voie4-3" class="sheet-boxability" title="@{voie4-3}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v5r3" value="1" />
-                <span name="attr_voie5-3" class="sheet-boxability" title="@{voie5-3}"></span>
+                <span name="attr_voie5-t3" class="sheet-boxability" title="@{voie5-t3}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v5r3" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie5-t3} }} {{desc=**@{voie5nom}, rang [[3]]** }} {{text=@{voie5-3} }}">w</button>
+                </span>
+                <br><span name="attr_voie5-3" class="sheet-boxability" title="@{voie5-3}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v6r3" value="1" />
-                <span name="attr_voie6-3" class="sheet-boxability" title="@{voie6-3}"></span>
+                <span name="attr_voie6-t3" class="sheet-boxability" title="@{voie6-t3}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v6r3" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie6-t3} }} {{desc=**@{voie6nom}, rang [[3]]** }} {{text=@{voie6-3} }}">w</button>
+                </span>
+                <br><span name="attr_voie6-3" class="sheet-boxability" title="@{voie6-3}"></span>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">4</td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v4r4" value="1" />
-                <span name="attr_voie4-4" class="sheet-boxability" title="@{voie4-4}"></span>
+                <span name="attr_voie4-t4" class="sheet-boxability" title="@{voie4-t4}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v4r4" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie4-t4} }} {{desc=**@{voie4nom}, rang [[4]]** }} {{text=@{voie4-4} }}">w</button>
+                </span>
+                <br><span name="attr_voie4-4" class="sheet-boxability" title="@{voie4-4}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v5r4" value="1" />
-                <span name="attr_voie5-4" class="sheet-boxability" title="@{voie5-4}"></span>
+                <span name="attr_voie5-t4" class="sheet-boxability" title="@{voie5-t4}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v5r4" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie5-t4} }} {{desc=**@{voie5nom}, rang [[4]]** }} {{text=@{voie5-4} }}">w</button>
+                </span>
+                <br><span name="attr_voie5-4" class="sheet-boxability" title="@{voie5-4}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v6r4" value="1" />
-                <span name="attr_voie6-4" class="sheet-boxability" title="@{voie6-4}"></span>
+                <span name="attr_voie6-t4" class="sheet-boxability" title="@{voie6-t4}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v6r4" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie6-t4} }} {{desc=**@{voie6nom}, rang [[4]]** }} {{text=@{voie6-4} }}">w</button>
+                </span>
+                <br><span name="attr_voie6-4" class="sheet-boxability" title="@{voie6-4}"></span>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">5</td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v4r5" value="1" />
-                <span name="attr_voie4-5" class="sheet-boxability" title="@{voie4-5}"></span>
+                <span name="attr_voie4-t5" class="sheet-boxability" title="@{voie4-t5}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v4r5" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie4-t5} }} {{desc=**@{voie4nom}, rang [[5]]** }} {{text=@{voie4-5} }}">w</button>
+                </span>
+                <br><span name="attr_voie4-5" class="sheet-boxability" title="@{voie4-5}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v5r5" value="1" />
-                <span name="attr_voie5-5" class="sheet-boxability" title="@{voie5-5}"></span>
+                <span name="attr_voie5-t5" class="sheet-boxability" title="@{voie5-t5}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v5r5" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie5-t5} }} {{desc=**@{voie5nom}, rang [[5]]** }} {{text=@{voie5-5} }}">w</button>
+                </span>
+                <br><span name="attr_voie5-5" class="sheet-boxability" title="@{voie5-5}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v6r5" value="1" />
-                <span name="attr_voie6-5" class="sheet-boxability" title="@{voie6-5}"></span>
+                <span name="attr_voie6-t5" class="sheet-boxability" title="@{voie6-t5}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v6r5" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie6-t5} }} {{desc=**@{voie6nom}, rang [[5]]** }} {{text=@{voie6-5} }}">w</button>
+                </span>
+                <br><span name="attr_voie6-5" class="sheet-boxability" title="@{voie6-5}"></span>
               </td>
             </tr>
           </table>
@@ -1367,75 +1517,150 @@
                   <td class="sheet-boxtitresmall">1</td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v7r1" value="1" />
-                    <span name="attr_voie7-1" class="sheet-boxability" title="@{voie7-1}"></span>
+                    <span name="attr_voie7-t1" class="sheet-boxability" title="@{voie7-t1}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v7r1" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie7-t1} }} {{desc=**@{voie7nom}, rang [[1]]** }} {{text=@{voie7-1} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie7-1" class="sheet-boxability" title="@{voie7-1}"></span>
                   </td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v8r1" value="1" />
-                    <span name="attr_voie8-1" class="sheet-boxability" title="@{voie8-1"></span>
+                    <span name="attr_voie8-t1" class="sheet-boxability" title="@{voie8-t1"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v8r1" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie8-t1} }} {{desc=**@{voie8nom}, rang [[1]]** }} {{text=@{voie8-1} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie8-1" class="sheet-boxability" title="@{voie8-1"></span>
                   </td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v9r1" value="1" />
-                    <span name="attr_voie9-1" class="sheet-boxability" title="@{voie9-1}"></span>
+                    <span name="attr_voie9-t1" class="sheet-boxability" title="@{voie9-t1}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v9r1" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie9-t1} }} {{desc=**@{voie9nom}, rang [[1]]** }} {{text=@{voie9-1} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie9-1" class="sheet-boxability" title="@{voie9-1}"></span>
                   </td>
                 </tr>
                 <tr>
                   <td class="sheet-boxtitresmall">2</td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v7r2" value="1" />
-                    <span name="attr_voie7-2" class="sheet-boxability" title="@{voie7-2}"></span>
+                    <span name="attr_voie7-t2" class="sheet-boxability" title="@{voie7-t2}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v7r2" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie7-t2} }} {{desc=**@{voie7nom}, rang [[2]]** }} {{text=@{voie7-2} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie7-2" class="sheet-boxability" title="@{voie7-2}"></span>
                   </td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v8r2" value="1" />
-                    <span name="attr_voie8-2" class="sheet-boxability" title="@{voie8-2}"></span>
+                    <span name="attr_voie8-t2" class="sheet-boxability" title="@{voie8-t2}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v8r2" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie8-t2} }} {{desc=**@{voie8nom}, rang [[2]]** }} {{text=@{voie8-2} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie8-2" class="sheet-boxability" title="@{voie8-2}"></span>
                   </td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v9r2" value="1" />
-                    <span name="attr_voie9-2" class="sheet-boxability" title="@{voie9-2}"></span>
+                    <span name="attr_voie9-t2" class="sheet-boxability" title="@{voie9-t2}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v9r2" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie9-t2} }} {{desc=**@{voie9nom}, rang [[2]]** }} {{text=@{voie9-2} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie9-2" class="sheet-boxability" title="@{voie9-2}"></span>
                   </td>
                 </tr>
                 <tr>
                   <td class="sheet-boxtitresmall">3</td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v7r3" value="1" />
-                    <span name="attr_voie7-3" class="sheet-boxability" title="@{voie7-3}"></span>
+                    <span name="attr_voie7-t3" class="sheet-boxability" title="@{voie7-t3}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v7r3" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie7-t3} }} {{desc=**@{voie7nom}, rang [[3]]** }} {{text=@{voie7-3} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie7-3" class="sheet-boxability" title="@{voie7-3}"></span>
                   </td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v8r3" value="1" />
-                    <span name="attr_voie8-3" class="sheet-boxability" title="@{voie8-3}"></span>
+                    <span name="attr_voie8-t3" class="sheet-boxability" title="@{voie8-t3}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v8r3" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie8-t3} }} {{desc=**@{voie8nom}, rang [[3]]** }} {{text=@{voie8-3} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie8-3" class="sheet-boxability" title="@{voie8-3}"></span>
                   </td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v9r3" value="1" />
-                    <span name="attr_voie9-3" class="sheet-boxability" title="@{voie9-3}"></span>
+                    <span name="attr_voie9-t3" class="sheet-boxability" title="@{voie9-t3}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v9r3" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie9-t3} }} {{desc=**@{voie9nom}, rang [[3]]** }} {{text=@{voie9-3} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie9-3" class="sheet-boxability" title="@{voie9-3}"></span>
                   </td>
                 </tr>
                 <tr>
                   <td class="sheet-boxtitresmall">4</td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v7r4" value="1" />
-                    <span name="attr_voie7-4" class="sheet-boxability" title="@{voie7-4}"></span>
+                    <span name="attr_voie7-t4" class="sheet-boxability" title="@{voie7-t4}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v7r4" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie7-t4} }} {{desc=**@{voie7nom}, rang [[4]]** }} {{text=@{voie7-4} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie7-4" class="sheet-boxability" title="@{voie7-4}"></span>
                   </td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v8r4" value="1" />
-                    <span name="attr_voie8-4" class="sheet-boxability" title="@{voie8-4}"></span>
+                    <span name="attr_voie8-t4" class="sheet-boxability" title="@{voie8-t4}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v8r4" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie8-t4} }} {{desc=**@{voie8nom}, rang [[4]]** }} {{text=@{voie8-4} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie8-4" class="sheet-boxability" title="@{voie8-4}"></span>
                   </td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v9r4" value="1" />
-                    <span name="attr_voie9-4" class="sheet-boxability" title="@{voie9-4}"></span>
+                    <span name="attr_voie9-t4" class="sheet-boxability" title="@{voie9-t4}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v9r4" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie9-t4} }} {{desc=**@{voie9nom}, rang [[4]]** }} {{text=@{voie9-4} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie9-4" class="sheet-boxability" title="@{voie9-4}"></span>
                   </td>
                 </tr>
                 <tr>
                   <td class="sheet-boxtitresmall">5</td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v7r5" value="1" />
-                    <span name="attr_voie7-5" class="sheet-boxability" title="@{voie7-5}"></span>
+                    <span name="attr_voie7-t5" class="sheet-boxability" title="@{voie7-t5}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v7r5" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie7-t5} }} {{desc=**@{voie7nom}, rang [[5]]** }} {{text=@{voie7-5} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie7-5" class="sheet-boxability" title="@{voie7-5}"></span>
                   </td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v8r5" value="1" />
-                    <span name="attr_voie8-5" class="sheet-boxability" title="@{voie8-5}"></span>
+                    <span name="attr_voie8-t5" class="sheet-boxability" title="@{voie8-t5}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v8r5" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie8-t5} }} {{desc=**@{voie8nom}, rang [[5]]** }} {{text=@{voie8-5} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie8-5" class="sheet-boxability" title="@{voie8-5}"></span>
                   </td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v9r5" value="1" />
-                    <span name="attr_voie9-5" class="sheet-boxability" title="@{voie9-5}"></span>
+                    <span name="attr_voie9-t5" class="sheet-boxability" title="@{voie9-t5}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v9r5" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie9-t5} }} {{desc=**@{voie9nom}, rang [[5]]** }} {{text=@{voie9-5} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie9-5" class="sheet-boxability" title="@{voie9-5}"></span>
                   </td>
                 </tr>
               </table>
@@ -1447,8 +1672,8 @@
             <tr>
               <td class="sheet-textfatleft" colspan="5">
                 CAPACITÉS DU PERSONNAGE
-                <input type="checkbox" class="sheet-setup-abilities" name="attr_setup_abilities"
-                  title="Editer les capacités">
+                <span class="sheet-setup-abilities">Affichage&nbsp;<input type="checkbox" name="attr_setup_abilities"
+                  title="Editer les capacités"></span>
               </td>
             </tr>
             <tr>
@@ -1476,75 +1701,90 @@
               <td class="sheet-boxtitresmall">1</td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v1r1" value="1" />
-                <textarea name="attr_voie1-1" class="sheet-boxability" title="@{voie1-1}"></textarea>
+                <input type="text" name="attr_voie1-t1" class="sheet-boxability" title="@{voie1-t1}" />
+                <br><textarea name="attr_voie1-1" class="sheet-boxability" title="@{voie1-1}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v2r1" value="1" />
-                <textarea name="attr_voie2-1" class="sheet-boxability" title="@{voie2-1}"></textarea>
+                <input type="text" name="attr_voie2-t1" class="sheet-boxability" title="@{voie2-t1}" />
+                <br><textarea name="attr_voie2-1" class="sheet-boxability" title="@{voie2-1}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v3r1" value="1" />
-                <textarea name="attr_voie3-1" class="sheet-boxability" title="@{voie3-1}"></textarea>
+                <input type="text" name="attr_voie3-t1" class="sheet-boxability" title="@{voie3-t1}" />
+                <br><textarea name="attr_voie3-1" class="sheet-boxability" title="@{voie3-1}"></textarea>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">2</td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v1r2" value="1" />
-                <textarea name="attr_voie1-2" class="sheet-boxability" title="@{voie1-2}"></textarea>
+                <input type="text" name="attr_voie1-t2" class="sheet-boxability" title="@{voie1-t2}" />
+                <br><textarea name="attr_voie1-2" class="sheet-boxability" title="@{voie1-2}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v2r2" value="1" />
-                <textarea name="attr_voie2-2" class="sheet-boxability" title="@{voie2-2}"></textarea>
+                <input type="text" name="attr_voie2-t2" class="sheet-boxability" title="@{voie2-t2}" />
+                <br><textarea name="attr_voie2-2" class="sheet-boxability" title="@{voie2-2}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v3r2" value="1" />
-                <textarea name="attr_voie3-2" class="sheet-boxability" title="@{voie3-2}"></textarea>
+                <input type="text" name="attr_voie3-t2" class="sheet-boxability" title="@{voie3-t2}" />
+                <br><textarea name="attr_voie3-2" class="sheet-boxability" title="@{voie3-2}"></textarea>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">3</td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v1r3" value="1" />
-                <textarea name="attr_voie1-3" class="sheet-boxability" title="@{voie1-3}"></textarea>
+                <input type="text" name="attr_voie1-t3" class="sheet-boxability" title="@{voie1-t3}" />
+                <br><textarea name="attr_voie1-3" class="sheet-boxability" title="@{voie1-3}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v2r3" value="1" />
-                <textarea name="attr_voie2-3" class="sheet-boxability" title="@{voie2-3}"></textarea>
+                <input type="text" name="attr_voie2-t3" class="sheet-boxability" title="@{voie2-t3}" />
+                <br><textarea name="attr_voie2-3" class="sheet-boxability" title="@{voie2-3}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v3r3" value="1" />
-                <textarea name="attr_voie3-3" class="sheet-boxability" title="@{voie3-3}"></textarea>
+                <input type="text" name="attr_voie3-t3" class="sheet-boxability" title="@{voie3-t3}" />
+                <br><textarea name="attr_voie3-3" class="sheet-boxability" title="@{voie3-3}"></textarea>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">4</td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v1r4" value="1" />
-                <textarea name="attr_voie1-4" class="sheet-boxability" title="@{voie1-4}"></textarea>
+                <input type="text" name="attr_voie1-t4" class="sheet-boxability" title="@{voie1-t4}" />
+                <br><textarea name="attr_voie1-4" class="sheet-boxability" title="@{voie1-4}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v2r4" value="1" />
-                <textarea name="attr_voie2-4" class="sheet-boxability" title="@{voie2-4}"></textarea>
+                <input type="text" name="attr_voie2-tt" class="sheet-boxability" title="@{voie2-t4}" />
+                <br><textarea name="attr_voie2-4" class="sheet-boxability" title="@{voie2-4}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v3r4" value="1" />
-                <textarea name="attr_voie3-4" class="sheet-boxability" title="@{voie3-4}"></textarea>
+                <input type="text" name="attr_voie3-t4" class="sheet-boxability" title="@{voie3-t4}" />
+                <br><textarea name="attr_voie3-4" class="sheet-boxability" title="@{voie3-4}"></textarea>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">5</td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v1r5" value="1" />
-                <textarea name="attr_voie1-5" class="sheet-boxability" title="@{voie1-5}"></textarea>
+                <input type="text" name="attr_voie1-t5" class="sheet-boxability" title="@{voie1-t5}" />
+                <br><textarea name="attr_voie1-5" class="sheet-boxability" title="@{voie1-5}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v2r5" value="1" />
-                <textarea name="attr_voie2-5" class="sheet-boxability" title="@{voie2-5}"></textarea>
+                <input type="text" name="attr_voie2-t5" class="sheet-boxability" title="@{voie2-t5}" />
+                <br><textarea name="attr_voie2-5" class="sheet-boxability" title="@{voie2-5}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v3r5" value="1" />
-                <textarea name="attr_voie3-5" class="sheet-boxability" title="@{voie3-5}"></textarea>
+                <input type="text" name="attr_voie3-t5" class="sheet-boxability" title="@{voie3-t5}" />
+                <br><textarea name="attr_voie3-5" class="sheet-boxability" title="@{voie3-5}"></textarea>
               </td>
             </tr>
           </table>
@@ -1574,75 +1814,90 @@
               <td class="sheet-boxtitresmall">1</td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v4r1" value="1" />
-                <textarea name="attr_voie4-1" class="sheet-boxability" title="@{voie4-1}"></textarea>
+                <input type="text" name="attr_voie4-t1" class="sheet-boxability" title="@{voie4-t1}" />
+                <br><textarea name="attr_voie4-1" class="sheet-boxability" title="@{voie4-1}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v5r1" value="1" />
-                <textarea name="attr_voie5-1" class="sheet-boxability" title="@{voie5-1}"></textarea>
+                <input type="text" name="attr_voie5-t1" class="sheet-boxability" title="@{voie5-t1}" />
+                <br><textarea name="attr_voie5-1" class="sheet-boxability" title="@{voie5-1}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v6r1" value="1" />
-                <textarea name="attr_voie6-1" class="sheet-boxability" title="@{voie6-1}"></textarea>
+                <input type="text" name="attr_voie6-t1" class="sheet-boxability" title="@{voie6-t1}" />
+                <br><textarea name="attr_voie6-1" class="sheet-boxability" title="@{voie6-1}"></textarea>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">2</td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v4r2" value="1" />
-                <textarea name="attr_voie4-2" class="sheet-boxability" title="@{voie4-2}"></textarea>
+                <input type="text" name="attr_voie4-t2" class="sheet-boxability" title="@{voi41-t2}" />
+                <br><textarea name="attr_voie4-2" class="sheet-boxability" title="@{voie4-2}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v5r2" value="1" />
-                <textarea name="attr_voie5-2" class="sheet-boxability" title="@{voie5-2}"></textarea>
+                <input type="text" name="attr_voie5-t2" class="sheet-boxability" title="@{voie5-t2}" />
+                <br><textarea name="attr_voie5-2" class="sheet-boxability" title="@{voie5-2}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v6r2" value="1" />
-                <textarea name="attr_voie6-2" class="sheet-boxability" title="@{voie6-2}"></textarea>
+                <input type="text" name="attr_voie6-t2" class="sheet-boxability" title="@{voie6-t2}" />
+                <br><textarea name="attr_voie6-2" class="sheet-boxability" title="@{voie6-2}"></textarea>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">3</td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v4r3" value="1" />
-                <textarea name="attr_voie4-3" class="sheet-boxability" title="@{voie4-3}"></textarea>
+                <input type="text" name="attr_voie4-t3" class="sheet-boxability" title="@{voie4-t3}" />
+                <br><textarea name="attr_voie4-3" class="sheet-boxability" title="@{voie4-3}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v5r3" value="1" />
-                <textarea name="attr_voie5-3" class="sheet-boxability" title="@{voie5-3}"></textarea>
+                <input type="text" name="attr_voie5-t3" class="sheet-boxability" title="@{voie5-t3}" />
+                <br><textarea name="attr_voie5-3" class="sheet-boxability" title="@{voie5-3}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v6r3" value="1" />
-                <textarea name="attr_voie6-3" class="sheet-boxability" title="@{voie6-3}"></textarea>
+                <input type="text" name="attr_voie6-t3" class="sheet-boxability" title="@{voie6-t3}" />
+                <br><textarea name="attr_voie6-3" class="sheet-boxability" title="@{voie6-3}"></textarea>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">4</td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v4r4" value="1" />
-                <textarea name="attr_voie4-4" class="sheet-boxability" title="@{voie4-4}"></textarea>
+                <input type="text" name="attr_voie4-t4" class="sheet-boxability" title="@{voie4-t4}" />
+                <br><textarea name="attr_voie4-4" class="sheet-boxability" title="@{voie4-4}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v5r4" value="1" />
-                <textarea name="attr_voie5-4" class="sheet-boxability" title="@{voie5-4}"></textarea>
+                <input type="text" name="attr_voie5-t4" class="sheet-boxability" title="@{voie5-t4}" />
+                <br><textarea name="attr_voie5-4" class="sheet-boxability" title="@{voie5-4}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v6r4" value="1" />
-                <textarea name="attr_voie6-4" class="sheet-boxability" title="@{voie6-4}"></textarea>
+                <input type="text" name="attr_voie6-t4" class="sheet-boxability" title="@{voie6-t4}" />
+                <br><textarea name="attr_voie6-4" class="sheet-boxability" title="@{voie6-4}"></textarea>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">5</td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v4r5" value="1" />
-                <textarea name="attr_voie4-5" class="sheet-boxability" title="@{voie4-5}"></textarea>
+                <input type="text" name="attr_voie4-t5" class="sheet-boxability" title="@{voie4-t5}" />
+                <br><textarea name="attr_voie4-5" class="sheet-boxability" title="@{voie4-5}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v5r5" value="1" />
-                <textarea name="attr_voie5-5" class="sheet-boxability" title="@{voie5-5}"></textarea>
+                <input type="text" name="attr_voie5-t5" class="sheet-boxability" title="@{voie5-t5}" />
+                <br><textarea name="attr_voie5-5" class="sheet-boxability" title="@{voie5-5}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v6r5" value="1" />
-                <textarea name="attr_voie6-5" class="sheet-boxability" title="@{voie6-5}"></textarea>
+                <input type="text" name="attr_voie6-t5" class="sheet-boxability" title="@{voie6-t5}" />
+                <br><textarea name="attr_voie6-5" class="sheet-boxability" title="@{voie6-5}"></textarea>
               </td>
             </tr>
           </table>
@@ -1676,75 +1931,90 @@
                   <td class="sheet-boxtitresmall">1</td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v7r1" value="1" />
-                    <textarea name="attr_voie7-1" class="sheet-boxability" title="@{voie7-1}"></textarea>
+                    <input type="text" name="attr_voie7-t1" class="sheet-boxability" title="@{voie7-t1}" />
+                    <br><textarea name="attr_voie7-1" class="sheet-boxability" title="@{voie7-1}"></textarea>
                   </td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v8r1" value="1" />
-                    <textarea name="attr_voie8-1" class="sheet-boxability" title="@{voie8-1"></textarea>
+                    <input type="text" name="attr_voie8-t1" class="sheet-boxability" title="@{voie8-t1}" />
+                    <br><textarea name="attr_voie8-1" class="sheet-boxability" title="@{voie8-1"></textarea>
                   </td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v9r1" value="1" />
-                    <textarea name="attr_voie9-1" class="sheet-boxability" title="@{voie9-1}"></textarea>
+                    <input type="text" name="attr_voie9-t1" class="sheet-boxability" title="@{voie9-t1}" />
+                    <br><textarea name="attr_voie9-1" class="sheet-boxability" title="@{voie9-1}"></textarea>
                   </td>
                 </tr>
                 <tr>
                   <td class="sheet-boxtitresmall">2</td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v7r2" value="1" />
-                    <textarea name="attr_voie7-2" class="sheet-boxability" title="@{voie7-2}"></textarea>
+                    <input type="text" name="attr_voie7-t2" class="sheet-boxability" title="@{voie7-t2}" />
+                    <br><textarea name="attr_voie7-2" class="sheet-boxability" title="@{voie7-2}"></textarea>
                   </td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v8r2" value="1" />
-                    <textarea name="attr_voie8-2" class="sheet-boxability" title="@{voie8-2}"></textarea>
+                    <input type="text" name="attr_voie8-t2" class="sheet-boxability" title="@{voie8-t2}" />
+                    <br><textarea name="attr_voie8-2" class="sheet-boxability" title="@{voie8-2}"></textarea>
                   </td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v9r2" value="1" />
-                    <textarea name="attr_voie9-2" class="sheet-boxability" title="@{voie9-2}"></textarea>
+                    <input type="text" name="attr_voie9-t2" class="sheet-boxability" title="@{voie9-t2}" />
+                    <br><textarea name="attr_voie9-2" class="sheet-boxability" title="@{voie9-2}"></textarea>
                   </td>
                 </tr>
                 <tr>
                   <td class="sheet-boxtitresmall">3</td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v7r3" value="1" />
-                    <textarea name="attr_voie7-3" class="sheet-boxability" title="@{voie7-3}"></textarea>
+                    <input type="text" name="attr_voie7-t3" class="sheet-boxability" title="@{voie7-t3}" />
+                    <br><textarea name="attr_voie7-3" class="sheet-boxability" title="@{voie7-3}"></textarea>
                   </td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v8r3" value="1" />
-                    <textarea name="attr_voie8-3" class="sheet-boxability" title="@{voie8-3}"></textarea>
+                    <input type="text" name="attr_voie3-t3" class="sheet-boxability" title="@{voie8-t3}" />
+                    <br><textarea name="attr_voie8-3" class="sheet-boxability" title="@{voie8-3}"></textarea>
                   </td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v9r3" value="1" />
-                    <textarea name="attr_voie9-3" class="sheet-boxability" title="@{voie9-3}"></textarea>
+                    <input type="text" name="attr_voie9-t3" class="sheet-boxability" title="@{voie9-t3}" />
+                    <br><textarea name="attr_voie9-3" class="sheet-boxability" title="@{voie9-3}"></textarea>
                   </td>
                 </tr>
                 <tr>
                   <td class="sheet-boxtitresmall">4</td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v7r4" value="1" />
-                    <textarea name="attr_voie7-4" class="sheet-boxability" title="@{voie7-4}"></textarea>
+                    <input type="text" name="attr_voie7-t4" class="sheet-boxability" title="@{voie7-t4}" />
+                    <br><textarea name="attr_voie7-4" class="sheet-boxability" title="@{voie7-4}"></textarea>
                   </td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v8r4" value="1" />
-                    <textarea name="attr_voie8-4" class="sheet-boxability" title="@{voie8-4}"></textarea>
+                    <input type="text" name="attr_voie8-t4" class="sheet-boxability" title="@{voie8-t4}" />
+                    <br><textarea name="attr_voie8-4" class="sheet-boxability" title="@{voie8-4}"></textarea>
                   </td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v9r4" value="1" />
-                    <textarea name="attr_voie9-4" class="sheet-boxability" title="@{voie9-4}"></textarea>
+                    <input type="text" name="attr_voie9-t4" class="sheet-boxability" title="@{voie9-t4}" />
+                    <br><textarea name="attr_voie9-4" class="sheet-boxability" title="@{voie9-4}"></textarea>
                   </td>
                 </tr>
                 <tr>
                   <td class="sheet-boxtitresmall">5</td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v7r5" value="1" />
-                    <textarea name="attr_voie7-5" class="sheet-boxability" title="@{voie7-5}"></textarea>
+                    <input type="text" name="attr_voie7-t5" class="sheet-boxability" title="@{voie7-t5}" />
+                    <br><textarea name="attr_voie7-5" class="sheet-boxability" title="@{voie7-5}"></textarea>
                   </td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v8r5" value="1" />
-                    <textarea name="attr_voie8-5" class="sheet-boxability" title="@{voie8-5}"></textarea>
+                    <input type="text" name="attr_voie8-t5" class="sheet-boxability" title="@{voie8-t5}" />
+                    <br><textarea name="attr_voie8-5" class="sheet-boxability" title="@{voie8-5}"></textarea>
                   </td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v9r5" value="1" />
-                    <textarea name="attr_voie9-5" class="sheet-boxability" title="@{voie9-5}"></textarea>
+                    <input type="text" name="attr_voie9-t5" class="sheet-boxability" title="@{voie9-t5}" />
+                    <br><textarea name="attr_voie9-5" class="sheet-boxability" title="@{voie9-5}"></textarea>
                   </td>
                 </tr>
               </table>
@@ -4148,6 +4418,29 @@ function migrateSheet(verfdp) {
       setAttrs(vrFlags);
     });
   }
+  // version 3.2 > 3.9
+  if (verfdp.major == 3 && verfdp.minor < 9) {
+    const abilities = [];
+    for (v = 1; v < 10; v++) {
+      for (r = 1; r < 6; r++) {
+        abilities.push(`voie${v}-${r}`);
+      }
+    }
+    getAttrs(abilities, function (values) {
+      const abilityAttrs = {};
+      Object.keys(values).forEach((ability) => {
+        if (!values[ability] || values[ability] === '') return;
+        const data = values[ability].split('\n');
+        const title = data.shift();
+        let desc = '';
+        if (data.length > 0) desc = data.join('\n');
+        abilityAttrs[ability] = desc;
+        abilityAttrs[ability.replace('-', '-t')] = title;
+      });
+      consoleLog(abilityAttrs);
+      setAttrs(abilityAttrs);
+    });
+  }
 }
 
 /**
@@ -5264,10 +5557,12 @@ on(
       function (values) {
         const vr = `${values.repeating_jetcapas_jetcapavoieno}${values.repeating_jetcapas_jetcapavoierang}`;
         if (vr.length !== 4) return;
-        getAttrs([vr.replace('v', 'voie').replace('r', '-')], function (value) {
-          const rankData = value[Object.keys(value)[0]].split('\n');
-          const rankName = rankData.shift();
-          const rankDesc = rankData.length > 0 ? rankData.join('\n') : '';
+        const rankData = [];
+        rankData.push(vr.replace('v', 'voie').replace('r', '-t'));
+        rankData.push(vr.replace('v', 'voie').replace('r', '-'));
+        getAttrs(rankData, function (values) {
+          const rankName = values[Object.keys(values)[0]];
+          const rankDesc = values[Object.keys(values)[1]];
           const updated = {
             repeating_jetcapas_jetcapanom: rankName,
             repeating_jetcapas_jetcapadesc: rankDesc,
@@ -5712,14 +6007,14 @@ function rebuildModAtkDM(section, buffAttr) {
           updateMatchBuffs(modNom, modOn);
         }
       );
-      getSectionIDs('repeating_armes', function (ids) {
-        const attrs = {};
-        for (const id of ids) {
-          attrs[`repeating_armes_${id}_${buffAttr}`] = armebuff;
-        }
-        setAttrs(attrs, { silent: true });
-      });
     }
+    getSectionIDs('repeating_armes', function (ids) {
+      const attrs = {};
+      for (const id of ids) {
+        attrs[`repeating_armes_${id}_${buffAttr}`] = armebuff;
+      }
+      setAttrs(attrs, { silent: true });
+    });
   });
 }
 
@@ -6718,11 +7013,11 @@ on('clicked:json_import', function () {
     jsonData.paths.forEach((path, ix) => {
       attrs[`voie${ix + 1}nom`] = path.name;
       path.abilities.forEach((ability, rank) => {
-        const abilityAttr = `voie${ix + 1}-${rank + 1}`;
         if (typeof ability === 'string') {
-          attrs[abilityAttr] = ability;
+          attrs[`voie${ix + 1}-t${rank + 1}`] = ability;
         } else {
-          attrs[abilityAttr] = ability.name + '\n' + ability.description;
+          attrs[`voie${ix + 1}-t${rank + 1}`] = ability.name;
+          attrs[`voie${ix + 1}-${rank + 1}`] = ability.description;
         }
       });
     });

--- a/ChroniquesOublieesContemporain/sheet.json
+++ b/ChroniquesOublieesContemporain/sheet.json
@@ -4,7 +4,7 @@
   "authors": "StéphaneD",
   "roll20userid": "84776",
   "preview": "coc_v2.png",
-  "instructions": "Feuille de Personnage pour [Chroniques Oubliées Contemporain](http://www.black-book-editions.fr/produit.php?id=4349). Chroniques Oubliées Contemporain est le dérivé de Chroniques Oubliées Fantasy adapté pour jouer dans la période 1900-2100. Il permet de jouer des aventures du genre espionnage, commando militaire, enquêtes policières occultes, vampires contre garous, mutants, super-héros, épouvante, pulp, apocalypse zombie, cyberpunk, et plus. Version 3.8.1 (01/03/2021). [Lisez-moi](https://github.com/Roll20/roll20-character-sheets/blob/master/ChroniquesOublieesContemporain/README.md).",
+  "instructions": "Feuille de Personnage pour [Chroniques Oubliées Contemporain](http://www.black-book-editions.fr/produit.php?id=4349). Chroniques Oubliées Contemporain est le dérivé de Chroniques Oubliées Fantasy adapté pour jouer dans la période 1900-2100. Il permet de jouer des aventures du genre espionnage, commando militaire, enquêtes policières occultes, vampires contre garous, mutants, super-héros, épouvante, pulp, apocalypse zombie, cyberpunk, et plus. Version 3.9.0 (30/03/2021). [Lisez-moi](https://github.com/Roll20/roll20-character-sheets/blob/master/ChroniquesOublieesContemporain/README.md).",
   "useroptions": [
     {
       "attribute": "coc_setting",


### PR DESCRIPTION
## Changes / Comments

- Added a title field for each ability (attributes @{voieN-tR} where N = skill path number and R = rank)
  - Sheet worker to migrate from older versions : first row in the ability textual description is assumed to be the title
  - Support for the new attribute in all related functions (binding an ability roll to a skill+rank, JSON profile data import)
- Corrected a bug occuring after removing the one and only attack or damage modifier from the repeating section (the removed modifier is not taken into account anymore in the attack rolls). Issue #7836 resolved

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
