### PR TITLE
Shadowrun Sixth World EMERGENCY FIX for roll20 roll template change

### DIFF
--- a/Shadowrun Sixth World/Shadowrun6thEdition.html
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.html
@@ -3777,14 +3777,14 @@
 <input type="hidden" name="attr_tasking" min="0" value="0" />
 <input type="hidden" name="attr_throwingweapons" min="0" value="0" />
 <input type="hidden" name="attr_tracking" min="0" value="0" />
-<input type="hidden" name="attr_unarmedcombat" min="0" value="0" /><script type="text/worker">
+<input type="hidden" name="attr_unarmedcombat" min="0" value="0" />
+<input type="hidden" name="attr_sheet_version" value="0.25">
 
+<script type="text/worker">
 //Sheet workers
 on("sheet:opened", function() {
-	const version = '0.25';
-	console.log(`%c Shadowrun 6th World v`+version, "color: blue; font-weight:bold");
-
-	getAttrs(['sheet_type'], (v) => {
+	getAttrs(['sheet_type', 'sheet_version'], (v) => {
+		console.log(`%c Shadowrun 6th World v${v['sheet_version']}`, "color: blue; font-weight:bold");
 		console.log(`%c Sheet Type: ${v['sheet_type']}`, "color: red; font-weight:bold");
 	});
 });

--- a/Shadowrun Sixth World/Shadowrun6thEdition.html
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.html
@@ -3577,6 +3577,66 @@
 		{{#opp}}<div class="template-row">{{opp}}</div>{{/opp}}
 	</div>
 </rolltemplate>
+<!--Roll Template for rolling without Focus-->
+<rolltemplate class="sheet-rolltemplate-rolls">
+	<div class="sheet-template-body">
+		<div class="sheet-template-header">
+			{{#header}}{{header}}{{/header}}{{#spec}}<span> ({{spec}})</span>{{/spec}}<br />
+			{{#arm}}<span>{{arm}}</span>{{/arm}}
+			{{#base}}<span>{{base}}</span>{{/base}}
+			{{#rollLess() wound 0}}<span> & </span><span data-i18n="wounds">Wounds</span>{{/rollLess() wound 0}}
+			{{#rollLess() mod 0}}<span> & </span><span data-i18n="modifier">Modifier</span>{{/rollLess() mod 0}}
+			{{#rollGreater() mod 0}}<span> & </span><span data-i18n="modifier">Modifier</span>{{/rollGreater() mod 0}}
+			{{#rollGreater() edge 0}}<span> & </span><span data-i18n="edge">Edge</span>{{/rollGreater() edge 0}}
+			{{#effecttype}}<br /><span>{{effecttype}}</span>{{/effecttype}}
+		</div>
+		{{#dice}}<div class="sheet-template-row">Hits: {{dice}}</div>{{/dice}}
+		{{#rollGreater() wilddie 0}}
+			<div class="sheet-template-row">Wild Die Rolled! {{wilddie}}<br>
+			{{#rollLess() wilddie 2}}
+				<div class="sheet-template-row"><span class="sheet-red">Remove all 5s!</span></div>
+			{{/rollLess() wilddie 2}}
+			{{#rollBetween() wilddie 2 4}}
+				<div class="sheet-template-row">No Change!</div>
+			{{/rollBetween() wilddie 2 4}}
+			{{#rollGreater() wilddie 4}}
+				<div class="sheet-template-row green"><span class="sheet-green">+3 Hits!</span></div>
+			{{/rollGreater() wilddie 4}}
+			</div>
+		{{/rollGreater() wilddie 0}}
+		{{#rating}}<div class="sheet-template-row">{{rating}}</div>{{/rating}}
+		{{#ampup}}{{#rollGreater() ampup 0}}
+		<div class="sheet-template-row">
+			<span class="sheet-template-desc">Amp Up: {{ampup}}</span>
+		</div>
+		{{/rollGreater() ampup 0}}{{/ampup}}
+		{{#drain}}{{#rollGreater() drain 0}}
+		<div class="sheet-template-row">
+			<span class="sheet-template-desc">Drain: {{drain}}</span>
+		</div>
+		{{/rollGreater() drain 0}}{{/drain}}
+		{{#increasearea}}{{#rollGreater() increasearea 0}}
+		<div class="sheet-template-row">
+			<span class="sheet-template-desc">Increase Area: {{increasearea}}m</span>
+		</div>
+		{{/rollGreater() increasearea 0}}{{/increasearea}}
+		{{#fade}}{{#rollGreater() fade 0}}
+		<div class="sheet-template-row">
+			<span class="sheet-template-desc">Fade: {{fade}}</span>
+		</div>
+		{{/rollGreater() fade 0}}{{/fade}}
+		{{#desc}}
+		<div class="sheet-template-row">
+			<span class="sheet-template-desc">
+			{{desc}}
+			{{#rollGreater() rea 0}}, <span data-i18n="reach">Reach<span> {{rea}}{{/rollGreater() rea 0}}
+			{{#rollLess() drain 2}}, <span data-i18n="drain-2">Drain 2<span>{{/rollLess() drain 2}}
+			</span>
+		</div>
+		{{/desc}}
+		{{#opp}}<div class="sheet-template-row">{{opp}}</div>{{/opp}}
+	</div>
+</rolltemplate>
 </div>
 <input type="hidden" name="attr_wounds" value="0" />
 <input type="hidden" name="attr_explode_toggle" value="" />


### PR DESCRIPTION
## Changes / Comments
In a patch on Tuesday unannounced to the community the code that automatically prefixed classes in roll templates with sheet- was removed.   This has caused several character sheets to stop working for roll buttons that use roll-templates.  This fixes the issue for the Shadowrun Sixth World sheet.

To be clear this makes the sheet un-useable for any rolls until this fix is in or roll20 reverts to adding sheet- to roll-template classes automatically.

This fixes this issue: https://github.com/Roll20/roll20-character-sheets/issues/8616#issue-847049214

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ Y ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ Y ] Is this a bug fix?
- [ N ] Does this add functional enhancements (new features or extending existing features) ?
- [ N ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ N ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ N ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net