### PR TITLE
[Metal Adventure] Fix checkboxes (with valid merge)

### DIFF
--- a/Metal Adventures/MetalAdventures.html
+++ b/Metal Adventures/MetalAdventures.html
@@ -252,7 +252,7 @@
 				<div class="column-header">Agilité</div>
 				<div class="row">
 					<div class="flex-grow1">
-						<span><input type="checkbox" name="attr_predilection_Technique" value="0">Techniques</span>
+						<span><input type="checkbox" name="attr_predilection_Technique" value="1">Techniques</span>
 					</div>
 					<div class="flex-grow1 flex-right">
 						<input type="number" name="attr_Technique" value="0">
@@ -337,7 +337,7 @@
 
 				<div class="row">
 					<div class="flex-grow1">
-						<span><input type="checkbox" name="attr_predilection_survie" value="0">Survie</span>
+						<span><input type="checkbox" name="attr_predilection_survie" value="1">Survie</span>
 					</div>
 					<div class="flex-grow1 flex-right">
 						<input type="number" name="attr_Survie" value="0">
@@ -422,7 +422,7 @@
 				<div class="column-header">Perception</div>
 				<div class="row">
 					<div class="flex-grow1">
-						<span><input type="checkbox" name="attr_predilection_espionnage" value="0">Espionnage</span>
+						<span><input type="checkbox" name="attr_predilection_espionnage" value="1">Espionnage</span>
 					</div>
 					<div class="flex-grow1 flex-right">
 						<input type="number" name="attr_Espionnage" value="0">
@@ -517,7 +517,7 @@
 
 				<div class="row">
 					<div class="flex-grow1">
-						<span><input type="checkbox" name="attr_predilection_Science" value="0">Science</span>
+						<span><input type="checkbox" name="attr_predilection_Science" value="1">Science</span>
 					</div>
 					<div class="flex-grow1 flex-right">
 						<input type="number" name="attr_Science" value="0">
@@ -660,7 +660,7 @@
 
 				<div class="row">
 					<div class="flex-grow1">
-						<span><input type="checkbox" name="attr_predilection_Negociation" value="0">Négociation</span>
+						<span><input type="checkbox" name="attr_predilection_Negociation" value="1">Négociation</span>
 					</div>
 					<div class="flex-grow1 flex-right">
 						<input type="number" name="attr_Negociation" value="0">
@@ -763,7 +763,7 @@
 
 				<div class="row">
 					<div class="flex-grow1">
-						<span><input type="checkbox" name="attr_predilection_Trempe" value="0">Trempe</span>
+						<span><input type="checkbox" name="attr_predilection_Trempe" value="1">Trempe</span>
 					</div>
 					<div class="flex-grow1 flex-right">
 						<input type="number" name="attr_Trempe" value="0">


### PR DESCRIPTION
## Changes / Comments

### Issue:
In character sheet, there are 6 checkboxes, that can be checked and unchecked.
However, once the checkbox is checked, the data is memorized and will always be checked when the character sheet is reopened. 

### Workaround:
If check by mistake, the only way to fix is to DELETE the character sheet an recreate a new one

I guess, the default value (uncheck) should be null
When we check, the value become "0" (from the code) 

And when we uncheck, it's still a falsy value like the check value... so nothing to save about that sheet.

### Workaround 2:
* Go to "Attributes Abilities" tab
1)
	* Remove the value "${carac}_predilection"
	* Close and open again the character sheet
2) OR
	* Update value "${carac}_predilection" for anything else "0"

### /!\ NOT RETROCOMPATIBLE /!\
All previous character sheets for Metal Adventure, will have these checkboxes uncheck
They are only use for character's evolution, and one by attribute (6 for this RPG)

### Changing
About the code, I put a value when check as "1"
We could simply remove the value attribute, if I understand the script engine but I was not sure about this behavior.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [X] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
