### PR TITLE
[Metal Adventure] Fix update max strategy

### DIFF
--- a/Metal Adventures/MetalAdventures.html
+++ b/Metal Adventures/MetalAdventures.html
@@ -1167,8 +1167,8 @@ on("change:Espionnage change:Deguisement change:Discretion change:Empathie chang
    });
 });
 
-on("change:Science change:Analyse change:Art change:Connaissance1 change:Connaissance2 change:Connaissance3 change:Esoterisme change:Histoire change:Ingenierie change:Medecine change:Navigation change:SciencesSolaires change:SciencesStellaires", function() {
-    getAttrs(["Science", "Analyse", "Art", "Connaissance1", "Connaissance2", "Connaissance3", "Esoterisme", "Histoire", "Ingenierie", "Medecine", "Navigation", "SciencesSolaires", "SciencesStellaires"], function(v) {
+on("change:Science change:Analyse change:Art change:Connaissance1 change:Connaissance2 change:Connaissance3 change:Esoterisme change:Histoire change:Ingenierie change:Medecine change:Navigation change:SciencesSolaires change:SciencesStellaires change:Stategie", function() {
+    getAttrs(["Science", "Analyse", "Art", "Connaissance1", "Connaissance2", "Connaissance3", "Esoterisme", "Histoire", "Ingenierie", "Medecine", "Navigation", "SciencesSolaires", "SciencesStellaires", "Stategie"], function(v) {
        setAttrs({
 			Analyse_max: +v.Science + +v.Analyse,
 			Art_max: +v.Science + +v.Art,
@@ -1182,6 +1182,7 @@ on("change:Science change:Analyse change:Art change:Connaissance1 change:Connais
 			Navigation_max: +v.Science + +v.Navigation,
 			SciencesSolaires_max: +v.SciencesSolaires > 0 ? +v.Science + +v.SciencesSolaires:0,
 			SciencesStellaires_max: +v.SciencesStellaires > 0 ? +v.Science + +v.SciencesStellaires:0,
+			Stategie_max: +v.Stategie > 0 ? +v.Science + +v.Stategie:0,
 		});
    });
 });
@@ -1228,7 +1229,7 @@ on("change:Trempe change:Survie change:repeating_pnjSante", function() {
 		else if(s <= 9) m = 5;
 		else if(s <= 15) m = 8;
 		else if(s > 15) m = 10;
-       setAttrs({
+       	setAttrs({
 			Indemne_max: t,
 			BlesseLeger_max: t,
 			BlesseGrave_max: t,


### PR DESCRIPTION
## Changes / Comments

### Issue:
In character sheet, there are automatic input updated by Carac+Skill, however the strategy skill was forgotten. The calculation between Caract+Skill still always blank.

### Workaround:
Do the calculation yourself, and update it from the "Attributes Abilities" tabs each time

### Changing
Add a max value for the attribute that was missing


This PR is **RETROCOMPATIBLE**

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
