### PR TITLE
ChroniquesGalactiques Version 3.114

### DIFF
--- a/ChroniquesGalactiques/ReadMe.md
+++ b/ChroniquesGalactiques/ReadMe.md
@@ -10,9 +10,16 @@ Le jeu complet est paru dans le magazine [Casus Belli](http://www.black-book-edi
 
 # Version courante
 
-V3.113 [Screenshot](cog_v3.png)
+V3.114 [Screenshot](cog_v3.png)
 
 # Notes de version
+
+## V3.114 (2021.04.12)
+
+- Ajout d'un champ titre pour chaque capacité (attributs @{voieN-tR} où N = no de voie et R = rang)
+  - Migration automatique d'une version antérieure : la première ligne de la capacité est considérée comme titre
+  - Prise en compte dans les autres fonctions (liaison d'un jet de capacité à une voie+rang)
+- Correction d'un bug après suppression du seul modificateur d'attaque ou de DM de la liste (le modificateur n'est plus pris en compte dans les jets d'attaque)
 
 ## V3.113 (2021.03.07)
 

--- a/ChroniquesGalactiques/cog.css
+++ b/ChroniquesGalactiques/cog.css
@@ -1,5 +1,10 @@
 @import url('https://fonts.googleapis.com/css?family=Titillium+Web&display=swap');
 
+/* this will be ignored by the Roll20 engine so that the next CSS selector won't be */
+.workaround-for-roll20-bug {
+  content: 'sacrificed';
+}
+
 /* Couleurs
     Base bleu = #2F5860
     Bleu light = #7F989D
@@ -140,8 +145,12 @@ span.sheet-label {
   padding: 0;
 }
 
-textarea.sheet-boxability {
+input[type='text'].sheet-boxability {
   width: 92%;
+  border-style: none;
+}
+
+textarea.sheet-boxability {
   overflow-x: hidden;
 }
 
@@ -255,12 +264,17 @@ button[type='action'].sheet-boxtitre:hover {
 button.sheet-flatbtn {
   border: 0px;
   background-color: transparent;
+  background-image: none;
   font-size: 12px !important;
 }
 
-button[type='action'].sheet-iconbtn {
+button[type='roll'].sheet-iconbtn::before {
+  content: '';
+}
+
+button.sheet-iconbtn {
   font-family: pictos;
-  font-size: large;
+  font-size: large !important;
 }
 
 img.sheet-iconimg {

--- a/ChroniquesGalactiques/cog.html
+++ b/ChroniquesGalactiques/cog.html
@@ -1,8 +1,8 @@
 <div class="sheet-mainBg">
   <!-- FDP -->
   <!-- INPUT HIDDEN Version FdP -->
-  <input type="hidden" name="attr_verfdp" value="3.113.0" />
-  <input type="hidden" name="attr_VERSION" value="3.113.0" />
+  <input type="hidden" name="attr_verfdp" value="3.114.0" />
+  <input type="hidden" name="attr_VERSION" value="3.114.0" />
   <!-- INPUT HIDDEN Univers (COF, CG, COC) -->
   <input type="hidden" name="attr_UNIVERS" value="CG" />
     <!-- INPUT HIDDEN Libellés -->
@@ -75,6 +75,7 @@
   <input type="hidden" name="attr_RANG_VOIE9" value="0" />
   <!-- INPUT HIDDEN Caractéristiques -->
   <input type="hidden" name="attr_CARACS" value="" />
+  <input type="hidden" name="attr_chatmsg" value="" />
   <!-- FIN Hidden -->
   <div style="display: none;">
     <button type="roll" name="roll_incident_tir"
@@ -83,7 +84,7 @@
   <div class="sheet-container">
     <!-- Identité -->
     <div style="width: 420px; vertical-align: middle; text-align: center;">
-      <img width="340" title="Version 3.113 - 07/03/2021"
+      <img width="340" title="Version 3.114 - 12/04/2021"
         src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_logo.png" />
     </div>
     <div style="width: 270px;">
@@ -934,14 +935,14 @@
     </div>
     <div class="sheet-tab-content sheet-tab2">
       <div>
-        <input class="block-switch" name="attr_setup_abilities" type="checkbox" value="1" checked>
+        <input class="block-switch" name="attr_setup_abilities" type="checkbox">
         <div class="block-hidden">
           <table>
             <tr>
               <td class="sheet-textfatleft" colspan="5">
                 CAPACITÉS DU PERSONNAGE
-                <input type="checkbox" class="sheet-setup-abilities" name="attr_setup_abilities"
-                  title="Editer les capacités" value="1">
+                <span class="sheet-setup-abilities sheet-textbase">Edition&nbsp;<input type="checkbox" name="attr_setup_abilities"
+                  title="Editer les capacités"></span>
               </td>
             </tr>
             <tr>
@@ -969,75 +970,150 @@
               <td class="sheet-boxtitresmall">1</td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v1r1" value="1" />
-                <span name="attr_voie1-1" class="sheet-boxability" title="@{voie1-1}"></span>
+                <span name="attr_voie1-t1" class="sheet-boxability" title="@{voie1-t1}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v1r1" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie1-t1} }} {{desc=**@{voie1nom}, rang [[1]]** }} {{text=@{voie1-1} }}">w</button>
+                </span>
+                <br><span name="attr_voie1-1" class="sheet-boxability" title="@{voie1-1}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v2r1" value="1" />
-                <span name="attr_voie2-1" class="sheet-boxability" title="@{voie2-1}"></span>
+                <span name="attr_voie2-t1" class="sheet-boxability" title="@{voie2-t1}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v2r1" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie2-t1} }} {{desc=**@{voie2nom}, rang [[1]]** }} {{text=@{voie2-1} }}">w</button>
+                </span>
+                <br><span name="attr_voie2-1" class="sheet-boxability" title="@{voie2-1}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v3r1" value="1" />
-                <span name="attr_voie3-1" class="sheet-boxability" title="@{voie3-1}"></span>
+                <span name="attr_voie3-t1" class="sheet-boxability" title="@{voie3-t1}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v3r1" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie3-t1} }} {{desc=**@{voie3nom}, rang [[1]]** }} {{text=@{voie3-1} }}">w</button>
+                </span>
+                <br><span name="attr_voie3-1" class="sheet-boxability" title="@{voie3-1}"></span>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">2</td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v1r2" value="1" />
-                <span name="attr_voie1-2" class="sheet-boxability" title="@{voie1-2}"></span>
+                <span name="attr_voie1-t2" class="sheet-boxability" title="@{voie1-t2}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v1r2" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie1-t2} }} {{desc=**@{voie1nom}, rang [[2]]** }} {{text=@{voie1-2} }}">w</button>
+                </span>
+                <br><span name="attr_voie1-2" class="sheet-boxability" title="@{voie1-2}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v2r2" value="1" />
-                <span name="attr_voie2-2" class="sheet-boxability" title="@{voie2-2}"></span>
+                <span name="attr_voie2-t2" class="sheet-boxability" title="@{voie2-t2}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v2r2" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie2-t2} }} {{desc=**@{voie2nom}, rang [[2]]** }} {{text=@{voie2-2} }}">w</button>
+                </span>
+                <br><span name="attr_voie2-2" class="sheet-boxability" title="@{voie2-2}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v3r2" value="1" />
-                <span name="attr_voie3-2" class="sheet-boxability" title="@{voie3-2}"></span>
+                <span name="attr_voie3-t2" class="sheet-boxability" title="@{voie3-t2}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v3r2" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie3-t2} }} {{desc=**@{voie3nom}, rang [[2]]** }} {{text=@{voie3-2} }}">w</button>
+                </span>
+                <br><span name="attr_voie3-2" class="sheet-boxability" title="@{voie3-2}"></span>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">3</td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v1r3" value="1" />
-                <span name="attr_voie1-3" class="sheet-boxability" title="@{voie1-3}"></span>
+                <span name="attr_voie1-t3" class="sheet-boxability" title="@{voie1-t3}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v1r3" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie1-t3} }} {{desc=**@{voie1nom}, rang [[3]]** }} {{text=@{voie1-3} }}">w</button>
+                </span>
+                <br><span name="attr_voie1-3" class="sheet-boxability" title="@{voie1-3}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v2r3" value="1" />
-                <span name="attr_voie2-3" class="sheet-boxability" title="@{voie2-3}"></span>
+                <span name="attr_voie2-t3" class="sheet-boxability" title="@{voie2-t3}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v2r3" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie2-t3} }} {{desc=**@{voie2nom}, rang [[3]]** }} {{text=@{voie2-3} }}">w</button>
+                </span>
+                <br><span name="attr_voie2-3" class="sheet-boxability" title="@{voie2-3}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v3r3" value="1" />
-                <span name="attr_voie3-3" class="sheet-boxability" title="@{voie3-3}"></span>
+                <span name="attr_voie3-t3" class="sheet-boxability" title="@{voie3-t3}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v3r3" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie3-t3} }} {{desc=**@{voie3nom}, rang [[3]]** }} {{text=@{voie3-3} }}">w</button>
+                </span>
+                <br><span name="attr_voie3-3" class="sheet-boxability" title="@{voie3-3}"></span>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">4</td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v1r4" value="1" />
-                <span name="attr_voie1-4" class="sheet-boxability" title="@{voie1-4}"></span>
+                <span name="attr_voie1-t4" class="sheet-boxability" title="@{voie1-t4}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v1r4" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie1-t4} }} {{desc=**@{voie1nom}, rang [[4]]** }} {{text=@{voie1-4} }}">w</button>
+                </span>
+                <br><span name="attr_voie1-4" class="sheet-boxability" title="@{voie1-4}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v2r4" value="1" />
-                <span name="attr_voie2-4" class="sheet-boxability" title="@{voie2-4}"></span>
+                <span name="attr_voie2-t4" class="sheet-boxability" title="@{voie2-t4}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v2r4" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie2-t4} }} {{desc=**@{voie2nom}, rang [[4]]** }} {{text=@{voie2-4} }}">w</button>
+                </span>
+                <br><span name="attr_voie2-4" class="sheet-boxability" title="@{voie2-4}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v3r4" value="1" />
-                <span name="attr_voie3-4" class="sheet-boxability" title="@{voie3-4}"></span>
+                <span name="attr_voie3-t4" class="sheet-boxability" title="@{voie3-t4}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v3r4" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie3-t4} }} {{desc=**@{voie3nom}, rang [[4]]** }} {{text=@{voie3-4} }}">w</button>
+                </span>
+                <br><span name="attr_voie3-4" class="sheet-boxability" title="@{voie3-4}"></span>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">5</td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v1r5" value="1" />
-                <span name="attr_voie1-5" class="sheet-boxability" title="@{voie1-5}"></span>
+                <span name="attr_voie1-t5" class="sheet-boxability" title="@{voie1-t5}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v1r5" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie1-t5} }} {{desc=**@{voie1nom}, rang [[5]]** }} {{text=@{voie1-5} }}">w</button>
+                </span>
+                <br><span name="attr_voie1-5" class="sheet-boxability" title="@{voie1-5}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v2r5" value="1" />
-                <span name="attr_voie2-5" class="sheet-boxability" title="@{voie2-5}"></span>
+                <span name="attr_voie2-t5" class="sheet-boxability" title="@{voie2-t5}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v2r5" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie2-t5} }} {{desc=**@{voie2nom}, rang [[5]]** }} {{text=@{voie2-5} }}">w</button>
+                </span>
+                <br><span name="attr_voie2-5" class="sheet-boxability" title="@{voie2-5}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v3r5" value="1" />
-                <span name="attr_voie3-5" class="sheet-boxability" title="@{voie3-5}"></span>
+                <span name="attr_voie3-t5" class="sheet-boxability" title="@{voie3-t5}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v3r5" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie3-t5} }} {{desc=**@{voie3nom}, rang [[5]]** }} {{text=@{voie3-5} }}">w</button>
+                </span>
+                <br><span name="attr_voie3-5" class="sheet-boxability" title="@{voie3-5}"></span>
               </td>
             </tr>
           </table>
@@ -1067,75 +1143,150 @@
               <td class="sheet-boxtitresmall">1</td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v4r1" value="1" />
-                <span name="attr_voie4-1" class="sheet-boxability" title="@{voie4-1}"></span>
+                <span name="attr_voie4-t1" class="sheet-boxability" title="@{voie4-t1}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v4r1" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie4-t1} }} {{desc=**@{voie4nom}, rang [[1]]** }} {{text=@{voie4-1} }}">w</button>
+                </span>
+                <br><span name="attr_voie4-1" class="sheet-boxability" title="@{voie4-1}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v5r1" value="1" />
-                <span name="attr_voie5-1" class="sheet-boxability" title="@{voie5-1}"></span>
+                <span name="attr_voie5-t1" class="sheet-boxability" title="@{voie5-t1}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v5r1" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie5-t1} }} {{desc=**@{voie5nom}, rang [[1]]** }} {{text=@{voie5-1} }}">w</button>
+                </span>
+                <br><span name="attr_voie5-1" class="sheet-boxability" title="@{voie5-1}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v6r1" value="1" />
-                <span name="attr_voie6-1" class="sheet-boxability" title="@{voie6-1}"></span>
+                <span name="attr_voie6-t1" class="sheet-boxability" title="@{voie6-t1}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v6r1" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie6-t1} }} {{desc=**@{voie6nom}, rang [[1]]** }} {{text=@{voie6-1} }}">w</button>
+                </span>
+                <br><span name="attr_voie6-1" class="sheet-boxability" title="@{voie6-1}"></span>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">2</td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v4r2" value="1" />
-                <span name="attr_voie4-2" class="sheet-boxability" title="@{voie4-2}"></span>
+                <span name="attr_voie4-t2" class="sheet-boxability" title="@{voie4-t2}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v4r2" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie4-t2} }} {{desc=**@{voie4nom}, rang [[2]]** }} {{text=@{voie4-2} }}">w</button>
+                </span>
+                <br><span name="attr_voie4-2" class="sheet-boxability" title="@{voie4-2}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v5r2" value="1" />
-                <span name="attr_voie5-2" class="sheet-boxability" title="@{voie5-2}"></span>
+                <span name="attr_voie5-t2" class="sheet-boxability" title="@{voie5-t2}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v5r2" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie5-t2} }} {{desc=**@{voie5nom}, rang [[2]]** }} {{text=@{voie5-2} }}">w</button>
+                </span>
+                <br><span name="attr_voie5-2" class="sheet-boxability" title="@{voie5-2}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v6r2" value="1" />
-                <span name="attr_voie6-2" class="sheet-boxability" title="@{voie6-2}"></span>
+                <span name="attr_voie6-t2" class="sheet-boxability" title="@{voie6-t2}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v6r2" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie6-t2} }} {{desc=**@{voie6nom}, rang [[2]]** }} {{text=@{voie6-2} }}">w</button>
+                </span>
+                <br><span name="attr_voie6-2" class="sheet-boxability" title="@{voie6-2}"></span>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">3</td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v4r3" value="1" />
-                <span name="attr_voie4-3" class="sheet-boxability" title="@{voie4-3}"></span>
+                <span name="attr_voie4-t3" class="sheet-boxability" title="@{voie4-t3}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v4r3" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie4-t3} }} {{desc=**@{voie4nom}, rang [[3]]** }} {{text=@{voie4-3} }}">w</button>
+                </span>
+                <br><span name="attr_voie4-3" class="sheet-boxability" title="@{voie4-3}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v5r3" value="1" />
-                <span name="attr_voie5-3" class="sheet-boxability" title="@{voie5-3}"></span>
+                <span name="attr_voie5-t3" class="sheet-boxability" title="@{voie5-t3}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v5r3" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie5-t3} }} {{desc=**@{voie5nom}, rang [[3]]** }} {{text=@{voie5-3} }}">w</button>
+                </span>
+                <br><span name="attr_voie5-3" class="sheet-boxability" title="@{voie5-3}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v6r3" value="1" />
-                <span name="attr_voie6-3" class="sheet-boxability" title="@{voie6-3}"></span>
+                <span name="attr_voie6-t3" class="sheet-boxability" title="@{voie6-t3}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v6r3" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie6-t3} }} {{desc=**@{voie6nom}, rang [[3]]** }} {{text=@{voie6-3} }}">w</button>
+                </span>
+                <br><span name="attr_voie6-3" class="sheet-boxability" title="@{voie6-3}"></span>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">4</td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v4r4" value="1" />
-                <span name="attr_voie4-4" class="sheet-boxability" title="@{voie4-4}"></span>
+                <span name="attr_voie4-t4" class="sheet-boxability" title="@{voie4-t4}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v4r4" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie4-t4} }} {{desc=**@{voie4nom}, rang [[4]]** }} {{text=@{voie4-4} }}">w</button>
+                </span>
+                <br><span name="attr_voie4-4" class="sheet-boxability" title="@{voie4-4}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v5r4" value="1" />
-                <span name="attr_voie5-4" class="sheet-boxability" title="@{voie5-4}"></span>
+                <span name="attr_voie5-t4" class="sheet-boxability" title="@{voie5-t4}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v5r4" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie5-t4} }} {{desc=**@{voie5nom}, rang [[4]]** }} {{text=@{voie5-4} }}">w</button>
+                </span>
+                <br><span name="attr_voie5-4" class="sheet-boxability" title="@{voie5-4}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v6r4" value="1" />
-                <span name="attr_voie6-4" class="sheet-boxability" title="@{voie6-4}"></span>
+                <span name="attr_voie6-t4" class="sheet-boxability" title="@{voie6-t4}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v6r4" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie6-t4} }} {{desc=**@{voie6nom}, rang [[4]]** }} {{text=@{voie6-4} }}">w</button>
+                </span>
+                <br><span name="attr_voie6-4" class="sheet-boxability" title="@{voie6-4}"></span>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">5</td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v4r5" value="1" />
-                <span name="attr_voie4-5" class="sheet-boxability" title="@{voie4-5}"></span>
+                <span name="attr_voie4-t5" class="sheet-boxability" title="@{voie4-t5}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v4r5" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie4-t5} }} {{desc=**@{voie4nom}, rang [[5]]** }} {{text=@{voie4-5} }}">w</button>
+                </span>
+                <br><span name="attr_voie4-5" class="sheet-boxability" title="@{voie4-5}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v5r5" value="1" />
-                <span name="attr_voie5-5" class="sheet-boxability" title="@{voie5-5}"></span>
+                <span name="attr_voie5-t5" class="sheet-boxability" title="@{voie5-t5}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v5r5" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie5-t5} }} {{desc=**@{voie5nom}, rang [[5]]** }} {{text=@{voie5-5} }}">w</button>
+                </span>
+                <br><span name="attr_voie5-5" class="sheet-boxability" title="@{voie5-5}"></span>
               </td>
               <td class="sheet-boxvoie sheet-boxtext">
                 <input type="checkbox" name="attr_v6r5" value="1" />
-                <span name="attr_voie6-5" class="sheet-boxability" title="@{voie6-5}"></span>
+                <span name="attr_voie6-t5" class="sheet-boxability" title="@{voie6-t5}"></span>
+                <span style="float: right;">
+                  <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v6r5" title="" 
+                  value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie6-t5} }} {{desc=**@{voie6nom}, rang [[5]]** }} {{text=@{voie6-5} }}">w</button>
+                </span>
+                <br><span name="attr_voie6-5" class="sheet-boxability" title="@{voie6-5}"></span>
               </td>
             </tr>
           </table>
@@ -1169,75 +1320,150 @@
                   <td class="sheet-boxtitresmall">1</td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v7r1" value="1" />
-                    <span name="attr_voie7-1" class="sheet-boxability" title="@{voie7-1}"></span>
+                    <span name="attr_voie7-t1" class="sheet-boxability" title="@{voie7-t1}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v7r1" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie7-t1} }} {{desc=**@{voie7nom}, rang [[1]]** }} {{text=@{voie7-1} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie7-1" class="sheet-boxability" title="@{voie7-1}"></span>
                   </td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v8r1" value="1" />
-                    <span name="attr_voie8-1" class="sheet-boxability" title="@{voie8-1"></span>
+                    <span name="attr_voie8-t1" class="sheet-boxability" title="@{voie8-t1"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v8r1" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie8-t1} }} {{desc=**@{voie8nom}, rang [[1]]** }} {{text=@{voie8-1} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie8-1" class="sheet-boxability" title="@{voie8-1"></span>
                   </td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v9r1" value="1" />
-                    <span name="attr_voie9-1" class="sheet-boxability" title="@{voie9-1}"></span>
+                    <span name="attr_voie9-t1" class="sheet-boxability" title="@{voie9-t1}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v9r1" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie9-t1} }} {{desc=**@{voie9nom}, rang [[1]]** }} {{text=@{voie9-1} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie9-1" class="sheet-boxability" title="@{voie9-1}"></span>
                   </td>
                 </tr>
                 <tr>
                   <td class="sheet-boxtitresmall">2</td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v7r2" value="1" />
-                    <span name="attr_voie7-2" class="sheet-boxability" title="@{voie7-2}"></span>
+                    <span name="attr_voie7-t2" class="sheet-boxability" title="@{voie7-t2}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v7r2" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie7-t2} }} {{desc=**@{voie7nom}, rang [[2]]** }} {{text=@{voie7-2} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie7-2" class="sheet-boxability" title="@{voie7-2}"></span>
                   </td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v8r2" value="1" />
-                    <span name="attr_voie8-2" class="sheet-boxability" title="@{voie8-2}"></span>
+                    <span name="attr_voie8-t2" class="sheet-boxability" title="@{voie8-t2}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v8r2" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie8-t2} }} {{desc=**@{voie8nom}, rang [[2]]** }} {{text=@{voie8-2} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie8-2" class="sheet-boxability" title="@{voie8-2}"></span>
                   </td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v9r2" value="1" />
-                    <span name="attr_voie9-2" class="sheet-boxability" title="@{voie9-2}"></span>
+                    <span name="attr_voie9-t2" class="sheet-boxability" title="@{voie9-t2}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v9r2" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie9-t2} }} {{desc=**@{voie9nom}, rang [[2]]** }} {{text=@{voie9-2} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie9-2" class="sheet-boxability" title="@{voie9-2}"></span>
                   </td>
                 </tr>
                 <tr>
                   <td class="sheet-boxtitresmall">3</td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v7r3" value="1" />
-                    <span name="attr_voie7-3" class="sheet-boxability" title="@{voie7-3}"></span>
+                    <span name="attr_voie7-t3" class="sheet-boxability" title="@{voie7-t3}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v7r3" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie7-t3} }} {{desc=**@{voie7nom}, rang [[3]]** }} {{text=@{voie7-3} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie7-3" class="sheet-boxability" title="@{voie7-3}"></span>
                   </td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v8r3" value="1" />
-                    <span name="attr_voie8-3" class="sheet-boxability" title="@{voie8-3}"></span>
+                    <span name="attr_voie8-t3" class="sheet-boxability" title="@{voie8-t3}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v8r3" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie8-t3} }} {{desc=**@{voie8nom}, rang [[3]]** }} {{text=@{voie8-3} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie8-3" class="sheet-boxability" title="@{voie8-3}"></span>
                   </td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v9r3" value="1" />
-                    <span name="attr_voie9-3" class="sheet-boxability" title="@{voie9-3}"></span>
+                    <span name="attr_voie9-t3" class="sheet-boxability" title="@{voie9-t3}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v9r3" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie9-t3} }} {{desc=**@{voie9nom}, rang [[3]]** }} {{text=@{voie9-3} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie9-3" class="sheet-boxability" title="@{voie9-3}"></span>
                   </td>
                 </tr>
                 <tr>
                   <td class="sheet-boxtitresmall">4</td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v7r4" value="1" />
-                    <span name="attr_voie7-4" class="sheet-boxability" title="@{voie7-4}"></span>
+                    <span name="attr_voie7-t4" class="sheet-boxability" title="@{voie7-t4}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v7r4" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie7-t4} }} {{desc=**@{voie7nom}, rang [[4]]** }} {{text=@{voie7-4} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie7-4" class="sheet-boxability" title="@{voie7-4}"></span>
                   </td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v8r4" value="1" />
-                    <span name="attr_voie8-4" class="sheet-boxability" title="@{voie8-4}"></span>
+                    <span name="attr_voie8-t4" class="sheet-boxability" title="@{voie8-t4}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v8r4" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie8-t4} }} {{desc=**@{voie8nom}, rang [[4]]** }} {{text=@{voie8-4} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie8-4" class="sheet-boxability" title="@{voie8-4}"></span>
                   </td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v9r4" value="1" />
-                    <span name="attr_voie9-4" class="sheet-boxability" title="@{voie9-4}"></span>
+                    <span name="attr_voie9-t4" class="sheet-boxability" title="@{voie9-t4}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v9r4" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie9-t4} }} {{desc=**@{voie9nom}, rang [[4]]** }} {{text=@{voie9-4} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie9-4" class="sheet-boxability" title="@{voie9-4}"></span>
                   </td>
                 </tr>
                 <tr>
                   <td class="sheet-boxtitresmall">5</td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v7r5" value="1" />
-                    <span name="attr_voie7-5" class="sheet-boxability" title="@{voie7-5}"></span>
+                    <span name="attr_voie7-t5" class="sheet-boxability" title="@{voie7-t5}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v7r5" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie7-t5} }} {{desc=**@{voie7nom}, rang [[5]]** }} {{text=@{voie7-5} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie7-5" class="sheet-boxability" title="@{voie7-5}"></span>
                   </td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v8r5" value="1" />
-                    <span name="attr_voie8-5" class="sheet-boxability" title="@{voie8-5}"></span>
+                    <span name="attr_voie8-t5" class="sheet-boxability" title="@{voie8-t5}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v8r5" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie8-t5} }} {{desc=**@{voie8nom}, rang [[5]]** }} {{text=@{voie8-5} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie8-5" class="sheet-boxability" title="@{voie8-5}"></span>
                   </td>
                   <td class="sheet-boxvoie sheet-boxtext">
                     <input type="checkbox" name="attr_v9r5" value="1" />
-                    <span name="attr_voie9-5" class="sheet-boxability" title="@{voie9-5}"></span>
+                    <span name="attr_voie9-t5" class="sheet-boxability" title="@{voie9-t5}"></span>
+                    <span style="float: right;">
+                      <button type="roll" class="sheet-flatbtn sheet-iconbtn" name="roll_v9r5" title="" 
+                      value="&{template:co1} {{perso=@{character_name} }} {{subtags=Capacité }} {{name=@{voie9-t5} }} {{desc=**@{voie9nom}, rang [[5]]** }} {{text=@{voie9-5} }}">w</button>
+                    </span>
+                    <br><span name="attr_voie9-5" class="sheet-boxability" title="@{voie9-5}"></span>
                   </td>
                 </tr>
               </table>
@@ -1249,8 +1475,8 @@
             <tr>
               <td class="sheet-textfatleft" colspan="5">
                 CAPACITÉS DU PERSONNAGE
-                <input type="checkbox" class="sheet-setup-abilities" name="attr_setup_abilities"
-                  title="Editer les capacités" value="1" checked>
+                <span class="sheet-setup-abilities">Affichage&nbsp;<input type="checkbox" name="attr_setup_abilities"
+                  title="Editer les capacités"></span>
               </td>
             </tr>
             <tr>
@@ -1278,75 +1504,90 @@
               <td class="sheet-boxtitresmall">1</td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v1r1" value="1" />
-                <textarea name="attr_voie1-1" class="sheet-boxability" title="@{voie1-1}"></textarea>
+                <input type="text" name="attr_voie1-t1" class="sheet-boxability" title="@{voie1-t1}" />
+                <br><textarea name="attr_voie1-1" class="sheet-boxability" title="@{voie1-1}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v2r1" value="1" />
-                <textarea name="attr_voie2-1" class="sheet-boxability" title="@{voie2-1}"></textarea>
+                <input type="text" name="attr_voie2-t1" class="sheet-boxability" title="@{voie2-t1}" />
+                <br><textarea name="attr_voie2-1" class="sheet-boxability" title="@{voie2-1}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v3r1" value="1" />
-                <textarea name="attr_voie3-1" class="sheet-boxability" title="@{voie3-1}"></textarea>
+                <input type="text" name="attr_voie3-t1" class="sheet-boxability" title="@{voie3-t1}" />
+                <br><textarea name="attr_voie3-1" class="sheet-boxability" title="@{voie3-1}"></textarea>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">2</td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v1r2" value="1" />
-                <textarea name="attr_voie1-2" class="sheet-boxability" title="@{voie1-2}"></textarea>
+                <input type="text" name="attr_voie1-t2" class="sheet-boxability" title="@{voie1-t2}" />
+                <br><textarea name="attr_voie1-2" class="sheet-boxability" title="@{voie1-2}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v2r2" value="1" />
-                <textarea name="attr_voie2-2" class="sheet-boxability" title="@{voie2-2}"></textarea>
+                <input type="text" name="attr_voie2-t2" class="sheet-boxability" title="@{voie2-t2}" />
+                <br><textarea name="attr_voie2-2" class="sheet-boxability" title="@{voie2-2}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v3r2" value="1" />
-                <textarea name="attr_voie3-2" class="sheet-boxability" title="@{voie3-2}"></textarea>
+                <input type="text" name="attr_voie3-t2" class="sheet-boxability" title="@{voie3-t2}" />
+                <br><textarea name="attr_voie3-2" class="sheet-boxability" title="@{voie3-2}"></textarea>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">3</td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v1r3" value="1" />
-                <textarea name="attr_voie1-3" class="sheet-boxability" title="@{voie1-3}"></textarea>
+                <input type="text" name="attr_voie1-t3" class="sheet-boxability" title="@{voie1-t3}" />
+                <br><textarea name="attr_voie1-3" class="sheet-boxability" title="@{voie1-3}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v2r3" value="1" />
-                <textarea name="attr_voie2-3" class="sheet-boxability" title="@{voie2-3}"></textarea>
+                <input type="text" name="attr_voie2-t3" class="sheet-boxability" title="@{voie2-t3}" />
+                <br><textarea name="attr_voie2-3" class="sheet-boxability" title="@{voie2-3}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v3r3" value="1" />
-                <textarea name="attr_voie3-3" class="sheet-boxability" title="@{voie3-3}"></textarea>
+                <input type="text" name="attr_voie3-t3" class="sheet-boxability" title="@{voie3-t3}" />
+                <br><textarea name="attr_voie3-3" class="sheet-boxability" title="@{voie3-3}"></textarea>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">4</td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v1r4" value="1" />
-                <textarea name="attr_voie1-4" class="sheet-boxability" title="@{voie1-4}"></textarea>
+                <input type="text" name="attr_voie1-t4" class="sheet-boxability" title="@{voie1-t4}" />
+                <br><textarea name="attr_voie1-4" class="sheet-boxability" title="@{voie1-4}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v2r4" value="1" />
-                <textarea name="attr_voie2-4" class="sheet-boxability" title="@{voie2-4}"></textarea>
+                <input type="text" name="attr_voie2-tt" class="sheet-boxability" title="@{voie2-t4}" />
+                <br><textarea name="attr_voie2-4" class="sheet-boxability" title="@{voie2-4}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v3r4" value="1" />
-                <textarea name="attr_voie3-4" class="sheet-boxability" title="@{voie3-4}"></textarea>
+                <input type="text" name="attr_voie3-t4" class="sheet-boxability" title="@{voie3-t4}" />
+                <br><textarea name="attr_voie3-4" class="sheet-boxability" title="@{voie3-4}"></textarea>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">5</td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v1r5" value="1" />
-                <textarea name="attr_voie1-5" class="sheet-boxability" title="@{voie1-5}"></textarea>
+                <input type="text" name="attr_voie1-t5" class="sheet-boxability" title="@{voie1-t5}" />
+                <br><textarea name="attr_voie1-5" class="sheet-boxability" title="@{voie1-5}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v2r5" value="1" />
-                <textarea name="attr_voie2-5" class="sheet-boxability" title="@{voie2-5}"></textarea>
+                <input type="text" name="attr_voie2-t5" class="sheet-boxability" title="@{voie2-t5}" />
+                <br><textarea name="attr_voie2-5" class="sheet-boxability" title="@{voie2-5}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v3r5" value="1" />
-                <textarea name="attr_voie3-5" class="sheet-boxability" title="@{voie3-5}"></textarea>
+                <input type="text" name="attr_voie3-t5" class="sheet-boxability" title="@{voie3-t5}" />
+                <br><textarea name="attr_voie3-5" class="sheet-boxability" title="@{voie3-5}"></textarea>
               </td>
             </tr>
           </table>
@@ -1376,75 +1617,90 @@
               <td class="sheet-boxtitresmall">1</td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v4r1" value="1" />
-                <textarea name="attr_voie4-1" class="sheet-boxability" title="@{voie4-1}"></textarea>
+                <input type="text" name="attr_voie4-t1" class="sheet-boxability" title="@{voie4-t1}" />
+                <br><textarea name="attr_voie4-1" class="sheet-boxability" title="@{voie4-1}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v5r1" value="1" />
-                <textarea name="attr_voie5-1" class="sheet-boxability" title="@{voie5-1}"></textarea>
+                <input type="text" name="attr_voie5-t1" class="sheet-boxability" title="@{voie5-t1}" />
+                <br><textarea name="attr_voie5-1" class="sheet-boxability" title="@{voie5-1}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v6r1" value="1" />
-                <textarea name="attr_voie6-1" class="sheet-boxability" title="@{voie6-1}"></textarea>
+                <input type="text" name="attr_voie6-t1" class="sheet-boxability" title="@{voie6-t1}" />
+                <br><textarea name="attr_voie6-1" class="sheet-boxability" title="@{voie6-1}"></textarea>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">2</td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v4r2" value="1" />
-                <textarea name="attr_voie4-2" class="sheet-boxability" title="@{voie4-2}"></textarea>
+                <input type="text" name="attr_voie4-t2" class="sheet-boxability" title="@{voi41-t2}" />
+                <br><textarea name="attr_voie4-2" class="sheet-boxability" title="@{voie4-2}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v5r2" value="1" />
-                <textarea name="attr_voie5-2" class="sheet-boxability" title="@{voie5-2}"></textarea>
+                <input type="text" name="attr_voie5-t2" class="sheet-boxability" title="@{voie5-t2}" />
+                <br><textarea name="attr_voie5-2" class="sheet-boxability" title="@{voie5-2}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v6r2" value="1" />
-                <textarea name="attr_voie6-2" class="sheet-boxability" title="@{voie6-2}"></textarea>
+                <input type="text" name="attr_voie6-t2" class="sheet-boxability" title="@{voie6-t2}" />
+                <br><textarea name="attr_voie6-2" class="sheet-boxability" title="@{voie6-2}"></textarea>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">3</td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v4r3" value="1" />
-                <textarea name="attr_voie4-3" class="sheet-boxability" title="@{voie4-3}"></textarea>
+                <input type="text" name="attr_voie4-t3" class="sheet-boxability" title="@{voie4-t3}" />
+                <br><textarea name="attr_voie4-3" class="sheet-boxability" title="@{voie4-3}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v5r3" value="1" />
-                <textarea name="attr_voie5-3" class="sheet-boxability" title="@{voie5-3}"></textarea>
+                <input type="text" name="attr_voie5-t3" class="sheet-boxability" title="@{voie5-t3}" />
+                <br><textarea name="attr_voie5-3" class="sheet-boxability" title="@{voie5-3}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v6r3" value="1" />
-                <textarea name="attr_voie6-3" class="sheet-boxability" title="@{voie6-3}"></textarea>
+                <input type="text" name="attr_voie6-t3" class="sheet-boxability" title="@{voie6-t3}" />
+                <br><textarea name="attr_voie6-3" class="sheet-boxability" title="@{voie6-3}"></textarea>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">4</td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v4r4" value="1" />
-                <textarea name="attr_voie4-4" class="sheet-boxability" title="@{voie4-4}"></textarea>
+                <input type="text" name="attr_voie4-t4" class="sheet-boxability" title="@{voie4-t4}" />
+                <br><textarea name="attr_voie4-4" class="sheet-boxability" title="@{voie4-4}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v5r4" value="1" />
-                <textarea name="attr_voie5-4" class="sheet-boxability" title="@{voie5-4}"></textarea>
+                <input type="text" name="attr_voie5-t4" class="sheet-boxability" title="@{voie5-t4}" />
+                <br><textarea name="attr_voie5-4" class="sheet-boxability" title="@{voie5-4}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v6r4" value="1" />
-                <textarea name="attr_voie6-4" class="sheet-boxability" title="@{voie6-4}"></textarea>
+                <input type="text" name="attr_voie6-t4" class="sheet-boxability" title="@{voie6-t4}" />
+                <br><textarea name="attr_voie6-4" class="sheet-boxability" title="@{voie6-4}"></textarea>
               </td>
             </tr>
             <tr>
               <td class="sheet-boxtitresmall">5</td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v4r5" value="1" />
-                <textarea name="attr_voie4-5" class="sheet-boxability" title="@{voie4-5}"></textarea>
+                <input type="text" name="attr_voie4-t5" class="sheet-boxability" title="@{voie4-t5}" />
+                <br><textarea name="attr_voie4-5" class="sheet-boxability" title="@{voie4-5}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v5r5" value="1" />
-                <textarea name="attr_voie5-5" class="sheet-boxability" title="@{voie5-5}"></textarea>
+                <input type="text" name="attr_voie5-t5" class="sheet-boxability" title="@{voie5-t5}" />
+                <br><textarea name="attr_voie5-5" class="sheet-boxability" title="@{voie5-5}"></textarea>
               </td>
               <td class="sheet-boxvoie">
                 <input type="checkbox" name="attr_v6r5" value="1" />
-                <textarea name="attr_voie6-5" class="sheet-boxability" title="@{voie6-5}"></textarea>
+                <input type="text" name="attr_voie6-t5" class="sheet-boxability" title="@{voie6-t5}" />
+                <br><textarea name="attr_voie6-5" class="sheet-boxability" title="@{voie6-5}"></textarea>
               </td>
             </tr>
           </table>
@@ -1478,75 +1734,90 @@
                   <td class="sheet-boxtitresmall">1</td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v7r1" value="1" />
-                    <textarea name="attr_voie7-1" class="sheet-boxability" title="@{voie7-1}"></textarea>
+                    <input type="text" name="attr_voie7-t1" class="sheet-boxability" title="@{voie7-t1}" />
+                    <br><textarea name="attr_voie7-1" class="sheet-boxability" title="@{voie7-1}"></textarea>
                   </td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v8r1" value="1" />
-                    <textarea name="attr_voie8-1" class="sheet-boxability" title="@{voie8-1"></textarea>
+                    <input type="text" name="attr_voie8-t1" class="sheet-boxability" title="@{voie8-t1}" />
+                    <br><textarea name="attr_voie8-1" class="sheet-boxability" title="@{voie8-1"></textarea>
                   </td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v9r1" value="1" />
-                    <textarea name="attr_voie9-1" class="sheet-boxability" title="@{voie9-1}"></textarea>
+                    <input type="text" name="attr_voie9-t1" class="sheet-boxability" title="@{voie9-t1}" />
+                    <br><textarea name="attr_voie9-1" class="sheet-boxability" title="@{voie9-1}"></textarea>
                   </td>
                 </tr>
                 <tr>
                   <td class="sheet-boxtitresmall">2</td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v7r2" value="1" />
-                    <textarea name="attr_voie7-2" class="sheet-boxability" title="@{voie7-2}"></textarea>
+                    <input type="text" name="attr_voie7-t2" class="sheet-boxability" title="@{voie7-t2}" />
+                    <br><textarea name="attr_voie7-2" class="sheet-boxability" title="@{voie7-2}"></textarea>
                   </td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v8r2" value="1" />
-                    <textarea name="attr_voie8-2" class="sheet-boxability" title="@{voie8-2}"></textarea>
+                    <input type="text" name="attr_voie8-t2" class="sheet-boxability" title="@{voie8-t2}" />
+                    <br><textarea name="attr_voie8-2" class="sheet-boxability" title="@{voie8-2}"></textarea>
                   </td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v9r2" value="1" />
-                    <textarea name="attr_voie9-2" class="sheet-boxability" title="@{voie9-2}"></textarea>
+                    <input type="text" name="attr_voie9-t2" class="sheet-boxability" title="@{voie9-t2}" />
+                    <br><textarea name="attr_voie9-2" class="sheet-boxability" title="@{voie9-2}"></textarea>
                   </td>
                 </tr>
                 <tr>
                   <td class="sheet-boxtitresmall">3</td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v7r3" value="1" />
-                    <textarea name="attr_voie7-3" class="sheet-boxability" title="@{voie7-3}"></textarea>
+                    <input type="text" name="attr_voie7-t3" class="sheet-boxability" title="@{voie7-t3}" />
+                    <br><textarea name="attr_voie7-3" class="sheet-boxability" title="@{voie7-3}"></textarea>
                   </td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v8r3" value="1" />
-                    <textarea name="attr_voie8-3" class="sheet-boxability" title="@{voie8-3}"></textarea>
+                    <input type="text" name="attr_voie3-t3" class="sheet-boxability" title="@{voie8-t3}" />
+                    <br><textarea name="attr_voie8-3" class="sheet-boxability" title="@{voie8-3}"></textarea>
                   </td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v9r3" value="1" />
-                    <textarea name="attr_voie9-3" class="sheet-boxability" title="@{voie9-3}"></textarea>
+                    <input type="text" name="attr_voie9-t3" class="sheet-boxability" title="@{voie9-t3}" />
+                    <br><textarea name="attr_voie9-3" class="sheet-boxability" title="@{voie9-3}"></textarea>
                   </td>
                 </tr>
                 <tr>
                   <td class="sheet-boxtitresmall">4</td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v7r4" value="1" />
-                    <textarea name="attr_voie7-4" class="sheet-boxability" title="@{voie7-4}"></textarea>
+                    <input type="text" name="attr_voie7-t4" class="sheet-boxability" title="@{voie7-t4}" />
+                    <br><textarea name="attr_voie7-4" class="sheet-boxability" title="@{voie7-4}"></textarea>
                   </td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v8r4" value="1" />
-                    <textarea name="attr_voie8-4" class="sheet-boxability" title="@{voie8-4}"></textarea>
+                    <input type="text" name="attr_voie8-t4" class="sheet-boxability" title="@{voie8-t4}" />
+                    <br><textarea name="attr_voie8-4" class="sheet-boxability" title="@{voie8-4}"></textarea>
                   </td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v9r4" value="1" />
-                    <textarea name="attr_voie9-4" class="sheet-boxability" title="@{voie9-4}"></textarea>
+                    <input type="text" name="attr_voie9-t4" class="sheet-boxability" title="@{voie9-t4}" />
+                    <br><textarea name="attr_voie9-4" class="sheet-boxability" title="@{voie9-4}"></textarea>
                   </td>
                 </tr>
                 <tr>
                   <td class="sheet-boxtitresmall">5</td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v7r5" value="1" />
-                    <textarea name="attr_voie7-5" class="sheet-boxability" title="@{voie7-5}"></textarea>
+                    <input type="text" name="attr_voie7-t5" class="sheet-boxability" title="@{voie7-t5}" />
+                    <br><textarea name="attr_voie7-5" class="sheet-boxability" title="@{voie7-5}"></textarea>
                   </td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v8r5" value="1" />
-                    <textarea name="attr_voie8-5" class="sheet-boxability" title="@{voie8-5}"></textarea>
+                    <input type="text" name="attr_voie8-t5" class="sheet-boxability" title="@{voie8-t5}" />
+                    <br><textarea name="attr_voie8-5" class="sheet-boxability" title="@{voie8-5}"></textarea>
                   </td>
                   <td class="sheet-boxvoie">
                     <input type="checkbox" name="attr_v9r5" value="1" />
-                    <textarea name="attr_voie9-5" class="sheet-boxability" title="@{voie9-5}"></textarea>
+                    <input type="text" name="attr_voie9-t5" class="sheet-boxability" title="@{voie9-t5}" />
+                    <br><textarea name="attr_voie9-5" class="sheet-boxability" title="@{voie9-5}"></textarea>
                   </td>
                 </tr>
               </table>
@@ -1555,7 +1826,7 @@
         </div>
         <!-- Voies -->
         <img class="sheet-imghr"
-          src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
+          src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesOublieesContemporain/coc_hr.jpg" />
         <table class="sheet-tabsep" title="repeating_jetcapas">
           <tr>
             <td class="sheet-textfatleft" style="min-width:245px;">Jets de Capacités</td>
@@ -4072,6 +4343,28 @@ function migrateSheet(verfdp) {
       if (value.type_personnage === 'vaisseau') updateShipDEF();
     });
   }
+  if (verfdp.major == 3 && verfdp.minor < 114) {
+    const abilities = [];
+    for (v = 1; v < 10; v++) {
+      for (r = 1; r < 6; r++) {
+        abilities.push(`voie${v}-${r}`);
+      }
+    }
+    getAttrs(abilities, function (values) {
+      const abilityAttrs = {};
+      Object.keys(values).forEach((ability) => {
+        if (!values[ability] || values[ability] === '') return;
+        const data = values[ability].split('\n');
+        const title = data.shift();
+        let desc = '';
+        if (data.length > 0) desc = data.join('\n');
+        abilityAttrs[ability] = desc;
+        abilityAttrs[ability.replace('-', '-t')] = title;
+      });
+      consoleLog(abilityAttrs);
+      setAttrs(abilityAttrs);
+    });
+  }
 }
 
 /**
@@ -4885,24 +5178,23 @@ on('clicked:sb_import', function () {
   });
 });
 
-const npcAtkAttribs = [
-  'atkatt',
-  'atknom',
-  'atkjet',
-  'atkbonus',
-  'atkcrit',
-  'atkdmg',
-  'atkdmnbde',
-  'atkdmde',
-  'atkdmbonus',
-  'atkportee',
-  'atkspec',
-];
-
 /**
  * Convert an NPC to a PC character sheet
  */
 function convertToPC() {
+  const npcAtkAttribs = [
+    'atkatt',
+    'atknom',
+    'atkjet',
+    'atkbonus',
+    'atkcrit',
+    'atkdmg',
+    'atkdmnbde',
+    'atkdmde',
+    'atkdmbonus',
+    'atkportee',
+    'atkspec',
+  ];
   getAttrs(
     [
       'pnj_for',
@@ -5270,15 +5562,25 @@ on(
  */
 function updateShipEP() {
   getAttrs(
-    ['type_fiche', 'NIVEAU', 'PEV_BUFF', 'FORCE', 'PEV_DMG'],
+    ['type_fiche', 'NIVEAU', 'PEV_BUFF', 'FORCE', 'PEV_DMG', 'PEV'],
     function (values) {
       if (values.type_fiche !== 'vaisseau') return;
+      const pev = parseInt(values.PEV) || 0;
       let pev_max = 0;
       pev_max += parseInt(values.NIVEAU) || 0;
       pev_max += parseInt(values.PEV_BUFF) || 0;
       pev_max += getMod(values.FORCE) || 0;
       pev_max -= parseInt(values.PEV_DMG) || 0;
-      setAttrs({ PEV_max: pev_max });
+      let chatmsg = '';
+      if (pev > pev_max) {
+        chatmsg = JSON.stringify({
+          template: {
+            id: 'co1',
+            props: [{ name: 'text', value: 'Trop de PE répartis' }],
+          },
+        });
+      }
+      setAttrs({ PEV_max: pev_max, chatmsg: chatmsg });
     }
   );
 }
@@ -5738,10 +6040,12 @@ on(
       function (values) {
         const vr = `${values.repeating_jetcapas_jetcapavoieno}${values.repeating_jetcapas_jetcapavoierang}`;
         if (vr.length !== 4) return;
-        getAttrs([vr.replace('v', 'voie').replace('r', '-')], function (value) {
-          const rankData = value[Object.keys(value)[0]].split('\n');
-          const rankName = rankData.shift();
-          const rankDesc = rankData.length > 0 ? rankData.join('\n') : '';
+        const rankData = [];
+        rankData.push(vr.replace('v', 'voie').replace('r', '-t'));
+        rankData.push(vr.replace('v', 'voie').replace('r', '-'));
+        getAttrs(rankData, function (values) {
+          const rankName = values[Object.keys(values)[0]];
+          const rankDesc = values[Object.keys(values)[1]];
           const updated = {
             repeating_jetcapas_jetcapanom: rankName,
             repeating_jetcapas_jetcapadesc: rankDesc,
@@ -6074,14 +6378,14 @@ function rebuildModAtkDM(section, buffAttr) {
           updateMatchBuffs(modNom, modOn);
         }
       );
-      getSectionIDs('repeating_armes', function (ids) {
-        const attrs = {};
-        for (const id of ids) {
-          attrs[`repeating_armes_${id}_${buffAttr}`] = armebuff;
-        }
-        setAttrs(attrs, { silent: true });
-      });
     }
+    getSectionIDs('repeating_armes', function (ids) {
+      const attrs = {};
+      for (const id of ids) {
+        attrs[`repeating_armes_${id}_${buffAttr}`] = armebuff;
+      }
+      setAttrs(attrs, { silent: true });
+    });
   });
 }
 

--- a/ChroniquesGalactiques/sheet.json
+++ b/ChroniquesGalactiques/sheet.json
@@ -1,13 +1,9 @@
 {
-  "html": "cog.html",
-  "css": "cog.css",
-  "authors": "Natha, StÃ©phane D and Ulti",
-  "roll20userid": [
-    "75857",
-    "84776",
-    "1794854"
-  ],
-  "preview": "cog_v3.png",
-  "instructions": "Feuille de Personnage (incluant quelques jets) pour Chroniques Galactiques (Chroniques Oubli&eacute;es Science-Fiction) paru dans le magazine Casus Belli 17,18 et 19 (http://www.black-book-editions.fr/catalogue.php?id=207). Version 3.113 (07/03/2021). [Lisez-moi](https://github.com/Roll20/roll20-character-sheets/blob/master/ChroniquesGalactiques/ReadMe.md).",
-  "legacy": true
+	"html": "cog.html",
+	"css": "cog.css",
+	"authors": "StéphaneD",
+	"roll20userid": "84776",
+	"preview": "cog_v3.png",
+	"instructions": "Feuille de Personnage (incluant quelques jets) pour Chroniques Galactiques (Chroniques Oubli&eacute;es Science-Fiction) paru dans le magazine Casus Belli 17,18 et 19 (http://www.black-book-editions.fr/catalogue.php?id=207). Version 3.114 (12/04/2021). [Lisez-moi](https://github.com/Roll20/roll20-character-sheets/blob/master/ChroniquesGalactiques/ReadMe.md).",
+	"legacy": true
 }


### PR DESCRIPTION
## Changes / Comments

This is basically a retrofit of the changes/enhancements made to ChroniquesOublieesContemporain Version 3.9, namely : 
- Added a title field for each ability (attributes @{voieN-tR} where N = skill path number and R = rank)
  - Sheet worker to migrate from older versions : first row in the ability textual description is assumed to be the title
  - Support for the new attribute in all related functions (binding an ability roll to a skill+rank)
- Corrected a bug occuring after removing the one and only attack or damage modifier from the repeating section (the removed modifier is not taken into account anymore in the attack rolls).

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
