### PR TITLE
[Das_Schwarze_Auge_4-1] Hotfix: Auto-calculating fields restored

### DIFF
--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -12630,6 +12630,23 @@
             </label>
             <br>
         </div>
+		<div class="sheet-hide">
+			<!-- Comfort Attributes (= to shorten rolls) -->
+			AT-Wert aus aktiver Waffe (bei Wahl mehrerer aktiver Waffen wird addiert!)
+			<!-- Berechnung AT Wert -->
+			<!-- <input type="number" name="attr_AT_Aktiv" disabled="disabled" value="((@{AT_NKW1}) * @{NKW_Aktiv1}) + ((@{AT_NKW2}) * @{NKW_Aktiv2}) + ((@{AT_NKW3}) * @{NKW_Aktiv3}) + ((@{AT_NKW4}) * @{NKW_Aktiv4})"> -->
+
+			Anzahl an W6 aus aktiver Waffe (bei Wahl mehrerer aktiver Waffen wird addiert!)
+			<input type="number" name="attr_TP_W_Aktiv" disabled="disabled" value="@{NKW_Aktiv1} * @{NKWschaden1_1} + @{NKW_Aktiv2} * @{NKWschaden2_1} + @{NKW_Aktiv3} * @{NKWschaden3_1} + @{NKW_Aktiv4} * @{NKWschaden4_1}">
+
+			Schadensbonus aus aktiver Waffe inkl. TP/KK (bei Wahl mehrerer aktiver Waffen wird addiert!)
+			<input type="number" name="attr_TP_Bonus_Aktiv" disabled="disabled" value="@{NKW_Aktiv1} * (@{NKWschaden1_2} + @{NKW1_SB}) + @{NKW_Aktiv2} * (@{NKWschaden2_2} + @{NKW2_SB}) + @{NKW_Aktiv3} * (@{NKWschaden3_2} + @{NKW3_SB}) + @{NKW_Aktiv4} * (@{NKWschaden4_2} + @{NKW4_SB})">
+
+			<!-- Wird jetzt mittels Sheet Worker berechnet <input type="number" name="attr_PA_Aktiv" disabled="disabled" value="((@{PA_NKW1}) * @{NKW_Aktiv1}) + ((@{PA_NKW2}) * @{NKW_Aktiv2}) + ((@{PA_NKW3}) * @{NKW_Aktiv3}) + ((@{PA_NKW4}) * @{NKW_Aktiv4})">-->
+
+			Ausweichen-Wert für den Kampf (quasi deaktiviert im Zuge der Umstellung auf das WdS-System zum Ausweichen)
+			<input type="number" name="attr_Ausweichen_Kampf" disabled="disabled" value="@{PABasis} - @{BE_TaW}">
+		</div>
     </div>
     
     <div class="sheet-section sheet-section-info" align="center">

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -12772,7 +12772,7 @@
     </div>
 
 
-    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20210413"><input type="hidden" class="sheet-stat-immutable sheet-stat-immutable-version" readonly="readonly" name="attr_data_version" value=""></b>
+    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20210415"><input type="hidden" class="sheet-stat-immutable sheet-stat-immutable-version" readonly="readonly" name="attr_data_version" value=""></b>
     </table>
 </div>
 

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -12661,6 +12661,10 @@
             <input type="text" class="sheet-selectable-text" style="width: 45em" value="https://www.youtube.com/watch?v=l2SCwz51T9g&list=PLGBXxa8pcNCqzNe4CrKvy-_QgjfgLDOZ-" />
         </p>
 
+        <h4>Updates auf Versio 20210415</h4>
+        <p>Beim letzten Update habe ich versehentlich einen sehr ärgerlichen Fehler eingebaut, der verhindert hat, dass der TP-Würfel-Knopf von Nahkampfwaffen funktioniert. Mit dieser Version wurde dies behoben.</p>
+        <p><strong>Hinweis:</strong> Wer einen der Workarounds benutzt hat, sollte die im Zuge dessen angelegten Attribute &bdquo;TP_W_Aktiv&ldquo; und &bdquo;TP_Bonus_Aktiv&ldquo; wieder löschen. Mehr Infos dazu gibt es in einem Video.</p>
+
         <h4>Updates auf Versionen 20200809 und 20210413</h4>
         <p>Es werden zwar gewisse Migrationen durchgeführt, dabei aber keine größeren Umstellungen vorgenommen. Daher gibt es hier auch keine alten Daten, die möglicherweise gerettet werden müssten. :)</p>
 


### PR DESCRIPTION
This contains a fix for an annoying issue commit d895e6b3cbab509114418df2ee7503d5da6becee caused. Two attributes were still stored in auto-calculating fields, but I thought they had long phased out of use. I was wrong and I did not test this. Shame on me, but at least here's the fix. Please apply and push to production asap.

## Changes / Comments

* **Fixes**
  * Restore auto-calculating fields for attributes 'TP_W_Aktiv' and 'TP_Bonus_Aktiv'

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
