### PR TITLE
[Ironsworn] [Fix] Vow Mark Progress

### DIFF
--- a/Ironsworn/Ironsworn.html
+++ b/Ironsworn/Ironsworn.html
@@ -6095,7 +6095,7 @@
                                   <div class="move-description">
                                     <p data-i18n="move-content-face-danger-1">When <strong>you attempt something risky or react to an imminent threat,</strong> envision your action and roll. If you act...</p>
                                     <ul>
-                                      <li data-i18n="move-list-face-danger-1-1">With speed, agility, or precision: Roll +edge.`</li>
+                                      <li data-i18n="move-list-face-danger-1-1">With speed, agility, or precision: Roll +edge.</li>
                                       <li data-i18n="move-list-face-danger-1-2">With charm, loyalty, or courage: Roll +heart.</li>
                                       <li data-i18n="move-list-face-danger-1-3">With aggressive action, forceful defense, strength, or endurance: Roll +iron.</li>
                                       <li data-i18n="move-list-face-danger-1-4">With deception, stealth, or trickery: Roll +shadow.</li>
@@ -27655,7 +27655,7 @@ on('change:close_changelog', function() {
     'changelog_2.2.1': 'on',
   });
 });
-  const progressStrings = [
+  const stdProgress = [
   'one',
   'two',
   'three',
@@ -27668,13 +27668,26 @@ on('change:close_changelog', function() {
   'ten'
 ]
 
+const vowProgress = [
+  '0',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9'
+]
+
 function getCurrentProgress (progressValues) {
   let total = 0
   progressValues.map(x =>{ total = x + total })
   return total
 }
 
-function updateProgressValues (newValue) {
+function updateProgressValues (newValue, progressStrings) {
   let progressNumber = 0
   for (; newValue > 0;) {
     let updateValue = (newValue < 4) ? newValue : 4
@@ -27687,10 +27700,10 @@ function updateProgressValues (newValue) {
   }
 }
 
-function updateProgress (mark, progressArray) {
+function updateProgress (mark, progressArray, progressStrings) {
   let newValue = mark + getCurrentProgress(progressArray)
   let finalValue = (newValue < 40) ? newValue : 40
-  updateProgressValues(finalValue)
+  updateProgressValues(finalValue, progressStrings)
 }
 
 function chosenDifficulty (rank) {
@@ -27712,6 +27725,8 @@ function chosenDifficulty (rank) {
 
 on('change:repeating_progress:mark_progress change:repeating_vow:mark_progress change:repeating_sites:mark_progress', function(values) {
   const type = values.sourceAttribute.match(/repeating_(.*?)_/)[1]
+  const progressStrings = type === 'vow' ? vowProgress : stdProgress
+
   getAttrs([
     `repeating_${type}_rank`,
     `repeating_${type}_progress_${progressStrings[0]}`,
@@ -27740,12 +27755,14 @@ on('change:repeating_progress:mark_progress change:repeating_vow:mark_progress c
     ]
     const rank = parseInt(attrValues[`repeating_${type}_rank`])
     const mark = chosenDifficulty(rank)
-    updateProgress(mark, progress)
+    updateProgress(mark, progress, progressStrings)
   });
 });
 
 on('change:repeating_progress:clear_progress change:repeating_vow:clear_progress change:repeating_sites:clear_progress', function(values) {
   const type = values.sourceAttribute.match(/repeating_(.*?)_/)[1]
+  const progressStrings = type === 'vow' ? vowProgress : stdProgress
+
   setAttrs({ 
     ['repeating_' + type + '_progress_' + progressStrings[0]]: '0',
     ['repeating_' + type + '_progress_' + progressStrings[1]]: '0',

--- a/Ironsworn/src/app/workers/scripts/progress.js
+++ b/Ironsworn/src/app/workers/scripts/progress.js
@@ -1,4 +1,4 @@
-const progressStrings = [
+const stdProgress = [
   'one',
   'two',
   'three',
@@ -11,13 +11,26 @@ const progressStrings = [
   'ten'
 ]
 
+const vowProgress = [
+  '0',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9'
+]
+
 function getCurrentProgress (progressValues) {
   let total = 0
   progressValues.map(x =>{ total = x + total })
   return total
 }
 
-function updateProgressValues (newValue) {
+function updateProgressValues (newValue, progressStrings) {
   let progressNumber = 0
   for (; newValue > 0;) {
     let updateValue = (newValue < 4) ? newValue : 4
@@ -30,10 +43,10 @@ function updateProgressValues (newValue) {
   }
 }
 
-function updateProgress (mark, progressArray) {
+function updateProgress (mark, progressArray, progressStrings) {
   let newValue = mark + getCurrentProgress(progressArray)
   let finalValue = (newValue < 40) ? newValue : 40
-  updateProgressValues(finalValue)
+  updateProgressValues(finalValue, progressStrings)
 }
 
 function chosenDifficulty (rank) {
@@ -55,6 +68,8 @@ function chosenDifficulty (rank) {
 
 on('change:repeating_progress:mark_progress change:repeating_vow:mark_progress change:repeating_sites:mark_progress', function(values) {
   const type = values.sourceAttribute.match(/repeating_(.*?)_/)[1]
+  const progressStrings = type === 'vow' ? vowProgress : stdProgress
+
   getAttrs([
     `repeating_${type}_rank`,
     `repeating_${type}_progress_${progressStrings[0]}`,
@@ -83,12 +98,14 @@ on('change:repeating_progress:mark_progress change:repeating_vow:mark_progress c
     ]
     const rank = parseInt(attrValues[`repeating_${type}_rank`])
     const mark = chosenDifficulty(rank)
-    updateProgress(mark, progress)
+    updateProgress(mark, progress, progressStrings)
   });
 });
 
 on('change:repeating_progress:clear_progress change:repeating_vow:clear_progress change:repeating_sites:clear_progress', function(values) {
   const type = values.sourceAttribute.match(/repeating_(.*?)_/)[1]
+  const progressStrings = type === 'vow' ? vowProgress : stdProgress
+
   setAttrs({ 
     ['repeating_' + type + '_progress_' + progressStrings[0]]: '0',
     ['repeating_' + type + '_progress_' + progressStrings[1]]: '0',


### PR DESCRIPTION
## Changes / Comments
### Overview
Added a fix for repeating vow mark progress. This was broken when using the `progressStrings` const.
Also added a small fix for grave accents in the base template.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
