### PR TITLE
[Shadows of Esteren] Fix Base Speed Calculation

### DIFF
--- a/Shadows of Esteren/ShadowsOfEsteren.html
+++ b/Shadows of Esteren/ShadowsOfEsteren.html
@@ -412,7 +412,7 @@
 	+ Bonus: <input class="sheet-skill-on" type="number" name="attr_DefenseBonus" value="0"/>
 	= <input class="sheet-skill-off" type="number" name="attr_DefenseSum" value="@{Defense}+@{DefenseBonus}" disabled="true"/>
 	<div class="sheet-header">Speed</div>
-	Base: <input class="sheet-skill-off" type="number" name="attr_Speed" value="@{Combativeness}+@{Empathy}+5+(@{Penalty})" disabled="true"/>
+	Base: <input class="sheet-skill-off" type="number" name="attr_Speed" value="@{Combativeness}+@{Empathy}+(@{Penalty})" disabled="true"/>
 	+ Bonus: <input class="sheet-skill-on" type="number" name="attr_SpeedBonus" value="0"/>
 	= <input class="sheet-skill-off" type="number" name="attr_SpeedSum" value="@{Speed}+@{SpeedBonus}" disabled="true"/>
 	<div class="sheet-header">Armor</div>


### PR DESCRIPTION
## Changes / Comments
The base speed is calculated incorrectly on the Shadows of Esteren Character sheet.
Rule book page 215 states: 
```
To know the initial Speed rating of a Character,
make the following addition: Way of
Combativeness + Way of Empathy
```

This looks like it might be a simple copy/paste issue where line 411 was copied here and Combativeness was changed, but the +5 was left in. There should be no +5 to Speed base. 


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [Y] Does the pull request title have the sheet name(s)? Include each sheet name.
- [Y] Is this a bug fix?
- [N] Does this add functional enhancements (new features or extending existing features) ?
- [N] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [N/A] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [N/A] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
