### PR TITLE
[SLA Industries 2ed] Fixes Unarmed Weapons

### DIFF
--- a/SLA Industries 2ed/sla.html
+++ b/SLA Industries 2ed/sla.html
@@ -294,9 +294,9 @@
 	<button name="roll_skillreroll" class="hidden" type="roll" value="&{template:skillreroll} {{name=@{rollname}}}{{skill=[[{[[@{skilldice}+1]]d10+@{skilltotal}+@{skillmod}}>@{skilltarget}]]}}">
 	<button name="roll_reroll" class="hidden" type="roll" value="&{template:reroll} {{name=@{rollname}}}{{success=[[{1d10+@{skilltotal}+@{successmod}}>@{skilltarget}]]}}{{skill=[[{[[@{skilldice}+1]]d10+@{skilltotal}+@{skillmod}}>@{skilltarget}]]}}">
 -->
-	<button name="roll_successreroll" class="hidden" type="roll" value="&{template:successreroll} !?{Target Number|10|9|8|7|6|5|4|11|12|13|14|15|16|17|18} ?{Total Dice Modifier|0|-1|-2|-3|-4|-5|-6|-7|-8|-9|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19} {{success=[[{1d10+?{Total Dice Modifier}}>?{Target Number}]]}}">
-	<button name="roll_skillreroll" class="hidden" type="roll" value="&{template:skillreroll} !?{Target Number|10|9|8|7|6|5|4|11|12|13|14|15|16|17|18} ?{Total Dice Modifier|0|-1|-2|-3|-4|-5|-6|-7|-8|-9|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19} ?{Number of Dice to Reroll|1|2|3|4|5} {{skill=[[{[[?{Number of Dice to Reroll}]]d10+?{Total Dice Modifier}}>?{Target Number}]]}}">
-	<button name="roll_reroll" class="hidden" type="roll" value="&{template:reroll} !?{Target Number|10|9|8|7|6|5|4|11|12|13|14|15|16|17|18} ?{Success Dice Modifier|0|-1|-2|-3|-4|-5|-6|-7|-8|-9|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19} ?{Skill Dice Modifier|0|-1|-2|-3|-4|-5|-6|-7|-8|-9|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19} ?{Number of Skill Dice to Reroll|1|2|3|4|5} {{success=[[{1d10+?{Success Dice Modifier}}>?{Target Number}]]}} {{skill=[[{[[?{Number of Skill Dice to Reroll}]]d10+?{Skill Dice Modifier}}>?{Target Number}]]}}">
+	<button name="roll_successreroll" class="hidden" type="roll" value="&{template:successreroll} !?{Target Number|10|9|8|7|6|5|4|11|12|13|14|15|16|17|18} ?{Total Dice Modifier|0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|-1|-2|-3|-4|-5|-6|-7|-8|-9} {{success=[[{1d10+?{Total Dice Modifier}}>?{Target Number}]]}}">
+	<button name="roll_skillreroll" class="hidden" type="roll" value="&{template:skillreroll} !?{Target Number|10|9|8|7|6|5|4|11|12|13|14|15|16|17|18} ?{Total Dice Modifier|0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|-1|-2|-3|-4|-5|-6|-7|-8|-9} ?{Number of Dice to Reroll|1|2|3|4|5} {{skill=[[{[[?{Number of Dice to Reroll}]]d10+?{Total Dice Modifier}}>?{Target Number}]]}}">
+	<button name="roll_reroll" class="hidden" type="roll" value="&{template:reroll} !?{Target Number|10|9|8|7|6|5|4|11|12|13|14|15|16|17|18} ?{Success Dice Modifier|0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|-1|-2|-3|-4|-5|-6|-7|-8|-9} ?{Skill Dice Modifier|0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|-1|-2|-3|-4|-5|-6|-7|-8|-9} ?{Number of Skill Dice to Reroll|1|2|3|4|5} {{success=[[{1d10+?{Success Dice Modifier}}>?{Target Number}]]}} {{skill=[[{[[?{Number of Skill Dice to Reroll}]]d10+?{Skill Dice Modifier}}>?{Target Number}]]}}">
   </div>
   <div class="sheet-basetitle">BASE</div>
   <div class="sheet-currenttitle">CURRENT</div>
@@ -3936,33 +3936,33 @@ on('change:meleeweapon_1', event => {
 		"Breacher Shield":					{meleeweapon_skill_1: 'ShieldCraft',	meleeweapon_damage_1: '1D10-3',	meleeweapon_mindamage_1: '2',	meleeweapon_armourdamage_1: '0',	meleeweapon_enc_1: '0'},
 		"DPB Gash Fist":					{meleeweapon_skill_1: 'Unarmed',		meleeweapon_damage_1: '1D10-1',	meleeweapon_mindamage_1: '3',	meleeweapon_armourdamage_1: '1',	meleeweapon_enc_1: '1'},
 		"DPB Vibro Sabre":					{meleeweapon_skill_1: 'meleewpn',		meleeweapon_damage_1: '1D10-1',	meleeweapon_mindamage_1: '4',	meleeweapon_armourdamage_1: '1',	meleeweapon_enc_1: '1'},
-		"DPB Flick Scythe":					{meleeweapon_skill_1: 'Polearm',		meleeweapon_damage_1: '1d10+5',	meleeweapon_mindamage_1: '6',	meleeweapon_armourdamage_1: '2',	meleeweapon_enc_1: '3'},
-		"GASH Chain Axe":					{meleeweapon_skill_1: 'Polearm',		meleeweapon_damage_1: '2d10+2',	meleeweapon_mindamage_1: '9',	meleeweapon_armourdamage_1: '4',	meleeweapon_enc_1: '3'},
-		"GASH Clearance Baton":				{meleeweapon_skill_1: 'Polearm',		meleeweapon_damage_1: '1d10+3',	meleeweapon_mindamage_1: '6',	meleeweapon_armourdamage_1: '4',	meleeweapon_enc_1: '3'},
+		"DPB Flick Scythe":					{meleeweapon_skill_1: 'polearm',		meleeweapon_damage_1: '1d10+5',	meleeweapon_mindamage_1: '6',	meleeweapon_armourdamage_1: '2',	meleeweapon_enc_1: '3'},
+		"GASH Chain Axe":					{meleeweapon_skill_1: 'polearm',		meleeweapon_damage_1: '2d10+2',	meleeweapon_mindamage_1: '9',	meleeweapon_armourdamage_1: '4',	meleeweapon_enc_1: '3'},
+		"GASH Clearance Baton":				{meleeweapon_skill_1: 'polearm',		meleeweapon_damage_1: '1d10+3',	meleeweapon_mindamage_1: '6',	meleeweapon_armourdamage_1: '4',	meleeweapon_enc_1: '3'},
 		"GASH Pacifier Baton":				{meleeweapon_skill_1: 'meleewpn',		meleeweapon_damage_1: '1d10-2',	meleeweapon_mindamage_1: '2',	meleeweapon_armourdamage_1: '3',	meleeweapon_enc_1: '1'},
 		"ITB Mutilator Fist":				{meleeweapon_skill_1: 'Unarmed',		meleeweapon_damage_1: '1d10',	meleeweapon_mindamage_1: '4',	meleeweapon_armourdamage_1: '3',	meleeweapon_enc_1: '1'},
 		"MAC Knife":						{meleeweapon_skill_1: 'meleewpn',		meleeweapon_damage_1: '1d10-3',	meleeweapon_mindamage_1: '2',	meleeweapon_armourdamage_1: '1',	meleeweapon_enc_1: '1'},
 		"MJL Power Claymore 300":			{meleeweapon_skill_1: 'meleewpn',		meleeweapon_damage_1: '2d10-3',	meleeweapon_mindamage_1: '7',	meleeweapon_armourdamage_1: '2',	meleeweapon_enc_1: '3'},
-		"Punch/Kick":						{meleeweapon_skill_1: 'Unarmed',		meleeweapon_damage_1: '0',		meleeweapon_mindamage_1: '1',	meleeweapon_armourdamage_1: '0',	meleeweapon_enc_1: '0'},
-		"Teeth/Tusks/Claws":				{meleeweapon_skill_1: 'Unarmed',		meleeweapon_damage_1: '0',		meleeweapon_mindamage_1: '2',	meleeweapon_armourdamage_1: '1',	meleeweapon_enc_1: '0'},
-		"Beak":								{meleeweapon_skill_1: 'Unarmed',		meleeweapon_damage_1: '3',		meleeweapon_mindamage_1: '2',	meleeweapon_armourdamage_1: '0',	meleeweapon_enc_1: '0'},
-		"Mandibles":						{meleeweapon_skill_1: 'Unarmed',		meleeweapon_damage_1: '1',		meleeweapon_mindamage_1: '2',	meleeweapon_armourdamage_1: '2',	meleeweapon_enc_1: '0'},
-		"Ebb Enhance: Teeth/Claws":			{meleeweapon_skill_1: 'Unarmed',		meleeweapon_damage_1: '3',		meleeweapon_mindamage_1: '5',	meleeweapon_armourdamage_1: '2',	meleeweapon_enc_1: '0'},
-		"Ebb Enhance: Razor Teeth/Claws":	{meleeweapon_skill_1: 'Unarmed',		meleeweapon_damage_1: '6',		meleeweapon_mindamage_1: '8',	meleeweapon_armourdamage_1: '3',	meleeweapon_enc_1: '0'},
+		"Punch/Kick":						{meleeweapon_skill_1: 'Unarmed',		meleeweapon_damage_1: 'STR-2',	meleeweapon_mindamage_1: '1',	meleeweapon_armourdamage_1: '0',	meleeweapon_enc_1: '0'},
+		"Teeth/Tusks/Claws":				{meleeweapon_skill_1: 'Unarmed',		meleeweapon_damage_1: 'STR-1',	meleeweapon_mindamage_1: '2',	meleeweapon_armourdamage_1: '1',	meleeweapon_enc_1: '0'},
+		"Beak":								{meleeweapon_skill_1: 'Unarmed',		meleeweapon_damage_1: 'STR-1',	meleeweapon_mindamage_1: '2',	meleeweapon_armourdamage_1: '0',	meleeweapon_enc_1: '0'},
+		"Mandibles":						{meleeweapon_skill_1: 'Unarmed',		meleeweapon_damage_1: 'STR+0',	meleeweapon_mindamage_1: '2',	meleeweapon_armourdamage_1: '2',	meleeweapon_enc_1: '0'},
+		"Ebb Enhance: Teeth/Claws":			{meleeweapon_skill_1: 'Unarmed',		meleeweapon_damage_1: 'STR+2',	meleeweapon_mindamage_1: '5',	meleeweapon_armourdamage_1: '2',	meleeweapon_enc_1: '0'},
+		"Ebb Enhance: Razor Teeth/Claws":	{meleeweapon_skill_1: 'Unarmed',		meleeweapon_damage_1: 'STR+5',	meleeweapon_mindamage_1: '8',	meleeweapon_armourdamage_1: '3',	meleeweapon_enc_1: '0'},
 		"Ebb Blue Thermal: Ice Blade":		{meleeweapon_skill_1: 'meleewpn',		meleeweapon_damage_1: '1d10+1',	meleeweapon_mindamage_1: '4',	meleeweapon_armourdamage_1: '1',	meleeweapon_enc_1: '0'},
 		"Ebb Blue Thermal: Razor Ice Blade":{meleeweapon_skill_1: 'meleewpn',		meleeweapon_damage_1: '2d10-4',	meleeweapon_mindamage_1: '8',	meleeweapon_armourdamage_1: '3',	meleeweapon_enc_1: '0'},
 		"Ebb Red Thermal: Body Blaze":		{meleeweapon_skill_1: 'Unarmed',		meleeweapon_damage_1: '1d10+4',	meleeweapon_mindamage_1: '5',	meleeweapon_armourdamage_1: '2',	meleeweapon_enc_1: '0'},
 		"Ebb Sword":						{meleeweapon_skill_1: 'meleewpn',		meleeweapon_damage_1: '1d10-1',	meleeweapon_mindamage_1: '2',	meleeweapon_armourdamage_1: '3',	meleeweapon_enc_1: '2'},
 		"Featherpoint Rapier":				{meleeweapon_skill_1: 'meleewpn',		meleeweapon_damage_1: '1d10-1',	meleeweapon_mindamage_1: '3',	meleeweapon_armourdamage_1: '1',	meleeweapon_enc_1: '0'},
 		"Shaktar Switchblade":				{meleeweapon_skill_1: 'meleewpn',		meleeweapon_damage_1: '1d10+2',	meleeweapon_mindamage_1: '4',	meleeweapon_armourdamage_1: '1',	meleeweapon_enc_1: '1'},
-		"Stormer Chuckleduster":			{meleeweapon_skill_1: 'meleewpn',		meleeweapon_damage_1: '2d10-4',	meleeweapon_mindamage_1: '8',	meleeweapon_armourdamage_1: '3',	meleeweapon_enc_1: '3'},
+		"Stormer Chuckleduster":			{meleeweapon_skill_1: 'Unarmed',		meleeweapon_damage_1: '2d10-4',	meleeweapon_mindamage_1: '8',	meleeweapon_armourdamage_1: '3',	meleeweapon_enc_1: '3'},
 		"Generic Unpowered Melee Weapon":	{meleeweapon_skill_1: 'meleewpn',		meleeweapon_damage_1: '1d10-4',	meleeweapon_mindamage_1: '1',	meleeweapon_armourdamage_1: '0',	meleeweapon_enc_1: '0'},
-		"Generic Unpowered Polearm":		{meleeweapon_skill_1: 'Polearm',		meleeweapon_damage_1: '1d10-3',	meleeweapon_mindamage_1: '2',	meleeweapon_armourdamage_1: '0',	meleeweapon_enc_1: '0'},
-		"Hockey Axe":						{meleeweapon_skill_1: 'Polearm',		meleeweapon_damage_1: '1d10-1',	meleeweapon_mindamage_1: '4',	meleeweapon_armourdamage_1: '1',	meleeweapon_enc_1: '3'},
-		"Hockey Stick":						{meleeweapon_skill_1: 'Polearm',		meleeweapon_damage_1: '1d10-3',	meleeweapon_mindamage_1: '2',	meleeweapon_armourdamage_1: '0',	meleeweapon_enc_1: '1'},
+		"Generic Unpowered Polearm":		{meleeweapon_skill_1: 'polearm',		meleeweapon_damage_1: '1d10-3',	meleeweapon_mindamage_1: '2',	meleeweapon_armourdamage_1: '0',	meleeweapon_enc_1: '0'},
+		"Hockey Axe":						{meleeweapon_skill_1: 'polearm',		meleeweapon_damage_1: '1d10-1',	meleeweapon_mindamage_1: '4',	meleeweapon_armourdamage_1: '1',	meleeweapon_enc_1: '3'},
+		"Hockey Stick":						{meleeweapon_skill_1: 'polearm',		meleeweapon_damage_1: '1d10-3',	meleeweapon_mindamage_1: '2',	meleeweapon_armourdamage_1: '0',	meleeweapon_enc_1: '1'},
 		"DN1 Cermanic":						{meleeweapon_skill_1: 'meleewpn',		meleeweapon_damage_1: '1d10-3',	meleeweapon_mindamage_1: '1',	meleeweapon_armourdamage_1: '0',	meleeweapon_enc_1: '0'},
 		"DN113 Power Machete":				{meleeweapon_skill_1: 'meleewpn',		meleeweapon_damage_1: '1d10-1',	meleeweapon_mindamage_1: '4',	meleeweapon_armourdamage_1: '1',	meleeweapon_enc_1: '1'},
-		"TT7 Chain Axe":					{meleeweapon_skill_1: 'Polearm',		meleeweapon_damage_1: '1d10+3',	meleeweapon_mindamage_1: '4',	meleeweapon_armourdamage_1: '3',	meleeweapon_enc_1: '0'},
+		"TT7 Chain Axe":					{meleeweapon_skill_1: 'polearm',		meleeweapon_damage_1: '1d10+3',	meleeweapon_mindamage_1: '4',	meleeweapon_armourdamage_1: '3',	meleeweapon_enc_1: '0'},
 		"Electro-Prod":						{meleeweapon_skill_1: 'meleewpn',		meleeweapon_damage_1: '1d10-3',	meleeweapon_mindamage_1: '2',	meleeweapon_armourdamage_1: '0',	meleeweapon_enc_1: '4'},
 		"FOW Staff":						{meleeweapon_skill_1: 'meleewpn',		meleeweapon_damage_1: '1d10-3',	meleeweapon_mindamage_1: '2',	meleeweapon_armourdamage_1: '2',	meleeweapon_enc_1: '1'},
 		"Grappler":							{meleeweapon_skill_1: 'meleewpn',		meleeweapon_damage_1: '1d10-1',	meleeweapon_mindamage_1: '2',	meleeweapon_armourdamage_1: '2',	meleeweapon_enc_1: '1'},
@@ -3970,7 +3970,7 @@ on('change:meleeweapon_1', event => {
 		"Mauler Axe":						{meleeweapon_skill_1: 'meleewpn',		meleeweapon_damage_1: '1d10',	meleeweapon_mindamage_1: '4',	meleeweapon_armourdamage_1: '1',	meleeweapon_enc_1: '1'},
 		"Punch Dagger":						{meleeweapon_skill_1: 'Unarmed',		meleeweapon_damage_1: '1',		meleeweapon_mindamage_1: '0',	meleeweapon_armourdamage_1: '0',	meleeweapon_enc_1: '0'},
 		"Ripper Gauntlet":					{meleeweapon_skill_1: 'Unarmed',		meleeweapon_damage_1: '1d10-1',	meleeweapon_mindamage_1: '3',	meleeweapon_armourdamage_1: '1',	meleeweapon_enc_1: '1'},
-		"Scav Chain Axe":					{meleeweapon_skill_1: 'Polearm',		meleeweapon_damage_1: '2d10+3',	meleeweapon_mindamage_1: '9',	meleeweapon_armourdamage_1: '5',	meleeweapon_enc_1: '4'},
+		"Scav Chain Axe":					{meleeweapon_skill_1: 'polearm',		meleeweapon_damage_1: '2d10+3',	meleeweapon_mindamage_1: '9',	meleeweapon_armourdamage_1: '5',	meleeweapon_enc_1: '4'},
 		"Scav Chainsaw":					{meleeweapon_skill_1: 'meleewpn',		meleeweapon_damage_1: '2d10+5',	meleeweapon_mindamage_1: '10',	meleeweapon_armourdamage_1: '6',	meleeweapon_enc_1: '5'},
 		"Sector Ranger Dagger":				{meleeweapon_skill_1: 'meleewpn',		meleeweapon_damage_1: '1d10-3',	meleeweapon_mindamage_1: '2',	meleeweapon_armourdamage_1: '1',	meleeweapon_enc_1: '1'},
 		"Fake GASH Fist":					{meleeweapon_skill_1: 'Unarmed',		meleeweapon_damage_1: '1d10-2',	meleeweapon_mindamage_1: '3',	meleeweapon_armourdamage_1: '1',	meleeweapon_enc_1: '0'},
@@ -3983,13 +3983,27 @@ on('change:meleeweapon_1', event => {
         if(output) setAttrs(output);
     });
 });
-on("change:meleeweapon_1 change:meleeweapon_skill_1 change:meleeweapon_damage_1 change:meleeweapon_mindamage_1 change:meleeweapon_armourdamage_1 change:strengthdam", function() {
-  getAttrs(["meleeweapon_1","meleeweapon_skill_1","meleeweapon_damage_1","meleeweapon_mindamage_1","meleeweapon_armourdamage_1","strengthdam"], function(values) {
+on("change:meleeweapon_1 change:meleeweapon_skill_1 change:meleeweapon_damage_1 change:meleeweapon_mindamage_1 change:meleeweapon_armourdamage_1 change:strengthdam change:strength", function() {
+  getAttrs(["meleeweapon_1","meleeweapon_skill_1","meleeweapon_damage_1","meleeweapon_mindamage_1","meleeweapon_armourdamage_1","strengthdam","strength"], function(values) {
 	  var strengthdam = parseInt(values["strengthdam"])||0;
       var setweaponname = values["meleeweapon_1"]||"";
       var setweaponskill = values["meleeweapon_skill_1"]||"";
-      var setweapondmg = values["meleeweapon_damage_1"]+"+"+strengthdam||"";
-      var setweaponmindmg = parseInt(values["meleeweapon_mindamage_1"])+strengthdam||0;
+      var setweapondmg = values["meleeweapon_damage_1"]||"";
+      var setweapondam = values["meleeweapon_damage_1"]||"";
+      var setweaponmindmg = parseInt(values["meleeweapon_mindamage_1"])||0;
+	  var strength = values["strength"]||0;
+	  
+	  if (setweapondmg.substring(0,3) == "STR") {
+		setweapondmg = setweapondmg.replace("STR",strength);
+		}
+	  else if (setweaponskill == "Unarmed") {
+		setweapondmg = setweapondmg;
+		setweaponmindmg = setweaponmindmg;
+	  }
+	  else {
+		setweapondmg = setweapondmg+"+"+strengthdam;
+		setweaponmindmg = setweaponmindmg+strengthdam;
+	  };
       var setweaponad = parseInt(values["meleeweapon_armourdamage_1"])||0;
 	  var setweaponroll = "&{template:weapon} !?{Target Number|10|9|8|7|6|5|4|11|12|13|14|15|16|17|18} ?{Success Dice Modifier|0|-1|-2|-3|-4|-5|-6|-7|-8|-9|1|2|3|4|5|6|7|8|9} ?{Skill Dice Modifier|0|-1|-2|-3|-4|-5|-6|-7|-8|-9|1|2|3|4|5|6|7|8|9} {{name="+setweaponname+":"+setweaponskill+"}}{{success=[[{1d10+@{"+setweaponskill+"_total}+?{Success Dice Modifier}}>?{Target Number}]]}}{{skill=[[{[[@{"+setweaponskill+"}+1]]d10+@{"+setweaponskill+"_total}+?{Skill Dice Modifier}}>?{Target Number}]]}}{{damage=[["+setweapondmg+"]]}}{{mindmg=[["+setweaponmindmg+"]]}}{{ad=[["+setweaponad+"]]}}{{successreroll=[Reroll Success](~@{character_name}|successreroll)}}{{skillreroll=[Reroll Skill](~@{character_name}|skillreroll)}}{{reroll=[Reroll](~@{character_name}|reroll)}}";
       setAttrs({
@@ -4003,33 +4017,33 @@ on('change:meleeweapon_2', event => {
 		"Breacher Shield":					{meleeweapon_skill_2: 'ShieldCraft',	meleeweapon_damage_2: '1D10-3',	meleeweapon_mindamage_2: '2',	meleeweapon_armourdamage_2: '0',	meleeweapon_enc_2: '0'},
 		"DPB Gash Fist":					{meleeweapon_skill_2: 'Unarmed',		meleeweapon_damage_2: '1D10-1',	meleeweapon_mindamage_2: '3',	meleeweapon_armourdamage_2: '1',	meleeweapon_enc_2: '1'},
 		"DPB Vibro Sabre":					{meleeweapon_skill_2: 'meleewpn',		meleeweapon_damage_2: '1D10-1',	meleeweapon_mindamage_2: '4',	meleeweapon_armourdamage_2: '1',	meleeweapon_enc_2: '1'},
-		"DPB Flick Scythe":					{meleeweapon_skill_2: 'Polearm',		meleeweapon_damage_2: '1d10+5',	meleeweapon_mindamage_2: '6',	meleeweapon_armourdamage_2: '2',	meleeweapon_enc_2: '3'},
-		"GASH Chain Axe":					{meleeweapon_skill_2: 'Polearm',		meleeweapon_damage_2: '2d10+2',	meleeweapon_mindamage_2: '9',	meleeweapon_armourdamage_2: '4',	meleeweapon_enc_2: '3'},
-		"GASH Clearance Baton":				{meleeweapon_skill_2: 'Polearm',		meleeweapon_damage_2: '1d10+3',	meleeweapon_mindamage_2: '6',	meleeweapon_armourdamage_2: '4',	meleeweapon_enc_2: '3'},
+		"DPB Flick Scythe":					{meleeweapon_skill_2: 'polearm',		meleeweapon_damage_2: '1d10+5',	meleeweapon_mindamage_2: '6',	meleeweapon_armourdamage_2: '2',	meleeweapon_enc_2: '3'},
+		"GASH Chain Axe":					{meleeweapon_skill_2: 'polearm',		meleeweapon_damage_2: '2d10+2',	meleeweapon_mindamage_2: '9',	meleeweapon_armourdamage_2: '4',	meleeweapon_enc_2: '3'},
+		"GASH Clearance Baton":				{meleeweapon_skill_2: 'polearm',		meleeweapon_damage_2: '1d10+3',	meleeweapon_mindamage_2: '6',	meleeweapon_armourdamage_2: '4',	meleeweapon_enc_2: '3'},
 		"GASH Pacifier Baton":				{meleeweapon_skill_2: 'meleewpn',		meleeweapon_damage_2: '1d10-2',	meleeweapon_mindamage_2: '2',	meleeweapon_armourdamage_2: '3',	meleeweapon_enc_2: '1'},
 		"ITB Mutilator Fist":				{meleeweapon_skill_2: 'Unarmed',		meleeweapon_damage_2: '1d10',	meleeweapon_mindamage_2: '4',	meleeweapon_armourdamage_2: '3',	meleeweapon_enc_2: '1'},
 		"MAC Knife":						{meleeweapon_skill_2: 'meleewpn',		meleeweapon_damage_2: '1d10-3',	meleeweapon_mindamage_2: '2',	meleeweapon_armourdamage_2: '1',	meleeweapon_enc_2: '1'},
 		"MJL Power Claymore 300":			{meleeweapon_skill_2: 'meleewpn',		meleeweapon_damage_2: '2d10-3',	meleeweapon_mindamage_2: '7',	meleeweapon_armourdamage_2: '2',	meleeweapon_enc_2: '3'},
-		"Punch/Kick":						{meleeweapon_skill_2: 'Unarmed',		meleeweapon_damage_2: '0',		meleeweapon_mindamage_2: '1',	meleeweapon_armourdamage_2: '0',	meleeweapon_enc_2: '0'},
-		"Teeth/Tusks/Claws":				{meleeweapon_skill_2: 'Unarmed',		meleeweapon_damage_2: '0',		meleeweapon_mindamage_2: '2',	meleeweapon_armourdamage_2: '1',	meleeweapon_enc_2: '0'},
-		"Beak":								{meleeweapon_skill_2: 'Unarmed',		meleeweapon_damage_2: '3',		meleeweapon_mindamage_2: '2',	meleeweapon_armourdamage_2: '0',	meleeweapon_enc_2: '0'},
-		"Mandibles":						{meleeweapon_skill_2: 'Unarmed',		meleeweapon_damage_2: '1',		meleeweapon_mindamage_2: '2',	meleeweapon_armourdamage_2: '2',	meleeweapon_enc_2: '0'},
-		"Ebb Enhance: Teeth/Claws":			{meleeweapon_skill_2: 'Unarmed',		meleeweapon_damage_2: '3',		meleeweapon_mindamage_2: '5',	meleeweapon_armourdamage_2: '2',	meleeweapon_enc_2: '0'},
-		"Ebb Enhance: Razor Teeth/Claws":	{meleeweapon_skill_2: 'Unarmed',		meleeweapon_damage_2: '6',		meleeweapon_mindamage_2: '8',	meleeweapon_armourdamage_2: '3',	meleeweapon_enc_2: '0'},
+		"Punch/Kick":						{meleeweapon_skill_2: 'Unarmed',		meleeweapon_damage_2: 'STR-2',	meleeweapon_mindamage_2: '1',	meleeweapon_armourdamage_2: '0',	meleeweapon_enc_2: '0'},
+		"Teeth/Tusks/Claws":				{meleeweapon_skill_2: 'Unarmed',		meleeweapon_damage_2: 'STR-1',	meleeweapon_mindamage_2: '2',	meleeweapon_armourdamage_2: '1',	meleeweapon_enc_2: '0'},
+		"Beak":								{meleeweapon_skill_2: 'Unarmed',		meleeweapon_damage_2: 'STR-1',	meleeweapon_mindamage_2: '2',	meleeweapon_armourdamage_2: '0',	meleeweapon_enc_2: '0'},
+		"Mandibles":						{meleeweapon_skill_2: 'Unarmed',		meleeweapon_damage_2: 'STR',	meleeweapon_mindamage_2: '2',	meleeweapon_armourdamage_2: '2',	meleeweapon_enc_2: '0'},
+		"Ebb Enhance: Teeth/Claws":			{meleeweapon_skill_2: 'Unarmed',		meleeweapon_damage_2: 'STR+2',	meleeweapon_mindamage_2: '5',	meleeweapon_armourdamage_2: '2',	meleeweapon_enc_2: '0'},
+		"Ebb Enhance: Razor Teeth/Claws":	{meleeweapon_skill_2: 'Unarmed',		meleeweapon_damage_2: 'STR+5',	meleeweapon_mindamage_2: '8',	meleeweapon_armourdamage_2: '3',	meleeweapon_enc_2: '0'},
 		"Ebb Blue Thermal: Ice Blade":		{meleeweapon_skill_2: 'meleewpn',		meleeweapon_damage_2: '1d10+1',	meleeweapon_mindamage_2: '4',	meleeweapon_armourdamage_2: '1',	meleeweapon_enc_2: '0'},
 		"Ebb Blue Thermal: Razor Ice Blade":{meleeweapon_skill_2: 'meleewpn',		meleeweapon_damage_2: '2d10-4',	meleeweapon_mindamage_2: '8',	meleeweapon_armourdamage_2: '3',	meleeweapon_enc_2: '0'},
 		"Ebb Red Thermal: Body Blaze":		{meleeweapon_skill_2: 'Unarmed',		meleeweapon_damage_2: '1d10+4',	meleeweapon_mindamage_2: '5',	meleeweapon_armourdamage_2: '2',	meleeweapon_enc_2: '0'},
 		"Ebb Sword":						{meleeweapon_skill_2: 'meleewpn',		meleeweapon_damage_2: '1d10-1',	meleeweapon_mindamage_2: '2',	meleeweapon_armourdamage_2: '3',	meleeweapon_enc_2: '2'},
 		"Featherpoint Rapier":				{meleeweapon_skill_2: 'meleewpn',		meleeweapon_damage_2: '1d10-1',	meleeweapon_mindamage_2: '3',	meleeweapon_armourdamage_2: '1',	meleeweapon_enc_2: '0'},
 		"Shaktar Switchblade":				{meleeweapon_skill_2: 'meleewpn',		meleeweapon_damage_2: '1d10+2',	meleeweapon_mindamage_2: '4',	meleeweapon_armourdamage_2: '1',	meleeweapon_enc_2: '1'},
-		"Stormer Chuckleduster":			{meleeweapon_skill_2: 'meleewpn',		meleeweapon_damage_2: '2d10-4',	meleeweapon_mindamage_2: '8',	meleeweapon_armourdamage_2: '3',	meleeweapon_enc_2: '3'},
+		"Stormer Chuckleduster":			{meleeweapon_skill_2: 'Unarmed',		meleeweapon_damage_2: '2d10-4',	meleeweapon_mindamage_2: '8',	meleeweapon_armourdamage_2: '3',	meleeweapon_enc_2: '3'},
 		"Generic Unpowered Melee Weapon":	{meleeweapon_skill_2: 'meleewpn',		meleeweapon_damage_2: '1d10-4',	meleeweapon_mindamage_2: '1',	meleeweapon_armourdamage_2: '0',	meleeweapon_enc_2: '0'},
-		"Generic Unpowered Polearm":		{meleeweapon_skill_2: 'Polearm',		meleeweapon_damage_2: '1d10-3',	meleeweapon_mindamage_2: '2',	meleeweapon_armourdamage_2: '0',	meleeweapon_enc_2: '0'},
-		"Hockey Axe":						{meleeweapon_skill_2: 'Polearm',		meleeweapon_damage_2: '1d10-1',	meleeweapon_mindamage_2: '4',	meleeweapon_armourdamage_2: '1',	meleeweapon_enc_2: '3'},
-		"Hockey Stick":						{meleeweapon_skill_2: 'Polearm',		meleeweapon_damage_2: '1d10-3',	meleeweapon_mindamage_2: '2',	meleeweapon_armourdamage_2: '0',	meleeweapon_enc_2: '1'},
+		"Generic Unpowered Polearm":		{meleeweapon_skill_2: 'polearm',		meleeweapon_damage_2: '1d10-3',	meleeweapon_mindamage_2: '2',	meleeweapon_armourdamage_2: '0',	meleeweapon_enc_2: '0'},
+		"Hockey Axe":						{meleeweapon_skill_2: 'polearm',		meleeweapon_damage_2: '1d10-1',	meleeweapon_mindamage_2: '4',	meleeweapon_armourdamage_2: '1',	meleeweapon_enc_2: '3'},
+		"Hockey Stick":						{meleeweapon_skill_2: 'polearm',		meleeweapon_damage_2: '1d10-3',	meleeweapon_mindamage_2: '2',	meleeweapon_armourdamage_2: '0',	meleeweapon_enc_2: '1'},
 		"DN1 Cermanic":						{meleeweapon_skill_2: 'meleewpn',		meleeweapon_damage_2: '1d10-3',	meleeweapon_mindamage_2: '1',	meleeweapon_armourdamage_2: '0',	meleeweapon_enc_2: '0'},
 		"DN113 Power Machete":				{meleeweapon_skill_2: 'meleewpn',		meleeweapon_damage_2: '1d10-1',	meleeweapon_mindamage_2: '4',	meleeweapon_armourdamage_2: '1',	meleeweapon_enc_2: '1'},
-		"TT7 Chain Axe":					{meleeweapon_skill_2: 'Polearm',		meleeweapon_damage_2: '1d10+3',	meleeweapon_mindamage_2: '4',	meleeweapon_armourdamage_2: '3',	meleeweapon_enc_2: '0'},
+		"TT7 Chain Axe":					{meleeweapon_skill_2: 'polearm',		meleeweapon_damage_2: '1d10+3',	meleeweapon_mindamage_2: '4',	meleeweapon_armourdamage_2: '3',	meleeweapon_enc_2: '0'},
 		"Electro-Prod":						{meleeweapon_skill_2: 'meleewpn',		meleeweapon_damage_2: '1d10-3',	meleeweapon_mindamage_2: '2',	meleeweapon_armourdamage_2: '0',	meleeweapon_enc_2: '4'},
 		"FOW Staff":						{meleeweapon_skill_2: 'meleewpn',		meleeweapon_damage_2: '1d10-3',	meleeweapon_mindamage_2: '2',	meleeweapon_armourdamage_2: '2',	meleeweapon_enc_2: '1'},
 		"Grappler":							{meleeweapon_skill_2: 'meleewpn',		meleeweapon_damage_2: '1d10-1',	meleeweapon_mindamage_2: '2',	meleeweapon_armourdamage_2: '2',	meleeweapon_enc_2: '1'},
@@ -4037,7 +4051,7 @@ on('change:meleeweapon_2', event => {
 		"Mauler Axe":						{meleeweapon_skill_2: 'meleewpn',		meleeweapon_damage_2: '1d10',	meleeweapon_mindamage_2: '4',	meleeweapon_armourdamage_2: '1',	meleeweapon_enc_2: '1'},
 		"Punch Dagger":						{meleeweapon_skill_2: 'Unarmed',		meleeweapon_damage_2: '1',		meleeweapon_mindamage_2: '0',	meleeweapon_armourdamage_2: '0',	meleeweapon_enc_2: '0'},
 		"Ripper Gauntlet":					{meleeweapon_skill_2: 'Unarmed',		meleeweapon_damage_2: '1d10-1',	meleeweapon_mindamage_2: '3',	meleeweapon_armourdamage_2: '1',	meleeweapon_enc_2: '1'},
-		"Scav Chain Axe":					{meleeweapon_skill_2: 'Polearm',		meleeweapon_damage_2: '2d10+3',	meleeweapon_mindamage_2: '9',	meleeweapon_armourdamage_2: '5',	meleeweapon_enc_2: '4'},
+		"Scav Chain Axe":					{meleeweapon_skill_2: 'polearm',		meleeweapon_damage_2: '2d10+3',	meleeweapon_mindamage_2: '9',	meleeweapon_armourdamage_2: '5',	meleeweapon_enc_2: '4'},
 		"Scav Chainsaw":					{meleeweapon_skill_2: 'meleewpn',		meleeweapon_damage_2: '2d10+5',	meleeweapon_mindamage_2: '10',	meleeweapon_armourdamage_2: '6',	meleeweapon_enc_2: '5'},
 		"Sector Ranger Dagger":				{meleeweapon_skill_2: 'meleewpn',		meleeweapon_damage_2: '1d10-3',	meleeweapon_mindamage_2: '2',	meleeweapon_armourdamage_2: '1',	meleeweapon_enc_2: '1'},
 		"Fake GASH Fist":					{meleeweapon_skill_2: 'Unarmed',		meleeweapon_damage_2: '1d10-2',	meleeweapon_mindamage_2: '3',	meleeweapon_armourdamage_2: '1',	meleeweapon_enc_2: '0'},
@@ -4050,14 +4064,27 @@ on('change:meleeweapon_2', event => {
         if(output) setAttrs(output);
     });
 });
-on("change:meleeweapon_2 change:meleeweapon_skill_2 change:meleeweapon_damage_2 change:meleeweapon_mindamage_2 change:meleeweapon_armourdamage_2 change:strengthdam", function() {
-  getAttrs(["meleeweapon_2","meleeweapon_skill_2","meleeweapon_damage_2","meleeweapon_mindamage_2","meleeweapon_armourdamage_2","strengthdam"], function(values) {
+on("change:meleeweapon_2 change:meleeweapon_skill_2 change:meleeweapon_damage_2 change:meleeweapon_mindamage_2 change:meleeweapon_armourdamage_2 change:strengthdam change:strength", function() {
+  getAttrs(["meleeweapon_2","meleeweapon_skill_2","meleeweapon_damage_2","meleeweapon_mindamage_2","meleeweapon_armourdamage_2","strengthdam","strength"], function(values) {
 	  var strengthdam = parseInt(values["strengthdam"])||0;
       var setweaponname = values["meleeweapon_2"]||"";
       var setweaponskill = values["meleeweapon_skill_2"]||"";
-      var setweapondmg = values["meleeweapon_damage_2"]+"+"+strengthdam||"";
-      var setweaponmindmg = parseInt(values["meleeweapon_mindamage_2"])+strengthdam||0;
+      var setweapondmg = values["meleeweapon_damage_2"]||"";
+      var setweaponmindmg = parseInt(values["meleeweapon_mindamage_2"])||0;
       var setweaponad = parseInt(values["meleeweapon_armourdamage_2"])||0;
+	  var strength = values["strength"]||0;
+	  
+	  if (setweapondmg.substring(0,3) == "STR") {
+		setweapondmg = setweapondmg.replace("STR",strength);
+		}
+	  else if (setweaponskill == "Unarmed") {
+		setweapondmg = setweapondmg;
+		setweaponmindmg = setweaponmindmg;
+	  }
+	  else {
+		setweapondmg = setweapondmg+"+"+strengthdam;
+		setweaponmindmg = setweaponmindmg+strengthdam;
+	  };
 	  var setweaponroll = "&{template:weapon} !?{Target Number|10|9|8|7|6|5|4|11|12|13|14|15|16|17|18} ?{Success Dice Modifier|0|-1|-2|-3|-4|-5|-6|-7|-8|-9|1|2|3|4|5|6|7|8|9} ?{Skill Dice Modifier|0|-1|-2|-3|-4|-5|-6|-7|-8|-9|1|2|3|4|5|6|7|8|9} {{name="+setweaponname+":"+setweaponskill+"}}{{success=[[{1d10+@{"+setweaponskill+"_total}+?{Success Dice Modifier}}>?{Target Number}]]}}{{skill=[[{[[@{"+setweaponskill+"}+1]]d10+@{"+setweaponskill+"_total}+?{Skill Dice Modifier}}>?{Target Number}]]}}{{damage=[["+setweapondmg+"]]}}{{mindmg=[["+setweaponmindmg+"]]}}{{ad=[["+setweaponad+"]]}}{{successreroll=[Reroll Success](~@{character_name}|successreroll)}}{{skillreroll=[Reroll Skill](~@{character_name}|skillreroll)}}{{reroll=[Reroll](~@{character_name}|reroll)}}";
       setAttrs({
 		"meleeweapon_roll_2": setweaponroll,
@@ -4070,33 +4097,33 @@ on('change:meleeweapon_3', event => {
 		"Breacher Shield":					{meleeweapon_skill_3: 'ShieldCraft',	meleeweapon_damage_3: '1D10-3',	meleeweapon_mindamage_3: '2',	meleeweapon_armourdamage_3: '0',	meleeweapon_enc_3: '0'},
 		"DPB Gash Fist":					{meleeweapon_skill_3: 'Unarmed',		meleeweapon_damage_3: '1D10-1',	meleeweapon_mindamage_3: '3',	meleeweapon_armourdamage_3: '1',	meleeweapon_enc_3: '1'},
 		"DPB Vibro Sabre":					{meleeweapon_skill_3: 'meleewpn',		meleeweapon_damage_3: '1D10-1',	meleeweapon_mindamage_3: '4',	meleeweapon_armourdamage_3: '1',	meleeweapon_enc_3: '1'},
-		"DPB Flick Scythe":					{meleeweapon_skill_3: 'Polearm',		meleeweapon_damage_3: '1d10+5',	meleeweapon_mindamage_3: '6',	meleeweapon_armourdamage_3: '2',	meleeweapon_enc_3: '3'},
-		"GASH Chain Axe":					{meleeweapon_skill_3: 'Polearm',		meleeweapon_damage_3: '2d10+2',	meleeweapon_mindamage_3: '9',	meleeweapon_armourdamage_3: '4',	meleeweapon_enc_3: '3'},
-		"GASH Clearance Baton":				{meleeweapon_skill_3: 'Polearm',		meleeweapon_damage_3: '1d10+3',	meleeweapon_mindamage_3: '6',	meleeweapon_armourdamage_3: '4',	meleeweapon_enc_3: '3'},
+		"DPB Flick Scythe":					{meleeweapon_skill_3: 'polearm',		meleeweapon_damage_3: '1d10+5',	meleeweapon_mindamage_3: '6',	meleeweapon_armourdamage_3: '2',	meleeweapon_enc_3: '3'},
+		"GASH Chain Axe":					{meleeweapon_skill_3: 'polearm',		meleeweapon_damage_3: '2d10+2',	meleeweapon_mindamage_3: '9',	meleeweapon_armourdamage_3: '4',	meleeweapon_enc_3: '3'},
+		"GASH Clearance Baton":				{meleeweapon_skill_3: 'polearm',		meleeweapon_damage_3: '1d10+3',	meleeweapon_mindamage_3: '6',	meleeweapon_armourdamage_3: '4',	meleeweapon_enc_3: '3'},
 		"GASH Pacifier Baton":				{meleeweapon_skill_3: 'meleewpn',		meleeweapon_damage_3: '1d10-2',	meleeweapon_mindamage_3: '2',	meleeweapon_armourdamage_3: '3',	meleeweapon_enc_3: '1'},
 		"ITB Mutilator Fist":				{meleeweapon_skill_3: 'Unarmed',		meleeweapon_damage_3: '1d10',	meleeweapon_mindamage_3: '4',	meleeweapon_armourdamage_3: '3',	meleeweapon_enc_3: '1'},
 		"MAC Knife":						{meleeweapon_skill_3: 'meleewpn',		meleeweapon_damage_3: '1d10-3',	meleeweapon_mindamage_3: '2',	meleeweapon_armourdamage_3: '1',	meleeweapon_enc_3: '1'},
 		"MJL Power Claymore 300":			{meleeweapon_skill_3: 'meleewpn',		meleeweapon_damage_3: '2d10-3',	meleeweapon_mindamage_3: '7',	meleeweapon_armourdamage_3: '2',	meleeweapon_enc_3: '3'},
-		"Punch/Kick":						{meleeweapon_skill_3: 'Unarmed',		meleeweapon_damage_3: '0',		meleeweapon_mindamage_3: '1',	meleeweapon_armourdamage_3: '0',	meleeweapon_enc_3: '0'},
-		"Teeth/Tusks/Claws":				{meleeweapon_skill_3: 'Unarmed',		meleeweapon_damage_3: '0',		meleeweapon_mindamage_3: '2',	meleeweapon_armourdamage_3: '1',	meleeweapon_enc_3: '0'},
-		"Beak":								{meleeweapon_skill_3: 'Unarmed',		meleeweapon_damage_3: '3',		meleeweapon_mindamage_3: '2',	meleeweapon_armourdamage_3: '0',	meleeweapon_enc_3: '0'},
-		"Mandibles":						{meleeweapon_skill_3: 'Unarmed',		meleeweapon_damage_3: '1',		meleeweapon_mindamage_3: '2',	meleeweapon_armourdamage_3: '2',	meleeweapon_enc_3: '0'},
-		"Ebb Enhance: Teeth/Claws":			{meleeweapon_skill_3: 'Unarmed',		meleeweapon_damage_3: '3',		meleeweapon_mindamage_3: '5',	meleeweapon_armourdamage_3: '2',	meleeweapon_enc_3: '0'},
-		"Ebb Enhance: Razor Teeth/Claws":	{meleeweapon_skill_3: 'Unarmed',		meleeweapon_damage_3: '6',		meleeweapon_mindamage_3: '8',	meleeweapon_armourdamage_3: '3',	meleeweapon_enc_3: '0'},
+		"Punch/Kick":						{meleeweapon_skill_3: 'Unarmed',		meleeweapon_damage_3: 'STR-2',	meleeweapon_mindamage_3: '1',	meleeweapon_armourdamage_3: '0',	meleeweapon_enc_3: '0'},
+		"Teeth/Tusks/Claws":				{meleeweapon_skill_3: 'Unarmed',		meleeweapon_damage_3: 'STR-1',	meleeweapon_mindamage_3: '2',	meleeweapon_armourdamage_3: '1',	meleeweapon_enc_3: '0'},
+		"Beak":								{meleeweapon_skill_3: 'Unarmed',		meleeweapon_damage_3: 'STR-1',	meleeweapon_mindamage_3: '2',	meleeweapon_armourdamage_3: '0',	meleeweapon_enc_3: '0'},
+		"Mandibles":						{meleeweapon_skill_3: 'Unarmed',		meleeweapon_damage_3: 'STR',	meleeweapon_mindamage_3: '2',	meleeweapon_armourdamage_3: '2',	meleeweapon_enc_3: '0'},
+		"Ebb Enhance: Teeth/Claws":			{meleeweapon_skill_3: 'Unarmed',		meleeweapon_damage_3: 'STR+2',	meleeweapon_mindamage_3: '5',	meleeweapon_armourdamage_3: '2',	meleeweapon_enc_3: '0'},
+		"Ebb Enhance: Razor Teeth/Claws":	{meleeweapon_skill_3: 'Unarmed',		meleeweapon_damage_3: 'STR+5',	meleeweapon_mindamage_3: '8',	meleeweapon_armourdamage_3: '3',	meleeweapon_enc_3: '0'},
 		"Ebb Blue Thermal: Ice Blade":		{meleeweapon_skill_3: 'meleewpn',		meleeweapon_damage_3: '1d10+1',	meleeweapon_mindamage_3: '4',	meleeweapon_armourdamage_3: '1',	meleeweapon_enc_3: '0'},
 		"Ebb Blue Thermal: Razor Ice Blade":{meleeweapon_skill_3: 'meleewpn',		meleeweapon_damage_3: '2d10-4',	meleeweapon_mindamage_3: '8',	meleeweapon_armourdamage_3: '3',	meleeweapon_enc_3: '0'},
 		"Ebb Red Thermal: Body Blaze":		{meleeweapon_skill_3: 'Unarmed',		meleeweapon_damage_3: '1d10+4',	meleeweapon_mindamage_3: '5',	meleeweapon_armourdamage_3: '2',	meleeweapon_enc_3: '0'},
 		"Ebb Sword":						{meleeweapon_skill_3: 'meleewpn',		meleeweapon_damage_3: '1d10-1',	meleeweapon_mindamage_3: '2',	meleeweapon_armourdamage_3: '3',	meleeweapon_enc_3: '2'},
 		"Featherpoint Rapier":				{meleeweapon_skill_3: 'meleewpn',		meleeweapon_damage_3: '1d10-1',	meleeweapon_mindamage_3: '3',	meleeweapon_armourdamage_3: '1',	meleeweapon_enc_3: '0'},
 		"Shaktar Switchblade":				{meleeweapon_skill_3: 'meleewpn',		meleeweapon_damage_3: '1d10+2',	meleeweapon_mindamage_3: '4',	meleeweapon_armourdamage_3: '1',	meleeweapon_enc_3: '1'},
-		"Stormer Chuckleduster":			{meleeweapon_skill_3: 'meleewpn',		meleeweapon_damage_3: '2d10-4',	meleeweapon_mindamage_3: '8',	meleeweapon_armourdamage_3: '3',	meleeweapon_enc_3: '3'},
+		"Stormer Chuckleduster":			{meleeweapon_skill_3: 'Unarmed',		meleeweapon_damage_3: '2d10-4',	meleeweapon_mindamage_3: '8',	meleeweapon_armourdamage_3: '3',	meleeweapon_enc_3: '3'},
 		"Generic Unpowered Melee Weapon":	{meleeweapon_skill_3: 'meleewpn',		meleeweapon_damage_3: '1d10-4',	meleeweapon_mindamage_3: '1',	meleeweapon_armourdamage_3: '0',	meleeweapon_enc_3: '0'},
-		"Generic Unpowered Polearm":		{meleeweapon_skill_3: 'Polearm',		meleeweapon_damage_3: '1d10-3',	meleeweapon_mindamage_3: '2',	meleeweapon_armourdamage_3: '0',	meleeweapon_enc_3: '0'},
-		"Hockey Axe":						{meleeweapon_skill_3: 'Polearm',		meleeweapon_damage_3: '1d10-1',	meleeweapon_mindamage_3: '4',	meleeweapon_armourdamage_3: '1',	meleeweapon_enc_3: '3'},
-		"Hockey Stick":						{meleeweapon_skill_3: 'Polearm',		meleeweapon_damage_3: '1d10-3',	meleeweapon_mindamage_3: '2',	meleeweapon_armourdamage_3: '0',	meleeweapon_enc_3: '1'},
+		"Generic Unpowered Polearm":		{meleeweapon_skill_3: 'polearm',		meleeweapon_damage_3: '1d10-3',	meleeweapon_mindamage_3: '2',	meleeweapon_armourdamage_3: '0',	meleeweapon_enc_3: '0'},
+		"Hockey Axe":						{meleeweapon_skill_3: 'polearm',		meleeweapon_damage_3: '1d10-1',	meleeweapon_mindamage_3: '4',	meleeweapon_armourdamage_3: '1',	meleeweapon_enc_3: '3'},
+		"Hockey Stick":						{meleeweapon_skill_3: 'polearm',		meleeweapon_damage_3: '1d10-3',	meleeweapon_mindamage_3: '2',	meleeweapon_armourdamage_3: '0',	meleeweapon_enc_3: '1'},
 		"DN1 Cermanic":						{meleeweapon_skill_3: 'meleewpn',		meleeweapon_damage_3: '1d10-3',	meleeweapon_mindamage_3: '1',	meleeweapon_armourdamage_3: '0',	meleeweapon_enc_3: '0'},
 		"DN113 Power Machete":				{meleeweapon_skill_3: 'meleewpn',		meleeweapon_damage_3: '1d10-1',	meleeweapon_mindamage_3: '4',	meleeweapon_armourdamage_3: '1',	meleeweapon_enc_3: '1'},
-		"TT7 Chain Axe":					{meleeweapon_skill_3: 'Polearm',		meleeweapon_damage_3: '1d10+3',	meleeweapon_mindamage_3: '4',	meleeweapon_armourdamage_3: '3',	meleeweapon_enc_3: '0'},
+		"TT7 Chain Axe":					{meleeweapon_skill_3: 'polearm',		meleeweapon_damage_3: '1d10+3',	meleeweapon_mindamage_3: '4',	meleeweapon_armourdamage_3: '3',	meleeweapon_enc_3: '0'},
 		"Electro-Prod":						{meleeweapon_skill_3: 'meleewpn',		meleeweapon_damage_3: '1d10-3',	meleeweapon_mindamage_3: '2',	meleeweapon_armourdamage_3: '0',	meleeweapon_enc_3: '4'},
 		"FOW Staff":						{meleeweapon_skill_3: 'meleewpn',		meleeweapon_damage_3: '1d10-3',	meleeweapon_mindamage_3: '2',	meleeweapon_armourdamage_3: '2',	meleeweapon_enc_3: '1'},
 		"Grappler":							{meleeweapon_skill_3: 'meleewpn',		meleeweapon_damage_3: '1d10-1',	meleeweapon_mindamage_3: '2',	meleeweapon_armourdamage_3: '2',	meleeweapon_enc_3: '1'},
@@ -4104,7 +4131,7 @@ on('change:meleeweapon_3', event => {
 		"Mauler Axe":						{meleeweapon_skill_3: 'meleewpn',		meleeweapon_damage_3: '1d10',	meleeweapon_mindamage_3: '4',	meleeweapon_armourdamage_3: '1',	meleeweapon_enc_3: '1'},
 		"Punch Dagger":						{meleeweapon_skill_3: 'Unarmed',		meleeweapon_damage_3: '1',		meleeweapon_mindamage_3: '0',	meleeweapon_armourdamage_3: '0',	meleeweapon_enc_3: '0'},
 		"Ripper Gauntlet":					{meleeweapon_skill_3: 'Unarmed',		meleeweapon_damage_3: '1d10-1',	meleeweapon_mindamage_3: '3',	meleeweapon_armourdamage_3: '1',	meleeweapon_enc_3: '1'},
-		"Scav Chain Axe":					{meleeweapon_skill_3: 'Polearm',		meleeweapon_damage_3: '2d10+3',	meleeweapon_mindamage_3: '9',	meleeweapon_armourdamage_3: '5',	meleeweapon_enc_3: '4'},
+		"Scav Chain Axe":					{meleeweapon_skill_3: 'polearm',		meleeweapon_damage_3: '2d10+3',	meleeweapon_mindamage_3: '9',	meleeweapon_armourdamage_3: '5',	meleeweapon_enc_3: '4'},
 		"Scav Chainsaw":					{meleeweapon_skill_3: 'meleewpn',		meleeweapon_damage_3: '2d10+5',	meleeweapon_mindamage_3: '10',	meleeweapon_armourdamage_3: '6',	meleeweapon_enc_3: '5'},
 		"Sector Ranger Dagger":				{meleeweapon_skill_3: 'meleewpn',		meleeweapon_damage_3: '1d10-3',	meleeweapon_mindamage_3: '2',	meleeweapon_armourdamage_3: '1',	meleeweapon_enc_3: '1'},
 		"Fake GASH Fist":					{meleeweapon_skill_3: 'Unarmed',		meleeweapon_damage_3: '1d10-2',	meleeweapon_mindamage_3: '3',	meleeweapon_armourdamage_3: '1',	meleeweapon_enc_3: '0'},
@@ -4117,14 +4144,27 @@ on('change:meleeweapon_3', event => {
         if(output) setAttrs(output);
     });
 });
-on("change:meleeweapon_3 change:meleeweapon_skill_3 change:meleeweapon_damage_3 change:meleeweapon_mindamage_3 change:meleeweapon_armourdamage_3 change:strengthdam", function() {
-  getAttrs(["meleeweapon_3","meleeweapon_skill_3","meleeweapon_damage_3","meleeweapon_mindamage_3","meleeweapon_armourdamage_3","strengthdam"], function(values) {
+on("change:meleeweapon_3 change:meleeweapon_skill_3 change:meleeweapon_damage_3 change:meleeweapon_mindamage_3 change:meleeweapon_armourdamage_3 change:strengthdam change:strength", function() {
+  getAttrs(["meleeweapon_3","meleeweapon_skill_3","meleeweapon_damage_3","meleeweapon_mindamage_3","meleeweapon_armourdamage_3","strengthdam","strength"], function(values) {
 	  var strengthdam = parseInt(values["strengthdam"])||0;
       var setweaponname = values["meleeweapon_3"]||"";
       var setweaponskill = values["meleeweapon_skill_3"]||"";
-      var setweapondmg = values["meleeweapon_damage_3"]+"+"+strengthdam||"";
-      var setweaponmindmg = parseInt(values["meleeweapon_mindamage_3"])+strengthdam||0;
+      var setweapondmg = values["meleeweapon_damage_3"]||"";
+      var setweaponmindmg = parseInt(values["meleeweapon_mindamage_3"])||0;
       var setweaponad = parseInt(values["meleeweapon_armourdamage_3"])||0;
+	  var strength = values["strength"]||0;
+	  
+	  if (setweapondmg.substring(0,3) == "STR") {
+		setweapondmg = setweapondmg.replace("STR",strength);
+		}
+	  else if (setweaponskill == "Unarmed") {
+		setweapondmg = setweapondmg;
+		setweaponmindmg = setweaponmindmg;
+	  }
+	  else {
+		setweapondmg = setweapondmg+"+"+strengthdam;
+		setweaponmindmg = setweaponmindmg+strengthdam;
+	  };
 	  var setweaponroll = "&{template:weapon} !?{Target Number|10|9|8|7|6|5|4|11|12|13|14|15|16|17|18} ?{Success Dice Modifier|0|-1|-2|-3|-4|-5|-6|-7|-8|-9|1|2|3|4|5|6|7|8|9} ?{Skill Dice Modifier|0|-1|-2|-3|-4|-5|-6|-7|-8|-9|1|2|3|4|5|6|7|8|9} {{name="+setweaponname+":"+setweaponskill+"}}{{success=[[{1d10+@{"+setweaponskill+"_total}+?{Success Dice Modifier}}>?{Target Number}]]}}{{skill=[[{[[@{"+setweaponskill+"}+1]]d10+@{"+setweaponskill+"_total}+?{Skill Dice Modifier}}>?{Target Number}]]}}{{damage=[["+setweapondmg+"]]}}{{mindmg=[["+setweaponmindmg+"]]}}{{ad=[["+setweaponad+"]]}}{{successreroll=[Reroll Success](~@{character_name}|successreroll)}}{{skillreroll=[Reroll Skill](~@{character_name}|skillreroll)}}{{reroll=[Reroll](~@{character_name}|reroll)}}";
       setAttrs({
 		"meleeweapon_roll_3": setweaponroll,
@@ -4137,33 +4177,33 @@ on('change:meleeweapon_4', event => {
 		"Breacher Shield":					{meleeweapon_skill_4: 'ShieldCraft',	meleeweapon_damage_4: '1D10-3',	meleeweapon_mindamage_4: '2',	meleeweapon_armourdamage_4: '0',	meleeweapon_enc_4: '0'},
 		"DPB Gash Fist":					{meleeweapon_skill_4: 'Unarmed',		meleeweapon_damage_4: '1D10-1',	meleeweapon_mindamage_4: '3',	meleeweapon_armourdamage_4: '1',	meleeweapon_enc_4: '1'},
 		"DPB Vibro Sabre":					{meleeweapon_skill_4: 'meleewpn',		meleeweapon_damage_4: '1D10-1',	meleeweapon_mindamage_4: '4',	meleeweapon_armourdamage_4: '1',	meleeweapon_enc_4: '1'},
-		"DPB Flick Scythe":					{meleeweapon_skill_4: 'Polearm',		meleeweapon_damage_4: '1d10+5',	meleeweapon_mindamage_4: '6',	meleeweapon_armourdamage_4: '2',	meleeweapon_enc_4: '3'},
-		"GASH Chain Axe":					{meleeweapon_skill_4: 'Polearm',		meleeweapon_damage_4: '2d10+2',	meleeweapon_mindamage_4: '9',	meleeweapon_armourdamage_4: '4',	meleeweapon_enc_4: '3'},
-		"GASH Clearance Baton":				{meleeweapon_skill_4: 'Polearm',		meleeweapon_damage_4: '1d10+3',	meleeweapon_mindamage_4: '6',	meleeweapon_armourdamage_4: '4',	meleeweapon_enc_4: '3'},
+		"DPB Flick Scythe":					{meleeweapon_skill_4: 'polearm',		meleeweapon_damage_4: '1d10+5',	meleeweapon_mindamage_4: '6',	meleeweapon_armourdamage_4: '2',	meleeweapon_enc_4: '3'},
+		"GASH Chain Axe":					{meleeweapon_skill_4: 'polearm',		meleeweapon_damage_4: '2d10+2',	meleeweapon_mindamage_4: '9',	meleeweapon_armourdamage_4: '4',	meleeweapon_enc_4: '3'},
+		"GASH Clearance Baton":				{meleeweapon_skill_4: 'polearm',		meleeweapon_damage_4: '1d10+3',	meleeweapon_mindamage_4: '6',	meleeweapon_armourdamage_4: '4',	meleeweapon_enc_4: '3'},
 		"GASH Pacifier Baton":				{meleeweapon_skill_4: 'meleewpn',		meleeweapon_damage_4: '1d10-2',	meleeweapon_mindamage_4: '2',	meleeweapon_armourdamage_4: '3',	meleeweapon_enc_4: '1'},
 		"ITB Mutilator Fist":				{meleeweapon_skill_4: 'Unarmed',		meleeweapon_damage_4: '1d10',	meleeweapon_mindamage_4: '4',	meleeweapon_armourdamage_4: '3',	meleeweapon_enc_4: '1'},
 		"MAC Knife":						{meleeweapon_skill_4: 'meleewpn',		meleeweapon_damage_4: '1d10-3',	meleeweapon_mindamage_4: '2',	meleeweapon_armourdamage_4: '1',	meleeweapon_enc_4: '1'},
 		"MJL Power Claymore 300":			{meleeweapon_skill_4: 'meleewpn',		meleeweapon_damage_4: '2d10-3',	meleeweapon_mindamage_4: '7',	meleeweapon_armourdamage_4: '2',	meleeweapon_enc_4: '3'},
-		"Punch/Kick":						{meleeweapon_skill_4: 'Unarmed',		meleeweapon_damage_4: '0',		meleeweapon_mindamage_4: '1',	meleeweapon_armourdamage_4: '0',	meleeweapon_enc_4: '0'},
-		"Teeth/Tusks/Claws":				{meleeweapon_skill_4: 'Unarmed',		meleeweapon_damage_4: '0',		meleeweapon_mindamage_4: '2',	meleeweapon_armourdamage_4: '1',	meleeweapon_enc_4: '0'},
-		"Beak":								{meleeweapon_skill_4: 'Unarmed',		meleeweapon_damage_4: '3',		meleeweapon_mindamage_4: '2',	meleeweapon_armourdamage_4: '0',	meleeweapon_enc_4: '0'},
-		"Mandibles":						{meleeweapon_skill_4: 'Unarmed',		meleeweapon_damage_4: '1',		meleeweapon_mindamage_4: '2',	meleeweapon_armourdamage_4: '2',	meleeweapon_enc_4: '0'},
-		"Ebb Enhance: Teeth/Claws":			{meleeweapon_skill_4: 'Unarmed',		meleeweapon_damage_4: '3',		meleeweapon_mindamage_4: '5',	meleeweapon_armourdamage_4: '2',	meleeweapon_enc_4: '0'},
-		"Ebb Enhance: Razor Teeth/Claws":	{meleeweapon_skill_4: 'Unarmed',		meleeweapon_damage_4: '6',		meleeweapon_mindamage_4: '8',	meleeweapon_armourdamage_4: '3',	meleeweapon_enc_4: '0'},
+		"Punch/Kick":						{meleeweapon_skill_4: 'Unarmed',		meleeweapon_damage_4: 'STR-2',	meleeweapon_mindamage_4: '1',	meleeweapon_armourdamage_4: '0',	meleeweapon_enc_4: '0'},
+		"Teeth/Tusks/Claws":				{meleeweapon_skill_4: 'Unarmed',		meleeweapon_damage_4: 'STR-1',	meleeweapon_mindamage_4: '2',	meleeweapon_armourdamage_4: '1',	meleeweapon_enc_4: '0'},
+		"Beak":								{meleeweapon_skill_4: 'Unarmed',		meleeweapon_damage_4: 'STR-1',	meleeweapon_mindamage_4: '2',	meleeweapon_armourdamage_4: '0',	meleeweapon_enc_4: '0'},
+		"Mandibles":						{meleeweapon_skill_4: 'Unarmed',		meleeweapon_damage_4: 'STR',	meleeweapon_mindamage_4: '2',	meleeweapon_armourdamage_4: '2',	meleeweapon_enc_4: '0'},
+		"Ebb Enhance: Teeth/Claws":			{meleeweapon_skill_4: 'Unarmed',		meleeweapon_damage_4: 'STR+2',	meleeweapon_mindamage_4: '5',	meleeweapon_armourdamage_4: '2',	meleeweapon_enc_4: '0'},
+		"Ebb Enhance: Razor Teeth/Claws":	{meleeweapon_skill_4: 'Unarmed',		meleeweapon_damage_4: 'STR+5',	meleeweapon_mindamage_4: '8',	meleeweapon_armourdamage_4: '3',	meleeweapon_enc_4: '0'},
 		"Ebb Blue Thermal: Ice Blade":		{meleeweapon_skill_4: 'meleewpn',		meleeweapon_damage_4: '1d10+1',	meleeweapon_mindamage_4: '4',	meleeweapon_armourdamage_4: '1',	meleeweapon_enc_4: '0'},
 		"Ebb Blue Thermal: Razor Ice Blade":{meleeweapon_skill_4: 'meleewpn',		meleeweapon_damage_4: '2d10-4',	meleeweapon_mindamage_4: '8',	meleeweapon_armourdamage_4: '3',	meleeweapon_enc_4: '0'},
 		"Ebb Red Thermal: Body Blaze":		{meleeweapon_skill_4: 'Unarmed',		meleeweapon_damage_4: '1d10+4',	meleeweapon_mindamage_4: '5',	meleeweapon_armourdamage_4: '2',	meleeweapon_enc_4: '0'},
 		"Ebb Sword":						{meleeweapon_skill_4: 'meleewpn',		meleeweapon_damage_4: '1d10-1',	meleeweapon_mindamage_4: '2',	meleeweapon_armourdamage_4: '3',	meleeweapon_enc_4: '2'},
 		"Featherpoint Rapier":				{meleeweapon_skill_4: 'meleewpn',		meleeweapon_damage_4: '1d10-1',	meleeweapon_mindamage_4: '3',	meleeweapon_armourdamage_4: '1',	meleeweapon_enc_4: '0'},
 		"Shaktar Switchblade":				{meleeweapon_skill_4: 'meleewpn',		meleeweapon_damage_4: '1d10+2',	meleeweapon_mindamage_4: '4',	meleeweapon_armourdamage_4: '1',	meleeweapon_enc_4: '1'},
-		"Stormer Chuckleduster":			{meleeweapon_skill_4: 'meleewpn',		meleeweapon_damage_4: '2d10-4',	meleeweapon_mindamage_4: '8',	meleeweapon_armourdamage_4: '3',	meleeweapon_enc_4: '3'},
+		"Stormer Chuckleduster":			{meleeweapon_skill_4: 'Unarmed',		meleeweapon_damage_4: '2d10-4',	meleeweapon_mindamage_4: '8',	meleeweapon_armourdamage_4: '3',	meleeweapon_enc_4: '3'},
 		"Generic Unpowered Melee Weapon":	{meleeweapon_skill_4: 'meleewpn',		meleeweapon_damage_4: '1d10-4',	meleeweapon_mindamage_4: '1',	meleeweapon_armourdamage_4: '0',	meleeweapon_enc_4: '0'},
-		"Generic Unpowered Polearm":		{meleeweapon_skill_4: 'Polearm',		meleeweapon_damage_4: '1d10-3',	meleeweapon_mindamage_4: '2',	meleeweapon_armourdamage_4: '0',	meleeweapon_enc_4: '0'},
-		"Hockey Axe":						{meleeweapon_skill_4: 'Polearm',		meleeweapon_damage_4: '1d10-1',	meleeweapon_mindamage_4: '4',	meleeweapon_armourdamage_4: '1',	meleeweapon_enc_4: '3'},
-		"Hockey Stick":						{meleeweapon_skill_4: 'Polearm',		meleeweapon_damage_4: '1d10-3',	meleeweapon_mindamage_4: '2',	meleeweapon_armourdamage_4: '0',	meleeweapon_enc_4: '1'},
+		"Generic Unpowered Polearm":		{meleeweapon_skill_4: 'polearm',		meleeweapon_damage_4: '1d10-3',	meleeweapon_mindamage_4: '2',	meleeweapon_armourdamage_4: '0',	meleeweapon_enc_4: '0'},
+		"Hockey Axe":						{meleeweapon_skill_4: 'polearm',		meleeweapon_damage_4: '1d10-1',	meleeweapon_mindamage_4: '4',	meleeweapon_armourdamage_4: '1',	meleeweapon_enc_4: '3'},
+		"Hockey Stick":						{meleeweapon_skill_4: 'polearm',		meleeweapon_damage_4: '1d10-3',	meleeweapon_mindamage_4: '2',	meleeweapon_armourdamage_4: '0',	meleeweapon_enc_4: '1'},
 		"DN1 Cermanic":						{meleeweapon_skill_4: 'meleewpn',		meleeweapon_damage_4: '1d10-3',	meleeweapon_mindamage_4: '1',	meleeweapon_armourdamage_4: '0',	meleeweapon_enc_4: '0'},
 		"DN113 Power Machete":				{meleeweapon_skill_4: 'meleewpn',		meleeweapon_damage_4: '1d10-1',	meleeweapon_mindamage_4: '4',	meleeweapon_armourdamage_4: '1',	meleeweapon_enc_4: '1'},
-		"TT7 Chain Axe":					{meleeweapon_skill_4: 'Polearm',		meleeweapon_damage_4: '1d10+3',	meleeweapon_mindamage_4: '4',	meleeweapon_armourdamage_4: '3',	meleeweapon_enc_4: '0'},
+		"TT7 Chain Axe":					{meleeweapon_skill_4: 'polearm',		meleeweapon_damage_4: '1d10+3',	meleeweapon_mindamage_4: '4',	meleeweapon_armourdamage_4: '3',	meleeweapon_enc_4: '0'},
 		"Electro-Prod":						{meleeweapon_skill_4: 'meleewpn',		meleeweapon_damage_4: '1d10-3',	meleeweapon_mindamage_4: '2',	meleeweapon_armourdamage_4: '0',	meleeweapon_enc_4: '4'},
 		"FOW Staff":						{meleeweapon_skill_4: 'meleewpn',		meleeweapon_damage_4: '1d10-3',	meleeweapon_mindamage_4: '2',	meleeweapon_armourdamage_4: '2',	meleeweapon_enc_4: '1'},
 		"Grappler":							{meleeweapon_skill_4: 'meleewpn',		meleeweapon_damage_4: '1d10-1',	meleeweapon_mindamage_4: '2',	meleeweapon_armourdamage_4: '2',	meleeweapon_enc_4: '1'},
@@ -4171,7 +4211,7 @@ on('change:meleeweapon_4', event => {
 		"Mauler Axe":						{meleeweapon_skill_4: 'meleewpn',		meleeweapon_damage_4: '1d10',	meleeweapon_mindamage_4: '4',	meleeweapon_armourdamage_4: '1',	meleeweapon_enc_4: '1'},
 		"Punch Dagger":						{meleeweapon_skill_4: 'Unarmed',		meleeweapon_damage_4: '1',		meleeweapon_mindamage_4: '0',	meleeweapon_armourdamage_4: '0',	meleeweapon_enc_4: '0'},
 		"Ripper Gauntlet":					{meleeweapon_skill_4: 'Unarmed',		meleeweapon_damage_4: '1d10-1',	meleeweapon_mindamage_4: '3',	meleeweapon_armourdamage_4: '1',	meleeweapon_enc_4: '1'},
-		"Scav Chain Axe":					{meleeweapon_skill_4: 'Polearm',		meleeweapon_damage_4: '2d10+3',	meleeweapon_mindamage_4: '9',	meleeweapon_armourdamage_4: '5',	meleeweapon_enc_4: '4'},
+		"Scav Chain Axe":					{meleeweapon_skill_4: 'polearm',		meleeweapon_damage_4: '2d10+3',	meleeweapon_mindamage_4: '9',	meleeweapon_armourdamage_4: '5',	meleeweapon_enc_4: '4'},
 		"Scav Chainsaw":					{meleeweapon_skill_4: 'meleewpn',		meleeweapon_damage_4: '2d10+5',	meleeweapon_mindamage_4: '10',	meleeweapon_armourdamage_4: '6',	meleeweapon_enc_4: '5'},
 		"Sector Ranger Dagger":				{meleeweapon_skill_4: 'meleewpn',		meleeweapon_damage_4: '1d10-3',	meleeweapon_mindamage_4: '2',	meleeweapon_armourdamage_4: '1',	meleeweapon_enc_4: '1'},
 		"Fake GASH Fist":					{meleeweapon_skill_4: 'Unarmed',		meleeweapon_damage_4: '1d10-2',	meleeweapon_mindamage_4: '3',	meleeweapon_armourdamage_4: '1',	meleeweapon_enc_4: '0'},
@@ -4184,14 +4224,27 @@ on('change:meleeweapon_4', event => {
         if(output) setAttrs(output);
     });
 });
-on("change:meleeweapon_4 change:meleeweapon_skill_4 change:meleeweapon_damage_4 change:meleeweapon_mindamage_4 change:meleeweapon_armourdamage_4 change:strengthdam", function() {
-  getAttrs(["meleeweapon_4","meleeweapon_skill_4","meleeweapon_damage_4","meleeweapon_mindamage_4","meleeweapon_armourdamage_4","strengthdam"], function(values) {
+on("change:meleeweapon_4 change:meleeweapon_skill_4 change:meleeweapon_damage_4 change:meleeweapon_mindamage_4 change:meleeweapon_armourdamage_4 change:strengthdam change:strength", function() {
+  getAttrs(["meleeweapon_4","meleeweapon_skill_4","meleeweapon_damage_4","meleeweapon_mindamage_4","meleeweapon_armourdamage_4","strengthdam","strength"], function(values) {
 	  var strengthdam = parseInt(values["strengthdam"])||0;
       var setweaponname = values["meleeweapon_4"]||"";
       var setweaponskill = values["meleeweapon_skill_4"]||"";
-      var setweapondmg = values["meleeweapon_damage_4"]+"+"+strengthdam||"";
-      var setweaponmindmg = parseInt(values["meleeweapon_mindamage_4"])+strengthdam||0;
+      var setweapondmg = values["meleeweapon_damage_4"]||"";
+      var setweaponmindmg = parseInt(values["meleeweapon_mindamage_4"])||0;
       var setweaponad = parseInt(values["meleeweapon_armourdamage_4"])||0;
+	  var strength = values["strength"]||0;
+	  
+	  if (setweapondmg.substring(0,3) == "STR") {
+		setweapondmg = setweapondmg.replace("STR",strength);
+		}
+	  else if (setweaponskill == "Unarmed") {
+		setweapondmg = setweapondmg;
+		setweaponmindmg = setweaponmindmg;
+	  }
+	  else {
+		setweapondmg = setweapondmg+"+"+strengthdam;
+		setweaponmindmg = setweaponmindmg+strengthdam;
+	  };
 	  var setweaponroll = "&{template:weapon} !?{Target Number|10|9|8|7|6|5|4|11|12|13|14|15|16|17|18} ?{Success Dice Modifier|0|-1|-2|-3|-4|-5|-6|-7|-8|-9|1|2|3|4|5|6|7|8|9} ?{Skill Dice Modifier|0|-1|-2|-3|-4|-5|-6|-7|-8|-9|1|2|3|4|5|6|7|8|9} {{name="+setweaponname+":"+setweaponskill+"}}{{success=[[{1d10+@{"+setweaponskill+"_total}+?{Success Dice Modifier}}>?{Target Number}]]}}{{skill=[[{[[@{"+setweaponskill+"}+1]]d10+@{"+setweaponskill+"_total}+?{Skill Dice Modifier}}>?{Target Number}]]}}{{damage=[["+setweapondmg+"]]}}{{mindmg=[["+setweaponmindmg+"]]}}{{ad=[["+setweaponad+"]]}}{{successreroll=[Reroll Success](~@{character_name}|successreroll)}}{{skillreroll=[Reroll Skill](~@{character_name}|skillreroll)}}{{reroll=[Reroll](~@{character_name}|reroll)}}";
       setAttrs({
 		"meleeweapon_roll_4": setweaponroll,


### PR DESCRIPTION
Fixes on unarmed weapon damages, so they do not get the strength damage bonus, but are correctly calculated from the correct base - STR+2, STR-1 etc...

## Changes / Comments
- fixed default skill for Chuckleduster to be Unarmed
- fixed polearm skill so it appears when a polearm weapon is selected
- altered damage bonuses so unarmed weapons do not get strength damage bonus to weapon damage and min damage
- Altered the calculation of natural weapons so they are correctly calculated from Strength - Str-1, Str+2 etc... 


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [Yes] Does the pull request title have the sheet name(s)? Include each sheet name.
- [Yes] Is this a bug fix?
- [No] Does this add functional enhancements (new features or extending existing features) ?
- [No] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [No changes to stats] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [But fix] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
