### PR TITLE
[Shadow of Esteren] Fix Prayer Disciplines

### DIFF
--- a/Shadows of Esteren/ShadowsOfEsteren.html
+++ b/Shadows of Esteren/ShadowsOfEsteren.html
@@ -274,7 +274,7 @@
     <fieldset class="repeating_PrayerDisc">
       <input class="sheet-skill-repeated-name" type="text" name="attr_DiscName" />
       <input class="sheet-skill-on" type="number" name="attr_Disc" min="6" max="15" value="6"/>
-      <button type='roll' name='roll_disc' value='&{template:basic} {{name=@{character_name} }} {{action=@{DiscName}}} {{conf=[[1d10]]}} {{attack=[[1d10+@{Disc}[@{DiscName}]+@{PrayerBonus}[Prayer Bonus]+@{Empathy}[Empathy]+@{Penalty}[Condition Penalty]]]}}'></button>
+      <button type='roll' name='roll_disc' value='&{template:basic} {{name=@{character_name} }} {{action=@{DiscName}}} {{conf=[[1d10]]}} {{attack=[[1d10+@{Disc}[@{DiscName}]+@{PrayerBonus}[Prayer Bonus]+@{Conviction}[Conviction]+@{Penalty}[Condition Penalty]]]}}'></button>
     </fieldset>
 </div>
 


### PR DESCRIPTION
## Changes / Comments
The disciplines under Prayer were using Empathy when they should be using Conviction.
Rule book page 198 lists Prayer as using Conviction.


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [Y] Does the pull request title have the sheet name(s)? Include each sheet name.
- [Y] Is this a bug fix?
- [N] Does this add functional enhancements (new features or extending existing features) ?
- [N] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [N/A] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [N/A] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.