### PR TITLE
[Only War Enhanced] hitroller bug fix

### DIFF
--- a/Only-War-Enhanced/OnlyWarEnhanced.html
+++ b/Only-War-Enhanced/OnlyWarEnhanced.html
@@ -1168,7 +1168,7 @@
 				<option value='10' >Half Aim (+10)</option>
 				<option value='20' >Full Aim (+20)</option>
 			  </select>
-			  <button name='weapon_hit' class='equipment_ranged_weapons_gs_a4 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }} {{weapon= @{R_weapon_name}}} {{burstwin=[[ceil([[[[1+ floor(abs([[{{ {@{R_weapon_target}+@{inlinemod-toggle}}, {@{bsTotal}-@{limiter}}}kh1, {@{bsTotal}+@{limiter}}}kl1]]-[[1d100@{R_weapon_mishap_chance}]])/10)]]+ceil(@{BS_unnat}/2)]]/2)]]}}{{target= $[[0]]}}{{roll= $[[1]]}}{{dof= $[[2]]}}{{dos=$[[3]]}}@{settings_hitroll}{{aim= [[@{R_weapon_aim}]]}}{{R_type= [[@{R_weapon_attack}]]}}{{range= [[@{R_weapon_attack_range}]]}}{{modifier= [[@{inlinemod-toggle}]]}}{{stat_name= Ballistic Skill}}{{stat=[[@{BS}]]}}{{advancement= [[@{BS_advancement}]]}}{{hitmod= [[@{R_weapon_mod1}]]}}{{trained= [[@{R_weapon_trained}-20]]}}{{burst=@{R_weapon_burst}}}{{auto=@{R_weapon_auto}}}{{fatigued=[[@{fatigued}]]}}
+			  <button name='weapon_hit' class='equipment_ranged_weapons_gs_a4 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }} {{weapon= @{R_weapon_name}}} {{burstwin=[[ceil([[[[1+ floor(abs([[{{ {@{R_weapon_target}+@{inlinemod-toggle}}, {@{bsTotal}-@{limiter}}}kh1, {@{bsTotal}+@{limiter}}}kl1]]-[[1d100@{R_weapon_mishap_chance}]])/10)]]+ceil(@{BS_unnat}/2)]]/2)]]}}{{target= $[[0]]}}{{roll= $[[1]]}}{{dof= $[[2]]}}{{dos=$[[3]]}} @{settings_hitroll} {{aim= [[@{R_weapon_aim}]]}}{{R_type= [[@{R_weapon_attack}]]}}{{range= [[@{R_weapon_attack_range}]]}}{{modifier= [[@{inlinemod-toggle}]]}}{{stat_name= Ballistic Skill}}{{stat=[[@{BS}]]}}{{advancement= [[@{BS_advancement}]]}}{{hitmod= [[@{R_weapon_mod1}]]}}{{trained= [[@{R_weapon_trained}-20]]}}{{burst=@{R_weapon_burst}}}{{auto=@{R_weapon_auto}}}{{fatigued=[[@{fatigued}]]}}
 !ammo @{character_id} repeating_rangedweapons_@{id}_R_weapon_mag [[@{ammo}*@{R_weapon_setting}]]'>Hit |<input name='attr_R_weapon_target' value='@{bsTotal} + @{R_weapon_trained} - 20 + @{R_weapon_mod1} + @{R_weapon_attack} + @{R_weapon_aim} + @{R_weapon_attack_range}+@{fatigued}' class='input_background input_char_background' disabled ></button>
 			  <button name='weapon_dmg' class='equipment_ranged_weapons_gs_a5 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{type= @{R_weapon_type}}} {{weapon= @{R_weapon_name}}} {{damage=[[@{R_weapon_real_dmg}]] }} {{spray= [[@{R_weapon_spray}]] }} {{pen=[[@{R_weapon_pen}+0@{R_weapon_pen2}]] }}  {{@{settings_weapondescription}=@{R_ability_r} }} @{R_weapon_accurate}'>DMG</button>
 			</div>
@@ -1290,7 +1290,7 @@
 				<option value='10' >Half Aim (+10)</option>
 				<option value='20' >Full Aim (+20)</option>
 			  </select>
-			  <button name='weapon_hit' class='equipment_melee_weapons_gs_a4 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }}{{weapon= @{M_weapon_name}}}{{burstwin=[[ceil([[[[1+ floor(abs([[{{ {@{M_weapon_target}+@{inlinemod-toggle}}, {@{wsTotal}-@{limiter}}}kh1, {@{wsTotal}+@{limiter}}}kl1]]-[[1d100]])/10)]]+ceil(@{WS_unnat}/2)]]/2)]]}}{{target= $[[0]]}}{{roll= $[[1]]}}{{dof= $[[2]]}}{{dos= $[[3]]}}@{settings_hitroll} {{aim= [[@{M_weapon_aim}]]}}{{M_type= [[@{M_weapon_attack}]]}}{{multi= [[@{M_weapon_multi}]]}}{{modifier= [[@{inlinemod-toggle}]]}}{{stat_name= Weapon Skill}}{{stat=[[@{WS}]]}}{{advancement=[[@{WS_advancement}]]}}{{hitmod=[[@{M_weapon_mod1}]]}}{{trained=[[@{M_weapon_trained}-20]]}}{{WS_bonus=[[@{wsB}]]}}{{fatigued=[[@{fatigued}]]}}' >Hit |<input name='attr_M_weapon_target' value='@{wsTotal}+@{M_weapon_trained}-20+@{M_weapon_mod1}+@{M_weapon_attack}+@{M_weapon_aim}+@{M_weapon_multi}+@{fatigued}' class='input_background input_char_background' disabled ></button>
+			  <button name='weapon_hit' class='equipment_melee_weapons_gs_a4 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }}{{weapon= @{M_weapon_name}}}{{burstwin=[[ceil([[[[1+ floor(abs([[{{ {@{M_weapon_target}+@{inlinemod-toggle}}, {@{wsTotal}-@{limiter}}}kh1, {@{wsTotal}+@{limiter}}}kl1]]-[[1d100]])/10)]]+ceil(@{WS_unnat}/2)]]/2)]]}}{{target= $[[0]]}}{{roll= $[[1]]}}{{dof= $[[2]]}}{{dos= $[[3]]}} @{settings_hitroll} {{aim= [[@{M_weapon_aim}]]}}{{M_type= [[@{M_weapon_attack}]]}}{{multi= [[@{M_weapon_multi}]]}}{{modifier= [[@{inlinemod-toggle}]]}}{{stat_name= Weapon Skill}}{{stat=[[@{WS}]]}}{{advancement=[[@{WS_advancement}]]}}{{hitmod=[[@{M_weapon_mod1}]]}}{{trained=[[@{M_weapon_trained}-20]]}}{{WS_bonus=[[@{wsB}]]}}{{fatigued=[[@{fatigued}]]}}' >Hit |<input name='attr_M_weapon_target' value='@{wsTotal}+@{M_weapon_trained}-20+@{M_weapon_mod1}+@{M_weapon_attack}+@{M_weapon_aim}+@{M_weapon_multi}+@{fatigued}' class='input_background input_char_background' disabled ></button>
 			  <button name='weapon_dmg' class='equipment_melee_weapons_gs_a5 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{weapon= @{M_weapon_name}}} {{type= @{M_weapon_type}}} {{damage=[[@{M_weapon_real_dmg}+[[floor((@{strTotal})/10) + @{str_unnat}]]]] }} {{pen= [[@{M_weapon_pen}]] }} {{@{settings_weapondescription}=@{M_ability_r} }}'>DMG</button>
 			</div>
 			<div class='equipment_melee_weapons_grid2'>
@@ -1828,7 +1828,7 @@
 	<!-- Settings -->
 	<h2>Settings</h2>
 	
-	<h3>Initiative Overrides</h3>
+	<h3>Initiative Tiebreakers</h3>
 	<select name='attr_initmod0' class='full_width edge_padding'>
 	  <option selected='selected' value='[[floor'>No tiebreaker</option>
 	  <option value='[['>Decimal tiebreaker</option>
@@ -1838,7 +1838,7 @@
 
 	<h3>Auto Roll Hit Locations</h3>
 	<select name='attr_settings_hitroll' class='full_width edge_padding'>
-	  <option value='{{loc=}}' selected='selected'>Automatically roll hit locations</option>
+	  <option value='{{loc= }}' selected='selected'>Automatically roll hit locations</option>
 	  <option value=' '>Don't automatically roll hit locations</option>
 	</select>
 	<br>
@@ -2498,7 +2498,7 @@
 				<option value='10' >Half Aim (+10)</option>
 				<option value='20' >Full Aim (+20)</option>
 			  </select>
-			  <button name='weapon_hit' class='equipment_ranged_weapons_gs_a4 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }} {{weapon= @{V_R_weapon_name}}} {{burstwin=[[ceil([[[[1+ floor(abs([[{{ {@{V_R_weapon_target}+@{inlinemod-toggle}}, {@{veh_atk_total_finder}-@{limiter}}}kh1, {@{veh_atk_total_finder}+@{limiter}}}kl1]]-[[1d100@{V_R_weapon_mishap_chance}]])/10)]]+ceil(@{veh_atk_unnat_finder}/2)]]/2)]]}}{{target= $[[0]]}}{{roll= $[[1]]}}{{dof= $[[2]]}}{{dos= $[[3]]}}@{settings_hitroll}{{aim= [[@{V_R_weapon_aim}]]}}{{R_type= [[@{V_R_weapon_attack}]]}}{{range= [[@{V_R_weapon_attack_range}]]}}{{modifier= [[@{inlinemod-toggle}]]}}{{stat_name= @{V_R_focus}}}{{stat=[[@{veh_atk_total_finder}]]}}{{hitmod= [[@{V_R_weapon_mod1}]]}}{{trained= [[@{V_R_weapon_trained}-20]]}}{{burst=@{V_R_weapon_burst}}}{{auto=@{V_R_weapon_auto}}}{{fatigued=[[@{fatigued}]]}}
+			  <button name='weapon_hit' class='equipment_ranged_weapons_gs_a4 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }} {{weapon= @{V_R_weapon_name}}} {{burstwin=[[ceil([[[[1+ floor(abs([[{{ {@{V_R_weapon_target}+@{inlinemod-toggle}}, {@{veh_atk_total_finder}-@{limiter}}}kh1, {@{veh_atk_total_finder}+@{limiter}}}kl1]]-[[1d100@{V_R_weapon_mishap_chance}]])/10)]]+ceil(@{veh_atk_unnat_finder}/2)]]/2)]]}}{{target= $[[0]]}}{{roll= $[[1]]}}{{dof= $[[2]]}}{{dos= $[[3]]}} @{settings_hitroll} {{aim= [[@{V_R_weapon_aim}]]}}{{R_type= [[@{V_R_weapon_attack}]]}}{{range= [[@{V_R_weapon_attack_range}]]}}{{modifier= [[@{inlinemod-toggle}]]}}{{stat_name= @{V_R_focus}}}{{stat=[[@{veh_atk_total_finder}]]}}{{hitmod= [[@{V_R_weapon_mod1}]]}}{{trained= [[@{V_R_weapon_trained}-20]]}}{{burst=@{V_R_weapon_burst}}}{{auto=@{V_R_weapon_auto}}}{{fatigued=[[@{fatigued}]]}}
 !ammo @{character_id} repeating_rangedweapons_@{id}_V_R_weapon_mag [[@{ammo}*@{V_R_weapon_setting}]]'>Hit |<input name='attr_V_R_weapon_target' value='@{veh_atk_total_finder} + @{V_R_weapon_trained} - 20 + @{V_R_weapon_mod1} + @{V_R_weapon_attack} + @{V_R_weapon_aim} + @{V_R_weapon_attack_range}+@{veh_fatigue_finder}' class='input_background input_char_background' disabled ></button>
 			  <button name='weapon_dmg' class='equipment_ranged_weapons_gs_a5 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{type= @{V_R_weapon_type}}} {{weapon= @{V_R_weapon_name}}} {{damage=[[@{V_R_weapon_real_dmg}]] }} {{spray= [[@{V_R_weapon_spray}]] }} {{pen=[[@{V_R_weapon_pen}+0@{V_R_weapon_pen2}]] }}  {{@{settings_weapondescription}=@{V_R_ability_r} }} @{V_R_weapon_accurate}'>DMG</button>
 			</div>
@@ -2627,7 +2627,7 @@
 				<option value='10' >Half Aim (+10)</option>
 				<option value='20' >Full Aim (+20)</option>
 			  </select>
-			  <button name='weapon_hit' class='equipment_melee_weapons_gs_a4 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }}{{weapon= @{V_M_weapon_name}}}{{burstwin=[[ceil([[[[1+ floor(abs([[{{ {@{V_M_weapon_target}+@{inlinemod-toggle}}, {@{wsTotal}-@{limiter}}}kh1, {@{wsTotal}+@{limiter}}}kl1]]-[[1d100]])/10)]]+ceil(@{WS_unnat}/2)]]/2)]]}}{{target= $[[0]]}}{{roll= $[[1]]}}{{dof= $[[2]]}}{{dos=$[[3]]}}@{settings_hitroll} {{aim= [[@{V_M_weapon_aim}]]}}{{M_type= [[@{V_M_weapon_attack}]]}}{{multi= [[@{V_M_weapon_multi}]]}}{{modifier= [[@{inlinemod-toggle}]]}}{{stat_name= Weapon Skill}}{{stat=[[@{WS}]]}}{{advancement=[[@{WS_advancement}]]}}{{hitmod=[[@{V_M_weapon_mod1}]]}}{{trained=[[@{V_M_weapon_trained}-20]]}}{{WS_bonus=[[@{wsB}]]}}{{fatigued=[[@{fatigued}]]}}' >Hit |<input name='attr_V_M_weapon_target' value='@{wsTotal}+@{V_M_weapon_trained}-20+@{V_M_weapon_mod1}+@{V_M_weapon_attack}+@{V_M_weapon_aim}+@{V_M_weapon_multi}+@{fatigued}' class='input_background input_char_background' disabled ></button>
+			  <button name='weapon_hit' class='equipment_melee_weapons_gs_a4 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }}{{weapon= @{V_M_weapon_name}}}{{burstwin=[[ceil([[[[1+ floor(abs([[{{ {@{V_M_weapon_target}+@{inlinemod-toggle}}, {@{wsTotal}-@{limiter}}}kh1, {@{wsTotal}+@{limiter}}}kl1]]-[[1d100]])/10)]]+ceil(@{WS_unnat}/2)]]/2)]]}}{{target= $[[0]]}}{{roll= $[[1]]}}{{dof= $[[2]]}}{{dos=$[[3]]}} @{settings_hitroll} {{aim= [[@{V_M_weapon_aim}]]}}{{M_type= [[@{V_M_weapon_attack}]]}}{{multi= [[@{V_M_weapon_multi}]]}}{{modifier= [[@{inlinemod-toggle}]]}}{{stat_name= Weapon Skill}}{{stat=[[@{WS}]]}}{{advancement=[[@{WS_advancement}]]}}{{hitmod=[[@{V_M_weapon_mod1}]]}}{{trained=[[@{V_M_weapon_trained}-20]]}}{{WS_bonus=[[@{wsB}]]}}{{fatigued=[[@{fatigued}]]}}' >Hit |<input name='attr_V_M_weapon_target' value='@{wsTotal}+@{V_M_weapon_trained}-20+@{V_M_weapon_mod1}+@{V_M_weapon_attack}+@{V_M_weapon_aim}+@{V_M_weapon_multi}+@{fatigued}' class='input_background input_char_background' disabled ></button>
 			  <button name='weapon_dmg' class='equipment_melee_weapons_gs_a5 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{weapon= @{V_M_weapon_name}}} {{type= @{V_M_weapon_type}}} {{damage=[[@{V_M_weapon_real_dmg}+[[floor((@{strTotal})/10) + @{str_unnat}]]]] }} {{pen= [[@{V_M_weapon_pen}]] }} {{@{settings_weapondescription}=@{V_M_ability_r} }}'>DMG</button>
 			</div>
 			<div class='equipment_melee_weapons_grid2'>
@@ -4338,412 +4338,412 @@
 	{{#loc}}
 	  {{^attack}}<div class="template-content template-round">{{/attack}}
 	  {{#attack}} <div class="template-content">{{/attack}}
-		<!-- Hit location: Head -->
-		{{#rollTotal() roll 10}}
-		  <div class="template-row template-center template-break">Hit Location: 01</div>
-		  <div class="template-row template-center">HEAD / MOTIVE SYSTEM</div>
-		{{/rollTotal() roll 10}}
-		{{#rollTotal() roll 20}}
-		  <div class="template-row template-center template-break">Hit Location: 02</div>
-		  <div class="template-row template-center">HEAD / MOTIVE SYSTEM</div>
-		{{/rollTotal() roll 20}}
-		{{#rollTotal() roll 30}}
-		  <div class="template-row template-center template-break">Hit Location: 03</div>
-		  <div class="template-row template-center">HEAD / MOTIVE SYSTEM</div>
-		{{/rollTotal() roll 30}}
-		{{#rollTotal() roll 40}}
-		  <div class="template-row template-center template-break">Hit Location: 04</div>
-		  <div class="template-row template-center">HEAD / MOTIVE SYSTEM</div>
-		{{/rollTotal() roll 40}}
-		{{#rollTotal() roll 50}}
-		  <div class="template-row template-center template-break">Hit Location: 05</div>
-		  <div class="template-row template-center">HEAD / MOTIVE SYSTEM</div>
-		{{/rollTotal() roll 50}}
-		{{#rollTotal() roll 60}}
-		  <div class="template-row template-center template-break">Hit Location: 06</div>
-		  <div class="template-row template-center">HEAD / MOTIVE SYSTEM</div>
-		{{/rollTotal() roll 60}}
-		{{#rollTotal() roll 70}}
-		  <div class="template-row template-center template-break">Hit Location: 07</div>
-		  <div class="template-row template-center">HEAD / MOTIVE SYSTEM</div>
-		{{/rollTotal() roll 70}}
-		{{#rollTotal() roll 80}}
-		  <div class="template-row template-center template-break">Hit Location: 08</div>
-		  <div class="template-row template-center">HEAD / MOTIVE SYSTEM</div>
-		{{/rollTotal() roll 80}}
-		{{#rollTotal() roll 90}}
-		  <div class="template-row template-center template-break">Hit Location: 09</div>
-		  <div class="template-row template-center">HEAD / MOTIVE SYSTEM</div>
-		{{/rollTotal() roll 90}}
-		{{#rollTotal() roll 1}}
-		  <div class="template-row template-center template-break">Hit Location: 10</div>
-		  <div class="template-row template-center">HEAD / MOTIVE SYSTEM</div>
-		{{/rollTotal() roll 1}}
-		<!-- Hit Location: Right Arm -->
-		{{#rollTotal() roll 11}}
-		  <div class="template-row template-center template-break">Hit Location: 11</div>
-		  <div class="template-row template-center">RIGHT ARM / MOTIVE SYSTEM</div>
-		{{/rollTotal() roll 11}}
-		{{#rollTotal() roll 21}}
-		  <div class="template-row template-center template-break">Hit Location: 12</div>
-		  <div class="template-row template-center">RIGHT ARM / MOTIVE SYSTEM</div>
-		{{/rollTotal() roll 21}}
-		{{#rollTotal() roll 31}}
-		  <div class="template-row template-center template-break">Hit Location: 13</div>
-		  <div class="template-row template-center">RIGHT ARM / MOTIVE SYSTEM</div>
-		{{/rollTotal() roll 31}}
-		{{#rollTotal() roll 41}}
-		  <div class="template-row template-center template-break">Hit Location: 14</div>
-		  <div class="template-row template-center">RIGHT ARM / MOTIVE SYSTEM</div>
-		{{/rollTotal() roll 41}}
-		{{#rollTotal() roll 51}}
-		  <div class="template-row template-center template-break">Hit Location: 15</div>
-		  <div class="template-row template-center">RIGHT ARM / MOTIVE SYSTEM</div>
-		{{/rollTotal() roll 51}}
-		{{#rollTotal() roll 61}}
-		  <div class="template-row template-center template-break">Hit Location: 16</div>
-		  <div class="template-row template-center">RIGHT ARM / MOTIVE SYSTEM</div>
-		{{/rollTotal() roll 61}}
-		{{#rollTotal() roll 71}}
-		  <div class="template-row template-center template-break">Hit Location: 17</div>
-		  <div class="template-row template-center">RIGHT ARM / MOTIVE SYSTEM</div>
-		{{/rollTotal() roll 71}}
-		{{#rollTotal() roll 81}}
-		  <div class="template-row template-center template-break">Hit Location: 18</div>
-		  <div class="template-row template-center">RIGHT ARM / MOTIVE SYSTEM</div>
-		{{/rollTotal() roll 81}}
-		{{#rollTotal() roll 91}}
-		  <div class="template-row template-center template-break">Hit Location: 19</div>
-		  <div class="template-row template-center">RIGHT ARM / MOTIVE SYSTEM</div>
-		{{/rollTotal() roll 91}}
-		{{#rollTotal() roll 2}}
-		  <div class="template-row template-center template-break">Hit Location: 20</div>
-		  <div class="template-row template-center">RIGHT ARM / MOTIVE SYSTEM</div>
-		{{/rollTotal() roll 2}}
-		<!-- Hit Location: Left Arm -->
-		{{#rollTotal() roll 12}}
-		  <div class="template-row template-center template-break">Hit Location: 21</div>
-		  <div class="template-row template-center">LEFT ARM / HULL</div>
-		{{/rollTotal() roll 12}}
-		{{#rollTotal() roll 22}}
-		  <div class="template-row template-center template-break">Hit Location: 22</div>
-		  <div class="template-row template-center">LEFT ARM / HULL</div>
-		{{/rollTotal() roll 22}}
-		{{#rollTotal() roll 32}}
-		  <div class="template-row template-center template-break">Hit Location: 23</div>
-		  <div class="template-row template-center">LEFT ARM / HULL</div>
-		{{/rollTotal() roll 32}}
-		{{#rollTotal() roll 42}}
-		  <div class="template-row template-center template-break">Hit Location: 24</div>
-		  <div class="template-row template-center">LEFT ARM / HULL</div>
-		{{/rollTotal() roll 42}}
-		{{#rollTotal() roll 52}}
-		  <div class="template-row template-center template-break">Hit Location: 25</div>
-		  <div class="template-row template-center">LEFT ARM / HULL</div>
-		{{/rollTotal() roll 52}}
-		{{#rollTotal() roll 62}}
-		  <div class="template-row template-center template-break">Hit Location: 26</div>
-		  <div class="template-row template-center">LEFT ARM / HULL</div>
-		{{/rollTotal() roll 62}}
-		{{#rollTotal() roll 72}}
-		  <div class="template-row template-center template-break">Hit Location: 27</div>
-		  <div class="template-row template-center">LEFT ARM / HULL</div>
-		{{/rollTotal() roll 72}}
-		{{#rollTotal() roll 82}}
-		  <div class="template-row template-center template-break">Hit Location: 28</div>
-		  <div class="template-row template-center">LEFT ARM / HULL</div>
-		{{/rollTotal() roll 82}}
-		{{#rollTotal() roll 92}}
-		  <div class="template-row template-center template-break">Hit Location: 29</div>
-		  <div class="template-row template-center">LEFT ARM / HULL</div>
-		{{/rollTotal() roll 92}}
-		{{#rollTotal() roll 3}}
-		  <div class="template-row template-center template-break">Hit Location: 30</div>
-		  <div class="template-row template-center">LEFT ARM / HULL</div>
-		{{/rollTotal() roll 3}}
-		<!-- Hit Location: Body -->
-		{{#rollTotal() roll 13}}
-		  <div class="template-row template-center template-break">Hit Location: 31</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 13}}
-		{{#rollTotal() roll 23}}
-		  <div class="template-row template-center template-break">Hit Location: 32</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 23}}
-		{{#rollTotal() roll 33}}
-		  <div class="template-row template-center template-break">Hit Location: 33</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 33}}
-		{{#rollTotal() roll 43}}
-		  <div class="template-row template-center template-break">Hit Location: 34</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 43}}
-		{{#rollTotal() roll 53}}
-		  <div class="template-row template-center template-break">Hit Location: 35</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 53}}
-		{{#rollTotal() roll 63}}
-		  <div class="template-row template-center template-break">Hit Location: 36</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 63}}
-		{{#rollTotal() roll 73}}
-		  <div class="template-row template-center template-break">Hit Location: 37</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 73}}
-		{{#rollTotal() roll 83}}
-		  <div class="template-row template-center template-break">Hit Location: 38</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 83}}
-		{{#rollTotal() roll 93}}
-		  <div class="template-row template-center template-break">Hit Location: 39</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 93}}
-		{{#rollTotal() roll 4}}
-		  <div class="template-row template-center template-break">Hit Location: 40</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 4}}
-		{{#rollTotal() roll 14}}
-		  <div class="template-row template-center template-break">Hit Location: 41</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 14}}
-		{{#rollTotal() roll 24}}
-		  <div class="template-row template-center template-break">Hit Location: 42</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 24}}
-		{{#rollTotal() roll 34}}
-		  <div class="template-row template-center template-break">Hit Location: 43</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 34}}
-		{{#rollTotal() roll 44}}
-		  <div class="template-row template-center template-break">Hit Location: 44</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 44}}
-		{{#rollTotal() roll 54}}
-		  <div class="template-row template-center template-break">Hit Location: 45</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 54}}
-		{{#rollTotal() roll 64}}
-		  <div class="template-row template-center template-break">Hit Location: 46</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 64}}
-		{{#rollTotal() roll 74}}
-		  <div class="template-row template-center template-break">Hit Location: 47</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 74}}
-		{{#rollTotal() roll 84}}
-		  <div class="template-row template-center template-break">Hit Location: 48</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 84}}
-		{{#rollTotal() roll 94}}
-		  <div class="template-row template-center template-break">Hit Location: 49</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 94}}
-		{{#rollTotal() roll 5}}
-		  <div class="template-row template-center template-break">Hit Location: 50</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 5}}
-		{{#rollTotal() roll 15}}
-		  <div class="template-row template-center template-break">Hit Location: 51</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 15}}
-		{{#rollTotal() roll 25}}
-		  <div class="template-row template-center template-break">Hit Location: 52</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 25}}
-		{{#rollTotal() roll 35}}
-		  <div class="template-row template-center template-break">Hit Location: 53</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 35}}
-		{{#rollTotal() roll 45}}
-		  <div class="template-row template-center template-break">Hit Location: 54</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 45}}
-		{{#rollTotal() roll 55}}
-		  <div class="template-row template-center template-break">Hit Location: 55</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 55}}
-		{{#rollTotal() roll 65}}
-		  <div class="template-row template-center template-break">Hit Location: 56</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 65}}
-		{{#rollTotal() roll 75}}
-		  <div class="template-row template-center template-break">Hit Location: 57</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 75}}
-		{{#rollTotal() roll 85}}
-		  <div class="template-row template-center template-break">Hit Location: 58</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 85}}
-		{{#rollTotal() roll 95}}
-		  <div class="template-row template-center template-break">Hit Location: 59</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 95}}
-		{{#rollTotal() roll 6}}
-		  <div class="template-row template-center template-break">Hit Location: 60</div>
-		  <div class="template-row template-center">BODY / HULL</div>
-		{{/rollTotal() roll 6}}
-		{{#rollTotal() roll 16}}
-		  <div class="template-row template-center template-break">Hit Location: 61</div>
-		  <div class="template-row template-center">BODY / WEAPON</div>
-		{{/rollTotal() roll 16}}
-		{{#rollTotal() roll 26}}
-		  <div class="template-row template-center template-break">Hit Location: 62</div>
-		  <div class="template-row template-center">BODY / WEAPON</div>
-		{{/rollTotal() roll 26}}
-		{{#rollTotal() roll 36}}
-		  <div class="template-row template-center template-break">Hit Location: 63</div>
-		  <div class="template-row template-center">BODY / WEAPON</div>
-		{{/rollTotal() roll 36}}
-		{{#rollTotal() roll 46}}
-		  <div class="template-row template-center template-break">Hit Location: 64</div>
-		  <div class="template-row template-center">BODY / WEAPON</div>
-		{{/rollTotal() roll 46}}
-		{{#rollTotal() roll 56}}
-		  <div class="template-row template-center template-break">Hit Location: 65</div>
-		  <div class="template-row template-center">BODY / WEAPON</div>
-		{{/rollTotal() roll 56}}
-		{{#rollTotal() roll 66}}
-		  <div class="template-row template-center template-break">Hit Location: 66</div>
-		  <div class="template-row template-center">BODY / WEAPON</div>
-		{{/rollTotal() roll 66}}
-		{{#rollTotal() roll 76}}
-		  <div class="template-row template-center template-break">Hit Location: 67</div>
-		  <div class="template-row template-center">BODY / WEAPON</div>
-		{{/rollTotal() roll 76}}
-		{{#rollTotal() roll 86}}
-		  <div class="template-row template-center template-break">Hit Location: 68</div>
-		  <div class="template-row template-center">BODY / WEAPON</div>
-		{{/rollTotal() roll 86}}
-		{{#rollTotal() roll 96}}
-		  <div class="template-row template-center template-break">Hit Location: 69</div>
-		  <div class="template-row template-center">BODY / WEAPON</div>
-		{{/rollTotal() roll 96}}
-		{{#rollTotal() roll 7}}
-		  <div class="template-row template-center template-break">Hit Location: 70</div>
-		  <div class="template-row template-center">BODY / WEAPON</div>
-		{{/rollTotal() roll 7}}
-		<!-- Hit Location: Right Leg -->
-		{{#rollTotal() roll 17}}
-		  <div class="template-row template-center template-break">Hit Location: 71</div>
-		  <div class="template-row template-center">RIGHT LEG / WEAPON</div>
-		{{/rollTotal() roll 17}}
-		{{#rollTotal() roll 27}}
-		  <div class="template-row template-center template-break">Hit Location: 72</div>
-		  <div class="template-row template-center">RIGHT LEG / WEAPON</div>
-		{{/rollTotal() roll 27}}
-		{{#rollTotal() roll 37}}
-		  <div class="template-row template-center template-break">Hit Location: 73</div>
-		  <div class="template-row template-center">RIGHT LEG / WEAPON</div>
-		{{/rollTotal() roll 37}}
-		{{#rollTotal() roll 47}}
-		  <div class="template-row template-center template-break">Hit Location: 74</div>
-		  <div class="template-row template-center">RIGHT LEG / WEAPON</div>
-		{{/rollTotal() roll 47}}
-		{{#rollTotal() roll 57}}
-		  <div class="template-row template-center template-break">Hit Location: 75</div>
-		  <div class="template-row template-center">RIGHT LEG / WEAPON</div>
-		{{/rollTotal() roll 57}}
-		{{#rollTotal() roll 67}}
-		  <div class="template-row template-center template-break">Hit Location: 76</div>
-		  <div class="template-row template-center">RIGHT LEG / WEAPON</div>
-		{{/rollTotal() roll 67}}
-		{{#rollTotal() roll 77}}
-		  <div class="template-row template-center template-break">Hit Location: 77</div>
-		  <div class="template-row template-center">RIGHT LEG / WEAPON</div>
-		{{/rollTotal() roll 77}}
-		{{#rollTotal() roll 87}}
-		  <div class="template-row template-center template-break">Hit Location: 78</div>
-		  <div class="template-row template-center">RIGHT LEG / WEAPON</div>
-		{{/rollTotal() roll 87}}
-		{{#rollTotal() roll 97}}
-		  <div class="template-row template-center template-break">Hit Location: 79</div>
-		  <div class="template-row template-center">RIGHT LEG / WEAPON</div>
-		{{/rollTotal() roll 97}}
-		{{#rollTotal() roll 8}}
-		  <div class="template-row template-center template-break">Hit Location: 80</div>
-		  <div class="template-row template-center">RIGHT LEG / WEAPON</div>
-		{{/rollTotal() roll 8}}
-		{{#rollTotal() roll 18}}
-		  <div class="template-row template-center template-break">Hit Location: 81</div>
-		  <div class="template-row template-center">RIGHT LEG / TURRET</div>
-		{{/rollTotal() roll 18}}
-		{{#rollTotal() roll 28}}
-		  <div class="template-row template-center template-break">Hit Location: 82</div>
-		  <div class="template-row template-center">RIGHT LEG / TURRET</div>
-		{{/rollTotal() roll 28}}
-		{{#rollTotal() roll 38}}
-		  <div class="template-row template-center template-break">Hit Location: 83</div>
-		  <div class="template-row template-center">RIGHT LEG / TURRET</div>
-		{{/rollTotal() roll 38}}
-		{{#rollTotal() roll 48}}
-		  <div class="template-row template-center template-break">Hit Location: 84</div>
-		  <div class="template-row template-center">RIGHT LEG / TURRET</div>
-		{{/rollTotal() roll 48}}
-		{{#rollTotal() roll 58}}
-		  <div class="template-row template-center template-break">Hit Location: 85</div>
-		  <div class="template-row template-center">RIGHT LEG / TURRET</div>
-		{{/rollTotal() roll 58}}
-		<!-- Hit Location: Left Leg -->
-		{{#rollTotal() roll 68}}
-		  <div class="template-row template-center template-break">Hit Location: 86</div>
-		  <div class="template-row template-center">LEFT LEG / TURRET</div>
-		{{/rollTotal() roll 68}}
-		{{#rollTotal() roll 78}}
-		  <div class="template-row template-center template-break">Hit Location: 87</div>
-		  <div class="template-row template-center">LEFT LEG / TURRET</div>
-		{{/rollTotal() roll 78}}
-		{{#rollTotal() roll 88}}
-		  <div class="template-row template-center template-break">Hit Location: 88</div>
-		  <div class="template-row template-center">LEFT LEG / TURRET</div>
-		{{/rollTotal() roll 88}}
-		{{#rollTotal() roll 98}}
-		  <div class="template-row template-center template-break">Hit Location: 89</div>
-		  <div class="template-row template-center">LEFT LEG / TURRET</div>
-		{{/rollTotal() roll 98}}
-		{{#rollTotal() roll 9}}
-		  <div class="template-row template-center template-break">Hit Location: 90</div>
-		  <div class="template-row template-center">LEFT LEG / TURRET</div>
-		{{/rollTotal() roll 9}}
-		{{#rollTotal() roll 19}}
-		  <div class="template-row template-center template-break">Hit Location: 91</div>
-		  <div class="template-row template-center">LEFT LEG / TURRET</div>
-		{{/rollTotal() roll 19}}
-		{{#rollTotal() roll 29}}
-		  <div class="template-row template-center template-break">Hit Location: 92</div>
-		  <div class="template-row template-center">LEFT LEG / TURRET</div>
-		{{/rollTotal() roll 29}}
-		{{#rollTotal() roll 39}}
-		  <div class="template-row template-center template-break">Hit Location: 93</div>
-		  <div class="template-row template-center">LEFT LEG / TURRET</div>
-		{{/rollTotal() roll 39}}
-		{{#rollTotal() roll 49}}
-		  <div class="template-row template-center template-break">Hit Location: 94</div>
-		  <div class="template-row template-center">LEFT LEG / TURRET</div>
-		{{/rollTotal() roll 49}}
-		{{#rollTotal() roll 59}}
-		  <div class="template-row template-center template-break">Hit Location: 95</div>
-		  <div class="template-row template-center">LEFT LEG / TURRET</div>
-		{{/rollTotal() roll 59}}
-		{{#rollTotal() roll 69}}
-		  <div class="template-row template-center template-break">Hit Location: 96</div>
-		  <div class="template-row template-center">LEFT LEG / TURRET</div>
-		{{/rollTotal() roll 69}}
-		{{#rollTotal() roll 79}}
-		  <div class="template-row template-center template-break">Hit Location: 97</div>
-		  <div class="template-row template-center">LEFT LEG / TURRET</div>
-		{{/rollTotal() roll 79}}
-		{{#rollTotal() roll 89}}
-		  <div class="template-row template-center template-break">Hit Location: 98</div>
-		  <div class="template-row template-center">LEFT LEG / TURRET</div>
-		{{/rollTotal() roll 89}}
-		{{#rollTotal() roll 99}}
-		  <div class="template-row template-center template-break">Hit Location: 99</div>
-		  <div class="template-row template-center">LEFT LEG / TURRET</div>
-		{{/rollTotal() roll 99}}
-		{{#rollTotal() roll 100}}
-		  <div class="template-row template-center template-break">Hit Location: 00</div>
-		  <div class="template-row template-center">LEFT LEG / TURRET</div>
-		{{/rollTotal() roll 100}}
+	  <!-- Hit location: Head -->
+	  {{#rollTotal() roll 10}}
+		<div class="template-row template-center template-break">Hit Location: 01</div>
+		<div class="template-row template-center">HEAD / MOTIVE SYSTEM</div>
+	  {{/rollTotal() roll 10}}
+	  {{#rollTotal() roll 20}}
+		<div class="template-row template-center template-break">Hit Location: 02</div>
+		<div class="template-row template-center">HEAD / MOTIVE SYSTEM</div>
+	  {{/rollTotal() roll 20}}
+	  {{#rollTotal() roll 30}}
+		<div class="template-row template-center template-break">Hit Location: 03</div>
+		<div class="template-row template-center">HEAD / MOTIVE SYSTEM</div>
+	  {{/rollTotal() roll 30}}
+	  {{#rollTotal() roll 40}}
+		<div class="template-row template-center template-break">Hit Location: 04</div>
+		<div class="template-row template-center">HEAD / MOTIVE SYSTEM</div>
+	  {{/rollTotal() roll 40}}
+	  {{#rollTotal() roll 50}}
+		<div class="template-row template-center template-break">Hit Location: 05</div>
+		<div class="template-row template-center">HEAD / MOTIVE SYSTEM</div>
+	  {{/rollTotal() roll 50}}
+	  {{#rollTotal() roll 60}}
+		<div class="template-row template-center template-break">Hit Location: 06</div>
+		<div class="template-row template-center">HEAD / MOTIVE SYSTEM</div>
+	  {{/rollTotal() roll 60}}
+	  {{#rollTotal() roll 70}}
+		<div class="template-row template-center template-break">Hit Location: 07</div>
+		<div class="template-row template-center">HEAD / MOTIVE SYSTEM</div>
+	  {{/rollTotal() roll 70}}
+	  {{#rollTotal() roll 80}}
+		<div class="template-row template-center template-break">Hit Location: 08</div>
+		<div class="template-row template-center">HEAD / MOTIVE SYSTEM</div>
+	  {{/rollTotal() roll 80}}
+	  {{#rollTotal() roll 90}}
+		<div class="template-row template-center template-break">Hit Location: 09</div>
+		<div class="template-row template-center">HEAD / MOTIVE SYSTEM</div>
+	  {{/rollTotal() roll 90}}
+	  {{#rollTotal() roll 1}}
+		<div class="template-row template-center template-break">Hit Location: 10</div>
+		<div class="template-row template-center">HEAD / MOTIVE SYSTEM</div>
+	  {{/rollTotal() roll 1}}
+	  <!-- Hit Location: Right Arm -->
+	  {{#rollTotal() roll 11}}
+		<div class="template-row template-center template-break">Hit Location: 11</div>
+		<div class="template-row template-center">RIGHT ARM / MOTIVE SYSTEM</div>
+	  {{/rollTotal() roll 11}}
+	  {{#rollTotal() roll 21}}
+		<div class="template-row template-center template-break">Hit Location: 12</div>
+		<div class="template-row template-center">RIGHT ARM / MOTIVE SYSTEM</div>
+	  {{/rollTotal() roll 21}}
+	  {{#rollTotal() roll 31}}
+		<div class="template-row template-center template-break">Hit Location: 13</div>
+		<div class="template-row template-center">RIGHT ARM / MOTIVE SYSTEM</div>
+	  {{/rollTotal() roll 31}}
+	  {{#rollTotal() roll 41}}
+		<div class="template-row template-center template-break">Hit Location: 14</div>
+		<div class="template-row template-center">RIGHT ARM / MOTIVE SYSTEM</div>
+	  {{/rollTotal() roll 41}}
+	  {{#rollTotal() roll 51}}
+		<div class="template-row template-center template-break">Hit Location: 15</div>
+		<div class="template-row template-center">RIGHT ARM / MOTIVE SYSTEM</div>
+	  {{/rollTotal() roll 51}}
+	  {{#rollTotal() roll 61}}
+		<div class="template-row template-center template-break">Hit Location: 16</div>
+		<div class="template-row template-center">RIGHT ARM / MOTIVE SYSTEM</div>
+	  {{/rollTotal() roll 61}}
+	  {{#rollTotal() roll 71}}
+		<div class="template-row template-center template-break">Hit Location: 17</div>
+		<div class="template-row template-center">RIGHT ARM / MOTIVE SYSTEM</div>
+	  {{/rollTotal() roll 71}}
+	  {{#rollTotal() roll 81}}
+		<div class="template-row template-center template-break">Hit Location: 18</div>
+		<div class="template-row template-center">RIGHT ARM / MOTIVE SYSTEM</div>
+	  {{/rollTotal() roll 81}}
+	  {{#rollTotal() roll 91}}
+		<div class="template-row template-center template-break">Hit Location: 19</div>
+		<div class="template-row template-center">RIGHT ARM / MOTIVE SYSTEM</div>
+	  {{/rollTotal() roll 91}}
+	  {{#rollTotal() roll 2}}
+		<div class="template-row template-center template-break">Hit Location: 20</div>
+		<div class="template-row template-center">RIGHT ARM / MOTIVE SYSTEM</div>
+	  {{/rollTotal() roll 2}}
+	  <!-- Hit Location: Left Arm -->
+	  {{#rollTotal() roll 12}}
+		<div class="template-row template-center template-break">Hit Location: 21</div>
+		<div class="template-row template-center">LEFT ARM / HULL</div>
+	  {{/rollTotal() roll 12}}
+	  {{#rollTotal() roll 22}}
+		<div class="template-row template-center template-break">Hit Location: 22</div>
+		<div class="template-row template-center">LEFT ARM / HULL</div>
+	  {{/rollTotal() roll 22}}
+	  {{#rollTotal() roll 32}}
+		<div class="template-row template-center template-break">Hit Location: 23</div>
+		<div class="template-row template-center">LEFT ARM / HULL</div>
+	  {{/rollTotal() roll 32}}
+	  {{#rollTotal() roll 42}}
+		<div class="template-row template-center template-break">Hit Location: 24</div>
+		<div class="template-row template-center">LEFT ARM / HULL</div>
+	  {{/rollTotal() roll 42}}
+	  {{#rollTotal() roll 52}}
+		<div class="template-row template-center template-break">Hit Location: 25</div>
+		<div class="template-row template-center">LEFT ARM / HULL</div>
+	  {{/rollTotal() roll 52}}
+	  {{#rollTotal() roll 62}}
+		<div class="template-row template-center template-break">Hit Location: 26</div>
+		<div class="template-row template-center">LEFT ARM / HULL</div>
+	  {{/rollTotal() roll 62}}
+	  {{#rollTotal() roll 72}}
+		<div class="template-row template-center template-break">Hit Location: 27</div>
+		<div class="template-row template-center">LEFT ARM / HULL</div>
+	  {{/rollTotal() roll 72}}
+	  {{#rollTotal() roll 82}}
+		<div class="template-row template-center template-break">Hit Location: 28</div>
+		<div class="template-row template-center">LEFT ARM / HULL</div>
+	  {{/rollTotal() roll 82}}
+	  {{#rollTotal() roll 92}}
+		<div class="template-row template-center template-break">Hit Location: 29</div>
+		<div class="template-row template-center">LEFT ARM / HULL</div>
+	  {{/rollTotal() roll 92}}
+	  {{#rollTotal() roll 3}}
+		<div class="template-row template-center template-break">Hit Location: 30</div>
+		<div class="template-row template-center">LEFT ARM / HULL</div>
+	  {{/rollTotal() roll 3}}
+	  <!-- Hit Location: Body -->
+	  {{#rollTotal() roll 13}}
+		<div class="template-row template-center template-break">Hit Location: 31</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 13}}
+	  {{#rollTotal() roll 23}}
+		<div class="template-row template-center template-break">Hit Location: 32</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 23}}
+	  {{#rollTotal() roll 33}}
+		<div class="template-row template-center template-break">Hit Location: 33</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 33}}
+	  {{#rollTotal() roll 43}}
+		<div class="template-row template-center template-break">Hit Location: 34</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 43}}
+	  {{#rollTotal() roll 53}}
+		<div class="template-row template-center template-break">Hit Location: 35</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 53}}
+	  {{#rollTotal() roll 63}}
+		<div class="template-row template-center template-break">Hit Location: 36</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 63}}
+	  {{#rollTotal() roll 73}}
+		<div class="template-row template-center template-break">Hit Location: 37</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 73}}
+	  {{#rollTotal() roll 83}}
+		<div class="template-row template-center template-break">Hit Location: 38</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 83}}
+	  {{#rollTotal() roll 93}}
+		<div class="template-row template-center template-break">Hit Location: 39</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 93}}
+	  {{#rollTotal() roll 4}}
+		<div class="template-row template-center template-break">Hit Location: 40</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 4}}
+	  {{#rollTotal() roll 14}}
+		<div class="template-row template-center template-break">Hit Location: 41</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 14}}
+	  {{#rollTotal() roll 24}}
+		<div class="template-row template-center template-break">Hit Location: 42</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 24}}
+	  {{#rollTotal() roll 34}}
+		<div class="template-row template-center template-break">Hit Location: 43</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 34}}
+	  {{#rollTotal() roll 44}}
+		<div class="template-row template-center template-break">Hit Location: 44</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 44}}
+	  {{#rollTotal() roll 54}}
+		<div class="template-row template-center template-break">Hit Location: 45</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 54}}
+	  {{#rollTotal() roll 64}}
+		<div class="template-row template-center template-break">Hit Location: 46</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 64}}
+	  {{#rollTotal() roll 74}}
+		<div class="template-row template-center template-break">Hit Location: 47</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 74}}
+	  {{#rollTotal() roll 84}}
+		<div class="template-row template-center template-break">Hit Location: 48</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 84}}
+	  {{#rollTotal() roll 94}}
+		<div class="template-row template-center template-break">Hit Location: 49</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 94}}
+	  {{#rollTotal() roll 5}}
+		<div class="template-row template-center template-break">Hit Location: 50</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 5}}
+	  {{#rollTotal() roll 15}}
+		<div class="template-row template-center template-break">Hit Location: 51</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 15}}
+	  {{#rollTotal() roll 25}}
+		<div class="template-row template-center template-break">Hit Location: 52</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 25}}
+	  {{#rollTotal() roll 35}}
+		<div class="template-row template-center template-break">Hit Location: 53</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 35}}
+	  {{#rollTotal() roll 45}}
+		<div class="template-row template-center template-break">Hit Location: 54</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 45}}
+	  {{#rollTotal() roll 55}}
+		<div class="template-row template-center template-break">Hit Location: 55</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 55}}
+	  {{#rollTotal() roll 65}}
+		<div class="template-row template-center template-break">Hit Location: 56</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 65}}
+	  {{#rollTotal() roll 75}}
+		<div class="template-row template-center template-break">Hit Location: 57</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 75}}
+	  {{#rollTotal() roll 85}}
+		<div class="template-row template-center template-break">Hit Location: 58</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 85}}
+	  {{#rollTotal() roll 95}}
+		<div class="template-row template-center template-break">Hit Location: 59</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 95}}
+	  {{#rollTotal() roll 6}}
+		<div class="template-row template-center template-break">Hit Location: 60</div>
+		<div class="template-row template-center">BODY / HULL</div>
+	  {{/rollTotal() roll 6}}
+	  {{#rollTotal() roll 16}}
+		<div class="template-row template-center template-break">Hit Location: 61</div>
+		<div class="template-row template-center">BODY / WEAPON</div>
+	  {{/rollTotal() roll 16}}
+	  {{#rollTotal() roll 26}}
+		<div class="template-row template-center template-break">Hit Location: 62</div>
+		<div class="template-row template-center">BODY / WEAPON</div>
+	  {{/rollTotal() roll 26}}
+	  {{#rollTotal() roll 36}}
+		<div class="template-row template-center template-break">Hit Location: 63</div>
+		<div class="template-row template-center">BODY / WEAPON</div>
+	  {{/rollTotal() roll 36}}
+	  {{#rollTotal() roll 46}}
+		<div class="template-row template-center template-break">Hit Location: 64</div>
+		<div class="template-row template-center">BODY / WEAPON</div>
+	  {{/rollTotal() roll 46}}
+	  {{#rollTotal() roll 56}}
+		<div class="template-row template-center template-break">Hit Location: 65</div>
+		<div class="template-row template-center">BODY / WEAPON</div>
+	  {{/rollTotal() roll 56}}
+	  {{#rollTotal() roll 66}}
+		<div class="template-row template-center template-break">Hit Location: 66</div>
+		<div class="template-row template-center">BODY / WEAPON</div>
+	  {{/rollTotal() roll 66}}
+	  {{#rollTotal() roll 76}}
+		<div class="template-row template-center template-break">Hit Location: 67</div>
+		<div class="template-row template-center">BODY / WEAPON</div>
+	  {{/rollTotal() roll 76}}
+	  {{#rollTotal() roll 86}}
+		<div class="template-row template-center template-break">Hit Location: 68</div>
+		<div class="template-row template-center">BODY / WEAPON</div>
+	  {{/rollTotal() roll 86}}
+	  {{#rollTotal() roll 96}}
+		<div class="template-row template-center template-break">Hit Location: 69</div>
+		<div class="template-row template-center">BODY / WEAPON</div>
+	  {{/rollTotal() roll 96}}
+	  {{#rollTotal() roll 7}}
+		<div class="template-row template-center template-break">Hit Location: 70</div>
+		<div class="template-row template-center">BODY / WEAPON</div>
+	  {{/rollTotal() roll 7}}
+	  <!-- Hit Location: Right Leg -->
+	  {{#rollTotal() roll 17}}
+		<div class="template-row template-center template-break">Hit Location: 71</div>
+		<div class="template-row template-center">RIGHT LEG / WEAPON</div>
+	  {{/rollTotal() roll 17}}
+	  {{#rollTotal() roll 27}}
+		<div class="template-row template-center template-break">Hit Location: 72</div>
+		<div class="template-row template-center">RIGHT LEG / WEAPON</div>
+	  {{/rollTotal() roll 27}}
+	  {{#rollTotal() roll 37}}
+		<div class="template-row template-center template-break">Hit Location: 73</div>
+		<div class="template-row template-center">RIGHT LEG / WEAPON</div>
+	  {{/rollTotal() roll 37}}
+	  {{#rollTotal() roll 47}}
+		<div class="template-row template-center template-break">Hit Location: 74</div>
+		<div class="template-row template-center">RIGHT LEG / WEAPON</div>
+	  {{/rollTotal() roll 47}}
+	  {{#rollTotal() roll 57}}
+		<div class="template-row template-center template-break">Hit Location: 75</div>
+		<div class="template-row template-center">RIGHT LEG / WEAPON</div>
+	  {{/rollTotal() roll 57}}
+	  {{#rollTotal() roll 67}}
+		<div class="template-row template-center template-break">Hit Location: 76</div>
+		<div class="template-row template-center">RIGHT LEG / WEAPON</div>
+	  {{/rollTotal() roll 67}}
+	  {{#rollTotal() roll 77}}
+		<div class="template-row template-center template-break">Hit Location: 77</div>
+		<div class="template-row template-center">RIGHT LEG / WEAPON</div>
+	  {{/rollTotal() roll 77}}
+	  {{#rollTotal() roll 87}}
+		<div class="template-row template-center template-break">Hit Location: 78</div>
+		<div class="template-row template-center">RIGHT LEG / WEAPON</div>
+	  {{/rollTotal() roll 87}}
+	  {{#rollTotal() roll 97}}
+		<div class="template-row template-center template-break">Hit Location: 79</div>
+		<div class="template-row template-center">RIGHT LEG / WEAPON</div>
+	  {{/rollTotal() roll 97}}
+	  {{#rollTotal() roll 8}}
+		<div class="template-row template-center template-break">Hit Location: 80</div>
+		<div class="template-row template-center">RIGHT LEG / WEAPON</div>
+	  {{/rollTotal() roll 8}}
+	  {{#rollTotal() roll 18}}
+		<div class="template-row template-center template-break">Hit Location: 81</div>
+		<div class="template-row template-center">RIGHT LEG / TURRET</div>
+	  {{/rollTotal() roll 18}}
+	  {{#rollTotal() roll 28}}
+		<div class="template-row template-center template-break">Hit Location: 82</div>
+		<div class="template-row template-center">RIGHT LEG / TURRET</div>
+	  {{/rollTotal() roll 28}}
+	  {{#rollTotal() roll 38}}
+		<div class="template-row template-center template-break">Hit Location: 83</div>
+		<div class="template-row template-center">RIGHT LEG / TURRET</div>
+	  {{/rollTotal() roll 38}}
+	  {{#rollTotal() roll 48}}
+		<div class="template-row template-center template-break">Hit Location: 84</div>
+		<div class="template-row template-center">RIGHT LEG / TURRET</div>
+	  {{/rollTotal() roll 48}}
+	  {{#rollTotal() roll 58}}
+		<div class="template-row template-center template-break">Hit Location: 85</div>
+		<div class="template-row template-center">RIGHT LEG / TURRET</div>
+	  {{/rollTotal() roll 58}}
+	  <!-- Hit Location: Left Leg -->
+	  {{#rollTotal() roll 68}}
+		<div class="template-row template-center template-break">Hit Location: 86</div>
+		<div class="template-row template-center">LEFT LEG / TURRET</div>
+	  {{/rollTotal() roll 68}}
+	  {{#rollTotal() roll 78}}
+		<div class="template-row template-center template-break">Hit Location: 87</div>
+		<div class="template-row template-center">LEFT LEG / TURRET</div>
+	  {{/rollTotal() roll 78}}
+	  {{#rollTotal() roll 88}}
+		<div class="template-row template-center template-break">Hit Location: 88</div>
+		<div class="template-row template-center">LEFT LEG / TURRET</div>
+	  {{/rollTotal() roll 88}}
+	  {{#rollTotal() roll 98}}
+		<div class="template-row template-center template-break">Hit Location: 89</div>
+		<div class="template-row template-center">LEFT LEG / TURRET</div>
+	  {{/rollTotal() roll 98}}
+	  {{#rollTotal() roll 9}}
+		<div class="template-row template-center template-break">Hit Location: 90</div>
+		<div class="template-row template-center">LEFT LEG / TURRET</div>
+	  {{/rollTotal() roll 9}}
+	  {{#rollTotal() roll 19}}
+		<div class="template-row template-center template-break">Hit Location: 91</div>
+		<div class="template-row template-center">LEFT LEG / TURRET</div>
+	  {{/rollTotal() roll 19}}
+	  {{#rollTotal() roll 29}}
+		<div class="template-row template-center template-break">Hit Location: 92</div>
+		<div class="template-row template-center">LEFT LEG / TURRET</div>
+	  {{/rollTotal() roll 29}}
+	  {{#rollTotal() roll 39}}
+		<div class="template-row template-center template-break">Hit Location: 93</div>
+		<div class="template-row template-center">LEFT LEG / TURRET</div>
+	  {{/rollTotal() roll 39}}
+	  {{#rollTotal() roll 49}}
+		<div class="template-row template-center template-break">Hit Location: 94</div>
+		<div class="template-row template-center">LEFT LEG / TURRET</div>
+	  {{/rollTotal() roll 49}}
+	  {{#rollTotal() roll 59}}
+		<div class="template-row template-center template-break">Hit Location: 95</div>
+		<div class="template-row template-center">LEFT LEG / TURRET</div>
+	  {{/rollTotal() roll 59}}
+	  {{#rollTotal() roll 69}}
+		<div class="template-row template-center template-break">Hit Location: 96</div>
+		<div class="template-row template-center">LEFT LEG / TURRET</div>
+	  {{/rollTotal() roll 69}}
+	  {{#rollTotal() roll 79}}
+		<div class="template-row template-center template-break">Hit Location: 97</div>
+		<div class="template-row template-center">LEFT LEG / TURRET</div>
+	  {{/rollTotal() roll 79}}
+	  {{#rollTotal() roll 89}}
+		<div class="template-row template-center template-break">Hit Location: 98</div>
+		<div class="template-row template-center">LEFT LEG / TURRET</div>
+	  {{/rollTotal() roll 89}}
+	  {{#rollTotal() roll 99}}
+		<div class="template-row template-center template-break">Hit Location: 99</div>
+		<div class="template-row template-center">LEFT LEG / TURRET</div>
+	  {{/rollTotal() roll 99}}
+	  {{#rollTotal() roll 100}}
+		<div class="template-row template-center template-break">Hit Location: 00</div>
+		<div class="template-row template-center">LEFT LEG / TURRET</div>
+	  {{/rollTotal() roll 100}}
 		
 		<!--
 			<div class="template-row template-center template-break">Hit Location {{loc}}</div>

--- a/Only-War-Enhanced/sheet.json
+++ b/Only-War-Enhanced/sheet.json
@@ -8,7 +8,7 @@
 	"useroptions": [
 		{
 			"attribute": "initmod0",
-			"displayname": "Initiative Overrides",
+			"displayname": "Initiative Tiebreakers",
 			"type": "select",
 			"options": [
 				"No tiebreaker|[[floor",
@@ -23,7 +23,7 @@
 			"displayname": "Auto Roll Hit Locations",
 			"type": "select",
 			"options": [
-				"Automatically roll hit locations from an independent d100|{{loc=}}",
+				"Automatically roll hit locations from an independent d100|{{loc= }}",
 				"Don't automatically roll hit locations| "
 			],
 			"default": "{{loc=}}",


### PR DESCRIPTION
Added a space to {{loc=}}, to create {{loc= }}, which I have no idea if it'll work but it won't break anything to try
separated {{@{settings_hitroll}} to have a space before and after, for readability
adjusted whitespacing for hitroller
Renamed "Initative Overrides" to "Initiative Tiebreakers"

## Changes / Comments






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
