### PR TITLE
[Mothership Official] Fix NPC description & equipment text boxes

### DIFF
--- a/Mothership Official/mothership.html
+++ b/Mothership Official/mothership.html
@@ -2234,7 +2234,7 @@
         </div>
         <div class="ms-npcequipment">
           <h3 data-i18n="equipment"></h3>
-          <textarea class="ms-npcequipment__equipment" data-i18n-placeholder="Enter the NPC's equipment here." name="attr_description"></textarea>
+          <textarea class="ms-npcequipment__equipment" data-i18n-placeholder="Enter the NPC's equipment here." name="attr_equipment"></textarea>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Changes / Comments

A bugfix for the Mothership Official NPC sheet.

The text boxes for "Equipment" and "Description" on the NPC sheet were attributed with the same `name="attr_description"`, so their contents were kept the same.  This PR fixes that by correctly attributing `name="attr_equipment"` tot he Equipment box.


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ Y ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ Y ] Is this a bug fix?
- [ N ] Does this add functional enhancements (new features or extending existing features) ?
- [ N ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ Should be better, reverts a previous behaviour ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ N/A  ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
