### PR TITLE
[Monster of the Week Official] Updates for week of May 10 2021

### DIFF
--- a/Monster of the Week Official/MotWHTML.html
+++ b/Monster of the Week Official/MotWHTML.html
@@ -4486,7 +4486,7 @@
 							<input type="checkbox" class="sheet-checkbox sheet-ExpToggle" name="attr_Toggle-History" value="1" checked><span class="sheet-anglebox"></span>
 							<span class="sheet-ExpHeader"></span>
 							<div class="sheet-Expander">
-								<textarea name="attr_History" rows="5" cols="5"></textarea>
+								<textarea name="attr_History" rows="15" cols="5"></textarea>
 								<input type="hidden" name="attr_SkinCheck" class="sheet-SkinCheck sheet-99-hider" value="0"> 
 								<div>
 									<input type="checkbox" class="sheet-checkbox sheet-ExpToggle" name="attr_Toggle-chosen-hx" value="1" checked><span class="sheet-anglebox"></span>
@@ -9229,6 +9229,7 @@
 										<span class="sheet-Custom" data-i18n="custom">Custom</span>
 										<span data-i18n="move">move</span><span class="sheet-Hex">, <span data-i18n="hex-advance2">or an additional <i>Rote</i></span></span>
 									</span>
+									<input type="checkbox" class="sheet-triggerbox" name="attr_Imp-PlaybookMove-1"><span class="sheet-triggertext"><input type="text" name="attr_Imp-PlaybookMove-1-Choice"></span>
 								</div>
 								<div class="sheet-move sheet-Constructed sheet-Spooktacular sheet-Actionscientist sheet-Chosen sheet-Crooked sheet-Divine sheet-Expert sheet-Flake sheet-Initiate sheet-Monstrous sheet-Mundane sheet-Professional sheet-Spellslinger sheet-Spooky sheet-Wronged sheet-Gumshoe sheet-Hex sheet-Pararomantic sheet-Searcher sheet-Exile sheet-Hardcase sheet-Luchador sheet-Meddlingkid sheet-Sidekick sheet-Summoned sheet-Traveler sheet-Custom">
 									<input type="checkbox" class="sheet-checkbox" name="attr_Imp-PlaybookMove-2"><span class="sheet-mainbox"></span>
@@ -9265,6 +9266,7 @@
 										<span class="sheet-Custom" data-i18n="custom">Custom</span>
 										<span data-i18n="move">move</span><span class="sheet-Hex">, <span data-i18n="hex-advance2">or an additional <i>Rote</i></span></span>
 									</span>
+									<input type="checkbox" class="sheet-triggerbox" name="attr_Imp-PlaybookMove-2"><span class="sheet-triggertext"><input type="text" name="attr_Imp-PlaybookMove-2-Choice"></span>
 								</div>
 
 								<div class="sheet-move sheet-Hardcase2020 sheet-Constructed sheet-Spooktacular sheet-Actionscientist sheet-Chosen sheet-Crooked sheet-Divine sheet-Expert sheet-Flake sheet-Initiate sheet-Monstrous sheet-Mundane sheet-Professional sheet-Spellslinger sheet-Spooky sheet-Wronged sheet-Hex sheet-Pararomantic sheet-Searcher sheet-Exile sheet-Hardcase sheet-Luchador sheet-Meddlingkid sheet-Sidekick sheet-Snoop sheet-Summoned sheet-Traveler sheet-Custom">
@@ -9272,12 +9274,14 @@
 									<span class="sheet-grayable">
 										<span data-i18n="playbook-move">Take a move from another playbook</span>
 									</span>
+									<input type="checkbox" class="sheet-triggerbox" name="attr_Imp-PlaybookMove-Other1"><span class="sheet-triggertext"><input type="text" name="attr_Imp-PlaybookMove-Other1-Choice"></span>
 								</div>
 								<div class="sheet-move sheet-Hardcase2020 sheet-Constructed sheet-Spooktacular sheet-Actionscientist sheet-Chosen sheet-Crooked sheet-Divine sheet-Expert sheet-Flake sheet-Initiate sheet-Monstrous sheet-Mundane sheet-Professional sheet-Spellslinger sheet-Spooky sheet-Wronged sheet-Pararomantic sheet-Searcher sheet-Exile sheet-Hardcase sheet-Luchador sheet-Meddlingkid sheet-Sidekick sheet-Snoop sheet-Summoned sheet-Traveler sheet-Custom">
 									<input type="checkbox" class="sheet-checkbox" name="attr_Imp-PlaybookMove-Other2"><span class="sheet-mainbox"></span>
 									<span class="sheet-grayable">
 										<span data-i18n="playbook-move">Take a move from another playbook</span>
 									</span>
+									<input type="checkbox" class="sheet-triggerbox" name="attr_Imp-PlaybookMove-Other2"><span class="sheet-triggertext"><input type="text" name="attr_Imp-PlaybookMove-Other2-Choice"></span>
 								</div>
 
 								<!-- Playbook Specific Options -->
@@ -9308,13 +9312,16 @@
 										<span class="sheet-Snoop" data-i18n="snoop-advance1">Gain a Haven, like the <i>Expert</i>, with one option plus a film lab</span>
 										<span class="sheet-Actionscientist" data-i18n="as-haven">Gain a haven, like the Expert has, with a Workshop and one other option.</span>
 									</span>
+									<input type="checkbox" class="sheet-triggerbox" name="attr_Imp-Haven"><span class="sheet-triggertext"><input type="text" name="attr_Imp-Haven-Choice"></span>
 								</div>
 
 								<div class="sheet-move sheet-Expert sheet-Flake sheet-Wronged">
 									<input type="checkbox" class="sheet-checkbox" name="attr_Imp-HavenOpt1"><span class="sheet-mainbox"></span><span class="sheet-grayable"> <span data-i18n="expert-advance1">Add a Haven option</span>
+									<input type="checkbox" class="sheet-triggerbox" name="attr_Imp-HavenOpt1"><span class="sheet-triggertext"><input type="text" name="attr_Imp-HavenOpt1-Choice"></span>
 								</span></div>
 								<div class="sheet-move sheet-Expert">
 									<input type="checkbox" class="sheet-checkbox" name="attr_Imp-HavenOpt2"><span class="sheet-mainbox"></span><span class="sheet-grayable"> <span data-i18n="expert-advance1">Add a Haven option</span>
+									<input type="checkbox" class="sheet-triggerbox" name="attr_Imp-HavenOpt2"><span class="sheet-triggertext"><input type="text" name="attr_Imp-HavenOpt2-Choice"></span>
 								</span></div>
 
 								<div class="sheet-move sheet-Spooktacular">
@@ -9322,6 +9329,7 @@
 									<span class="sheet-grayable">
 										<span data-i18n="spooktacular-imp1">Take another Show option</span>
 									</span>
+									<input type="checkbox" class="sheet-triggerbox" name="attr_Imp-Show"><span class="sheet-triggertext"><input type="text" name="attr_Imp-Show-Choice"></span>
 								</div>
 
 								<div class="sheet-move sheet-Constructed">
@@ -9472,7 +9480,8 @@
 								<div class="sheet-move sheet-Hardcase2020 sheet-Constructed sheet-Spooktacular sheet-Actionscientist sheet-Chosen sheet-Crooked sheet-Divine sheet-Expert sheet-Flake sheet-Initiate sheet-Monstrous sheet-Mundane sheet-Professional sheet-Spellslinger sheet-Spooky sheet-Wronged sheet-Gumshoe sheet-Hex sheet-Pararomantic sheet-Searcher sheet-Exile sheet-Hardcase sheet-Luchador sheet-Meddlingkid sheet-Sidekick sheet-Snoop sheet-Summoned sheet-Traveler sheet-Custom">
 									<input type="checkbox" class="sheet-checkbox" name="attr_AdvImp-Any-1"><span class="sheet-mainbox"></span>
 									<span class="sheet-grayable">
-										+1 <span data-i18n="rating">to any rating</span> (<span data-i18n="max">max</span> +3) <input type="text" name="attr_AdvImp-Any-1-Choice"> 
+										+1 <span data-i18n="rating">to any rating</span> (<span data-i18n="max">max</span> +3) 
+										<input type="checkbox" class="sheet-triggerbox" name="attr_AdvImp-Any-1"><span class="sheet-triggertext"><input type="text" name="attr_AdvImp-Any-1-Choice"></span>
 									</span>
 								</div>
 								<div class="sheet-move sheet-Hardcase2020 sheet-Constructed sheet-Spooktacular sheet-Actionscientist sheet-Chosen sheet-Crooked sheet-Divine sheet-Expert sheet-Flake sheet-Initiate sheet-Monstrous sheet-Mundane sheet-Professional sheet-Spellslinger sheet-Spooky sheet-Wronged sheet-Gumshoe sheet-Hex sheet-Pararomantic sheet-Searcher sheet-Exile sheet-Hardcase sheet-Luchador sheet-Meddlingkid sheet-Sidekick sheet-Snoop sheet-Summoned sheet-Traveler sheet-Custom">
@@ -9611,7 +9620,7 @@
 								<div class="sheet-move sheet-Snoop">
 									<input type="checkbox" class="sheet-checkbox" name="attr_AdvImp-MakeItBig"><span class="sheet-mainbox"></span>
 									<span class="sheet-grayable">
-										<span data-i18n="snoop-advance2">Take another Show option</span>
+										<span data-i18n="snoop-advance2">Make it big. You're a superstar now!</span>
 									</span>
 								</div>
 


### PR DESCRIPTION
## Changes / Comments

A couple small quality of life improvements.

The History & Notes field is now triple in height, so folks will both notice and use it, and also be able to see more of what they put in.

A few of the advances now display a text field when you pick those advances so you can write down what specific choice you made after taking that advance.

No impacts on player data expected.

**PLEASE ALSO NOTE:** On live production Roll20, the Monster of the Week By Evil Hat sheet does not (at the time of this writing) correctly display some of the moves, despite the code and translation.json source file being correct for months now. As you might expect, I can't do anything about problems that don't actually exist in the code, so those problems are Roll20's to fix. Some sort of total refresh of the translation json and sheet html code on the production server probably needs to happen. I've reported this to Roll20 by email as well. 

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
