### PR TITLE
PokemonTabletopAdventure_v3 - Allow using the word 'Special' in JSON import instead

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -2995,7 +2995,7 @@
     const moveClass = inputData["move_class"];
     if(moveClass == "Attack"){
       responseData[`repeating_moves_${id}_move_category`] = 1;
-    } else if(moveClass == "Special Attack"){
+    } else if(moveClass == "Special Attack" || moveClass == "Special"){
       responseData[`repeating_moves_${id}_move_category`] = 2;
     } else if(moveClass == "Effect"){
       responseData[`repeating_moves_${id}_move_category`] = 3;


### PR DESCRIPTION
## Changes / Comments

The Pokelicious sheets have the word Special, not Special Attack. Allow this.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
