### PR TITLE
Update .gitignore to remove .DS_Store files from root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/*/.DS_Store
+.DS_Store


### PR DESCRIPTION
## Changes / Comments

### Issue
When using Github Desktop to manage the git repo on macOS, a .DS_Store file gets created in the root directory.

### What this PR does
Adds `.DS_Store` to the .gitignore file to fix the issue.

### How to review
- [ ] Download this PR
- [ ] In macOS, create a file name `.DS_Store` in the root of the project.
- [ ] Confirm that it is ignored by git.


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
