### PR TITLE
[approved.yaml] set publisher sheet Mythic D6

### DIFF
--- a/approved.yaml
+++ b/approved.yaml
@@ -3987,8 +3987,9 @@ finalfantasy4ed:
 - Final Fantasy Roleplaying Game 4th Edition
 mythicd6:
 - MythicD6
+- Mythic D6 by Khepera Publishing
 - Mythic D6
-- Mythic D6
+- publisher
 farsightrpg:
 - Farsight RPG Community Edition
 - Farsight RPG


### PR DESCRIPTION
## Changes / Comments
- Mythic D6 was never named as a publisher sheet, even though it was clearly stated in the original #8730 .
- I don't know if it works by retroactively updating the name & adding the "publisher" parameter, but this is the most practical method for bringing it to your attention.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
