### PR TITLE
[Splittermond] Spell damage and tooltips

### DIFF
--- a/Splittermond/Sheet.css
+++ b/Splittermond/Sheet.css
@@ -681,6 +681,23 @@ label {
     margin: 0 0 0 25px;
 }
 
+.sheet-switch__content--active {
+    display: none;
+}
+
+.sheet-switch__content--inactive {
+    display: block;
+    opacity: 0.5;
+}
+
+.sheet-switch[type="checkbox"]:checked ~ .sheet-switch__content--inactive {
+    display: none;
+}
+
+.sheet-switch[type="checkbox"]:checked ~ .sheet-switch__content--active {
+    display: block;
+}
+
 .sheet-form__group {
     position: relative;
     padding: 10px 0 0 0;
@@ -828,6 +845,11 @@ input[type="number"].sheet-form__field {
     background: #0489b1;
     color: #ffffff;
     word-break: break-all;
+}
+
+.sheet-popover .sheet-popover__content--md {
+    width: 21em;
+    word-break: normal;
 }
 
 .sheet-popover .sheet-popover__arrow {
@@ -1177,7 +1199,7 @@ input.sheet-button-image__checkbox {
 }
 
 .sheet-collapse_switch:checked + .sheet-collapse_child--lg {
-    max-height: 200px;
+    max-height: 300px;
 }
 
 .sheet-collapse_switch:checked + .sheet-arrow {

--- a/Splittermond/Sheet.html
+++ b/Splittermond/Sheet.html
@@ -2783,14 +2783,18 @@
                         <input type="text" name="attr_zauberwirkung" class="form__field" />
                     </div>
                     <div class="d--flex text--center">
-                        <button class="button" type=roll value="@{abilityroll} {{name=Zauber: @{zaubername}}} {{charactername=@{character_name}}} {{Probe=[[?{Art des Wurfs|Standardwurf, 2d10cs>10cf<1 | Sicherheitswurf, 2d10d1cs>10cf<1 | Risikowurf, 4d10k2cs>10cf<1} + @{zauberwert} + @{zaubermod1} + @{zaubermod2} + @{hiddenmod} + @{zauberattrmod} + ?{Modifikator|0} + @{hiddenallfert} - @{geblendet} - @{glaubenskrise} - @{schadensmod}]]}} {{schwierigkeit=[[1d0 + ?{Schwierigkeit|@{zauberschwierigkeit}}]]}} {{Ticks=[[3+@{gesamttickplus}+@{benommen} @{initracker_input}]]}} {{fokus=@{zauberkosten}}} {{sm27=[[?{Schwierigkeit}-27]]}} {{sm26=[[?{Schwierigkeit}-26]]}} {{sm24=[[?{Schwierigkeit}-24]]}} {{sm23=[[?{Schwierigkeit}-23]]}} {{sm21=[[?{Schwierigkeit}-21]]}} {{sm20=[[?{Schwierigkeit}-20]]}}  {{sm18=[[?{Schwierigkeit}-18]]}} {{sm17=[[?{Schwierigkeit}-17]]}} {{sm15=[[?{Schwierigkeit}-15]]}} {{sm14=[[?{Schwierigkeit}-14]]}} {{sm12=[[?{Schwierigkeit}-12]]}} {{sm11=[[?{Schwierigkeit}-11]]}} {{sm9=[[?{Schwierigkeit}-9]]}} {{sm8=[[?{Schwierigkeit}-8]]}} {{sm6=[[?{Schwierigkeit}-6]]}} {{sm5=[[?{Schwierigkeit}-5]]}} {{sm3=[[?{Schwierigkeit}-3]]}} {{sm2=[[?{Schwierigkeit}-2]]}} {{sm1=[[?{Schwierigkeit}-1]]}} {{s0=[[?{Schwierigkeit}]]}} {{s2=[[2+?{Schwierigkeit}]]}} {{s3=[[3+?{Schwierigkeit}]]}} {{s5=[[5+?{Schwierigkeit}]]}} {{s6=[[6+?{Schwierigkeit}]]}} {{s8=[[8+?{Schwierigkeit}]]}} {{s9=[[9+?{Schwierigkeit}]]}} {{s11=[[11+?{Schwierigkeit}]]}} {{s12=[[12+?{Schwierigkeit}]]}} {{s14=[[14+?{Schwierigkeit}]]}} {{s15=[[15+?{Schwierigkeit}]]}} {{s17=[[17+?{Schwierigkeit}]]}} {{s18=[[18+?{Schwierigkeit}]]}} {{s20=[[20+?{Schwierigkeit}]]}} {{s21=[[21+?{Schwierigkeit}]]}} {{s23=[[23+?{Schwierigkeit}]]}} {{s24=[[24+?{Schwierigkeit}]]}} {{s26=[[26+?{Schwierigkeit}]]}} {{s27=[[27+?{Schwierigkeit}]]}} {{s28=[[28+?{Schwierigkeit}]]}} {{s29=[[29+?{Schwierigkeit}]]}} {{s30=[[30+?{Schwierigkeit}]]}} {{s31=[[31+?{Schwierigkeit}]]}} {{s32=[[32+?{Schwierigkeit}]]}} {{s33=[[33+?{Schwierigkeit}]]}} {{s34=[[34+?{Schwierigkeit}]]}} {{s35=[[35+?{Schwierigkeit}]]}} {{s36=[[36+?{Schwierigkeit}]]}} {{s37=[[37+?{Schwierigkeit}]]}} {{s38=[[38+?{Schwierigkeit}]]}} {{s39=[[39+?{Schwierigkeit}]]}} {{s40=[[40+?{Schwierigkeit}]]}} {{s41=[[41+?{Schwierigkeit}]]}}"></button>
+                        <input type="hidden" name="attr_damagerollspell" />
+                        <input type="hidden" name="attr_spelldamagechanger" value=0 />
+                        <input type="hidden" name="attr_rolldamagespell" value="[Wirf!](~repeating_zauber_show_damage_spell)" />
+                        <button type="roll" name="roll_show_damage_spell" style="display: none" value="@{showing_damage_spell}" class="btn ui-draggable"></button>
+                        <input type="hidden" name="attr_showing_damage_spell" value="&{template:splittermond_damage} {{charactername=@{character_name}}} {{name=Zauber: @{zaubername}}} {{damage=[[@{damagerollspell}]]}}" />
+                        <button class="button" type=roll value="@{abilityroll} {{name=Zauber: @{zaubername}}} {{changer=@{spelldamagechanger}}} {{damage=@{rolldamagespell}}} {{charactername=@{character_name}}} {{Probe=[[?{Art des Wurfs|Standardwurf, 2d10cs>10cf<1 | Sicherheitswurf, 2d10d1cs>10cf<1 | Risikowurf, 4d10k2cs>10cf<1} + @{zauberwert} + @{zaubermod1} + @{zaubermod2} + @{hiddenmod} + @{zauberattrmod} + ?{Modifikator|0} + @{hiddenallfert} - @{geblendet} - @{glaubenskrise} - @{schadensmod}]]}} {{schwierigkeit=[[1d0 + ?{Schwierigkeit|@{zauberschwierigkeit}}]]}} {{Ticks=[[3+@{gesamttickplus}+@{benommen} @{initracker_input}]]}} {{fokus=@{zauberkosten}}} {{sm27=[[?{Schwierigkeit}-27]]}} {{sm26=[[?{Schwierigkeit}-26]]}} {{sm24=[[?{Schwierigkeit}-24]]}} {{sm23=[[?{Schwierigkeit}-23]]}} {{sm21=[[?{Schwierigkeit}-21]]}} {{sm20=[[?{Schwierigkeit}-20]]}}  {{sm18=[[?{Schwierigkeit}-18]]}} {{sm17=[[?{Schwierigkeit}-17]]}} {{sm15=[[?{Schwierigkeit}-15]]}} {{sm14=[[?{Schwierigkeit}-14]]}} {{sm12=[[?{Schwierigkeit}-12]]}} {{sm11=[[?{Schwierigkeit}-11]]}} {{sm9=[[?{Schwierigkeit}-9]]}} {{sm8=[[?{Schwierigkeit}-8]]}} {{sm6=[[?{Schwierigkeit}-6]]}} {{sm5=[[?{Schwierigkeit}-5]]}} {{sm3=[[?{Schwierigkeit}-3]]}} {{sm2=[[?{Schwierigkeit}-2]]}} {{sm1=[[?{Schwierigkeit}-1]]}} {{s0=[[?{Schwierigkeit}]]}} {{s2=[[2+?{Schwierigkeit}]]}} {{s3=[[3+?{Schwierigkeit}]]}} {{s5=[[5+?{Schwierigkeit}]]}} {{s6=[[6+?{Schwierigkeit}]]}} {{s8=[[8+?{Schwierigkeit}]]}} {{s9=[[9+?{Schwierigkeit}]]}} {{s11=[[11+?{Schwierigkeit}]]}} {{s12=[[12+?{Schwierigkeit}]]}} {{s14=[[14+?{Schwierigkeit}]]}} {{s15=[[15+?{Schwierigkeit}]]}} {{s17=[[17+?{Schwierigkeit}]]}} {{s18=[[18+?{Schwierigkeit}]]}} {{s20=[[20+?{Schwierigkeit}]]}} {{s21=[[21+?{Schwierigkeit}]]}} {{s23=[[23+?{Schwierigkeit}]]}} {{s24=[[24+?{Schwierigkeit}]]}} {{s26=[[26+?{Schwierigkeit}]]}} {{s27=[[27+?{Schwierigkeit}]]}} {{s28=[[28+?{Schwierigkeit}]]}} {{s29=[[29+?{Schwierigkeit}]]}} {{s30=[[30+?{Schwierigkeit}]]}} {{s31=[[31+?{Schwierigkeit}]]}} {{s32=[[32+?{Schwierigkeit}]]}} {{s33=[[33+?{Schwierigkeit}]]}} {{s34=[[34+?{Schwierigkeit}]]}} {{s35=[[35+?{Schwierigkeit}]]}} {{s36=[[36+?{Schwierigkeit}]]}} {{s37=[[37+?{Schwierigkeit}]]}} {{s38=[[38+?{Schwierigkeit}]]}} {{s39=[[39+?{Schwierigkeit}]]}} {{s40=[[40+?{Schwierigkeit}]]}} {{s41=[[41+?{Schwierigkeit}]]}}"></button>
                     </div>
-                    <input type="hidden" name="attr_fernwaffenattrmod" value="0">
                 </div>
                 <input type="checkbox" name="attr_zaubersprueche_collapse"  class="collapse_switch d--none" />
                 <div class="collapse_child collapse_child--lg">
-                    <div class="d--flex mb--1">
-                        <div class="form__group mr--2">
+                    <div class="d--flex d--flex--align-bottom mb--1">
+                        <div class="form__group d--flex__item--grow2 mr--2">
                             <select class="form__box" name="attr_magieschulen">                
                                 <option value="nix"></option>
                                 <option value="arkanekundezauber">Arkane Kunde</option>
@@ -2832,11 +2836,73 @@
                             <input class="form__field" type="text" name="attr_zauberwd" />
                             <label class="form__label">Wirkungsdauer</label>
                         </div>
-                    </div>                    
-                    <div class="form__group form__group--lg">
+                    </div>
+                    <div class="form__group form__group--lg mb--3">
                         <textarea name="attr_zauberbeschreibung"></textarea>
                         <label class="form__label">Beschreibung</label>
                     </div>
+                    <div class="d--flex d--flex--align-center">
+                        <span class="d--flex__item--grow0 mr--1">Zauberschaden aktivieren?</span> 
+                        <label class="d--flex__item--grow0">
+                            <input type="checkbox" name="attr_spelldmgactive" class="switch" />
+                            <span class="switch__slider"></span>
+                        </label>
+                    </div>
+                    <input type="checkbox" name="attr_spelldmgactive" class="switch" />
+                    <div class="switch__content--inactive">
+                        <div class="d--flex d--flex--align-bottom">
+                            <div class="form__group pr--2">
+                                <input class="form__field" type="number" value=0 disabled />
+                                <label class="form__label">W&uuml;rfelanzahl</label>
+                            </div>
+                            <div class="form__group pr--1">
+                                <select class="sheet-form__box" name="attr_zauberschadenwuerfel" disabled>  
+                                    <optgroup>
+                                        <option>W6</option>
+                                    </optgroup>
+                                </select>
+                                <label class="form__label">W&uuml;rfelseiten</label>
+                            </div>
+                            <span class="d--flex__item--grow0 text--lg pr--1">+</span>
+                            <div class="form__group pr--2">
+                                <input class="form__field" type="number" value=0 disabled />
+                                <label class="form__label">Schadensmod.</label>
+                            </div>
+                            <div class="form__group d--flex__item--grow3">
+                                <input class="form__field" type="text" value="-" disabled />
+                                <label class="form__label">Merkmale</label>
+                            </div>
+                        </div> 
+                    </div>
+                    <div class="switch__content--active">
+                        <div class="d--flex d--flex--align-bottom">
+                            <div class="form__group pr--2">
+                                <input class="form__field" type="number" name="attr_zauberschaden1" value="1" />
+                                <label class="form__label">W&uuml;rfelanzahl</label>
+                            </div>
+                            <div class="form__group pr--1">
+                                <select class="sheet-form__box" name="attr_zauberschadenwuerfel">  
+                                    <optgroup>
+                                        <option value="d6">W6</option>
+                                        <option value="d10">W10</option>
+                                    </optgroup>
+                                </select>
+                                <label class="form__label">W&uuml;rfelseiten</label>
+                            </div>
+                            <span class="d--flex__item--grow0 text--lg pr--1">+</span>
+                            <div class="form__group pr--2">
+                                <input class="form__field" type="number" name="attr_zauberschaden3" value="0" />
+                                <label class="form__label">Schadensmod.</label>
+                            </div>
+                            <div class="form__group d--flex__item--grow3">
+                                <input class="form__field" type="text" name="attr_zaubermerkmale" />
+                                <input type="hidden" name="attr_zauberexakt" value="0" />
+                                <input type="hidden" name="attr_zauberscharf" value="0"  />
+                                <input type="hidden" name="attr_zauberkritisch" value="0" />
+                                <label class="form__label">Merkmale</label>
+                            </div>
+                        </div>  
+                    </div> 
                 </div>
             </fieldset>
             <h2 class="mt--3">Magieschulen</h2>
@@ -3738,7 +3804,6 @@
                     <input type="hidden" name="attr_showing_damage" value="&{template:splittermond_damage} {{charactername=@{character_name}}} {{name=Waffe: @{waffenname}}} {{damage=[[@{damageroll}]]}}" />
                     <div class="d--flex d--flex__item--grow2 text--center">
                         <button class="button button--primary" type=roll value="@{abilityroll} {{name=Waffe: @{waffenname}}} {{charactername=@{character_name}}} {{damage=@{rolldamage}}} {{Probe=[[?{Art des Wurfs|Standardwurf, 2d10cs>10cf<1 | Sicherheitswurf, 2d10d1cs>10cf<1 | Risikowurf, 4d10k2cs>10cf<1} + @{waffenwert} + @{waffenmod} + @{nahwaffenattrmod} + ?{Modifikator|0} + @{angriffsbonus} + @{kampffertigkeitenbonus} + @{hiddenallfert} - @{geblendet} - @{erschoepft} - @{schadensmod}]]}} {{schwierigkeit=[[1d0 + ?{Schwierigkeit|15}]]}} {{Ticks=[[@{waffenwgs}+@{gesamttickplus}+@{benommen}} @{initracker_input}]]}} {{sm27=[[?{Schwierigkeit}-27]]}} {{sm26=[[?{Schwierigkeit}-26]]}} {{sm24=[[?{Schwierigkeit}-24]]}} {{sm23=[[?{Schwierigkeit}-23]]}} {{sm21=[[?{Schwierigkeit}-21]]}} {{sm20=[[?{Schwierigkeit}-20]]}}  {{sm18=[[?{Schwierigkeit}-18]]}} {{sm17=[[?{Schwierigkeit}-17]]}} {{sm15=[[?{Schwierigkeit}-15]]}} {{sm14=[[?{Schwierigkeit}-14]]}} {{sm12=[[?{Schwierigkeit}-12]]}} {{sm11=[[?{Schwierigkeit}-11]]}} {{sm9=[[?{Schwierigkeit}-9]]}} {{sm8=[[?{Schwierigkeit}-8]]}} {{sm6=[[?{Schwierigkeit}-6]]}} {{sm5=[[?{Schwierigkeit}-5]]}} {{sm3=[[?{Schwierigkeit}-3]]}} {{sm2=[[?{Schwierigkeit}-2]]}} {{sm1=[[?{Schwierigkeit}-1]]}} {{s0=[[?{Schwierigkeit}]]}} {{s2=[[2+?{Schwierigkeit}]]}} {{s3=[[3+?{Schwierigkeit}]]}} {{s5=[[5+?{Schwierigkeit}]]}} {{s6=[[6+?{Schwierigkeit}]]}} {{s8=[[8+?{Schwierigkeit}]]}} {{s9=[[9+?{Schwierigkeit}]]}} {{s11=[[11+?{Schwierigkeit}]]}} {{s12=[[12+?{Schwierigkeit}]]}} {{s14=[[14+?{Schwierigkeit}]]}} {{s15=[[15+?{Schwierigkeit}]]}} {{s17=[[17+?{Schwierigkeit}]]}} {{s18=[[18+?{Schwierigkeit}]]}} {{s20=[[20+?{Schwierigkeit}]]}} {{s21=[[21+?{Schwierigkeit}]]}} {{s23=[[23+?{Schwierigkeit}]]}} {{s24=[[24+?{Schwierigkeit}]]}} {{s26=[[26+?{Schwierigkeit}]]}} {{s27=[[27+?{Schwierigkeit}]]}} {{s28=[[28+?{Schwierigkeit}]]}} {{s29=[[29+?{Schwierigkeit}]]}} {{s30=[[30+?{Schwierigkeit}]]}} {{s31=[[31+?{Schwierigkeit}]]}} {{s32=[[32+?{Schwierigkeit}]]}} {{s33=[[33+?{Schwierigkeit}]]}} {{s34=[[34+?{Schwierigkeit}]]}} {{s35=[[35+?{Schwierigkeit}]]}} {{s36=[[36+?{Schwierigkeit}]]}} {{s37=[[37+?{Schwierigkeit}]]}} {{s38=[[38+?{Schwierigkeit}]]}} {{s39=[[39+?{Schwierigkeit}]]}} {{s40=[[40+?{Schwierigkeit}]]}} {{s41=[[41+?{Schwierigkeit}]]}}"></button>
-                        <!--<button type=roll value="&{template:splittermond_aktiveabwehr} {{waffenname=@{waffenname}}} {{naming=[[2d1]]}} {{def=[[1d0 + @{waffendefensiv}]]}} {{charactername=@{character_name}}} {{Wurf=[[?{Art des Wurfs|Standardwurf, 2d10cs>10cf<1 | Sicherheitswurf, 2d10d1cs>10cf<1 | Risikowurf, 4d10k2cs>10cf<1} + ?{Modifikator|0} + @{waffenwert} + @{waffenmod} + @{kampffertigkeitenbonus} + @{hiddenallfert} - @{erschoepft} - @{schadensmod}]]}} {{schwierigkeit=[[?{Schwierigkeit|15}]]}} {{v=[[1d0 + @{verteidigung}]]}} {{Ticks=[[3]]}} {{v1=[[1d1 + @{verteidigung}]]}} {{v2=[[2d1 + @{verteidigung}]]}} {{v3=[[3d1 + @{verteidigung}]]}} {{v4=[[4d1 + @{verteidigung}]]}} {{v5=[[5d1 + @{verteidigung}]]}} {{v6=[[6d1 + @{verteidigung}]]}} {{v7=[[7d1 + @{verteidigung}]]}} {{v8=[[8d1 + @{verteidigung}]]}} {{v9=[[9d1 + @{verteidigung}]]}} {{v10=[[10d1 + @{verteidigung}]]}} {{v11=[[11d1 + @{verteidigung}]]}} {{v12=[[12d1 + @{verteidigung}]]}} {{v13=[[13d1 + @{verteidigung}]]}} {{v14=[[14d1 + @{verteidigung}]]}} {{v15=[[15d1 + @{verteidigung}]]}} {{v16=[[16d1 + @{verteidigung}]]}} {{v17=[[17d1 + @{verteidigung}]]}} {{v18=[[18d1 + @{verteidigung}]]}} {{v19=[[19d1 + @{verteidigung}]]}} {{v20=[[20d1 + @{verteidigung}]]}} {{v21=[[21d1 + @{verteidigung}]]}}"></button>-->
                         <button class="button" type=roll value="&{template:splittermond_aktiveabwehr} {{waffenname=@{waffenname}}} {{naming=[[2d1]]}} {{def=[[1d0 + @{waffendefensiv}]]}} {{charactername=@{character_name}}} {{Wurf=[[?{Art des Wurfs|Standardwurf, 2d10cs>10cf<1 | Sicherheitswurf, 2d10d1cs>10cf<1 | Risikowurf, 4d10k2cs>10cf<1} + ?{Modifikator|0} + @{waffenwert} + @{waffenmod} + @{kampffertigkeitenbonus} + @{hiddenallfert} - @{erschoepft} - @{schadensmod}]]}} {{schwierigkeit=[[?{Schwierigkeit|15}]]}} {{v=[[1d0 + @{verteidigung}]]}} {{Ticks=[[3 @{initracker_input}]]}} {{v1=[[1d1 + @{verteidigung}]]}} {{v2=[[2d1 + @{verteidigung}]]}} {{v3=[[3d1 + @{verteidigung}]]}} {{v4=[[4d1 + @{verteidigung}]]}} {{v5=[[5d1 + @{verteidigung}]]}} {{v6=[[6d1 + @{verteidigung}]]}} {{v7=[[7d1 + @{verteidigung}]]}} {{v8=[[8d1 + @{verteidigung}]]}} {{v9=[[9d1 + @{verteidigung}]]}} {{v10=[[10d1 + @{verteidigung}]]}} {{v11=[[11d1 + @{verteidigung}]]}} {{v12=[[12d1 + @{verteidigung}]]}} {{v13=[[13d1 + @{verteidigung}]]}} {{v14=[[14d1 + @{verteidigung}]]}} {{v15=[[15d1 + @{verteidigung}]]}} {{v16=[[16d1 + @{verteidigung}]]}} {{v17=[[17d1 + @{verteidigung}]]}} {{v18=[[18d1 + @{verteidigung}]]}} {{v19=[[19d1 + @{verteidigung}]]}} {{v20=[[20d1 + @{verteidigung}]]}} {{v21=[[21d1 + @{verteidigung}]]}}"></button>
                     </div>
                     <input type="hidden" name="attr_nahwaffenattrmod" value="0">
@@ -4702,6 +4767,10 @@
         <input type="checkbox" name="attr_updates" class="d--none" value="42" title="Updates" />
     </label>
     <h1 style="color: white;">Letzte Updates</h1> <br/>
+    <h2 style="color: white;">24.05.2021</h2>
+    <ul>
+        <li>Bei Zaubespr&uuml;chen ist jetzt der Zauberschaden einstellbar.</li>
+    </ul>
     <h2 style="color: white;">02.05.2021</h2>
     <b>Umfangreiches Redesign:</b> Anpassung von Layout, Schrift, Farben, Eingabefeldern und Struktur auf dem Spielercharakterbogen. NSC- und Kreaturenbogen werden demnächst angepasst. Sowie der Genesis-Importer und die Einstellungen.
     <ul>
@@ -4715,12 +4784,6 @@
     <h2 style="color: white;">17.03.2021</h2>
     <ul>
         <li>Die Einstellung, ob der Turn Tracker verwendet wird, wird ab jetzt im <i>Einstellungen</i>-Reiter (de-)aktiviert.</li>
-    </ul>
-    <h2 style="color: white;">16.03.2021</h2>
-    Der Charakterbogen unterst&uuml;tzt jetzt den Roll20 Turn Tracker. Ihr findet ihn unter Kampf & Meisterschaften &rarr; "Roll20 Turn Tracker verwenden?" (unter den Patzer-W&uuml;rfen)
-    <ul>
-        <li>Turn Tracker-Unterst&uuml;tzung f&uuml;r den SC-Bogen implementiert</li>
-        <li>Turn Tracker-Unterst&uuml;tzung f&uuml;r den NSC-Bogen implementiert</li>
     </ul>
 </div>
 <p class="text--center">Mit Dank an alle begeisterten Splittermond-Spieler, die diesen Charakterbogen nutzen und mit ihrem Feedback für stetige Verbesserungen sorgen!</p>
@@ -5137,9 +5200,9 @@
         {{#Ticks}}
             <tr><td width="90%"><b>Ticks</b></td><td width="10%" align="center"><b>{{Ticks}}</b></td></tr>
         {{/Ticks}}
-        {{#damage}}
-           <tr><td width="90%"><b>Schaden</b></td><td width="10%" align="center"><b>{{damage}}</b></td></tr>
-        {{/damage}}
+        {{#rollBetween() changer 1 1}}
+            <tr><td width="90%"><b>Schaden</b></td><td width="10%" align="center"><b>{{damage}}</b></td></tr>
+        {{/rollBetween() changer 1 1}}
         {{#rollGreater() Probe schwierigkeit}}
         <tr><td colspan="2" class="sheet-header" align="center" style="color:#298A08;">Gelungen!</td>
         {{/rollGreater() Probe schwierigkeit}}
@@ -7847,6 +7910,32 @@ on("change:repeating_nahkampfwaffen:waffenmerkmale", function(eventInfo) {
     });
 });
 
+on("change:repeating_zauber:zaubermerkmale", function(eventInfo) {
+    getAttrs(["repeating_zauber_zaubermerkmale"], function(v) {
+        let zaubermerkmale = v["repeating_zauber_zaubermerkmale"].toLowerCase().split(",");
+        let exakt = 0;
+        let scharf = 0;
+        let kritisch = 0;
+        let defensiv = 0;
+        for (var i = 0; i < zaubermerkmale.length; i++) {
+            if (zaubermerkmale[i].search("exakt") != -1) {
+                exakt = zaubermerkmale[i].slice(6).trim();
+            }
+            if (zaubermerkmale[i].search("scharf") != -1) {
+                scharf = zaubermerkmale[i].slice(7).trim();
+            }
+            if (zaubermerkmale[i].search("kritisch") != -1) {
+                kritisch = zaubermerkmale[i].slice(9).trim();
+            }
+        }
+        setAttrs({
+           'repeating_zauber_zauberexakt': +exakt,
+           'repeating_zauber_zauberscharf': +scharf,
+           'repeating_zauber_zauberkritisch': +kritisch
+        });  
+    });
+});
+
 on("change:repeating_nahkampfwaffen:waffenscharf change:repeating_nahkampfwaffen:waffenexakt change:repeating_nahkampfwaffen:waffenkritisch change:repeating_nahkampfwaffen:waffenschaden1 change:repeating_nahkampfwaffen:waffenschadenwuerfel change:repeating_nahkampfwaffen:waffenschaden3 change:repeating_nahkampfwaffen:waffenname", function(eventInfo) {
     getAttrs(["repeating_nahkampfwaffen_waffenexakt", "repeating_nahkampfwaffen_waffenkritisch", "repeating_nahkampfwaffen_waffenscharf", "repeating_nahkampfwaffen_waffenschaden1", "repeating_nahkampfwaffen_waffenschadenwuerfel", "repeating_nahkampfwaffen_waffenschaden3"], function(v) {
         let exakt = v["repeating_nahkampfwaffen_waffenexakt"];
@@ -7885,6 +7974,55 @@ on("change:repeating_nahkampfwaffen:waffenscharf change:repeating_nahkampfwaffen
         }
         setAttrs({
             'repeating_nahkampfwaffen_damageroll': damagerollstring
+        });
+    });
+});
+
+on("change:repeating_zauber:zauberscharf change:repeating_zauber:spelldmgactive change:repeating_zauber:zauberexakt change:repeating_zauber:zauberkritisch change:repeating_zauber:zauberschaden1 change:repeating_zauber:zauberschadenwuerfel change:repeating_zauber:zauberschaden3 change:repeating_zauber:zaubername", function(eventInfo) {
+    getAttrs(["repeating_zauber_zauberexakt", "repeating_zauber_spelldmgactive", "repeating_zauber_zauberkritisch", "repeating_zauber_zauberscharf", "repeating_zauber_zauberschaden1", "repeating_zauber_zauberschadenwuerfel", "repeating_zauber_zauberschaden3"], function(v) {
+        let spelldamagechanger = "[[0d1]]";
+        let spelldmgactive = v["repeating_zauber_spelldmgactive"];
+        if (spelldmgactive == "on") {
+            spelldamagechanger = "[[1d1]]";
+        }
+        let damagerollstring = "";
+        let exakt = v["repeating_zauber_zauberexakt"];
+        let scharf = v["repeating_zauber_zauberscharf"];
+        let kritisch = v["repeating_zauber_zauberkritisch"];
+        let zauberschaden1 = v["repeating_zauber_zauberschaden1"];
+        let zauberschadenwuerfel = v["repeating_zauber_zauberschadenwuerfel"];
+        let zauberschaden3 = v["repeating_zauber_zauberschaden3"];
+        let die_max = 0;
+        let die_minus = 0;
+        
+        if (scharf < 0) { scharf = 0; }
+        if (exakt < 0) { exakt = 0; }
+        if (kritisch < 0) { kritisch = 0; }
+        if (kritisch > 0) {
+            damagerollstring = "";
+            die_max = zauberschadenwuerfel.substr(1);
+            die_minus = +zauberschadenwuerfel.substr(1) - 1;
+            if ((+zauberschaden1 + +exakt) == 1) {
+                damagerollstring += "{1" + zauberschadenwuerfel + "}<" + +die_minus + "*([[{1d" + +die_minus + "," + scharf + "d1}k1]]-" +  (+die_max + +kritisch) + ")+"  + (+die_max + +kritisch) + "+" + zauberschaden3;
+            } else {
+                damagerollstring = "{";
+                for (i = 1; i <= +zauberschaden1 + +exakt; i++) {
+                    damagerollstring = damagerollstring + "{1" + zauberschadenwuerfel + "}<" + +die_minus + "*([[{1d" + +die_minus + "," + scharf + "d1}k1]]-" + (+die_max + +kritisch) + ")+" + (+die_max + +kritisch) + ",";
+                }
+                damagerollstring = damagerollstring.slice(0, -1);
+                damagerollstring += "}k" + zauberschaden1 + " + " + zauberschaden3;
+            }
+        } else if (kritisch == 0) {
+            damagerollstring = "{";
+            for (i = 1; i <= +zauberschaden1 + +exakt; i++) {
+                damagerollstring = damagerollstring + "{1" + zauberschadenwuerfel+", " + scharf + "d1}k1,";
+            }
+            damagerollstring = damagerollstring.slice(0, -1);
+            damagerollstring = damagerollstring +"}k" + zauberschaden1 + " + " + zauberschaden3;
+        }
+        setAttrs({
+            'repeating_zauber_damagerollspell': damagerollstring,
+            'repeating_zauber_spelldamagechanger': spelldamagechanger
         });
     });
 });
@@ -8415,27 +8553,6 @@ function writeToSheet (characterData) {
                 character["repeating_zauber_" + newrowid + "_zauberwd"] = characterData["spells"][i]["spellDuration"];
                 if (characterData["spells"][i]["longDescription"] != null) {
                     spelllongdescription = characterData["spells"][i]["longDescription"];
-                    spelldamage = spelllongdescription.toString().match(/\d+[W,w]+[6,10]+\+\d+/g);
-                    if (spelldamage != null) {
-                        newrowid = generateRowID();
-                        let zauberschaden1 = spelldamage.toString().split("W")[0];
-                        let zauberschadenw = spelldamage.toString().indexOf("W6") > -1 ? "d6" : "d10";
-                        let zauberschaden2 = spelldamage.toString().indexOf("+") > -1 ? spelldamage.toString().split("+")[1] : "";
-                        let school = characterData["spells"][i]["school"].toString().toLowerCase();
-                        let schoolsattributes = {"bannmagie":"mys/wil","beherrschungsmagie":"mys/wil","bewegungsmagie":"mys/bew","erkenntnismagie":"mys/ver","felsmagie":"mys/kon","feuermagie":"mys/aus","heilungsmagie":"mys/aus","illusionsmagie":"mys/aus","kampfmagie":"mys/stae","lichtmagie":"mys/aus","naturmagie":"mys/aus","schattenmagie":"mys/int","schicksalsmagie":"mys/aus","schutzmagie":"mys/aus","staerkungsmagie":"mys/stae","todesmagie":"mys/ver","verwandlungsmagie":"mys/kon","wassermagie":"mys/int","windmagie":"mys/ver"};
-                    
-                        character["repeating_fernkampfwaffen_" + newrowid + "_waffennamefern"] = characterData["spells"][i]["name"];
-                        character["repeating_fernkampfwaffen_" + newrowid + "_waffenskillfern"] = school;
-                        
-                        character["repeating_fernkampfwaffen_" + newrowid + "_waffenattr1fern"] = schoolsattributes[school].toString().split("/")[0];
-                        character["repeating_fernkampfwaffen_" + newrowid + "_waffenattr2fern"] = schoolsattributes[school].toString().split("/")[1];
-                        
-                        character["repeating_fernkampfwaffen_" + newrowid + "_waffenwgsfern"] = characterData["spells"][i]["castDuration"].split("T")[0];
-                        
-                        character["repeating_fernkampfwaffen_" + newrowid + "_waffenschaden1fern"] = +zauberschaden1;
-                        character["repeating_fernkampfwaffen_" + newrowid + "_waffenschadenwuerfelfern"] = zauberschadenw;
-                        character["repeating_fernkampfwaffen_" + newrowid + "_waffenschaden3fern"] = +zauberschaden2;
-                    }
                     character["repeating_zauber_" + newrowid + "_zauberbeschreibung"] = spelllongdescription;
                 }
             }


### PR DESCRIPTION
## Changes / Comments

- Adding input fields for spell damage
- Adding sheetworker for filling spell damage fields
- Changing rolltemplate to allow players to enable and disable damage rolls


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [X] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
