### PR TITLE
[Fate] Developer mode & compendium support

### DIFF
--- a/Fate/FateOmni.html
+++ b/Fate/FateOmni.html
@@ -1448,9 +1448,8 @@
 									</span>
 								</div>
 								<div>
-									<span class="deeptriggered"><input type="checkbox" class="triggerbox" name="attr_rollthis" value="1"><span>(+<span name="attr_rollvalue"></span>)</span></span>
 									<span class="deeptriggered"><input type="checkbox" class="checkbox" name="attr_rollthis" value="1"><span class="checkmark"></span></span>
-									<span name="attr_aspect" class="name"></span>
+									<span class="name"><span class="deeptriggered"><input type="checkbox" class="triggerbox" name="attr_rollthis" value="1"><span>+</span></span><span name="attr_aspect"></span><span class="deeptriggered"> (+<span name="attr_rollvalue"></span>)</span></span>
 									<input type="hidden" value="" name="attr_flags" class="hideIfNull"><span>(<span name="attr_flags"></span>)</span>
 									<span>
 										<input type="checkbox" class="checkbox" name="attr_options" value="1"><span class="optionsbox"></span>

--- a/Fate/FateOmni.html
+++ b/Fate/FateOmni.html
@@ -34,9 +34,19 @@
 				<div data-i18n="custom-aspects-desc"></div>
 			</div>
 			<div>
-				<b><span data-i18n="custom-conditions"></span>:</b>
-				<input type="text" name="attr_custom-conditions" value="">
-				<div data-i18n="custom-conditions-desc"></div>
+				<b><span data-i18n="custom-skills"></span>:</b>
+				<input type="text" name="attr_custom-skills" value="">
+				<div data-i18n="custom-skills-desc"></div>
+			</div>
+			<div>
+				<b><span data-i18n="custom-combos-columns"></span>:</b>
+				<input type="text" name="attr_custom-combos" value="">
+				<div data-i18n="custom-combos-desc"></div>
+			</div>
+			<div>
+				<b><span data-i18n="custom-stress"></span>:</b>
+				<input type="text" name="attr_custom-stress" value="">
+				<div data-i18n="custom-stress-desc"></div>
 			</div>
 			<div>
 				<b><span data-i18n="custom-consequences"></span>:</b>
@@ -44,14 +54,9 @@
 				<div data-i18n="custom-consequences-desc"></div>
 			</div>
 			<div>
-				<b><span data-i18n="custom-skills"></span>:</b>
-				<input type="text" name="attr_custom-skills" value="">
-				<div data-i18n="custom-skills-desc"></div>
-			</div>
-			<div>
-				<b><span data-i18n="custom-stress"></span>:</b>
-				<input type="text" name="attr_custom-stress" value="">
-				<div data-i18n="custom-stress-desc"></div>
+				<b><span data-i18n="custom-conditions"></span>:</b>
+				<input type="text" name="attr_custom-conditions" value="">
+				<div data-i18n="custom-conditions-desc"></div>
 			</div>
 		</div>
 	</div>
@@ -2073,6 +2078,8 @@ var gamesets = {
 		consequences: [],
 		conditions: [],
 		skills: [],
+		combos: [[],[],[]],
+		combosnames: [],
 		settings: {}
 	},
 	ngen: {
@@ -3174,10 +3181,11 @@ var loadGame = function(key) {
 			if ( key === "custom" ) {
 				
 				getAttrs(
-					[ "custom-aspects", "custom-consequences", "custom-skills", "custom-stress", "custom-conditions" ],
+					[ "custom-aspects", "custom-consequences", "custom-skills", "custom-stress", "custom-conditions", "custom-combos" ],
 					function(c) {
 						var aspects = c["custom-aspects"].trim();
 						var skills = c["custom-skills"].trim();
+						var combos = c["custom-combos"].trim();
 						var consequences = c["custom-consequences"].trim();
 						var conditions = c["custom-conditions"].trim();
 						var stresses = c["custom-stress"].trim();
@@ -3187,6 +3195,41 @@ var loadGame = function(key) {
 						if ( skills !== "" ) { 
 							set.skills = skills.toString().split(/\s*,\s*/);
 							set.settings["SkillStyle"] = "list"; // So it'll display something at all
+						}
+						if ( combos !== "" ) { 
+							var tempsplit = [];
+							set.combos = combos.toString().split(/\s*;\s*/); // column groups are separated by semicolons
+							set.combosnames = ["","",""]; // ZOD
+							if ( typeof set.combos[0] !== "undefined" && set.combos[0] !== "" ) {
+								set.combos[0] = set.combos[0].toString().split(/\s*,\s*/); // split up the comma separated skills in the column, make it an array entry
+							}
+							if ( typeof set.combos[1] !== "undefined" && set.combos[1] !== "" ) {
+								set.combos[1] = set.combos[1].toString().split(/\s*,\s*/); // split up the comma separated skills in the column, make it an array entry
+							}
+							if ( typeof set.combos[2] !== "undefined" && set.combos[2] !== "" ) {
+								set.combos[2] = set.combos[2].toString().split(/\s*,\s*/); // split up the comma separated skills in the column, make it an array entry
+							}
+							tempsplit = set.combos[0][0].toString().split(/\s*:\s*/);
+							if(typeof tempsplit[1] !== "undefined" && tempsplit[1] !== "") {
+								log("got a column label: " + tempsplit[0]);
+								// Then we've got the column label in tempsplit[0] and the actual skill name in tempsplit[1]
+								set.combosnames[0] = tempsplit[0];
+								set.combos[0][0] = tempsplit[1];
+							}
+							tempsplit = set.combos[1][0].toString().split(/\s*:\s*/);
+							if(typeof tempsplit[1] !== "undefined" && tempsplit[1] !== "") {
+								log("got a column label: " + tempsplit[0]);
+								// Then we've got the column label in tempsplit[0] and the actual skill name in tempsplit[1]
+								set.combosnames[1] = tempsplit[0];
+								set.combos[1][0] = tempsplit[1];
+							}
+							tempsplit = set.combos[1][0].toString().split(/\s*:\s*/);
+							if(typeof tempsplit[1] !== "undefined" && tempsplit[1] !== "") {
+								log("got a column label: " + tempsplit[0]);
+								// Then we've got the column label in tempsplit[0] and the actual skill name in tempsplit[1]
+								set.combosnames[2] = tempsplit[0];
+								set.combos[2][0] = tempsplit[1];
+							}
 						}
 						if ( consequences !== "" ) { 
 							var cons = consequences.toString().split(/\s*,\s*/);
@@ -3677,6 +3720,14 @@ var addSkills = function(values) {
 	}
 	var attrs = { addskills: "" };
 	
+	if ( typeof values.combosnames === "object" ) {
+		// ZOD combocol1, 2, 3 
+		for(var i=0; i < values.combosnames.length; i++) {
+			var colnum = i+1;
+			attrs["combocol"+colnum] = values.combosnames[i];
+		}
+	}
+	
 	getSectionIDs("skills", function(currentskills) {
 
 		var skillFilter = {};
@@ -3709,7 +3760,20 @@ var addSkills = function(values) {
 						var skillid = "repeating_skills_" + newid + "_skill";
 						attrs[skillid] = skillname;
 						attrs["repeating_skills_" + newid + "_rating"] = 0;
-						attrs["repeating_skills_" + newid + "_column"] = 1;
+						attrs["repeating_skills_" + newid + "_column"] = 1; // ZOD ZOD ZOD ZOD ZOD ZOD ZOD ZOD
+						if ( typeof values.combos === "object" ) {
+							for(var x=0;x < values.combos.length;x++) {
+								var stopnow = false;
+								for(var y=0;y < values.combos[x].length;y++) {
+									if ( skillname === values.combos[x][y] ) {
+										attrs["repeating_skills_" + newid + "_column"] = x+1;
+										stopnow = true; break;
+									}
+								}
+								if (stopnow) { break; }
+							}
+						}
+
 						// loadSkills() does this work too, but this makes sure that it won't have weird gaps if the rating attribute is encountered before the skill
 						skillFilter[skillname] = true;
 						skillNameByID[skillid] = skillname;
@@ -4660,7 +4724,7 @@ on("clicked:repeating_swaps:loadswap", function(e) {
 // their at-rest state is empty anyway.
 
 const attributes = [
-	"character_name", "uninitialized", "SheetOptions", "Show-Aspects", "Show-Combinable", "Show-Conditions", "Show-Consequences", "Show-Corruption", "Show-Diceprompts", "Show-Extras", "Show-FP", "Show-Logo", "Show-Modes", "Show-Notes", "Show-Packages", "Show-Powers", "Show-Refresh", "Show-Roles", "Show-RollableAspects", "Show-Skills", "Show-Skillswaps", "Show-Stress", "Show-Stunts", "Show-TempAspects", "EditAspects", "EditCombos", "EditConditions", "EditConsequences", "EditExtras", "EditModes", "EditNotes", "EditPackages", "EditPowers", "EditRoles", "EditSkills", "EditStress", "EditStunts", "EditSwaps", "EditTempAspects", "aspectlist", "combomulti", "combotally", "combotext", "combocol1", "combocol2", "combocol3", "corruption", "custom-aspects", "custom-conditions", "custom-consequences", "custom-skills", "custom-stress", "focused", "fp", "lastswapped", "pronouns", "refresh", "rolllist", "rolltally", "setgame", "skillcount", "SkillStyle", "specialized", "stuntcount", "theme"
+	"character_name", "uninitialized", "SheetOptions", "Show-Aspects", "Show-Combinable", "Show-Conditions", "Show-Consequences", "Show-Corruption", "Show-Diceprompts", "Show-Extras", "Show-FP", "Show-Logo", "Show-Modes", "Show-Notes", "Show-Packages", "Show-Powers", "Show-Refresh", "Show-Roles", "Show-RollableAspects", "Show-Skills", "Show-Skillswaps", "Show-Stress", "Show-Stunts", "Show-TempAspects", "EditAspects", "EditCombos", "EditConditions", "EditConsequences", "EditExtras", "EditModes", "EditNotes", "EditPackages", "EditPowers", "EditRoles", "EditSkills", "EditStress", "EditStunts", "EditSwaps", "EditTempAspects", "aspectlist", "combomulti", "combotally", "combotext", "combocol1", "combocol2", "combocol3", "corruption", "custom-aspects", "custom-combos", "custom-conditions", "custom-consequences", "custom-skills", "custom-stress", "focused", "fp", "lastswapped", "pronouns", "refresh", "rolllist", "rolltally", "setgame", "skillcount", "SkillStyle", "specialized", "stuntcount", "theme"
 ];
 
 const fieldsets = {

--- a/Fate/FateOmni.html
+++ b/Fate/FateOmni.html
@@ -1,5 +1,6 @@
 <input type="hidden" name="attr_theme" value="blue" class="theme">
 <div class="Wrapper">
+
 	<!-- input type="checkbox" name="attr_uninitialized" value="1" checked> (Testing Only) -->
 	<input type="checkbox" name="attr_uninitialized" value="1" class="triggerbox" checked>
 	<div>
@@ -62,6 +63,7 @@
 		<span><input type="checkbox" class="checkbox" name="attr_Show-Conditions" value="1" checked><span class="checker" data-i18n="conditions">Conditions</span> </span>
 		<span><input type="checkbox" class="checkbox" name="attr_Show-Consequences" value="1" checked><span class="checker" data-i18n="consequences">Consequences</span> </span>
 		<span><input type="checkbox" class="checkbox" name="attr_Show-Corruption" value="1"><span class="checker" data-i18n="corruption">Corruption</span> </span>
+		<span><input type="checkbox" class="checkbox" name="attr_Show-DeveloperMode" value="1"><span class="checker" data-i18n="developer-mode">Developer Mode</span> </span>
 		<span><input type="checkbox" class="checkbox" name="attr_Show-Extras" value="1"><span class="checker" data-i18n="extras">Extras</span> </span>
 		<span><input type="checkbox" class="checkbox" name="attr_Show-FP" value="1" checked><span class="checker" data-i18n="fp">Fate Points</span> </span>
 		<span><input type="checkbox" class="checkbox" name="attr_Show-Logo" value="1"><span class="checker" data-i18n="logo">Logo</span> </span>
@@ -137,6 +139,20 @@
 			</div>
 		</div>
 	</div>
+
+	<input type="checkbox" class="triggerbox" name="attr_Show-DeveloperMode" value="1"><div class="StuntCell"><div class="SectionHeader"><span data-i18n="developer-mode"></span></div><div class="StuntDisplay">
+		Please proceed with caution. The stuff here messes with the sheet data directly and extensively.
+		<hr>
+		Click this button to export the entire sheet as a JSON object that can be imported to another sheet using the import area below.
+		<div><button type="action" name="act_exportsheet">Export</button></div>
+		<div><textarea name="attr_exportsheetdata" style="width: 90%"></textarea></div>
+		<hr>
+		Clicking this button will empty out all the dynamic elements of the sheet. It will leave some attributes untouched, but should blank out aspects, skills, stunts, stress, consequences, conditions, tempaspects, modes, roles, swaps, packages, powers, extras, and notes. 
+		<div><button type="action" name="act_clearsheet">Clear Sheet</button></div>
+		<hr>
+		Import: If you paste the JSON in this field and then move out of it, the sheet will notice and perform an import of the data. Please note, this will ADD to the existing content of this sheet rather than overwrite it where possible (causing duplicates in your skill list, potentially, etc). If you need it to REPLACE everything, please first click the "clear sheet" button above.
+		<div><textarea name="attr_importsheetdata" style="width: 90%"></textarea></div>
+	</div></div>
 
 	<div class="SheetFlex">
 		<div class="SheetCol">
@@ -1222,7 +1238,7 @@
 					</div> <!-- /ExtraEdit -->
 					
 					<div class="ExtraDisplay">
-						<fieldset class="repeating_Extras">
+						<fieldset class="repeating_extras">
 							<input type="hidden" name="attr_element" class="element" value="">
 							<div class="title clear-all space-above" width="100%">
 								<span name="attr_name"></span>
@@ -1818,7 +1834,7 @@
 								<div class="OptionsBox">
 									<div class="OptionsEdit">
 										<div class="OptionsTitleBar">
-											<span><span name="attr_label"></span> <span name="options">Options</span></span>
+											<span><span name="options">Options</span></span>
 											<span>
 												<input type="checkbox" class="checkbox" name="attr_options" value="1"><span class="optionsbox"></span>
 											</span>
@@ -3485,7 +3501,6 @@ on("clicked:repeating_packages:add", function(e) {
 					}
 				}
 			}
-			// ZOD 
 			setAttrs(attrs);
 			log(attrs);
 		});
@@ -4383,10 +4398,12 @@ on("change:addconsequence", function() {
 
 on("change:setgame sheet:opened", function() {
 	log("Event: setgame change");
-	getAttrs(["setgame","uninitialized"], function(values) {
+	getAttrs(["setgame","uninitialized","importsheetdata"], function(values) {
 		if ( values.setgame !== "" ) {
 			log("setgame: non null setgame detected");
-			if ( values.uninitialized == "1" ) {
+			if ( values.importsheetdata !== "" ) {
+				log("setgame: sheet has non-null importsheetdata, and as such shouldn't load any presets");
+			} else if ( values.uninitialized == "1" ) {  
 				log("setgame: sheet has not been initialized");
 				loadGame(values.setgame);
 			} else {
@@ -4612,6 +4629,411 @@ on("clicked:repeating_swaps:loadswap", function(e) {
 		});
 	});
 });
+
+// 
+// COMPENDIUM EXPORT/IMPORT SUPPORT AREA
+//
+
+// a bunch of skill-rowX-Y attributes exist, but those 
+// should be created as skill list gets populated and/or
+// sheet gets opened
+// 
+// Similarly there are a few action-triggering attributes
+// like "addskills", etc, which aren't a part of this as
+// their at-rest state is empty anyway.
+
+const attributes = [
+	"character_name", "SheetOptions", "Show-Aspects", "Show-Combinable", "Show-Conditions", "Show-Consequences", "Show-Corruption", "Show-Diceprompts", "Show-Extras", "Show-FP", "Show-Logo", "Show-Modes", "Show-Notes", "Show-Packages", "Show-Powers", "Show-Refresh", "Show-Roles", "Show-RollableAspects", "Show-Skills", "Show-Skillswaps", "Show-Stress", "Show-Stunts", "Show-TempAspects", "EditAspects", "EditCombos", "EditConditions", "EditConsequences", "EditExtras", "EditModes", "EditNotes", "EditPackages", "EditPowers", "EditRoles", "EditSkills", "EditStress", "EditStunts", "EditSwaps", "EditTempAspects", "aspectlist", "combomulti", "combotally", "combotext", "corruption", "custom-aspects", "custom-conditions", "custom-consequences", "custom-skills", "custom-stress", "focused", "fp", "lastswapped", "pronouns", "refresh", "rolllist", "rolltally", "setgame", "skillcount", "SkillStyle", "specialized", "stuntcount", "theme", "uninitialized"
+];
+
+const fieldsets = {
+	aspects: [
+		"category","label","aspect","flags","invokes",
+		"rollvalue","notes","rollthis","options",
+		"check1","check2","check3","check4","check5",
+		"check6","check7","check8","check9","check10"
+	],
+	skills: [
+		"skill","rating","bonus","column","rating-word",
+		"rollthis"
+	],
+	stunts: [
+		"name","desc","skill","skillvalue","bonus","rollable"
+	],
+	stress: [
+		"label","track","notes","options",
+		"track1","track2","track3","track4","track5",
+		"track6","track7","track8","track9","track10",
+		"check1","check2","check3","check4","check5",
+		"check6","check7","check8","check9","check10"
+	],
+	consequences: [
+		"label","track","trackcheck","recovery","aspect"
+	],
+	conditions: [
+		"label","track","notes","options",
+		"track1","track2","track3","track4","track5",
+		"track6","track7","track8","track9","track10",
+		"check1","check2","check3","check4","check5",
+		"check6","check7","check8","check9","check10"
+	],
+	tempaspects: [
+		"aspect","invokes","notes","options",
+		"check1","check2","check3","check4","check5",
+		"check6","check7","check8","check9","check10"
+	],
+	modes: [
+		"mode","rating","word","skills"
+	],
+	roles: [
+		"role","skills"
+	],
+	swaps: [
+		"label","skills"
+	],
+	packages: [
+		"package","aspects","skills","stunts",
+	],
+	powers: [
+		"name","desc","breakdown","sfx","sfxmenu", 
+		"drawbacks","collateral","cost"
+	],
+	extras: [
+		"element","name","label","icon","icon2","icon3",
+		"skill","rating","word","rollable","bonus",
+		"skillvalue","text","track",
+		"track1","track2","track3","track4","track5",
+		"track6","track7","track8","track9","track10",
+		"check1","check2","check3","check4","check5",
+		"check6","check7","check8","check9","check10"
+	],
+	notes: [
+		"name","desc"
+	]
+};
+
+// Deadly button: click it, and all your fieldset data goes bye-bye.
+
+on("clicked:clearsheet", function(e) {
+	log("clear sheet clicked");
+	for(const [id,value] of Object.entries(fieldsets) ) {
+		log("working "+id);
+		getSectionIDs(id, function(clearme) {
+			log(clearme);
+			for(var i=0; i < clearme.length; i++) {
+				var rowid = "repeating_"+id+"_"+clearme[i];
+				removeRepeatingRow(rowid);
+			}
+		});
+	}
+});
+
+// This is the importer. Hopefully works clean!
+// ZOD
+
+on("change:importsheetdata sheet:opened", function() {
+	log("Event: importsheetdata change or sheet open");
+	getAttrs(["importsheetdata"], function(values) {
+		if ( values.importsheetdata !== "" ) { // Then it's gonna get processed.
+			log("importsheetdata: non null importablesheetdata detected");
+			var impsheet = JSON.parse(values.importsheetdata); // Hope this works!
+			var attrs = impsheet.attr; // this should get us the "flat attributes" that are just gonna get overwritten, as our starter object
+			var fsets = impsheet.fieldset; // An array of objects each representing a row in one of the many fieldsets this sheet uses
+			attrs["importsheetdata"] = ""; // Initialize the import field now that we've read it in.
+			for(var i=0; i < fsets.length; i++) {
+				var row = fsets[i]; // This is an object
+				var fs = row["_fieldset"]; // This is the name of the fieldset the row's content goes into
+				var newid = generateActuallyUniqueRowID(); // This gets us an actual unique row ID for the new entry
+				var rowprefix = "repeating_" + fs + "_" + newid + "_";
+				for(const [rowfield,rowcontent] of Object.entries(row) ) {
+					if ( rowfield !== "_fieldset" ) {
+						var rfname = rowprefix + rowfield;
+						attrs[rfname] = rowcontent;
+					}
+				}
+			}
+			log("Committing changes for importsheetdata")
+			setAttrs(attrs);
+			loadSkills("importsheetdata",{silent:false},function() { log("importsheetdata callback to loadSkills"); loadSkills("addSkills"); });
+		}
+	});
+});
+
+// all the fieldsets so far: 
+// aspects, skills, stunts, stress, consequences, conditions, tempaspects, modes, roles, swaps, packages, powers, extras, notes
+// ZOD
+
+on("clicked:exportsheet", function(e) {
+	var exsheet = { "attr": {}, "fieldset": [] };
+	var fields = [];
+	fields = fields.concat(attributes); // grab the list of flat non-fieldset attributes into the master fields list
+
+	getSectionIDs("aspects", function(aspectsList) {
+		var flist = fieldsets["aspects"];
+		var fnames = [];
+		for(var i=0; i < aspectsList.length; i++) {
+			for(var j=0; j < flist.length; j++) {
+				fnames[i*flist.length+j] = "repeating_aspects_" + aspectsList[i] + "_" + flist[j];
+			}
+		}
+		fields = fields.concat(fnames);
+		
+		getSectionIDs("skills", function(skillsList) {
+			var flist = fieldsets["skills"];
+			var fnames = [];
+			for(var i=0; i < skillsList.length; i++) {
+				for(var j=0; j < flist.length; j++) {
+					fnames[i*flist.length+j] = "repeating_skills_" + skillsList[i] + "_" + flist[j];
+				}
+			}
+			fields = fields.concat(fnames);
+
+			getSectionIDs("stunts", function(stuntsList) {
+				var flist = fieldsets["stunts"];
+				var fnames = [];
+				for(var i=0; i < stuntsList.length; i++) {
+					for(var j=0; j < flist.length; j++) {
+						fnames[i*flist.length+j] = "repeating_stunts_" + stuntsList[i] + "_" + flist[j];
+					}
+				}
+				fields = fields.concat(fnames);
+
+				getSectionIDs("stress", function(stressList) {
+					var flist = fieldsets["stress"];
+					var fnames = [];
+					for(var i=0; i < stressList.length; i++) {
+						for(var j=0; j < flist.length; j++) {
+							fnames[i*flist.length+j] = "repeating_stress_" + stressList[i] + "_" + flist[j];
+						}
+					}
+					fields = fields.concat(fnames);
+
+					getSectionIDs("consequences", function(consequencesList) {
+						var flist = fieldsets["consequences"];
+						var fnames = [];
+						for(var i=0; i < consequencesList.length; i++) {
+							for(var j=0; j < flist.length; j++) {
+								fnames[i*flist.length+j] = "repeating_consequences_" + consequencesList[i] + "_" + flist[j];
+							}
+						}
+						fields = fields.concat(fnames);
+
+						getSectionIDs("conditions", function(conditionsList) {
+							var flist = fieldsets["conditions"];
+							var fnames = [];
+							for(var i=0; i < conditionsList.length; i++) {
+								for(var j=0; j < flist.length; j++) {
+									fnames[i*flist.length+j] = "repeating_conditions_" + conditionsList[i] + "_" + flist[j];
+								}
+							}
+							fields = fields.concat(fnames);
+
+							getSectionIDs("tempaspects", function(tempaspectsList) {
+								var flist = fieldsets["tempaspects"];
+								var fnames = [];
+								for(var i=0; i < tempaspectsList.length; i++) {
+									for(var j=0; j < flist.length; j++) {
+										fnames[i*flist.length+j] = "repeating_tempaspects_" + tempaspectsList[i] + "_" + flist[j];
+									}
+								}
+								fields = fields.concat(fnames);
+
+								getSectionIDs("modes", function(modesList) {
+									var flist = fieldsets["modes"];
+									var fnames = [];
+									for(var i=0; i < modesList.length; i++) {
+										for(var j=0; j < flist.length; j++) {
+											fnames[i*flist.length+j] = "repeating_modes_" + modesList[i] + "_" + flist[j];
+										}
+									}
+									fields = fields.concat(fnames);
+
+									getSectionIDs("roles", function(rolesList) {
+										var flist = fieldsets["roles"];
+										var fnames = [];
+										for(var i=0; i < rolesList.length; i++) {
+											for(var j=0; j < flist.length; j++) {
+												fnames[i*flist.length+j] = "repeating_roles_" + rolesList[i] + "_" + flist[j];
+											}
+										}
+										fields = fields.concat(fnames);
+
+										getSectionIDs("swaps", function(swapsList) {
+											var flist = fieldsets["swaps"];
+											var fnames = [];
+											for(var i=0; i < swapsList.length; i++) {
+												for(var j=0; j < flist.length; j++) {
+													fnames[i*flist.length+j] = "repeating_swaps_" + swapsList[i] + "_" + flist[j];
+												}
+											}
+											fields = fields.concat(fnames);
+
+											getSectionIDs("packages", function(packagesList) {
+												var flist = fieldsets["packages"];
+												var fnames = [];
+												for(var i=0; i < packagesList.length; i++) {
+													for(var j=0; j < flist.length; j++) {
+														fnames[i*flist.length+j] = "repeating_packages_" + packagesList[i] + "_" + flist[j];
+													}
+												}
+												fields = fields.concat(fnames);
+
+												getSectionIDs("powers", function(powersList) {
+													var flist = fieldsets["powers"];
+													var fnames = [];
+													for(var i=0; i < powersList.length; i++) {
+														for(var j=0; j < flist.length; j++) {
+															fnames[i*flist.length+j] = "repeating_powers_" + powersList[i] + "_" + flist[j];
+														}
+													}
+													fields = fields.concat(fnames);
+
+													getSectionIDs("extras", function(extrasList) {
+														var flist = fieldsets["extras"];
+														var fnames = [];
+														for(var i=0; i < extrasList.length; i++) {
+															for(var j=0; j < flist.length; j++) {
+																fnames[i*flist.length+j] = "repeating_extras_" + extrasList[i] + "_" + flist[j];
+															}
+														}
+														fields = fields.concat(fnames);
+
+														getSectionIDs("notes", function(notesList) {
+															var flist = fieldsets["notes"];
+															var fnames = [];
+															for(var i=0; i < notesList.length; i++) {
+																for(var j=0; j < flist.length; j++) {
+																	fnames[i*flist.length+j] = "repeating_notes_" + notesList[i] + "_" + flist[j];
+																}
+															}
+															fields = fields.concat(fnames);
+
+															// We actually get ALL the data now
+															getAttrs(fields, function(v) {
+																log(v);
+																for(var i = 0; i < attributes.length; i++) {
+																	var fname = attributes[i];
+																	exsheet["attr"][fname] = v[fname];
+																}
+																for(var i=0; i < aspectsList.length; i++) {
+																	var thisrow = { "_fieldset": "aspects" };
+																	for(var j=0; j < fieldsets["aspects"].length; j++) {
+																		thisrow[fieldsets["aspects"][j]] = v["repeating_aspects_" + aspectsList[i] + "_" + fieldsets["aspects"][j]];
+																	}
+																	exsheet["fieldset"].push(thisrow);
+																}
+																for(var i=0; i < skillsList.length; i++) {
+																	var thisrow = { "_fieldset": "skills" };
+																	for(var j=0; j < fieldsets["skills"].length; j++) {
+																		thisrow[fieldsets["skills"][j]] = v["repeating_skills_" + skillsList[i] + "_" + fieldsets["skills"][j]];
+																	}
+																	exsheet["fieldset"].push(thisrow);
+																}
+																for(var i=0; i < stuntsList.length; i++) {
+																	var thisrow = { "_fieldset": "stunts" };
+																	for(var j=0; j < fieldsets["stunts"].length; j++) {
+																		thisrow[fieldsets["stunts"][j]] = v["repeating_stunts_" + stuntsList[i] + "_" + fieldsets["stunts"][j]];
+																	}
+																	exsheet["fieldset"].push(thisrow);
+																}
+																for(var i=0; i < stressList.length; i++) {
+																	var thisrow = { "_fieldset": "stress" };
+																	for(var j=0; j < fieldsets["stress"].length; j++) {
+																		thisrow[fieldsets["stress"][j]] = v["repeating_stress_" + stressList[i] + "_" + fieldsets["stress"][j]];
+																	}
+																	exsheet["fieldset"].push(thisrow);
+																}
+																for(var i=0; i < consequencesList.length; i++) {
+																	var thisrow = { "_fieldset": "consequences" };
+																	for(var j=0; j < fieldsets["consequences"].length; j++) {
+																		thisrow[fieldsets["consequences"][j]] = v["repeating_consequences_" + consequencesList[i] + "_" + fieldsets["consequences"][j]];
+																	}
+																	exsheet["fieldset"].push(thisrow);
+																}
+																for(var i=0; i < conditionsList.length; i++) {
+																	var thisrow = { "_fieldset": "conditions" };
+																	for(var j=0; j < fieldsets["conditions"].length; j++) {
+																		thisrow[fieldsets["conditions"][j]] = v["repeating_conditions_" + conditionsList[i] + "_" + fieldsets["conditions"][j]];
+																	}
+																	exsheet["fieldset"].push(thisrow);
+																}
+																for(var i=0; i < tempaspectsList.length; i++) {
+																	var thisrow = { "_fieldset": "tempaspects" };
+																	for(var j=0; j < fieldsets["tempaspects"].length; j++) {
+																		thisrow[fieldsets["tempaspects"][j]] = v["repeating_tempaspects_" + tempaspectsList[i] + "_" + fieldsets["tempaspects"][j]];
+																	}
+																	exsheet["fieldset"].push(thisrow);
+																}
+																for(var i=0; i < modesList.length; i++) {
+																	var thisrow = { "_fieldset": "modes" };
+																	for(var j=0; j < fieldsets["modes"].length; j++) {
+																		thisrow[fieldsets["modes"][j]] = v["repeating_modes_" + modesList[i] + "_" + fieldsets["modes"][j]];
+																	}
+																	exsheet["fieldset"].push(thisrow);
+																}
+																for(var i=0; i < rolesList.length; i++) {
+																	var thisrow = { "_fieldset": "roles" };
+																	for(var j=0; j < fieldsets["roles"].length; j++) {
+																		thisrow[fieldsets["roles"][j]] = v["repeating_roles_" + rolesList[i] + "_" + fieldsets["roles"][j]];
+																	}
+																	exsheet["fieldset"].push(thisrow);
+																}
+																for(var i=0; i < swapsList.length; i++) {
+																	var thisrow = { "_fieldset": "swaps" };
+																	for(var j=0; j < fieldsets["swaps"].length; j++) {
+																		thisrow[fieldsets["swaps"][j]] = v["repeating_swaps_" + swapsList[i] + "_" + fieldsets["swaps"][j]];
+																	}
+																	exsheet["fieldset"].push(thisrow);
+																}
+																for(var i=0; i < packagesList.length; i++) {
+																	var thisrow = { "_fieldset": "packages" };
+																	for(var j=0; j < fieldsets["packages"].length; j++) {
+																		thisrow[fieldsets["packages"][j]] = v["repeating_packages_" + packagesList[i] + "_" + fieldsets["packages"][j]];
+																	}
+																	exsheet["fieldset"].push(thisrow);
+																}
+																for(var i=0; i < powersList.length; i++) {
+																	var thisrow = { "_fieldset": "powers" };
+																	for(var j=0; j < fieldsets["powers"].length; j++) {
+																		thisrow[fieldsets["powers"][j]] = v["repeating_powers_" + powersList[i] + "_" + fieldsets["powers"][j]];
+																	}
+																	exsheet["fieldset"].push(thisrow);
+																}
+																for(var i=0; i < extrasList.length; i++) {
+																	var thisrow = { "_fieldset": "extras" };
+																	for(var j=0; j < fieldsets["extras"].length; j++) {
+																		thisrow[fieldsets["extras"][j]] = v["repeating_extras_" + extrasList[i] + "_" + fieldsets["extras"][j]];
+																	}
+																	exsheet["fieldset"].push(thisrow);
+																}
+																for(var i=0; i < notesList.length; i++) {
+																	var thisrow = { "_fieldset": "notes" };
+																	for(var j=0; j < fieldsets["notes"].length; j++) {
+																		thisrow[fieldsets["notes"][j]] = v["repeating_notes_" + notesList[i] + "_" + fieldsets["notes"][j]];
+																	}
+																	exsheet["fieldset"].push(thisrow);
+																}
+																
+																// And finally, we stringify the object and set the export field value
+																setAttrs({ "exportsheetdata": JSON.stringify(exsheet) });
+															});
+
+														}); // notes
+													}); // extras
+												}); // powers
+											}); // packages
+										}); // swaps
+									}); // roles
+								}); // modes
+							}); // tempaspects
+						}); // conditions
+					}); // consequences
+				}); // stress
+			}); // stunts
+		}); // skills
+	}); // aspects
+});
+
 
 </script>
 

--- a/Fate/FateOmni.html
+++ b/Fate/FateOmni.html
@@ -357,6 +357,18 @@
 						<div>
 						<input type="checkbox" class="checkbox" name="attr_combomulti" value="1"><span class="checkmark"></span> <span data-i18n="combine-skills-multi">Allow selection of multiple skills from the same column</span>
 						</div>
+						<div class="fieldlabel" data-i18n="column names optional">
+							Column Names (Optional)
+						</div>
+						<div>
+							#1&nbsp;<input type="text" name="attr_combocol1" value="">
+						</div>
+						<div>
+							#2&nbsp;<input type="text" name="attr_combocol2" value="">
+						</div>
+						<div>
+							#3&nbsp;<input type="text" name="attr_combocol3" value="">
+						</div>
 					</div> <!-- end edit frame -->
 					<div>
 						<div>
@@ -371,7 +383,11 @@
 							</div>
 						</div>
 						<div class="ComboColumns">
+							<input type="hidden" name="attr_combocol1" value="">
+							<input type="hidden" name="attr_combocol2" value="">
+							<input type="hidden" name="attr_combocol3" value="">
 							<div class="ComboColumn">
+								<div class="fieldlabel"><span name="attr_combocol1" class="label"></span></div>
 								<fieldset class="repeating_skills">
 									<input type="hidden" name="attr_skill">
 									<input type="hidden" name="attr_rating-word">
@@ -383,6 +399,7 @@
 								</fieldset>
 							</div>
 							<div class="ComboColumn">
+								<div class="fieldlabel"><span name="attr_combocol2" class="label"></span></div>
 								<fieldset class="repeating_skills">
 									<input type="hidden" name="attr_skill">
 									<input type="hidden" name="attr_rating-word">
@@ -394,6 +411,7 @@
 								</fieldset>
 							</div>
 							<div class="ComboColumn">
+								<div class="fieldlabel"><span name="attr_combocol3" class="label"></span></div>
 								<fieldset class="repeating_skills">
 									<input type="hidden" name="attr_skill">
 									<input type="hidden" name="attr_rating-word">
@@ -4643,7 +4661,7 @@ on("clicked:repeating_swaps:loadswap", function(e) {
 // their at-rest state is empty anyway.
 
 const attributes = [
-	"character_name", "SheetOptions", "Show-Aspects", "Show-Combinable", "Show-Conditions", "Show-Consequences", "Show-Corruption", "Show-Diceprompts", "Show-Extras", "Show-FP", "Show-Logo", "Show-Modes", "Show-Notes", "Show-Packages", "Show-Powers", "Show-Refresh", "Show-Roles", "Show-RollableAspects", "Show-Skills", "Show-Skillswaps", "Show-Stress", "Show-Stunts", "Show-TempAspects", "EditAspects", "EditCombos", "EditConditions", "EditConsequences", "EditExtras", "EditModes", "EditNotes", "EditPackages", "EditPowers", "EditRoles", "EditSkills", "EditStress", "EditStunts", "EditSwaps", "EditTempAspects", "aspectlist", "combomulti", "combotally", "combotext", "corruption", "custom-aspects", "custom-conditions", "custom-consequences", "custom-skills", "custom-stress", "focused", "fp", "lastswapped", "pronouns", "refresh", "rolllist", "rolltally", "setgame", "skillcount", "SkillStyle", "specialized", "stuntcount", "theme", "uninitialized"
+	"character_name", "uninitialized", "SheetOptions", "Show-Aspects", "Show-Combinable", "Show-Conditions", "Show-Consequences", "Show-Corruption", "Show-Diceprompts", "Show-Extras", "Show-FP", "Show-Logo", "Show-Modes", "Show-Notes", "Show-Packages", "Show-Powers", "Show-Refresh", "Show-Roles", "Show-RollableAspects", "Show-Skills", "Show-Skillswaps", "Show-Stress", "Show-Stunts", "Show-TempAspects", "EditAspects", "EditCombos", "EditConditions", "EditConsequences", "EditExtras", "EditModes", "EditNotes", "EditPackages", "EditPowers", "EditRoles", "EditSkills", "EditStress", "EditStunts", "EditSwaps", "EditTempAspects", "aspectlist", "combomulti", "combotally", "combotext", "combocol1", "combocol2", "combocol3", "corruption", "custom-aspects", "custom-conditions", "custom-consequences", "custom-skills", "custom-stress", "focused", "fp", "lastswapped", "pronouns", "refresh", "rolllist", "rolltally", "setgame", "skillcount", "SkillStyle", "specialized", "stuntcount", "theme"
 ];
 
 const fieldsets = {

--- a/Fate/sheet.json
+++ b/Fate/sheet.json
@@ -225,6 +225,15 @@
 			"default": "0"
 		},
 		{
+			"attribute": "Show-DeveloperMode",
+			"displayname": "Developer Mode",
+			"displaytranslationkey": "developer-mode",
+			"type": "select",
+			"options": [ "Show|1", "Hide|0" ],
+			"optiontranslationkeys": [ "show", "hide" ],
+			"default": "0"
+		},
+		{
 			"attribute": "custom-aspects",
 			"displayname": "Custom Aspect Labels",
 			"displaytranslationkey": "custom-aspects",

--- a/Fate/sheet.json
+++ b/Fate/sheet.json
@@ -234,13 +234,31 @@
 			"descriptiontranslationkey": "custom-aspects-desc"
 		},
 		{
-			"attribute": "custom-conditions",
-			"displayname": "Custom Conditions",
-			"displaytranslationkey": "custom-conditions",
+			"attribute": "custom-skills",
+			"displayname": "Custom Skill List",
+			"displaytranslationkey": "custom-skills",
 			"type": "text",
 			"value": "",
-			"description": "Enter a list separated by commas, with each entry in this format (not including the quotes): \"Label:Length\", e.g., \"Indebted:5\". You may optionally include values for each box separated by spaces after the length, e.g., \"Doomed:1 6\". You must select the Custom Build option up top for this to be used.",
-			"descriptiontranslationkey": "custom-conditions-desc"
+			"description": "Enter a list separated by commas. You must select the Custom Build option up top for this to be used.",
+			"descriptiontranslationkey": "custom-skills-desc"
+		},
+		{
+			"attribute": "custom-combos",
+			"displayname": "Custom Combinable Skill Columns",
+			"displaytranslationkey": "custom-combos-columns",
+			"type": "text",
+			"value": "",
+			"description": "You must define the skills in the skill list, before categorizing them into columns here. Separate skills by commas and columns (up to 3) by semicolons: \"Skill, Skill; Skill, Skill\", e.g., \"Body, Mind; Air, Earth, Fire, Water\" for two columns skills. If each column has a label, put that at the start of each list followed by a colon, e.g., \"Self: Body, Mind; Element: Air, Earth, Fire, Water\", Make sure to enable Combinable Skills. You must select the Custom Build option up top for this to be used.",
+			"descriptiontranslationkey": "custom-combos-desc"
+		},
+		{
+			"attribute": "custom-stress",
+			"displayname": "Custom Stress Tracks",
+			"displaytranslationkey": "custom-stress",
+			"type": "text",
+			"value": "",
+			"description": "Enter a list separated by commas, with each entry in this format (not including the quotes): \"Label:Default Length\", e.g., \"Social:2\". You may optionally include values for each box (including ones beyond the default length) separated by spaces after the length, e.g., \"Social:2 1 2 3 4 5 6\". You must select the Custom Build option up top for this to be used.",
+			"descriptiontranslationkey": "custom-stress-desc"
 		},
 		{
 			"attribute": "custom-consequences",
@@ -252,22 +270,13 @@
 			"descriptiontranslationkey": "custom-consequences-desc"
 		},
 		{
-			"attribute": "custom-skills",
-			"displayname": "Custom Skill List",
-			"displaytranslationkey": "custom-skills",
+			"attribute": "custom-conditions",
+			"displayname": "Custom Conditions",
+			"displaytranslationkey": "custom-conditions",
 			"type": "text",
 			"value": "",
-			"description": "Enter a list separated by commas. You must select the Custom Build option up top for this to be used.",
-			"descriptiontranslationkey": "custom-skills-desc"
-		},
-		{
-			"attribute": "custom-stress",
-			"displayname": "Custom Stress Tracks",
-			"displaytranslationkey": "custom-stress",
-			"type": "text",
-			"value": "",
-			"description": "Enter a list separated by commas, with each entry in this format (not including the quotes): \"Label:Default Length\", e.g., \"Social:2\". You may optionally include values for each box (including ones beyond the default length) separated by spaces after the length, e.g., \"Social:2 1 2 3 4 5 6\". You must select the Custom Build option up top for this to be used.",
-			"descriptiontranslationkey": "custom-stress-desc"
+			"description": "Enter a list separated by commas, with each entry in this format (not including the quotes): \"Label:Length\", e.g., \"Indebted:5\". You may optionally include values for each box separated by spaces after the length, e.g., \"Doomed:1 6\". You must select the Custom Build option up top for this to be used.",
+			"descriptiontranslationkey": "custom-conditions-desc"
 		}
 	],
 	"legacy": true

--- a/Fate/sheet.json
+++ b/Fate/sheet.json
@@ -207,15 +207,6 @@
 			"default": "1"
 		},
 		{
-			"attribute": "Show-Stunts",
-			"displayname": "Stunts",
-			"displaytranslationkey": "stunts",
-			"type": "select",
-			"options": [ "Show|1", "Hide|0" ],
-			"optiontranslationkeys": [ "show", "hide" ],
-			"default": "1"
-		},
-		{
 			"attribute": "Show-Skillswaps",
 			"displayname": "Swappable Skillsets",
 			"displaytranslationkey": "swap-skills",

--- a/Fate/translation.json
+++ b/Fate/translation.json
@@ -31,6 +31,8 @@
 	"cost": "Cost",
 	"Crafts": "Crafts",
 	"custom-track": "Custom Track (?-?-?)",
+	"custom-combos-columns": "Custom Combinable Skill Columns",
+	"custom-combos-desc": "You must define the skills in the skill list, before categorizing them into columns here. Separate skills by commas and columns (up to 3) by semicolons: \"Skill, Skill; Skill, Skill\", e.g., \"Body, Mind; Air, Earth, Fire, Water\" for two columns skills. If each column has a label, put that at the start of each list followed by a colon, e.g., \"Self: Body, Mind; Element: Air, Earth, Fire, Water\", Make sure to enable Combinable Skills. You must select the Custom Build option up top for this to be used.",
 	"Deceive": "Deceive",
 	"del-skills": "Remove Skillset",
 	"desc": "Description",

--- a/Fate/translation.json
+++ b/Fate/translation.json
@@ -18,6 +18,7 @@
 	"choose-gameset": "[Choose a Gameset to Load]",
 	"Clever": "Clever",
 	"collateral-damage": "Collateral Damage",
+	"column names optional": "Column Names (Optional)",
 	"Computers": "Computers",
 	"con-val": "Consequence Value",
 	"condition": "Condition",

--- a/Fate/translation.json
+++ b/Fate/translation.json
@@ -33,6 +33,7 @@
 	"Deceive": "Deceive",
 	"del-skills": "Remove Skillset",
 	"desc": "Description",
+	"developer-mode": "Developer Mode",
 	"dfa": "Dresden Files Accelerated",
 	"display-by-list": "Compact List",
 	"display-by-rating": "Group By Rating",


### PR DESCRIPTION
## Changes / Comments

- Made changes/additions to the sheet to support JSON object export of sheet data and import of same, with an eye on supporting compendium features down the line. Should not cause a change to any existing character data.
- Optional labels for combinable skills columns added.
- Altered rollable aspect formatting so the rating value of each aspect is constantly visible rather than conditionally.
- Settings support for preconfiguring column groupings for combinable skills
- Bugfix: Removed duplicate Stunts preference setting in sheet.json

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
