### PR TITLE
Genefunk 2090: Statblock Importer and Fix for NPC damage rolls and hit dice calc

### DIFF
--- a/Genefunk 2090/genefunk2090.css
+++ b/Genefunk 2090/genefunk2090.css
@@ -1,6 +1,3 @@
-.sheet-import{
-    display:none!important;/*Hide import functionality till testing done*/
-}
 .sheet-rolltemplate-general,
 .sheet-whole{
     --hexagon:polygon(100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%, 50% 0%);

--- a/Genefunk 2090/genefunk2090.html
+++ b/Genefunk 2090/genefunk2090.html
@@ -2386,6 +2386,9 @@
               <div class="bordered-checkbox npc-checkbox">
                 <input name="attr_character_type" value="npc" type="radio"/><span data-i18n="npc"></span>
               </div>
+              <div class="bordered-checkbox import">
+                <input class="import" type="checkbox" value="import" name="attr_import"/><span class="import" data-i18n="import"></span>
+              </div>
             </div>
           </div>
           <div class="statblock-section">
@@ -3155,7 +3158,7 @@
 <!-- End Roll Templates-->
 <!-- Start Scripts-->
 <script type="text/worker">var genefunk2090 = genefunk2090 || (function() {
-	const version = 1.12;
+	const version = 1.20;
 	const displayControllers = ['sheet_view','advantage_state','character_type','whisper_state'],
 	importControls = ['import','import_cancel'],
 	abilityScores = {str:'strength',dex:'dexterity',con:'constitution',int:'intelligence',wis:'wisdom',cha:'charisma'},
@@ -4161,7 +4164,9 @@
 
 	var registerEventHandlers = function(){
 		on('sheet:opened',openSheet);
-		on('change:repeating_action:attack_enable_item change:repeating_hack:attack_enable_item',updateActionMacro);
+		['repeating_action:attack_enable_item','repeating_hack:attack_enable_item','repeating_action:damage_1_enable_item','repeating_hack:damage_1_enable_item','repeating_action:damage_2_enable_item','repeating_hack:damage_2_enable_item'].forEach((name)=>{
+			on(`change:${name}`,updateActionMacro);
+		});
 		displayControllers.forEach((attr)=>{
 			on(`change:${attr}`,importReact);
 		});
@@ -4173,7 +4178,7 @@
 		});
 		on('change:character_type',changeCharacter);
 		on('change:challenge',convertChallenge);
-		on('change:hp',averageHP);
+		on('change:hit_dice',averageHP);
 		hitDice.forEach((attr)=>{
 			on(`change:${attr}`,updateHDmacro);
 		});
@@ -4287,16 +4292,24 @@
 			return;
 		}
 		getAttrs(['character_type'],(attributes)=>{
-			log('got attributes for action update');
 			const setObj = {};
-			let macroAttr = event.sourceAttribute.replace(/attack_enable_item/,'attack_macro');
-			if(event.newValue*1){
-				setObj[macroAttr] = `{{d20=[[@{advantage_state} ${attributes.character_type === 'pc' ? '+ @{attack_ability} + @{action_proficiency}' : ''} + 0@{attack_bonus}]]}}`;
-			}else{
-				setObj[macroAttr] = ' ';
-			}
+			adjustActionMacro(event,attributes,setObj);
 			set(setObj);
 		});
+	},
+
+	adjustActionMacro = function(event,attributes,setObj = {}){
+		let macroAttr = event.sourceAttribute.replace(/enable_item/,'macro');
+		if(event.newValue*1){
+			setObj[macroAttr] = `{{d20=[[@{advantage_state} ${attributes.character_type === 'pc' ? '+ @{attack_ability} + @{action_proficiency}' : ''} + 0@{attack_bonus}]]}}`;
+		}else if(/{{damage_type_\d=@{damage_type_\d}}} @{damage_\d_macro}/.test(event.newValue)){
+			event.sourceAttribute.replace(/_(\d)_/,(match,num)=>{
+				setObj[macroAttr] = `{{damage_${num}=[[0@{damage_${num}}${attributes.character_type === 'pc' ? `+ @{damage_ability_${num}}` : ''}]]}} {{regular_critical_${num}=[[0@{damage_${num}}]]}} {{is_custom_crit_${num}=@{critical_damage_${num}}}} {{custom_critical_${num}=[[0@{critical_damage_${num}}]]}}`;
+			});
+		}else{
+			setObj[macroAttr] = ' ';
+		}
+		set(setObj);
 	},
 
 	trueCopy = function(obj){
@@ -4578,7 +4591,6 @@
 	},
 
 	beginImport = function(toGet,sections){
-		log('Beginning import');
 		let setObj = {};
 		wipeSheet(sections,setObj);
 		getAttrs(toGet,(attributes)=>{
@@ -4590,7 +4602,6 @@
 				attributes = {...attributes,...setObj};
 				setObj = {...setObj,...processDisplayChange(attributes)};
 			}
-			log({setObj});
 			set(setObj);
 		});
 	},
@@ -4688,12 +4699,12 @@
 			'^\\s*languages\\s+(.+)':[['languages']],
 			'^\\s*challenge\\s+([\\d\\/]+)\\s*\\(([\\d,]+)\\s*xp\\)':[['challenge'],['experience_points']]
 		};
-		let line = lines.shift();
+		let line = assembleDetailLine(lines);
 		if(/^\s*skills\s+/i.test(line)){
-			line = assembleSkills(line,lines);
 			parseSkills(setObj,line);
+		}else if(/^\s*senses\s+/i.test(line)){
+			parseSenses(setObj,line);
 		}else{
-			log({'detail line':line});
 			processRegex(setObj,line,regexs);
 		}
 		if(/^\s*challenge/i.test(line) && !/^\s*(hacking\.|actions)/i.test(lines[0])){
@@ -4702,16 +4713,21 @@
 		return [setObj,lines];
 	},
 
-	assembleSkills = function(line,lines){
-		while(lines.length && !/\d\s*$/.test(line)){
-			line = `${line} ${lines.shift()}`;
-		}
-		return line;
+	assembleDetailLine = function(lines,line){
+		line = line ? `${line} ${lines.shift()}` : lines.shift();
+		return /^\s*(?:saves|skills|senses|languages|challenge|damage resistance|hacking|actions)/i.test(lines[0]) ? line : assembleDetailLine(lines,line);
 	},
 
 	parseSkills = function(setObj,line){
 		line.replace(/(?:,\s*|skills\s+)(.+?)\s+\+?(\-?\d+)/ig,(match,skill,bonus)=>{
 			setObj[skill.replace(/\s+/,'_').toLowerCase()]=bonus;
+		});
+	},
+
+	parseSenses = function(setObj,line){
+		line.replace(/senses\s*(?:(.+?),\s*)?passive \s*perception\s*(\d+)(?:,\s*(.+?))?$/i,(match,senses,pp='',senses2)=>{
+			setObj.passive_perception = pp;
+			setObj.senses = [senses,senses2].filter(a=>a).join(', ');
 		});
 	},
 
@@ -4953,8 +4969,20 @@
     		}
     		if(attr.sheet_version*1 < 1.1) updateTo1_1(attr,setObj);//First update applied
     		if(attr.sheet_version*1 < 1.12) updateTo1_12(attr,setObj);//update 1.12; npc hp attribute change
+    		if(attr.sheet_version*1 < 1.20) updateTo1_20(attr,setObj);
     		set(setObj);
     	});
+    },
+
+    updateTo1_20 = function(attr,setObj){
+    	const damageEnablers = Object.keys(attr).filter(k => /(?:attack|damage_\d)_enable_item/.test(k));
+    	damageEnablers.forEach(d => adjustActionMacro({sourceAttribute:d,triggerName:d,newValue:attr[d]},attr,setObj));
+    	if(attr.character_type === 'npc'){
+    		setObj.hit_points = attr.hp
+    		setObj.hit_points_max = attr.hp_max;
+    	}
+    	attr = {...attr,...setObj};
+    	setObj.sheet_version = 1.20;
     },
 
     updateTo1_12 = function(attr,setObj){

--- a/Genefunk 2090/genefunk2090.pug
+++ b/Genefunk 2090/genefunk2090.pug
@@ -658,7 +658,7 @@ input(type='hidden' name='attr_template_start' value='@{whisper_state} &{templat
 
 					.statblock-section
 						.grid-container
-							each section in [{div:{class:'pc-checkbox'},span:{'data-i18n':'pc'},input:{name:'attr_character_type',value:'pc',type:'radio'}},{div:{class:'npc-checkbox'},span:{'data-i18n':'npc'},input:{name:'attr_character_type',value:'npc',type:'radio'}}/*,{div:{class:'import'},span:{class:'import','data-i18n':'import'},input:{type:'checkbox',value:'import',class:'import',name:'attr_import'}}*/]/*Import inaccessible for live till testing complete*/
+							each section in [{div:{class:'pc-checkbox'},span:{'data-i18n':'pc'},input:{name:'attr_character_type',value:'pc',type:'radio'}},{div:{class:'npc-checkbox'},span:{'data-i18n':'npc'},input:{name:'attr_character_type',value:'npc',type:'radio'}},{div:{class:'import'},span:{class:'import','data-i18n':'import'},input:{type:'checkbox',value:'import',class:'import',name:'attr_import'}}]
 								+bordered-checkbox(section.div,section.input,section.span)
 							//- End each
 					.statblock-section


### PR DESCRIPTION
## Bug Fixes
- NPC damage rolls should no longer cause an `attribute not found` chat error.
- NPC hit dice averaging should now work again

## New Features
- Statblock Importer for Genefunk2090 statblocks





## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [X] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
