### PR TITLE
[Only War Enhanced] Add accurate d10s to dmg roll

### DIFF
--- a/Only-War-Enhanced/OnlyWarEnhanced.html
+++ b/Only-War-Enhanced/OnlyWarEnhanced.html
@@ -1170,7 +1170,7 @@
 			  </select>
 			  <button name='weapon_hit' class='equipment_ranged_weapons_gs_a4 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }} {{weapon= @{R_weapon_name}}} {{burstwin=[[ceil([[[[1+ floor(abs([[{{ {@{R_weapon_target}+@{inlinemod-toggle}}, {@{bsTotal}-@{limiter}}}kh1, {@{bsTotal}+@{limiter}}}kl1]]-[[1d100@{R_weapon_mishap_chance}]])/10)]]+ceil(@{BS_unnat}/2)]]/2)]]}}{{target= $[[0]]}}{{roll= $[[1]]}}{{dof= $[[2]]}}{{dos=$[[3]]}} @{settings_hitroll} {{aim= [[@{R_weapon_aim}]]}}{{R_type= [[@{R_weapon_attack}]]}}{{range= [[@{R_weapon_attack_range}]]}}{{modifier= [[@{inlinemod-toggle}]]}}{{stat_name= Ballistic Skill}}{{stat=[[@{BS}]]}}{{advancement= [[@{BS_advancement}]]}}{{hitmod= [[@{R_weapon_mod1}]]}}{{trained= [[@{R_weapon_trained}-20]]}}{{burst=@{R_weapon_burst}}}{{auto=@{R_weapon_auto}}}{{fatigued=[[@{fatigued}]]}}
 !ammo @{character_id} repeating_rangedweapons_@{id}_R_weapon_mag [[@{ammo}*@{R_weapon_setting}]]'>Hit |<input name='attr_R_weapon_target' value='@{bsTotal} + @{R_weapon_trained} - 20 + @{R_weapon_mod1} + @{R_weapon_attack} + @{R_weapon_aim} + @{R_weapon_attack_range}+@{fatigued}' class='input_background input_char_background' disabled ></button>
-			  <button name='weapon_dmg' class='equipment_ranged_weapons_gs_a5 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{type= @{R_weapon_type}}} {{weapon= @{R_weapon_name}}} {{damage=[[@{R_weapon_real_dmg}]] }} {{spray= [[@{R_weapon_spray}]] }} {{pen=[[@{R_weapon_pen}+0@{R_weapon_pen2}]] }}  {{@{settings_weapondescription}=@{R_ability_r} }} @{R_weapon_accurate}'>DMG</button>
+			  <button name='weapon_dmg' class='equipment_ranged_weapons_gs_a5 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{type= @{R_weapon_type}}} {{weapon= @{R_weapon_name}}} {{damage=[[@{R_weapon_real_dmg}+@{R_weapon_accurate}]] }} {{spray= [[@{R_weapon_spray}]] }} {{pen=[[@{R_weapon_pen}+0@{R_weapon_pen2}]] }}  {{@{settings_weapondescription}=@{R_ability_r} }} '>DMG</button>
 			</div>
 			<div class='equipment_ranged_weapons_grid2'>
 			  <input name='attr_wep_display' type='checkbox' value='min' class='collapsible_entity_switch hidden' />
@@ -1206,7 +1206,7 @@
 			  <input class='equipment_ranged_weapons_gs_d6 full_width' type='text' value='0' name='attr_R_weapon_vengeful' />
 			  <input type='hidden' value='' name='attr_R_weapon_real_dmg' />
 			  <div class='equipment_ranged_weapons_gs_d7'>Accurate</div>
-			  <input class='equipment_ranged_weapons_gs_d8' type='checkbox' value='{{accurate=?{DoS |1, [[0]]|2-3, [[1d10cs0cf0]]|4+, [[2d10cs0cf0]]}}}' name='attr_R_weapon_accurate' />
+			  <input class='equipment_ranged_weapons_gs_d8' type='checkbox' value='?{DoS |1, [[0]]|2-3, [[1d10cs0cf0]]|4+, [[2d10cs0cf0]]}' name='attr_R_weapon_accurate' />
 			</div>
 			<div class='equipment_ranged_weapons_grid5 collapsible_entity_toggle '>
 			  <div class='equipment_ranged_weapons_gs_e1'>RoF</div>
@@ -2502,7 +2502,7 @@
 			  </select>
 			  <button name='weapon_hit' class='equipment_ranged_weapons_gs_a4 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{attack= }} {{weapon= @{V_R_weapon_name}}} {{burstwin=[[ceil([[[[1+ floor(abs([[{{ {@{V_R_weapon_target}+@{inlinemod-toggle}}, {@{veh_atk_total_finder}-@{limiter}}}kh1, {@{veh_atk_total_finder}+@{limiter}}}kl1]]-[[1d100@{V_R_weapon_mishap_chance}]])/10)]]+ceil(@{veh_atk_unnat_finder}/2)]]/2)]]}}{{target= $[[0]]}}{{roll= $[[1]]}}{{dof= $[[2]]}}{{dos= $[[3]]}} @{settings_hitroll} {{aim= [[@{V_R_weapon_aim}]]}}{{R_type= [[@{V_R_weapon_attack}]]}}{{range= [[@{V_R_weapon_attack_range}]]}}{{modifier= [[@{inlinemod-toggle}]]}}{{stat_name= @{V_R_focus}}}{{stat=[[@{veh_atk_total_finder}]]}}{{hitmod= [[@{V_R_weapon_mod1}]]}}{{trained= [[@{V_R_weapon_trained}-20]]}}{{burst=@{V_R_weapon_burst}}}{{auto=@{V_R_weapon_auto}}}{{fatigued=[[@{fatigued}]]}}
 !ammo @{character_id} repeating_rangedweapons_@{id}_V_R_weapon_mag [[@{ammo}*@{V_R_weapon_setting}]]'>Hit |<input name='attr_V_R_weapon_target' value='@{veh_atk_total_finder} + @{V_R_weapon_trained} - 20 + @{V_R_weapon_mod1} + @{V_R_weapon_attack} + @{V_R_weapon_aim} + @{V_R_weapon_attack_range}+@{veh_fatigue_finder}' class='input_background input_char_background' disabled ></button>
-			  <button name='weapon_dmg' class='equipment_ranged_weapons_gs_a5 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{type= @{V_R_weapon_type}}} {{weapon= @{V_R_weapon_name}}} {{damage=[[@{V_R_weapon_real_dmg}]] }} {{spray= [[@{V_R_weapon_spray}]] }} {{pen=[[@{V_R_weapon_pen}+0@{V_R_weapon_pen2}]] }}  {{@{settings_weapondescription}=@{V_R_ability_r} }} @{V_R_weapon_accurate}'>DMG</button>
+			  <button name='weapon_dmg' class='equipment_ranged_weapons_gs_a5 full_width clear' type='roll' value='@{to-gm}&{template:mythic} {{character= @{character_name}}} {{type= @{V_R_weapon_type}}} {{weapon= @{V_R_weapon_name}}} {{damage=[[@{V_R_weapon_real_dmg} + @{V_R_weapon_accurate}]] }} {{spray= [[@{V_R_weapon_spray}]] }} {{pen=[[@{V_R_weapon_pen}+0@{V_R_weapon_pen2}]] }}  {{@{settings_weapondescription}=@{V_R_ability_r} }} '>DMG</button>
 			</div>
 			<input class='hidden' type='text' name='attr_veh_atk_total_finder' readonly />
 			<input class='hidden' type='text' name='attr_veh_atk_unnat_finder' readonly />
@@ -2541,7 +2541,7 @@
 			  <input class='equipment_ranged_weapons_gs_d6 full_width' type='text' value='0' name='attr_V_R_weapon_vengeful' />
 			  <input type='hidden' value='' name='attr_V_R_weapon_real_dmg' />
 			  <div class='equipment_ranged_weapons_gs_d7'>Accurate</div>
-			  <input class='equipment_ranged_weapons_gs_d8' type='checkbox' value='{{accurate=?{DoS |1, [[0]]|2-3, [[1d10cs0cf0]]|4+, [[2d10cs0cf0]]}}}' name='attr_V_R_weapon_accurate' />
+			  <input class='equipment_ranged_weapons_gs_d8' type='checkbox' value='?{DoS |1, [[0]]|2-3, [[1d10cs0cf0]]|4+, [[2d10cs0cf0]]}' name='attr_V_R_weapon_accurate' />
 			</div>
 			<div class='equipment_ranged_weapons_grid5 collapsible_entity_toggle '>
 			  <div class='equipment_ranged_weapons_gs_e1'>RoF</div>


### PR DESCRIPTION
The accurate d10s were being tracked, but not where you could see

## Changes / Comments






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
