### PR TITLE
[sheet: RatasEnLasParedes] Restore default width on inputs to PV, PC and PE atributes

### DIFF
--- a/RatasEnLasParedes/RatasEnLasParedes.html
+++ b/RatasEnLasParedes/RatasEnLasParedes.html
@@ -48,19 +48,19 @@
 		<div class="sheet-Salud">
 		<div class="sheet-separatorVertical">
 		<label class="sheet-label">PV:</label>
-		<input name="attr_pv1" style="width: 10%;" type="number" value="0" min="0">
+		<input name="attr_pv1" type="number" value="0" min="0">
 		<label class="sheet-label">/</label>
-		<input name="attr_pv2" style="width: 10%;" type="number" value="0" min="0">
+		<input name="attr_pv2" type="number" value="0" min="0">
 		</div>
 		<div class="sheet-separatorVertical">
 		<label class="sheet-label">PC:</label>
-		<input name="attr_pc1" style="width: 10%;" type="number" value="0" min="0">
+		<input name="attr_pc1" type="number" value="0" min="0">
 		<label class="sheet-label">/</label>
-		<input name="attr_pc2" style="width: 10%;" type="number" value="0" min="0">
+		<input name="attr_pc2" type="number" value="0" min="0">
 		</div>
 		<div class="sheet-separatorVerticalGrande3">
 		<label class="sheet-label">PE:</label>
-		<input name="attr_pe" style="width: 10%;" type="number" value="0" min="0">
+		<input name="attr_pe" type="number" value="0" min="0">
 		</div>
 		</div>
 	</div>


### PR DESCRIPTION
## Changes / Comments
With this changes I want to fix visual bug associated with the `<input type=number>` in PV, PC and PE atributs. The aforesaid bug consist of a too small width that hide the second number. This problem is caused to the `style="width: 10%;"`.

**Before commit:**
![Ficha precambios - Focus PV + PC + PE](https://user-images.githubusercontent.com/85062629/120897940-fd900e00-c628-11eb-82dd-d129eb7751ca.jpg)


When we remove this HTML Style Attribute, the `<input type=number>` recover its default width (3.5em) from `charsheet.css` and we can see two-digit numbers.


**After commit:**
![Ficha cambios - Focus PV + PC + PE](https://user-images.githubusercontent.com/85062629/120898362-d0dcf600-c62a-11eb-9797-c1a67a723af4.jpg)

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.