### PR TITLE
[Basic_Roleplaying]Added a "None" option for the Damage Bonus

### DIFF
--- a/Basic_Roleplaying/Basic_Roleplaying.html
+++ b/Basic_Roleplaying/Basic_Roleplaying.html
@@ -1,3 +1,4 @@
+
 <div class="sheet-row">
 	<div class="sheet-cdiv">
 		<input class="sheet-HideConfig" type="checkbox" checked="checked" name="attr_is_config"><span class="sheet-is-config"><span style="font-family: &quot;pictos&quot;">y</span></span>
@@ -1367,6 +1368,7 @@
 					<select style="font-size: 9px; margin-bottom: 0px; width: 45px" name="attr_weapon_typeB">
 						<option selected="selected" value="1">Full</option>
 						<option value="0.5">Half</option>
+						<option value="0">None</option>						
 					</select>
 					</td>					
 					<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Brawl-Damage}+(ceil(@{Damage_Bonus}*@{weapon_typeB}))]]}} {{success=[[ceil(@{Brawl}*@{Multiplier}+@{Mods})]]}} {{fumble=[[ceil(95+(@{Brawl}*@{Multiplier}+@{Mods})/20))]]}} {{crit=[[ceil((@{Brawl}*@{Multiplier}+@{Mods})/20)+1]]}} {{special=[[ceil((@{Brawl}*@{Multiplier}+@{Mods})/5)+1]]}}  {{skillvalue=@{Brawl}}}  {{roll=[[1d100]]}} {{skillname=Brawl}}" /></td>
@@ -1408,6 +1410,7 @@
 					<select style="font-size: 9px; margin-bottom: 0px; width: 45px" name="attr_weapon_typeG">
 						<option selected="selected" value="1">Full</option>
 						<option value="0.5">Half</option>
+						<option value="0">None</option>	
 					</select>
 					</td>					
 					<td><button type="roll" value="&{template:melee-roll} {{tot=[[@{Grapple-Damage}+(ceil(@{Damage_Bonus}*@{weapon_typeG}))]]}} {{success=[[ceil(@{Grapple}*@{Multiplier}+@{Mods})]]}} {{fumble=[[ceil(95+(@{Grapple}*@{Multiplier}+@{Mods})/20))]]}} {{crit=[[ceil((@{Grapple}*@{Multiplier}+@{Mods})/20)+1]]}} {{special=[[ceil((@{Grapple}*@{Multiplier}+@{Mods})/5)+1]]}} {{roll=[[1d100]]}} {{skillname=Grapple}}" /></td>						
@@ -1450,6 +1453,7 @@
 				    <select style="font-size: 9px; margin-bottom: 0px; width: 45px" name="attr_weapon_type">
 					    <option selected="selected" value="1">Full</option>
 					    <option value="0.5">Half</option>
+						<option value="0">None</option>	
 				    </select>						
 				</td>					
 					<td><button type="roll" value="&{template:melee-roll} {{name=@{Name}}}{{tot=[[@{Damagex}+(ceil(@{Damage_Bonus}*@{weapon_type}))]]}} {{success=[[ceil(@{Score}*@{Multiplier}+@{Mods})]]}} {{fumble=[[ceil(95+(@{Score}*@{Multiplier}+@{Mods})/20))]]}} {{crit=[[ceil((@{Score}*@{Multiplier}+@{Mods})/20)+1]]}} {{special=[[ceil((@{Score}*@{Multiplier}+@{Mods})/5)+1]]}} {{skillvalue=@{Score}}}  {{roll=[[1d100]]}} {{skillname=@{Attack-Weapon}}}" /></td>					   				


### PR DESCRIPTION
## Changes / Comments
Added a "None" option for the Damage Bonus in Hand-to-Hand Weapons.





## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ X ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ X ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
