### PR TITLE
[CROSSED / FATES] Change asset URLs from main to master

### DIFF
--- a/Crossed-Fates/CrossedFates.css
+++ b/Crossed-Fates/CrossedFates.css
@@ -390,7 +390,7 @@
 }
 
 .charsheet .rivals-header .logo {
-  background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/main/Crossed-Fates/assets/square.png);
+  background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Crossed-Fates/assets/square.png);
   background-position: center;
   background-repeat: no-repeat;
   background-size: 100px 100px;

--- a/Crossed-Fates/CrossedFates.html
+++ b/Crossed-Fates/CrossedFates.html
@@ -556,7 +556,7 @@
   <div class="catscratcher">
     <label><a href="https://catscratcher.itch.io/" target="_blank" data-i18n="catscratcher">Catscratcher Studio</a></label>
   </div>
-  <div class="catscratcher-logo"><img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/main/Crossed-Fates/assets/cat.png" height="50" width="50" data-i18n-title="crossed_fates" data-i18n-alt="crossed_fates"/></div>
+  <div class="catscratcher-logo"><img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Crossed-Fates/assets/cat.png" height="50" width="50" data-i18n-title="crossed_fates" data-i18n-alt="crossed_fates"/></div>
 </footer>
 <rolltemplate class="sheet-rolltemplate-sheetname">
   {{#rollName}}

--- a/Crossed-Fates/source/app/components/acts/acts.pug
+++ b/Crossed-Fates/source/app/components/acts/acts.pug
@@ -1,4 +1,4 @@
-include ..\..\data\acts
+include ../../data/acts
 
 mixin act_title_block(act)
   div.act-title-block

--- a/Crossed-Fates/source/app/components/header/header.scss
+++ b/Crossed-Fates/source/app/components/header/header.scss
@@ -15,7 +15,7 @@
   }
 
   .logo {
-    background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/main/Crossed-Fates/assets/square.png);
+    background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Crossed-Fates/assets/square.png);
     background-position: center;
     background-repeat: no-repeat;
     background-size: 100px 100px;

--- a/Crossed-Fates/source/app/pages/acts/acts.pug
+++ b/Crossed-Fates/source/app/pages/acts/acts.pug
@@ -1,5 +1,5 @@
 include ../../components/acts/acts
-include ..\..\data\acts
+include ../../data/acts
 
 mixin acts_page
   div.page-container

--- a/Crossed-Fates/source/app/pages/index.pug
+++ b/Crossed-Fates/source/app/pages/index.pug
@@ -32,7 +32,7 @@ footer.footer
         data-i18n='catscratcher')=locals['catscratcher']
   div.catscratcher-logo
     img(
-      src='https://raw.githubusercontent.com/Roll20/roll20-character-sheets/main/Crossed-Fates/assets/cat.png'
+      src='https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Crossed-Fates/assets/cat.png'
       height=50
       width=50
       data-i18n-title='crossed_fates'


### PR DESCRIPTION
## Changes / Comments
- used `main` instead of `master` branch for asset URLs
- acts.pug files had backslash include statements that compiled on Windows, but not macOS

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?