### PR TITLE
[CWOD-Vampire] FIX dice pools width

### DIFF
--- a/CWOD-Vampire/Vampire.css
+++ b/CWOD-Vampire/Vampire.css
@@ -216,8 +216,9 @@ h2, h3 {
     position: initial;
 }
 
-.sheet-dice-pools-grid > select {
-    width: auto;
+.sheet-dice-pools-grid > select,
+.sheet-dice-pools-grid > select > option {
+    width: 98%;
 }
 
 button.sheet-DP1,


### PR DESCRIPTION
## Changes / Comments
This is a very small fix for Chrome browsers.
`select` and `option` elements width was calculated differently in Firefox and Chrome due to an `auto` setting. Now it calculates correctly in both browsers.





## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
