### PR TITLE
[PokemonTabletopAdventures_v3] Updates config option descriptions

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -1131,8 +1131,8 @@
         <b class="sheet-info-tooltip" title="Default value: [[d20]]"> ℹ </b>
         <input name="attr_initiative-tie-breaker" title="Attribute: initiative-tie-breaker" type="text" value="[[d20]]" /><br />
         <p class="sheet-dark-text">
-          This setting is not used by the character sheet, but is included so that you can, if you wish, add it to the character's speed when determining their
-          initiative order. (Note this isn't an official rule, but it's helpful when characters have the same speed!)
+          This is included so that you can, if you wish, add it to the character's speed when determining their initiative order.
+          (Note this isn't an official rule, but it's helpful when characters have the same speed!)
           <br />For best results, leave this as something you can add to a die-roll.
         </p>
       </div>
@@ -1171,8 +1171,8 @@
           <b class="sheet-info-tooltip" title="Select the attribute you want to use for the selected skill."> ℹ </b>
         </div>
         <p class="sheet-dark-text">
-          This setting area allows you to change the base ability modifier added to each skill total. Select the skill you want to modify with the left
-          selector, and then assign the stat you want to use with the right selector.
+          This setting allows you to change the stat each skill is associated with. Select the skill you want to modify with the left
+          field, and then assign the stat you want to use with the right field. Use this for features like the Ninja's "Ninjutsu".
         </p>
       </div>
       <div class="sheet-custom-ball-default-selecton">
@@ -1223,6 +1223,7 @@
         </tr>
 
         <!-- Accuracy Check -->
+        {{#accuracy}}
         <tr>
           <td class="sheet-label"><span>Accuracy Check:</span></td>
           <td class="sheet-accuracy-roll">
@@ -1231,6 +1232,7 @@
             {{/target}}
           </td>
         </tr>
+        {{/accuracy}}
 
         <!-- Effectiveness -->
         {{#^rollTotal() effectiveness-roll 2}}

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -31,6 +31,10 @@ Things we want to add to the character sheet, presented in no particular order o
 
 ## Changelog
 
+### Jun 22nd, 2021
+- Updated the description of some of the configuration options for better wording, and to make them accurate
+- Allows hiding the accuracy check in a customised `move` roll template, by not supplying an `accuracy` field
+
 ### Apr 11th, 2021
 - Import/Export support
   - Supports either roll20 or Pokelicious Google Sheet data


### PR DESCRIPTION
## Changes / Comments
- Corrects the initiative tie-breaker config description, as the attribute is now used by the sheet
- Provides cleaner wording, and an example, for the skill modifier selection
- Allows hiding the accuracy field when building a customised move roll template





## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
