### PR TITLE
Genefunk 2090: Fix for statblock importer not parsing damage correctly

### DIFF
--- a/Genefunk 2090/genefunk2090.html
+++ b/Genefunk 2090/genefunk2090.html
@@ -4837,7 +4837,7 @@
 				setObj[`repeating_action_${rowID}_damage_1`] = damageRoll;
 				setObj[`repeating_action_${rowID}_damage_type_1`] = damageType||'';
 				setObj[`repeating_action_${rowID}_damage_1_enable_item`] = '{{damage_type_1=@{damage_type_1}}} @{damage_1_macro}';
-
+				setObj[`repeating_action_${rowID}_damage_1_macro`] = `{{damage_${num}=[[0@{damage_${num}}]]}} {{regular_critical_${num}=[[0@{damage_${num}}]]}} {{is_custom_crit_${num}=@{critical_damage_${num}}}} {{custom_critical_${num}=[[0@{critical_damage_${num}}]]}}`;
 			}
 			if(description){
 				setObj[`repeating_action_${rowID}_description`] = description||'';

--- a/Genefunk 2090/genefunk2090.js
+++ b/Genefunk 2090/genefunk2090.js
@@ -1678,7 +1678,7 @@ var genefunk2090 = genefunk2090 || (function() {
 				setObj[`repeating_action_${rowID}_damage_1`] = damageRoll;
 				setObj[`repeating_action_${rowID}_damage_type_1`] = damageType||'';
 				setObj[`repeating_action_${rowID}_damage_1_enable_item`] = '{{damage_type_1=@{damage_type_1}}} @{damage_1_macro}';
-
+				setObj[`repeating_action_${rowID}_damage_1_macro`] = `{{damage_${num}=[[0@{damage_${num}}]]}} {{regular_critical_${num}=[[0@{damage_${num}}]]}} {{is_custom_crit_${num}=@{critical_damage_${num}}}} {{custom_critical_${num}=[[0@{critical_damage_${num}}]]}}`;
 			}
 			if(description){
 				setObj[`repeating_action_${rowID}_description`] = description||'';

--- a/Genefunk 2090/genefunk2090.pug
+++ b/Genefunk 2090/genefunk2090.pug
@@ -146,6 +146,10 @@ mixin borderedContainer(divObj,sectionHeadObj,columnHeaderArray,columnHeaderObj)
 		//- End if
 		block
 //-End mixin
+mixin pseudoControl(name)
+	.pseudo-control
+		button(type='action' class='repcontrol_add' name=`act_add_${name}`)
+//- End Mixin
 mixin templateConditionalDisplay(fieldBool,fieldDisplay,invert)
 	!=`{{${invert ? '^' : '#'}${fieldBool}}}`
 	if /\^{/.test(fieldDisplay)
@@ -155,10 +159,11 @@ mixin templateConditionalDisplay(fieldBool,fieldDisplay,invert)
 			!=`${fieldDisplay}`
 	!=`{{/${fieldBool}}}`
 //- End mixin
-mixin templateBorderedContainer(divObj)
-	.bordered-container&attributes(divObj)
-		block
-//- End mixin
+mixin rollTemplateHelperFunction(helperObj)
+	!=`{{${helperObj.positive ? '#' : (helperObj.func ? '#^' : '^')}${helperObj.func ? `${helperObj.func}() `:''}${helperObj.field}${helperObj.values ? ` ${helperObj.values.join(' ')}` : ''}}}`
+	block
+	!=`{{/${(helperObj.positive || !helperObj.func) ? '' : '^'}${helperObj.func ? `${helperObj.func}() `:''}${helperObj.field}${helperObj.values ? ` ${helperObj.values.join(' ')}` : ''}}}`
+//- End Mixin
 mixin templateHexagonLabelContainer(divClass,field,def,invert)
 	+trueHexagon(null,divClass)
 		block
@@ -166,11 +171,10 @@ mixin templateHexagonLabelContainer(divClass,field,def,invert)
 		if def
 			+templateConditionalDisplay(field,def,!invert)
 //- End mixin
-mixin rollTemplateHelperFunction(helperObj)
-	!=`{{${helperObj.positive ? '#' : (helperObj.func ? '#^' : '^')}${helperObj.func ? `${helperObj.func}() `:''}${helperObj.field}${helperObj.values ? ` ${helperObj.values.join(' ')}` : ''}}}`
-	block
-	!=`{{/${(helperObj.positive || !helperObj.func) ? '' : '^'}${helperObj.func ? `${helperObj.func}() `:''}${helperObj.field}${helperObj.values ? ` ${helperObj.values.join(' ')}` : ''}}}`
-//- End Mixin
+mixin templateBorderedContainer(divObj)
+	.bordered-container&attributes(divObj)
+		block
+//- End mixin
 mixin hack-header(level)
 	div(class=`hack-header pentagon-hexagon-label-container`)
 		+trueHexagon(locked)
@@ -338,11 +342,7 @@ mixin trait(pc)
 				//- End collapsed-view
 			//- End Expandable Section
 		//- End fieldset
-//- End mixin	
-mixin pseudoControl(name)
-	.pseudo-control
-		button(type='action' class='repcontrol_add' name=`act_add_${name}`)
-//- End Mixin
+//- End mixin
 mixin settingLabel(inputObj,i18n)
 	if !inputObj.type || inputObj.type!=='select'
 		label


### PR DESCRIPTION
## Changes / Comments
- Fix for imported statblocks not having their damage macros correct.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
