### PR TITLE
[HarnMaster3] Bugfix - Fix drag-and-drop to macro bar for repeating weapons roll

### DIFF
--- a/HarnMaster3/harnsheet.html
+++ b/HarnMaster3/harnsheet.html
@@ -680,7 +680,7 @@
     		</button>		
     		<input type="text" name="attr_kick_weapon_note" class="skill-label">		
     
-    		<fieldset class="repeating_weapon weapons-carried">
+    		<fieldset class="repeating_weapon">
     			<input type="hidden" name="attr_weapon_iscarried" class="display-carried-weapon"> <!-- this is filled with the value set by the is carried checkbox above-->
     			<div class="weapon-display"> 
     				<input type="text" name="attr_weapon_name" class="weapon-label" readonly>

--- a/HarnMaster3/harnsheet.html
+++ b/HarnMaster3/harnsheet.html
@@ -734,7 +734,7 @@
     		<div class="skill-header skill-value">&nbsp;</div>
     		<div class="skill-header skill-value">Ammo</div>
     		
-    		<fieldset class="repeating_missileweapon weapons-carried">
+    		<fieldset class="repeating_missileweapon">
     		<input type="hidden" name="attr_missileweapon_iscarried" class="display-carried-missileweapon"> <!-- this is filled with the value set by the is carried checkbox above-->
     			<div class="missileweapon-display">
     				<input type="text" name="attr_missileweapon_name" class="weapon-label" readonly>

--- a/HarnMaster3/harnsheet.html
+++ b/HarnMaster3/harnsheet.html
@@ -1524,13 +1524,15 @@
 			<input id=showpietytoggle name="attr_hrconsolidatedpiety" type="checkbox" value="1" checked>
 			<div class="full-width skill-header">Sheet version</div>
 			<div class="full-width">
-			  <input name="attr_character_sheet_version" type="number" value="20210802" readonly>
+			  <input name="attr_character_sheet_version" type="number" value="20210803" readonly>
 			  <input type="hidden" name="attr_data_version" value="" readonly>
 			</div>
     	</div>
 	</div>
 	<div class="changelog">
 		<h2>Changelog</h2>
+		<h3>20210803 - Version 2.2</h3>
+		<p>Small bugfix to address issue with drag-and-drop of roll buttons from repeating weapon section to macro quick bar</p>
 		<h3>20210802 - Version 2.1</h3>
 		<details>
 			<summary class="changelog-summary">

--- a/HarnMaster3/harnstyle.css
+++ b/HarnMaster3/harnstyle.css
@@ -937,7 +937,8 @@ input.display-mounted-status[value="1"] ~ div.mounted-display, div.unmounted-dis
     display: contents;
 }
 
-.character-grid fieldset.repeating_weapon~.repcontrol {
+.character-grid fieldset.repeating_weapon~.repcontrol,
+.character-grid fieldset.repeating_missileweapon~.repcontrol {
 	display: none;
 }
 

--- a/HarnMaster3/harnstyle.css
+++ b/HarnMaster3/harnstyle.css
@@ -937,7 +937,7 @@ input.display-mounted-status[value="1"] ~ div.mounted-display, div.unmounted-dis
     display: contents;
 }
 
-fieldset.weapons-carried~.repcontrol {
+.character-grid fieldset.repeating_weapon~.repcontrol {
 	display: none;
 }
 


### PR DESCRIPTION
## Changes / Comments

A small bugfix where using two classes in the repeating weapons section prevented the roll buttons being drag&dropped to the macro bar properly.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name. yes
- [x] Is this a bug fix? yes
- [x] Does this add functional enhancements (new features or extending existing features) ? no
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ?  no
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ? n/a
- [x] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ? bugfix only


