### PR TITLE
Shadowrun sixth world v.38

### DIFF
--- a/Shadowrun Sixth World/CHANGELOG.md
+++ b/Shadowrun Sixth World/CHANGELOG.md
@@ -1,5 +1,9 @@
 Change Log
 ==============================================
+**2021-07-12 ** v.38 Chuz (James Culp)
+	Bugfix - NPC->Grunt fixed a bug or oversight on grunt repeating skills.   They were all showing Agility on the roll template as their ability.  Upon first opening a grunt sheet all repeating skills for the grunt will be re-set to use their default associated attribute and the display attribute will also be fixed.
+	Bugfix - NPC->Host IC dice roll buttons weren't working.
+	Bugfix - PC->Rolls->Misc fixed width on conversions
 **2021-07-05 ** v.37 Chuz (James Culp)
 	Rolls->Misc tab added and now contains a way to do quick and dirty conversions for Standard to Metric and vice versa.  Feet <=> Meters, Pounds <=> Kilograms, and Miles <=> Kilometers.
 	PC->Arms->Range/Melee Added "Engineering" option to the skill dropdown.

--- a/Shadowrun Sixth World/Shadowrun6thEdition.css
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.css
@@ -2940,7 +2940,7 @@ div.contacts div.repitem div.itemcontrol button.repcontrol_del {
   display: grid !important;
   grid-column-gap: 5px;
   grid-row-gap: 2px;
-  grid-template-columns: 1fr 6em 6em 6em 1fr; }
+  grid-template-columns: 1fr 6em 12em 6em 1fr; }
 .rolls .pc-box .rolls-col .rolls-misc input[type="number"] {
   width: 100%; }
 .rolls .pc-box .rolls-col .rolls-misc h1,

--- a/Shadowrun Sixth World/Shadowrun6thEdition.html
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.html
@@ -5208,7 +5208,7 @@
 <input type="hidden" name="attr_combat_paralysis" value="0" />
 <input type="hidden" name="attr_combat_paralysis_initiative_mod" value="" />
 
-<input type="hidden" name="attr_sheet_version" value="0.37">
+<input type="hidden" name="attr_sheet_version" value="0.38">
 <input type="hidden" name="attr_data_version" value="0">
 <script type="text/worker">
 //Sheet workers
@@ -5253,6 +5253,10 @@ on("sheet:opened", function() {
 	});
 });
 
+
+var _v38_update = () => {
+
+}
 
 var _pre_v37_update = () => {
 	// Update trigger sheetworkers for weapons to set attribute and attr_rating values

--- a/Shadowrun Sixth World/Shadowrun6thEdition.html
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.html
@@ -4459,7 +4459,7 @@
 				<input name="attr_IC" type="hidden" value=""/>
 				<input class="toggle" name="attr_powered_on_IC" type="checkbox" value='1'/>
 				<span class="pictos">Q</span>
-				<button name="roll_IC" type="roll" value="@{gm_toggle} &{template:rolls}{{mod=[[@{modifiers_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{header=@{character_name}}}{{base=^{ic}: @{IC_name}}}{{dice=[[(@{dice}+@{modifiers_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}{{desc=vs. @{IC_attribute}+@{IC_matrix}}}{{wilddie=[[@{wild_die}d6]]}}"><span name="attr_IC_name"></span></button>
+				<button name="roll_IC" type="roll" value="@{gm_toggle} &{template:rolls}{{mod=[[@{modifiers_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{header=@{character_name}}}{{base=^{ic}: @{IC_name}}}{{dice=[[(@{IC_dice}+@{modifiers_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}{{desc=vs. @{IC_attribute}+@{IC_matrix}}}{{wilddie=[[@{wild_die}d6]]}}"><span name="attr_IC_name"></span></button>
 				<span class="center" name="attr_IC_dice"></span>
 				<span class="center" name="attr_IC_ar"></span>
 				<label data-i18n-title="cm" title="Condition Monitor">

--- a/Shadowrun Sixth World/Shadowrun6thEdition.html
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.html
@@ -5239,7 +5239,9 @@ on("sheet:opened", function() {
 				case '0.37':
 					_pre_v37_update();
 					console.log("Data now fits v.37");
-
+				case '0.38':
+					_v38_update();
+					console.log("Data now fits v.38");
 				default:
 					setAttrs({
 						'data_version': v.sheet_version
@@ -5255,6 +5257,62 @@ on("sheet:opened", function() {
 
 
 var _v38_update = () => {
+	getAttrs(['sheet_type'], (v) => {
+		if(v.sheet_type === 'grunt') {
+			// Grunt skills somehow ended up thinking they were all based on agility at least for the display part and for many apparently the actual selected attribute.
+			// this code just sets them to their default associated attribute which should annoy the fewest users.
+			getSectionIDs('repeating_skills', (skill) => {
+				skill.forEach((skillID) => {
+					getAttrs([`repeating_skills_${skillID}_attribute`, `repeating_skills_${skillID}_display_attribute`, `repeating_skills_${skillID}_name`], (attrs) => {
+						var attribute;
+						switch(attrs[`repeating_skills_${skillID}_name`]) {
+							case 'Athletics':
+							case 'Close Combat':
+							case 'Exotic Weapons':
+							case 'Firearms':
+							case 'Stealth':
+								attribute = 'Agility';
+								break;
+							case 'Con':
+							case 'Influence':
+								attribute = 'Charisma';
+								break;
+							case 'Astral':
+							case 'Outdoors':
+							case 'Perception':
+								attribute = 'Intuition';
+								break;
+							case 'Biotech':
+							case 'Cracking':
+							case 'Electronics':
+							case 'Engineering':
+								attribute = 'Logic';
+								break;
+							case 'Conjuring':
+							case 'Enchanting':
+							case 'Sorcery':
+								attribute = 'Magic';
+								break;
+							case 'Piloting':
+								attribute = 'Reaction';
+								break;
+							case 'Tasking':
+								attribute = 'Resonance';
+								break;
+							default:
+								attribute = 'Agility';
+								break;
+						}
+
+						setAttrs({
+							[`repeating_skills_${skillID}_attribute`]: '@{'+attribute.toLowerCase()+'}',
+							[`repeating_skills_${skillID}_display_attribute`]: attribute
+						});
+					});
+				});
+			});
+		}
+	});
 
 }
 


### PR DESCRIPTION
## Changes / Comments
Bugfix - NPC->Grunt fixed a bug or oversight on grunt repeating skills.   They were all showing Agility on the roll template as their ability.  Upon first opening a grunt sheet all repeating skills for the grunt will be re-set to use their default associated attribute and the display attribute will also be fixed.
Bugfix - NPC->Host IC dice roll buttons weren't working.
Bugfix - PC->Rolls->Misc fixed width on conversions

## Roll20 Requests
Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.
- [ Y ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ Y ] Is this a bug fix?
- [ N ] Does this add functional enhancements (new features or extending existing features) ?
- [ N ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ NA ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ NA ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?
