### PR TITLE
Valor sheet accuracy fixes

### DIFF
--- a/Valor/Valor Character Sheet.html
+++ b/Valor/Valor Character Sheet.html
@@ -201,6 +201,8 @@
         { cost: 3, levelUp: 0, speed: 0, id: 'illusoryDisguise', namePattern: '^illusory disguise' },
         { cost: 4, levelUp: 2, speed: 2, id: 'illusoryTerrain', namePattern: '^illusory terrain' },
         { cost: 4, levelUp: 0, speed: 0, id: 'pierceIllusion', namePattern: '^pierce illusion' },
+        { cost: 5, levelUp: 0, speed: 0, id: 'polearmWielder', namePattern: '^polearm' },
+        { cost: 4, levelUp: 2, speed: 1, id: 'rangedWeaponWielder', namePattern: '^ranged weapon' },
         { cost: 4, levelUp: 2, speed: 1, id: 'elementalResistance', namePattern: '^elemental resist' },
         { cost: 3, levelUp: 0, speed: 0, id: 'elementalAttunement', namePattern: '^elemental attune' },
         { cost: 2, levelUp: 0, speed: 0, id: 'changeAttributes', namePattern: '^change attr' },
@@ -2047,7 +2049,7 @@
                 } else if(limit.indexOf('vitality') == 0) {
                     let threshold = Math.ceil(health * 0.4);
                     limitSummary += getTranslationByKey('desc-limits-vitality').replace("{{0}}", threshold);
-                    limitSt += 3 * limitLevel;
+                    limitSt += 3;
                 } else if(limit.indexOf('valor') == 0) {
                     if(limit.indexOf('valor consumption') > -1) {
                         limitSummary += getTranslationByKey('desc-limits-valor-consumption').replace("{{0}}", limitLevel);
@@ -2337,7 +2339,8 @@
     });
 
     on('change:strengthattack change:agilityattack change:mindattack change:spiritattack ' +
-        'change:patkbonus change:eatkbonus change:atkrollbonus change:iatkrollbonus change:rollbonus', function() {
+        'change:patkbonus change:eatkbonus change:atkrollbonus change:iatkrollbonus change:rollbonus ' +
+        'change:strength change:agility change:mind change:spirit change:guts', function() {
         getSectionIDs('repeating_techs', function(tidarray) {
             tidarray.forEach(function(techId) {
                 calculateTech(techId);


### PR DESCRIPTION
## Changes / Comments

Sheet: **Valor**
- Bugfix: Added SP values for skills "Polearm Wielder" and "Ranged Weapon Wielder".
- Bugfix: Vitality Limit could be leveled up.
- Bugfix: Guts-based techs (e.g. healing core) wouldn't update when changing Guts value.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
