### PR TITLE
[Warhammer 4e Character Sheet] 1.51 fixes

### DIFF
--- a/Warhammer 4e Character Sheet/README.md
+++ b/Warhammer 4e Character Sheet/README.md
@@ -31,7 +31,7 @@ The sheet should work on latest version of Firefox, MS Egde & Chrome.
 
 - Armor and Damage absorption system with Enc, AP, Durable, Damage, Damage point & Robust Talent tracking. 
 
-- Magic system with separate Magic/Channeling types, all 8 colors, Witch, Dark, Chaos and a Misc for custom spell Lores. includes Spell book system, with core book spell/blessing/miracle name list, plus optional custom spell names. Intgrated core spell talent modifiers (like, atheryic attunement and instinctive diction) and including miscast management and clickies in the roll template output. Additionally, advantage can be disabled for spells in the settings tab, allowing for seamless integration the Unofficial Grimoire rules (@ http://www.lahiette.com/leratierbretonnien/wp-content/uploads/2021/04/WFRP4-Grimoire-Non-Officiel-VF-2.03-PDF.pdf).
+- Magic system with separate Magic/Channeling types, all 8 colors, Witch, Dark, Chaos and a Misc for custom spell Lores. includes Spell book system, with core book spell/blessing/miracle name list, plus optional custom spell names. Intgrated core spell talent modifiers (like, atheryic attunement and instinctive diction) and including miscast management and clickies in the roll template output. Additionally, advantage can be disabled for spells in the settings tab, allowing for seamless integration the Unofficial Grimoire rules (@ https://pdfcoffee.com/unofficial-grimoire-12-pdf-pdf-free.html).
 
 - Full combat Advantage & Condition Tracking, per core rules. Tracked by sheet attribute and integrated to automatically modify roll tamplate output and all Roll Target displays across all core / skill / weapons and magic tabs.
 
@@ -76,8 +76,10 @@ Note conditions are not intended for out of combat situations, GM simply makes t
 July 12th 2021 v1.51 
 
 - XP tab: clean up, added styling and some text. 
-- Spellbook: Petty & Arcane spell tabs have been changed to display the PCs Willpower Bonus (WPB) next the spell damage field. This mirrors the way the weapon tab works. Spell dmg will now automatically add WPB to the cast roll damage. Dmg input field will now be invisible if Damage spell checkbox is not ticked.
-
+- Spellbook: Petty & Arcane spell tabs have been cleaned up a bit to allow adding Willpower Bouns to the spell damage. This is similar the way the ranged weapons work. Wehn ticked this will now automatically add WPB to the cast roll damage. WPB? and Dmg input fields will now be invisible if the Dmg? checkbox is not ticked.
+- Houserules are no longer seperated main PC and NPCs on the same sheet. The settings options now configures both.
+- Default settings added to Game Settings page on Roll20 when this sheet is selected (Roll20 website, out side of the game). This is handy for GM's to set defaults before char sheets are created and less fiddling about each time you create a new one.
+- PC crit roll now shows modifer in the roll template. NPC crit roll had 2 pop up boxes for modifier, fixed
 
 
 July 5th 2021 v1.5 

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -437,7 +437,7 @@
 			</div>
 			<div class="sheet-col-1-9 sheet-center">
 				<div class="sheet-center">
-							<button type="roll" class="sheet-combat-actions-np" name="roll_CriticalTest" value="@{Whisper} &amp&{template:whfrp2e} {{unconscious=[[@{UnconsciousMod}]]}} {{title=Critical Roll}} {{character_name=@{character_name}}} {{attacktype=^{CRITICAL}}} {{critlocation=[[?{Choose a Hit Location|Random (1d100),[[1d100]]|Head,1|Right Arm,10|Left Arm,30|Body,46|Right Leg,85|Left Leg,96}]]}} {{critroll=[[1d(100+?{Crit Roll Modifier|0})]]}}">
+							<button type="roll" class="sheet-combat-actions-np" name="roll_CriticalTest" value="@{Whisper} &amp&{template:whfrp2e} {{unconscious=[[@{UnconsciousMod}]]}} {{title=Critical Roll}} {{character_name=@{character_name}}} {{attacktype=^{CRITICAL}}} {{critlocation=[[?{Choose a Hit Location|Random (1d100),[[1d100]]|Head,1|Right Arm,10|Left Arm,30|Body,46|Right Leg,85|Left Leg,96}]]}} {{critroll=[[1d(100+?{Crit Roll Modifier|0})]]}} {{modvalue=[[?{Crit Roll Modifier|0}]]}}">
 						<span data-i18n="CRITICAL-HIT">Critical Hit</span>
 					</button>
 				</div>
@@ -1108,7 +1108,7 @@
 						</div>
 				<input type="checkbox" name="attr_SkillRollNPC" class="sheet-hidden sheet-hider" value="2" />												
 						<div class="sheet-col-7-100 sheet-center sheet-pad-r-sm sheet-vert-middle">
-							<button type="roll" class="sheet-roll" name="roll_CriticalTest" value="@{Whisper} &amp&{template:whfrp2e} {{modvalue=[[?{@{translation_modifier}|0}]]}} {{unconscious=[[@{UnconsciousStat}]]}} {{title=Critical Roll}} {{character_name=@{npc_name}}} {{attacktype=^{CRITICAL}}} {{critlocation=[[?{Choose a Hit Location|Random (1d100),[[1d100]]|Head,1|Right Arm,10|Left Arm,30|Body,46|Right Leg,85|Left Leg,96}]]}} {{critroll=[[1d(100+?{Crit Roll Modifier|0})]]}} {{reroll=@{NPC-rep}CriticalTest)}}">
+							<button type="roll" class="sheet-roll" name="roll_CriticalTest" value="@{Whisper} &amp&{template:whfrp2e} {{modvalue=[[?{Crit Roll Modifier|0}]]}} {{unconscious=[[@{UnconsciousStat}]]}} {{title=Critical Roll}} {{character_name=@{npc_name}}} {{attacktype=^{CRITICAL}}} {{critlocation=[[?{Choose a Hit Location|Random (1d100),[[1d100]]|Head,1|Right Arm,10|Left Arm,30|Body,46|Right Leg,85|Left Leg,96}]]}} {{critroll=[[1d(100+?{Crit Roll Modifier|0})]]}} {{reroll=@{NPC-rep}CriticalTest)}}">
 						</div>
 				<input type="checkbox" name="attr_SkillRollNPC" class="sheet-hidden sheet-hider" value="3" />												
 						<div class="sheet-col-7-100 sheet-center sheet-pad-r-sm sheet-vert-middle">
@@ -2442,7 +2442,7 @@
 						</div>
 				<input type="checkbox" name="attr_SkillRollNPC" class="sheet-hidden sheet-hider" value="2" />												
 						<div class="sheet-col-7-100 sheet-center sheet-pad-r-sm sheet-vert-middle">
-							<button type="roll" class="sheet-roll" name="roll_CriticalTest" value="@{Whisper} &amp&{template:whfrp2e} {{modvalue=[[?{@{translation_modifier}|0}]]}} {{unconscious=[[@{UnconsciousStat}]]}} {{title=Critical Roll}} {{character_name=@{npc_name}}} {{attacktype=^{CRITICAL}}} {{critlocation=[[?{Choose a Hit Location|Random (1d100),[[1d100]]|Head,1|Right Arm,10|Left Arm,30|Body,46|Right Leg,85|Left Leg,96}]]}} {{critroll=[[1d(100+?{Crit Roll Modifier|0})]]}} {{reroll=@{NPC-rep}CriticalTest)}}">
+							<button type="roll" class="sheet-roll" name="roll_CriticalTest" value="@{Whisper} &amp&{template:whfrp2e} {{modvalue=[[?{Crit Roll Modifier|0}]]}} {{unconscious=[[@{UnconsciousStat}]]}} {{title=Critical Roll}} {{character_name=@{npc_name}}} {{attacktype=^{CRITICAL}}} {{critlocation=[[?{Choose a Hit Location|Random (1d100),[[1d100]]|Head,1|Right Arm,10|Left Arm,30|Body,46|Right Leg,85|Left Leg,96}]]}} {{critroll=[[1d(100+?{Crit Roll Modifier|0})]]}} {{reroll=@{NPC-rep}CriticalTest)}}">
 						</div>
 				<input type="checkbox" name="attr_SkillRollNPC" class="sheet-hidden sheet-hider" value="3" />												
 						<div class="sheet-col-7-100 sheet-center sheet-pad-r-sm sheet-vert-middle">
@@ -3775,7 +3775,7 @@
 						</div>
 				<input type="checkbox" name="attr_SkillRollNPC" class="sheet-hidden sheet-hider" value="2" />												
 						<div class="sheet-col-7-100 sheet-center sheet-pad-r-sm sheet-vert-middle">
-							<button type="roll" class="sheet-roll" name="roll_CriticalTest" value="@{Whisper} &amp&{template:whfrp2e} {{modvalue=[[?{@{translation_modifier}|0}]]}} {{unconscious=[[@{UnconsciousStat}]]}} {{title=Critical Roll}} {{character_name=@{npc_name}}} {{attacktype=^{CRITICAL}}} {{critlocation=[[?{Choose a Hit Location|Random (1d100),[[1d100]]|Head,1|Right Arm,10|Left Arm,30|Body,46|Right Leg,85|Left Leg,96}]]}} {{critroll=[[1d(100+?{Crit Roll Modifier|0})]]}} {{reroll=@{NPC-rep}CriticalTest)}}">
+							<button type="roll" class="sheet-roll" name="roll_CriticalTest" value="@{Whisper} &amp&{template:whfrp2e} {{modvalue=[[?{Crit Roll Modifier|0}]]}} {{unconscious=[[@{UnconsciousStat}]]}} {{title=Critical Roll}} {{character_name=@{npc_name}}} {{attacktype=^{CRITICAL}}} {{critlocation=[[?{Choose a Hit Location|Random (1d100),[[1d100]]|Head,1|Right Arm,10|Left Arm,30|Body,46|Right Leg,85|Left Leg,96}]]}} {{critroll=[[1d(100+?{Crit Roll Modifier|0})]]}} {{reroll=@{NPC-rep}CriticalTest)}}">
 						</div>
 				<input type="checkbox" name="attr_SkillRollNPC" class="sheet-hidden sheet-hider" value="3" />												
 						<div class="sheet-col-7-100 sheet-center sheet-pad-r-sm sheet-vert-middle">
@@ -5108,7 +5108,7 @@
 						</div>
 				<input type="checkbox" name="attr_SkillRollNPC" class="sheet-hidden sheet-hider" value="2" />												
 						<div class="sheet-col-7-100 sheet-center sheet-pad-r-sm sheet-vert-middle">
-							<button type="roll" class="sheet-roll" name="roll_CriticalTest" value="@{Whisper} &amp&{template:whfrp2e} {{modvalue=[[?{@{translation_modifier}|0}]]}} {{unconscious=[[@{UnconsciousStat}]]}} {{title=Critical Roll}} {{character_name=@{npc_name}}} {{attacktype=^{CRITICAL}}} {{critlocation=[[?{Choose a Hit Location|Random (1d100),[[1d100]]|Head,1|Right Arm,10|Left Arm,30|Body,46|Right Leg,85|Left Leg,96}]]}} {{critroll=[[1d(100+?{Crit Roll Modifier|0})]]}} {{reroll=@{NPC-rep}CriticalTest)}}">
+							<button type="roll" class="sheet-roll" name="roll_CriticalTest" value="@{Whisper} &amp&{template:whfrp2e} {{modvalue=[[?{Crit Roll Modifier|0}]]}} {{unconscious=[[@{UnconsciousStat}]]}} {{title=Critical Roll}} {{character_name=@{npc_name}}} {{attacktype=^{CRITICAL}}} {{critlocation=[[?{Choose a Hit Location|Random (1d100),[[1d100]]|Head,1|Right Arm,10|Left Arm,30|Body,46|Right Leg,85|Left Leg,96}]]}} {{critroll=[[1d(100+?{Crit Roll Modifier|0})]]}} {{reroll=@{NPC-rep}CriticalTest)}}">
 						</div>
 				<input type="checkbox" name="attr_SkillRollNPC" class="sheet-hidden sheet-hider" value="3" />												
 						<div class="sheet-col-7-100 sheet-center sheet-pad-r-sm sheet-vert-middle">
@@ -18662,7 +18662,7 @@
 		<div class="sheet-spacer-xl"></div>
 		<!-- FOOTER -->
 		<div class="sheet-row sheet-footer">
-			<div class="sheet-col-1 sheet-small-label sheet-center">Sheet version 1.5 : July 5th 2021 | by Djjus & Pote</div>
+			<div class="sheet-col-1 sheet-small-label sheet-center">Sheet version 1.51 : July 12th 2021 | by Djjus & Pote</div>
 		</div>
 		</div>
 	</div>		


### PR DESCRIPTION
## Changes / Comments

- PC crit roll now shows modifier in the roll template. NPC crit roll removed first modifier box pop up which did nothing.




## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
