### PR TITLE
[PokémonTabletopAdventures_v3]: Adds level tracker to hybrid characters

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -370,7 +370,7 @@ label {
 
 .sheet-character-name-grid {
   display: grid;
-  grid-template-columns: 1fr 4fr;
+  grid-template-columns: 3fr 8fr;
   align-items: center;
 }
 

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -190,8 +190,11 @@
           </select>
           <b>Origin</b>
           <input class="sheet-top-information" name="attr_origin" spellcheck="false" title="Attribute: origin" type="text" />
-          <b>Honors</b>
-          <input class="sheet-top-information" name="attr_honor_count" title="Attribute: honor_count" type="number" />
+          <b>Level / Honors</b>
+          <span>
+            <input class="sheet-top-information" name="attr_level1" title="Attribute: level1" type="number" />
+            <input class="sheet-top-information" name="attr_honor_count" title="Attribute: honor_count" type="number" />
+          </span>
           <b>Credits</b>
           <input class="sheet-top-information sheet-long-number" name="attr_credits" title="Attribute: credits" type="number" />
         </div>

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -31,6 +31,11 @@ Things we want to add to the character sheet, presented in no particular order o
 
 ## Changelog
 
+### Jul 17th, 2021
+- Added a level field to the `hybrid` _(or Pokémon (Character Class))_ character type.
+  - Uses the `level1` attribute, so it matches what is shown in the main class for the Trainer character type.
+- Altered some CSS ever so slightly to ensure the new _"Level / Honors"_ label is displayed on one line for the default font size.
+
 ### Jul 1st, 2021
 - Updated the `roll-quick-move` button value to include an `effectiveness-roll` parameter, so that the roll-template doesn't add an undesired row to the chat log output
 


### PR DESCRIPTION
## Changes / Comments

- Added a level field to the `hybrid` _(or Pokémon (Character Class))_ character type.
- Altered some CSS ever so slightly to ensure the new _"Level / Honors"_ label is displayed on one line for the default font size.
- Updates the README accordingly.





## Roll20 Requests
- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Does this add or change functional aesthetics (such as layout or color scheme)? 
