### PR TITLE
Deathwatch.html - Fame field change

### DIFF
--- a/Deathwatch/Deathwatch.html
+++ b/Deathwatch/Deathwatch.html
@@ -71,8 +71,8 @@
                 <div class="sheet-row">
                     <div class="sheet-item" style="width:15%"><label data-i18n="Rank">Rank</label></div>
                     <div class="sheet-item" style="width:33%"><input name="attr_Rank" type="text" /></div>
-                    <div class="sheet-item" style="width:15%"><label data-i18n="Fame">Fame</label></div>
-                    <div class="sheet-item" style="width:32%"><input name="attr_Fame" type="text" /></div>
+                    <div class="sheet-item" style="width:15%"><label data-i18n="Renown">Renown</label></div>
+                    <div class="sheet-item" style="width:30%;margin-left: 5px;"><input name="Renown" type="text" /></div>
                 </div>
                 <div class="sheet-row">
                     <div class="sheet-item" style="width:45%"><label data-i18n="PowerArmourHistory">Power Armour History</label></div>


### PR DESCRIPTION


## Changes / Comments


Fame is not used in Deathwatch, instead it uses "Renown" that is synonymous but has clearly defined mechanics in the game.
Changed the name as well as the margin so it all still looks fit.



## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
