### PR TITLE
Deathwatch/translation.json - Fame Field Change

### DIFF
--- a/Deathwatch/translation.json
+++ b/Deathwatch/translation.json
@@ -4,7 +4,7 @@
   "ChapterDemeanour": "Chapter&nbsp;Demeanour",
   "Speciality": "Speciality",
   "Rank": "Rank",
-  "Fame": "Fame",
+  "Renown": "Renown",
   "PowerArmourHistory": "Power&nbsp;Armour&nbsp;History",
   "PlayerName": "Player Name",
   "Gender": "Gender",


### PR DESCRIPTION


## Changes / Comments


Fame is not used for Deathwatch.
Renown is the corrent naming for the influence mechanic present in the books.

This change goes with the other one on the HTML to make the change complete.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [X] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
No data is removed only renamed. With no need to roll on the attribute there should be no data loss.
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
