### PR TITLE
[DnD_5e] Add Spells Prepared count to spell table in spellbook

### DIFF
--- a/DnD_5e/DnD_5e.html
+++ b/DnD_5e/DnD_5e.html
@@ -18295,6 +18295,101 @@
 	</div>
   <script type="text/worker">
 
+    const countPreparedSpells = () => {
+      const doCalc = (level1IDs, level2IDs, level3IDs, level4IDs, level5IDs, level6IDs, level7IDs, level8IDs, level9IDs) => {
+        const attrs = [
+          ...level1IDs.map(id => `repeating_spellbooklevel1_${id}_spellisprepared`),
+          ...level2IDs.map(id => `repeating_spellbooklevel2_${id}_spellisprepared`),
+          ...level3IDs.map(id => `repeating_spellbooklevel3_${id}_spellisprepared`),
+          ...level4IDs.map(id => `repeating_spellbooklevel4_${id}_spellisprepared`),
+          ...level5IDs.map(id => `repeating_spellbooklevel5_${id}_spellisprepared`),
+          ...level6IDs.map(id => `repeating_spellbooklevel6_${id}_spellisprepared`),
+          ...level7IDs.map(id => `repeating_spellbooklevel7_${id}_spellisprepared`),
+          ...level8IDs.map(id => `repeating_spellbooklevel8_${id}_spellisprepared`),
+          ...level9IDs.map(id => `repeating_spellbooklevel9_${id}_spellisprepared`)
+        ];
+        getAttrs(attrs, v => {
+          values = Object.values(v).map(a=>(parseInt(a)));
+          const total = values.reduce((a,b) => a + b, 0);
+          console.log({total});
+          setAttrs({
+            spells_prepared_count: total
+          });
+        });
+      };
+
+      getSectionIDs("repeating_spellbooklevel1", level1IDs => {
+        getSectionIDs("repeating_spellbooklevel2", level2IDs => {
+          getSectionIDs("repeating_spellbooklevel3", level3IDs => {
+            getSectionIDs("repeating_spellbooklevel4", level4IDs => {
+              getSectionIDs("repeating_spellbooklevel5", level5IDs => {
+                getSectionIDs("repeating_spellbooklevel6", level6IDs => {
+                  getSectionIDs("repeating_spellbooklevel7", level7IDs => {
+                    getSectionIDs("repeating_spellbooklevel8", level8IDs => {
+                      getSectionIDs("repeating_spellbooklevel9", level9IDs => doCalc(level1IDs, level2IDs, level3IDs, level4IDs, level5IDs, level6IDs, level7IDs, level8IDs, level9IDs));
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    };
+    on("change:repeating_spellbooklevel1", function(eventInfo) {
+      if(eventInfo.sourceAttribute.match(/spellisprepared/)) {
+        countPreparedSpells();
+      }
+   });
+
+    on("change:repeating_spellbooklevel2", function(eventInfo) {
+      if(eventInfo.sourceAttribute.match(/spellisprepared/)) {
+        countPreparedSpells();
+      }
+   });
+
+    on("change:repeating_spellbooklevel3", function(eventInfo) {
+      if(eventInfo.sourceAttribute.match(/spellisprepared/)) {
+        countPreparedSpells();
+      }
+   });
+
+    on("change:repeating_spellbooklevel4", function(eventInfo) {
+      if(eventInfo.sourceAttribute.match(/spellisprepared/)) {
+        countPreparedSpells();
+      }
+   });
+
+    on("change:repeating_spellbooklevel5", function(eventInfo) {
+      if(eventInfo.sourceAttribute.match(/spellisprepared/)) {
+        countPreparedSpells();
+      }
+   });
+
+    on("change:repeating_spellbooklevel6", function(eventInfo) {
+      if(eventInfo.sourceAttribute.match(/spellisprepared/)) {
+        countPreparedSpells();
+      }
+   });
+
+    on("change:repeating_spellbooklevel7", function(eventInfo) {
+      if(eventInfo.sourceAttribute.match(/spellisprepared/)) {
+        countPreparedSpells();
+      }
+   });
+
+    on("change:repeating_spellbooklevel8", function(eventInfo) {
+      if(eventInfo.sourceAttribute.match(/spellisprepared/)) {
+        countPreparedSpells();
+      }
+   });
+
+    on("change:repeating_spellbooklevel9", function(eventInfo) {
+      if(eventInfo.sourceAttribute.match(/spellisprepared/)) {
+        countPreparedSpells();
+      }
+   });
+
     on("change:drop_category", function(eventinfo) {
         if(eventinfo.newValue === "Monsters") {
             handle_drop_monster(eventinfo.newValue);

--- a/DnD_5e/DnD_5e.html
+++ b/DnD_5e/DnD_5e.html
@@ -11846,6 +11846,39 @@
 						</div>
 					</div>
 					<div class="sheet-row">
+						<div class="sheet-col-1-6 sheet-margin-top sheet-center">Prepared</div>
+						<div class="sheet-col-1-12">
+							<input type="number" name="attr_spells_prepared_count_arcane_trickster" value="0" disabled="disabled" />
+					</div>
+						<div class="sheet-col-1-12">
+							<input type="number" name="attr_spells_prepared_count_bard" value="0" disabled="disabled" />
+						</div>
+						<div class="sheet-col-1-12">
+							<input type="number" name="attr_spells_prepared_count_cleric" value="(@{spells_prepared_count})" disabled="disabled" />
+						</div>
+						<div class="sheet-col-1-12">
+							<input type="number" name="attr_spells_prepared_count_druid" value="(@{spells_prepared_count})" disabled="disabled" />
+						</div>
+						<div class="sheet-col-1-12">
+							<input type="number" name="attr_spells_prepared_count_eldritch_knight" value="0" disabled="disabled" />
+						</div>
+						<div class="sheet-col-1-12">
+							<input type="number" name="attr_spells_prepared_count_paladin" value="(@{spells_prepared_count})" disabled="disabled" />
+						</div>
+						<div class="sheet-col-1-12">
+							<input type="number" name="attr_spells_prepared_count_ranger" value="0" disabled="disabled" />
+						</div>
+						<div class="sheet-col-1-12">
+							<input type="number" name="attr_spells_prepared_count_sorcerer" value="0" disabled="disabled" />
+						</div>
+						<div class="sheet-col-1-12">
+							<input type="number" name="attr_spells_prepared_count_warlock" value="0" disabled="disabled" />
+						</div>
+						<div class="sheet-col-1-12">
+							<input type="number" name="attr_spells_prepared_count_wizard" value="(@{spells_prepared_count})" disabled="disabled" />
+						</div>
+					</div>
+					<div class="sheet-row">
 						<div class="sheet-col-1-6 sheet-margin-top sheet-center">Save DC</div>
 						<div class="sheet-col-1-12">
 							<input type="number" name="attr_arcane_trickster_spell_dc" value="(@{base_spell_dc}+@{arcane_trickster_spell_bonus})" disabled="disabled" />

--- a/DnD_5e/DnD_5e.html
+++ b/DnD_5e/DnD_5e.html
@@ -11849,7 +11849,7 @@
 						<div class="sheet-col-1-6 sheet-margin-top sheet-center">Prepared</div>
 						<div class="sheet-col-1-12">
 							<input type="number" name="attr_spells_prepared_count_arcane_trickster" value="0" disabled="disabled" />
-					</div>
+						</div>
 						<div class="sheet-col-1-12">
 							<input type="number" name="attr_spells_prepared_count_bard" value="0" disabled="disabled" />
 						</div>
@@ -18336,6 +18336,11 @@
         });
       });
     };
+
+    on('sheet:opened',function(){
+      countPreparedSpells();
+    });
+
     on("change:repeating_spellbooklevel1", function(eventInfo) {
       if(eventInfo.sourceAttribute.match(/spellisprepared/)) {
         countPreparedSpells();
@@ -18391,9 +18396,9 @@
    });
 
     on("change:drop_category", function(eventinfo) {
-        if(eventinfo.newValue === "Monsters") {
-            handle_drop_monster(eventinfo.newValue);
-        }
+      if(eventinfo.newValue === "Monsters") {
+        handle_drop_monster(eventinfo.newValue);
+      }
     });
 
     var handle_drop_monster = function(category, eventinfo) {

--- a/DnD_5e/DnD_5e.html
+++ b/DnD_5e/DnD_5e.html
@@ -18311,7 +18311,6 @@
         getAttrs(attrs, v => {
           values = Object.values(v).map(a=>(parseInt(a)));
           const total = values.reduce((a,b) => a + b, 0);
-          console.log({total});
           setAttrs({
             spells_prepared_count: total
           });


### PR DESCRIPTION
## Changes / Comments

This Pull Request adds a new row, "Prepared", to the spell table on the Spellbook tab of the DnD_5e character sheet. Included are the HTML changes to add the row to the table, and javascript changes to calculate and set the attribute whenever a spells preparation status is changed.
The code only listens to changes on spell levels 1-9, since changes to cantrips do not impact the number of spells prepared.
The javascript code starts by checking which field on the spell was changed, and only continues if it was the "prepared" field.
The javascript code also runs when the sheet is first loaded, to ensure the spells_prepared_count attribute exists for all users and does not generate an error.
The fields in the Prepared row of the spell table are auto-calced.
This is informational only, and does not impose any restrictions on how many spells a user can mark as Prepared.
Only classes that prepare their spells (Cleric, Druid, Paladin, Wizard) are updated by the code. However, the field is set for all classes, to match the pattern of the Can Prepare row above.
The prepared count is the same for those four classes; it makes no effort to associate any spells with given classes, though that could potentially be a future enhancement (based on the "Gained From" field on the spells).

<img width="862" alt="SpellsPrepared" src="https://user-images.githubusercontent.com/2908283/128642957-105d48a1-9fdf-40e6-90f2-d4f539a70f45.png">

- **Sheet name:** DnD 5e
- **Is this a bug fix?** No
- **Does this add functional enhancements (new features or extending existing features)?** Yes, adds a row to the spells table to display the count of spells that have been marked as prepared.
- **Does this add or change functional aesthetics (such as layout or color scheme)?** The only layout change is to add a new row to the spells table, which shifts the rest of the page down very slightly.
- **If changing or removing attributes, what steps have you taken, if any, to preserve player data?** No attributes have been changed or removed. To handle having new fields that are autocalc'ed from a new attribute, the javascript code runs when the sheet is first loaded to populate the attribute.
- **If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository)?** N/A, not a new sheet


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [x] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
