### PR TITLE
[Hero System 6e Heroic] Changes to damage roll handling

### DIFF
--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -1806,7 +1806,9 @@ text-align: center;
 	border-radius: 5px;
 	max-width: 333px;
 	background: gold;
+	height: 630px;
 	padding: 5px;
+	padding-bottom: 0px;
 	margin-bottom: 2px;
 }
 
@@ -1848,7 +1850,7 @@ text-align: center;
 
 .item-talent-textbox textarea {
 	max-width: 315px;
-	max-height: 35px;
+	max-height: 36px;
 	padding: 3px;
 	border: solid 1px darkgray;
 }
@@ -2017,7 +2019,7 @@ text-align: center;
 }
 
 .button-Power-Roll {
-	background-color: #9184E2; // lihter than mediumslateblue
+	background-color: #9184E2; // lighter than mediumslateblue
 }
 
 .flex-container-powers-right,

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1649,7 +1649,7 @@
 					<input type="text" name="attr_powerEffect01" />
 					<input type="text" name="attr_powerDice01" value="0d6"/>
 					
-					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll01" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName01} - @{powerEffect01}}} {{desc=@{powerText01}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{powerDice01}]]}} {{END=[[@{powerEND01}]]}}">Roll</button>
+					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll01" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName01} - @{powerEffect01}}} {{desc=@{powerText01}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{hiddenPowerDice01}]]}} {{END=[[@{powerEND01}]]}}">Roll</button>
 					
 					<button type="action" class="button button-Power-END-left" name="act_buttonPower01">END:</button><br>
 					<input type="number" name="attr_powerEND01" value="0" readonly/>
@@ -1710,7 +1710,7 @@
 					<input type="text" name="attr_powerEffect02" />
 					<input type="text" name="attr_powerDice02" value="0d6"/>
 					
-					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll02" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName02} - @{powerEffect02}}} {{desc=@{powerText02}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{powerDice02}]]}} {{END=[[@{powerEND02}]]}}">Roll</button>
+					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll02" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName02} - @{powerEffect02}}} {{desc=@{powerText02}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{hiddenPowerDice02}]]}} {{END=[[@{powerEND02}]]}}">Roll</button>
 					
 					<button type="action" class="button button-Power-END-left" name="act_buttonPower02">END:</button><br>
 					<input type="number" name="attr_powerEND02" value="0" readonly/>
@@ -1771,7 +1771,7 @@
 					<input type="text" name="attr_powerEffect03" />
 					<input type="text" name="attr_powerDice03" value="0d6"/>
 					
-					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll03" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName03} - @{powerEffect03}}} {{desc=@{powerText03}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{powerDice03}]]}} {{END=[[@{powerEND03}]]}}">Roll</button>
+					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll03" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName03} - @{powerEffect03}}} {{desc=@{powerText03}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{hiddenPowerDice03}]]}} {{END=[[@{powerEND03}]]}}">Roll</button>
 					
 					<button type="action" class="button button-Power-END-left" name="act_buttonPower03">END:</button><br>
 					<input type="number" name="attr_powerEND03" value="0" readonly/>
@@ -1832,7 +1832,7 @@
 					<input type="text" name="attr_powerEffect04" />
 					<input type="text" name="attr_powerDice04" value="0d6"/>
 					
-					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll04" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName04} - @{powerEffect04}}} {{desc=@{powerText04}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{powerDice04}]]}} {{END=[[@{powerEND04}]]}}">Roll</button>
+					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll04" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName04} - @{powerEffect04}}} {{desc=@{powerText04}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{hiddenPowerDice04}]]}} {{END=[[@{powerEND04}]]}}">Roll</button>
 					
 					<button type="action" class="button button-Power-END-left" name="act_buttonPower04">END:</button><br>
 					<input type="number" name="attr_powerEND04" value="0" readonly/>
@@ -1893,7 +1893,7 @@
 					<input type="text" name="attr_powerEffect05" />
 					<input type="text" name="attr_powerDice05" value="0d6"/>
 					
-					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll05" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName05} - @{powerEffect05}}} {{desc=@{powerText05}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{powerDice05}]]}} {{END=[[@{powerEND05}]]}}">Roll</button>
+					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll05" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName05} - @{powerEffect05}}} {{desc=@{powerText05}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{hiddenPowerDice05}]]}} {{END=[[@{powerEND05}]]}}">Roll</button>
 					
 					<button type="action" class="button button-Power-END-left" name="act_buttonPower05">END:</button><br>
 					<input type="number" name="attr_powerEND05" value="0" readonly/>
@@ -1957,7 +1957,7 @@
 					<input type="text" name="attr_powerEffect06" />
 					<input type="text" name="attr_powerDice06" value="0d6"/>
 					
-					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll06" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName06} - @{powerEffect06}}} {{desc=@{powerText06}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{powerDice06}]]}} {{END=[[@{powerEND06}]]}}">Roll</button>
+					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll06" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName06} - @{powerEffect06}}} {{desc=@{powerText06}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{hiddenPowerDice06}]]}} {{END=[[@{powerEND06}]]}}">Roll</button>
 					
 					<button type="action" class="button button-Power-END-right" name="act_buttonPower06">END:</button><br>
 					<input type="number" name="attr_powerEND06" value="0" readonly/>
@@ -2018,7 +2018,7 @@
 					<input type="text" name="attr_powerEffect07" />
 					<input type="text" name="attr_powerDice07" value="0d6"/>
 					
-					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll07" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName07} - @{powerEffect07}}} {{desc=@{powerText07}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{powerDice07}]]}} {{END=[[@{powerEND07}]]}}">Roll</button>
+					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll07" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName07} - @{powerEffect07}}} {{desc=@{powerText07}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{hiddenPowerDice07}]]}} {{END=[[@{powerEND07}]]}}">Roll</button>
 					
 					<button type="action" class="button button-Power-END-right" name="act_buttonPower07">END:</button><br>
 					<input type="number" name="attr_powerEND07" value="0" readonly/>
@@ -2079,7 +2079,7 @@
 					<input type="text" name="attr_powerEffect08" />
 					<input type="text" name="attr_powerDice08" value="0d6"/>
 					
-					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll08" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName08} - @{powerEffect08}}} {{desc=@{powerText08}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{powerDice08}]]}} {{END=[[@{powerEND08}]]}}">Roll</button>
+					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll08" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName08} - @{powerEffect08}}} {{desc=@{powerText08}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{hiddenPowerDice08}]]}} {{END=[[@{powerEND08}]]}}">Roll</button>
 					
 					<button type="action" class="button button-Power-END-right" name="act_buttonPower08">END:</button><br>
 					<input type="number" name="attr_powerEND08" value="0" readonly/>
@@ -2140,7 +2140,7 @@
 					<input type="text" name="attr_powerEffect09" />
 					<input type="text" name="attr_powerDice09" value="0d6"/>
 					
-					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll09" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName09} - @{powerEffect09}}} {{desc=@{powerText09}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{powerDice09}]]}} {{END=[[@{powerEND09}]]}}">Roll</button>
+					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll09" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName09} - @{powerEffect09}}} {{desc=@{powerText09}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{hiddenPowerDice09}]]}} {{END=[[@{powerEND09}]]}}">Roll</button>
 					
 					<button type="action" class="button button-Power-END-right" name="act_buttonPower09">END:</button><br>
 					<input type="number" name="attr_powerEND09" value="0" readonly/>
@@ -2201,7 +2201,7 @@
 					<input type="text" name="attr_powerEffect10" />
 					<input type="text" name="attr_powerDice10" value="0d6"/>
 					
-					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll10" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName10} - @{powerEffect10}}} {{desc=@{powerText10}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{powerDice10}]]}} {{END=[[@{powerEND10}]]}}">Roll</button>
+					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll10" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName10} - @{powerEffect10}}} {{desc=@{powerText10}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{hiddenPowerDice10}]]}} {{END=[[@{powerEND10}]]}}">Roll</button>
 					
 					<button type="action" class="button button-Power-END-right" name="act_buttonPower10">END:</button><br>
 					<input type="number" name="attr_powerEND10" value="0" readonly/>
@@ -3371,7 +3371,19 @@
 <input type="hidden" name="attr_hiddenWeaponDamage03"  value="0"/>
 <input type="hidden" name="attr_hiddenWeaponDamage04"  value="0"/>
 <input type="hidden" name="attr_hiddenWeaponDamage05"  value="0"/>
-<input type="hidden" name="attr_hiddenManeuverDamage01"  value="0"/>
+<input type="hidden" name="attr_hiddenManeuverDamage01"  value="2d6"/>
+
+<!-- Hidden variables for clean power dice strings -->
+<input type="hidden" name="attr_hiddenPowerDice01"  value="0"/>
+<input type="hidden" name="attr_hiddenPowerDice02"  value="0"/>
+<input type="hidden" name="attr_hiddenPowerDice03"  value="0"/>
+<input type="hidden" name="attr_hiddenPowerDice04"  value="0"/>
+<input type="hidden" name="attr_hiddenPowerDice05"  value="0"/>
+<input type="hidden" name="attr_hiddenPowerDice06"  value="0"/>
+<input type="hidden" name="attr_hiddenPowerDice07"  value="0"/>
+<input type="hidden" name="attr_hiddenPowerDice08"  value="0"/>
+<input type="hidden" name="attr_hiddenPowerDice09"  value="0"/>
+<input type="hidden" name="attr_hiddenPowerDice10"  value="0"/>
 
 <!-- Hidden variable for token display -->
 <input type="hidden" name="attr_currentDCV" value="0"/>
@@ -4652,8 +4664,8 @@
 	}
 	
 	/* Update Power01 after detecting change to any of the numerical vales in the flex container */
-	on("change:powerType01 change:powerBaseCost01 change:powerAdvantages01 change:powerReducedEND01 change:powerLimitations01", function () {
-		getAttrs(["powerType01","powerBaseCost01","powerAdvantages01","powerReducedEND01","powerLimitations01"], function(values) {
+	on("change:powerType01 change:powerBaseCost01 change:powerAdvantages01 change:powerReducedEND01 change:powerLimitations01 change:powerDice01", function () {
+		getAttrs(["powerType01","powerBaseCost01","powerAdvantages01","powerReducedEND01","powerLimitations01","powerDice01"], function(values) {
 			
 			let powerType = values.powerType01;
 			const powerBaseCost = parseInt(values.powerBaseCost01)||0;
@@ -4663,6 +4675,7 @@
 			let powerModifiedCost=0;
 			let powerRealCost=0;
 			let powerEND=0;
+			let thePowerDice=values.powerDice01;
 			
 			var increasedENDLimitation=increasedENDlimitation(powerReducedEND);
 			var powerLimitations = (parseFloat(values.powerLimitations01)||0)+increasedENDLimitation;
@@ -4671,6 +4684,7 @@
 			powerEND=calculatePowerEND(powerPreReducedEndActiveCost, powerReducedEND);
 			powerActiveCost=calculateActiveCost(powerBaseCost, powerAdvantages, powerReducedEND);
 			powerActiveCost=heroRoundLow(powerActiveCost);
+			thePowerDice=thePowerDice.replace(/[^\ddD\\+\\-]/g,"");
 			
 			if (powerBaseCost != 0) {
 				switch (powerType) {
@@ -4700,7 +4714,8 @@
 			setAttrs({
 				"powerActiveCost01":powerActiveCost,
 				"powerEND01":powerEND,
-				"powerCP01":powerRealCost
+				"powerCP01":powerRealCost,
+				"hiddenPowerDice01":thePowerDice
 			});
 			
 		});
@@ -4725,8 +4740,8 @@
 	});	
 	
 	/* Update Power02 after detecting change to any of the numerical vales in the flex container */
-	on("change:powerType02 change:powerBaseCost02 change:powerAdvantages02 change:powerReducedEND02 change:powerLimitations02", function () {
-		getAttrs(["powerType02","powerBaseCost02","powerAdvantages02","powerReducedEND02","powerLimitations02"], function(values) {
+	on("change:powerType02 change:powerBaseCost02 change:powerAdvantages02 change:powerReducedEND02 change:powerLimitations02 change:powerDice02", function () {
+		getAttrs(["powerType02","powerBaseCost02","powerAdvantages02","powerReducedEND02","powerLimitations02","powerDice02"], function(values) {
 			
 			let powerType = values.powerType02;
 			const powerBaseCost = parseInt(values.powerBaseCost02)||0;
@@ -4736,6 +4751,7 @@
 			let powerModifiedCost=0;
 			let powerRealCost=0;
 			let powerEND=0;
+			let thePowerDice=values.powerDice02;
 			
 			var increasedENDLimitation=increasedENDlimitation(powerReducedEND);
 			var powerLimitations = (parseFloat(values.powerLimitations02)||0)+increasedENDLimitation;
@@ -4744,6 +4760,7 @@
 			powerEND=calculatePowerEND(powerPreReducedEndActiveCost, powerReducedEND);
 			powerActiveCost=calculateActiveCost(powerBaseCost, powerAdvantages, powerReducedEND);
 			powerActiveCost=heroRoundLow(powerActiveCost);
+			thePowerDice=thePowerDice.replace(/[^\ddD\\+\\-]/g,"");
 			
 			if (powerBaseCost != 0) {
 				switch (powerType) {
@@ -4773,7 +4790,8 @@
 			setAttrs({
 				"powerActiveCost02":powerActiveCost,
 				"powerEND02":powerEND,
-				"powerCP02":powerRealCost
+				"powerCP02":powerRealCost,
+				"hiddenPowerDice02":thePowerDice
 			});
 			
 		});
@@ -4798,8 +4816,8 @@
 	});	
 	
 	/* Update Power03 after detecting change to any of the numerical vales in the flex container */
-	on("change:powerType03 change:powerBaseCost03 change:powerAdvantages03 change:powerReducedEND03 change:powerLimitations03", function () {
-		getAttrs(["powerType03","powerBaseCost03","powerAdvantages03","powerReducedEND03","powerLimitations03"], function(values) {
+	on("change:powerType03 change:powerBaseCost03 change:powerAdvantages03 change:powerReducedEND03 change:powerLimitations03 change:powerDice03", function () {
+		getAttrs(["powerType03","powerBaseCost03","powerAdvantages03","powerReducedEND03","powerLimitations03","powerDice03"], function(values) {
 			
 			let powerType = values.powerType03;
 			const powerBaseCost = parseInt(values.powerBaseCost03)||0;
@@ -4809,6 +4827,7 @@
 			let powerModifiedCost=0;
 			let powerRealCost=0;
 			let powerEND=0;
+			let thePowerDice=values.powerDice03;
 			
 			var increasedENDLimitation=increasedENDlimitation(powerReducedEND);
 			var powerLimitations = (parseFloat(values.powerLimitations03)||0)+increasedENDLimitation;
@@ -4817,6 +4836,7 @@
 			powerEND=calculatePowerEND(powerPreReducedEndActiveCost, powerReducedEND);
 			powerActiveCost=calculateActiveCost(powerBaseCost, powerAdvantages, powerReducedEND);
 			powerActiveCost=heroRoundLow(powerActiveCost);
+			thePowerDice=thePowerDice.replace(/[^\ddD\\+\\-]/g,"");
 			
 			if (powerBaseCost != 0) {
 				switch (powerType) {
@@ -4846,7 +4866,8 @@
 			setAttrs({
 				"powerActiveCost03":powerActiveCost,
 				"powerEND03":powerEND,
-				"powerCP03":powerRealCost
+				"powerCP03":powerRealCost,
+				"hiddenPowerDice03":thePowerDice
 			});
 			
 		});
@@ -4871,8 +4892,8 @@
 	});	
 	
 	/* Update Power04 after detecting change to any of the numerical vales in the flex container */
-	on("change:powerType04 change:powerBaseCost04 change:powerAdvantages04 change:powerReducedEND04 change:powerLimitations04", function () {
-		getAttrs(["powerType04","powerBaseCost04","powerAdvantages04","powerReducedEND04","powerLimitations04"], function(values) {
+	on("change:powerType04 change:powerBaseCost04 change:powerAdvantages04 change:powerReducedEND04 change:powerLimitations04 change:powerDice04", function () {
+		getAttrs(["powerType04","powerBaseCost04","powerAdvantages04","powerReducedEND04","powerLimitations04","powerDice04"], function(values) {
 			
 			let powerType = values.powerType04;
 			const powerBaseCost = parseInt(values.powerBaseCost04)||0;
@@ -4882,6 +4903,7 @@
 			let powerModifiedCost=0;
 			let powerRealCost=0;
 			let powerEND=0;
+			let thePowerDice=values.powerDice04;
 			
 			var increasedENDLimitation=increasedENDlimitation(powerReducedEND);
 			var powerLimitations = (parseFloat(values.powerLimitations04)||0)+increasedENDLimitation;
@@ -4890,6 +4912,7 @@
 			powerEND=calculatePowerEND(powerPreReducedEndActiveCost, powerReducedEND);
 			powerActiveCost=calculateActiveCost(powerBaseCost, powerAdvantages, powerReducedEND);
 			powerActiveCost=heroRoundLow(powerActiveCost);
+			thePowerDice=thePowerDice.replace(/[^\ddD\\+\\-]/g,"");
 			
 			if (powerBaseCost != 0) {
 				switch (powerType) {
@@ -4919,7 +4942,8 @@
 			setAttrs({
 				"powerActiveCost04":powerActiveCost,
 				"powerEND04":powerEND,
-				"powerCP04":powerRealCost
+				"powerCP04":powerRealCost,
+				"hiddenPowerDice04":thePowerDice
 			});
 			
 		});
@@ -4944,8 +4968,8 @@
 	});	
 	
 	/* Update Power05 after detecting change to any of the numerical vales in the flex container */
-	on("change:powerType05 change:powerBaseCost05 change:powerAdvantages05 change:powerReducedEND05 change:powerLimitations05", function () {
-		getAttrs(["powerType05","powerBaseCost05","powerAdvantages05","powerReducedEND05","powerLimitations05"], function(values) {
+	on("change:powerType05 change:powerBaseCost05 change:powerAdvantages05 change:powerReducedEND05 change:powerLimitations05 change:powerDice05", function () {
+		getAttrs(["powerType05","powerBaseCost05","powerAdvantages05","powerReducedEND05","powerLimitations05","powerDice05"], function(values) {
 			
 			let powerType = values.powerType05;
 			const powerBaseCost = parseInt(values.powerBaseCost05)||0;
@@ -4955,6 +4979,7 @@
 			let powerModifiedCost=0;
 			let powerRealCost=0;
 			let powerEND=0;
+			let thePowerDice=values.powerDice05;
 			
 			var increasedENDLimitation=increasedENDlimitation(powerReducedEND);
 			var powerLimitations = (parseFloat(values.powerLimitations05)||0)+increasedENDLimitation;
@@ -4963,6 +4988,7 @@
 			powerEND=calculatePowerEND(powerPreReducedEndActiveCost, powerReducedEND);
 			powerActiveCost=calculateActiveCost(powerBaseCost, powerAdvantages, powerReducedEND);
 			powerActiveCost=heroRoundLow(powerActiveCost);
+			thePowerDice=thePowerDice.replace(/[^\ddD\\+\\-]/g,"");
 			
 			if (powerBaseCost != 0) {
 				switch (powerType) {
@@ -4992,7 +5018,8 @@
 			setAttrs({
 				"powerActiveCost05":powerActiveCost,
 				"powerEND05":powerEND,
-				"powerCP05":powerRealCost
+				"powerCP05":powerRealCost,
+				"hiddenPowerDice05":thePowerDice
 			});
 			
 		});
@@ -5017,8 +5044,8 @@
 	});
 	
 	/* Update Power06 after detecting change to any of the numerical vales in the flex container */
-	on("change:powerType06 change:powerBaseCost06 change:powerAdvantages06 change:powerReducedEND06 change:powerLimitations06", function () {
-		getAttrs(["powerType06","powerBaseCost06","powerAdvantages06","powerReducedEND06","powerLimitations06"], function(values) {
+	on("change:powerType06 change:powerBaseCost06 change:powerAdvantages06 change:powerReducedEND06 change:powerLimitations06 change:powerDice06", function () {
+		getAttrs(["powerType06","powerBaseCost06","powerAdvantages06","powerReducedEND06","powerLimitations06","powerDice06"], function(values) {
 			
 			let powerType = values.powerType06;
 			const powerBaseCost = parseInt(values.powerBaseCost06)||0;
@@ -5028,6 +5055,7 @@
 			let powerModifiedCost=0;
 			let powerRealCost=0;
 			let powerEND=0;
+			let thePowerDice=values.powerDice06;
 			
 			var increasedENDLimitation=increasedENDlimitation(powerReducedEND);
 			var powerLimitations = (parseFloat(values.powerLimitations06)||0)+increasedENDLimitation;
@@ -5036,6 +5064,7 @@
 			powerEND=calculatePowerEND(powerPreReducedEndActiveCost, powerReducedEND);
 			powerActiveCost=calculateActiveCost(powerBaseCost, powerAdvantages, powerReducedEND);
 			powerActiveCost=heroRoundLow(powerActiveCost);
+			thePowerDice=thePowerDice.replace(/[^\ddD\\+\\-]/g,"");
 			
 			if (powerBaseCost != 0) {
 				switch (powerType) {
@@ -5065,7 +5094,8 @@
 			setAttrs({
 				"powerActiveCost06":powerActiveCost,
 				"powerEND06":powerEND,
-				"powerCP06":powerRealCost
+				"powerCP06":powerRealCost,
+				"hiddenPowerDice06":thePowerDice
 			});
 			
 		});
@@ -5090,8 +5120,8 @@
 	});
 	
 	/* Update Power07 after detecting change to any of the numerical vales in the flex container */
-	on("change:powerType07 change:powerBaseCost07 change:powerAdvantages07 change:powerReducedEND07 change:powerLimitations07", function () {
-		getAttrs(["powerType07","powerBaseCost07","powerAdvantages07","powerReducedEND07","powerLimitations07"], function(values) {
+	on("change:powerType07 change:powerBaseCost07 change:powerAdvantages07 change:powerReducedEND07 change:powerLimitations07 change:powerDice07", function () {
+		getAttrs(["powerType07","powerBaseCost07","powerAdvantages07","powerReducedEND07","powerLimitations07","powerDice07"], function(values) {
 			
 			let powerType = values.powerType07;
 			const powerBaseCost = parseInt(values.powerBaseCost07)||0;
@@ -5101,6 +5131,7 @@
 			let powerModifiedCost=0;
 			let powerRealCost=0;
 			let powerEND=0;
+			let thePowerDice=values.powerDice07;
 			
 			var increasedENDLimitation=increasedENDlimitation(powerReducedEND);
 			var powerLimitations = (parseFloat(values.powerLimitations07)||0)+increasedENDLimitation;
@@ -5109,6 +5140,7 @@
 			powerEND=calculatePowerEND(powerPreReducedEndActiveCost, powerReducedEND);
 			powerActiveCost=calculateActiveCost(powerBaseCost, powerAdvantages, powerReducedEND);
 			powerActiveCost=heroRoundLow(powerActiveCost);
+			thePowerDice=thePowerDice.replace(/[^\ddD\\+\\-]/g,"");
 			
 			if (powerBaseCost != 0) {
 				switch (powerType) {
@@ -5138,7 +5170,8 @@
 			setAttrs({
 				"powerActiveCost07":powerActiveCost,
 				"powerEND07":powerEND,
-				"powerCP07":powerRealCost
+				"powerCP07":powerRealCost,
+				"hiddenPowerDice07":thePowerDice
 			});
 			
 		});
@@ -5163,8 +5196,8 @@
 	});
 	
 	/* Update Power08 after detecting change to any of the numerical vales in the flex container */
-	on("change:powerType08 change:powerBaseCost08 change:powerAdvantages08 change:powerReducedEND08 change:powerLimitations08", function () {
-		getAttrs(["powerType08","powerBaseCost08","powerAdvantages08","powerReducedEND08","powerLimitations08"], function(values) {
+	on("change:powerType08 change:powerBaseCost08 change:powerAdvantages08 change:powerReducedEND08 change:powerLimitations08 change:powerDice08", function () {
+		getAttrs(["powerType08","powerBaseCost08","powerAdvantages08","powerReducedEND08","powerLimitations08","powerDice08"], function(values) {
 			
 			let powerType = values.powerType08;
 			const powerBaseCost = parseInt(values.powerBaseCost08)||0;
@@ -5174,6 +5207,7 @@
 			let powerModifiedCost=0;
 			let powerRealCost=0;
 			let powerEND=0;
+			let thePowerDice=values.powerDice08;
 			
 			var increasedENDLimitation=increasedENDlimitation(powerReducedEND);
 			var powerLimitations = (parseFloat(values.powerLimitations08)||0)+increasedENDLimitation;
@@ -5182,6 +5216,7 @@
 			powerEND=calculatePowerEND(powerPreReducedEndActiveCost, powerReducedEND);
 			powerActiveCost=calculateActiveCost(powerBaseCost, powerAdvantages, powerReducedEND);
 			powerActiveCost=heroRoundLow(powerActiveCost);
+			thePowerDice=thePowerDice.replace(/[^\ddD\\+\\-]/g,"");
 			
 			if (powerBaseCost != 0) {
 				switch (powerType) {
@@ -5211,7 +5246,8 @@
 			setAttrs({
 				"powerActiveCost08":powerActiveCost,
 				"powerEND08":powerEND,
-				"powerCP08":powerRealCost
+				"powerCP08":powerRealCost,
+				"hiddenPowerDice08":thePowerDice
 			});
 			
 		});
@@ -5236,8 +5272,8 @@
 	});
 	
 	/* Update Power09 after detecting change to any of the numerical vales in the flex container */
-	on("change:powerType09 change:powerBaseCost09 change:powerAdvantages09 change:powerReducedEND09 change:powerLimitations09", function () {
-		getAttrs(["powerType09","powerBaseCost09","powerAdvantages09","powerReducedEND09","powerLimitations09"], function(values) {
+	on("change:powerType09 change:powerBaseCost09 change:powerAdvantages09 change:powerReducedEND09 change:powerLimitations09 change:powerDice09", function () {
+		getAttrs(["powerType09","powerBaseCost09","powerAdvantages09","powerReducedEND09","powerLimitations09","powerDice09"], function(values) {
 			
 			let powerType = values.powerType09;
 			const powerBaseCost = parseInt(values.powerBaseCost09)||0;
@@ -5247,6 +5283,7 @@
 			let powerModifiedCost=0;
 			let powerRealCost=0;
 			let powerEND=0;
+			let thePowerDice=values.powerDice09;
 			
 			var increasedENDLimitation=increasedENDlimitation(powerReducedEND);
 			var powerLimitations = (parseFloat(values.powerLimitations09)||0)+increasedENDLimitation;
@@ -5255,6 +5292,7 @@
 			powerEND=calculatePowerEND(powerPreReducedEndActiveCost, powerReducedEND);
 			powerActiveCost=calculateActiveCost(powerBaseCost, powerAdvantages, powerReducedEND);
 			powerActiveCost=heroRoundLow(powerActiveCost);
+			thePowerDice=thePowerDice.replace(/[^\ddD\\+\\-]/g,"");
 			
 			if (powerBaseCost != 0) {
 				switch (powerType) {
@@ -5284,7 +5322,8 @@
 			setAttrs({
 				"powerActiveCost09":powerActiveCost,
 				"powerEND09":powerEND,
-				"powerCP09":powerRealCost
+				"powerCP09":powerRealCost,
+				"hiddenPowerDice09":thePowerDice
 			});
 			
 		});
@@ -5309,8 +5348,8 @@
 	});
 	
 	/* Update Power10 after detecting change to any of the numerical vales in the flex container */
-	on("change:powerType10 change:powerBaseCost10 change:powerAdvantages10 change:powerReducedEND10 change:powerLimitations10", function () {
-		getAttrs(["powerType10","powerBaseCost10","powerAdvantages10","powerReducedEND10","powerLimitations10"], function(values) {
+	on("change:powerType10 change:powerBaseCost10 change:powerAdvantages10 change:powerReducedEND10 change:powerLimitations10 change:powerDice10", function () {
+		getAttrs(["powerType10","powerBaseCost10","powerAdvantages10","powerReducedEND10","powerLimitations10","powerDice10"], function(values) {
 			
 			let powerType = values.powerType10;
 			const powerBaseCost = parseInt(values.powerBaseCost10)||0;
@@ -5320,6 +5359,7 @@
 			let powerModifiedCost=0;
 			let powerRealCost=0;
 			let powerEND=0;
+			let thePowerDice=values.powerDice10;
 			
 			var increasedENDLimitation=increasedENDlimitation(powerReducedEND);
 			var powerLimitations = (parseFloat(values.powerLimitations10)||0)+increasedENDLimitation;
@@ -5328,6 +5368,7 @@
 			powerEND=calculatePowerEND(powerPreReducedEndActiveCost, powerReducedEND);
 			powerActiveCost=calculateActiveCost(powerBaseCost, powerAdvantages, powerReducedEND);
 			powerActiveCost=heroRoundLow(powerActiveCost);
+			thePowerDice=thePowerDice.replace(/[^\ddD\\+\\-]/g,"");
 			
 			if (powerBaseCost != 0) {
 				switch (powerType) {
@@ -5357,7 +5398,8 @@
 			setAttrs({
 				"powerActiveCost10":powerActiveCost,
 				"powerEND10":powerEND,
-				"powerCP10":powerRealCost
+				"powerCP10":powerRealCost,
+				"hiddenPowerDice10":thePowerDice
 			});
 			
 		});

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -3364,6 +3364,16 @@
 <input type="hidden" name="attr_hiddenEnhancerSkillsCost"  value="0"/>
 <input type="hidden" name="attr_hiddenMartialSkillsCost"  value="0"/>
 
+<!-- Hidden variables for clean weapon damage strings -->
+<input type="hidden" name="attr_hiddenShieldDamage01"  value="0"/>
+<input type="hidden" name="attr_hiddenWeaponDamage01"  value="0"/>
+<input type="hidden" name="attr_hiddenWeaponDamage02"  value="0"/>
+<input type="hidden" name="attr_hiddenWeaponDamage03"  value="0"/>
+<input type="hidden" name="attr_hiddenWeaponDamage04"  value="0"/>
+<input type="hidden" name="attr_hiddenWeaponDamage05"  value="0"/>
+<input type="hidden" name="attr_hiddenManeuverDamage01"  value="0"/>
+
+<!-- Hidden variable for token display -->
 <input type="hidden" name="attr_currentDCV" value="0"/>
 
 <!-- Jackob's Roll Template -->
@@ -6826,9 +6836,57 @@
 	/* --- Weapon Attacks   --- */
 	/* ------------------------ */
 	
+	on("change:shieldDamage change:weaponDamage01 change:weaponDamage02 change:weaponDamage03 change:weaponDamage04 change:weaponDamage05 change:strength", function () {
+		// This function attempts to clean damage text input into text more likely to be rollable dice.
+		// Only characters 0-9, d, D, +, and - are passed to attack rolls.
+		
+		getAttrs(["shieldDamage","weaponDamage01","weaponDamage02","weaponDamage03","weaponDamage04","weaponDamage05","strength"], function(values) {
+		
+			var theShieldDamage=values.shieldDamage;
+			theShieldDamage=theShieldDamage.replace(/[^\ddD\\+\\-]/g,"");
+			
+			var theWeaponDamage01=values.weaponDamage01;
+			theWeaponDamage01=theWeaponDamage01.replace(/[^\ddD\\+\\-]/g,"");
+			
+			var theWeaponDamage02=values.weaponDamage02;
+			theWeaponDamage02=theWeaponDamage02.replace(/[^\ddD\\+\\-]/g,"");
+			
+			var theWeaponDamage03=values.weaponDamage03;
+			theWeaponDamage03=theWeaponDamage03.replace(/[^\ddD\\+\\-]/g,"");
+			
+			var theWeaponDamage04=values.weaponDamage04;
+			theWeaponDamage04=theWeaponDamage04.replace(/[^\ddD\\+\\-]/g,"");
+			
+			var theWeaponDamage05=values.weaponDamage05;
+			theWeaponDamage05=theWeaponDamage05.replace(/[^\ddD\\+\\-]/g,"");
+			
+			
+			// Calculate basic strength damage dice and create a roll20 dice string of d6s and d3s.
+			let theStrength=parseInt(values.strength)||0;
+			let theNumberOfD6=(parseInt((theStrength-(theStrength%5))/5)||0).toString();
+			
+			let theNumberOfD3=0;
+			if (theStrength%5>2) {
+				theNumberOfD3=1;
+			}
+			
+			var theStrengthDamage=theNumberOfD6.concat("d6+",theNumberOfD3.toString(),"d3");
+			
+			setAttrs({
+				hiddenShieldDamage01:theShieldDamage,
+				hiddenWeaponDamage01:theWeaponDamage01,
+				hiddenWeaponDamage02:theWeaponDamage02,
+				hiddenWeaponDamage03:theWeaponDamage03,
+				hiddenWeaponDamage04:theWeaponDamage04,
+				hiddenWeaponDamage05:theWeaponDamage05,
+				hiddenManeuverDamage01:theStrengthDamage
+			});
+		});
+	});
+	
 	
 	on('clicked:attackWeapon01', (info) => {
-		startRoll("&{template:custom-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= Attacks with @{weaponName01}}} {{OCV=[[?{Modifier|0}+@{weaponOCV01}+@{weaponOCVPenalty01}+@{ocv}]]}} {{Result=[[3d6cf<0cs>0]]}} {{BODY=[[@{weaponDamage01}]]}}", (results) => {
+		startRoll("&{template:custom-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= Attacks with @{weaponName01}}} {{OCV=[[?{Modifier|0}+@{weaponOCV01}+@{weaponOCVPenalty01}+@{ocv}]]}} {{Result=[[3d6cf<0cs>0]]}} {{BODY=[[@{hiddenWeaponDamage01}]]}}", (results) => {
 			
 			let computed = parseInt(results.results.BODY.result)||0;
 			
@@ -6885,7 +6943,7 @@
 	});
 	
 	on('clicked:attackWeapon02', (info) => {
-		startRoll("&{template:custom-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= Attacks with @{weaponName02}}} {{OCV=[[?{Modifier|0}+@{weaponOCV02}+@{weaponOCVPenalty02}+@{ocv}]]}} {{Result=[[3d6cf<0cs>0]]}} {{BODY=[[@{weaponDamage02}]]}}", (results) => {
+		startRoll("&{template:custom-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= Attacks with @{weaponName02}}} {{OCV=[[?{Modifier|0}+@{weaponOCV02}+@{weaponOCVPenalty02}+@{ocv}]]}} {{Result=[[3d6cf<0cs>0]]}} {{BODY=[[@{hiddenWeaponDamage02}]]}}", (results) => {
 			
 			let computed = parseInt(results.results.BODY.result)||0;
 			
@@ -6942,7 +7000,7 @@
 	});
 	
 	on('clicked:attackWeapon03', (info) => {
-		startRoll("&{template:custom-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= Attacks with @{weaponName03}}} {{OCV=[[?{Modifier|0}+@{weaponOCV03}+@{weaponOCVPenalty03}+@{ocv}]]}} {{Result=[[3d6cf<0cs>0]]}} {{BODY=[[@{weaponDamage03}]]}}", (results) => {
+		startRoll("&{template:custom-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= Attacks with @{weaponName03}}} {{OCV=[[?{Modifier|0}+@{weaponOCV03}+@{weaponOCVPenalty03}+@{ocv}]]}} {{Result=[[3d6cf<0cs>0]]}} {{BODY=[[@{hiddenWeaponDamage03}]]}}", (results) => {
 			
 			let computed = parseInt(results.results.BODY.result)||0;
 			
@@ -6999,7 +7057,7 @@
 	});
 	
 	on('clicked:attackWeapon04', (info) => {
-		startRoll("&{template:custom-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= Attacks with @{weaponName04}}} {{OCV=[[?{Modifier|0}+@{weaponOCV04}+@{weaponOCVPenalty04}+@{ocv}]]}} {{Result=[[3d6cf<0cs>0]]}} {{BODY=[[@{weaponDamage04}]]}}", (results) => {
+		startRoll("&{template:custom-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= Attacks with @{weaponName04}}} {{OCV=[[?{Modifier|0}+@{weaponOCV04}+@{weaponOCVPenalty04}+@{ocv}]]}} {{Result=[[3d6cf<0cs>0]]}} {{BODY=[[@{hiddenWeaponDamage04}]]}}", (results) => {
 			
 			let computed = parseInt(results.results.BODY.result)||0;
 			
@@ -7058,13 +7116,13 @@
 	on('clicked:attackWeapon05', (info) => {
 		// Weapon05 does normal damage.
 		
-		startRoll("&{template:custom-normal-attack} {{title=@{character_name} - @{character_title}}} {{subtitle=Attacks with @{weaponName05}}} {{OCV=[[?{Modifier|0}+@{weaponOCV05}+@{weaponOCVPenalty05}+@{ocv}]]}} {{Result=[[3d6cf<0cs>0]]}} {{STUN=[[@{weaponDamage05}]]}}", (results) => {
+		startRoll("&{template:custom-normal-attack} {{title=@{character_name} - @{character_title}}} {{subtitle=Attacks with @{weaponName05}}} {{OCV=[[?{Modifier|0}+@{weaponOCV05}+@{weaponOCVPenalty05}+@{ocv}]]}} {{Result=[[3d6cf<0cs>0]]}} {{STUN=[[@{hiddenWeaponDamage05}]]}}", (results) => {
 			
 			// Convert dice roll to equivalent BODY damage.
 			
 			let computed =0;
 			const theDice = results.results.STUN.rolls;
-
+			
 			// For each type of dice (d3 or d6) calculate BODY:
 			for(let groupOfDice of theDice) {
 				if (groupOfDice.sides == 3) {
@@ -7127,7 +7185,7 @@
 	on('clicked:attackShield', (info) => {
 		// The shield does normal damage.
 		
-		startRoll("&{template:custom-normal-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= Attacks with @{shieldName}}} {{OCV=[[?{Modifiers|0}-@{shieldDCV}+@{targetOCVpenalty}+@{ocv}]]}} {{Result=[[3d6cf<0cs>0]]}} {{STUN=[[@{shieldDamage}]]}}", (results) => {
+		startRoll("&{template:custom-normal-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= Attacks with @{shieldName}}} {{OCV=[[?{Modifiers|0}-@{shieldDCV}+@{targetOCVpenalty}+@{ocv}]]}} {{Result=[[3d6cf<0cs>0]]}} {{STUN=[[@{hiddenShieldDamage01}]]}}", (results) => {
 			
 			// Convert dice roll to equivalent BODY damage.
 			
@@ -7191,7 +7249,7 @@
 	});
 	
 	on('clicked:standardAttackRoll', (info) => {
-		startRoll("&{template:custom-normal-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= Attacks with Strength @{strength}}} {{OCV=[[?{Modifiers|0}+@{ocv}+@{targetOCVpenalty}]]}} {{Result=[[3d6cf<0cs>0]]}} {{STUN=[[((@{strength}-(@{strength}%5))/5)d6+((@{strength}%5)/5)d3]]}}", (results) => {
+		startRoll("&{template:custom-normal-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= Attacks with Strength @{strength}}} {{OCV=[[?{Modifiers|0}+@{ocv}+@{targetOCVpenalty}]]}} {{Result=[[3d6cf<0cs>0]]}} {{STUN=[[@{hiddenManeuverDamage01}]]}}", (results) => {
 			// A standard strength-based attack is complicated by the need to use a 1d3 for strength%5 == 3 or 4, such as 4, 8, 13, 19, etc.
 			
 			getAttrs(["optionHitLocationSystem", "targetSelection","strength"], function(values) {

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -26,7 +26,7 @@
 				</div>
 				
 				<div class="item-characteristics-bio-nameText">
-					<input type="text" value=" " name="attr_character_name"/>
+					<input type="text" value=" " name="attr_character_name" maxlength="29"/>
 				</div>
 				
 				<div class="item-characteristics-bio-titleLabel">
@@ -34,7 +34,7 @@
 				</div>
 				
 				<div class="item-characteristics-bio-titleText">
-					<input type="text" value=" " name="attr_character_title"/>
+					<input type="text" value=" " name="attr_character_title" maxlength="29"/>
 				</div>
 				
 				<div class="item-characteristics-bio-backgroundLabel">
@@ -42,7 +42,7 @@
 				</div>
 				
 				<div class="item-characteristics-bio-backgroundText">
-					<textarea name="attr_backgroundText"cols="28" rows="3"/></textarea>
+					<textarea name="attr_backgroundText" cols="28" rows="3" maxlength="54"/></textarea>
 				</div>
 			</div>
 				
@@ -230,7 +230,7 @@
 				
 				<!-- Sticky Note -->
 				<div class="item-portrait-02">
-					<textarea name="attr_portraitStickyNote">Sticky Note</textarea>	
+					<textarea name="attr_portraitStickyNote" maxlength="403">Sticky Note</textarea>	
 				</div>
 				
 				<!-- Portrait frame select buttons -->
@@ -301,7 +301,7 @@
 			</div>
 			
 			<div class="item-characteristics-history">
-				<textarea name="attr_historyText">Biography</textarea>
+				<textarea name="attr_historyText" maxlength="4440">Biography</textarea>
 			</div> 
 		 </div>
 	</div>
@@ -332,7 +332,7 @@
 			
 			<!-- Skill 01 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName01"/>
+				<input type="text" value=" " name="attr_skillName01" maxlength="16"/>
 				<div class="custom-select-alternate">
 					<select name="attr_skillType01">
 						<option value="none" selected>-</option>
@@ -362,7 +362,7 @@
 			
 			<!-- Skill 02 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName02"/>
+				<input type="text" value=" " name="attr_skillName02" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType02">
 						<option value="none" selected>-</option>
@@ -391,7 +391,7 @@
 			
 			<!-- Skill 03 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName03"/>
+				<input type="text" value=" " name="attr_skillName03" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType03">
 						<option value="none" selected>-</option>
@@ -420,7 +420,7 @@
 			
 			<!-- Skill 04 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName04"/>
+				<input type="text" value=" " name="attr_skillName04" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType04">
 						<option value="none" selected>-</option>
@@ -449,7 +449,7 @@
 			
 			<!-- Skill 05 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName05"/>
+				<input type="text" value=" " name="attr_skillName05" maxlength="16"/>
 				<div class="custom-select-alternate">
 					<select name="attr_skillType05">
 						<option value="none" selected>-</option>
@@ -479,7 +479,7 @@
 			
 			<!-- Skill 06 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName06"/>
+				<input type="text" value=" " name="attr_skillName06" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType06">
 						<option value="none" selected>-</option>
@@ -508,7 +508,7 @@
 			
 			<!-- Skill 07 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName07"/>
+				<input type="text" value=" " name="attr_skillName07" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType07">
 						<option value="none" selected>-</option>
@@ -537,7 +537,7 @@
 			
 			<!-- Skill 08 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName08"/>
+				<input type="text" value=" " name="attr_skillName08" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType08">
 						<option value="none" selected>-</option>
@@ -566,7 +566,7 @@
 			
 			<!-- Skill 09 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName09"/>
+				<input type="text" value=" " name="attr_skillName09" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType09">
 						<option value="none" selected>-</option>
@@ -595,7 +595,7 @@
 			
 			<!-- Skill 10 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName10"/>
+				<input type="text" value=" " name="attr_skillName10" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType10">
 						<option value="none" selected>-</option>
@@ -628,7 +628,7 @@
 			
 			<!-- Skill 11 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName11"/>
+				<input type="text" value=" " name="attr_skillName11" maxlength="16"/>
 				<div class="custom-select-alternate">
 					<select name="attr_skillType11">
 						<option value="none" selected>-</option>
@@ -658,7 +658,7 @@
 			
 			<!-- Skill 12 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName12"/>
+				<input type="text" value=" " name="attr_skillName12" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType12">
 						<option value="none" selected>-</option>
@@ -687,7 +687,7 @@
 			
 			<!-- Skill 13 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName13"/>
+				<input type="text" value=" " name="attr_skillName13" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType13">
 						<option value="none" selected>-</option>
@@ -716,7 +716,7 @@
 			
 			<!-- Skill 14 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName14"/>
+				<input type="text" value=" " name="attr_skillName14" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType14">
 						<option value="none" selected>-</option>
@@ -745,7 +745,7 @@
 			
 			<!-- Skill 15 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName15"/>
+				<input type="text" value=" " name="attr_skillName15" maxlength="16"/>
 				<div class="custom-select-alternate">
 					<select name="attr_skillType15">
 						<option value="none" selected>-</option>
@@ -775,7 +775,7 @@
 			
 			<!-- Skill 16 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName16"/>
+				<input type="text" value=" " name="attr_skillName16" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType16">
 						<option value="none" selected>-</option>
@@ -804,7 +804,7 @@
 			
 			<!-- Skill 17 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName17"/>
+				<input type="text" value=" " name="attr_skillName17" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType17">
 						<option value="none" selected>-</option>
@@ -833,7 +833,7 @@
 			
 			<!-- Skill 18 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName18"/>
+				<input type="text" value=" " name="attr_skillName18" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType18">
 						<option value="none" selected>-</option>
@@ -862,7 +862,7 @@
 			
 			<!-- Skill 19 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName19"/>
+				<input type="text" value=" " name="attr_skillName19" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType19">
 						<option value="none" selected>-</option>
@@ -891,7 +891,7 @@
 			
 			<!-- Skill 20 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName20"/>
+				<input type="text" value=" " name="attr_skillName20" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType20">
 						<option value="none" selected>-</option>
@@ -924,7 +924,7 @@
 			
 			<!-- Skill 21 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName21"/>
+				<input type="text" value=" " name="attr_skillName21" maxlength="16"/>
 				<div class="custom-select-alternate">
 					<select name="attr_skillType21">
 						<option value="none" selected>-</option>
@@ -954,7 +954,7 @@
 			
 			<!-- Skill 22 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName22"/>
+				<input type="text" value=" " name="attr_skillName22" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType22">
 						<option value="none" selected>-</option>
@@ -983,7 +983,7 @@
 			
 			<!-- Skill 23 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName23"/>
+				<input type="text" value=" " name="attr_skillName23" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType23">
 						<option value="none" selected>-</option>
@@ -1012,7 +1012,7 @@
 			
 			<!-- Skill 24 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName24"/>
+				<input type="text" value=" " name="attr_skillName24" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType24">
 						<option value="none" selected>-</option>
@@ -1041,7 +1041,7 @@
 			
 			<!-- Skill 25 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName25"/>
+				<input type="text" value=" " name="attr_skillName25" maxlength="16"/>
 				<div class="custom-select-alternate">
 					<select name="attr_skillType25">
 						<option value="none" selected>-</option>
@@ -1071,7 +1071,7 @@
 			
 			<!-- Skill 26 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName26"/>
+				<input type="text" value=" " name="attr_skillName26" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType26">
 						<option value="none" selected>-</option>
@@ -1100,7 +1100,7 @@
 			
 			<!-- Skill 27 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName27"/>
+				<input type="text" value=" " name="attr_skillName27" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType27">
 						<option value="none" selected>-</option>
@@ -1129,7 +1129,7 @@
 			
 			<!-- Skill 28 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName28"/>
+				<input type="text" value=" " name="attr_skillName28" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType28">
 						<option value="none" selected>-</option>
@@ -1158,7 +1158,7 @@
 			
 			<!-- Skill 29 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName29"/>
+				<input type="text" value=" " name="attr_skillName29" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType29">
 						<option value="none" selected>-</option>
@@ -1187,7 +1187,7 @@
 			
 			<!-- Skill 30 -->
 			<div class="subitem-skillsTab-flex-container-skill">
-				<input type="text" value=" " name="attr_skillName30"/>
+				<input type="text" value=" " name="attr_skillName30" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillType30">
 						<option value="none" selected>-</option>
@@ -1221,13 +1221,13 @@
 			<!-- Combat skill names -->
 			<div class="subitem-skillsTab-flex-container-combat-skills-names">
 				<h1>Combat Skills</h1>
-				<input type="text" value=" " name="attr_skillName31"/>
-				<input type="text" value=" " name="attr_skillName32"/>
-				<input type="text" value=" " name="attr_skillName33"/>
-				<input type="text" value=" " name="attr_skillName34"/>
-				<input type="text" value=" " name="attr_skillName35"/>
-				<input type="text" value=" " name="attr_skillName36"/>
-				<input type="text" value=" " name="attr_skillName37"/>
+				<input type="text" value=" " name="attr_skillName31" maxlength="16"/>
+				<input type="text" value=" " name="attr_skillName32" maxlength="16"/>
+				<input type="text" value=" " name="attr_skillName33" maxlength="16"/>
+				<input type="text" value=" " name="attr_skillName34" maxlength="16"/>
+				<input type="text" value=" " name="attr_skillName35" maxlength="16"/>
+				<input type="text" value=" " name="attr_skillName36" maxlength="16"/>
+				<input type="text" value=" " name="attr_skillName37" maxlength="16"/>
 			</div>
 				
 			<div class="subitem-skillsTab-flex-container-combat-skills-level-names">	
@@ -1363,7 +1363,7 @@
 				
 			<!-- Language skill 01 (41 overall) -->
 			<div class="subitem-skillsTab-flex-container-language">
-				<input type="text" value="Native Language" name="attr_skillName41"/>
+				<input type="text" value="Native Language" name="attr_skillName41" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillFluency41">
 						<option value="native" selected >Native</option>
@@ -1384,7 +1384,7 @@
 			
 			<!-- Language skill 02 (42 overall) -->
 			<div class="subitem-skillsTab-flex-container-language">
-				<input type="text" value=" " name="attr_skillName42"/>
+				<input type="text" value=" " name="attr_skillName42" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillFluency42">
 						<option value="native">Native</option>
@@ -1405,7 +1405,7 @@
 			
 			<!-- Language skill 03 (43 overall) -->
 			<div class="subitem-skillsTab-flex-container-language">
-				<input type="text" value=" " name="attr_skillName43"/>
+				<input type="text" value=" " name="attr_skillName43" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillFluency43">
 						<option value="native">Native</option>
@@ -1426,7 +1426,7 @@
 			
 			<!-- Language skill 04 (44 overall) -->
 			<div class="subitem-skillsTab-flex-container-language">
-				<input type="text" value=" " name="attr_skillName44"/>
+				<input type="text" value=" " name="attr_skillName44" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillFluency44">
 						<option value="native">Native</option>
@@ -1447,7 +1447,7 @@
 			
 			<!-- Language skill 05 (45 overall) -->
 			<div class="subitem-skillsTab-flex-container-language">
-				<input type="text" value=" " name="attr_skillName45"/>
+				<input type="text" value=" " name="attr_skillName45" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillFluency45">
 						<option value="native">Native</option>
@@ -1468,7 +1468,7 @@
 			
 			<!-- Language skill 06 (46 overall) -->
 			<div class="subitem-skillsTab-flex-container-language">
-				<input type="text" value=" " name="attr_skillName46"/>
+				<input type="text" value=" " name="attr_skillName46" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillFluency46">
 						<option value="native">Native</option>
@@ -1489,7 +1489,7 @@
 			
 			<!-- Language skill 07 (47 overall) -->
 			<div class="subitem-skillsTab-flex-container-language">
-				<input type="text" value=" " name="attr_skillName47"/>
+				<input type="text" value=" " name="attr_skillName47" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillFluency47">
 						<option value="native">Native</option>
@@ -1510,7 +1510,7 @@
 			
 			<!-- Language skill 08 (48 overall) -->
 			<div class="subitem-skillsTab-flex-container-language">
-				<input type="text" value=" " name="attr_skillName48"/>
+				<input type="text" value=" " name="attr_skillName48" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillFluency48">
 						<option value="native">Native</option>
@@ -1531,7 +1531,7 @@
 			
 			<!-- Language skill 09 (49 overall) -->
 			<div class="subitem-skillsTab-flex-container-language">
-				<input type="text" value=" " name="attr_skillName49"/>
+				<input type="text" value=" " name="attr_skillName49" maxlength="16"/>
 				<div class="custom-select">
 					<select name="attr_skillFluency49">
 						<option value="native">Native</option>
@@ -1641,13 +1641,13 @@
 			<!-- Power 01 -->
 			<div class="item-flex-power">
 				<div class="subitem-flex-power-heading-left">
-					<input type="text" name="attr_powerName01"/>
+					<input type="text" name="attr_powerName01" maxlength="25"/>
 					<h1>Real CP:</h1>
 					<input type="number" name="attr_powerCP01" value="0" min="0" readonly/>
 				</div>
 				<div class="subitem-flex-power-effect-left">
-					<input type="text" name="attr_powerEffect01" />
-					<input type="text" name="attr_powerDice01" value="0d6"/>
+					<input type="text" name="attr_powerEffect01" maxlength="19"/>
+					<input type="text" name="attr_powerDice01" value="0d6" maxlength="16"/>
 					
 					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll01" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName01} - @{powerEffect01}}} {{desc=@{powerText01}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{hiddenPowerDice01}]]}} {{END=[[@{powerEND01}]]}}">Roll</button>
 					
@@ -1696,19 +1696,19 @@
 						</select>
 					</div>
 				</div>
-				<textarea name="attr_powerText01"></textarea>
+				<textarea name="attr_powerText01" maxlength="512"></textarea>
 			</div>
 			
 			<!-- Power 02 -->
 			<div class="item-flex-power">
 				<div class="subitem-flex-power-heading-left">
-					<input type="text" name="attr_powerName02"/>
+					<input type="text" name="attr_powerName02" maxlength="25"/>
 					<h1>Real CP:</h1>
 					<input type="number" name="attr_powerCP02" value="0" min="0" readonly/>
 				</div>
 				<div class="subitem-flex-power-effect-left">
-					<input type="text" name="attr_powerEffect02" />
-					<input type="text" name="attr_powerDice02" value="0d6"/>
+					<input type="text" name="attr_powerEffect02" maxlength="19"/>
+					<input type="text" name="attr_powerDice02" value="0d6" maxlength="16"/>
 					
 					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll02" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName02} - @{powerEffect02}}} {{desc=@{powerText02}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{hiddenPowerDice02}]]}} {{END=[[@{powerEND02}]]}}">Roll</button>
 					
@@ -1757,19 +1757,19 @@
 						</select>
 					</div>
 				</div>
-				<textarea name="attr_powerText02"></textarea>
+				<textarea name="attr_powerText02" maxlength="512"></textarea>
 			</div>
 			
 			<!-- Power 03 -->
 			<div class="item-flex-power">
 				<div class="subitem-flex-power-heading-left">
-					<input type="text" name="attr_powerName03"/>
+					<input type="text" name="attr_powerName03" maxlength="25"/>
 					<h1>Real CP:</h1>
 					<input type="number" name="attr_powerCP03" value="0" min="0" readonly/>
 				</div>
 				<div class="subitem-flex-power-effect-left">
-					<input type="text" name="attr_powerEffect03" />
-					<input type="text" name="attr_powerDice03" value="0d6"/>
+					<input type="text" name="attr_powerEffect03" maxlength="19"/>
+					<input type="text" name="attr_powerDice03" value="0d6" maxlength="16"/>
 					
 					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll03" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName03} - @{powerEffect03}}} {{desc=@{powerText03}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{hiddenPowerDice03}]]}} {{END=[[@{powerEND03}]]}}">Roll</button>
 					
@@ -1818,19 +1818,19 @@
 						</select>
 					</div>
 				</div>
-				<textarea name="attr_powerText03"></textarea>
+				<textarea name="attr_powerText03" maxlength="512"></textarea>
 			</div>
 			
 			<!-- Power 04 -->
 			<div class="item-flex-power">
 				<div class="subitem-flex-power-heading-left">
-					<input type="text" name="attr_powerName04"/>
+					<input type="text" name="attr_powerName04" maxlength="25"/>
 					<h1>Real CP:</h1>
 					<input type="number" name="attr_powerCP04" value="0" min="0" readonly/>
 				</div>
 				<div class="subitem-flex-power-effect-left">
-					<input type="text" name="attr_powerEffect04" />
-					<input type="text" name="attr_powerDice04" value="0d6"/>
+					<input type="text" name="attr_powerEffect04" maxlength="19"/>
+					<input type="text" name="attr_powerDice04" value="0d6" maxlength="16"/>
 					
 					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll04" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName04} - @{powerEffect04}}} {{desc=@{powerText04}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{hiddenPowerDice04}]]}} {{END=[[@{powerEND04}]]}}">Roll</button>
 					
@@ -1879,19 +1879,19 @@
 						</select>
 					</div>
 				</div>
-				<textarea name="attr_powerText04"></textarea>
+				<textarea name="attr_powerText04" maxlength="512"></textarea>
 			</div>
 			
 			<!-- Power 05 -->
 			<div class="item-flex-power">
 				<div class="subitem-flex-power-heading-left">
-					<input type="text" name="attr_powerName05"/>
+					<input type="text" name="attr_powerName05" maxlength="25"/>
 					<h1>Real CP:</h1>
 					<input type="number" name="attr_powerCP05" value="0" min="0" readonly/>
 				</div>
 				<div class="subitem-flex-power-effect-left">
-					<input type="text" name="attr_powerEffect05" />
-					<input type="text" name="attr_powerDice05" value="0d6"/>
+					<input type="text" name="attr_powerEffect05" maxlength="19"/>
+					<input type="text" name="attr_powerDice05" value="0d6" maxlength="16"/>
 					
 					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll05" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName05} - @{powerEffect05}}} {{desc=@{powerText05}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{hiddenPowerDice05}]]}} {{END=[[@{powerEND05}]]}}">Roll</button>
 					
@@ -1940,7 +1940,7 @@
 						</select>
 					</div>
 				</div>
-				<textarea name="attr_powerText05"></textarea>
+				<textarea name="attr_powerText05" maxlength="512"></textarea>
 			</div>
 		</div>
 		
@@ -1949,13 +1949,13 @@
 			<!-- Power 06 -->
 			<div class="item-flex-power">
 				<div class="subitem-flex-power-heading-right">
-					<input type="text" name="attr_powerName06"/>
+					<input type="text" name="attr_powerName06" maxlength="25"/>
 					<h1>Real CP:</h1>
 					<input type="number" name="attr_powerCP06" value="0" min="0" readonly/>
 				</div>
 				<div class="subitem-flex-power-effect-right">
-					<input type="text" name="attr_powerEffect06" />
-					<input type="text" name="attr_powerDice06" value="0d6"/>
+					<input type="text" name="attr_powerEffect06" maxlength="19"/>
+					<input type="text" name="attr_powerDice06" value="0d6" maxlength="16"/>
 					
 					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll06" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName06} - @{powerEffect06}}} {{desc=@{powerText06}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{hiddenPowerDice06}]]}} {{END=[[@{powerEND06}]]}}">Roll</button>
 					
@@ -2004,19 +2004,19 @@
 						</select>
 					</div>
 				</div>
-				<textarea name="attr_powerText06"></textarea>
+				<textarea name="attr_powerText06" maxlength="512"></textarea>
 			</div>
 			
 			<!-- Power 07 -->
 			<div class="item-flex-power">
 				<div class="subitem-flex-power-heading-right">
-					<input type="text" name="attr_powerName07"/>
+					<input type="text" name="attr_powerName07" maxlength="25"/>
 					<h1>Real CP:</h1>
 					<input type="number" name="attr_powerCP07" value="0" min="0" readonly/>
 				</div>
 				<div class="subitem-flex-power-effect-right">
-					<input type="text" name="attr_powerEffect07" />
-					<input type="text" name="attr_powerDice07" value="0d6"/>
+					<input type="text" name="attr_powerEffect07" maxlength="19"/>
+					<input type="text" name="attr_powerDice07" value="0d6" maxlength="16"/>
 					
 					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll07" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName07} - @{powerEffect07}}} {{desc=@{powerText07}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{hiddenPowerDice07}]]}} {{END=[[@{powerEND07}]]}}">Roll</button>
 					
@@ -2065,19 +2065,19 @@
 						</select>
 					</div>
 				</div>
-				<textarea name="attr_powerText07"></textarea>
+				<textarea name="attr_powerText07" maxlength="512"></textarea>
 			</div>
 			
 			<!-- Power 08 -->
 			<div class="item-flex-power">
 				<div class="subitem-flex-power-heading-right">
-					<input type="text" name="attr_powerName08"/>
+					<input type="text" name="attr_powerName08" maxlength="25"/>
 					<h1>Real CP:</h1>
 					<input type="number" name="attr_powerCP08" value="0" min="0" readonly/>
 				</div>
 				<div class="subitem-flex-power-effect-right">
-					<input type="text" name="attr_powerEffect08" />
-					<input type="text" name="attr_powerDice08" value="0d6"/>
+					<input type="text" name="attr_powerEffect08" maxlength="19"/>
+					<input type="text" name="attr_powerDice08" value="0d6" maxlength="16"/>
 					
 					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll08" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName08} - @{powerEffect08}}} {{desc=@{powerText08}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{hiddenPowerDice08}]]}} {{END=[[@{powerEND08}]]}}">Roll</button>
 					
@@ -2126,19 +2126,19 @@
 						</select>
 					</div>
 				</div>
-				<textarea name="attr_powerText08"></textarea>
+				<textarea name="attr_powerText08" maxlength="512"></textarea>
 			</div>
 			
 			<!-- Power 09 -->
 			<div class="item-flex-power">
 				<div class="subitem-flex-power-heading-right">
-					<input type="text" name="attr_powerName09"/>
+					<input type="text" name="attr_powerName09" maxlength="25"/>
 					<h1>Real CP:</h1>
 					<input type="number" name="attr_powerCP09" value="0" min="0" readonly/>
 				</div>
 				<div class="subitem-flex-power-effect-right">
-					<input type="text" name="attr_powerEffect09" />
-					<input type="text" name="attr_powerDice09" value="0d6"/>
+					<input type="text" name="attr_powerEffect09" maxlength="19"/>
+					<input type="text" name="attr_powerDice09" value="0d6" maxlength="16"/>
 					
 					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll09" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName09} - @{powerEffect09}}} {{desc=@{powerText09}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{hiddenPowerDice09}]]}} {{END=[[@{powerEND09}]]}}">Roll</button>
 					
@@ -2187,19 +2187,19 @@
 						</select>
 					</div>
 				</div>
-				<textarea name="attr_powerText09"></textarea>
+				<textarea name="attr_powerText09" maxlength="512"></textarea>
 			</div>
 			
 			<!-- Power 10 -->
 			<div class="item-flex-power">
 				<div class="subitem-flex-power-heading-right">
-					<input type="text" name="attr_powerName10"/>
+					<input type="text" name="attr_powerName10" maxlength="25"/>
 					<h1>Real CP:</h1>
 					<input type="number" name="attr_powerCP10" value="0" min="0" readonly/>
 				</div>
 				<div class="subitem-flex-power-effect-right">
-					<input type="text" name="attr_powerEffect10" />
-					<input type="text" name="attr_powerDice10" value="0d6"/>
+					<input type="text" name="attr_powerEffect10" maxlength="19"/>
+					<input type="text" name="attr_powerDice10" value="0d6" maxlength="16"/>
 					
 					<button type="roll" class="button button-Power-Roll" name="roll_powerRoll10" value="&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} {{subtitle= @{powerName10} - @{powerEffect10}}} {{desc=@{powerText10}}} {{Success Roll=[[3d6cf<0cs>0]]}} {{Effect Roll=[[@{hiddenPowerDice10}]]}} {{END=[[@{powerEND10}]]}}">Roll</button>
 					
@@ -2248,7 +2248,7 @@
 						</select>
 					</div>
 				</div>
-				<textarea name="attr_powerText10"></textarea>
+				<textarea name="attr_powerText10" maxlength="512"></textarea>
 			</div>
 		</div>
 	</div>
@@ -2271,7 +2271,7 @@
 				<input type="number" name="attr_talentCP01" value="0" min="0" />
 			</div>
 			<div class="item-talent-textbox">
-				<textarea name="attr_talentText01"></textarea>
+				<textarea name="attr_talentText01" maxlength="240"></textarea>
 			</div>
 			
 			<!-- Talent 02 -->
@@ -2281,7 +2281,7 @@
 				<input type="number" name="attr_talentCP02" value="0" min="0" />
 			</div>
 			<div class="item-talent-textbox">
-				<textarea name="attr_talentText02"></textarea>
+				<textarea name="attr_talentText02" maxlength="240"></textarea>
 			</div>
 			
 			<!-- Talent 03 -->
@@ -2291,7 +2291,7 @@
 				<input type="number" name="attr_talentCP03" value="0" min="0" />
 			</div>
 			<div class="item-talent-textbox">
-				<textarea name="attr_talentText03"></textarea>
+				<textarea name="attr_talentText03" maxlength="240"></textarea>
 			</div>
 			
 			<!-- Talent 04 -->
@@ -2301,7 +2301,7 @@
 				<input type="number" name="attr_talentCP04" value="0" min="0" />
 			</div>
 			<div class="item-talent-textbox">
-				<textarea name="attr_talentText04"></textarea>
+				<textarea name="attr_talentText04" maxlength="240"></textarea>
 			</div>
 			
 			<!-- Talent 05 -->
@@ -2311,7 +2311,7 @@
 				<input type="number" name="attr_talentCP05" value="0" min="0" />
 			</div>
 			<div class="item-talent-textbox">
-				<textarea name="attr_talentText05"></textarea>
+				<textarea name="attr_talentText05" maxlength="240"></textarea>
 			</div>
 			
 			<!-- Talent 06 -->
@@ -2321,7 +2321,7 @@
 				<input type="number" name="attr_talentCP06" value="0" min="0" />
 			</div>
 			<div class="item-talent-textbox">
-				<textarea name="attr_talentText06"></textarea>
+				<textarea name="attr_talentText06" maxlength="240"></textarea>
 			</div>
 			
 			<!-- Talent 07 -->
@@ -2331,7 +2331,7 @@
 				<input type="number" name="attr_talentCP07" value="0" min="0" />
 			</div>
 			<div class="item-talent-textbox">
-				<textarea name="attr_talentText07"></textarea>
+				<textarea name="attr_talentText07" maxlength="240"></textarea>
 			</div>
 		</div>
 		
@@ -2346,7 +2346,7 @@
 				<input type="number" name="attr_complicationCP01" value="0" min="0" />
 			</div>
 			<div class="item-complication-textbox">
-				<textarea name="attr_complicationText01"></textarea>
+				<textarea name="attr_complicationText01" maxlength="240"></textarea>
 			</div>
 			
 			<!-- Complication 02 -->
@@ -2356,7 +2356,7 @@
 				<input type="number" name="attr_complicationCP02" value="0" min="0" />
 			</div>
 			<div class="item-complication-textbox">
-				<textarea name="attr_complicationText02"></textarea>
+				<textarea name="attr_complicationText02" maxlength="240"></textarea>
 			</div>
 			
 			<!-- Complication 03 -->
@@ -2366,7 +2366,7 @@
 				<input type="number" name="attr_complicationCP03" value="0" min="0" />
 			</div>
 			<div class="item-complication-textbox">
-				<textarea name="attr_complicationText03"></textarea>
+				<textarea name="attr_complicationText03" maxlength="240"></textarea>
 			</div>
 			
 			<!-- Complication 04 -->
@@ -2376,7 +2376,7 @@
 				<input type="number" name="attr_complicationCP04" value="0" min="0" />
 			</div>
 			<div class="item-complication-textbox">
-				<textarea name="attr_complicationText04"></textarea>
+				<textarea name="attr_complicationText04" maxlength="240"></textarea>
 			</div>
 			
 			<!-- Complication 05 -->
@@ -2386,7 +2386,7 @@
 				<input type="number" name="attr_complicationCP05" value="0" min="0" />
 			</div>
 			<div class="item-complication-textbox">
-				<textarea name="attr_complicationText05"></textarea>
+				<textarea name="attr_complicationText05" maxlength="240"></textarea>
 			</div>
 			
 			<!-- Complication 06 -->
@@ -2396,14 +2396,14 @@
 				<input type="number" name="attr_complicationCP06" value="0" min="0" />
 			</div>
 			<div class="item-complication-textbox">
-				<textarea name="attr_complicationText06"></textarea>
+				<textarea name="attr_complicationText06" maxlength="240"></textarea>
 			</div>
 		</div>
 		
 		<!-- Complications Notes -->
 		<div class="flex-container-complications-bottom">
-			<textarea name="attr_complicationsTextLeft"></textarea>
-			<textarea name="attr_complicationsTextRight"></textarea>
+			<textarea name="attr_complicationsTextLeft" maxlength="768"></textarea>
+			<textarea name="attr_complicationsTextRight" maxlength="768"></textarea>
 		</div>
 	</div>
 </div>
@@ -2463,7 +2463,7 @@
 				
 				<!-- Armor Item 01 -->
 				<div class="subitem-tab-gear-flex-container-armor-row">
-					<input type="text" name="attr_armorName01"/>
+					<input type="text" name="attr_armorName01" maxlength="16"/>
 					<input type="number" name="attr_armorPD01" step="1" value="0" min="0" step="1"/>
 					<input type="number" name="attr_armorED01" step="1" value="0" min="0" step="1"/>
 					<div class="custom-select">
@@ -2489,13 +2489,13 @@
 						</select>
 					</div>
 					<button type="roll" class="button buttonRollActivate" name="roll_armorActivation01" value="&{template:custom-activate} {{title=@{character_name} - @{character_title}}} {{subtitle= Defends with @{armorName01}**}} {{Activate on = [[@{armorActivation01}]] **or less**}} {{Result = [[3d6cf<0cs>0]]}} {{PD @{armorPD01}= **ED @{armorED01}**}}" >Roll</button>
-					<input type="text" class="armorLocationsText" name="attr_armorLocations01"/>
+					<input type="text" class="armorLocationsText" name="attr_armorLocations01" maxlength="16"/>
 					<input type="number" name="attr_armorMass01" value="0" min="0" step="0.1"/>
 				</div>
 				
 				<!-- Armor Item 02 -->
 				<div class="subitem-tab-gear-flex-container-armor-row">
-					<input type="text" name="attr_armorName02"/>
+					<input type="text" name="attr_armorName02" maxlength="16"/>
 					<input type="number" name="attr_armorPD02" step="1" value="0" min="0" step="1"/>
 					<input type="number" name="attr_armorED02" step="1" value="0" min="0" step="1"/>
 					<div class="custom-select">
@@ -2521,13 +2521,13 @@
 						</select>
 					</div>
 					<button type="roll" class="button buttonRollActivate" name="roll_armorActivation02" value="&{template:custom-activate} {{title=@{character_name} - @{character_title}}} {{subtitle= Defends with @{armorName02}**}} {{Activate on = [[@{armorActivation02}]] **or less**}} {{Result = [[3d6cf<0cs>0]]}} {{PD @{armorPD02}= **ED @{armorED02}**}}" >Roll</button>
-					<input type="text" class="armorLocationsText" name="attr_armorLocations02"/>
+					<input type="text" class="armorLocationsText" name="attr_armorLocations02" maxlength="16"/>
 					<input type="number" name="attr_armorMass02" value="0" min="0" step="0.1"/>
 				</div>
 				
 				<!-- Armor Item 03 -->
 				<div class="subitem-tab-gear-flex-container-armor-row">
-					<input type="text" name="attr_armorName03"/>
+					<input type="text" name="attr_armorName03" maxlength="16"/>
 					<input type="number" name="attr_armorPD03" step="1" value="0" min="0" step="1"/>
 					<input type="number" name="attr_armorED03" step="1" value="0" min="0" step="1"/>
 					<div class="custom-select">
@@ -2553,13 +2553,13 @@
 						</select>
 					</div>
 					<button type="roll" class="button buttonRollActivate" name="roll_armorActivation03" value="&{template:custom-activate} {{title=@{character_name} - @{character_title}}} {{subtitle= Defends with @{armorName03}**}} {{Activate on = [[@{armorActivation03}]] **or less**}} {{Result = [[3d6cf<0cs>0]]}} {{PD @{armorPD03}= **ED @{armorED03}**}}" >Roll</button>
-					<input type="text" class="armorLocationsText" name="attr_armorLocations03"/>
+					<input type="text" class="armorLocationsText" name="attr_armorLocations03" maxlength="16"/>
 					<input type="number" name="attr_armorMass03" value="0" min="0" step="0.1"/>
 				</div>
 				
 				<!-- Armor Item 04 -->
 				<div class="subitem-tab-gear-flex-container-armor-row">
-					<input type="text" name="attr_armorName04"/>
+					<input type="text" name="attr_armorName04" maxlength="16"/>
 					<input type="number" name="attr_armorPD04" step="1" value="0" min="0" step="1"/>
 					<input type="number" name="attr_armorED04" step="1" value="0" min="0" step="1"/>
 					<div class="custom-select">
@@ -2585,7 +2585,7 @@
 						</select>
 					</div>
 					<button type="roll" class="button buttonRollActivate" name="roll_armorActivation04" value="&{template:custom-activate} {{title=@{character_name} - @{character_title}}} {{subtitle= Defends with @{armorName04}**}} {{Activate on = [[@{armorActivation04}]] **or less**}} {{Result = [[3d6cf<0cs>0]]}} {{PD @{armorPD04}= **ED @{armorED04}**}}" >Roll</button>
-					<input type="text" class="armorLocationsText" name="attr_armorLocations04"/>
+					<input type="text" class="armorLocationsText" name="attr_armorLocations04" maxlength="16"/>
 					<input type="number" name="attr_armorMass04" value="0" min="0" step="0.1"/>
 				</div>
 			</div>
@@ -2606,9 +2606,9 @@
 				<input type="hidden" name="attr_targetOCVpenalty" value="0"/>
 				
 				<div class="subitem-tab-gear-flex-container-shield-row">
-					<input type="text" name="attr_shieldName" value=" "/>
+					<input type="text" name="attr_shieldName" value=" " maxlength="16"/>
 					<input type="number" name="attr_shieldDCV" step="1"  min="0" value="0"/>
-					<input type="text" name="attr_shieldDamage" step="1"  min="0" value="0"/>
+					<input type="text" name="attr_shieldDamage" step="1"  min="0" value="0" maxlength="16"/>
 					<button type="action" class='button buttonRollNormalDamage' name="act_attackShield">Roll</button>
 					<input type="number" name="attr_shieldStrength"step="1"  min="0" value="0"/>
 					<input type="number" name="attr_shieldBody" step="1"  min="0" value="0"/>
@@ -2638,8 +2638,8 @@
 			<input type="hidden" name="attr_weaponOCVPenalty01" value="0"/>
 			
 			<div class="subitem-tab-gear-flex-container-weapon-row">
-				<input type="text" name="attr_weaponName01" value=" "/>
-				<input type="text" name="attr_weaponDamage01" value="0"/>
+				<input type="text" name="attr_weaponName01" value=" " maxlength="16"/>
+				<input type="text" name="attr_weaponDamage01" value="0" maxlength="16"/>
 				<button type="action" class="button buttonRollDamage" name="act_attackWeapon01">Roll</button>
 				<input type="number" name="attr_weaponOCV01" step="1" value="0"/>
 				<input type="number" name="attr_weaponRangeMod01" step="1" value="0"/>
@@ -2659,8 +2659,8 @@
 			<input type="hidden" name="attr_weaponOCVPenalty02" value="0"/>
 			
 			<div class="subitem-tab-gear-flex-container-weapon-row">
-				<input type="text" name="attr_weaponName02" value=" "/>
-				<input type="text" name="attr_weaponDamage02" value="0"/>
+				<input type="text" name="attr_weaponName02" value=" " maxlength="16"/>
+				<input type="text" name="attr_weaponDamage02" value="0" maxlength="16"/>
 				<button type="action" class="button buttonRollDamage" name="act_attackWeapon02">Roll</button>
 				<input type="number" name="attr_weaponOCV02" step="1" value="0"/>
 				<input type="number" name="attr_weaponRangeMod02" step="1" value="0"/>
@@ -2680,8 +2680,8 @@
 			<input type="hidden" name="attr_weaponOCVPenalty03" value="0"/>
 			
 			<div class="subitem-tab-gear-flex-container-weapon-row">
-				<input type="text" name="attr_weaponName03" value=" "/>
-				<input type="text" name="attr_weaponDamage03" value="0"/>
+				<input type="text" name="attr_weaponName03" value=" " maxlength="16"/>
+				<input type="text" name="attr_weaponDamage03" value="0" maxlength="16"/>
 				<button type="action" class="button buttonRollDamage" name="act_attackWeapon03">Roll</button>
 				<input type="number" name="attr_weaponOCV03" step="1" value="0"/>
 				<input type="number" name="attr_weaponRangeMod03" step="1" value="0"/>
@@ -2701,8 +2701,8 @@
 			<input type="hidden" name="attr_weaponOCVPenalty04" value="0"/>
 			
 			<div class="subitem-tab-gear-flex-container-weapon-row">
-				<input type="text" name="attr_weaponName04" value=" "/>
-				<input type="text" name="attr_weaponDamage04" value="0"/>
+				<input type="text" name="attr_weaponName04" value=" " maxlength="16"/>
+				<input type="text" name="attr_weaponDamage04" value="0" maxlength="16"/>
 				<button type="action" class="button buttonRollDamage" name="act_attackWeapon04">Roll</button>
 				<input type="number" name="attr_weaponOCV04" step="1" value="0"/>
 				<input type="number" name="attr_weaponRangeMod04" step="1" value="0"/>
@@ -2722,8 +2722,8 @@
 			<input type="hidden" name="attr_weaponOCVPenalty05" value="0"/>
 			
 			<div class="subitem-tab-gear-flex-container-weapon-row">
-				<input type="text" name="attr_weaponName05" vvalue=" "/>
-				<input type="text" name="attr_weaponDamage05"value="0"/>
+				<input type="text" name="attr_weaponName05" vvalue=" " maxlength="16"/>
+				<input type="text" name="attr_weaponDamage05"value="0" maxlength="16"/>
 				<button type="action" class="button buttonRollNormalDamage" name="act_attackWeapon05">Roll</button>
 				<input type="number" name="attr_weaponOCV05" step="1" value="0"/>
 				<input type="number" name="attr_weaponRangeMod05" step="1" value="0"/>
@@ -2746,67 +2746,67 @@
 				<h1>Mass</h1>
 			</div>
 			<div class="subitem-tab-gear-flex-container-equipment">
-				<input type="text" name="attr_equipText01"/>
+				<input type="text" name="attr_equipText01" maxlength="24"/>
 				<input type="number" name="attr_equipMass01" min="0" step="0.1"/>
 			</div>
 			<div class="subitem-tab-gear-flex-container-equipment">
-				<input type="text" name="attr_equipText02"/>
+				<input type="text" name="attr_equipText02" maxlength="24"/>
 				<input type="number" name="attr_equipMass02" min="0" step="0.1"/>
 			</div>
 			<div class="subitem-tab-gear-flex-container-equipment">
-				<input type="text" name="attr_equipText03"/>
+				<input type="text" name="attr_equipText03" maxlength="24"/>
 				<input type="number" name="attr_equipMass03" min="0" step="0.1"/>
 			</div>
 			<div class="subitem-tab-gear-flex-container-equipment">
-				<input type="text" name="attr_equipText04"/>
+				<input type="text" name="attr_equipText04" maxlength="24"/>
 				<input type="number" name="attr_equipMass04" min="0" step="0.1"/>
 			</div>
 			<div class="subitem-tab-gear-flex-container-equipment">
-				<input type="text" name="attr_equipText05"/>
+				<input type="text" name="attr_equipText05" maxlength="24"/>
 				<input type="number" name="attr_equipMass05" min="0" step="0.1"/>
 			</div>
 			<div class="subitem-tab-gear-flex-container-equipment">
-				<input type="text" name="attr_equipText06"/>
+				<input type="text" name="attr_equipText06" maxlength="24"/>
 				<input type="number" name="attr_equipMass06" min="0" step="0.1"/>
 			</div>
 			<div class="subitem-tab-gear-flex-container-equipment">
-				<input type="text" name="attr_equipText07"/>
+				<input type="text" name="attr_equipText07" maxlength="24"/>
 				<input type="number" name="attr_equipMass07" min="0" step="0.1"/>
 			</div>
 			<div class="subitem-tab-gear-flex-container-equipment">
-				<input type="text" name="attr_equipText08"/>
+				<input type="text" name="attr_equipText08" maxlength="24"/>
 				<input type="number" name="attr_equipMass08" min="0" step="0.1"/>
 			</div>
 			<div class="subitem-tab-gear-flex-container-equipment">
-				<input type="text" name="attr_equipText09"/>
+				<input type="text" name="attr_equipText09" maxlength="24"/>
 				<input type="number" name="attr_equipMass09" min="0" step="0.1"/>
 			</div>
 			<div class="subitem-tab-gear-flex-container-equipment">
-				<input type="text" name="attr_equipText10"/>
+				<input type="text" name="attr_equipText10" maxlength="24"/>
 				<input type="number" name="attr_equipMass10" min="0" step="0.1"/>
 			</div>
 			<div class="subitem-tab-gear-flex-container-equipment">
-				<input type="text" name="attr_equipText11"/>
+				<input type="text" name="attr_equipText11" maxlength="24"/>
 				<input type="number" name="attr_equipMass11" min="0" step="0.1"/>
 			</div>
 			<div class="subitem-tab-gear-flex-container-equipment">
-				<input type="text" name="attr_equipText12"/>
+				<input type="text" name="attr_equipText12" maxlength="24"/>
 				<input type="number" name="attr_equipMass12" min="0" step="0.1"/>
 			</div>
 			<div class="subitem-tab-gear-flex-container-equipment">
-				<input type="text" name="attr_equipText13"/>
+				<input type="text" name="attr_equipText13" maxlength="24"/>
 				<input type="number" name="attr_equipMass13" min="0" step="0.1"/>
 			</div>
 			<div class="subitem-tab-gear-flex-container-equipment">
-				<input type="text" name="attr_equipText14"/>
+				<input type="text" name="attr_equipText14" maxlength="24"/>
 				<input type="number" name="attr_equipMass14" min="0" step="0.1"/>
 			</div>
 			<div class="subitem-tab-gear-flex-container-equipment">
-				<input type="text" name="attr_equipText15"/>
+				<input type="text" name="attr_equipText15" maxlength="24"/>
 				<input type="number" name="attr_equipMass15" min="0" step="0.1"/>
 			</div>
 			<div class="subitem-tab-gear-flex-container-equipment">
-				<input type="text" name="attr_equipText16"/>
+				<input type="text" name="attr_equipText16" maxlength="24"/>
 				<input type="number" name="attr_equipMass16" min="0" step="0.1"/>
 			</div>
 		</div>

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -7178,7 +7178,7 @@
 							  computed = computed+0; // Add nothing.
 						  }
 					}
-				} else {
+				} else if (groupOfDice.sides == 6) {
 					// calculate normal damage of d6 dice.
 					for (let element of groupOfDice.results) {
 						  if (element === 1) {
@@ -7247,7 +7247,7 @@
 							  computed = computed+0; // Add nothing.
 						  }
 					}
-				} else {
+				} else if (groupOfDice.sides == 6) {
 					// calculate normal damage of d6 dice.
 					for (let element of groupOfDice.results) {
 						  if (element === 1) {


### PR DESCRIPTION
## Changes / Comments
To minimize dice roll errors, Roll buttons now call hidden variables that are equal to user-defined dice strings, but cleaned of all characters save for 0-9, d, D, +, and -.
The basic strength attack damage dice roll is now understandable as Xd6+Yd3+Z when hovered over.
Limited normal damage dice to type d3 and d6 for BODY calculations.
Added max length limits to all textarea and text fields to prevent excessive input problems.
Small cosmetic fix to talent section styling.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
