### PR TITLE
[Basic Roleplaying] Fixed the Dodge Button

### DIFF
--- a/Basic_Roleplaying/Basic_Roleplaying.html
+++ b/Basic_Roleplaying/Basic_Roleplaying.html
@@ -1,4 +1,3 @@
-
 <div class="sheet-row">
 	<div class="sheet-cdiv">
 		<input class="sheet-HideConfig" type="checkbox" checked="checked" name="attr_is_config"><span class="sheet-is-config"><span style="font-family: &quot;pictos&quot;">y</span></span>
@@ -1676,8 +1675,15 @@
 <div style="width: 100%; color: #FFF; background-color: #000;">
 	<div style="margin-left: 5px ; display: inline">
 		Dodge
-		<input style="width:47px" class="sheet-section-header" disabled="true" value="@{Dodge}" type="number" name="attr_Dodge_display" />
-		<td><button type="roll" style="color:black"  value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Dodge}}} {{fumble=[[ceil(95+(@{Dodge}*@{Multiplier}+@{Mods})/20))]]}} {{crit=[[ceil((@{Dodge}*@{Multiplier}+@{Mods})/20)+1]]}} {{special=[[ceil((@{Dodge}*@{Multiplier}+@{Mods})/5)+1]]}}        {{success=[[ceil(@{Dodge}*@{Multiplier}+@{Mods})]]}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>																																																																																																				
+        <input style="width:47px" class="sheet-section-header" disabled="true" value="@{Dodge}" type="number" name="attr_Dodge_display" />
+            <input type="checkbox" class="sheet-toggle-alphabetical" name="attr_toggle-alphabetic"  style="display: none">
+                    <div class="sheet-skills-alphabetical" />
+                		<td><button type="roll" style="color:black"  value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Dodge}}} {{fumble=[[ceil(95+(@{Dodge}*@{Multiplier}+@{Mods})/20))]]}} {{crit=[[ceil((@{Dodge}*@{Multiplier}+@{Mods})/20)+1]]}} {{special=[[ceil((@{Dodge}*@{Multiplier}+@{Mods})/5)+1]]}}        {{success=[[ceil(@{Dodge}*@{Multiplier}+@{Mods})]]}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>																																																																																																				
+                    </div>
+        <input type="checkbox" class="sheet-toggle-categories" name="attr_toggle-categories"  checked="checked" style="display: none">
+                    <div class="sheet-skills-by-category" />
+                		<td><button type="roll" style="color:black"  value="&{template:skillRoll}  {{name=@{Name}}} {{skillvalue=@{Dodge}}} {{fumble=[[ceil(95+((@{Dodge}+@{Physical})*@{Multiplier}+@{Mods})/20)]]}} {{crit=[[ceil(((@{Dodge}+@{Physical})*@{Multiplier}+@{Mods})/20)+1]]}} {{special=[[ceil(((@{Dodge}+@{Physical})*@{Multiplier}+@{Mods})/5)+1]]}}        {{success=[[ceil((@{Dodge}+@{Physical})*@{Multiplier}+@{Mods})]]}} {{roll=[[1d100]]}} {{skillname=Dodge}}"/></td>																																																																																																				
+                    </div>
 	</div>
 	<div style="display: inline">
 		Fumble 


### PR DESCRIPTION
## Changes / Comments
Fixed the Dodge Button in the bar underneath the Ranged Weapon section to include category bonuses in skills when skills by category is chosen.





## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ X] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
