### PR TITLE
Update /Legacy - Life Among the Ruins/LegacyRoll20sheets.html

### DIFF
--- a/Legacy - Life Among the Ruins/LegacyRoll20sheets.html
+++ b/Legacy - Life Among the Ruins/LegacyRoll20sheets.html
@@ -12172,6 +12172,17 @@
               twist the area or your body.</p>
             <p><i>When you die,</i> terrible energies plague the area. Those that brave the maelstrom can find a Device
               on your body.</p>
+            <p><input type="checkbox" class="sheet-Moves-Quick" name="attr_Moves-Quick5"> <b>Prophet</b> <i>When someone 
+              acts in a way contrary to your Family's Doctrine,</i> ask the GM how it'll bring them ill fortune. When 
+              you act on this information, roll with Advantage.</p>
+            <p><i>When you die,</i> name a Faction you preached to. That Faction will honour your Doctrine above all 
+              others from here on out.</p>
+            <p><input type="checkbox" class="sheet-Moves-Quick" name="attr_Moves-Quick6"> <b>Traitor</b> <i>When you 
+              betray kith and kin,</i> hold 3. Spend hold to gain access to: a critical location, secret lore, 
+              a device that can be weaponised, or a leader in their moment of weakness. It must always belong to 
+              your sworn allies, but for the last hold, to be spent on your truest nemesis.</p>
+            <p><i>When you die,</i> name an enemy that will relent on their aggression thanks to your influence. Tell
+              the backstory behind this.</p>	  
           </div>
           <div class="sheet-OtherMoves-Quick">
             <i><b>Other Moves</b></i><br>


### PR DESCRIPTION
## Changes / Comments
Added the Prophet and Traitor Role to the quick character sheet role section as in the End Game Handbook. 

Currently although the sheets contain all the families and primary characters from Engine of Life and End Game as well as the additional roles that were added with these supplements the Quick Character sheet did not receive this update. This proposed change just brings the Quick Character sheet in line with all the other Primary Character sheets content wise.

First time doing one of these, I do not believe it should have any carryover effect to anything else but would still appreciate someone confirming they work correctly.


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
/Life Among the Ruins/LegacyRoll20sheets.html

- [ ] Is this a bug fix?

- [X] Does this add functional enhancements (new features or extending existing features) ?
Yes, it extends an existing feature related to quick character sheets.

- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [X] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
This does not alter any attributes to my knowledge as it only adds an additional checkbox that is used purely for record keeping.

- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
