### PR TITLE
[Legacy - Life Among the Ruins] Add Wisdom Tracker to Historian Sheet

### DIFF
--- a/Legacy - Life Among the Ruins/LegacyRoll20sheets.html
+++ b/Legacy - Life Among the Ruins/LegacyRoll20sheets.html
@@ -10145,6 +10145,8 @@
               <li>Its unique format.</li>
             </ul>
             <p>For each you check off, gain 1-Wisdom. If you find the tome, swap wisdom for Data 1-for-1.</p>
+		<label>Wisdom</label>
+		<input type="number" name="attr_Wisdom" min="0" value="0" />
 
             <p><input type="checkbox" class="sheet-Moves-EoLHistorian" name="attr_Moves-EoLHistorian2" checked=true> <b>Writing of God</b>
               <i>When you plan a grand societal change,</i> study one of your tomes and tell the GM how its lore 
@@ -10164,7 +10166,7 @@
                 
                 <p><input type="checkbox" class="sheet-Moves-EoLHistorian" name="attr_Moves-EoLHistorian4"> <b>Kings 
                 and Labyrinths</b> When another Character agrees to bring you a tome from Library of Babel, 
-                spend 1-Wisdom and give them an edditional Role:</p>
+                spend 1-Wisdom and give them an additional Role:</p>
                 <ul>
                   <li><input type="checkbox" class="sheet-Moves-EoLHistorian" name="attr_EoLHistorian_Labyrinths_Finder" value=1>
                   Finder: Mark when you're the only hope of finding a legendary tome. Describe the dangerous or 


### PR DESCRIPTION


## Changes / Comments
- Adding a tracker for the Historian character specific resource called Wisdom. 
- Also a minor spelling error is fixed on line 10167(pre-wisdom)/10169(post-wisdom).

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.

It should but if it doesn't it is "Legacy - Life Among the Ruins/LegacyRoll20sheets.html"

- [ ] Is this a bug fix?
- [X] Does this add functional enhancements (new features or extending existing features) ?

Historian character specific resource tracking added

- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
