### PR TITLE
Shadowrun Sixth World v.40

### DIFF
--- a/Shadowrun Sixth World/CHANGELOG.md
+++ b/Shadowrun Sixth World/CHANGELOG.md
@@ -1,5 +1,7 @@
 Change Log
 ==============================================
+**2021-08-24 ** v.40 Chuz (James Culp)
+	
 **2021-07-19 ** v.39 Chuz (James Culp)
 	Added Grunt Groups and Autocalculations based on the # of grunts
 	Bugfix - PC->Rolls tab was showing conversions on the Matrix Actions Tab

--- a/Shadowrun Sixth World/CHANGELOG.md
+++ b/Shadowrun Sixth World/CHANGELOG.md
@@ -1,7 +1,7 @@
 Change Log
 ==============================================
-**2021-08-24 ** v.40 Chuz (James Culp)
-	
+**2021-08-31 ** v.40 Chuz (James Culp)
+	Added the ability to add Spells, NPC Spells, Qualities and Augmentations by pasting raw data into the Notes textarea for a new repeating row.
 **2021-07-19 ** v.39 Chuz (James Culp)
 	Added Grunt Groups and Autocalculations based on the # of grunts
 	Bugfix - PC->Rolls tab was showing conversions on the Matrix Actions Tab

--- a/Shadowrun Sixth World/CHANGELOG.md
+++ b/Shadowrun Sixth World/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change Log
 ==============================================
 **2021-08-31 ** v.40 Chuz (James Culp)
+	Added Social Rating to derived tests (even though it's not a test) just to the right of the Edge Attribute.  This is a total of Charisma + any cumulative + primary armor social adjustments.
+	Added mouseovers for Composure, Judge Intentions, Memory and Lift & Carry buttons detailing where the values come from for those of us that forget.
 	Added the ability to add Spells, NPC Spells, Qualities and Augmentations by pasting raw data into the Notes textarea for a new repeating row.
 **2021-07-19 ** v.39 Chuz (James Culp)
 	Added Grunt Groups and Autocalculations based on the # of grunts

--- a/Shadowrun Sixth World/Shadowrun6thEdition.css
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.css
@@ -2093,7 +2093,7 @@ h2[data-i18n='nuyen'], h3[data-i18n='nuyen'] {
   div.magic-defense {
     display: grid !important;
     width: 100% !important;
-    grid-template-columns: 1fr auto 3em auto 1fr !important; }
+    grid-template-columns: 1fr auto 1fr auto 1fr auto 1fr !important; }
   div.armor-resists {
     display: grid !important;
     grid-template-columns: .2fr .2fr .2fr .2fr .2fr !important; }

--- a/Shadowrun Sixth World/Shadowrun6thEdition.html
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.html
@@ -342,7 +342,7 @@
 				</div>
 				<!-- ~~:+: Composure :+:~~ -->
 				<input type="hidden" name="attr_composure" value="" />
-				<button type="roll" name="composure" value="@{gm_toggle} &{template:rolls}{{header=@{character_name}}}{{base=^{composure}}}{{dice=[[(@{composure}+@{wounds_toggle}+@{modifiers_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}{{mod=[[@{modifiers_toggle}]]}}{{wound=[[@{wounds_toggle}]]}}{{edge=[[@{edge_toggle}]]}}}{{wilddie=[[@{wild_die}d6]]}}"><span data-i18n="composure">Composure</span></button>
+				<button type="roll" name="composure" data-i18n-title="Willpower + Charisma" value="@{gm_toggle} &{template:rolls}{{header=@{character_name}}}{{base=^{composure}}}{{dice=[[(@{composure}+@{wounds_toggle}+@{modifiers_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}{{mod=[[@{modifiers_toggle}]]}}{{wound=[[@{wounds_toggle}]]}}{{edge=[[@{edge_toggle}]]}}}{{wilddie=[[@{wild_die}d6]]}}"><span data-i18n="composure">Composure</span></button>
 				<div class="attr-und">
 					<div class="settings">
 						<input type="number" name="attr_composure_modifier" placeholder="0" title="@{composure_modifier}" /><span class="tiny-span"> = </span>
@@ -354,7 +354,7 @@
 				</div>
 				<!-- ~~:+: Judge Intentions :+:~~ -->
 				<input type="hidden" name="attr_judge_intentions" value="" />
-				<button type="roll" name="judge intentions" value="@{gm_toggle} &{template:rolls}{{header=@{character_name}}}{{base=^{judgeintentions}}}{{dice=[[(@{judge_intentions}+@{wounds_toggle}+@{modifiers_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}{{mod=[[@{modifiers_toggle}]]}}{{wound=[[@{wounds_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{wilddie=[[@{wild_die}d6]]}}">
+				<button type="roll" name="judge intentions" data-i18n-title="Willpower + Intuition" value="@{gm_toggle} &{template:rolls}{{header=@{character_name}}}{{base=^{judgeintentions}}}{{dice=[[(@{judge_intentions}+@{wounds_toggle}+@{modifiers_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}{{mod=[[@{modifiers_toggle}]]}}{{wound=[[@{wounds_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{wilddie=[[@{wild_die}d6]]}}">
 					<span data-i18n="judgeintentions">Judge Intentions</span>
 				</button>
 				<div class="attr-und">
@@ -368,7 +368,7 @@
 				</div>
 				<!-- ~~:+: Memory :+:~~ -->
 				<input type="hidden" name="attr_memory" value="" />
-				<button type="roll" name="memory" value="@{gm_toggle} &{template:rolls}{{header=@{character_name}}}{{base=^{memory}}}{{dice=[[(@{memory}+@{wounds_toggle}+@{modifiers_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}{{mod=[[@{modifiers_toggle}]]}}{{wound=[[@{wounds_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{wilddie=[[@{wild_die}d6]]}}">
+				<button type="roll" name="memory" data-i18n-title="Logic + Intuition" value="@{gm_toggle} &{template:rolls}{{header=@{character_name}}}{{base=^{memory}}}{{dice=[[(@{memory}+@{wounds_toggle}+@{modifiers_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}{{mod=[[@{modifiers_toggle}]]}}{{wound=[[@{wounds_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{wilddie=[[@{wild_die}d6]]}}">
 					<span data-i18n="memory">Memory</span>
 				</button>
 				<div class="attr-und">
@@ -380,9 +380,22 @@
 						<span name="attr_memory" title="@{memory}"></span>
 					</div>
 				</div>
+				<!-- ~~:+: Social Rating :+:~~ -->
+				<input type="hidden" name="attr_social_rating" value="" />
+				<button type="roll" name="roll_social_rating" data-i18n-title="social_rating_desc" value="@{gm_toggle} &{template:rolls}{{header=@{character_name}}}{{base=^{social_rating}}}{{rating=@{social_rating}}}">
+					<span data-i18n="social_rating">Social Rating</span>
+				</button>
+				<div class="attr-und">
+					<div class="settings">
+						<span name="attr_social_rating" title="@{social_rating}"></span>
+					</div>
+					<div class="display">
+						<span name="attr_social_rating" title="@{social_rating}"></span>
+					</div>
+				</div>
 				<!-- ~~:+: Lift & Carry :+:~~ -->
 				<input type="hidden" name="attr_lift_carry" value="" />
-				<button type="roll" name="lift & carry" value="@{gm_toggle} &{template:rolls}{{header=@{character_name}}}{{base=^{liftcarry}}}{{dice=[[(@{lift_carry}+@{wounds_toggle}+@{modifiers_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}{{mod=[[@{modifiers_toggle}]]}}{{wound=[[@{wounds_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{wilddie=[[@{wild_die}d6]]}}">
+				<button type="roll" name="lift & carry" data-i18n-title="Body + Willpower" value="@{gm_toggle} &{template:rolls}{{header=@{character_name}}}{{base=^{liftcarry}}}{{dice=[[(@{lift_carry}+@{wounds_toggle}+@{modifiers_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}{{mod=[[@{modifiers_toggle}]]}}{{wound=[[@{wounds_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{wilddie=[[@{wild_die}d6]]}}">
 					<span data-i18n="liftcarry">Lift & Carry</span>
 				</button>
 				<div class="attr-und">
@@ -674,6 +687,10 @@
 					<div>&nbsp;</div>
 				</div>
 				<div class="magic-defense">
+					<div>&nbsp;</div>
+					<button type="roll" name="roll_magic_dr" value="@{gm_toggle} &{template:rolls}{{header=@{character_name}}}{{base=^{magic} ^{attack} ^{rating}}}{{rating=@{magic_ar}}}">
+						<span class="center"><span data-i18n="magicar">Magic AR</span> <span name="attr_magic_ar"></span></span>
+					</button>
 					<div>&nbsp;</div>
 					<button type="roll" name="roll_direct_magic_defense" value="@{gm_toggle} &{template:rolls}{{header=@{character_name}}}{{base=^{direct} ^{magic} ^{defense}}}{{dice=[[((@{willpower}+@{intuition})+@{modifiers_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}{{mod=[[@{modifiers_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{desc=Willpower + Intuition}}{{wilddie=[[@{wild_die}d6]]}}">
 						<span class="center"><span class="center" data-i18n="directmagicdefense">Direct Magic Defense</span></span>
@@ -6262,17 +6279,20 @@ on("change:repeating_armor change:body", (eventInfo) => {
 			chemTot = 0,
 			coldTot = 0,
 			elecTot = 0,
-			fireTot = 0;
+			fireTot = 0,
+			socialTot = 0;
 
-		getAttrs(['body'], (v) => {
+		getAttrs(['body', 'charisma'], (v) => {
 			ratingTot = v['body'];
+			socialTot = v['charisma'];
 		});
 
 		ids.forEach(id => {
-			var armorFields = [`${arm}_${id}_rating`, `${arm}_${id}_chem`, `${arm}_${id}_cold`, `${arm}_${id}_elec`, `${arm}_${id}_fire`, `${arm}_${id}_primary`, `${arm}_${id}_cumulative`];
+			var armorFields = [`${arm}_${id}_rating`, `${arm}_${id}_chem`, `${arm}_${id}_cold`, `${arm}_${id}_elec`, `${arm}_${id}_fire`, `${arm}_${id}_social`, `${arm}_${id}_primary`, `${arm}_${id}_cumulative`];
 			getAttrs(armorFields, (af) => {
 				if(af[`${arm}_${id}_primary`] != 0 || af[`${arm}_${id}_cumulative`] != 0) {
 					ratingTot += parseInt(af[`${arm}_${id}_rating`]);
+					socialTot += parseInt(af[`${arm}_${id}_social`]);
 				}
 
 				chemTot += parseInt(af[`${arm}_${id}_chem`]);
@@ -6286,6 +6306,7 @@ on("change:repeating_armor change:body", (eventInfo) => {
 					'resist_chem_total': chemTot,
 					'resist_elec_total': elecTot,
 					'resist_fire_total': fireTot,
+					'social_rating': socialTot,
 				});
 			});
 		});

--- a/Shadowrun Sixth World/Shadowrun6thEdition.html
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.html
@@ -1542,8 +1542,7 @@
                     <option data-i18n="los" value="LOS" selected="selected">los</option>
                     <option data-i18n="los (a)" value="LOS (A)">los (a)</option>
                     <option data-i18n="special" value="Special">special</option>
-                    <option data-i18n="t" value="T">t</option>
-                    <option data-i18n="t (a)" value="T (A)">t (a)</option>
+                    <option data-i18n="touch" value="T">touch</option>
                   </select>
                   <select name="attr_duration" title="@{repeating_spell_${x}_duration}">
                     <option data-i18n="instant" value="Instant" selected="selected">Instant</option>
@@ -1567,9 +1566,9 @@
                     <select name="attr_effect_type" title="@{repeating_spell_${x}_effect_type}">
                       <option data-i18n="none" value="" selected="selected">None</option>
                       <option data-i18n="directcombat" value="Direct Combat">Direct Combat</option>
-                      <option data-i18n="directcombatarea" value="Direct Combat">Direct Combat, Area</option>
+                      <option data-i18n="directcombatarea" value="Direct Combat, Area">Direct Combat, Area</option>
                       <option data-i18n="indirectcombat" value="Indirect Combat">Indirect Combat</option>
-                      <option data-i18n="indirectcombatarea" value="Indirect Combat">Indirect Combat, Area</option>
+                      <option data-i18n="indirectcombatarea" value="Indirect Combat, Area">Indirect Combat, Area</option>
                       <option data-i18n="singlesense" value="Single-Sense">Single-Sense</option>
                       <option data-i18n="multisense" value="Multi-Sense">Multi-Sense</option>
                     </select>
@@ -4365,8 +4364,7 @@
 						<option data-i18n="los" value="LOS">los</option>
 						<option data-i18n="los (a)" value="LOS (A)">los (a)</option>
 						<option data-i18n="special" value="Special">special</option>
-						<option data-i18n="t" value="T">t</option>
-						<option data-i18n="t (a)" value="T (A)">t (a)</option>
+						<option data-i18n="touch" value="T">Touch</option>
 					</select>
 					<select name="attr_duration" title="@{repeating_NPCspell_${x}_duration}">
 						<option data-i18n="instant" value="Instant">instant</option>
@@ -4391,12 +4389,12 @@
 						<option data-i18n="manipulation" value="Manipulation">manipulation</option>
 					</select>
 					<h3 class="right" data-i18n="effecttype">Effect Type</h3>
-               <select name="attr_effect_type" title="@{repeating_spell_${x}_effect_type}">
+               <select name="attr_effect_type" title="@{repeating_NPCspell_${x}_effect_type}">
                  <option data-i18n="none" value="" selected="selected">None</option>
                  <option data-i18n="directcombat" value="Direct Combat">Direct Combat</option>
-                 <option data-i18n="directcombatarea" value="Direct Combat">Direct Combat, Area</option>
+                 <option data-i18n="directcombatarea" value="Direct Combat, Area">Direct Combat, Area</option>
                  <option data-i18n="indirectcombat" value="Indirect Combat">Indirect Combat</option>
-                 <option data-i18n="indirectcombatarea" value="Indirect Combat">Indirect Combat, Area</option>
+                 <option data-i18n="indirectcombatarea" value="Indirect Combat, Area">Indirect Combat, Area</option>
                  <option data-i18n="singlesense" value="Single-Sense">Single-Sense</option>
                  <option data-i18n="multisense" value="Multi-Sense">Multi-Sense</option>
                </select>
@@ -5232,6 +5230,32 @@
 
 <script type="text/worker">
 //Sheet workers
+
+
+on("change:repeating_spell:notes change:repeating_npcspell:notes change:repeating_augmentations:notes change:repeating_quality:notes", (eventInfo) => {
+	if(eventInfo.sourceType != 'player') {
+		return;
+	}
+
+	var rep_row = eventInfo.sourceAttribute.match(/(repeating_[^_]+?)_([^_]+?)_(.+)/);
+	var note = eventInfo.newValue;
+	var dat = {};
+
+	if(note.search("JSON=") == 0) {
+		note = note.slice(5);
+		dat = JSON.parse(note);
+
+		toSave = {};
+		Object.keys(dat).forEach(k => {
+			toSave[`${rep_row[1]}_${rep_row[2]}_${k}`] = dat[k];
+		});
+
+		setAttrs(toSave);
+	}
+});
+
+
+
 on("clicked:natural_healing_physical", (eventInfo) => {
 console.log("clicked");
 console.log(eventInfo);
@@ -5552,6 +5576,7 @@ console.log("Program not active");
 
 	});
 });
+
 
 
 

--- a/Shadowrun Sixth World/Shadowrun6thEdition.html
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.html
@@ -5227,7 +5227,7 @@
 <input type="hidden" name="attr_combat_paralysis_initiative_mod" value="" />
 <input type="hidden" name="attr_bad_luck" value="1" />
 
-<input type="hidden" name="attr_sheet_version" value="0.39">
+<input type="hidden" name="attr_sheet_version" value="0.40">
 <input type="hidden" name="attr_data_version" value="0">
 
 <script type="text/worker">

--- a/Shadowrun Sixth World/translation.json
+++ b/Shadowrun Sixth World/translation.json
@@ -54,6 +54,7 @@
 	"blast": "Blast",
 	"boat": "Boat",
 	"body": "Body",
+	"Body + Willpower": "Body + Willpower",
 	"bonuses": "Bonuses",
 	"bruteforce": "Brute Force",
 	"burstfire": "Burst Fire (BF)",
@@ -278,6 +279,7 @@
 	"liftcarry": "Lift & Carry",
 	"limited": "Limited",
 	"logic": "Logic",
+	"Logic + Intuition": "Logic + Intuition",
 	"los": "LOS",
 	"los (a)": "LOS (A)",
 	"lowpaintolerance": "Low Pain Tolerance",
@@ -463,6 +465,8 @@
 	"soakmatrix": "Soak Matrix",
 	"soakbiofeedback": "Soak Biofeedback",
 	"social": "Social",
+	"social_rating": "Social Rating",
+	"social_rating_desc": "Charisma + Armor Social Mods",
 	"sorcery": "Sorcery",
 	"special": "Special",
 	"specialization": "Specialization (+2)",
@@ -532,5 +536,7 @@
 	"whispergm": "Whisper rolls to GM",
 	"wilddie": "Roll a single wild die",
 	"willpower": "Willpower",
+	"Willpower + Charisma": "Willpower + Charisma",
+	"Willpower + Intuition": "Willpower + Intuition",
 	"wounds": "Wounds"
 }

--- a/Shadowrun Sixth World/translation.json
+++ b/Shadowrun Sixth World/translation.json
@@ -508,6 +508,7 @@
 	"topps": "The Topps Company, Inc. has sole ownership of the names, logo, artwork, marks, photographs, sounds, audio, video and/or any proprietary material used in connection with the game Shadowrun. The Topps Company, Inc. has granted permission to use such names, logos, artwork, marks and/or any proprietary materials for promotional and informational purposes on its website but does not endorse, and is not affiliated with any official capacity whatsoever.",
 	"total": "Total",
 	"total karma": "Total Karma",
+	"touch": "Touch",
 	"traceicon": "Trace Icon",
 	"tradition": "Tradition",
 	"trigger": "Trigger",


### PR DESCRIPTION
## Changes / Comments
Added Social Rating to derived tests (even though it's not a test) just to the right of the Edge Attribute.  This is a total of Charisma + any cumulative + primary armor social adjustments.
Added mouseovers for Composure, Judge Intentions, Memory and Lift & Carry buttons detailing where the values come from for those of us that forget.
Added the ability to add Spells, NPC Spells, Qualities and Augmentations by pasting raw data into the Notes textarea for a new repeating row.

## Roll20 Requests
- [ Y ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ N ] Is this a bug fix?
- [ Y ] Does this add functional enhancements (new features or extending existing features) ?
- [ N ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ NA ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ NA ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?
