### PR TITLE
[HarnMaster3] 202109 bugfixes

### DIFF
--- a/HarnMaster3/harnsheet.html
+++ b/HarnMaster3/harnsheet.html
@@ -1616,6 +1616,7 @@
 				<li>Fix bug in horse penalty calculation (encumbrance was ignored)</li>
 				<li>Fixed horse dodge roll button not working</li> 
 				<li>Add SB field to spells to allow for optional rule Individual Spell skills (Shek-Pvar 24)</li>
+				<li>Added more fields to spells to quickly see time, duration etc. Added auto-calculation for Skill Index (SI) </li>
 				<li>layout changes to spells section to track additional info and create more space for spell description</li>
 			</ul>
 		</details>		
@@ -2514,7 +2515,21 @@ on('change:repeating_armoritems remove:repeating_armoritems', function() {
 }); 
 
 <!-- spell characteristics -->
-<!-- TODO build sheetworker to calculate SI from SB . and SB from spell level and magic skill? (complicated?) ; attr_spell_si attr_spell_sb -->
+<!-- calculate SI from SB -->
+on('change:repeating_spells:spell_eml change:repeating_rituals:ritual_eml change:repeating_psionics:talent_eml', function() {
+    getAttrs(['repeating_spells_spell_eml', 'repeating_rituals_ritual_eml', 'repeating_psionics_talent_eml'], function(values) {
+		var spellsi = Math.floor(parseInt(values['repeating_spells_spell_eml']/10));
+		var ritualsi = Math.floor(parseInt(values['repeating_rituals_ritual_eml']/10));
+		var talentsi = Math.floor(parseInt(values['repeating_psionics_talent_eml']/10));
+		console.log("spell si: ", spellsi);
+		setAttrs({
+			repeating_spells_spell_si: spellsi,
+			repeating_rituals_ritual_si: ritualsi,
+			repeating_psionics_talent_si: talentsi
+		});
+	});
+});
+
 
 <!-- miscellaneous -->
 

--- a/HarnMaster3/harnsheet.html
+++ b/HarnMaster3/harnsheet.html
@@ -797,7 +797,7 @@
 			<div class="skill-header skill-value">Lvl</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Casting Time (seconds)">CT</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Duration (seconds)">Dur</div>
-			<div class="skill-header skill-value harntooltip" data-tooltiptext="Range (meters, self or touch)">Rng</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Range (meters, self or touch)">Range</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Base of spell when using individual spell skills">SB</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Index of spell when using individual spell skills">SI</div>
 			<div class="skill-header skill-value">ML</div>
@@ -829,7 +829,7 @@
 			<div class="skill-header skill-value">Lvl</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Casting Time (seconds)">CT</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Duration (seconds)">Dur</div>
-			<div class="skill-header skill-value harntooltip" data-tooltiptext="Range (meters, self or touch)">Rng</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Range (meters, self or touch)">Range</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Base of spell when using individual ritual skills">SB</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Index of spell when using individual ritual skills">SI</div>
 			<div class="skill-header skill-value">ML</div>
@@ -858,7 +858,7 @@
 			<div class="skill-value skill-header harntooltip" data-tooltiptext="Fatigue Penalty">FP</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Casting Time (seconds)">CT</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Duration (seconds)">Dur</div>
-			<div class="skill-header skill-value harntooltip" data-tooltiptext="Range (meters, self or touch)">Rng</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Range (meters, self or touch)">Range</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Base of spell when using individual spell skills">SB</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Index of spell when using individual spell skills">SI</div>
 			<div class="skill-header skill-value">ML</div>
@@ -1589,8 +1589,11 @@
 			<input id=showhorsetoggle name="attr_hrhorseonsheet" type="checkbox" value="1" checked>
 			<label for=showpietytoggle class="harntooltip" data-tooltiptext="When this is unchecked the sheet will show space for tracking piety per god with repeating rows" >Show consolidated piety?</label>
 			<input id=showpietytoggle name="attr_hrconsolidatedpiety" type="checkbox" value="1" checked>
+			<div class="full-width skill-header">Legacy info</div>
 			<label for=showlegacyarmortoggle>Hide armor info from legacy (v1) sheet?</label>
-			<input id=showlegacyarmortoggle name="attr_legacyarmorhidden" type="checkbox" value="1">			
+			<input id=showlegacyarmortoggle name="attr_legacyarmorhidden" type="checkbox" value="1">	
+			<label for=legacycharname class="full-width">Name stored in old "name" field:</label>
+			<input id=legacycharname name="attr_name" type="text" class="full-width" readonly>
 			<div class="full-width skill-header">Sheet version</div>
 			<div class="full-width">
 			  <input name="attr_character_sheet_version" type="number" value="20210912" readonly>
@@ -1618,6 +1621,7 @@
 				<li>Add SB field to spells to allow for optional rule Individual Spell skills (Shek-Pvar 24)</li>
 				<li>Added more fields to spells to quickly see time, duration etc. Added auto-calculation for Skill Index (SI) </li>
 				<li>layout changes to spells section to track additional info and create more space for spell description</li>
+				<li>background script to copy back character name to old "name" field for backward compatibility</li>
 			</ul>
 		</details>		
 		<h3>20210804 - Version 2.3</h3>
@@ -1991,8 +1995,8 @@ function migrateTo20210801 (migrationChain) {
 		setAttrs({
 		    'combat_effectivecondition': effectivecondition,
 			'healing_effectivecondition': healeffcondition,
-			'character_name': charname,
-			'name': 0 /* clear the old name so we don't keep resetting back the version */
+			'character_name': charname
+			/* 'name': 0  we don't need to clear the old name, migration check works based on presence of old name field and version being set or not*/
 			});
 		});
 	/* re-calculate all weapons in the repeating weapons section. */ 
@@ -2025,7 +2029,16 @@ function migrateTo20210801 (migrationChain) {
 		});
 }
 
-
+<!-- restore Character name in old name variable in parallel to new character_name for backward compatibility (old variable was empty out by migration script -->
+on('sheet:opened', function() {
+	getAttrs(['character_name'], function(values) {	
+		var charactername = values['character_name'];
+		setAttrs({
+			'name': charactername
+		});
+	});
+});	
+		
 <!-- weapon load totals /-->
 on('change:repeating_weapon remove:repeating_weapon', function() {
 	repeatingSum('load_weapons_total', 'weapon',['weapon_wgt','weapon_iscarried']);

--- a/HarnMaster3/harnsheet.html
+++ b/HarnMaster3/harnsheet.html
@@ -797,6 +797,7 @@
 			<div class="skill-header skill-value">Lvl</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Casting Time (seconds)">CT</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Duration (seconds)">Dur</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Range (meters)">Rng</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Base of spell when using individual spell skills">SB</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Index of spell when using individual spell skills">SI</div>
 			<div class="skill-header skill-value">EML</div>
@@ -808,6 +809,7 @@
 				<input type="number" name="attr_spell_level" class="skill-value" value="0">
 				<input type="number" name="attr_spell_ct" class="skill-value" value="0">
 				<input type="number" name="attr_spell_duration" class="skill-value" value="0">
+				<input type="number" name="attr_spell_range" class="skill-value" value="0">
 				<input type="number" name="attr_spell_sb" class="skill-value" value="0">
 				<input type="number" name="attr_spell_si" class="skill-value" value="0" readonly>
 				<input type="number" name="attr_spell_eml" class="skill-value" value="0">
@@ -815,7 +817,7 @@
 				</button>
 				
 				<label for="spell-description">Spell description</label>
-				<input id="spell-description" type="textarea" name="attr_spell_note" class="magic-note">
+				<input id="spell-description" type="text" name="attr_spell_note" class="magic-note">
 				
 			</fieldset>
 		</div>
@@ -823,34 +825,58 @@
 		    <div class="skill-section-title">RITUALS</div>
 			<div class="skill-header">Name</div>
 			<div class="skill-header">Deity</div>
-			<div class="skill-value skill-header">Lvl</div>
-			<div class="skill-value skill-header">EML</div>
-			<div class="skill-value skill-header">&nbsp;</div>
-			<div class="magic-label skill-header">Notes</div>
+			<div class="skill-header">&nbsp;</div>
+			<div class="skill-header skill-value">Lvl</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Casting Time (seconds)">CT</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Duration (seconds)">Dur</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Range (meters)">Rng</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Base of spell when using individual ritual skills">SB</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Index of spell when using individual ritual skills">SI</div>
+			<div class="skill-header skill-value">EML</div>
+			<div class="skill-header">&nbsp;</div>
 			<fieldset class="repeating_rituals">
 				<input type="text" name="attr_ritual_name" class="magic-label ">
 				<input type="text" name="attr_ritual_religion" class="piety-label">
+				<div>&nbsp;</div>
 				<input type="number" name="attr_ritual_level" class="skill-value" value="0">
+				<input type="number" name="attr_ritual_ct" class="skill-value" value="0">
+				<input type="number" name="attr_ritual_duration" class="skill-value" value="0">
+				<input type="number" name="attr_ritual_range" class="skill-value" value="0">
+				<input type="number" name="attr_ritual_sb" class="skill-value" value="0">
+				<input type="number" name="attr_ritual_si" class="skill-value" value="0" readonly>
 				<input type="number" name="attr_ritual_eml" class="skill-value" value="0">
 				<button type="roll" value="&{template:custom} {{color=harn}} {{title=@{character_name} performs @{ritual_name}}} {{subtitle=@{ritual_religion}}} {{rolltarget=[[{[[{[[@{ritual_eml} - [[(@{universal_penalty})*5]] + ?{Target Modifier?|0}]],5}kh1]],95}kl1]]}} {{Mastery Lvl=[[@{ritual_eml}]]}} {{penalty=[[(@{universal_penalty})*5]]}} {{rollresult=[[1d100cs5cs10cs15cs20cs25cs30cs35cs40cs45cs50cs55cs60cs65cs70cs75cs80cs85cs90cs95cs100]]}} {{Modifiers=[[?{Target Modifier?|0}]]}} {{successdesc=@{ritual_note}}}" name="roll_ritualcheck"></button>
-				<input type="text" name="attr_ritual_note" class="spell-note">
+				<label for="ritual-description">Ritual description</label>
+				<input id="ritual-description" type="text" name="attr_ritual_note" class="magic-note">
 			</fieldset>			
 		</div>    
         <div class='character-grid-section magic magic-grid mr-psionic colored-grid'>
 			<div class="skill-section-title">PSIONIC POWERS</div>
 			<div class="skill-header">Talent</div>
-			<div class="skill-value skill-header">Fatigue</div>
-			<div class="skill-value skill-header">Time</div>
-			<div class="skill-value skill-header">EML</div>
-			<div class="skill-value skill-header">&nbsp;</div>
-			<div class="magic-label skill-header">Notes</div>
+			<div class="skill-header">&nbsp;</div>
+			<div class="skill-header">&nbsp;</div>
+			<div class="skill-value skill-header harntooltip" data-tooltiptext="Fatigue">Fat</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Casting Time (seconds)">CT</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Duration (seconds)">Dur</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Range (meters)">Rng</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Base of spell when using individual spell skills">SB</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Index of spell when using individual spell skills">SI</div>
+			<div class="skill-header skill-value">EML</div>
+			<div class="skill-header">&nbsp;</div>
 			<fieldset class="repeating_psionics">
 				<input type="text" name="attr_talent_name" class="magic-label ">
+				<div>&nbsp;</div>
+				<div>&nbsp;</div>
 				<input type="number" name="attr_talent_fatigue" class="skill-value" value="0">
-				<input type="number" name="attr_talent_time" class="skill-value" value="">
+				<input type="number" name="attr_talent_time" class="skill-value" value="0">
+				<input type="number" name="attr_talent_duration" class="skill-value" value="0">
+				<input type="number" name="attr_talent_range" class="skill-value" value="0">
+				<input type="number" name="attr_talent_sb" class="skill-value" value="0">
+				<input type="number" name="attr_talent_si" class="skill-value" value="0" readonly>
 				<input type="number" name="attr_talent_eml" class="skill-value" value="0">
 				<button type="roll" value="&{template:custom} {{color=harn}} {{title=@{character_name} invokes @{talent_name}}}  {{rolltarget=[[{[[{[[@{talent_eml} - [[(@{universal_penalty})*5]] + ?{Target Modifier?|0}]],5}kh1]],95}kl1]]}} {{Mastery Lvl=[[@{talent_eml}]]}} {{penalty=[[(@{universal_penalty})*5]]}} {{rollresult=[[1d100cs5cs10cs15cs20cs25cs30cs35cs40cs45cs50cs55cs60cs65cs70cs75cs80cs85cs90cs95cs100]]}} {{Modifiers=[[?{Target Modifier?|0}]]}} {{successdesc=(@{talent_time}); @{talent_note}}}" name="roll_talentcheck"></button>
-				<input type="text" name="attr_talent_note" class="spell-note">
+				<label for="psionic-description">Talent description</label>
+				<input id="psionic-description" type="text" name="attr_talent_note" class="magic-note">
 			</fieldset>			
 		</div>   
         <input class="showsinglepiety" name="attr_hrconsolidatedpiety" type="hidden" value="1"/>

--- a/HarnMaster3/harnsheet.html
+++ b/HarnMaster3/harnsheet.html
@@ -855,7 +855,7 @@
 			<div class="skill-header">Talent</div>
 			<div class="skill-header">&nbsp;</div>
 			<div class="skill-header">&nbsp;</div>
-			<div class="skill-value skill-header harntooltip" data-tooltiptext="Fatigue">Fat</div>
+			<div class="skill-value skill-header harntooltip" data-tooltiptext="Fatigue Penalty">FP</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Casting Time (seconds)">CT</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Duration (seconds)">Dur</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Range (meters)">Rng</div>

--- a/HarnMaster3/harnsheet.html
+++ b/HarnMaster3/harnsheet.html
@@ -797,7 +797,7 @@
 			<div class="skill-header skill-value">Lvl</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Casting Time (seconds)">CT</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Duration (seconds)">Dur</div>
-			<div class="skill-header skill-value harntooltip" data-tooltiptext="Range (meters)">Rng</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Range (meters, self or touch)">Rng</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Base of spell when using individual spell skills">SB</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Index of spell when using individual spell skills">SI</div>
 			<div class="skill-header skill-value">ML</div>
@@ -809,7 +809,7 @@
 				<input type="number" name="attr_spell_level" class="skill-value" value="0">
 				<input type="number" name="attr_spell_ct" class="skill-value" value="0">
 				<input type="number" name="attr_spell_duration" class="skill-value" value="0">
-				<input type="number" name="attr_spell_range" class="skill-value" value="0">
+				<input type="text" name="attr_spell_range" class="skill-value" value="0">
 				<input type="number" name="attr_spell_sb" class="skill-value" value="0">
 				<input type="number" name="attr_spell_si" class="skill-value" value="0" readonly>
 				<input type="number" name="attr_spell_eml" class="skill-value" value="0">
@@ -829,7 +829,7 @@
 			<div class="skill-header skill-value">Lvl</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Casting Time (seconds)">CT</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Duration (seconds)">Dur</div>
-			<div class="skill-header skill-value harntooltip" data-tooltiptext="Range (meters)">Rng</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Range (meters, self or touch)">Rng</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Base of spell when using individual ritual skills">SB</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Index of spell when using individual ritual skills">SI</div>
 			<div class="skill-header skill-value">ML</div>
@@ -841,7 +841,7 @@
 				<input type="number" name="attr_ritual_level" class="skill-value" value="0">
 				<input type="number" name="attr_ritual_ct" class="skill-value" value="0">
 				<input type="number" name="attr_ritual_duration" class="skill-value" value="0">
-				<input type="number" name="attr_ritual_range" class="skill-value" value="0">
+				<input type="text" name="attr_ritual_range" class="skill-value" value="0">
 				<input type="number" name="attr_ritual_sb" class="skill-value" value="0">
 				<input type="number" name="attr_ritual_si" class="skill-value" value="0" readonly>
 				<input type="number" name="attr_ritual_eml" class="skill-value" value="0">
@@ -858,7 +858,7 @@
 			<div class="skill-value skill-header harntooltip" data-tooltiptext="Fatigue Penalty">FP</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Casting Time (seconds)">CT</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Duration (seconds)">Dur</div>
-			<div class="skill-header skill-value harntooltip" data-tooltiptext="Range (meters)">Rng</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Range (meters, self or touch)">Rng</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Base of spell when using individual spell skills">SB</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Index of spell when using individual spell skills">SI</div>
 			<div class="skill-header skill-value">ML</div>
@@ -870,7 +870,7 @@
 				<input type="number" name="attr_talent_fatigue" class="skill-value" value="0">
 				<input type="number" name="attr_talent_time" class="skill-value" value="0">
 				<input type="number" name="attr_talent_duration" class="skill-value" value="0">
-				<input type="number" name="attr_talent_range" class="skill-value" value="0">
+				<input type="text" name="attr_talent_range" class="skill-value" value="0">
 				<input type="number" name="attr_talent_sb" class="skill-value" value="0">
 				<input type="number" name="attr_talent_si" class="skill-value" value="0" readonly>
 				<input type="number" name="attr_talent_eml" class="skill-value" value="0">

--- a/HarnMaster3/harnsheet.html
+++ b/HarnMaster3/harnsheet.html
@@ -791,20 +791,32 @@
 		<input class="showsinglepiety" name="attr_hrconsolidatedpiety" type="hidden" value="1"/>
 		<div class='character-grid-section magic magic-grid mr-spells colored-grid'>
 		    <div class="skill-section-title">SPELLS</div>
-			<div class="skill-header">Name</div>
+			<div class="skill-header ">Name</div>
 			<div class="skill-header">Convocation</div>
-			<div class="skill-header">Lvl</div>
-			<div class="skill-header">EML</div>
 			<div class="skill-header">&nbsp;</div>
-			<div class="skill-header">Notes</div>
+			<div class="skill-header skill-value">Lvl</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Casting Time (seconds)">CT</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Duration (seconds)">Dur</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Base of spell when using individual spell skills">SB</div>
+			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Index of spell when using individual spell skills">SI</div>
+			<div class="skill-header skill-value">EML</div>
+			<div class="skill-header">&nbsp;</div>
 			<fieldset class="repeating_spells">
 				<input type="text" name="attr_spell_name" class="magic-label">
 				<input type="text" name="attr_spell_convocation" class="magic-label">
+				<div>&nbsp;</div>
 				<input type="number" name="attr_spell_level" class="skill-value" value="0">
+				<input type="number" name="attr_spell_ct" class="skill-value" value="0">
+				<input type="number" name="attr_spell_duration" class="skill-value" value="0">
+				<input type="number" name="attr_spell_sb" class="skill-value" value="0">
+				<input type="number" name="attr_spell_si" class="skill-value" value="0" readonly>
 				<input type="number" name="attr_spell_eml" class="skill-value" value="0">
 				<button type="roll" value="&{template:custom} {{color=harn}} {{title=@{character_name} casts @{spell_name}}} {{subtitle=@{spell_convocation}}} {{rolltarget=[[{[[{[[@{spell_eml} - [[(@{universal_penalty})*5]] + ?{Target Modifier?|0}]],5}kh1]],95}kl1]]}} {{Mastery Lvl=[[@{spell_eml}]]}} {{penalty=[[(@{universal_penalty})*5]]}} {{rollresult=[[1d100cs5cs10cs15cs20cs25cs30cs35cs40cs45cs50cs55cs60cs65cs70cs75cs80cs85cs90cs95cs100]]}} {{Modifiers=[[?{Target Modifier?|0}]]}} {{successdesc=@{spell_note}}}" name="roll_spellcastcheck">
 				</button>
-				<input type="text" name="attr_spell_note" class="magic-label">
+				
+				<label for="spell-description">Spell description</label>
+				<input id="spell-description" type="textarea" name="attr_spell_note" class="magic-note">
+				
 			</fieldset>
 		</div>
         <div class='character-grid-section magic magic-grid mr-rituals colored-grid'>
@@ -912,27 +924,27 @@
 			<input type="text" class="skill-label" name="attr_hawareness_name" value="Awareness" disabled="true">
 			<input type="number" name="attr_hawareness_sb" class="skill-value" value="0">
 			<input type="number" name="attr_hawareness_ml" class="skill-value" value="0">
-			<button type="roll" value="&{template:custom} {{color=harn}} {{title=@{hname} tests @{hawareness_name}}} {{rolltarget=[[{[[{[[@{hawareness_ml} - [[(@{hphysical_penalty})*5]] + ?{Target Modifier?|0}]],5}kh1]],95}kl1]]}} {{penalty=[[(@{hphysical_penalty})*5]]}} {{rollresult=[[1d100cs5cs10cs15cs20cs25cs30cs35cs40cs45cs50cs55cs60cs65cs70cs75cs80cs85cs90cs95cs100]]}} {{Modifiers=[[?{Target Modifier?|0}]]}} {{Mastery Lvl=[[@{hawareness_ml}]]}}" name="roll_HorseAwarenessCheck">
+			<button type="roll" value="&{template:custom} {{color=harn}} {{title=@{hname} tests @{hawareness_name}}} {{rolltarget=[[{[[{[[@{hawareness_ml} - [[(@{hphysical_penalty})*5]] + ?{Target Modifier?|0}]],5}kh1]],95}kl1]]}} {{Mastery Lvl=[[@{hawareness_ml}]]}} {{Modifiers=[[?{Target Modifier?|0}]]}} {{penalty=[[(@{hphysical_penalty})*5]]}} {{rollresult=[[1d100cs5cs10cs15cs20cs25cs30cs35cs40cs45cs50cs55cs60cs65cs70cs75cs80cs85cs90cs95cs100]]}}" name="roll_HorseAwarenessCheck">
 			</button>
 			<input type="text" class="skill-label" name="attr_hdodge_name" value="Dodge" disabled="true">
 			<input type="number" name="attr_hdodge_sb" class="skill-value" value="0">
 			<input type="number" name="attr_hdodge_ml" class="skill-value" value="0">
-			<button type="roll" value="&{template:custom} {{color=harn}} {{title=@{hname} tests @{hdodge_name}}} {{rolltarget=[[{[[{[[@{hdodge_ml} - [[(@{hphysical_penalty})*5]] + ?{Target Modifier?|0}]],5}kh1]],95}kl1]]}} {{penalty=[[(@{hphysical_penalty})*5]]}} {{rollresult=[[1d100cs5cs10cs15cs20cs25cs30cs35cs40cs45cs50cs55cs60cs65cs70cs75cs80cs85cs90cs95cs100]]}} {{Modifiers=[[?{Target Modifier?|0}]]}} {{Mastery Lvl=[[@{hdodge_ml}]]}}" name="roll_HorseDodgeCheck">
+			<button type="roll" value="&{template:custom} {{color=harn}} {{title=@{hname} tests @{hdodge_name}}} {{rolltarget=[[{[[{[[@{hdodge_ml} - [[(@{hphysical_penalty})*5]] + ?{Target Modifier?|0}]],5}kh1]],95}kl1]]}} {{Mastery Lvl=[[@{hdodge_ml}]]}} {{Modifiers=[[?{Target Modifier?|0}]]}} {{penalty=[[(@{hphysical_penalty})*5]]}} {{rollresult=[[1d100cs5cs10cs15cs20cs25cs30cs35cs40cs45cs50cs55cs60cs65cs70cs75cs80cs85cs90cs95cs100]]}}" name="roll_HorseDodgeCheck">
 			</button>
 			<input type="text" class="skill-label" name="attr_hinitiative_name" value="Horse Initiative" disabled="true">
 			<input type="number" name="attr_hinitiative_sb" class="skill-value" value="0">
 			<input type="number" name="attr_hinitiative_ml" class="skill-value" value="0">
-			<button type="roll" value="&{template:custom} {{color=harn}} {{title=@{hname} tests @{hinitiative_name}}} {{rolltarget=[[{[[{[[@{hinitiative_ml} - [[(@{hphysical_penalty})*5]] + ?{Target Modifier?|0}]],5}kh1]],95}kl1]]}} {{penalty=[[(@{hphysical_penalty})*5]]}} {{rollresult=[[1d100cs5cs10cs15cs20cs25cs30cs35cs40cs45cs50cs55cs60cs65cs70cs75cs80cs85cs90cs95cs100]]}} {{Modifiers=[[?{Target Modifier?|0}]]}} {{Mastery Lvl=[[@{hinitiative_ml}]]}}" name="roll_HorseInitiativeCheck">
+			<button type="roll" value="&{template:custom} {{color=harn}} {{title=@{hname} tests @{hinitiative_name}}} {{rolltarget=[[{[[{[[@{hinitiative_ml} - [[(@{hphysical_penalty})*5]] + ?{Target Modifier?|0}]],5}kh1]],95}kl1]]}} {{Mastery Lvl=[[@{hinitiative_ml}]]}} {{Modifiers=[[?{Target Modifier?|0}]]}} {{penalty=[[(@{hphysical_penalty})*5]]}} {{rollresult=[[1d100cs5cs10cs15cs20cs25cs30cs35cs40cs45cs50cs55cs60cs65cs70cs75cs80cs85cs90cs95cs100]]}}" name="roll_HorseInitiativeCheck">
 			</button>
 			<input type="text" class="skill-label" name="attr_hjumping_name" value="Jumping" disabled="true">
 			<input type="number" name="attr_hjumping_sb" class="skill-value" value="0">
 			<input type="number" name="attr_hjumping_ml" class="skill-value" value="0">
-			<button type="roll" value="&{template:custom} {{color=harn}} {{title=@{hname} tests @{hjumping_name}}} {{rolltarget=[[{[[{[[@{hjumping_ml} - [[(@{hphysical_penalty})*5]] + ?{Target Modifier?|0}]],5}kh1]],95}kl1]]}} {{penalty=[[(@{hphysical_penalty})*5]]}} {{rollresult=[[1d100cs5cs10cs15cs20cs25cs30cs35cs40cs45cs50cs55cs60cs65cs70cs75cs80cs85cs90cs95cs100]]}} {{Modifiers=[[?{Target Modifier?|0}]]}} {{Mastery Lvl=[[@{hjumping_ml}]]}}" name="roll_HorseJumpCheck">
+			<button type="roll" value="&{template:custom} {{color=harn}} {{title=@{hname} tests @{hjumping_name}}} {{rolltarget=[[{[[{[[@{hjumping_ml} - [[(@{hphysical_penalty})*5]] + ?{Target Modifier?|0}]],5}kh1]],95}kl1]]}} {{Mastery Lvl=[[@{hjumping_ml}]]}} {{Modifiers=[[?{Target Modifier?|0}]]}} {{penalty=[[(@{hphysical_penalty})*5]]}} {{rollresult=[[1d100cs5cs10cs15cs20cs25cs30cs35cs40cs45cs50cs55cs60cs65cs70cs75cs80cs85cs90cs95cs100]]}}" name="roll_HorseJumpCheck">
 			</button>
 			<input type="text" class="skill-label" name="attr_hstealth_name" value="Stealth" disabled="true">
 			<input type="number" name="attr_hstealth_sb" class="skill-value" value="0">
 			<input type="number" name="attr_hstealth_ml" class="skill-value" value="0">
-			<button type="roll" value="&{template:custom} {{color=harn}} {{title=@{hname} tests @{hstealth_name}}} {{rolltarget=[[{[[{[[@{hstealth_ml} - [[(@{hphysical_penalty})*5]] + ?{Target Modifier?|0}]],5}kh1]],95}kl1]]}} {{penalty=[[(@{hphysical_penalty})*5]]}} {{rollresult=[[1d100cs5cs10cs15cs20cs25cs30cs35cs40cs45cs50cs55cs60cs65cs70cs75cs80cs85cs90cs95cs100]]}} {{Modifiers=[[?{Target Modifier?|0}]]}} {{Mastery Lvl=[[@{hstealth_ml}]]}}" name="roll_HorseStealthCheck">
+			<button type="roll" value="&{template:custom} {{color=harn}} {{title=@{hname} tests @{hstealth_name}}} {{rolltarget=[[{[[{[[@{hstealth_ml} - [[(@{hphysical_penalty})*5]] + ?{Target Modifier?|0}]],5}kh1]],95}kl1]]}} {{Mastery Lvl=[[@{hstealth_ml}]]}} {{Modifiers=[[?{Target Modifier?|0}]]}} {{penalty=[[(@{hphysical_penalty})*5]]}} {{rollresult=[[1d100cs5cs10cs15cs20cs25cs30cs35cs40cs45cs50cs55cs60cs65cs70cs75cs80cs85cs90cs95cs100]]}}" name="roll_HorseStealthCheck">
 			</button>
 			<input type="text" class="skill-label" name="attr_htrample_name" value="Trample" disabled="true">
 			<input type="number" name="attr_htrample_sb" class="skill-value" value="0">
@@ -959,7 +971,7 @@
 			<div>&nbsp </div>
 			<label for=horsecombatdodge>Dodge</label>
 			<input id=horsecombatdodge type="number" name="attr_hdodge_ml" class="skill-value" readonly>
-			<button type="roll" value="&{template:custom} {{color=harn}} {{title=@{hname}} dodges}  {{rolltarget=[[{[[{[[@{hcombat_dodge} - [[(@{hphysical_penalty})*5]] + ?{Target Modifier?|0}]],5}kh1]],95}kl1]]}} {{penalty=[[(@{hphysical_penalty})*5]]}} {{rollresult=[[1d100cs5cs10cs15cs20cs25cs30cs35cs40cs45cs50cs55cs60cs65cs70cs75cs80cs85cs90cs95cs100]]}} {{Modifiers=[[?{Target Modifier?|0}]]}} {{Mastery Lvl=[[@{hcombat_dodge}]]}}" name="roll_HorseCombatDodgeCheck">
+			<button type="roll" value="&{template:custom} {{color=harn}} {{title=@{hname} dodges}}  {{rolltarget=[[{[[{[[@{hdodge_ml} - [[(@{hphysical_penalty})*5]] + ?{Target Modifier?|0}]],5}kh1]],95}kl1]]}} {{Mastery Lvl=[[@{hdodge_ml}]]}} {{Modifiers=[[?{Target Modifier?|0}]]}} {{penalty=[[(@{hphysical_penalty})*5]]}} {{rollresult=[[1d100cs5cs10cs15cs20cs25cs30cs35cs40cs45cs50cs55cs60cs65cs70cs75cs80cs85cs90cs95cs100]]}}" name="roll_HorseCombatDodgeCheck">
 			</button>
 			<label for=horsespeed>Horse speed:</label>
             <select id=horsespeed name="attr_horse_speed" class="skill-label width-2col">
@@ -1027,7 +1039,7 @@
 				<input type="number" name="attr_hinjury_level" class="skill-value" value="0">
 				<input type="number" name="attr_hinjury_healingroll" class="skill-value" value="0">
 				<input type="number" name="attr_hinjury_day" class="skill-value" value="0">
-				<button type="roll" value="&{template:custom} {{color=harn}} {{title=@{hname} rolls a healing check}} {{infected=[[@{hinjury_infected_feedback}]]}} {{rolltarget=[[{[[{[[(@{hinjury_healingroll} * [[@{hcombat_endurance}]]) + ?{Target Modifier?|0}]],5}kh1]],95}kl1]]}} {{penalty=[[0]]}} {{rollresult=[[1d100cs5cs10cs15cs20cs25cs30cs35cs40cs45cs50cs55cs60cs65cs70cs75cs80cs85cs90cs95cs100]]}} {{Modifiers=[[?{Target Modifier?|0}]]}} {{Healing Roll=[[@{hinjury_healingroll} * [[@{hcombat_endurance}]]]]}} {{desc=@{hinjury_location} @{hinjury_severity}@{hinjury_level} h@{hinjury_healingroll}}}" name="roll_horsehealingcheck">
+				<button type="roll" value="&{template:custom} {{color=harn}} {{title=@{hname} rolls a healing check}} {{infected=[[@{hinjury_infected_feedback}]]}} {{rolltarget=[[{[[{[[(@{hinjury_healingroll} * [[@{hcombat_endurance}]]) + ?{Target Modifier?|0}]],5}kh1]],95}kl1]]}} {{Healing Roll=[[@{hinjury_healingroll} * [[@{hcombat_endurance}]]]]}} {{Modifiers=[[?{Target Modifier?|0}]]}} {{penalty=[[0]]}} {{rollresult=[[1d100cs5cs10cs15cs20cs25cs30cs35cs40cs45cs50cs55cs60cs65cs70cs75cs80cs85cs90cs95cs100]]}} {{desc=@{hinjury_location} @{hinjury_severity}@{hinjury_level} h@{hinjury_healingroll}}}" name="roll_horsehealingcheck">
 				</button>
 				<input type="checkbox" name="attr_hinjury_infected"><span></span>
 				<input type="hidden" name="attr_hinjury_infected_feedback" value="0" readonly>
@@ -1041,7 +1053,7 @@
 			<input id=hfatigue type="number" name="attr_hfatigue_total" class="skill-value" value="0">
 			<label for=hunipenalty class="sumrow">Universal</label>
 			<input id=hunipenalty type="number" value="0" class="skill-value sumrow" name="attr_huniversal_penalty" readonly>
-			<label for=hencumbrance>Encum.</label>
+			<label for=hencumbrance>Encumbrance</label>
 			<input id=hencumbrance type="number" name="attr_hencumbrance" class="skill-value" value="0" readonly>
 			<label for=hphyspenalty class="sumrow">Physical</label>
 			<input id=hphyspenalty type="number" name="attr_hphysical_penalty" class="skill-value sumrow" value="0" readonly>
@@ -1061,7 +1073,7 @@
 			<input type="number" name="attr_trample_weapon_p" class="skill-value" disabled="true" value="0">
 			<input type="number" name="attr_htrample_ml" class="skill-value" readonly>
 			<input type="number" name="attr_htrample_ml" class="skill-value" readonly>
-			<button type="roll" value="&{template:custom} {{color=harn}} {{title=@{hname} tramples}} {{rolltarget=[[{[[{[[@{htrample_ml} - [[(@{hphysical_penalty})*5]] + ?{Target Modifier?|0}]],5}kh1]],95}kl1]]}} {{penalty=[[(@{hphysical_penalty})*5]]}} {{rollresult=[[1d100cs5cs10cs15cs20cs25cs30cs35cs40cs45cs50cs55cs60cs65cs70cs75cs80cs85cs90cs95cs100]]}} {{Modifiers=[[?{Target Modifier?|0}]]}} {{Mastery Lvl=[[@{htrample_ml}]]}} {{note=B(@{trample_weapon_b}) E(@{trample_weapon_e}) P(@{trample_weapon_p})}}" name="roll_trampleweaponamlskillcheck">
+			<button type="roll" value="&{template:custom} {{color=harn}} {{title=@{hname} tramples}} {{rolltarget=[[{[[{[[@{htrample_ml} - [[(@{hphysical_penalty})*5]] + ?{Target Modifier?|0}]],5}kh1]],95}kl1]]}} {{Mastery Lvl=[[@{htrample_ml}]]}} {{Modifiers=[[?{Target Modifier?|0}]]}} {{penalty=[[(@{hphysical_penalty})*5]]}} {{rollresult=[[1d100cs5cs10cs15cs20cs25cs30cs35cs40cs45cs50cs55cs60cs65cs70cs75cs80cs85cs90cs95cs100]]}}  {{note=B(@{trample_weapon_b}) E(@{trample_weapon_e}) P(@{trample_weapon_p})}}" name="roll_trampleweaponamlskillcheck">
 			</button>
 		</div>
     </div> 
@@ -1194,7 +1206,7 @@
 		<fieldset class="repeating_armoritems">
 			<input type="text" name="attr_armor_name" class="skill-label">
 			<input type="checkbox" name="attr_armor_iscarried" value="1">
-			<input type="number" name="attr_armor_wgt" class="skill-value" value="0">
+			<input type="number" step="any" name="attr_armor_wgt" class="skill-value" value="0">
 			<input type="number" name="attr_armor_aq" class="skill-value" value="0">
 			<input type="number" name="attr_armor_b" class="skill-value" value="0">
 			<input type="number" name="attr_armor_e" class="skill-value" value="0">
@@ -1468,7 +1480,7 @@
        	<fieldset class="repeating_harmoritems">
        		<input type="text" name="attr_harmor_name" class="inventory-label-xsmall">
        		<input type="number" name="attr_harmor_aq" class="skill-value" value="0">
-       		<input type="number" name="attr_harmor_wgt" class="skill-value" value="0">
+       		<input type="number" step="any" name="attr_harmor_wgt" class="skill-value" value="0">
        	</fieldset>
        	<div class="footnote">Note: this armour counts towards horse's encumbrance</div>
 	</div>
@@ -1555,24 +1567,32 @@
 			<input id=showlegacyarmortoggle name="attr_legacyarmorhidden" type="checkbox" value="1">			
 			<div class="full-width skill-header">Sheet version</div>
 			<div class="full-width">
-			  <input name="attr_character_sheet_version" type="number" value="20210804" readonly>
+			  <input name="attr_character_sheet_version" type="number" value="20210912" readonly>
 			  <input type="hidden" name="attr_data_version" value="" readonly>
 			</div>
     	</div>
 	</div>
 	<div class="changelog">
 		<h2>Changelog</h2>
-		<!-- upcoming version <h3>20210805 - Version 2.4</h3>
+		<!-- upcoming version <h3>2021???? - Version x</h3>
 		<details>
 			<summary class="changelog-summary">
-				<p class="changelog-summary">Add a header to the sheet inspired by the paper version of the character sheet and roll20's new ability to include the avatar image. Plus some minor tweaks and fixes:</p>
+				<p class="changelog-summary">Updated header to the sheet to include roll20's new ability to include the avatar image. </p>
+			</summary>
+		</details> end future version -->
+		<h3>20210912 - Version 2.4</h3>
+		<details>
+			<summary class="changelog-summary">
+				<p class="changelog-summary">Some minor tweaks and fixes:</p>
 			</summary>
 			<ul>
-				<li>Restored AQ (armour quality) information in legacy armour section</li>
-				<li>Added option in settings to unhide armor information from legacy (v1) sheet if it was accidentally hidden but still needed</li> 
-				<li>Added some more tooltips for clarification</li>
+				<li>Allow decimal value input for armour</li>
+				<li>Fix bug in horse penalty calculation (encumbrance was ignored)</li>
+				<li>Fixed horse dodge roll button not working</li> 
+				<li>Add SB field to spells to allow for optional rule Individual Spell skills (Shek-Pvar 24)</li>
+				<li>layout changes to spells section to track additional info and create more space for spell description</li>
 			</ul>
-		</details> end future version -->
+		</details>		
 		<h3>20210804 - Version 2.3</h3>
 		<details>
 			<summary class="changelog-summary">
@@ -2088,7 +2108,7 @@ on('change:load_weapons_total change:load_armor_total change:load_inventory_tota
 });
 
 <!-- horse load limit, load and encumbrance /-->
-on('change:hstr change:weight change:load_total change:hload_armor_total change:hload_inventory_total', 
+on('change:hstr change:weight change:load_total change:hload_armor_total change:hload_inventory_total change:hcombat_endurance change:hstr', 
 function() {
     var total = 0.0;
     getAttrs(['weight', 'load_total', 'hload_armor_total', 'hload_inventory_total', 'hcombat_endurance', 'hstr'], 
@@ -2103,10 +2123,10 @@ function() {
 		var hadjustedload = Math.max(0, hadjustedloadtemp);
 		var hcomend = parseInt(values['hcombat_endurance'])||0;			
         if ( hcomend != 0 ) {
-			var hencumbrance = Math.round(hadjustedload/hcomend)||0;
+			var hencumb = Math.round(hadjustedload/hcomend)||0;
 		} else {
-			var hencumbrance = 0;
-			console.log("Horse endurance not known, setting encumbrance to 0");
+			var hencumb = 0;
+			console.log("Horse endurance not known, setting horse encumbrance to 0");
 		}
 			
 		var riderweight = parseFloat(values['weight'])||0;
@@ -2115,7 +2135,7 @@ function() {
             'hloadlimit': hllimit,
 			'hadjusted_load': hadjustedload,
 			'hload_total': parseInt(total)||0,
-            'hencumbrance': hencumbrance,
+            'hencumbrance': hencumb,
 			'hload_rider_total': riderload
         });
     });
@@ -2180,7 +2200,7 @@ on('change:is_mounted change:injury_total change:fatigue_total change:encumbranc
 
 <!-- horse universal and physical penalties  /-->
 on('change:hinjury_total change:hfatigue_total change:hencumbrance', function() {
-    getAttrs(['hinjury_total', 'hfatigue_total'], function(values) {
+    getAttrs(['hinjury_total', 'hfatigue_total', 'hencumbrance'], function(values) {
         var hfat = parseInt(values.hfatigue_total)||0;
 		var hinj = parseInt(values.hinjury_total)||0;
 		var henc = parseInt(values.hencumbrance)||0;
@@ -2466,6 +2486,9 @@ on('change:repeating_armoritems remove:repeating_armoritems', function() {
 	repeatingSum('ft_p', 'armoritems',['armor_ft_pvalue', 'armor_loc_ft','armor_iscarried']);
 	repeatingSum('ft_f', 'armoritems',['armor_ft_fvalue', 'armor_loc_ft','armor_iscarried']);
 }); 
+
+<!-- spell characteristics -->
+<!-- TODO build sheetworker to calculate SI from SB . and SB from spell level and magic skill? (complicated?) ; attr_spell_si attr_spell_sb -->
 
 <!-- miscellaneous -->
 

--- a/HarnMaster3/harnsheet.html
+++ b/HarnMaster3/harnsheet.html
@@ -800,7 +800,7 @@
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Range (meters)">Rng</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Base of spell when using individual spell skills">SB</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Index of spell when using individual spell skills">SI</div>
-			<div class="skill-header skill-value">EML</div>
+			<div class="skill-header skill-value">ML</div>
 			<div class="skill-header">&nbsp;</div>
 			<fieldset class="repeating_spells">
 				<input type="text" name="attr_spell_name" class="magic-label">
@@ -832,7 +832,7 @@
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Range (meters)">Rng</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Base of spell when using individual ritual skills">SB</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Index of spell when using individual ritual skills">SI</div>
-			<div class="skill-header skill-value">EML</div>
+			<div class="skill-header skill-value">ML</div>
 			<div class="skill-header">&nbsp;</div>
 			<fieldset class="repeating_rituals">
 				<input type="text" name="attr_ritual_name" class="magic-label ">
@@ -861,7 +861,7 @@
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Range (meters)">Rng</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Base of spell when using individual spell skills">SB</div>
 			<div class="skill-header skill-value harntooltip" data-tooltiptext="Skill Index of spell when using individual spell skills">SI</div>
-			<div class="skill-header skill-value">EML</div>
+			<div class="skill-header skill-value">ML</div>
 			<div class="skill-header">&nbsp;</div>
 			<fieldset class="repeating_psionics">
 				<input type="text" name="attr_talent_name" class="magic-label ">

--- a/HarnMaster3/harnsheet.html
+++ b/HarnMaster3/harnsheet.html
@@ -2030,7 +2030,7 @@ function migrateTo20210801 (migrationChain) {
 }
 
 <!-- restore Character name in old name variable in parallel to new character_name for backward compatibility (old variable was empty out by migration script -->
-on('sheet:opened', function() {
+on('change:character_name sheet:opened', function() {
 	getAttrs(['character_name'], function(values) {	
 		var charactername = values['character_name'];
 		setAttrs({

--- a/HarnMaster3/harnstyle.css
+++ b/HarnMaster3/harnstyle.css
@@ -478,13 +478,13 @@ input[type="hidden"].showhorse[value="0"] ~ .inven-personal {
 .magic-grid,
 .magic-grid .repcontainer > .repitem {
    display: grid;
-   grid-template-columns: 1.5fr 110px 0.5fr repeat(6, 3em) 2.2em ;
+   grid-template-columns: 1.5fr 110px 0.5fr repeat(7, 3em) 2.2em ;
    align-items: center;	
    align-content: baseline;	
 }
 
 .magic-grid input.magic-note {
-	grid-column: span 9;
+	grid-column: span 10;
 }
 
 input[type="hidden"].showsinglepiety[value="0"] ~ .piety-grid,

--- a/HarnMaster3/harnstyle.css
+++ b/HarnMaster3/harnstyle.css
@@ -478,7 +478,7 @@ input[type="hidden"].showhorse[value="0"] ~ .inven-personal {
 .magic-grid,
 .magic-grid .repcontainer > .repitem {
    display: grid;
-   grid-template-columns: 1.5fr 110px 0.5fr repeat(7, 3em) 2.2em ;
+   grid-template-columns: 1.5fr 110px 0.5fr repeat(3, 3em) 4em repeat(3, 3em) 2.2em ;
    align-items: center;	
    align-content: baseline;	
 }

--- a/HarnMaster3/harnstyle.css
+++ b/HarnMaster3/harnstyle.css
@@ -478,9 +478,13 @@ input[type="hidden"].showhorse[value="0"] ~ .inven-personal {
 .magic-grid,
 .magic-grid .repcontainer > .repitem {
    display: grid;
-   grid-template-columns: 20% 100px 3em 3em 2.2em 1fr;
+   grid-template-columns: 1.5fr 110px 0.5fr repeat(6, 3em) 2.2em ;
    align-items: center;	
    align-content: baseline;	
+}
+
+.magic-grid input.magic-note {
+	grid-column: span 9;
 }
 
 input[type="hidden"].showsinglepiety[value="0"] ~ .piety-grid,
@@ -915,6 +919,15 @@ label.sumrow {
    padding: 4px 0 4px 3px !important; /* resorting to important, roll20 styling keeps getting in the way */
 }
 
+.charsheet .magic-grid label {
+	text-transform: uppercase;
+    font-size: smaller;
+    font-family: 'Roboto Slab', serif;
+    font-weight: normal;
+    text-align: end;
+	padding-right: 1em;
+}
+
 /* disable spinners in Firefox too */
 
 .charactersheet input[type=number] {
@@ -1083,6 +1096,7 @@ summary.changelog-summary::marker {
 summary.changelog-summary::after {
 	content: "";
 }
+
 
 /* classes to span some columns if needed  */
 .width-2col {


### PR DESCRIPTION
## Changes / Comments

- Small changes and some fixes:
- Allow decimal value input for armour
- Fix bug in horse penalty calculation (encumbrance was ignored)
- Fixed horse dodge roll button not working
- Add SB field to spells to allow for optional rule Individual Spell skills (Shek-Pvar 24)
- Added more fields to spells to quickly see time, duration etc. Added auto-calculation for Skill Index (SI)
- layout changes to spells section to track additional info and create more space for spell description
- background script to copy back character name to old "name" field for backward compatibility




## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name. yes
- [X] Is this a bug fix? yes
- [X] Does this add functional enhancements (new features or extending existing features) ? yes
- [X] Does this add or change functional aesthetics (such as layout or color scheme) ? one section in a minor way 
- [X] If changing or removing attributes, what steps have you taken, if any, to preserve player data ? n/a
- [X] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ? Not a new sheet


