### PR TITLE
[Starfinder (Simple)] Added Operative Sniper to Trick attack

### DIFF
--- a/Starfinder (simple)/Starfinder (simple).html
+++ b/Starfinder (simple)/Starfinder (simple).html
@@ -1309,6 +1309,7 @@
     	            <select title="trick-attack" name="attr_trick-attack">
     	                <option value="" selected>No</option>
 						<option value="&{template:pf_check}{{name=Trick Attack}}{{check=**CR**[[@{trick-attack-skill} - 20]]or lower }} {{foo=If you succeed at the check, you deal @{trick-attack-level} additional damage?{Which condition to apply? | none, | flat-footed, and the target is flat-footed | off-target, and the target is off-target | bleed, and the target is bleeding ?{How much bleed? &amp;#124; 1 &amp;#125; | hampered, and the target is hampered (half speed and no guarded step) | interfering, and the target is unable to take reactions | staggered, and the target is staggered (Fort **DC**[[10+[[(floor(@{level}/2))]]+[[@{DEX-mod}]]]]negates) | stun, and the target is stunned (Fort **DC**[[10+[[(floor(@{level}/2))]]+[[@{DEX-mod}]]]]negates) | knockout, and the target is unconscious for 1 minute (Fort **DC**[[10+[[(floor(@{level}/2))]]+[[@{DEX-mod}]]]]negates) | disarm, and must succeed at a Reflex save **DC**[[10+[[(floor(@{level}/2))]]+[[@{DEX-mod}]]]] or drop that item. | disrupt, and must succeed at a Will save **DC**[[10+[[(floor(@{level}/2))]]+[[@{DEX-mod}]]]] or be unable to cast spells or spell-like abilities for 1 round | knock prone, and must succeed at a reflex save **DC**[[10+[[(floor(@{level}/2))]]+[[@{DEX-mod}]]]] or fall prone. | ricochet, and gain 2nd shot at nearby create at -6 and with no trick damage. | blinding, and must succeed at a Fort save **DC**[[10+[[(floor(@{level}/2))]]+[[@{DEX-mod}]]]] or be blind for 1 round. | deactivating, and [[1d20 + ?{Operative Level? &amp;#124; 1 &amp;#125;]] vs DC 10 + target item level. If success the device is deactivated until your next turn.  Constructs must make a Fort save **DC**[[10+[[(floor(@{level}/2))]]+[[@{DEX-mod}]]]] or be stunned until beginnning of your next turn. } }} {{notes=@{trick-attack-notes} }}">Yes</option>
+						<option value="&{template:pf_check}{{name=Trick Attack}}{{check=**CR * 1.5** [[@{trick-attack-skill} - 20]]or lower }} {{foo=If you succeed at the check, you deal @{trick-attack-level} additional damage?{Which condition to apply? | none, | flat-footed, and the target is flat-footed | off-target, and the target is off-target | bleed, and the target is bleeding ?{How much bleed? &amp;#124; 1 &amp;#125; | hampered, and the target is hampered (half speed and no guarded step) | interfering, and the target is unable to take reactions | staggered, and the target is staggered (Fort **DC**[[10+[[(floor(@{level}/2))]]+[[@{DEX-mod}]]]]negates) | stun, and the target is stunned (Fort **DC**[[10+[[(floor(@{level}/2))]]+[[@{DEX-mod}]]]]negates) | knockout, and the target is unconscious for 1 minute (Fort **DC**[[10+[[(floor(@{level}/2))]]+[[@{DEX-mod}]]]]negates) | disarm, and must succeed at a Reflex save **DC**[[10+[[(floor(@{level}/2))]]+[[@{DEX-mod}]]]] or drop that item. | disrupt, and must succeed at a Will save **DC**[[10+[[(floor(@{level}/2))]]+[[@{DEX-mod}]]]] or be unable to cast spells or spell-like abilities for 1 round | knock prone, and must succeed at a reflex save **DC**[[10+[[(floor(@{level}/2))]]+[[@{DEX-mod}]]]] or fall prone. | ricochet, and gain 2nd shot at nearby create at -6 and with no trick damage. | blinding, and must succeed at a Fort save **DC**[[10+[[(floor(@{level}/2))]]+[[@{DEX-mod}]]]] or be blind for 1 round. | deactivating, and [[1d20 + ?{Operative Level? &amp;#124; 1 &amp;#125;]] vs DC 10 + target item level. If success the device is deactivated until your next turn.  Constructs must make a Fort save **DC**[[10+[[(floor(@{level}/2))]]+[[@{DEX-mod}]]]] or be stunned until beginnning of your next turn. } }} {{notes=@{trick-attack-notes} }}">Sniper</option>
 					</select>
     	        </div>
     	        <div class="row-options">
@@ -1334,6 +1335,8 @@
         		                    <option value="[[10 + [[@{Intimidate}]] ]]">Intimidate (take 10)</option>
 									<option value="[[d20 + [[@{Mysticism}]] +4]]">Disciple's Mysticism</option>
 		                            <option value="[[10 + [[@{Mysticism}]] +4]]">Disciple's Mysticism (take 10)</option>
+									<option value="[[d20 + [[@{Perception}]] ]]">Perception</option>
+		                            <option value="[[10 + [[@{Perception}]] ]]">Perception (take 10)</option>
 		                            <option value="[[d20 + [[@{Sense-Motive}]] +4]]">Detective's Sense Motive</option>
 		                            <option value="[[10 + [[@{Sense-Motive}]] +4]]">Detective's Sense Motive (take 10)</option>
 		                            <option value="[[d20 + [[@{Sleight-of-Hand}]] ]]">Thief's Sleight of Hand</option>
@@ -1358,6 +1361,16 @@
 	                                <option value="[[8d8]]">15</option>
 	                                <option value="[[9d8]]">17</option>
         	                        <option value="[[10d8]]">19</option>
+									<option value="[[1d3]]">Sniper 1</option>
+        	                        <option value="[[1d6]]">Sniper 3</option>
+	                                <option value="[[2d6]]">Sniper 5</option>
+	                                <option value="[[3d6]]">Sniper 7</option>
+	                                <option value="[[4d6]]">Sniper 9</option>
+        	                        <option value="[[5d6]]">Sniper 11</option>
+	                                <option value="[[6d6]]">Sniper 13</option>
+	                                <option value="[[7d6]]">Sniper 15</option>
+	                                <option value="[[8d6]]">Sniper 17</option>
+        	                        <option value="[[9d6]]">Sniper 19</option>
 	                            </select>
                             </span>
                         </div>


### PR DESCRIPTION
## Changes / Comments
Updated Trick attack to include sniper alternate class ability.
Added in Sniper level damages to the list of drop downs for trick attack level.


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [X] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
