### PR TITLE
[Alien Roleplaying Game] Fixed roll template: allprops and stress hits

### DIFF
--- a/Alien Roleplaying Game/Alien-Roleplaying-Game.html
+++ b/Alien Roleplaying Game/Alien-Roleplaying-Game.html
@@ -3,7 +3,8 @@
         v1.01 The Quick Start Rules Adjustments 8/04/2019
         v1.02 Updated some of the layout, adjusted to mirror the layout/tone of the game's character sheet and to make it a bit more understandable after play session feedback 15/08/2020
         V1.03 Yann : adding i18n 21/11/2020
-        v1.04 Richard W: Added ship tab
+        v2.0 Richard W: Added ship tab
+        v2.01 Richard W: Fixed Rolltemplate AllProps and Stress hits
 -->
 
 <input class="tab-sheet" type="hidden" name="attr_tab_sheet" value="Character">
@@ -1559,7 +1560,7 @@
                         <div class="template-stress-between"></div>
                     {{/rollBetween() stress-roll-one 2 5}}
                     {{#rollWasCrit() stress-roll-one}}
-                        <div class="template-stress-success"></div>
+                        <div class="template-stress-success hit"></div>
                     {{/rollWasCrit() stress-roll-one}}
                 </div>
                 {{/rollGreater() stress-dice 0}}
@@ -1573,7 +1574,7 @@
                         <div class="template-stress-between"></div>
                     {{/rollBetween() stress-roll-two 2 5}}
                     {{#rollWasCrit() stress-roll-two}}
-                        <div class="template-stress-success"></div>
+                        <div class="template-stress-success hit"></div>
                     {{/rollWasCrit() stress-roll-two}}
                 </div>
                 {{/rollGreater() stress-dice 1}}
@@ -1587,7 +1588,7 @@
                         <div class="template-stress-between"></div>
                     {{/rollBetween() stress-roll-three 2 5}}
                     {{#rollWasCrit() stress-roll-three}}
-                        <div class="template-stress-success"></div>
+                        <div class="template-stress-success hit"></div>
                     {{/rollWasCrit() stress-roll-three}}
                 </div>
                 {{/rollGreater() stress-dice 2}}
@@ -1601,7 +1602,7 @@
                         <div class="template-stress-between"></div>
                     {{/rollBetween() stress-roll-four 2 5}}
                     {{#rollWasCrit() stress-roll-four}}
-                        <div class="template-stress-success"></div>
+                        <div class="template-stress-success hit"></div>
                     {{/rollWasCrit() stress-roll-four}}
                 </div>
                 {{/rollGreater() stress-dice 3}}
@@ -1615,7 +1616,7 @@
                         <div class="template-stress-between"></div>
                     {{/rollBetween() stress-roll-five 2 5}}
                     {{#rollWasCrit() stress-roll-five}}
-                        <div class="template-stress-success"></div>
+                        <div class="template-stress-success hit"></div>
                     {{/rollWasCrit() stress-roll-five}}
                 </div>
                 {{/rollGreater() stress-dice 4}}
@@ -1629,7 +1630,7 @@
                         <div class="template-stress-between"></div>
                     {{/rollBetween() stress-roll-six 2 5}}
                     {{#rollWasCrit() stress-roll-six}}
-                        <div class="template-stress-success"></div>
+                        <div class="template-stress-success hit"></div>
                     {{/rollWasCrit() stress-roll-six}}
                 </div>
                 {{/rollGreater() stress-dice 5}}
@@ -1643,7 +1644,7 @@
                         <div class="template-stress-between"></div>
                     {{/rollBetween() stress-roll-seven 2 5}}
                     {{#rollWasCrit() stress-roll-seven}}
-                        <div class="template-stress-success"></div>
+                        <div class="template-stress-success hit"></div>
                     {{/rollWasCrit() stress-roll-seven}}
                 </div>
                 {{/rollGreater() stress-dice 6}}
@@ -1657,7 +1658,7 @@
                         <div class="template-stress-between"></div>
                     {{/rollBetween() stress-roll-eight 2 5}}
                     {{#rollWasCrit() stress-roll-eight}}
-                        <div class="template-stress-success"></div>
+                        <div class="template-stress-success hit"></div>
                     {{/rollWasCrit() stress-roll-eight}}
                 </div>
                 {{/rollGreater() stress-dice 7}}
@@ -1671,7 +1672,7 @@
                         <div class="template-stress-between"></div>
                     {{/rollBetween() stress-roll-nine 2 5}}
                     {{#rollWasCrit() stress-roll-nine}}
-                        <div class="template-stress-success"></div>
+                        <div class="template-stress-success hit"></div>
                     {{/rollWasCrit() stress-roll-nine}}
                 </div>
                 {{/rollGreater() stress-dice 8}}
@@ -1685,7 +1686,7 @@
                         <div class="template-stress-between"></div>
                     {{/rollBetween() stress-roll-ten 2 5}}
                     {{#rollWasCrit() stress-roll-ten}}
-                        <div class="template-stress-success"></div>
+                        <div class="template-stress-success hit"></div>
                     {{/rollWasCrit() stress-roll-ten}}
                 </div>
                 {{/rollGreater() stress-dice 9}}
@@ -1784,19 +1785,11 @@
                     </div>
                 {{/current-comment}}
         
-                <!-- {{#allprops() }}
-                    <div class="template-grid-item template-span-six">
-                        {{key}} {{value}}
-                    </div>
-                {{/allprops() }} -->
-        
-        
-          <!--       {{#allprops() character-name roll-name roll-type roll-dice base-dice base-roll-one base-roll-two base-roll-three base-roll-four base-roll-five base-roll-six base-roll-seven base-roll-eight base-roll-nine base-roll-ten base-roll-eleven base-roll-twelve base-roll-thirteen base-roll-fourteen base-roll-fifteen base-roll-sixteen base-roll-seventeen base-roll-eighteen stress-dice stress-roll-one stress-roll-two stress-roll-three stress-roll-four stress-roll-five stress-roll-six stress-roll-seven stress-roll-eight stress-roll-nine stress-roll-ten supply-dice supply-roll-one supply-roll-two supply-roll-three supply-roll-four supply-roll-five supply-roll-six show-weapon current-bonus current-damage current-range current-comment }}
+                {{#allprops() character-name roll-name roll-type roll-dice base-dice base-roll-one base-roll-two base-roll-three base-roll-four base-roll-five base-roll-six base-roll-seven base-roll-eight base-roll-nine base-roll-ten base-roll-eleven base-roll-twelve base-roll-thirteen base-roll-fourteen base-roll-fifteen base-roll-sixteen base-roll-seventeen base-roll-eighteen stress-dice stress-roll-one stress-roll-two stress-roll-three stress-roll-four stress-roll-five stress-roll-six stress-roll-seven stress-roll-eight stress-roll-nine stress-roll-ten supply-dice supply-roll-one supply-roll-two supply-roll-three supply-roll-four supply-roll-five supply-roll-six show-weapon current-bonus current-damage current-range current-comment }}
                     <div class="template-grid-item template-span-six">
                         {{key}} {{value}}
                     </div>
                 {{/allprops() character-name roll-name roll-type roll-dice base-dice base-roll-one base-roll-two base-roll-three base-roll-four base-roll-five base-roll-six base-roll-seven base-roll-eight base-roll-nine base-roll-ten base-roll-eleven base-roll-twelve base-roll-thirteen base-roll-fourteen base-roll-fifteen base-roll-sixteen base-roll-seventeen base-roll-eighteen stress-dice stress-roll-one stress-roll-two stress-roll-three stress-roll-four stress-roll-five stress-roll-six stress-roll-seven stress-roll-eight stress-roll-nine stress-roll-ten supply-dice supply-roll-one supply-roll-two supply-roll-three supply-roll-four supply-roll-five supply-roll-six show-weapon current-bonus current-damage current-range current-comment }}
-         -->
         </div>
     </div>
 </rolltemplate>    


### PR DESCRIPTION
## Changes / Comments
Fixed the rolltemplate so that it again includes allprops section. 
Fixed Success counter to also include the stress dice hits. 

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
