### PR TITLE
[RuneQuest:Glorantha] Changes to account for damage reduction in attack results tables

### DIFF
--- a/RunequestGQS/ReadMe.md
+++ b/RunequestGQS/ReadMe.md
@@ -35,6 +35,12 @@ To remove the experience checkbox from a skill add a - at the start of the name 
 STR and DEX minimums are not currently supported this maybe added in a future release.
 
 
+## 10.06.2021
+
+	To account for damage reduction in the attack results tables
+	Added display of special damage and normal damage to critical attack results
+	Added display of normal damage to critical attack results
+
 ## 23.08.2021
 
 	Added inputs for final attack and parry values

--- a/RunequestGQS/RunequestGQS.html
+++ b/RunequestGQS/RunequestGQS.html
@@ -24,7 +24,7 @@
 
 
 						</div>
-						<b>Version 23.08.2021</b>
+						<b>Version 10.06.2021</b>
 						<input name="attr_versiony" style="background: none; border: currentColor; border-image: none; width: 400px; color: red; font-weight: bold;" type="text" readonly="" value="(https://tinyurl.com/yb9tgmlv)">
 						
 						
@@ -5016,7 +5016,7 @@
 					<input name="attr_is_config" class="sheet-HideConfig" type="checkbox" checked="checked"><span class="sheet-is-config" ><span style='font-family:pictos;' >y</span></span>
 					<div class="sheet-config" style="border-style: dotted; border-color: gray; padding: 5px; background-image: none; background-color: white;">
 						<div>
-							<b>Version 23.08.2021</b> <input name="attr_versiony" style="background: none; border: currentColor; border-image: none; width: 400px; color: red; font-weight: bold;" type="text" readonly="" value="(https://tinyurl.com/yb9tgmlv)">
+							<b>Version 10.06.2021</b> <input name="attr_versiony" style="background: none; border: currentColor; border-image: none; width: 400px; color: red; font-weight: bold;" type="text" readonly="" value="(https://tinyurl.com/yb9tgmlv)">
 						</div><br>
 						<input name="attr_toggleQSSheet" class="sheet-toggleQSSheet" type="checkbox" checked="checked">Display Quick Start Sheet <input name="attr_toggleFullSheet" class="sheet-toggleFullSheet" type="checkbox">Display Full Sheet <input name="attr_toggleNPC1Sheet" class="sheet-toggleNPC1Sheet" type="checkbox">Display NPC Sheet
 					</div>
@@ -10865,7 +10865,7 @@
 							{{#rollLess() roll crit}}
 								{{#rollTotal() type 2}}
 
-										<b>Damage:</b> {{critCrsh}}					
+										<b data-i18n="Damage">Damage:</b> <b data-i18n-title="Maximum" title="Maximum"  data-i18n="M">M</b>:{{critCrsh}} <b  data-i18n-title="Special" title="Special"   data-i18n="S">S</b>:{{crshDam}} <b data-i18n-title="Special" title="Normal"  data-i18n="N">N</b>:{{tot}}					
 
 								{{/rollTotal() type 2}}	
 								{{#^rollTotal() type 2}}
@@ -10873,10 +10873,10 @@
 										
 										<b data-i18n="Damage">Damage:</b>
 										{{#rollTotal() mntTogVal 0}}								
-											{{critSI}}
+											<b data-i18n-title="Maximum" title="Maximum"  data-i18n="M">M</b>:{{critSI}}<b  data-i18n-title="Special" title="Special"   data-i18n="S">S</b>:{{spclDam}} <b data-i18n-title="Special" title="Normal"  data-i18n="N">N</b>:{{tot}}
 										{{/rollTotal() mntTogVal 0}}
 										{{#rollTotal() mntTogVal 1}}							
-											{{mntCrit}}
+											<b data-i18n-title="Maximum" title="Maximum"  data-i18n="M">M</b>:{{mntCrit}} <b  data-i18n-title="Special" title="Special"   data-i18n="S">S</b>:{{mntSpcl}}  <b data-i18n-title="Special" title="Normal"  data-i18n="N">N</b>:{{mntTot}}
 										{{/rollTotal() mntTogVal 1}}
 										
 									
@@ -10889,17 +10889,17 @@
 
 									{{#rollTotal() type 2}}
 									
-											<b data-i18n="Damage">Damage:</b>{{crshDam}}					
+											<b data-i18n="Damage">Damage:</b>  <b  data-i18n-title="Special" title="Special"   data-i18n="S">S</b>:{{crshDam}}	<b data-i18n-title="Special" title="Normal"  data-i18n="N">N</b>:{{tot}}				
 									{{/rollTotal() type 2}}	
 									{{#^rollTotal() type 2}}
 									
 										
 										<b data-i18n="Damage">Damage:</b>
 										{{#rollTotal() mntTogVal 0}}	
-											{{spclDam}}
+											 <b  data-i18n-title="Special" title="Special"   data-i18n="S">S</b>:{{spclDam}} <b data-i18n-title="Special" title="Normal"  data-i18n="N">N</b>:{{tot}}
 										{{/rollTotal() mntTogVal 0}}	
 										{{#rollTotal() mntTogVal 1}}							
-											{{mntSpcl}}
+											<b  data-i18n-title="Special" title="Special"   data-i18n="S">S</b>:{{mntSpcl}} <b data-i18n-title="Special" title="Normal"  data-i18n="N">N</b>:{{mntTot}}
 										{{/rollTotal() mntTogVal 1}}								
 										
 									{{/^rollTotal() type 2}}

--- a/RunequestGQS/translation.json
+++ b/RunequestGQS/translation.json
@@ -1,4 +1,10 @@
 {
+	"Special":"Special",
+	"Maximum":"Maximum",
+	"Normal":"Normal",
+	"M":"M", 
+	"S":"S", 	
+	"N":"N", 	
 	"other-notes":"Other Notes",
 	"combat-notes":"Combat Notes",	
 	"show-othrunes":"Show Other Runes",


### PR DESCRIPTION
## Changes / Comments

	To account for damage reduction in the attack results tables
	Added display of special damage and normal damage to critical attack results
	Added display of normal damage to critical attack results

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
