### PR TITLE
Correct the formula for spell skill values in dod_91.html

### DIFF
--- a/Drakar_och_Demoner-91/dod_91.html
+++ b/Drakar_och_Demoner-91/dod_91.html
@@ -1995,7 +1995,7 @@
                                             name="attr_besvarjelse_1_text" /></div>
                                     <div class="sheet-dod-roll-d20-right">
                                         <button class="sheet-dod-roll-button" type="roll" name="roll_besvarjelse_1"
-                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_1_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_1_s}-((?{Effektgrad}*2)+2)]]}}">
+                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_1_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_1_s}-(?{Effektgrad}*2)+2]]}}">
                                         </button>
                                     </div>
                                 </div>
@@ -2010,7 +2010,7 @@
                                             name="attr_besvarjelse_2_text" /></div>
                                     <div class="sheet-dod-roll-d20-right">
                                         <button class="sheet-dod-roll-button" type="roll" name="roll_besvarjelse_2"
-                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_2_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_2_s}-((?{Effektgrad}*2)+2)]]}}">
+                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_2_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_2_s}-(?{Effektgrad}*2)+2]]}}">
                                         </button>
                                     </div>
                                 </div>
@@ -2025,7 +2025,7 @@
                                             name="attr_besvarjelse_3_text" /></div>
                                     <div class="sheet-dod-roll-d20-right">
                                         <button class="sheet-dod-roll-button" type="roll" name="roll_besvarjelse_3"
-                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_3_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_3_s}-((?{Effektgrad}*2)+2)]]}}">
+                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_3_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_3_s}-(?{Effektgrad}*2)+2]]}}">
                                         </button>
                                     </div>
                                 </div>
@@ -2040,7 +2040,7 @@
                                             name="attr_besvarjelse_4_text" /></div>
                                     <div class="sheet-dod-roll-d20-right">
                                         <button class="sheet-dod-roll-button" type="roll" name="roll_besvarjelse_4"
-                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_4_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_4_s}-((?{Effektgrad}*2)+2)]]}}">
+                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_4_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_4_s}-(?{Effektgrad}*2)+2]]}}">
                                         </button>
                                     </div>
                                 </div>
@@ -2055,7 +2055,7 @@
                                             name="attr_besvarjelse_5_text" /></div>
                                     <div class="sheet-dod-roll-d20-right">
                                         <button class="sheet-dod-roll-button" type="roll" name="roll_besvarjelse_5"
-                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_5_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_5_s}-((?{Effektgrad}*2)+2)]]}}">
+                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_5_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_5_s}-(?{Effektgrad}*2)+2]]}}">
                                         </button>
                                     </div>
                                 </div>
@@ -2070,7 +2070,7 @@
                                             name="attr_besvarjelse_6_text" /></div>
                                     <div class="sheet-dod-roll-d20-right">
                                         <button class="sheet-dod-roll-button" type="roll" name="roll_besvarjelse_6"
-                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_6_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_6_s}-((?{Effektgrad}*2)+2)]]}}">
+                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_6_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_6_s}-(?{Effektgrad}*2)+2]]}}">
                                         </button>
                                     </div>
                                 </div>
@@ -2085,7 +2085,7 @@
                                             name="attr_besvarjelse_7_text" /></div>
                                     <div class="sheet-dod-roll-d20-right">
                                         <button class="sheet-dod-roll-button" type="roll" name="roll_besvarjelse_7"
-                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_7_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_7_s}-((?{Effektgrad}*2)+2)]]}}">
+                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_7_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_7_s}-(?{Effektgrad}*2)+2]]}}">
                                         </button>
                                     </div>
                                 </div>
@@ -2100,7 +2100,7 @@
                                             name="attr_besvarjelse_8_text" /></div>
                                     <div class="sheet-dod-roll-d20-right">
                                         <button class="sheet-dod-roll-button" type="roll" name="roll_besvarjelse_8"
-                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_8_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_8_s}-((?{Effektgrad}*2)+2)]]}}">
+                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_8_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_8_s}-(?{Effektgrad}*2)+2]]}}">
                                         </button>
                                     </div>
                                 </div>
@@ -2115,7 +2115,7 @@
                                             name="attr_besvarjelse_9_text" /></div>
                                     <div class="sheet-dod-roll-d20-right">
                                         <button class="sheet-dod-roll-button" type="roll" name="roll_besvarjelse_9"
-                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_9_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_9_s}-((?{Effektgrad}*2)+2)]]}}">
+                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_9_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_9_s}-(?{Effektgrad}*2)+2]]}}">
                                         </button>
                                     </div>
                                 </div>
@@ -2130,7 +2130,7 @@
                                             name="attr_besvarjelse_10_text" /></div>
                                     <div class="sheet-dod-roll-d20-right">
                                         <button class="sheet-dod-roll-button" type="roll" name="roll_besvarjelse_10"
-                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_10_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_10_s}-((?{Effektgrad}*2)+2)]]}}">
+                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_10_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_10_s}-(?{Effektgrad}*2)+2]]}}">
                                         </button>
                                     </div>
                                 </div>
@@ -2145,7 +2145,7 @@
                                             name="attr_besvarjelse_11_text" /></div>
                                     <div class="sheet-dod-roll-d20-right">
                                         <button class="sheet-dod-roll-button" type="roll" name="roll_besvarjelse_11"
-                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_11_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_11_s}-((?{Effektgrad}*2)+2)]]}}">
+                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_11_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_11_s}-(?{Effektgrad}*2)+2]]}}">
                                         </button>
                                     </div>
                                 </div>
@@ -2160,7 +2160,7 @@
                                             name="attr_besvarjelse_12_text" /></div>
                                     <div class="sheet-dod-roll-d20-right">
                                         <button class="sheet-dod-roll-button" type="roll" name="roll_besvarjelse_12"
-                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_12_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_12_s}-((?{Effektgrad}*2)+2)]]}}">
+                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_12_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_12_s}-(?{Effektgrad}*2)+2]]}}">
                                         </button>
                                     </div>
                                 </div>
@@ -2175,7 +2175,7 @@
                                             name="attr_besvarjelse_13_text" /></div>
                                     <div class="sheet-dod-roll-d20-right">
                                         <button class="sheet-dod-roll-button" type="roll" name="roll_besvarjelse_13"
-                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_13_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_13_s}-((?{Effektgrad}*2)+2)]]}}">
+                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_13_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_13_s}-(?{Effektgrad}*2)+2]]}}">
                                         </button>
                                     </div>
                                 </div>
@@ -2190,7 +2190,7 @@
                                             name="attr_besvarjelse_14_text" /></div>
                                     <div class="sheet-dod-roll-d20-right">
                                         <button class="sheet-dod-roll-button" type="roll" name="roll_besvarjelse_14"
-                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_14_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_14_s}-((?{Effektgrad}*2)+2)]]}}">
+                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_14_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_14_s}-(?{Effektgrad}*2)+2]]}}">
                                         </button>
                                     </div>
                                 </div>
@@ -2205,7 +2205,7 @@
                                             name="attr_besvarjelse_15_text" /></div>
                                     <div class="sheet-dod-roll-d20-right">
                                         <button class="sheet-dod-roll-button" type="roll" name="roll_besvarjelse_15"
-                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_15_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_15_s}-((?{Effektgrad}*2)+2)]]}}">
+                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_15_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_15_s}-(?{Effektgrad}*2)+2]]}}">
                                         </button>
                                     </div>
                                 </div>
@@ -2220,7 +2220,7 @@
                                             name="attr_besvarjelse_16_text" /></div>
                                     <div class="sheet-dod-roll-d20-right">
                                         <button class="sheet-dod-roll-button" type="roll" name="roll_besvarjelse_16"
-                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_16_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_16_s}-((?{Effektgrad}*2)+2)]]}}">
+                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_16_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_16_s}-(?{Effektgrad}*2)+2]]}}">
                                         </button>
                                     </div>
                                 </div>
@@ -2235,7 +2235,7 @@
                                             name="attr_besvarjelse_17_text" /></div>
                                     <div class="sheet-dod-roll-d20-right">
                                         <button class="sheet-dod-roll-button" type="roll" name="roll_besvarjelse_17"
-                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_17_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_17_s}-((?{Effektgrad}*2)+2)]]}}">
+                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_17_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_17_s}-(?{Effektgrad}*2)+2]]}}">
                                         </button>
                                     </div>
                                 </div>
@@ -2250,7 +2250,7 @@
                                             name="attr_besvarjelse_18_text" /></div>
                                     <div class="sheet-dod-roll-d20-right">
                                         <button class="sheet-dod-roll-button" type="roll" name="roll_besvarjelse_18"
-                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_18_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_18_s}-((?{Effektgrad}*2)+2)]]}}">
+                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_18_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_18_s}-(?{Effektgrad}*2)+2]]}}">
                                         </button>
                                     </div>
                                 </div>
@@ -2265,7 +2265,7 @@
                                             name="attr_besvarjelse_19_text" /></div>
                                     <div class="sheet-dod-roll-d20-right">
                                         <button class="sheet-dod-roll-button" type="roll" name="roll_besvarjelse_19"
-                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_19_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_19_s}-((?{Effektgrad}*2)+2)]]}}">
+                                            value="&{template:dodDefault} {{char_name=@{character_name}}} {{skill_name=@{besvarjelse_19_text}}} {{rolls=[[1d20cs1cf20]]}} {{effectgrade=?{Effektgrad|1}}} {{skill=[[@{besvarjelse_19_s}-(?{Effektgrad}*2)+2]]}}">
                                         </button>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Changes / Comments

Fixing a bug regarding how spell skill values are calculated.

The formula should be FV - (2 * E) + 2 not FV - ((2 * E) + 2).

Previously FV 10 and E 1 gave Skill 6
Now FV 10 and E 1 gives Skill 10.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
