### PR TITLE
[Shadowrun 3e] - metatype bugfix

### DIFF
--- a/Shadowrun3e/shadowrun3e.html
+++ b/Shadowrun3e/shadowrun3e.html
@@ -29,7 +29,6 @@
                 <option value="Human" data-i18n="human" selected>Human</option>
                 <option value="Dwarf" data-i18n="dwarf">Dwarf</option>
                 <option value="Elf" data-i18n="efl">Elf</option>
-        <input type='hidden' class='buttontoggle' name='attr_sheettype' value="Character" />
                 <option value="Ork" data-i18n="ork">Ork</option>
                 <option value="Troll" data-i18n="troll">Troll</option>
             </select>


### PR DESCRIPTION
## Changes / Comments
Ork, Troll and Dwarf were not displaying in the metatype dropdown menu. 





## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
