### PR TITLE
[Repository] fix LF line endings enforcement

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,21 @@
 # Auto detect text files and perform LF normalization
-text auto
+* text=auto  eol=lf
 
 # Ensure LF line endings for these files
-*.css	eol=lf
-*.htm	eol=lf
-*.html	eol=lf
-*.json	eol=lf
+*.css   text eol=lf
+*.htm	  text eol=lf
+*.html  text eol=lf
+*.json  text eol=lf
+
+# Scripts
+*.bash  text eol=lf
+*.fish  text eol=lf
+*.sh    text eol=lf
+*.zsh   text eol=lf
+# These are explicitly windows files and should use crlf
+*.bat   text eol=crlf
+*.cmd   text eol=crlf
+*.ps1   text eol=crlf
 
 # Custom for Visual Studio
 *.cs     diff=csharp
@@ -26,3 +36,5 @@ text auto
 *.PDF	 diff=astextplain
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
+*.md   text diff=markdown
+*.MD   text diff=markdown


### PR DESCRIPTION
## Changes
* Update `.gitattributes` to properly enforce LF eol on files.
* couple of other recommended `.gitattributes` changes

## Comments
As mentioned in #9675, it seems the repo doesn't enforce LF line endings for some people, even though the [.gitattributes](https://github.com/Roll20/roll20-character-sheets/blob/master/.gitattributes) seems to have `text auto`, and I suspect we should set it as`* text=auto  eol=lf`, as suggested [here](https://www.aleksandrhovhannisyan.com/blog/crlf-vs-lf-normalizing-line-endings-in-git/#a-simple-gitattributes-config).

Past Issues caused by this: #9450, #8463, #8191, #8092 

Places that states `* text=auto` is the correct syntax:
* [Git-scm - gitattributes](https://git-scm.com/docs/gitattributes)
  * [Git v.2.10 Release note example](https://github.com/git/git/blob/master/Documentation/RelNotes/2.10.0.txt#L248)
* [Github Docs](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#example)
* [mdn/content](https://github.com/mdn/content/blob/main/.gitattributes)
* [Stackoverflow - How do I force git to use LF instead of CR+LF under windows?](https://stackoverflow.com/questions/2517190/how-do-i-force-git-to-use-lf-instead-of-crlf-under-windows)
* [Stackoverflow - How to change line-ending settings](https://stackoverflow.com/questions/10418975/how-to-change-line-ending-settings)