### PR TITLE
Impulse_Drive: Updated apostrophes from â�� to character 39

### DIFF
--- a/Impulse_Drive/Impulse Drive.html
+++ b/Impulse_Drive/Impulse Drive.html
@@ -191,11 +191,11 @@
                 <ul class="sheet-list-plain">
                     <li class="odd">
                         <input name="attr_harmch1" class="sheet-fancy-checkbox" type="checkbox" /><span></span>
-                        <label>Just a Scratch:</label>Youâre a bit banged up, but itâs nothing serious. Can be healed by choosing Shrug it off when you roll Recover, or when a Scene ends.
+                        <label>Just a Scratch:</label>You're a bit banged up, but it's nothing serious. Can be healed by choosing Shrug it off when you roll Recover, or when a Scene ends.
                     </li>
                     <li>
                         <input name="attr_harmch2" class="sheet-fancy-checkbox" type="checkbox" /><span></span>
-                        <label>Iâm Rattled:</label> Youâre shaken and shocked, you have Disadvantage ongoing to any +Slick or +Calculating rolls. Can be healed by choosing Shrug it off when you roll Recover, or when a Scene ends.
+                        <label>I'm Rattled:</label> You're shaken and shocked, you have Disadvantage ongoing to any +Slick or +Calculating rolls. Can be healed by choosing Shrug it off when you roll Recover, or when a Scene ends.
                     </li>
                     <li class="odd">
                         <input name="attr_harmch3" class="sheet-fancy-checkbox" type="checkbox" /><span></span>
@@ -203,11 +203,11 @@
                     </li>
                     <li>
                         <input name="attr_harmch4" class="sheet-fancy-checkbox" type="checkbox" /><span></span>
-                        <label>Iâm Knocked out:</label> Youâve been knocked unconscious and canât move, act, or even see anything.  Can be healed when an Ally chooses âFirst Aidâ when they roll Recover, or when a Scene ends.
+                        <label>I'm Knocked out:</label> You've been knocked unconscious and can't move, act, or even see anything.  Can be healed when an Ally chooses âFirst Aidâ when they roll Recover, or when a Scene ends.
                     </li>
                     <li class="odd">
                         <input name="attr_harmch5" class="sheet-fancy-checkbox" type="checkbox" /><span></span>
-                        <label>I canât go on:</label> Your journey is over, you pass away, unmourned and unnoticed by the vast black of space.
+                        <label>I can't go on:</label> Your journey is over, you pass away, unmourned and unnoticed by the vast black of space.
 
                     </li>
                 </ul>
@@ -440,8 +440,8 @@
                         <b>On a 10+</b>, you get there with no complications. 
                         <b>On a 7-9</b>, you must waste precious time dropping out of Drill-Space in between the stars to let the drive cool down 
                         as events continue without you. The SM will mark an Episode Burn. 
-                        <b>On a 6-</b>, youâre out in the black for longer than anyone should be, 
-                        The SM marks 1 Episode Burn, and each Crew Member suffers 1 Stress from cabin fever and low Life Support by journeyâs end.
+                        <b>On a 6-</b>, you're out in the black for longer than anyone should be, 
+                        The SM marks 1 Episode Burn, and each Crew Member suffers 1 Stress from cabin fever and low Life Support by journey's end.
                     </p>
                 </div>
 
@@ -464,13 +464,13 @@
                     <p class="sheet-note">
                         <b>When you power up your Hyper Drive to jump to a Remote or closer star system,  roll+Alien.</b> 
                         <b>On a 10+, you travel with no complications. </b>
-                        <b>On a 7-9, you get there, but itâs a rough ride. Choose 1.</b> 
+                        <b>On a 7-9, you get there, but it's a rough ride. Choose 1.</b> 
                         <b>On a 6-, you get there, but the SM chooses 2:</b>
                         <ul>
                             <li>You have to maneuver and work the drive hard to avoid the worst hyperspace turbulence, Mark 1 Maintenance.</li>
-                            <li>You donât come out exactly where you expected.</li>
+                            <li>You don't come out exactly where you expected.</li>
                             <li>Your ship sustained 1 Damage, Penetrating during the trip.</li>
-                            <li>Youâve picked up an unlikely passenger.</li>
+                            <li>You've picked up an unlikely passenger.</li>
                             <li>The SM asks each Crew Member a question from The Abyss Stares Back.</li>
                         </ul>
                     </p>
@@ -553,7 +553,7 @@
                     <li class="odd">
                         <input type="checkbox" class="sheet-fancy-checkbox" name="attr_superficial_damage" /><span></span>
                         <label>Superficial Damage:</label>
-                        Carbon scoring, melted plating, or scratched paint. Superficial Damage makes your ship look uglier, but it doesnât have any other negative effects.
+                        Carbon scoring, melted plating, or scratched paint. Superficial Damage makes your ship look uglier, but it doesn't have any other negative effects.
                     </li>
                     <li>
                         <input type="checkbox" class="sheet-fancy-checkbox" name="attr_directhit" /><span></span>


### PR DESCRIPTION
Character Sheet for Impulse Drive.

## Changes / Comments

Characters for apostrophes was causing display issues in Roll20 (using Chrome).
Original:  Iâ��m Rattled: Youâ��re shaken and shocked
Updated: I'm Rattled: You're shaken and shocked


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [Y] Does the pull request title have the sheet name(s)? Include each sheet name.
- [Y] Is this a bug fix?
- [N] Does this add functional enhancements (new features or extending existing features) ?
- [N] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [N] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [N/A] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
