### PR TITLE
MnM 3E Official macro fixes

### DIFF
--- a/Mutants and Masterminds 3E Official/mutants-and-masterminds3e.html
+++ b/Mutants and Masterminds 3E Official/mutants-and-masterminds3e.html
@@ -1725,6 +1725,7 @@
           <fieldset class="repeating_equipment">
             <input class="controller" type="hidden" name="attr_element_type" value="menu">
             <input type="hidden" name="attr_label">
+            <input type="hidden" name="attr_descriptor">
             <input type="hidden" name="attr_crit" value="20">
             <input type="hidden" name="attr_damage" value="0">
             <input type="hidden" name="attr_afflictions_type">
@@ -1762,6 +1763,7 @@
           <fieldset class="repeating_vehicles">
             <input class="controller" type="hidden" name="attr_element_type" value="menu">
             <input type="hidden" name="attr_label">
+            <input type="hidden" name="attr_descriptor">
             <input type="hidden" name="attr_crit" value="20">
             <input type="hidden" name="attr_damage" value="0">
             <input type="hidden" name="attr_afflictions_type">
@@ -1798,6 +1800,7 @@
           <fieldset class="repeating_headquarters">
             <input class="controller" type="hidden" name="attr_element_type" value="menu">
             <input type="hidden" name="attr_label">
+            <input type="hidden" name="attr_descriptor">
             <input type="hidden" name="attr_crit" value="20">
             <input type="hidden" name="attr_damage" value="0">
             <input type="hidden" name="attr_afflictions_type">

--- a/Mutants and Masterminds 3E Official/mutants-and-masterminds3e.html
+++ b/Mutants and Masterminds 3E Official/mutants-and-masterminds3e.html
@@ -1,5 +1,5 @@
 <!---Mutants n Masterminds 3E Official Sheet by Green Ronin, sheet authors Richard Tran and Scott Casey
-  v1.0 -- Initial release
+  v1.02 -- Initial release
   ---> 
 <input type="hidden" name="attr_op_animation" value="on">
 <input type="hidden" name="attr_op_bleach" value="0">
@@ -2382,7 +2382,7 @@
   // If its in a repeating section, make sure its in repeating_section_details. 
   // Make sure its in the cascade
   //# Script Variables #
-  const version = 1.1;
+  const version = 1.02;
   //Object that defines how the attributes affect each other
   const abilities = ['strength','stamina','agility','dexterity','fighting','intellect','awareness','presence'];
   const defenses = ['dodge','parry','fortitude','toughness','will'];

--- a/Mutants and Masterminds 3E Official/mutants-and-masterminds3e.html
+++ b/Mutants and Masterminds 3E Official/mutants-and-masterminds3e.html
@@ -2382,7 +2382,7 @@
   // If its in a repeating section, make sure its in repeating_section_details. 
   // Make sure its in the cascade
   //# Script Variables #
-  const version = 0.2;
+  const version = 1.1;
   //Object that defines how the attributes affect each other
   const abilities = ['strength','stamina','agility','dexterity','fighting','intellect','awareness','presence'];
   const defenses = ['dodge','parry','fortitude','toughness','will'];


### PR DESCRIPTION
The attribute descriptor wasn't being passed on to attack macros in repeating sections outside of basic Powers.

## Changes / Comments






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
