### PR TITLE
Runequest 6 | Remove extra closing brace on the first combat weapon row

### DIFF
--- a/Runequest_6/Runequest_6.css
+++ b/Runequest_6/Runequest_6.css
@@ -693,9 +693,9 @@ td.sheet-effect_mp_cost {
 .sheet-rolltemplate-runequest caption {
   text-align: center;
   background: url(http://i.imgur.com/VnqY9Kh.png);
-  color: #F59111;
+  color: #fffbf6;
   font-weight: bold;
-  padding: 2px;
+  padding: 4px;
   border: 1px solid black;
   line-height: 1.5em;
 }
@@ -734,9 +734,9 @@ td.sheet-effect_mp_cost {
 .sheet-rolltemplate-runequest-weapon caption {
   text-align: center;
   background: url(http://i.imgur.com/VnqY9Kh.png);
-  color: #F59111;
+  color: #fffbf6;
   font-weight: bold;
-  padding: 2px;
+  padding: 4px;
   border: 1px solid black;
   line-height: 1.5em;
 }

--- a/Runequest_6/Runequest_6.html
+++ b/Runequest_6/Runequest_6.html
@@ -703,7 +703,7 @@
                   </tr>
                   <tr>
                       <td class="weapon"><input class="full" type="text" name="attr_weapon1_name"/></td>
-                      <td class="weapon_damage"><input class="damage" type="text" name="attr_weapon1_damage"/><select name="attr_weapon1_db" class="db"><option value="0" selected>+0</option><option value="@{damage_mod}">+db</option></select><button type="roll" name="roll_weapon1_damage_check" value="&{template:runequest-weapon} {{name=@{weapon1_name}}} {{damage=[[@{weapon1_damage}+@{weapon1_db}]]}} {{size=@{weapon1_size}}} {{impale_size=@{weapon1_impale_size}}} {{effects=@{weapon1_effects}}}}"/></td>
+                      <td class="weapon_damage"><input class="damage" type="text" name="attr_weapon1_damage"/><select name="attr_weapon1_db" class="db"><option value="0" selected>+0</option><option value="@{damage_mod}">+db</option></select><button type="roll" name="roll_weapon1_damage_check" value="&{template:runequest-weapon} {{name=@{weapon1_name}}} {{damage=[[@{weapon1_damage}+@{weapon1_db}]]}} {{size=@{weapon1_size}}} {{impale_size=@{weapon1_impale_size}}} {{effects=@{weapon1_effects}}}"/></td>
                       <td class="weapon_size"><input class="value_full" type="text" name="attr_weapon1_size"/></td>
                       <td class="weapon_reach"><input class="value_full" type="text" name="attr_weapon1_reach"/></td>
                       <td class="weapon_enc"><input class="value_full" type="number" name="attr_weapon1_enc" value="0"/></td>


### PR DESCRIPTION
## Changes / Comments
Runequest_6.html
Bugfix
Removed extra closing brace on the first button to roll weapon damage, adding an "}" character on the Effects cell when the input is empty.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
