### PR TITLE
[D&D_BECM] Clarified and changed names of the basic armors for in BDnDsheet

### DIFF
--- a/D&D_BECM/BDnDSheet.html
+++ b/D&D_BECM/BDnDSheet.html
@@ -897,12 +897,12 @@
 						<div class="sheet-col-2-3 sheet-small-label sheet-center">
 							<select name="attr_eqarmour">
 								<option value="0" selected="selected">None</option>
-								<option value="200">Leather</option>
-								<option value="300">Scale</option>
-								<option value="400">Chain</option>
-								<option value="450">Banded</option>
-								<option value="500">Plate</option>
-								<option value="750">Suit</option>
+								<option value="200">Leather Armor (AC 7)</option>
+								<option value="300">Scale Mail (AC 6)</option>
+								<option value="400">Chain Mail (AC 5)</option>
+								<option value="450">Banded Mail (AC 4)</option>
+								<option value="500">Plate Mail (AC 3)</option>
+								<option value="750">Suit Armor (AC 0)</option>
 								<option value="50">Protective Skins</option>
 								<option value="150">Fur</option>
 								<option value="80">Paper</option>									
@@ -921,7 +921,7 @@
 								<option value="350">Lamellare</option>									
 								<option value="400">Chainmail</option>
 								<option value="450">Splint</option>
-								<option value="500">Banded Mail</option>
+								<option value="500">Banded-Mail</option>
 								<option value="600">Plate-mail</option>
 								<option value="900">Full Plate</option>
 							</select>


### PR DESCRIPTION
## Changes / Comments
changes to BDnDsheet

Changed the names of the basic armors from the rules cyclopedia to match those in the book and made them clearly stand out as the basic options by adding the AC value in the name




## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
