### PR TITLE
Twilight 2000 4th Edition | Update Vehicle Reliability from Letter to Number

### DIFF
--- a/T2K 4e/twilight-2k-4e.html
+++ b/T2K 4e/twilight-2k-4e.html
@@ -1213,11 +1213,12 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=Coolnes
         <input type="text" name="attr_vehicle_one_name" class="input-text vehicle-one vehicle-name" />
         <input type="text" name="attr_vehicle_one_type" class="input-text vehicle-one vehicle-type" />
         <select name='attr_vehicle_one_reliability' class="vehicle-one vehicle-rel short">
-            <option value=''>-</option>
-            <option value='A'>A</option>
-            <option value='B'>B</option>
-            <option value='C'>C</option>
-            <option value='D'>D</option>
+	    <option value='0'>0</option>
+	    <option value='1'>1</option>
+	    <option value='2'>2</option>
+	    <option value='3'>3</option>
+	    <option value='4'>4</option>
+	    <option value='5'>5</option>
         </select>
         <input type="text" name="attr_vehicle_one_speed_travel" class="input-text vehicle-one vehicle-travel-speed short-input" />
         <input type="text" name="attr_vehicle_one_speed_combat" class="input-text vehicle-one vehicle-combat-speed short-input" />
@@ -1385,11 +1386,12 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=Coolnes
         <input type="text" name="attr_vehicle_two_name" class="input-text vehicle-one vehicle-name" />
         <input type="text" name="attr_vehicle_two_type" class="input-text vehicle-one vehicle-type" />
         <select name='attr_vehicle_two_reliability' class="vehicle-one vehicle-rel short">
-            <option value=''>-</option>
-            <option value='A'>A</option>
-            <option value='B'>B</option>
-            <option value='C'>C</option>
-            <option value='D'>D</option>
+	    <option value='0'>0</option>
+	    <option value='1'>1</option>
+	    <option value='2'>2</option>
+	    <option value='3'>3</option>
+	    <option value='4'>4</option>
+	    <option value='5'>5</option>
         </select>
         <input type="text" name="attr_vehicle_two_speed_travel" class="input-text vehicle-one vehicle-travel-speed short-input" />
         <input type="text" name="attr_vehicle_two_speed_combat" class="input-text vehicle-one vehicle-combat-speed short-input" />
@@ -1557,11 +1559,12 @@ value="&{template:t2k} {{character-name=@{character_name} }} {{roll-name=Coolnes
         <input type="text" name="attr_vehicle_three_name" class="input-text vehicle-one vehicle-name" />
         <input type="text" name="attr_vehicle_three_type" class="input-text vehicle-one vehicle-type" />
         <select name='attr_vehicle_three_reliability' class="vehicle-one vehicle-rel short">
-            <option value=''>-</option>
-            <option value='A'>A</option>
-            <option value='B'>B</option>
-            <option value='C'>C</option>
-            <option value='D'>D</option>
+	    <option value='0'>0</option>
+	    <option value='1'>1</option>
+	    <option value='2'>2</option>
+	    <option value='3'>3</option>
+	    <option value='4'>4</option>
+	    <option value='5'>5</option>
         </select>
         <input type="text" name="attr_vehicle_three_speed_travel" class="input-text vehicle-one vehicle-travel-speed short-input" />
         <input type="text" name="attr_vehicle_three_speed_combat" class="input-text vehicle-one vehicle-combat-speed short-input" />


### PR DESCRIPTION
Another change from Alpha to full release.

## Changes / Comments

Replaces the Alpha letter system for vehicle reliability with the official release version of using a number.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- Yes. A correction between the alpha ruleset and the official release
- [x] Does this add functional enhancements (new features or extending existing features) ?
- It does not.
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- It does not.
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- Unfortunately because of the change, there isn't a way to preserve existing data, however the change is mostly minor and doesn't impact any sheet-based roles.
- [x] If this is a new sheet, did you follow [Building Character Sheets standards]
- Not applicable.
(https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
