### PR TITLE
[Warhammer Fantasy Roleplay 4e Official] fixed Polish translation of …

### DIFF
--- a/Warhammer Fantasy Roleplay 4e Official/translations/pl.json
+++ b/Warhammer Fantasy Roleplay 4e Official/translations/pl.json
@@ -134,7 +134,7 @@
     "Sleight of Hand": "Zwinne palce",
     "Stealth": "Skradanie",
     "Swim": "Pływanie",
-    "Track": "Utwór",
+    "Track": "Tropienie",
     "Trade": "Rzemiosło",
     "Talents": "Talenty",
     "Ranks": "Rangi",


### PR DESCRIPTION
…a word Track

## Changes / Comments
- changed wrong translation of a word 'track' in Polish translation sheet
- as a comparison, there is a correct translation in [Warhammer 4e Character Sheet]
- https://github.com/Roll20/roll20-character-sheets/blob/master/Warhammer%204e%20Character%20Sheet/translations/pl.json#L259





## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ YES] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ YES] Is this a bug fix?
- [NO ] Does this add functional enhancements (new features or extending existing features) ?
- [NO ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ NOT APPLICABLE] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ NOT APPLICABLE] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
