### PR TITLE
Robotech: The Macross Saga | Fix for Drama not being saved on sheet.

### DIFF
--- a/Robotech The Macross Saga (SMG)/robotech.html
+++ b/Robotech The Macross Saga (SMG)/robotech.html
@@ -47,9 +47,9 @@
             </div>
 
             <div class="rowflex nowrap">
-                <input class="dramaDesc" type="text" />
-                <input class="dramaDesc" type="text" />
-                <input class="dramaDesc" type="text" />
+                <input class="dramaDesc" type="text" name="attr_drama_1"/>
+                <input class="dramaDesc" type="text" name="attr_drama_3"/>
+                <input class="dramaDesc" type="text" name="attr_drama_3"/>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Drama was only defined as a field, and didn't have a variable assigned to each field. As a result, every time the sheet was closed and then opened, the changes vanished.

## Changes / Comments






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
