### PR TITLE
[Warhammer 4e Character Sheet] DW changes

### DIFF
--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -46868,7 +46868,17 @@ on('clicked:meleeattackoff clicked:meleechargeoff clicked:furiousassaultoff clic
 	if (eventInfo.sourceType === 'sheetworker') return;
 			getAttrs(["Used_DefenseWeaponSkill", "Talent_AmbidextrousLvl","Used_MeleeTwohanded","Advantageinput","LastRollMain","LastCritRoll", "Talent_BattleRageLvl", "Talent_FrenzyLvl", "MeleeMode_Frenzy", "MeleeMode_BNE", "MeleeMode_Infight", "MeleeMode_Drilled"], function(values) {	
 			
-			lastcrit = values.LastCritRoll;
+
+	 		prevcrit = JSON.stringify(values["LastCritRoll"])||0;
+			if (prevcrit >= 1 && prevcrit <= 9) {
+			prevcrit2 = JSON.stringify(prevcrit * 10)||0;
+               console.log(prevcrit2);
+			prevcrit = prevcrit2.split("").reverse().join("");   
+			}
+			critrevc = prevcrit.split("").reverse().join("");
+			if (critrevc == "001") {critrevc = "100"}
+			lastcrit = parseInt(critrevc)||0;			
+			
 	 		prevroll = JSON.stringify(values["LastRollMain"])||0;
 			if (prevroll >= 1 && prevroll <= 9) {
 			prevroll2 = JSON.stringify(prevroll * 10)||0;
@@ -46899,10 +46909,12 @@ on('clicked:meleeattackoff clicked:meleechargeoff clicked:furiousassaultoff clic
 	}
 	if (trigger == "dualwieldoff") {rollEnd = ' {{berserkcharge=[[0]]}} {{RTfuriousassault=@{RT-furiousassaultoff}}} {{furiousassault=[[@{Talent_FuriousAssaultLvl}]]}} {{reroll=@{RT-reroll}MeleeAttackOff)}} {{dualwield=[[@{Talent_DualWielderLvl}]]}} {{dwuse}}';
 	rollPart2 = roll.replaceAll('>addsl<', '+@{Talent_DualWielderLvl}>addsldf<');
+	if (lastcrit > 0) {	
+	rollPart3 = rollPart2.replaceAll('>test<', `${lastcrit}`);
+	} else {	
 	rollPart3 = rollPart2.replaceAll('>test<', `${rollrev}`);
-	if (lastcrit > 0) {rollPart4 = rollPart3.replaceAll('>target<', `${lastcrit}`);
-	} else {rollPart4 = rollPart3.replaceAll('>target<', ' [[@{condgen_see_move}*-1]] [COND] + [[>ambi<]] [PEN] + [[@{Used_DefenseWeaponSkill}]] [SKILL] + ?{Opposed Attack Modifier|@{Used_DefenseBonus}} [MOD] + [[@{Advantage}*10]] [ADV] ');}
 	}
+	rollPart4 = rollPart3.replaceAll('>target<', ' [[@{condgen_see_move}*-1]] [COND] + [[>ambi<]] [PEN] + [[@{Used_DefenseWeaponSkill}]] [SKILL] + ?{Opposed Attack Modifier|@{Used_DefenseBonus}} [MOD] + [[@{Advantage}*10]] [ADV] ');}
 	if (trigger == "meleechargeoff") {rollEnd = '  {{charge=true}} {{berserkcharge=[[@{Talent_BerserkChargeLvl}]]}} {{RTfuriousassault=@{RT-furiousassaultmain}}} {{furiousassault=[[@{Talent_FuriousAssaultLvl}]]}} {{reroll=@{RT-reroll}MeleeChargeOff)}} {{RTdualwield=@{RT-dualwieldmain}}} {{dualwield=[[@{Talent_DualWielderLvl}]]}}';
 	rollPart2 = roll.replaceAll('>addsl<', '+@{Talent_BerserkChargeLvl}>addsldf<');	
 	rollPart3 = rollPart2.replaceAll('>test<', '@{roll_rule}');
@@ -47445,7 +47457,7 @@ on('clicked:repeating_spellbookpetty:spellcast clicked:repeating_spellbookpetty:
 on('clicked:repeating_spellbookarcane:spellcast clicked:repeating_spellbookarcane:spellcastdmg', (eventInfo) => {
 	getAttrs(["initiative_houserule"], function(v) {	
 	
-   let roll = '{{sl=[[0 [Roll SL]]]}} {{slbonus=[[@{Talent_InstinctiveDictionLvl}+@{Talent_PerfectPitchLvl} [SL TOTAL]]]}} {{slbonusatk=[[@{slbonusCast}]]}} {{sladd=[[0]]}} {{modvalue=[[?{@{translation_modifier}|@{prefix2-_SpellMod}}]]}} {{title=@{prefix2-_spellname}}} {{character_name=@{character_name}}} {{advantage=[[@{Advantage}*10*@{Advantage_casting}]]}} {{unconscious=[[@{UnconsciousMod}]]}} {{cond=[[@{condgen_see}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{spelltype=^{PETTY-SPELL}}} {{spellrange=Range: @{prefix2-_spellrange}}} {{spelltarget=Targets: @{prefix2-_spelltarget}}} {{spellduration=Duration: @{prefix2-_spellduration}}} {{target=[[ [[(@{condgen_see}*-1)]] [COND] + [[{@{LangMagick}}]] [SKILL] + ?{@{translation_modifier}|0} [MOD] + [[@{Advantage}*10*@{Advantage_casting}]] [ADV] ]]}} {{spelldescription=@{prefix2-_spelldesc}}} {{test=[[@{roll_rule}]]}} {{SLmod=[[?{SL Modifier|0}]]}} {{spelltest=[[1d10]]}} {{arcanetest=true}} {{rolltype=[[6]]}} {{spellcastingnumber=[[@{prefix2-_spellcastingnumber}]]}} {{accuchanexlsl=[[@{prefix2-_spellchannelsl}]]}} {{mod1type=[[@{prefix2-_ArcaneSpell_modtype1}]]}} {{mod1=@{prefix2-_ArcaneSpell_mod1}}} {{mod2type=[[@{prefix2-_ArcaneSpell_modtype2}]]}} {{mod2=@{prefix2-_ArcaneSpell_mod2}}} {{mod3type=[[@{prefix2-_ArcaneSpell_modtype3}]]}} {{mod3=@{prefix2-_ArcaneSpell_mod3}}} {{NPC=[[0]]}} {{RTminor=@{RT-minor}}} {{RTmajor=@{RT-major}}} {{reroll=[1](~@{character_name}|prefix2-_spellcast)}} {{sptal2=[[@{Talent_InstinctiveDictionLvl}]]}} {{sptal3=[[@{Talent_PerfectPitchLvl}]]}} {{sptal23=[[@{Talent_InstinctiveandPitch}]]}}';
+   let roll = '{{sl=[[0 [Roll SL]]]}} {{slbonus=[[@{Talent_InstinctiveDictionLvl}+@{Talent_PerfectPitchLvl} [SL TOTAL]]]}} {{slbonusatk=[[@{slbonusCast}]]}} {{sladd=[[0]]}} {{modvalue=[[?{@{translation_modifier}|@{prefix2-_SpellMod}}]]}} {{title=@{prefix2-_spellname}}} {{character_name=@{character_name}}} {{advantage=[[@{Advantage}*10*@{Advantage_casting}]]}} {{unconscious=[[@{UnconsciousMod}]]}} {{cond=[[@{condgen_see}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{spelltype=^{ARCANE-SPELL}}} {{spellrange=Range: @{prefix2-_spellrange}}} {{spelltarget=Targets: @{prefix2-_spelltarget}}} {{spellduration=Duration: @{prefix2-_spellduration}}} {{target=[[ [[(@{condgen_see}*-1)]] [COND] + [[{@{LangMagick}}]] [SKILL] + ?{@{translation_modifier}|0} [MOD] + [[@{Advantage}*10*@{Advantage_casting}]] [ADV] ]]}} {{spelldescription=@{prefix2-_spelldesc}}} {{test=[[@{roll_rule}]]}} {{SLmod=[[?{SL Modifier|0}]]}} {{spelltest=[[1d10]]}} {{arcanetest=true}} {{rolltype=[[6]]}} {{spellcastingnumber=[[@{prefix2-_spellcastingnumber}]]}} {{accuchanexlsl=[[@{prefix2-_spellchannelsl}]]}} {{mod1type=[[@{prefix2-_ArcaneSpell_modtype1}]]}} {{mod1=@{prefix2-_ArcaneSpell_mod1}}} {{mod2type=[[@{prefix2-_ArcaneSpell_modtype2}]]}} {{mod2=@{prefix2-_ArcaneSpell_mod2}}} {{mod3type=[[@{prefix2-_ArcaneSpell_modtype3}]]}} {{mod3=@{prefix2-_ArcaneSpell_mod3}}} {{NPC=[[0]]}} {{RTminor=@{RT-minor}}} {{RTmajor=@{RT-major}}} {{reroll=[1](~@{character_name}|prefix2-_spellcast)}} {{sptal2=[[@{Talent_InstinctiveDictionLvl}]]}} {{sptal3=[[@{Talent_PerfectPitchLvl}]]}} {{sptal23=[[@{Talent_InstinctiveandPitch}]]}}';
    var trigger = eventInfo.triggerName.slice(8);
    var skillpre = trigger.split('_');
    var skill = skillpre[3];

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -26650,13 +26650,13 @@
 								<span data-i18n="ABBREVIATE-INITIATIVE"></span>
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-vert-middle">
-								<input class="sheet-center" type="number" name="attr_Talent_NumismaticsLvl" value="0" min="0" max="1" />
+								<input class="sheet-center" type="number" name="attr_Talent_NumismaticsLvl" value="0" min="0" />
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-vert-middle">
 								<input class="sheet-center" type="number" name="attr_Talent_NumismaticsMax" value="@{InitiativeBonus}" disabled />
 							</div>
 							<button class="sheet-right" type="compendium" value="Talents:Numismatics" data-i18n-title="COMPENDIUM-LINK"></button>
-							<span style="font-family: pictos; color: #858585;" data-i18n-title="SHEET-INTEGRATION-NO" >*</span>
+							<span style="font-family: pictos; color: #b89000;" data-i18n-title="SHEET-INTEGRATION-PART" >j</span>
 						</div>
 		<input type="checkbox" name="attr_ShowOldSalt" class="sheet-hidden sheet-hider" value="1" />	
 						<div class="sheet-col-1-2 sheet-vert-top">
@@ -26670,13 +26670,13 @@
 								<span data-i18n="ABBREVIATE-AGILITY"></span>
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-vert-middle">
-								<input class="sheet-center" type="number" name="attr_Talent_OldSaltLvl" value="0" min="0" max="1" />
+								<input class="sheet-center" type="number" name="attr_Talent_OldSaltLvl" value="0" min="0" />
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-vert-middle">
 								<input class="sheet-center" type="number" name="attr_Talent_OldSaltMax" value="@{AgilityBonus}" disabled />
 							</div>
 							<button class="sheet-right" type="compendium" value="Talents:Old Salt" data-i18n-title="COMPENDIUM-LINK"></button>
-							<span style="font-family: pictos; color: #858585;" data-i18n-title="SHEET-INTEGRATION-NO" >*</span>
+							<span style="font-family: pictos; color: #b89000;" data-i18n-title="SHEET-INTEGRATION-PART" >j</span>
 						</div>
 		<input type="checkbox" name="attr_ShowOrientation" class="sheet-hidden sheet-hider" value="1" />	
 						<div class="sheet-col-1-2 sheet-vert-top">
@@ -26690,13 +26690,13 @@
 								<span data-i18n="ABBREVIATE-INITIATIVE"></span>
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-vert-middle">
-								<input class="sheet-center" type="number" name="attr_Talent_OrientationLvl" value="0" min="0" max="1" />
+								<input class="sheet-center" type="number" name="attr_Talent_OrientationLvl" value="0" min="0"/>
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-vert-middle">
 								<input class="sheet-center" type="number" name="attr_Talent_OrientationMax" value="@{InitiativeBonus}" disabled />
 							</div>
 							<button class="sheet-right" type="compendium" value="Talents:Orientation" data-i18n-title="COMPENDIUM-LINK"></button>
-							<span style="font-family: pictos; color: #858585;" data-i18n-title="SHEET-INTEGRATION-NO" >*</span>
+							<span style="font-family: pictos; color: #b89000;" data-i18n-title="SHEET-INTEGRATION-PART" >j</span>
 						</div>
 		<input type="checkbox" name="attr_ShowPanhandle" class="sheet-hidden sheet-hider" value="1" />	
 						<div class="sheet-col-1-2 sheet-vert-top">
@@ -26710,13 +26710,13 @@
 								<span data-i18n="ABBREVIATE-FELLOWSHIP"></span>
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-vert-middle">
-								<input class="sheet-center" type="number" name="attr_Talent_PanhandleLvl" value="0" min="0" max="1" />
+								<input class="sheet-center" type="number" name="attr_Talent_PanhandleLvl" value="0" min="0" />
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-vert-middle">
 								<input class="sheet-center" type="number" name="attr_Talent_PanhandleMax" value="@{FellowshipBonus}" disabled />
 							</div>
 							<button class="sheet-right" type="compendium" value="Talents:Panhandle" data-i18n-title="COMPENDIUM-LINK"></button>
-							<span style="font-family: pictos; color: #858585;" data-i18n-title="SHEET-INTEGRATION-NO" >*</span>
+							<span style="font-family: pictos; color: #b89000;" data-i18n-title="SHEET-INTEGRATION-PART" >j</span>
 						</div>
 		<input type="checkbox" name="attr_ShowPerfectPitch" class="sheet-hidden sheet-hider" value="1" />	
 						<div class="sheet-col-1-2 sheet-vert-top">
@@ -26767,19 +26767,19 @@
 								<input type="checkbox" name="attr_CarrierPharmacist" value="1" />
 							</div>
 							<div class="sheet-col-1-2 sheet-left sheet-vert-middle">
-								<span data-i18n="PANHANDLE">Pharmacist</span>
+								<span data-i18n="PHARMACIST">Pharmacist</span>
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-talents-border">
 								<span data-i18n="ABBREVIATE-INTELLIGENCE"></span>
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-vert-middle">
-								<input class="sheet-center" type="number" name="attr_Talent_PharmacistLvl" value="0" min="0" max="1" />
+								<input class="sheet-center" type="number" name="attr_Talent_PharmacistLvl" value="0" min="0" />
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-vert-middle">
 								<input class="sheet-center" type="number" name="attr_Talent_PharmacistMax" value="@{IntelligenceBonus}" disabled />
 							</div>
 							<button class="sheet-right" type="compendium" value="Talents:Pharmacist" data-i18n-title="COMPENDIUM-LINK"></button>
-							<span style="font-family: pictos; color: #858585;" data-i18n-title="SHEET-INTEGRATION-NO" >*</span>
+							<span style="font-family: pictos; color: #b89000;" data-i18n-title="SHEET-INTEGRATION-PART" >j</span>
 						</div>
 		<input type="checkbox" name="attr_ShowPilot" class="sheet-hidden sheet-hider" value="1" />	
 						<div class="sheet-col-1-2 sheet-vert-top">
@@ -26793,13 +26793,13 @@
 								<span data-i18n="ABBREVIATE-INITIATIVE"></span>
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-vert-middle">
-								<input class="sheet-center" type="number" name="attr_Talent_PilotLvl" value="0" min="0" max="1" />
+								<input class="sheet-center" type="number" name="attr_Talent_PilotLvl" value="0" min="0" />
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-vert-middle">
 								<input class="sheet-center" type="number" name="attr_Talent_PilotMax" value="@{InitiativeBonus}" disabled />
 							</div>
 							<button class="sheet-right" type="compendium" value="Talents:Pilot" data-i18n-title="COMPENDIUM-LINK"></button>
-							<span style="font-family: pictos; color: #858585;" data-i18n-title="SHEET-INTEGRATION-NO" >*</span>
+							<span style="font-family: pictos; color: #b89000;" data-i18n-title="SHEET-INTEGRATION" >j</span>
 						</div>
 		<input type="checkbox" name="attr_ShowPublicSpeaker" class="sheet-hidden sheet-hider" value="1" />	
 						<div class="sheet-col-1-2 sheet-vert-top">
@@ -26813,7 +26813,7 @@
 								<span data-i18n="ABBREVIATE-FELLOWSHIP"></span>
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-vert-middle">
-								<input class="sheet-center" type="number" name="attr_Talent_PublicSpeakerLvl" value="0" min="0" max="1" />
+								<input class="sheet-center" type="number" name="attr_Talent_PublicSpeakerLvl" value="0" min="0" />
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-vert-middle">
 								<input class="sheet-center" type="number" name="attr_Talent_PublicSpeakerMax" value="@{FellowshipBonus}" disabled />
@@ -27484,6 +27484,26 @@
 							<button class="sheet-right" type="compendium" value="Talents:Surgery" data-i18n-title="COMPENDIUM-LINK"></button>
 							<span style="font-family: pictos; color: #55b800;" data-i18n-title="SHEET-INTEGRATION" >j</span>
 						</div>
+		<input type="checkbox" name="attr_ShowStrikeMightyBlow" class="sheet-hidden sheet-hider" value="1" />	
+						<div class="sheet-col-1-2 sheet-vert-top">
+							<div class="sheet-col-1-10 sheet-center sheet-vert-middle">
+								<input type="checkbox" name="attr_CarrierStrikeMightyBlow" value="1" />
+							</div>
+							<div class="sheet-col-1-2 sheet-left sheet-vert-middle">
+								<span data-i18n="STRIKE-MIGHTY-BLOW">Strike Mighty Blow</span>
+							</div>
+							<div class="sheet-col-8-100 sheet-center sheet-talents-border">
+								<span data-i18n="ABBREVIATE-STRENGTH"></span>
+							</div>
+							<div class="sheet-col-8-100 sheet-center sheet-vert-middle">
+								<input class="sheet-center" type="number" name="attr_Talent_StrikeMightyBlowLvl" value="0" min="0" />
+							</div>
+							<div class="sheet-col-8-100 sheet-center sheet-vert-middle">
+								<input class="sheet-center" type="number" name="attr_Talent_StrikeMightyBlowMax" value="@{StrengthBonus}" disabled />
+							</div>
+							<button class="sheet-right" type="compendium" value="Talents:Strike Mighty Blow" data-i18n-title="COMPENDIUM-LINK"></button>
+							<span style="font-family: pictos; color: #55b800;" data-i18n-title="SHEET-INTEGRATION" >j</span>
+						</div>
 		<input type="checkbox" name="attr_ShowStrikeToInjure" class="sheet-hidden sheet-hider" value="1" />	
 						<div class="sheet-col-1-2 sheet-vert-top">
 							<div class="sheet-col-1-10 sheet-center sheet-vert-middle">
@@ -27504,25 +27524,25 @@
 							<button class="sheet-right" type="compendium" value="Talents:Strike To Injure" data-i18n-title="COMPENDIUM-LINK"></button>
 							<span style="font-family: pictos; color: #55b800;" data-i18n-title="SHEET-INTEGRATION" >j</span>
 						</div>
-		<input type="checkbox" name="attr_ShowStrikeMightyBlow" class="sheet-hidden sheet-hider" value="1" />	
+		<input type="checkbox" name="attr_ShowStrikeToStun" class="sheet-hidden sheet-hider" value="1" />	
 						<div class="sheet-col-1-2 sheet-vert-top">
 							<div class="sheet-col-1-10 sheet-center sheet-vert-middle">
-								<input type="checkbox" name="attr_CarrierStrikeMightyBlow" value="1" />
+								<input type="checkbox" name="attr_CarrierStrikeToStun" value="1" />
 							</div>
 							<div class="sheet-col-1-2 sheet-left sheet-vert-middle">
-								<span data-i18n="STRIKE-MIGHTY-BLOW">Strike Mighty Blow</span>
+								<span data-i18n="STRIKE-TO-STUN">Strike To Stun</span>
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-talents-border">
-								<span data-i18n="ABBREVIATE-STRENGTH"></span>
+								<span data-i18n="ABBREVIATE-WEAPON-SKILL"></span>
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-vert-middle">
-								<input class="sheet-center" type="number" name="attr_Talent_StrikeMightyBlowLvl" value="0" min="0" />
+								<input class="sheet-center" type="number" name="attr_Talent_StrikeToStunLvl" value="0" min="0" />
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-vert-middle">
-								<input class="sheet-center" type="number" name="attr_Talent_StrikeMightyBlowMax" value="@{StrengthBonus}" disabled />
+								<input class="sheet-center" type="number" name="attr_Talent_StrikeToStunMax" value="@{WeaponSkillBonus}" disabled />
 							</div>
-							<button class="sheet-right" type="compendium" value="Talents:Strike Mighty Blow" data-i18n-title="COMPENDIUM-LINK"></button>
-							<span style="font-family: pictos; color: #55b800;" data-i18n-title="SHEET-INTEGRATION" >j</span>
+							<button class="sheet-right" type="compendium" value="Talents:Strike To Stun" data-i18n-title="COMPENDIUM-LINK"></button>
+							<span style="font-family: pictos; color: #b89000;" data-i18n-title="SHEET-INTEGRATION-PART" >j</span>
 						</div>
 		<input type="checkbox" name="attr_ShowStrongBack" class="sheet-hidden sheet-hider" value="1" />	
 						<div class="sheet-col-1-2 sheet-vert-top">
@@ -37309,6 +37329,9 @@
 				{{#rollGreater() infight 0}}
 					<div class="sheet-col-1 sheet-center sheet-pad-l-md sheet-pad-r-md sheet-rt-slmod" style="color: #55B800">+{{infight}}SL <span data-i18n="IN-FIGHTER"></span></div>
 				{{/rollGreater() infight 0}}
+				{{#rollGreater() orientation 0}}
+					<div class="sheet-col-1 sheet-center sheet-pad-l-md sheet-pad-r-md sheet-rt-slmod" style="color: #55B800">+{{orientation}}SL <span data-i18n="ORIENTATION"></span></div>
+				{{/rollGreater() orientation 0}}
 				{{#rollGreater() shieldsman 0}}		
 					<div class="sheet-col-1 sheet-center sheet-pad-l-md sheet-pad-r-md sheet-rt-slmod" style="color: #55B800">+{{shieldsman}}SL <span data-i18n="SHIELDSMAN"></span></div>
 				{{/rollGreater() shieldsman 0}}
@@ -37659,6 +37682,21 @@
 							{{#rollGreater() nosefortrouble 0}}
 								<div class="sheet-col-1 sheet-center sheet-pad-l-md sheet-pad-r-md sheet-rt-slmod" style="color: #858585">+{{nosefortrouble}}SL <span  data-i18n="NOSE-FOR-TROUBLE"></span></div>
 							{{/rollGreater() nosefortrouble 0}}
+							{{#rollGreater() numismatics 0}}
+								<div class="sheet-col-1 sheet-center sheet-pad-l-md sheet-pad-r-md sheet-rt-slmod" style="color: #858585">+{{numismatics}}SL <span  data-i18n="NUMISMATICS"></span></div>
+							{{/rollGreater() numismatics 0}}
+							{{#rollGreater() oldsalt 0}}
+								<div class="sheet-col-1 sheet-center sheet-pad-l-md sheet-pad-r-md sheet-rt-slmod" style="color: #858585">+{{oldsalt}}SL <span  data-i18n="OLD-SALT"></span></div>
+							{{/rollGreater() oldsalt 0}}
+							{{#rollGreater() pharmacist 0}}
+								<div class="sheet-col-1 sheet-center sheet-pad-l-md sheet-pad-r-md sheet-rt-slmod" style="color: #858585">+{{pharmacist}}SL <span  data-i18n="PHARMACIST"></span></div>
+							{{/rollGreater() pharmacist 0}}
+							{{#rollGreater() panhandle 0}}
+								<div class="sheet-col-1 sheet-center sheet-pad-l-md sheet-pad-r-md sheet-rt-slmod" style="color: #858585">+{{panhandle}}SL <span  data-i18n="PANHANDLE"></span></div>
+							{{/rollGreater() panhandle 0}}
+							{{#rollGreater() pilot 0}}
+								<div class="sheet-col-1 sheet-center sheet-pad-l-md sheet-pad-r-md sheet-rt-slmod" style="color: #858585">+{{pilot}}SL <span  data-i18n="PILOT"></span></div>
+							{{/rollGreater() pilot 0}}
 							{{#rollGreater() resistance1 0}}
 								<div class="sheet-col-1 sheet-center sheet-pad-l-md sheet-pad-r-md sheet-rt-slmod" style="color: #858585">+{{resistance1}}SL <span  data-i18n="RESISTANCE"></span> {{resistance1name}} </div>
 							{{/rollGreater() resistance1 0}}
@@ -37712,6 +37750,9 @@
 							{{#rollGreater() fielddressing 0}}
 								<div class="sheet-col-1 sheet-pad-l-md sheet-pad-r-md sheet-rt-effects" style="color: #858585"><span  data-i18n="FIELD-DRESSING"></span>: <span  data-i18n="USE-REVERSE-DICE"></span></div>
 							{{/rollGreater() fielddressing 0}}	
+							{{#rollGreater() pilot 0}}
+								<div class="sheet-col-1 sheet-pad-l-md sheet-pad-r-md sheet-rt-effects" style="color: #858585"><span  data-i18n="PILOT"></span>: <span  data-i18n="USE-REVERSE-DICE"></span></div>
+							{{/rollGreater() pilot 0}}
 						{{/rollGreater() test target}}
 					{{/rollGreater() sitfail 0}}	
 
@@ -47719,9 +47760,10 @@ on('clicked:repeating_divinemiracles:miracle clicked:repeating_divinemiracles:mi
 	if (trigger === 'art') {cond = '{{cond=[[@{condgen_see}]]}}  {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{artistic=[[@{Talent_ArtisticLvl}]]}}';
 	addsl = '+@{Talent_ArtisticLvl}';
 	rollPart = rollPart2.replaceAll('cond-', `condgen`).replaceAll('>addsl<', addsl);}   
-	else if (trigger === 'evaluate') {cond = '{{cond=[[@{condgen_see}]]}}  {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}}';
+	else if (trigger === 'evaluate') {cond = '{{cond=[[@{condgen_see}]]}}  {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{numismatics=[[@{Talent_NumismaticsLvl}]]}}';
 	addtak= '*@{EvaluateTaken}';
-	rollPart = rollPart2.replaceAll('cond-', `condgen`).replaceAll('>addtak<', addtak);} 
+	sitmods = '+@{Talent_NumismaticsLvl}';	
+	rollPart = rollPart2.replaceAll('cond-', `condgen`).replaceAll('>addtak<', addtak).replaceAll('>sitmod<', sitmods);} 
 	else if (trigger === 'picklock') {cond = '{{cond=[[@{condgen_see}]]}}  {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}}';
 	addtak= '*@{PickLockTaken}';
 	rollPart = rollPart2.replaceAll('cond-', `condgen`).replaceAll('>addtak<', addtak);} 
@@ -47740,8 +47782,9 @@ on('clicked:repeating_divinemiracles:miracle clicked:repeating_divinemiracles:mi
 	else if (trigger === 'drive') {cond = '{{cond=[[@{condgen_see_move}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{crackthewhip=[[@{Talent_CracktheWhipLvl}]]}}';
 	sitmods = '+@{Talent_CracktheWhipLvl}';
 	rollPart = rollPart2.replaceAll('cond-', `condgen_see_move`).replaceAll('>sitmod<', sitmods);}   	
-	else if (trigger === 'navigation') {cond = '{{cond=[[@{condgen_see_move}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}}';
-	rollPart = rollPart2.replaceAll('cond-', `condgen_see_move`);}   	
+	else if (trigger === 'navigation') {cond = '{{cond=[[@{condgen_see_move}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{orientation=[[@{Talent_OrientationLvl}]]}}';
+	addsl = '+@{Talent_OrientationLvl}';	
+	rollPart = rollPart2.replaceAll('cond-', `condgen_see_move`).replaceAll('>addsl<', addsl);}   	
 	else if (trigger === 'outdoorsurvival') {cond = '{{cond=[[@{condgen_see_move}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}}';
 	rollPart = rollPart2.replaceAll('cond-', `condgen_see_move`);}    	
 	else if (trigger === 'ride') {cond = '{{cond=[[@{condgen_see_move}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{crackthewhip=[[@{Talent_CracktheWhipLvl}]]}}';
@@ -47804,8 +47847,8 @@ on('clicked:repeating_divinemiracles:miracle clicked:repeating_divinemiracles:mi
 	else if (trigger === 'bribery') {cond = '{{cond=[[@{condgen}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[0]]}} {{deafened=[[0]]}} {{briber=[[@{Talent_BriberyLvl}]]}}';
 	addsl = '+@{Talent_BriberyLvl}';
 	rollPart = rollPart2.replaceAll('cond-', `condgen_see_move`).replaceAll('>addsl<', addsl);}    
-	else if (trigger === 'charm') {cond = '{{cond=[[@{condgen}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[0]]}} {{deafened=[[0]]}} {{argumetative=[[@{Talent_ArgumentativeLvl}]]}} {{attractive=[[@{Talent_AttractiveLvl}]]}} {{blather=[[@{Talent_BlatherLvl}]]}} {{carouser2=[[@{Talent_CarouserLvl}]]}} {{cattongued=[[@{Talent_CattonguedLvl}]]}} {{etiquette1=[[@{Talent_Etiquette1Lvl}]]}} {{etiquette1name=@{Talent_Etiquette1}}} {{etiquette2=[[@{Talent_Etiquette2Lvl}]]}} {{etiquette2name=@{Talent_Etiquette2}}} {{etiquette3=[[@{Talent_Etiquette3Lvl}]]}} {{etiquette3name=@{Talent_Etiquette3}}} {{etiquette4=[[@{Talent_Etiquette4Lvl}]]}} {{etiquette4name=@{Talent_Etiquette4}}} {{etiquette5=[[@{Talent_Etiquette5Lvl}]]}} {{etiquette5name=@{Talent_Etiquette5}}} {{etiquette6=[[@{Talent_Etiquette6Lvl}]]}} {{etiquette6name=@{Talent_Etiquette6}}} {{impzeal=[[@{Talent_ImpassionedZealLvl}]]}} {{nobleblood=[[@{Talent_NobleBloodLvl}]]}}';
-	sitmods = '+@{Talent_ArgumentativeLvl}+@{Talent_AttractiveLvl}+@{Talent_BlatherLvl}+@{Talent_CarouserLvl}+@{Talent_CattonguedLvl}+@{Talent_Etiquette1Lvl}+@{Talent_Etiquette2Lvl}+@{Talent_Etiquette3Lvl}+@{Talent_Etiquette4Lvl}+@{Talent_Etiquette5Lvl}+@{Talent_Etiquette6Lvl}+@{Talent_ImpassionedZealLvl}+@{Talent_NobleBloodLvl}';
+	else if (trigger === 'charm') {cond = '{{cond=[[@{condgen}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[0]]}} {{deafened=[[0]]}} {{argumetative=[[@{Talent_ArgumentativeLvl}]]}} {{attractive=[[@{Talent_AttractiveLvl}]]}} {{blather=[[@{Talent_BlatherLvl}]]}} {{carouser2=[[@{Talent_CarouserLvl}]]}} {{cattongued=[[@{Talent_CattonguedLvl}]]}} {{etiquette1=[[@{Talent_Etiquette1Lvl}]]}} {{etiquette1name=@{Talent_Etiquette1}}} {{etiquette2=[[@{Talent_Etiquette2Lvl}]]}} {{etiquette2name=@{Talent_Etiquette2}}} {{etiquette3=[[@{Talent_Etiquette3Lvl}]]}} {{etiquette3name=@{Talent_Etiquette3}}} {{etiquette4=[[@{Talent_Etiquette4Lvl}]]}} {{etiquette4name=@{Talent_Etiquette4}}} {{etiquette5=[[@{Talent_Etiquette5Lvl}]]}} {{etiquette5name=@{Talent_Etiquette5}}} {{etiquette6=[[@{Talent_Etiquette6Lvl}]]}} {{etiquette6name=@{Talent_Etiquette6}}} {{impzeal=[[@{Talent_ImpassionedZealLvl}]]}} {{nobleblood=[[@{Talent_NobleBloodLvl}]]}} {{panhandle=[[@{Talent_PanhandleLvl}]]}}';
+	sitmods = '+@{Talent_ArgumentativeLvl}+@{Talent_AttractiveLvl}+@{Talent_BlatherLvl}+@{Talent_CarouserLvl}+@{Talent_CattonguedLvl}+@{Talent_Etiquette1Lvl}+@{Talent_Etiquette2Lvl}+@{Talent_Etiquette3Lvl}+@{Talent_Etiquette4Lvl}+@{Talent_Etiquette5Lvl}+@{Talent_Etiquette6Lvl}+@{Talent_ImpassionedZealLvl}+@{Talent_NobleBloodLvl}+@{Talent_PanhandleLvl}';
 	rollPart = rollPart2.replaceAll('cond-', `condgen`).replaceAll('>sitmod<', sitmods);}
 	else if (trigger === 'charmanimal') {cond = '{{cond=[[@{condgen}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[0]]}} {{deafened=[[0]]}} {{animalaffinity=[[@{Talent_AnimalAffinityLvl}]]}}';
 	rollPart = rollPart2.replaceAll('cond-', `condgen`);
@@ -47836,9 +47879,11 @@ on('clicked:repeating_divinemiracles:miracle clicked:repeating_divinemiracles:mi
 	addsl = '+@{Talent_CommandingPresenceLvl}+@{Talent_NobleBloodLvl}';
 	sitmods = '+@{Talent_WarLeaderLvl}+@{Talent_InspiringLvl}';
 	rollPart = rollPart2.replaceAll('cond-', `condgen`).replaceAll('>addsl<', addsl).replaceAll('>sitmod<', sitmods);}
-	else if (trigger === 'row') {cond = '{{cond=[[@{condgen}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[0]]}} {{deafened=[[0]]}} {{strongback=[[@{Talent_StrongBackLvl}]]}}'
+	else if (trigger === 'row') {cond = '{{cond=[[@{condgen}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[0]]}} {{deafened=[[0]]}} {{strongback=[[@{Talent_StrongBackLvl}]]}} {{pilot=[[@{Talent_PilotLvl}]]}}'
 	addsl = '+@{Talent_StrongBackLvl}';
-	rollPart = rollPart2.replaceAll('cond-', `condgen`).replaceAll('>addsl<', addsl);}
+	sitmods = '+@{Talent_PilotLvl}';
+	sitfail = '+@{Talent_PilotLvl}';
+	rollPart = rollPart2.replaceAll('cond-', `condgen`).replaceAll('>addsl<', addsl).replaceAll('>sitmod<', sitmods).replaceAll('>sitfail<', sitfail);}
 	else if (trigger === 'animalcare') {cond = '{{cond=[[@{condgen}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[0]]}} {{deafened=[[0]]}}';
 	addtak= '*@{AnimalCareTaken}';
 	rollPart = rollPart2.replaceAll('cond-', `condgen`).replaceAll('>addtak<', addtak);}  
@@ -48053,7 +48098,7 @@ on('clicked:repeating_divinemiracles:miracle clicked:repeating_divinemiracles:mi
     on('clicked:repeating_animaltraining:animaltrainingroll clicked:repeating_language:languageroll clicked:repeating_lore:loreroll clicked:repeating_perform:performroll clicked:repeating_play:playroll clicked:repeating_sail:sailroll clicked:repeating_secretsigns:secretsignsroll clicked:repeating_trade:traderoll', (eventInfo) => {
                console.log("test");
 	
-   let roll = '{{test=[[@{roll_rule}]]}} {{sl=[[0]]}} {{slbonus=[[0>addsl<]]}} {{sladd=[[0]]}} {{slbonusatk=[[0>addsl<]]}} {{target=[[ [[@{cond-}*-1]] [COND] + [[(@{prefix-Char}+@{prefix-Adv}+@{prefix-Misc})>addtak<]] [SKILL] +?{@{translation_modifier}|0} [MOD] ]]}} {{modvalue=[[?{@{translation_modifier}|0}]]}} {{unconscious=[[@{UnconsciousMod}]]}} {{title=@{prefix-Specialization}}} {{sitmod=[[@{prefix-_modtype1}+@{prefix-_modtype2}+@{prefix-_modtype3}>sitmod<]]}} {{skill=^{>Skill<}}} {{character_name=@{character_name}}} {{skilltest=true}} {{SLmod=[[?{SL Modifier|0}]]}} {{mod1type=[[@{prefix-_modtype1}]]}} {{mod1=@{prefix-_mod1}}} {{mod2type=[[@{prefix-_modtype2}]]}} {{mod2=@{prefix-_mod2}}} {{mod3type=[[@{prefix-_modtype3}]]}} {{mod3=@{prefix-_mod3}}} {{reroll=[1](~@{character_name}|prefix-roll)}}';
+   let roll = '{{test=[[@{roll_rule}]]}} {{sl=[[0]]}} {{slbonus=[[0>addsl<]]}} {{sladd=[[0]]}} {{slbonusatk=[[0>addsl<]]}} {{target=[[ [[@{cond-}*-1]] [COND] + [[(@{prefix-Char}+@{prefix-Adv}+@{prefix-Misc})>addtak<]] [SKILL] +?{@{translation_modifier}|0} [MOD] ]]}} {{modvalue=[[?{@{translation_modifier}|0}]]}} {{unconscious=[[@{UnconsciousMod}]]}} {{title=@{prefix-Specialization}}} {{sitmod=[[@{prefix-_modtype1}+@{prefix-_modtype2}+@{prefix-_modtype3}>sitmod<]]}} {{sitfail=[[0>sitfail<]]}} {{skill=^{>Skill<}}} {{character_name=@{character_name}}} {{skilltest=true}} {{SLmod=[[?{SL Modifier|0}]]}} {{mod1type=[[@{prefix-_modtype1}]]}} {{mod1=@{prefix-_mod1}}} {{mod2type=[[@{prefix-_modtype2}]]}} {{mod2=@{prefix-_mod2}}} {{mod3type=[[@{prefix-_modtype3}]]}} {{mod3=@{prefix-_mod3}}} {{reroll=[1](~@{character_name}|prefix-roll)}}';
    var trigger = eventInfo.triggerName.slice(8, -4);
    var prefix = trigger.split('_').slice(0,3).join('_') + '_';
    var prefix2 = eventInfo.triggerName.slice(8, -18);
@@ -48071,10 +48116,11 @@ on('clicked:repeating_divinemiracles:miracle clicked:repeating_divinemiracles:mi
 	addtak= '*@{prefix-Taken}';
 	rollPart2 = roll.replaceAll('cond-', `condgen_see`).replaceAll('>addtak<', addtak);}
 	
-	else if (skill === 'sail') {cond = '{{cond=[[@{condgen_see}]]}}  {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{waterman=[[@{Talent_WatermanLvl}]]}}';
-	sitmods = '+@{Talent_WatermanLvl}';
+	else if (skill === 'sail') {cond = '{{cond=[[@{condgen_see}]]}}  {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{waterman=[[@{Talent_WatermanLvl}]]}} {{oldsalt=[[@{Talent_OldSaltLvl}]]}} {{pilot=[[@{Talent_PilotLvl}]]}}';
+	sitmods = '+@{Talent_WatermanLvl}+@{Talent_OldSaltLvl}+@{Talent_PilotLvl}';
+	sitfail = '+@{Talent_PilotLvl}';
 	addtak= '*@{prefix-Taken}';
-	rollPart2 = roll.replaceAll('cond-', `condgen_see`).replaceAll('>addtak<', addtak).replaceAll('>sitmod<', sitmods);}
+	rollPart2 = roll.replaceAll('cond-', `condgen_see`).replaceAll('>addtak<', addtak).replaceAll('>sitmod<', sitmods).replaceAll('>sitfail<', sitfail);}
 	
 	else if (skill === 'secretsigns') {cond = '{{cond=[[@{condgen_see}]]}}  {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}}';
 	addtak= '*@{prefix-Taken}';
@@ -48092,10 +48138,11 @@ on('clicked:repeating_divinemiracles:miracle clicked:repeating_divinemiracles:mi
 	addtak= '*@{prefix-Taken}';
 	rollPart2 = roll.replaceAll('cond-', `condgen`).replaceAll('>addtak<', addtak);}
 	
-	else if (skill === 'trade') {cond = '{{cond=[[@{condgen}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[0]]}} {{deafened=[[0]]}} {{craftsman1=[[@{Talent_Craftsman1Lvl}]]}} {{craftsman2=[[@{Talent_Craftsman2Lvl}]]}} {{craftsman3=[[@{Talent_Craftsman3Lvl}]]}}';
+	else if (skill === 'trade') {cond = '{{cond=[[@{condgen}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[0]]}} {{deafened=[[0]]}} {{craftsman1=[[@{Talent_Craftsman1Lvl}]]}} {{craftsman2=[[@{Talent_Craftsman2Lvl}]]}} {{craftsman3=[[@{Talent_Craftsman3Lvl}]]}} {{pharmacist=[[@{Talent_PharmacistLvl}]]}}';
+	sitmods = '+@{Talent_PharmacistLvl}';
 	addsl = '+@{Talent_Craftsman1Lvl}+@{Talent_Craftsman2Lvl}+@{Talent_Craftsman3Lvl}';
 	addtak= '*@{prefix-Taken}';
-	rollPart2 = roll.replaceAll('cond-', `condgen_see`).replaceAll('>addtak<', addtak).replaceAll('>addsl<', addsl);}
+	rollPart2 = roll.replaceAll('cond-', `condgen_see`).replaceAll('>addtak<', addtak).replaceAll('>addsl<', addsl).replaceAll('>sitmod<', sitmods);}
 	
 	else {cond = ''}
 	


### PR DESCRIPTION
## Changes / Comments

- Functionality: (DEV Mode) Dual Wield Talent ability now uses the reverses crit roll if one occurs right before the 2nd DW hit is rolled using the icon in the roll output of the first hit. If no crit is roll before it will reverse the previous roll as normal. This is a slight deviation from the core book rules, because they dont really make sense to make the 2nd hit harder if you crit roll is higher (i.e. penalised for a crit), like this is more random due to the roll reversal just like the none crited 2nd hit..
- Cosmetic: Arcane Spells roll output now correctly state Arcane Spell, rather then Petty Spell.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
