### PR TITLE
[BESM4eExtras] v1.4.6

### DIFF
--- a/BESM4eExtras/BESM4eExtras.css
+++ b/BESM4eExtras/BESM4eExtras.css
@@ -1,5 +1,5 @@
 /* === VERSION === */
-/*      1.3.2      */
+/*      1.4.0      */
 
 /* === GENERAL === */
 .charsheet {
@@ -1506,6 +1506,7 @@ input.sheet-theme[value="1"]:checked ~ div > div > div > div > div > div > div >
 input.sheet-theme[value="1"]:checked ~ div > div > div > div > div > h4 > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="1"]:checked ~ div > div > div > div > div > div > h4 > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="1"]:checked ~ div > div > div > div > div > h4 > div > div > div > div > div > div > div > button[type="action"],
+input.sheet-theme[value="1"]:checked ~ div > div > div > div > div > div > div > div > div > h4 > span > div > div > button[type="action"],
 input.sheet-theme[value="1"]:checked ~ div > div > div > div > div > div > h4 > div > div > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="1"]:checked ~ div > div > div > div > div > div > div > div > div > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="1"]:checked ~ div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > button[type="action"]
@@ -1556,6 +1557,7 @@ input.sheet-theme[value="2"]:checked ~ div > div > div > div > div > div > div >
 input.sheet-theme[value="2"]:checked ~ div > div > div > div > div > h4 > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="2"]:checked ~ div > div > div > div > div > div > h4 > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="2"]:checked ~ div > div > div > div > div > h4 > div > div > div > div > div > div > div > button[type="action"],
+input.sheet-theme[value="2"]:checked ~ div > div > div > div > div > div > div > div > div > h4 > span > div > div > button[type="action"],
 input.sheet-theme[value="2"]:checked ~ div > div > div > div > div > div > h4 > div > div > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="2"]:checked ~ div > div > div > div > div > div > div > div > div > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="2"]:checked ~ div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > button[type="action"]
@@ -1606,6 +1608,7 @@ input.sheet-theme[value="3"]:checked ~ div > div > div > div > div > div > div >
 input.sheet-theme[value="3"]:checked ~ div > div > div > div > div > h4 > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="3"]:checked ~ div > div > div > div > div > div > h4 > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="3"]:checked ~ div > div > div > div > div > h4 > div > div > div > div > div > div > div > button[type="action"],
+input.sheet-theme[value="3"]:checked ~ div > div > div > div > div > div > div > div > div > h4 > span > div > div > button[type="action"],
 input.sheet-theme[value="3"]:checked ~ div > div > div > div > div > div > h4 > div > div > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="3"]:checked ~ div > div > div > div > div > div > div > div > div > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="3"]:checked ~ div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > button[type="action"]
@@ -1656,6 +1659,7 @@ input.sheet-theme[value="4"]:checked ~ div > div > div > div > div > div > div >
 input.sheet-theme[value="4"]:checked ~ div > div > div > div > div > h4 > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="4"]:checked ~ div > div > div > div > div > div > h4 > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="4"]:checked ~ div > div > div > div > div > h4 > div > div > div > div > div > div > div > button[type="action"],
+input.sheet-theme[value="4"]:checked ~ div > div > div > div > div > div > div > div > div > h4 > span > div > div > button[type="action"],
 input.sheet-theme[value="4"]:checked ~ div > div > div > div > div > div > h4 > div > div > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="4"]:checked ~ div > div > div > div > div > div > div > div > div > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="4"]:checked ~ div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > button[type="action"]
@@ -1706,6 +1710,7 @@ input.sheet-theme[value="5"]:checked ~ div > div > div > div > div > div > div >
 input.sheet-theme[value="5"]:checked ~ div > div > div > div > div > h4 > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="5"]:checked ~ div > div > div > div > div > div > h4 > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="5"]:checked ~ div > div > div > div > div > h4 > div > div > div > div > div > div > div > button[type="action"],
+input.sheet-theme[value="5"]:checked ~ div > div > div > div > div > div > div > div > div > h4 > span > div > div > button[type="action"],
 input.sheet-theme[value="5"]:checked ~ div > div > div > div > div > div > h4 > div > div > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="5"]:checked ~ div > div > div > div > div > div > div > div > div > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="5"]:checked ~ div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > button[type="action"]
@@ -1756,6 +1761,7 @@ input.sheet-theme[value="6"]:checked ~ div > div > div > div > div > div > div >
 input.sheet-theme[value="6"]:checked ~ div > div > div > div > div > h4 > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="6"]:checked ~ div > div > div > div > div > div > h4 > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="6"]:checked ~ div > div > div > div > div > h4 > div > div > div > div > div > div > div > button[type="action"],
+input.sheet-theme[value="6"]:checked ~ div > div > div > div > div > div > div > div > div > h4 > span > div > div > button[type="action"],
 input.sheet-theme[value="6"]:checked ~ div > div > div > div > div > div > h4 > div > div > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="6"]:checked ~ div > div > div > div > div > div > div > div > div > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="6"]:checked ~ div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > button[type="action"]
@@ -1806,6 +1812,7 @@ input.sheet-theme[value="7"]:checked ~ div > div > div > div > div > div > div >
 input.sheet-theme[value="7"]:checked ~ div > div > div > div > div > h4 > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="7"]:checked ~ div > div > div > div > div > div > h4 > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="7"]:checked ~ div > div > div > div > div > h4 > div > div > div > div > div > div > div > button[type="action"],
+input.sheet-theme[value="7"]:checked ~ div > div > div > div > div > div > div > div > div > h4 > span > div > div > button[type="action"],
 input.sheet-theme[value="7"]:checked ~ div > div > div > div > div > div > h4 > div > div > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="7"]:checked ~ div > div > div > div > div > div > div > div > div > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="7"]:checked ~ div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > button[type="action"]
@@ -1856,6 +1863,7 @@ input.sheet-theme[value="8"]:checked ~ div > div > div > div > div > div > div >
 input.sheet-theme[value="8"]:checked ~ div > div > div > div > div > h4 > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="8"]:checked ~ div > div > div > div > div > div > h4 > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="8"]:checked ~ div > div > div > div > div > h4 > div > div > div > div > div > div > div > button[type="action"],
+input.sheet-theme[value="8"]:checked ~ div > div > div > div > div > div > div > div > div > h4 > span > div > div > button[type="action"],
 input.sheet-theme[value="8"]:checked ~ div > div > div > div > div > div > h4 > div > div > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="8"]:checked ~ div > div > div > div > div > div > div > div > div > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="8"]:checked ~ div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > button[type="action"]
@@ -1906,6 +1914,7 @@ input.sheet-theme[value="9"]:checked ~ div > div > div > div > div > div > div >
 input.sheet-theme[value="9"]:checked ~ div > div > div > div > div > h4 > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="9"]:checked ~ div > div > div > div > div > div > h4 > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="9"]:checked ~ div > div > div > div > div > h4 > div > div > div > div > div > div > div > button[type="action"],
+input.sheet-theme[value="9"]:checked ~ div > div > div > div > div > div > div > div > div > h4 > span > div > div > button[type="action"],
 input.sheet-theme[value="9"]:checked ~ div > div > div > div > div > div > h4 > div > div > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="9"]:checked ~ div > div > div > div > div > div > div > div > div > div > div > div > div > div > button[type="action"],
 input.sheet-theme[value="9"]:checked ~ div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > div > button[type="action"]
@@ -2337,6 +2346,13 @@ div.sheet-flex-container-right {
 	flex-flow: row nowrap;
 	justify-content: flex-start;
 	align-content: space-between;
+}
+
+div.sheet-flex-container-wrap {
+	display: flex;
+	
+	flex-flow: row wrap;
+	align-content: space-around;
 }
 
 div.sheet-flex-grow {

--- a/BESM4eExtras/BESM4eExtras.html
+++ b/BESM4eExtras/BESM4eExtras.html
@@ -30,7 +30,7 @@
 											<div class="row padt padb"><h3 class="col-1 center border"><span>Sheet Options</span></h3></div>
 											<div class="row center padb">
 												<div class="col-1-5 padr"><h4 class="center border"><span>Sheet Version
-													<input type="text" class="center" name="attr_version" value="1.4.5" readonly />
+													<input type="text" class="center" name="attr_version" value="1.4.6" readonly />
 												</span></h4></div>
 												<div class="col-1-5 padr"><h4 class="center border"><span>Sheet Type
 													<select class="border"><option value="Sheet">Character</option><!--<option value="NPC Sheet">NPC</option><option value="Thing Sheet">Thing</option><option value="GM Sheet">GM</option>--></select>
@@ -6504,6 +6504,7 @@
 		const special_defects_regex = /uniquedefect/i;
 		const rollable_attributes_regex = /(healing|inspire|unaffected|exorcism|illusion|metamorphosis|mimic|mindcontrol|nullify|powerflux|powervariation|projection|sixthsense|supersense|telepathy|transfer|transmute)/i;
 		const targetable_attributes_regex = /(healing|exorcism|illusion|metamorphosis|mimic|mindcontrol|nullify|telepathy|transfer)/i;
+		const dymanicGrouRegex = /(flux|variation)/i;
 		
 		const upgrade_to_1_3_1_array = ["upgraded_1_3_1", "attrdb"];
 		const upgrade_to_1_2_2_array = ["upgraded_1_2_2", "name", "charactername"];
@@ -6852,7 +6853,7 @@
 		
 		function setGroupDefectPointsOnActivation(debug, attrIDs, attrdb, value, sectionName, rowID, setObj){
 			const groupid = getGroupID(value, 'attr');
-			const groupType = value[`static_attrgroup_${groupid}_type`] || 'standard';
+			const groupType = value[`static_attrgroup_${groupid}_type`] || 'Standard';
 			const groupSourceID = value[`static_attrgroup_${groupid}_source`];
 			const isPowerFlux = /flux/i.test(groupType);
 			const fluxcost = parseInt(value[`repeating_attr_${groupSourceID}_totalcost`]);
@@ -6888,7 +6889,7 @@
 			const groupType = value[`static_attrgroup_${groupid}_type`];
 			const groupSourceID = value[`static_attrgroup_${groupid}_source`];
 			const isGroupActive = parseInt(value[`repeating_attr_${groupSourceID}_activate`]) || 0;
-			const result = groupType == 'power flux' ? groupSourceID == rowID ? true : 
+			const result = /flux/i.test(groupType) ? groupSourceID == rowID ? true : 
 				isGroupActive ? true : false : true;
 			if(debug){
 				console.log(`${debugtext} groupid = ${groupid}`);
@@ -6903,7 +6904,7 @@
 		function setPoolCostIfGroupIsVariation(debug, isActive, attrIDs, value, rowID, setObj){
 			const debugtext = '[setPoolCostIfGroupIsVariation()]';
 			const groupid = getGroupID(value, 'attr');
-			const groupType = value[`static_attrgroup_${groupid}_type`] || 'standard';
+			const groupType = value[`static_attrgroup_${groupid}_type`] || 'Standard';
 			const isPowerVariation = /variation/i.test(groupType);
 			const groupSourceID = value[`static_attrgroup_${groupid}_source`];
 			const groupIsActive = parseInt(value[`repeating_attr_${groupSourceID}_activate`]);
@@ -6939,7 +6940,7 @@
 		function setPoolCostIfGroupIsFlux(debug, isActive, attrIDs, value, rowID, setObj){
 			const debugtext = '[setPoolCostIfGroupIsFlux()]';
 			const groupid = getGroupID(value, 'attr');
-			const groupType = value[`static_attrgroup_${groupid}_type`] || 'standard';
+			const groupType = value[`static_attrgroup_${groupid}_type`] || 'Standard';
 			const isPowerFlux = /flux/i.test(groupType);
 			if(!isPowerFlux){
 				if(debug) console.log(`${debugtext} isPowerFlux = ${isPowerFlux}`);
@@ -7468,11 +7469,11 @@
 		}
 		
 		function convertToDynamicGroup(debug, attrIDs, attrdb, eventInfo, value, rowID, setObj){
-			const groupType = eventInfo.newValue.toLowerCase();
+			const groupType = capital(eventInfo.newValue);
 			if(debug) console.log(`[convertToDynamicGroup()] groupType = ${groupType}`);
-			if(groupType == 'power flux'){
+			if (/flux/i.test(groupType)) {
 				makeGroupPowerFlux(debug, attrIDs, attrdb, eventInfo, value, rowID, setObj);
-			}else if(groupType == 'power variation'){
+			}else if (/variation/i.test(groupType)) {
 				makeGroupPowerVariation(debug, attrIDs, attrdb, eventInfo, value, rowID, setObj);
 			}else{
 				return;
@@ -7489,21 +7490,21 @@
 			setObj[`static_attrgroup_${groupid}_changemax`] = 0;
 			setObj[`static_attrgroup_${groupid}_changegroup`] = 1;
 			setObj[`static_attrgroup_${groupid}_pointype`] = 'Flux Points';
-			setObj[`static_attrgroup_${groupid}_type`] = 'power flux';
+			setObj[`static_attrgroup_${groupid}_type`] = 'Power Flux';
 			setObj[`static_attrgroup_${groupid}_spent`] = aggregatePoolCost;
 			setObj[`static_attrgroup_${groupid}_groupcost`] = aggregateAttrCost + aggregateDefectPoints;
 		}
 		
-		function makeGroupPowerVariation(debug, attrIDs, attrdb, value, rowID, setObj){
+		function makeGroupPowerVariation(debug, attrIDs, attrdb, eventInfo, value, rowID, setObj){
 			const groupid = getGroupID(value, 'attr');
 			const aggregateAttrCost = getAggregateAttrGroupCost(debug, attrIDs, value, 'attr', rowID, setObj);
 			const aggregateDefectPoints = getAggregateGroupDefectPoints(debug, attrIDs, attrdb, value, rowID, setObj);
-			const aggregatePoolCost = getAggregatePoolCost(debug, attrIDs, value, 'attr', rowID, setObj);
+			const aggregatePoolCost = getAggregatePoolCost(debug, attrIDs, eventInfo, value, 'attr', rowID, setObj);
 			if(debug) console.log(`[makeGroupPowerVariation()] groupid = ${groupid}`);
 			setObj[`static_attrgroup_${groupid}_changemax`] = 1;
 			setObj[`static_attrgroup_${groupid}_changegroup`] = 1;
 			setObj[`static_attrgroup_${groupid}_pointype`] = 'Character Points';
-			setObj[`static_attrgroup_${groupid}_type`] = 'power variation';
+			setObj[`static_attrgroup_${groupid}_type`] = 'Power Variation';
 			setObj[`static_attrgroup_${groupid}_spent`] = aggregatePoolCost;
 			setObj[`static_attrgroup_${groupid}_groupcost`] = aggregateAttrCost + aggregateDefectPoints;
 		}
@@ -7524,11 +7525,12 @@
 		}
 		
 		function setGroupType(debug, attrIDs, attrdb, eventInfo, value, sectionName, rowID, setObj){
-			const dymanicGrouRegex = /(flux|variation)/i;
 			const dynamicGroup = attr => dymanicGrouRegex.test(attr);
-			if(!dynamicGroup(eventInfo.newValue) && !dynamicGroup(eventInfo.previousValue)){
+			const isDynamic = dynamicGroup(eventInfo.newValue);
+			const wasDynamic = dynamicGroup(eventInfo.previousValue);
+			if(!isDynamic && !wasDynamic){
 				return;
-			}else if(!dynamicGroup(eventInfo.newValue) && dynamicGroup(eventInfo.previousValue)){
+			}else if(!isDynamic && wasDynamic){
 				convertToStandardGroup(debug, attrIDs, attrdb, value, rowID, setObj);
 			}else{
 				convertToDynamicGroup(debug, attrIDs, attrdb, eventInfo, value, rowID, setObj);
@@ -7541,22 +7543,22 @@
 				case `standard`: //standard
 					setObj[`static_attrgroup_${groupid}_changegroup`] = 0;
 					setObj[`static_attrgroup_${groupid}_pointype`] = "";
-					setObj[`static_attrgroup_${groupid}_type`] = "standard";
+					setObj[`static_attrgroup_${groupid}_type`] = "Standard";
 					break;
 				case `power flux`: //power flux
 					setObj[`static_attrgroup_${groupid}_changegroup`] = 1;
 					setObj[`static_attrgroup_${groupid}_pointype`] = "Flux Points";
-					setObj[`static_attrgroup_${groupid}_type`] = "power flux";
+					setObj[`static_attrgroup_${groupid}_type`] = "Power Flux";
 					break;
 				case `power variation`: //power variation
 					setObj[`static_attrgroup_${groupid}_changegroup`] = 1;
 					setObj[`static_attrgroup_${groupid}_pointype`] = "Character Points";
-					setObj[`static_attrgroup_${groupid}_type`] = "power variation";
+					setObj[`static_attrgroup_${groupid}_type`] = "Power Variation";
 					break;
 				default:
 					setObj[`static_attrgroup_${groupid}_changegroup`] = 0;
 					setObj[`static_attrgroup_${groupid}_pointype`] = "";
-					setObj[`static_attrgroup_${groupid}_type`] = "standard";
+					setObj[`static_attrgroup_${groupid}_type`] = "Standard";
 			}
 			if (debug) {
 				console.log(`[setAttrGroupType(${sourceAttr})] grouptype = ${grouptype}`);
@@ -7621,7 +7623,7 @@
 		}
 		
 		function getGroupID(value, sectionName) {
-			return parseInt(value[`static_${sectionName}group_selected_tab`].replace(/\D/g, '')) || 0;
+			return parseInt(value[`static_${sectionName}group_selected_tab`].replace(/\D/ig, '')) || 0;
 		}
 		
 		function setDynamicGroupSourceID(debug, eventInfo, value, attrIDs, source, rowID, setObj) {
@@ -9243,22 +9245,14 @@
 						parseInt(value.static_button_personal_defense) ?
 						'personal' :
 						'';
-					console.log(`[setCombatRoll(TEST)] defensetype = ${defensetype}`);
-					
 					const bonus = defensetype != '' ? 
 						getSumOfActiveAttrLevels(attrdb, 'rangeddefense', defensetype) * 2 :
 						0;
-					console.log(`[setCombatRoll(TEST)] bonus = ${bonus}`);
-					
 					cv = getCV(debug, value, attrdb, setObj, sourceAttr, 'dcv')  + bonus;
-					console.log(`[setCombatRoll(TEST)] cv = ${cv}`);
-		
 					type = '{{dcvroll=1}}';
 					title = '{{title=Roll DCV}}';
 					stat = `{{dcv=${cv}}}`;
 					base = cv;
-					console.log(`[setCombatRoll(TEST)] base = ${base}`);
-		
 					result = `${result} ${buildProtectionsString(debug, value)}`;
 					break;
 				case 'initiative':
@@ -10131,7 +10125,6 @@
 						setArms(debug, rowID, setObj, name, true, extraarmID);
 						setObj[`repeating_extraarm_${extraarmID}_type`] = 0;
 						setObj[`repeating_extraarm_${extraarmID}_label`] = capital(attribute);
-						//updateWeaponStates(debug, attrdb, extraarmIDs, value, extraarmID, sourceAttr, setObj);
 					} else {
 						var source = setObj[`repeating_attr_${rowID}_source`] || 
 							value[`repeating_attr_${rowID}_source`] || "";
@@ -10151,7 +10144,6 @@
 							});
 							result = mountid.toString();
 						}
-						//updateWeaponStates(debug, attrdb, extraarmIDs, value, result, sourceAttr, setObj);
 						removeRepeatingRow(`repeating_extraarm_${result}`);
 					}
 				break;
@@ -10549,15 +10541,15 @@
 					const totalcost = parseInt(value[`repeating_attr_${id}_totalcost`]);
 					const appliedCost = group == groupid ? 
 						id == rowID ? 0 : 
-						groupType == 'power flux' ? activated ? totalcost : 0 :
+						/flux/i.test(groupType) ? activated ? totalcost : 0 :
 						totalcost : 0;
 					return appliedCost;
 				})
 				.reduce((memo, num)=>{ return memo + num; }, 0)
 				.value();
-			const max = isActive ? groupType == 'power flux' ? 
+			const max = isActive ? /flux/i.test(groupType) ? 
 				parseInt(value[`repeating_${sectionName}_${rowID}_effectivelevel`]) * 5 : 
-				groupType == 'power variation' ? groupCost : 0 : 0;
+				/variation/i.test(groupType) ? groupCost : 0 : 0;
 			setObj[`static_${sectionName}group_${groupid}_groupmax`] = max;
 		}
 		
@@ -10571,15 +10563,15 @@
 					const activated = parseInt(setObj[`repeating_${sectionName}_${id}_activate`]) ||
 						parseInt(value[`repeating_${sectionName}_${id}_activate`]);
 					const totalcost = parseInt(value[`repeating_${sectionName}_${id}_totalcost`]);
-					const appliedCost = group == groupid ? groupType == 'power flux' ? activated ? totalcost : 0 :
-						groupType == 'power variation' ? totalcost : 0 : 0;
+					const appliedCost = group == groupid ? /flux/i.test(groupType) ? activated ? totalcost : 0 :
+						/variation/i.test(groupType) ? totalcost : 0 : 0;
 					return appliedCost;
 				})
 				.reduce((memo, num)=>{ return memo + num; }, 0)
 				.value();
 			if(isActive){
-				const groupcost = groupType == 'power flux' ? dynamicGroupCost : 
-					groupType == 'power variation' ? aggregateAttrCost : 0;
+				const groupcost = /flux/i.test(groupType) ? dynamicGroupCost : 
+					/variation/i.test(groupType) ? aggregateAttrCost : 0;
 				setObj[`static_${sectionName}group_${groupid}_spent`] = aggregateAttrCost - dynamicGroupCost;
 				setObj[`static_${sectionName}group_${groupid}_groupcost`] = groupcost;
 			}else{
@@ -10930,7 +10922,7 @@
 					getAmmoMax(debug, customization.rank) : 
 					parseInt(value[`repeating_attr_${rowID}_ammostate`]);
 				const capacity = isNaN(parseInt(value[`repeating_attr_${rowID}_capacitystate`])) ?
-					0 : //parseInt(value[`repeating_attr_${rowID}_capacity`]) :
+					0 :
 					parseInt(value[`repeating_attr_${rowID}_capacitystate`]);
 				setObj.weapon_ammo_reloads = ammo;
 				setObj.weapon_ammo_capacity = capacity;
@@ -11291,7 +11283,6 @@
 					`[[${acv}]]]]}} {{roll=$[[0]]}}`;
 			} else if (dcv > 0) {
 				if (maneuver == 'defendother') result = `${result} {{target_name=@{target|charactername}}}`;
-				//if ()
 				result = `${result} {{dcv=${dcv}}} {{title=Defend}} {{defense=1}} ` +
 					`{{total=[[[[?{Roll is|Normal, ${setDice(rollmod)}` +
 					`|Minor Edge, ${setDice(rollmod, 1)}|Minor Obstacle, ${setDice(rollmod, -1)}` +

--- a/BESM4eExtras/BESM4eExtras.html
+++ b/BESM4eExtras/BESM4eExtras.html
@@ -30,7 +30,7 @@
 											<div class="row padt padb"><h3 class="col-1 center border"><span>Sheet Options</span></h3></div>
 											<div class="row center padb">
 												<div class="col-1-5 padr"><h4 class="center border"><span>Sheet Version
-													<input type="text" class="center" name="attr_version" value="1.4.3" readonly />
+													<input type="text" class="center" name="attr_version" value="1.4.4" readonly />
 												</span></h4></div>
 												<div class="col-1-5 padr"><h4 class="center border"><span>Sheet Type
 													<select class="border"><option value="Sheet">Character</option><!--<option value="NPC Sheet">NPC</option><option value="Thing Sheet">Thing</option><option value="GM Sheet">GM</option>--></select>
@@ -10900,11 +10900,14 @@
 				const weapon = _.find(attrdb[`${type}`], w => {
 					if (w.source == rowID) return true;
 				});
+				if (!getIsObject(weapon)) return;
 				const customization = _.find(weapon.customizations, c => {
 					if (c.name == 'ammo') return true;
 				});
+				if (!getIsObject(customization)) return;
 				const ammo = isNaN(parseInt(value[`repeating_attr_${rowID}_ammostate`])) ?
-					getAmmoMax(debug, customization.rank) : parseInt(value[`repeating_attr_${rowID}_ammostate`]);
+					getAmmoMax(debug, customization.rank) : 
+					parseInt(value[`repeating_attr_${rowID}_ammostate`]);
 				const capacity = isNaN(parseInt(value[`repeating_attr_${rowID}_capacitystate`])) ?
 					0 : //parseInt(value[`repeating_attr_${rowID}_capacity`]) :
 					parseInt(value[`repeating_attr_${rowID}_capacitystate`]);
@@ -11029,6 +11032,7 @@
 			const damagetype = 
 				isWeapon ? weapon.damagetype : 'blunt';
 			const isMelee = 
+				type == 'shield' ? true :
 				getIsMelee(debug, weaponclass);
 			const muscle = 
 				isMelee > 0 ? 1 :
@@ -11054,7 +11058,7 @@
 				((level + (superstrength * muscle) + massivedamage + targetedmd) * 5) + acv;
 			let edge = 
 				(isWeapon) ? _.find(weapon.customizations, c => { 
-					if (c.name == 'accurate') return true; 
+					if (c.name == 'accurate' || c.name == 'parry') return true; 
 				}) ||  { rank: 0 } : { rank: 0 };
 			let obstacle = 
 				(isWeapon) ? _.find(weapon.customizations, c => { 
@@ -11266,6 +11270,7 @@
 					`[[${acv}]]]]}} {{roll=$[[0]]}}`;
 			} else if (dcv > 0) {
 				if (maneuver == 'defendother') result = `${result} {{target_name=@{target|charactername}}}`;
+				//if ()
 				result = `${result} {{dcv=${dcv}}} {{title=Defend}} {{defense=1}} ` +
 					`{{total=[[[[?{Roll is|Normal, ${setDice(rollmod)}` +
 					`|Minor Edge, ${setDice(rollmod, 1)}|Minor Obstacle, ${setDice(rollmod, -1)}` +

--- a/BESM4eExtras/BESM4eExtras.html
+++ b/BESM4eExtras/BESM4eExtras.html
@@ -30,7 +30,7 @@
 											<div class="row padt padb"><h3 class="col-1 center border"><span>Sheet Options</span></h3></div>
 											<div class="row center padb">
 												<div class="col-1-5 padr"><h4 class="center border"><span>Sheet Version
-													<input type="text" class="center" name="attr_version" value="1.4.4" readonly />
+													<input type="text" class="center" name="attr_version" value="1.4.5" readonly />
 												</span></h4></div>
 												<div class="col-1-5 padr"><h4 class="center border"><span>Sheet Type
 													<select class="border"><option value="Sheet">Character</option><!--<option value="NPC Sheet">NPC</option><option value="Thing Sheet">Thing</option><option value="GM Sheet">GM</option>--></select>
@@ -9233,11 +9233,32 @@
 					base = cv;
 					break;
 				case 'dcv':
-					cv = getCV(debug, value, attrdb, setObj, sourceAttr, 'dcv');
+					const defensetype = 
+						parseInt(setObj.static_button_movement_defense) ?
+						'movement' :
+						parseInt(setObj.static_button_personal_defense) ?
+						'personal' :
+						parseInt(value.static_button_movement_defense) ?
+						'movement' :
+						parseInt(value.static_button_personal_defense) ?
+						'personal' :
+						'';
+					console.log(`[setCombatRoll(TEST)] defensetype = ${defensetype}`);
+					
+					const bonus = defensetype != '' ? 
+						getSumOfActiveAttrLevels(attrdb, 'rangeddefense', defensetype) * 2 :
+						0;
+					console.log(`[setCombatRoll(TEST)] bonus = ${bonus}`);
+					
+					cv = getCV(debug, value, attrdb, setObj, sourceAttr, 'dcv')  + bonus;
+					console.log(`[setCombatRoll(TEST)] cv = ${cv}`);
+		
 					type = '{{dcvroll=1}}';
 					title = '{{title=Roll DCV}}';
 					stat = `{{dcv=${cv}}}`;
 					base = cv;
+					console.log(`[setCombatRoll(TEST)] base = ${base}`);
+		
 					result = `${result} ${buildProtectionsString(debug, value)}`;
 					break;
 				case 'initiative':

--- a/BESM4eExtras/BESM4eExtras.html
+++ b/BESM4eExtras/BESM4eExtras.html
@@ -30,7 +30,7 @@
 											<div class="row padt padb"><h3 class="col-1 center border"><span>Sheet Options</span></h3></div>
 											<div class="row center padb">
 												<div class="col-1-5 padr"><h4 class="center border"><span>Sheet Version
-													<input type="text" class="center" name="attr_version" value="1.3.2" readonly />
+													<input type="text" class="center" name="attr_version" value="1.4.0" readonly />
 												</span></h4></div>
 												<div class="col-1-5 padr"><h4 class="center border"><span>Sheet Type
 													<select class="border"><option value="Sheet">Character</option><!--<option value="NPC Sheet">NPC</option><option value="Thing Sheet">Thing</option><option value="GM Sheet">GM</option>--></select>
@@ -544,7 +544,7 @@
 									<div class="flex-container-evenlyspace">
 										<div class='flex-1-8'></div>
 										<div class="flex-7-10">
-											<select class="border" name="attr_static_activity_maneuver_name">
+											<select class="border" name="attr_static_weapon_maneuver_name">
 												<option value=""></option>
 												<option disabled style="background:gray;font-weight:bold;color:white;">Offense</option>
 													<option value="attack">Attack</option>
@@ -708,6 +708,96 @@
 						<div class="flex-1-2 padr"><h4 class="center border"><span name="attr_label_actionturns">Actions by Initiative
 						<input type="text" class="center border" name="attr_actionsbyinitiative" value="" readonly /></span></h4></div>
 					</div>
+					<div>
+						<input type="checkbox" class="block-switch" name="attr_weapon_range" value="1" />
+						<div class="block-a"></div>
+						<div class="block-b">
+							<div class="row">
+								<div style="padding-left: 20px;" class="col-1 padr">
+									<div class="flex-container-evenlyspace padb">
+										<div class="flex-1 padr padb">
+											<h4 class="center border">
+												<span style="font-weight: normal;">
+													<div class="flex-container-evenlyspace">
+														<div class="flex-1">Range
+															<div class="flex-container-evenlyspace">
+																<div class="flex-9-20">
+																	<select class="border center" name="attr_static_weapon_range_selection">
+																		<option value=1>Effective</option>
+																		<option value=2>Intermediate</option>
+																		<option value=3>Remote</option>
+																	</select>
+																</div>
+																<div class="flex-9-20">
+																	<input type="text" class="border center" name="attr_weapon_range_distance" value="" readonly />
+																</div>
+															</div>
+														</div>
+													</div>
+												</span>
+											</h4>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+
+					<div style="padding-left: 20px;" class="padr">
+						<input type="checkbox" class="block-switch" name="attr_weapon_ammo_autofire" value="1" />
+						<div class="block-a"></div>
+						<div class="block-b">
+							<div class="flex-container">
+								<div class="flex-1-2">
+									<input type="checkbox" class="block-switch" name="attr_weapon_ammo" value="1" />
+									<div class="block-a">
+										<div class="col-1 padb padr">
+											<h4 class="center border">
+												<span style="font-size: 99px;">&nbsp;</span>
+											</h4>
+										</div>
+									</div>
+									<div class="block-b">
+										<div class="col-1 padb padr">
+											<h4 class="center border">
+												<span style="font-weight: normal;">
+													<div class="flex-container-evenlyspace">
+														<div class="flex-3-10 padr">Reloads<input type="number" class="border" name="attr_weapon_ammo_reloads" value=0 /></div>
+														<div class="flex-3-10 padr">Capacity<input type="number" class="border" name="attr_weapon_ammo_capacity" value=0 /></div>
+														<div class="flex-3-10"><button style='width: 20px; height: 25px;' type='action' name='act_static_button_ammo_reload'><span style="font-family: Pictos; font-size: large;">1</span></button></div>
+													</div>
+												</span>
+											</h4>
+										</div>
+									</div>
+								</div>
+								<div class="flex-1-2">
+									<input type="checkbox" class="block-switch" name="attr_weapon_autofire" value="1" />
+									<div class="block-a">
+										<div class="col-1 padb padr">
+											<h4 class="center border">
+												<span style="font-size: 99px;">&nbsp;</span>
+											</h4>
+										</div>
+									</div>
+									<div class="block-b">
+										<div class="col-1 padb padr">
+											<h4 class="center border">
+												<span style="font-weight: normal;">&nbsp;&nbsp;&nbsp;Autofire&nbsp;Mode&nbsp;&nbsp;&nbsp;
+													<select class="border" name="attr_static_weapon_autofire_selection">
+														<option value=1>Single</option>
+														<option value=3>Burst</option>
+														<option value=6>Full Auto</option>
+													</select>
+												</span>
+											</h4>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+
 					<div class="flex-container-evenlyspace padb padt">
 						<div class="flex-8-9"><span class="col-1 header border">Weapon Selection</span></div>
 					</div>
@@ -3158,14 +3248,28 @@
 																	</div>
 																</div>
 															</div>
+															<!--
 															<div>
 																<input type="checkbox" class="block-switch" name="attr_showammo" value="1" />
 																<div class="block-a"></div>
 																<div class="block-b">
 																	<div class="col-1 padr">
 																		<h4 class="center border">
-																			<span>Ammo</span>
-																			<input type="text" class="border center" name="attr_ammo" value="0" readonly />
+																			<span>Reloads</span>
+																			<input type="text" class="border center" name="attr_ammo" value="0" />
+																		</h4>
+																	</div>
+																</div>
+															</div>
+															-->
+															<div>
+																<input type="checkbox" class="block-switch" name="attr_showammo" value="1" />
+																<div class="block-a"></div>
+																<div class="block-b">
+																	<div class="col-1 padr">
+																		<h4 class="center border">
+																			<span>Capacity</span>
+																			<input type="text" class="border center" name="attr_capacity" value="0" />
 																		</h4>
 																	</div>
 																</div>
@@ -3177,7 +3281,7 @@
 																	<div class="col-1 padr">
 																		<h4 class="center border">
 																			<span>Charges</span>
-																			<input type="text" class="border center" name="attr_charges" value="0" readonly />
+																			<input type="text" class="border center" name="attr_charges" value="0" />
 																		</h4>
 																	</div>
 																</div>
@@ -5188,7 +5292,7 @@
 																	<div class="tab-content limitertab35"><!-- Weapons -->
 																		<div class="row">
 																			<div class="col-1-2 padr fontsize-12px"><input type="text" value="Ammo" disabled /></div>
-																			<div class="col-1-2 padr fontsize-12px"><select name="attr_limiterammo"><option value=0>False</option><option value=1>6 shots</option><option value=2>3 shots</option><option value=3>1 shot</option><option value=4>Single use</option></select></div>
+																			<div class="col-1-2 padr fontsize-12px"><select name="attr_limiterammo"><option value=0>False</option><option value=1>6 reloads</option><option value=2>3 reloads</option><option value=3>1 reload</option><option value=4>Single use</option></select></div>
 																		</div>
 																		<div class="row">
 																			<div class="col-1-2 padr fontsize-12px"><input type="text" value="Backblast" disabled /></div>
@@ -5811,28 +5915,34 @@
 				{{/duration}} {{#range}}
 				<div class="row">
 					<div class="col-5-12 padl padr rt-key">Range</div>
-					<div class="col-7-12 padr rt-value center">{{distance}} {{kilometers}}m</div>
+					<div class="col-7-12 padr rt-value center">{{range}}</div>
 				</div>
 				{{/range}} {{#autofire}}
 				<div class="row">
-					<div class="col-5-12 padl padr rt-key">Autofire - Attack</div>
-					<div class="col-7-12 padr rt-value center">Number of Hits</div>
-				</div>
-				<div class="row">
-					<div class="col-5-12 padl padr rt-key">>1-3</div>
-					<div class="col-7-12 padr rt-value center">1</div>
-				</div>
-				<div class="row">
-					<div class="col-5-12 padl padr rt-key">>4-6</div>
-					<div class="col-7-12 padr rt-value center">2</div>
-				</div>
-				<div class="row">
-					<div class="col-5-12 padl padr rt-key">>7-9</div>
-					<div class="col-7-12 padr rt-value center">3</div>
-				</div>
-				<div class="row">
-					<div class="col-5-12 padl padr rt-key">>10-12</div>
-					<div class="col-7-12 padr rt-value center">4</div>
+					<div class="col-5-12 padl padr rt-key">Autofire</div>
+					{{#rollTotal() roll 2}}
+					<div class="col-7-12 padr rt-value center">hits: {{hits2}}/{{rof}}</div>
+					{{/rollTotal() roll 2}} {{#rollTotal() roll 3}}
+					<div class="col-7-12 padr rt-value center">hits: {{hits3}}/{{rof}}</div>
+					{{/rollTotal() roll 3}} {{#rollTotal() roll 4}}
+					<div class="col-7-12 padr rt-value center">hits: {{hits4}}/{{rof}}</div>
+					{{/rollTotal() roll 4}} {{#rollTotal() roll 5}}
+					<div class="col-7-12 padr rt-value center">hits: {{hits5}}/{{rof}}</div>
+					{{/rollTotal() roll 5}} {{#rollTotal() roll 6}}
+					<div class="col-7-12 padr rt-value center">hits: {{hits6}}/{{rof}}</div>
+					{{/rollTotal() roll 6}} {{#rollTotal() roll 7}}
+					<div class="col-7-12 padr rt-value center">hits: {{hits7}}/{{rof}}</div>
+					{{/rollTotal() roll 7}} {{#rollTotal() roll 8}}
+					<div class="col-7-12 padr rt-value center">hits: {{hits8}}/{{rof}}</div>
+					{{/rollTotal() roll 8}} {{#rollTotal() roll 9}}
+					<div class="col-7-12 padr rt-value center">hits: {{hits9}}/{{rof}}</div>
+					{{/rollTotal() roll 9}} {{#rollTotal() roll 10}}
+					<div class="col-7-12 padr rt-value center">hits: {{hits10}}/{{rof}}</div>
+					{{/rollTotal() roll 10}} {{#rollTotal() roll 11}}
+					<div class="col-7-12 padr rt-value center">hits: {{hits11}}/{{rof}}</div>
+					{{/rollTotal() roll 11}} {{#rollTotal() roll 12}}
+					<div class="col-7-12 padr rt-value center">hits: {{hits12}}/{{rof}}</div>
+					{{/rollTotal() roll 12}}
 				</div>
 				{{/autofire}} {{#blight}}
 				<div class="row">
@@ -6329,7 +6439,7 @@
 		const combattechniques_array = ['blackout', 'blindfighting', 'blindshooting', 'criticalstrike', 'enhancedknockback', 'extendedrange', 'farshot', 'lethalblow', 'multipletargets', 'perciseaim', 'rushattack', 'twoweapons'];
 		const stats_array = ['static_stat_type_set', 'static_stat_temp_energy', 'static_stat_temp_health', 'stat_total_social', 'static_stat_total_shame', 'stat_total_sanity', 'static_stat_total_maddness', 'stat_total_energy', 'static_stat_total_fatigue', 'stat_total_health', 'static_stat_total_wounds', 'stat_total_shock', 'static_character_points_spent', 'bodystate', 'mindstate', 'soulstate', 'static_stat_base_body', 'static_stat_base_mind', 'static_stat_base_soul', 'stat_total_body', 'stat_total_mind', 'stat_total_soul', 'stat_total_acv', 'stat_total_dcv', 'stat_total_str', 'stat_total_cre', 'stat_total_com', 'stat_total_awa', 'stat_total_dex', 'stat_total_agi', 'stat_total_con', 'stat_total_int', 'stat_total_per', 'stat_total_rea', 'stat_total_wil', 'stat_total_cha', 'strstate', 'agistate', 'dexstate', 'constate', 'intstate', 'reastate', 'perstate', 'crestate', 'wilstate', 'chastate', 'awastate', 'comstate'];
 		const rolls_array = ['static_roll_type_selection','static_button_personal_defense','static_button_movement_defense'];
-		const combat_stats_array = ['mainhand_state', 'offhand_state', 'mainhand_source', 'offhand_source', 'extraarms', 'extraarms_inuse', 'attrdb', 'static_button_targeted_damage', 'static_button_targeted_attack', 'static_button_targeted_defense', 'massivedamage_targeted', 'massivedamage', 'enemyattack', 'enemydefense'];
+		const combat_stats_array = ['static_weapon_autofire_selection','weapon_ammo_capacity','weapon_ammo_reloads','static_weapon_range_selection','mainhand_state', 'offhand_state', 'mainhand_source', 'offhand_source', 'extraarms', 'extraarms_inuse', 'attrdb', 'static_button_targeted_damage', 'static_button_targeted_attack', 'static_button_targeted_defense', 'massivedamage_targeted', 'massivedamage', 'enemyattack', 'enemydefense'];
 		const size_template_values_array = ['size', 'height', 'mass', 'size_lift', 'size_strdmg', 'size_ar', 'size_extradmg', 'size_rnghitdef', 'size_rngspd'];
 		const all_attributes_array = ['absorption','alternate form','alternate identity','armor','attack mastery','augmented','capacity','change state','cognition','combat technique','companion','connected','control environment','conversion','data access','defect','defense mastery','dimension walk','dynamic powers','elasticity','enemy attack','enemy defense','energized','exorcism','extra actions','extra arms','extra defenses','features','flight','forcefield','gear','ground speed','healing','heightened awareness','heightened senses','illusion','immovable','immunity','immutable','inspire','jumping','massive damage','melee attack','melee defense','merge','metamorphosis','mimic','mind control','mind shield','minions','mulligan','nullify','plant control','pocket dimension','portal','power flux','power variation','projection','ranged attack','ranged defense','regeneration','reincarnation','resilient','sensory block','shield','sixth sense','size change','skill','social mastery','spaceflight','special movement','summon creatures','supersense','superspeed','superstrength','swarm','telekinesis','telepathy','teleport','tough','transfer','transmute','tunneling','unaffected','unassailable','undetectable','unique attribute','unknown power','water speed','wealth','weapon'];
 		const all_attributes_regex = /(absorption|alternate form|alternate identity|armor|attack mastery|augmented|capacity|change state|cognition|combat technique|companion|connected|control environment|conversion|data access|defect|defense mastery|dimension walk|dynamic powers|elasticity|enemy attack|enemy defense|energized|exorcism|extra actions|extra arms|extra defenses|features|flight|forcefield|gear|ground speed|healing|heightened awareness|heightened senses|illusion|immovable|immunity|immutable|inspire|jumping|massive damage|melee attack|melee defense|merge|metamorphosis|mimic|mind control|mind shield|minions|mulligan|nullify|plant control|pocket dimension|portal|power flux|power variation|projection|ranged attack|ranged defense|regeneration|reincarnation|resilient|sensory block|shield|sixth sense|size change|skill|social mastery|spaceflight|special movement|summon creatures|supersense|superspeed|superstrength|swarm|telekinesis|telepathy|teleport|tough|transfer|transmute|tunneling|unaffected|unassailable|undetectable|unique attribute|unknown power|water speed|wealth|weapon)/i;
@@ -6531,12 +6641,15 @@
 			const attrs = [
 				`activate`,
 				`ammo`,
+				`ammostate`,
 				`armorlayer`,
 				`attrdefecttoggle`,
 				`attribute`,
 				`attrsrc`,
 				`augmentedstat`,
 				`bonus`,
+				`capacity`,
+				`capacitystate`,
 				`capacitytype`,
 				`characteristic`,
 				`charges`,
@@ -10645,8 +10758,169 @@
 			return /(bite|disarm|grab|lock|pin|throw)/i.test(maneuver);
 		}
 		
+		function setRange(debug, attrdb, customization, selection, setObj) {
+			const result = getRange(debug, attrdb, customization, selection);
+			setObj.weapon_range_distance = result;
+			if(debug) {
+				console.log(`[setRange()] result = ${result}`);
+			}
+		}
+		
+		function getRangeRollmod(debug, selection) {
+			const result = selection == 3 ? -2 :
+				selection == 2 ? -1 :
+				0;
+			if(debug) console.log(`[getRangeRollmod()] result = ${result}`);
+			return result;
+		}
+		
+		function getRangeDistance(debug, selection) {
+			console.log(`[getRangeDistance()] selection = ${selection}`);
+			const selectobj = {
+				1:0.2,
+				2:0.5,
+				3:1
+			};
+			const result = selectobj[selection] || 0;
+			if(debug) console.log(`[getRangeDistance()] result = ${result}`);
+			return result;
+		}
+		
+		function getRange(debug, attrdb, customization, selection) {
+			console.log(`[getRange()] selection = ${selection}`);
+			const extended = 
+				getSumOfActiveSubAttrRanks(attrdb, 'combattechnique', 'extendedrange') ||
+				0;
+			const rangeobj = {
+				1:3,
+				2:10,
+				3:100,
+				4:1000,
+				5:10000,
+				6:100000
+			};
+			const distance = 
+				`${Math.round(((rangeobj[customization.rank] ||
+				0) * (extended + 1)) * getRangeDistance(debug, selection))}` ||
+				"0";
+			const length = distance.length;
+			const range = length > 3 ? 
+				`${parseInt(distance)/1000} km` :
+				`${distance} m`;
+			if(debug) console.log(`[getRange()] range = ${range}`);
+			return range;
+		}
+		
+		function getAmmoMax(debug, rank) {
+			const result = rank == 4 ? 0 : 6 / rank;
+			if(debug) console.log(`[getAmmoMax()] result = ${result}`);
+			return result;
+		}
+		
+		function setWeaponReload(debug, attrdb, value, setObj) {
+			const debugtext = '[setWeaponReload()]';
+			const rowID = value.active_weapon;
+			const weapon = _.find(attrdb.weapon, w => {
+				if (w.source == rowID) return true;
+			});
+			const customization = _.find(weapon.customizations, c => {
+				if (c.name == 'ammo') return true;
+			});
+			const ammo = getAmmoMax(debug, customization.rank);
+			const capacity = parseInt(value[`repeating_attr_${rowID}_capacity`]);
+			let ammostate = parseInt(value.weapon_ammo_reloads);
+			let capacitystate = parseInt(value.weapon_ammo_capacity);
+			const reloadammo = ammo => ammo > 0 ? ammostate -= 1 : ammostate;
+			const reloadcapacity = ammo => ammo > 0 ? capacitystate = capacity : capacitystate;
+			setObj.weapon_ammo_reloads = reloadammo(ammostate);
+			setObj.weapon_ammo_capacity = reloadcapacity(ammostate);
+		}
+		
+		function setWeaponAmmo(debug, attrdb, value, handsource, setObj) {
+			const debugtext = '[setWeaponAmmo()]';
+			const state = setObj[`${handsource}_state`];
+			const rowID = value[`${handsource}_source`];
+			if (state) {//weapon armed, load ammo state
+				const weapon = _.find(attrdb.weapon, w => {
+					if (w.source == rowID) return true;
+				});
+				const customization = _.find(weapon.customizations, c => {
+					if (c.name == 'ammo') return true;
+				});
+				const ammo = isNaN(parseInt(value[`repeating_attr_${rowID}_ammostate`])) ?
+					getAmmoMax(debug, customization.rank) : parseInt(value[`repeating_attr_${rowID}_ammostate`]);
+				const capacity = isNaN(parseInt(value[`repeating_attr_${rowID}_capacitystate`])) ?
+					parseInt(value[`repeating_attr_${rowID}_capacity`]) :
+					parseInt(value[`repeating_attr_${rowID}_capacitystate`]);
+				setObj.weapon_ammo_reloads = ammo;
+				setObj.weapon_ammo_capacity = capacity;
+				if(debug){
+					console.log(`${debugtext} ammo = ${ammo}`);
+					console.log(`${debugtext} capacity = ${capacity}`);
+				}
+			} else {//weapon unarmed, save ammo state
+				const ammostate = parseInt(value.weapon_ammo_reloads);
+				const capacitystate = parseInt(value.weapon_ammo_capacity);
+				setObj[`repeating_attr_${rowID}_ammostate`] = ammostate;
+				setObj[`repeating_attr_${rowID}_capacitystate`] = capacitystate;
+				if(debug){
+					console.log(`${debugtext} ammostate = ${ammostate}`);
+					console.log(`${debugtext} capacitystate = ${capacitystate}`);
+				}
+			}	
+		}
+		
+		function setActiveWeaponUI(debug, attrdb, value, setObj) {
+			//set defaults
+			setObj.weapon_range = 0;
+			setObj.weapon_ammo_autofire = 0;
+			setObj.weapon_ammo = 0;
+			setObj.weapon_autofire = 0;
+			const weapon = setObj.active_weapon;
+			if (weapon == '') return;
+			const weapondb = attrdb.weapon.find(o => {
+				if (o.source == weapon) return true;
+			});
+			const customizations = weapondb.customizations;	
+			//set default overrides
+			_.each(weapondb.customizations, customization => {
+				switch(customization.name){
+					case 'ammo':
+						setObj.weapon_ammo_autofire = 1;
+						setObj.weapon_ammo = 1;
+						/*
+						const ammostate = parseInt(value[`repeating_attr_${weapon}_ammostate`]);
+						const ammo = isNaN(ammostate) ?
+							getAmmoMax(debug, customization.rank) : 
+							ammostate;
+						const capacitystate = parseInt(value[`repeating_attr_${weapon}_capacitystate`]);
+						const capacity = isNaN(capacitystate) ? 
+							parseInt(value[`repeating_attr_${weapon}_capacity`]) :
+							capacitystate;
+						setObj.weapon_ammo_reloads = ammo;
+						setObj.weapon_ammo_capacity = capacity;
+						*/
+					break;
+					case 'autofire':
+						setObj.weapon_ammo_autofire = 1;
+						setObj.weapon_autofire = 1
+					break;
+					case 'range':
+						const selection = customization.rank > 2 ?
+							parseInt(setObj.static_weapon_range_selection) || 
+							parseInt(value.static_weapon_range_selection) ||
+							1 :
+							1;
+						setObj.weapon_range = customization.rank > 0 ? 1 : 0;
+						setRange(debug, attrdb, customization, selection, setObj);
+					break;
+				}
+			})
+		}
+		
 		function setCombatRoll(debug, value, attrdb, rowID, sourceAttr, setObj, invertState = false) {
-			const activeweapon = setObj.active_weapon;
+			const debugtext = '[setCombatRoll()]';
+			const activeweapon = setObj.active_weapon === undefined ? rowID : setObj.active_weapon;
 			const weapon = 
 				_.find(attrdb.weapon, o => { if (o.source == activeweapon) return o; }) ||
 				_.find(attrdb.swarm, o => { if (o.source == activeweapon) return o; });
@@ -10691,7 +10965,7 @@
 			const absorption2 = parseInt(value.protection_absorption2_ar) || 0;
 			const conversion = parseInt(value.protection_conversion_ar) || 0;
 			let maneuver = 
-				setObj.static_activity_maneuver_name || value.static_activity_maneuver_name;
+				setObj.static_weapon_maneuver_name || value.static_weapon_maneuver_name;
 			maneuver = 
 				`${maneuver.replace(/\s+/g, '')}`;
 			const acv = 
@@ -10732,14 +11006,23 @@
 				result = `${result} {{title=Attack}} {{attack=1}} {{target_name=@{target|charactername}}} {{acv=${acv}}} {{damage_type=${damagetype}}} {{damage2=${Math.round(damage * 0.25)}}} {{damage3=${Math.round(damage * 0.35)}}} {{damage4=${Math.round(damage * 0.45)}}} {{damage5=${Math.round(damage * 0.55)}}} {{damage6=${Math.round(damage * 0.65)}}} {{damage7=${Math.round(damage * 0.75)}}} {{damage8=${Math.round(damage * 0.9)}}} {{damage9=${Math.round(damage * 1.05)}}} {{damage10=${Math.round(damage * 1.2)}}} {{damage11=${Math.round(damage * 1.35)}}} {{damage12=${Math.round(damage * 1.5)}}}`;
 				if (isWeapon > 0){
 					_.each(weapon.customizations, customization => {
+						console.log(`${debugtext} customization:`); console.log(customization);
 						switch (customization.name) {
-							case 'ammo':
-								const ammunition = parseInt(value[`repeating_attr_${rowID}_ammo`]) || 0;
-								result = `${result} {{${customization.name}=${customization.rank}}} {{ammunition=${ammunition}}}`;
-							break;
 							case 'area':
 								const radius = get1or3(customization.rank, 3) * (10 ** (Math.ceil((customization.rank) / 2)));
 								result = `${result} {{${customization.name}=${customization.rank}}} {{radius=${radius}}}`;
+							break;
+							case 'autofire':
+								const firemode = parseInt(setObj[`static_weapon_autofire_selection`]) || 
+									parseInt(value[`static_weapon_autofire_selection`]);
+								const numhits = firemode == 1 ?
+									`{{hits2=1}} {{hits3=1}} {{hits4=1}} {{hits5=1}} {{hits6=1}} {{hits7=1}} {{hits8=1}} {{hits9=1}} {{hits10=1}} {{hits11=1}} {{hits12=1}}` :
+									firemode == 3 ?
+									`{{hits2=1}} {{hits3=1}} {{hits4=1}} {{hits5=1}} {{hits6=2}} {{hits7=2}} {{hits8=2}} {{hits9=2}} {{hits10=3}} {{hits11=3}} {{hits12=3}}` :
+									firemode == 6 ?
+									`{{hits2=1}} {{hits3=1}} {{hits4=1}} {{hits5=2}} {{hits6=2}} {{hits7=2}} {{hits8=3}} {{hits9=3}} {{hits10=4}} {{hits11=5}} {{hits12=6}}` :
+									'';
+								result = `${result} {{${customization.name}=${customization.rank}}} {{rof=${firemode}}} ${numhits}`;
 							break;
 							case 'backblast':
 								const bystander = customization.rank > 1 ? 'User and bystanders' :
@@ -10837,18 +11120,15 @@
 								result = `${result} {{${customization.name}=${customization.rank}}} {{fissure=${fissure}}}`;
 							break;
 							case 'range':
-								const extended = getSumOfActiveSubAttrRanks(attrdb, 'combattechnique', 'extendedrange') || 0;
-								const distanceobj = {
-									1:3,
-									2:10,
-									3:100,
-									4:1,
-									5:10,
-									6:100
-								};
-								const distance = distanceobj[customization.rank] * (extended + 1) || "0";
-								const kilometers = customization.rank > 3 ? 'k' : '';
-								result = `${result} {{${customization.name}=${customization.rank}}} {{distance=${distance}}} {{kilometers=${kilometers}}}`;
+								const selection = customization.rank > 2 ?
+									parseInt(setObj.static_weapon_range_selection) || 
+									parseInt(value.static_weapon_range_selection) ||
+									1 :
+									1;
+								setRange(debug, attrdb, customization, selection, setObj);
+								const range = setObj.weapon_range_distance;
+								rollmod = rollmod + getRangeRollmod(debug, selection);
+								result = `${result} {{${customization.name}=${customization.rank}}} {{range=${range}}}`;
 							break;
 							case 'stoppable':
 								const stopdamage = parseInt(value[`repeating_attr_${rowID}_level`]) * 10;
@@ -10881,7 +11161,6 @@
 									customization.rank > 0 ? 'Restore' : '';
 								result = `${result} {{${customization.name}=${customization.rank}}} {{stolenhealth=${stolenhealth}}}`;
 							break;
-							case 'autofire':
 							case 'contact':
 							case 'contagious':
 							case 'fieldless':
@@ -11016,6 +11295,10 @@
 		}
 		
 		function disableActiveWeapon(debug, value, rowID, setObj) {
+			setObj.weapon_range = 0;
+			setObj.weapon_ammo_autofire = 0;
+			setObj.weapon_ammo = 0;
+			setObj.weapon_autofire = 0;
 			const state = parseInt(setObj[`repeating_attr_${rowID}_activate`]) || 
 				parseInt(value[`repeating_attr_${rowID}_activate`]);
 			const activeweapon = value.active_weapon;
@@ -11060,14 +11343,16 @@
 		}
 		
 		function getHandSource(debug, rowID){
-			const result = /(mainhand|offhand)/i.test(rowID) ? 
+			const handsource = /(mainhand|offhand)/i.test(rowID) ? 
 				rowID : `repeating_extraarm_${rowID}`;
+			const handscheck = handsource.indexOf(',') > 0 ? handsource.split(',') : handsource;
+			const result = _.isArray(handscheck) ? handscheck[0] : handscheck;
 			if(debug) console.log(`[getHandSource()] result = ${result}`);
 			return result;
 		}
 		
 		function setWeaponStates(debug, extraarmIDs, value, rowID, setObj) {
-			const armedID = setObj[`${rowID}_source`] || 
+			const armedID = setObj[`${rowID}_source`] ||
 				value[`${rowID}_source`] || '';
 			const handsArray = buildHandsArray(debug, extraarmIDs);
 			const handsStateArray = _.map(handsArray, hand => {
@@ -11323,7 +11608,9 @@
 		
 		function registerEvents() {
 			const eventsToRegister = [
-				"static_activity_maneuver_name",
+				"static_weapon_autofire_selection",
+				"static_weapon_range_selection",
+				"static_weapon_maneuver_name",
 				"static_stat_type_set",
 				"static_roll_type_selection",
 				"static_stat_temp_health",
@@ -11381,6 +11668,7 @@
 					"repeating_skilltemplate:addskill",
 					"repeating_extraarm:armedstate",
 					"repeating_skill",
+					"static_button_ammo_reload",
 					"static_button_targeted_damage",
 					"static_button_targeted_attack",
 					"static_button_targeted_defense",
@@ -11495,7 +11783,7 @@
 					getAttrsString = getAttrsString.concat(rolls_array);
 					getAttrsString = getAttrsString.concat([
 						`theme`, 
-						`static_activity_maneuver_name`, 
+						`static_weapon_maneuver_name`, 
 						`active_weapon`, 
 						`static_attrgroup_selected_tab`, 
 						`static_skillgroup_selected_tab`
@@ -11576,9 +11864,12 @@
 											if (!getIsLocked(debug, value, rowID, sourceAttr)) return;
 											if (!getFluxGroupIsActive(debug, value, rowID)) return;
 											const isActive = setButtonState(debug, value, source, rowID, sourceAttr, setObj);
+											const handsource = getHandSource(debug, value[`repeating_attr_${rowID}_source`]);
+											const handstate = parseInt(value[`${handsource}_state`]);
 											setAttrEffects(debug, isActive, value, attrdb, extraarmIDs, attrIDs, sectionName, rowID, sourceAttr, setObj);
 											setPoolCostIfGroupIsFlux(debug, isActive, attrIDs, value, rowID, setObj);
 											setPoolCostIfGroupIsVariation(debug, isActive, attrIDs, value, rowID, setObj);
+											if (handstate) setWeaponAmmo(debug, attrdb, value, handsource, setObj);
 											disableActiveWeapon(debug, value, rowID, setObj);
 											setGroupDefectPointsOnActivation(debug, attrIDs, attrdb, value, sectionName, rowID, setObj);
 										break;
@@ -11634,7 +11925,9 @@
 										case `armedstate`:
 											const handsource = getHandSource(debug, rowID);
 											setWeaponStates(debug, extraarmIDs, value, handsource, setObj);
-											setActiveWeapon(debug, value, handsource, setObj);	
+											setActiveWeapon(debug, value, handsource, setObj);
+											setActiveWeaponUI(debug, attrdb, value, setObj);
+											setWeaponAmmo(debug, attrdb, value, handsource, setObj);
 											setCombatRoll(debug, value, attrdb, value[`${source}_source`], sourceAttr, setObj);
 										break;
 									}
@@ -11662,9 +11955,11 @@
 							return;
 						} else if (sourceType==`static`) {
 							switch (sectionName) {
-								case `activity`:
+								case `weapon`:
 									switch (rowID) {
+										case `autofire`:
 										case `maneuver`:
+										case `range`:
 											setCombatRoll(debug, value, attrdb, value.active_weapon, sourceAttr, setObj);
 										break;
 									}
@@ -11726,11 +12021,16 @@
 										setButtonState(debug, value, source, rowID, sourceAttr, setObj);
 										setDynamicRollValue(debug, eventInfo, value, attrdb, rowID, sourceAttr, setObj);
 									}
+									if (rowID == 'ammo') {
+										setWeaponReload(debug, attrdb, value, setObj);
+									}
 									setStatButtonStatsAndRolls(debug, eventInfo, value, rowID, sourceAttr, setObj);
 									switch (`${sourceAttr}`) {
 										case `armedstate`:
 											setWeaponStates(debug, extraarmIDs, value, rowID, setObj);
 											setActiveWeapon(debug, value, rowID, setObj);
+											setActiveWeaponUI(debug, attrdb, value, setObj);
+											setWeaponAmmo(debug, attrdb, value, rowID, setObj);
 											setCombatRoll(debug, value, attrdb, value[`${rowID}_source`], sourceAttr, setObj);
 										break;
 									}

--- a/BESM4eExtras/BESM4eExtras.html
+++ b/BESM4eExtras/BESM4eExtras.html
@@ -30,7 +30,7 @@
 											<div class="row padt padb"><h3 class="col-1 center border"><span>Sheet Options</span></h3></div>
 											<div class="row center padb">
 												<div class="col-1-5 padr"><h4 class="center border"><span>Sheet Version
-													<input type="text" class="center" name="attr_version" value="1.4.2" readonly />
+													<input type="text" class="center" name="attr_version" value="1.4.3" readonly />
 												</span></h4></div>
 												<div class="col-1-5 padr"><h4 class="center border"><span>Sheet Type
 													<select class="border"><option value="Sheet">Character</option><!--<option value="NPC Sheet">NPC</option><option value="Thing Sheet">Thing</option><option value="GM Sheet">GM</option>--></select>
@@ -6232,10 +6232,18 @@
 				{{/conversion}}
 				<div class="row">
 					<div class="col-5-12 padl padr rt-key">Shock Value</div>
-					<div class="col-7-12 padr rt-value center">{{shock}}</div>
+					<div class="col-7-12 padr rt-value center">{{shockvalue}}</div>
 				</div>
 				{{/defense}} {{#doesnothing}}
 				<div class="rt-emote"><i>{{character_name}} does nothing...</i></div>
+				<div class="row">
+					<div class="col-5-12 padl padr rt-key">Melee</div>
+					<div class="col-7-12 padr rt-value center">TN 0</div>
+				</div>
+				<div class="row">
+					<div class="col-5-12 padl padr rt-key">Ranged</div>
+					<div class="col-7-12 padr rt-value center">TN 12</div>
+				</div>
 				{{#forcefield}}
 				<div class="row">
 					<div class="col-5-12 padl padr rt-key">Forcefield</div>
@@ -6284,7 +6292,7 @@
 				{{/conversion}}
 				<div class="row">
 					<div class="col-5-12 padl padr rt-key">Shock Value</div>
-					<div class="col-7-12 padr rt-value center">{{shock}}</div>
+					<div class="col-7-12 padr rt-value center">{{shockvalue}}</div>
 				</div>
 				{{/doesnothing}} {{#twodsix}}
 				<div class="rt-emote"><i>{{character_name}} rolls 2d6...</i></div>
@@ -6319,6 +6327,51 @@
 				<div class="row">
 					<div class="col-5-12 padl padr rt-key">Total</div>
 					<div class="col-7-12 padr rt-value center">{{total}}</div>
+				</div>
+				{{#forcefield}}
+				<div class="row">
+					<div class="col-5-12 padl padr rt-key">Forcefield</div>
+					<div class="col-7-12 padr rt-value center">{{forcefield}}</div>
+				</div>
+				{{/forcefield}} {{#armor1}}
+				<div class="row">
+					<div class="col-5-12 padl padr rt-key">Primary Armor</div>
+					<div class="col-7-12 padr rt-value center">{{armor1}}</div>
+				</div>
+				{{/armor1}} {{#armor2}}
+				<div class="row">
+					<div class="col-5-12 padl padr rt-key">Secondary Armor</div>
+					<div class="col-7-12 padr rt-value center">{{armor2}}</div>
+				</div>
+				{{/armor2}} {{#armor3}}
+				<div class="row">
+					<div class="col-5-12 padl padr rt-key">Tertiary Armor</div>
+					<div class="col-7-12 padr rt-value center">{{armor3}}</div>
+				</div>
+				{{/armor3}} {{#mindshield}}
+				<div class="row">
+					<div class="col-5-12 padl padr rt-key">Mind Shield</div>
+					<div class="col-7-12 padr rt-value center">{{mindshield}}</div>
+				</div>
+				{{/mindshield}} {{#absorption1}}
+				<div class="row">
+					<div class="col-5-12 padl padr rt-key">Absorption - Health</div>
+					<div class="col-7-12 padr rt-value center">{{absorption1}}</div>
+				</div>
+				{{/absorption1}} {{#absorption2}}
+				<div class="row">
+					<div class="col-5-12 padl padr rt-key">Absorption - Energy</div>
+					<div class="col-7-12 padr rt-value center">{{absorption2}}</div>
+				</div>
+				{{/absorption2}} {{#conversion}}
+				<div class="row">
+					<div class="col-5-12 padl padr rt-key">Conversion</div>
+					<div class="col-7-12 padr rt-value center">{{conversion}}</div>
+				</div>
+				{{/conversion}}
+				<div class="row">
+					<div class="col-5-12 padl padr rt-key">Shock Value</div>
+					<div class="col-7-12 padr rt-value center">{{shockvalue}}</div>
 				</div>
 				{{/dcvroll}} {{#initiative}}
 				<div class="rt-emote"><i>{{character_name}} rolls {{pronoun}} initiative</i></div>
@@ -6431,7 +6484,7 @@
 		const attack_manuevers_array = ['attack', 'bite', 'bypassarmor', 'disarm', 'grab', 'lock', 'pin', 'reducearmor', 'throw', 'vitalspot', 'weakpoint'];
 		const attack_maneuvers_regex = /(attack|bite|bypassarmor|disarm|grab|lock|pin|reducearmor|throw|vitalspot|weakpoint)/i;
 		const defense_manuevers_array = ['defend', 'defendother', 'doesnothing', 'escape'];
-		const defense_maneuvers_regex = /(defend|defendother|doesnothing|escape)/i;
+		const defense_maneuvers_regex = /(defend|defendother|escape)/i;
 		const non_damaging_attack_regex = /(disarm|grab|pin|defend|defendother|doesnothing|escape)/i;
 		const minor_obstacle_maneuvers_regex = /(bite|reducearmor|defendother)/i;
 		const major_obstacle_maneuvers_regex = /(bypassarmor|vitalspot)/i;
@@ -9166,7 +9219,7 @@
 			let stat = '';
 			let base = 0;
 			let turntracker = '';
-			let result = '';
+			let result = `&{template:besmDefault} {{rolls=1}} {{character_name=@{charactername}}} {{pronoun=@{pronoun}}} `;
 			switch (rolltype) {
 				case '2d6':
 					type = '{{twodsix=1}}';
@@ -9185,6 +9238,7 @@
 					title = '{{title=Roll DCV}}';
 					stat = `{{dcv=${cv}}}`;
 					base = cv;
+					result = `${result} ${buildProtectionsString(debug, value)}`;
 					break;
 				case 'initiative':
 					cv = getCV(debug, value, attrdb, setObj, sourceAttr, 'acv', '');
@@ -9207,8 +9261,8 @@
 					setStatButtonStatsAndRolls(debug, eventInfo, value, rowID, sourceAttr, setObj);
 					break;
 			}
-			result = `&{template:besmDefault} {{rolls=1}} ${type} ${title} {{character_name=@{charactername}}}` +
-				`{{pronoun=@{pronoun}}} ${stat} {{total=[[[[?{Roll is|Normal, ${setDice(rollmod)}` +
+			result = `${result} ${type} ${title} ${stat} ` +
+				`{{total=[[[[?{Roll is|Normal, ${setDice(rollmod)}` +
 				`|Minor Edge, ${setDice(rollmod, 1)}|Minor Obstacle, ${setDice(rollmod, -1)}` +
 				`|Major Edge, ${setDice(rollmod, 2)}|Major Obstacle, ${setDice(rollmod, -2)}}]]` +
 				`+[[${base}]] ${turntracker}]]}} {{roll=$[[0]]}}`;
@@ -10840,8 +10894,10 @@
 			const debugtext = '[setWeaponAmmo()]';
 			const state = setObj[`${handsource}_state`];
 			const rowID = value[`${handsource}_source`];
+			const type = value[`repeating_attr_${rowID}_attribute`];
+			if (type != 'weapon') return;
 			if (state) {//weapon armed, load ammo state
-				const weapon = _.find(attrdb.weapon, w => {
+				const weapon = _.find(attrdb[`${type}`], w => {
 					if (w.source == rowID) return true;
 				});
 				const customization = _.find(weapon.customizations, c => {
@@ -10877,8 +10933,9 @@
 			setObj.weapon_ammo = 0;
 			setObj.weapon_autofire = 0;
 			const weapon = setObj.active_weapon;
+			const type = value[`repeating_attr_${weapon}_attribute`];
 			if (weapon == '') return;
-			const weapondb = attrdb.weapon.find(o => {
+			const weapondb = attrdb[`${type}`].find(o => {
 				if (o.source == weapon) return true;
 			});
 			const customizations = weapondb.customizations;	
@@ -10918,12 +10975,38 @@
 			})
 		}
 		
+		function buildProtectionsString(debug, value, maneuver='') {
+			const shockvalue = parseInt(value.stat_total_shock) || 0;
+			const forcefield = parseInt(value.protection_forcefield_ar) || 0;
+			const shield = parseInt(value.protection_shield_ar) || 0;
+			const armor1 = parseInt(value.protection_armor1_ar) || 0;
+			const armor2 = parseInt(value.protection_armor2_ar) || 0;
+			const armor3 = parseInt(value.protection_armor3_ar) || 0;
+			const mindshield = parseInt(value.protection_mindshield_ar) || 0;
+			const absorption1 = parseInt(value.protection_absorption1_ar) || 0;
+			const absorption2 = parseInt(value.protection_absorption2_ar) || 0;
+			const conversion = parseInt(value.protection_conversion_ar) || 0;
+			let result = '';
+			if(forcefield > 0) result = `${result}{{forcefield=${forcefield}}} `;
+			if(shield > 0 && maneuver == 'doesnothing') result = `${result}{{shield=${shield}}} `;
+			if(armor1 > 0) result = `${result}{{armor1=${armor1}}} `;
+			if(armor2 > 0) result = `${result}{{armor2=${armor2}}} `;
+			if(armor3 > 0) result = `${result}{{armor3=${armor3}}} `;
+			if(mindshield > 0) result = `${result}{{mindshield=${mindshield}}} `;
+			if(absorption1 > 0) result = `${result}{{absorption1=${absorption1}}} `;
+			if(absorption2 > 0) result = `${result}{{absorption2=${absorption2}}} `;
+			if(conversion > 0) result = `${result}{{conversion=${conversion}}} `;
+			result = `${result}{{shockvalue=${shockvalue}}}`;
+			if(debug) console.log(`[buildProtectionsString()] result = ${result}`);
+			return result;
+		}
+		
 		function setCombatRoll(debug, value, attrdb, rowID, sourceAttr, setObj, invertState = false) {
 			const debugtext = '[setCombatRoll()]';
 			const activeweapon = setObj.active_weapon === undefined ? rowID : setObj.active_weapon;
+			const type = value[`repeating_attr_${activeweapon}_attribute`];
 			const weapon = 
-				_.find(attrdb.weapon, o => { if (o.source == activeweapon) return o; }) ||
-				_.find(attrdb.swarm, o => { if (o.source == activeweapon) return o; });
+				_.find(attrdb[`${type}`], o => { if (o.source == activeweapon) return o; });
 			const isWeapon = 
 				getIsObject(weapon);
 			const isSwarm = 
@@ -10954,16 +11037,6 @@
 				getSumOfActiveAttrLevels(attrdb, 'massivedamage', weaponclass) || 0;
 			const superstrength = 
 				getSumOfActiveAttrLevels(attrdb, 'superstrength') || 0;
-			const shockvalue = parseInt(value.stat_total_shock) || 0;
-			const forcefield = parseInt(value.protection_forcefield_ar) || 0;
-			const shield = parseInt(value.protection_shield_ar) || 0;
-			const armor1 = parseInt(value.protection_armor1_ar) || 0;
-			const armor2 = parseInt(value.protection_armor2_ar) || 0;
-			const armor3 = parseInt(value.protection_armor3_ar) || 0;
-			const mindshield = parseInt(value.protection_mindshield_ar) || 0;
-			const absorption1 = parseInt(value.protection_absorption1_ar) || 0;
-			const absorption2 = parseInt(value.protection_absorption2_ar) || 0;
-			const conversion = parseInt(value.protection_conversion_ar) || 0;
 			let maneuver = 
 				setObj.static_weapon_maneuver_name || value.static_weapon_maneuver_name;
 			maneuver = 
@@ -10999,11 +11072,20 @@
 				rollmod;
 			const weakpoint = 
 				maneuver == 'weakpoint' ? 
-				`{{weakpoint=[[ [[?{Weak Point is|Large, ${setDice(rollmod, -2)}|Small, ${setDice(rollmod, -1)}|Tiny, ${setDice(rollmod, -1)}}]] ]] }}` : 
+				`{{weakpoint=[[ [[?{Weak Point is|Large, ${setDice(rollmod, -2)}` +
+				`|Small, ${setDice(rollmod, -1)}|Tiny, ${setDice(rollmod, -1)}}]] ]] }}` : 
 				'';
-			var result = `&{template:besmDefault} {{ismelee=${isMelee}}} {{character_name=@{charactername}}} {{pronoun=@{pronoun}}} {{maneuver=${maneuver}}} {{weapon_name=${name}}} {{shock=${shockvalue}}}`;
+			var result = `&{template:besmDefault} {{ismelee=${isMelee}}} ` +
+				`{{character_name=@{charactername}}} {{pronoun=@{pronoun}}} ` +
+				`{{maneuver=${maneuver}}} {{weapon_name=${name}}}`;
 			if (acv > 0) {
-				result = `${result} {{title=Attack}} {{attack=1}} {{target_name=@{target|charactername}}} {{acv=${acv}}} {{damage_type=${damagetype}}} {{damage2=${Math.round(damage * 0.25)}}} {{damage3=${Math.round(damage * 0.35)}}} {{damage4=${Math.round(damage * 0.45)}}} {{damage5=${Math.round(damage * 0.55)}}} {{damage6=${Math.round(damage * 0.65)}}} {{damage7=${Math.round(damage * 0.75)}}} {{damage8=${Math.round(damage * 0.9)}}} {{damage9=${Math.round(damage * 1.05)}}} {{damage10=${Math.round(damage * 1.2)}}} {{damage11=${Math.round(damage * 1.35)}}} {{damage12=${Math.round(damage * 1.5)}}}`;
+				result = `${result} {{title=Attack}} {{attack=1}} {{target_name=@{target|charactername}}} ` +
+					`{{acv=${acv}}} {{damage_type=${damagetype}}} {{damage2=${Math.round(damage * 0.25)}}} ` +
+					`{{damage3=${Math.round(damage * 0.35)}}} {{damage4=${Math.round(damage * 0.45)}}} ` +
+					`{{damage5=${Math.round(damage * 0.55)}}} {{damage6=${Math.round(damage * 0.65)}}} ` +
+					`{{damage7=${Math.round(damage * 0.75)}}} {{damage8=${Math.round(damage * 0.9)}}} ` +
+					`{{damage9=${Math.round(damage * 1.05)}}} {{damage10=${Math.round(damage * 1.2)}}} ` +
+					`{{damage11=${Math.round(damage * 1.35)}}} {{damage12=${Math.round(damage * 1.5)}}}`;
 				if (isWeapon > 0){
 					_.each(weapon.customizations, customization => {
 						console.log(`${debugtext} customization:`); console.log(customization);
@@ -11178,29 +11260,21 @@
 						}
 					});
 				}
-				result = `${result} {{total=[[[[?{Roll is|Normal, ${setDice(rollmod)}|Minor Edge, ${setDice(rollmod, 1)}|Minor Obstacle, ${setDice(rollmod, -1)}|Major Edge, ${setDice(rollmod, 2)}|Major Obstacle, ${setDice(rollmod, -2)}}]]+[[${acv}]]]]}} {{roll=$[[0]]}}`;
+				result = `${result} {{total=[[[[?{Roll is|Normal, ${setDice(rollmod)}` +
+					`|Minor Edge, ${setDice(rollmod, 1)}|Minor Obstacle, ${setDice(rollmod, -1)}` +
+					`|Major Edge, ${setDice(rollmod, 2)}|Major Obstacle, ${setDice(rollmod, -2)}}]]+` +
+					`[[${acv}]]]]}} {{roll=$[[0]]}}`;
 			} else if (dcv > 0) {
 				if (maneuver == 'defendother') result = `${result} {{target_name=@{target|charactername}}}`;
-				result = `${result} {{dcv=${dcv}}} {{title=Defend}} {{defense=1}} {{total=[[[[?{Roll is|Normal, ${setDice(rollmod)}|Minor Edge, ${setDice(rollmod, 1)}|Minor Obstacle, ${setDice(rollmod, -1)}|Major Edge, ${setDice(rollmod, 2)}|Major Obstacle, ${setDice(rollmod, -2)}}]]+[[${dcv}]]]]}} {{roll=$[[0]]}}`;
-				if(forcefield > 0) result = `${result} {{forcefield=${forcefield}}}`;
-				if(armor1 > 0) result = `${result} {{armor1=${armor1}}}`;
-				if(armor2 > 0) result = `${result} {{armor2=${armor2}}}`;
-				if(armor3 > 0) result = `${result} {{armor3=${armor3}}}`;
-				if(mindshield > 0) result = `${result} {{mindshield=${mindshield}}}`;
-				if(absorption1 > 0) result = `${result} {{absorption1=${absorption1}}}`;
-				if(absorption2 > 0) result = `${result} {{absorption2=${absorption2}}}`;
-				if(conversion > 0) result = `${result} {{conversion=${conversion}}}`;
+				result = `${result} {{dcv=${dcv}}} {{title=Defend}} {{defense=1}} ` +
+					`{{total=[[[[?{Roll is|Normal, ${setDice(rollmod)}` +
+					`|Minor Edge, ${setDice(rollmod, 1)}|Minor Obstacle, ${setDice(rollmod, -1)}` +
+					`|Major Edge, ${setDice(rollmod, 2)}|Major Obstacle, ${setDice(rollmod, -2)}}]]+` +
+					`[[${dcv}]]]]}} {{roll=$[[0]]}} ${buildProtectionsString(debug, value, maneuver)}`;
 			} else {
-				result = `&{template:besmDefault} {{character_name=@{charactername}}} {{maneuver=${sourceAttr}}} {{doesnothing=1}} {{title=Does Nothing}}`;
-				if(forcefield > 0) result = `${result} {{forcefield=${forcefield}}}`;
-				if(shield > 0) result = `${result} {{shield=${shield}}}`;
-				if(armor1 > 0) result = `${result} {{armor1=${armor1}}}`;
-				if(armor2 > 0) result = `${result} {{armor2=${armor2}}}`;
-				if(armor3 > 0) result = `${result} {{armor3=${armor3}}}`;
-				if(mindshield > 0) result = `${result} {{mindshield=${mindshield}}}`;
-				if(absorption1 > 0) result = `${result} {{absorption1=${absorption1}}}`;
-				if(absorption2 > 0) result = `${result} {{absorption2=${absorption2}}}`;
-				if(conversion > 0) result = `${result} {{conversion=${conversion}}}`;
+				result = `&{template:besmDefault} {{character_name=@{charactername}}} ` +
+					`{{maneuver=does nothing}} {{doesnothing=1}} {{title=Does Nothing}} ` +
+					`${buildProtectionsString(debug, value, maneuver)}`;
 			}
 			if (debug){
 				console.log(`[setCombatRoll()] activeweapon = ${activeweapon}`);
@@ -11218,7 +11292,6 @@
 				console.log(`[setCombatRoll()] muscle = ${muscle}`);
 				console.log(`[setCombatRoll()] massivedamage = ${massivedamage}`);
 				console.log(`[setCombatRoll()] superstrength = ${superstrength}`);
-				console.log(`[setCombatRoll()] shockvalue = ${shockvalue}`);
 				console.log(`[setCombatRoll()] maneuver = ${maneuver}`);
 				console.log(`[setCombatRoll()] acv = ${acv}`);
 				console.log(`[setCombatRoll()] dcv = ${dcv}`);

--- a/BESM4eExtras/BESM4eExtras.html
+++ b/BESM4eExtras/BESM4eExtras.html
@@ -30,7 +30,7 @@
 											<div class="row padt padb"><h3 class="col-1 center border"><span>Sheet Options</span></h3></div>
 											<div class="row center padb">
 												<div class="col-1-5 padr"><h4 class="center border"><span>Sheet Version
-													<input type="text" class="center" name="attr_version" value="1.4.1" readonly />
+													<input type="text" class="center" name="attr_version" value="1.4.2" readonly />
 												</span></h4></div>
 												<div class="col-1-5 padr"><h4 class="center border"><span>Sheet Type
 													<select class="border"><option value="Sheet">Character</option><!--<option value="NPC Sheet">NPC</option><option value="Thing Sheet">Thing</option><option value="GM Sheet">GM</option>--></select>
@@ -6048,8 +6048,8 @@
 				</div>
 				{{/multidimensional}} {{#pen}}
 				<div class="row">
-					<div class="col-5-12 padl padr rt-key">{{penname}}</div>
-					<div class="col-7-12 padr rt-value center">{{pentype}} -{{pen}}</div>
+					<div class="col-5-12 padl padr rt-key">{{pentype}}</div>
+					<div class="col-7-12 padr rt-value center">{{penname}} -{{pen}}</div>
 				</div>
 				{{/pen}} {{#psychic}}
 				<div class="row">

--- a/BESM4eExtras/BESM4eExtras.html
+++ b/BESM4eExtras/BESM4eExtras.html
@@ -30,7 +30,7 @@
 											<div class="row padt padb"><h3 class="col-1 center border"><span>Sheet Options</span></h3></div>
 											<div class="row center padb">
 												<div class="col-1-5 padr"><h4 class="center border"><span>Sheet Version
-													<input type="text" class="center" name="attr_version" value="1.4.0" readonly />
+													<input type="text" class="center" name="attr_version" value="1.4.1" readonly />
 												</span></h4></div>
 												<div class="col-1-5 padr"><h4 class="center border"><span>Sheet Type
 													<select class="border"><option value="Sheet">Character</option><!--<option value="NPC Sheet">NPC</option><option value="Thing Sheet">Thing</option><option value="GM Sheet">GM</option>--></select>
@@ -10850,7 +10850,7 @@
 				const ammo = isNaN(parseInt(value[`repeating_attr_${rowID}_ammostate`])) ?
 					getAmmoMax(debug, customization.rank) : parseInt(value[`repeating_attr_${rowID}_ammostate`]);
 				const capacity = isNaN(parseInt(value[`repeating_attr_${rowID}_capacitystate`])) ?
-					parseInt(value[`repeating_attr_${rowID}_capacity`]) :
+					0 : //parseInt(value[`repeating_attr_${rowID}_capacity`]) :
 					parseInt(value[`repeating_attr_${rowID}_capacitystate`]);
 				setObj.weapon_ammo_reloads = ammo;
 				setObj.weapon_ammo_capacity = capacity;


### PR DESCRIPTION
## Changes / Comments
BESM4eExtras.html
BESM4eExtras.css

v1.4.6
Group Types (Standard, Power Flux, and Power Variation) now display in title case.

v1.4.5
Ranged Defense attribute (Personal or Movement) now apply to DCV Roll when the respective button is depressed.

v1.4.4
Shield Parry Enhancement now applies to defense rolls.

v1.4.3
Added active Protection values to DCV Roll roll template.

Shock Value now correctly displays in relevant roll templates.

Minor bug fixes.

v1.4.2
Corrected roll template for Penetrating/Piercing. Key=value descriptors were reversed.

v1.4.1
Corrected initial Capacity value for Ammo. Should have been 0 instead of full Capacity value.

v1.4.0
Added support for range penalties on weapons when Range Enhancement is applied (Extras rulebook).

Added support for weapons with Ammo Limiter.

Added support for weapons with Autofire Enhancement.

New UI additions for players to interact with Range, Ammo, and Autofire.


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
