### PR TITLE
[Warhammer 4e Character Sheet] fixes

### DIFF
--- a/Warhammer 4e Character Sheet/README.md
+++ b/Warhammer 4e Character Sheet/README.md
@@ -73,6 +73,11 @@ Note conditions are not intended for out of combat situations, GM simply makes t
  
 ///// ============ Change Log ============ /////  
 
+January 3rd 2022 v1.53.2
+
+- Fix for Characteristics modifier which was adding twice on the skill target display in rolls.
+
+
 December 6th 2021 v1.53.1
 
 - Completed experimental talent list (all 166 talents) in the Dev mode, nearly all are implemented at this time. This causes talent bonuses to show when rolling skills and weapons, to allow superior flow of game and especially combat. Includes advanced combat actions, like Charge/Furious Assault/Feint/DW/Fast Shot etc rules which are implemented directly into the sheet so they show when rolling ( i.e. you don't have to remember at the +SL or complex rule). Also includes a new SL system which adds together the total SL bonus each roll. Enable Dev mode to test this feature.

--- a/Warhammer 4e Character Sheet/README.md
+++ b/Warhammer 4e Character Sheet/README.md
@@ -76,7 +76,7 @@ Note conditions are not intended for out of combat situations, GM simply makes t
 January 3rd 2022 v1.53.2
 
 - Fix for Characteristics modifier which was adding twice on the skill target display in rolls.
-
+- Resolved issue with Custom Spell Advantage rule (which basic removed advantage modifier from casting), this will now also disable Advantage for Langange Magick skill roll aswell as spellbook rolls. And removes the gold star indicator when disabled too.
 
 December 6th 2021 v1.53.1
 

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -18982,8 +18982,13 @@
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<input type="checkbox" name="attr_LangMagickCareer" value="1">
 							</div>
+		<input type="checkbox" name="attr_Advantage_casting" class="sheet-hidden sheet-hider" value="1" />	
 							<div class="sheet-col-3-8 sheet-pad-r-sm sheet-vert-middle">
 								<span data-i18n="LANG-MAGICK">Language (Magick)</span><span  data-i18n-title="SKILLADV" title="Modified by Advantage" style="margin-left: 5px; font-family: pictos; color: gold; font-size: 10px; padding-bottom: 2px; vertical-align: top">S</span>
+							</div>
+		<input type="checkbox" name="attr_Advantage_casting" class="sheet-hidden sheet-hider" value="0" />	
+							<div class="sheet-col-3-8 sheet-pad-r-sm sheet-vert-middle">
+								<span data-i18n="LANG-MAGICK">Language (Magick)</span>
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_LangMagickChar">
@@ -47938,7 +47943,7 @@ on('clicked:repeating_divinemiracles:miracle clicked:repeating_divinemiracles:mi
 	
    on('clicked:coolroll clicked:dodgeroll clicked:meleebasicroll clicked:meleebrawlingroll clicked:meleecavalryroll clicked:meleefencingroll clicked:meleeflailroll clicked:meleeparryroll clicked:meleepolearmroll clicked:meleetwohandedroll clicked:langmagickroll clicked:rangedblackpowderroll clicked:rangedbowroll clicked:rangedcrossbowroll clicked:rangedengineeringroll clicked:rangedentanglingroll clicked:rangedexplosivesroll clicked:rangedslingroll clicked:rangedthrowingroll', (eventInfo) => {
 	
-   let roll = '{{test=[[@{roll_rule}]]}} {{sl=[[0]]}} {{slbonus=[[0>addsl<]]}} {{sladd=[[0]]}} {{slbonusatk=[[0>addsl<]]}} {{modvalue=[[?{@{translation_modifier}|0}]]}} {{unconscious=[[@{UnconsciousMod}]]}} {{title=^{>Charcap<}}} {{skill=^{BASIC-SKILL}}} {{character_name=@{character_name}}} {{target=[[ [[@{cond-}*-1]] [COND] + [[(@{>Char<Char}+@{>Char<Adv}+@{>Char<Misc})>addtak<]] [SKILL] + [[@{Advantage}*10]] [ADV] + ?{@{translation_modifier}|0} [MOD] ]]}} {{skilltest=true}} {{SLmod=[[?{SL Modifier|0}]]}} {{advantage=[[@{AdvantageDisplay}]]}} {{sitmod=[[0>sitmod<]]}} {{mod1type=[[@{>Char<_modtype1}]]}} {{mod1=@{>Char<_mod1}}} {{mod2type=[[@{>Char<_modtype2}]]}} {{mod2=@{>Char<_mod2}}} {{mod3type=[[@{>Char<_modtype3}]]}} {{mod3=@{>Char<_mod3}}} {{reroll=@{RT-reroll}>Char<roll)}}';
+   let roll = '{{test=[[@{roll_rule}]]}} {{sl=[[0]]}} {{slbonus=[[0>addsl<]]}} {{sladd=[[0]]}} {{slbonusatk=[[0>addsl<]]}} {{modvalue=[[?{@{translation_modifier}|0}]]}} {{unconscious=[[@{UnconsciousMod}]]}} {{title=^{>Charcap<}}} {{skill=^{BASIC-SKILL}}} {{character_name=@{character_name}}} {{target=[[ [[@{cond-}*-1]] [COND] + [[(@{>Char<Char}+@{>Char<Adv}+@{>Char<Misc})>addtak<]] [SKILL] + [[@{Advantage}*10>MagAdv<]] [ADV] + ?{@{translation_modifier}|0} [MOD] ]]}} {{skilltest=true}} {{SLmod=[[?{SL Modifier|0}]]}} {{advantage=[[@{AdvantageDisplay}>MagAdv<]]}} {{sitmod=[[0>sitmod<]]}} {{mod1type=[[@{>Char<_modtype1}]]}} {{mod1=@{>Char<_mod1}}} {{mod2type=[[@{>Char<_modtype2}]]}} {{mod2=@{>Char<_mod2}}} {{mod3type=[[@{>Char<_modtype3}]]}} {{mod3=@{>Char<_mod3}}} {{reroll=@{RT-reroll}>Char<roll)}}';
    var trigger = eventInfo.triggerName.slice(8, -4);
    var triggercap = trigger.toUpperCase();		
    var prefix = trigger.split('_').slice(0,3).join('_') + '_';
@@ -47996,7 +48001,8 @@ on('clicked:repeating_divinemiracles:miracle clicked:repeating_divinemiracles:mi
 
 	else if (trigger === 'langmagick') {cond = '{{cond=[[@{condgen_see}]]}}  {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}}';
 	addtak= '*@{LangMagickTaken}';
-	rollPart = rollPart2.replaceAll('cond-', `condgen_see`).replaceAll('>addtak<', addtak);} 
+	MagAdv= '*@{Advantage_casting}';
+	rollPart = rollPart2.replaceAll('cond-', `condgen_see`).replaceAll('>MagAdv<', MagAdv);} 
 	
 	else {cond = ''}
 	

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -12981,16 +12981,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_ArtChar">
-										<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-										<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-										<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-										<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-										<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-										<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-										<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY" selected="selected">Dex</option>
-										<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-										<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-										<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+										<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+										<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+										<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+										<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+										<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+										<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+										<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY" selected="selected">Dex</option>
+										<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+										<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+										<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
@@ -13081,16 +13081,16 @@
 								</div>
 								<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 									<select class="sheet-select-no-arrow-center" name="attr_ArtSpecializationChar">
-										<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-										<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-										<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-										<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-										<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-										<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-										<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY" selected="selected">Dex</option>
-										<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-										<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-										<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+										<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+										<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+										<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+										<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+										<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+										<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+										<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY" selected="selected">Dex</option>
+										<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+										<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+										<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 									</select>
 								</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -13186,16 +13186,16 @@
 								</div>
 								<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 									<select class="sheet-select-no-arrow-center" name="attr_ArtSpecializationChar">
-										<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-										<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-										<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-										<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-										<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-										<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-										<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY" selected="selected">Dex</option>
-										<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-										<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-										<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+										<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+										<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+										<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+										<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+										<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+										<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+										<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY" selected="selected">Dex</option>
+										<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+										<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+										<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 									</select>
 								</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -13290,16 +13290,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_AthleticsChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_AthleticsXP" value="0" readonly />
@@ -13391,16 +13391,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_BriberyChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP" selected="selected">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP" selected="selected">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_BriberyXP" value="0" readonly />
@@ -13490,16 +13490,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_CharmChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP" selected="selected">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP" selected="selected">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_CharmXP" value="0" readonly />
@@ -13589,16 +13589,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_CharmAnimalChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_CharmAnimalXP" value="0" readonly />
@@ -13686,16 +13686,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_ClimbChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH" selected="selected">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH" selected="selected">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_ClimbXP" value="0" readonly />
@@ -13783,16 +13783,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_ConsumeAlcoholChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS" selected="selected">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS" selected="selected">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_ConsumeAlcoholXP" value="0" readonly />
@@ -13880,16 +13880,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_CoolChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_CoolXP" value="0" readonly />
@@ -13977,16 +13977,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_DodgeChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_DodgeXP" value="0" readonly />
@@ -14074,16 +14074,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_DriveChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_DriveXP" value="0" readonly />
@@ -14171,16 +14171,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_EnduranceChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS" selected="selected">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS" selected="selected">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_EnduranceXP" value="0" readonly />
@@ -14268,16 +14268,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_EntertainChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP" selected="selected">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP" selected="selected">Fel</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
@@ -14368,16 +14368,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_EntertainSpecializationChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP" selected="selected">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP" selected="selected">Fel</option>
 										</select>
 									</div>
 									<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -14470,16 +14470,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_EntertainSpecializationChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP" selected="selected">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP" selected="selected">Fel</option>
 										</select>
 									</div>
 									<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -14569,16 +14569,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_GambleChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_GambleXP" value="0" readonly />
@@ -14666,16 +14666,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_GossipChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP" selected="selected">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP" selected="selected">Fel</option>
 							</select>
 						</div>
 						<input class="sheet-hidden" type="number" name="attr_GossipXP" value="0" readonly />
@@ -14763,16 +14763,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_HaggleChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP" selected="selected">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP" selected="selected">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_HaggleXP" value="0" readonly />
@@ -14860,16 +14860,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_IntimidateChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH" selected="selected">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH" selected="selected">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_IntimidateXP" value="0" readonly />
@@ -14957,16 +14957,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_IntuitionChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE" selected="selected">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE" selected="selected">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_IntuitionXP" value="0" readonly />
@@ -15054,16 +15054,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_LeadershipChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP" selected="selected">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP" selected="selected">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_LeadershipXP" value="0" readonly />
@@ -15242,16 +15242,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_MeleeBasicChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL" selected="selected">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL" selected="selected">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_MeleeBasicXP" value="0" readonly />
@@ -15343,16 +15343,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_MeleeBrawlingChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL" selected="selected">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL" selected="selected">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_MeleeBrawlingXP" value="0" readonly />
@@ -15444,16 +15444,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_MeleeCavalryChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL" selected="selected">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL" selected="selected">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_MeleeCavalryXP" value="0" readonly />
@@ -15544,16 +15544,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_MeleeFencingChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL" selected="selected">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL" selected="selected">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_MeleeFencingXP" value="0" readonly />
@@ -15644,16 +15644,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_MeleeFlailChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL" selected="selected">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL" selected="selected">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_MeleeFlailXP" value="0" readonly />
@@ -15744,16 +15744,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_MeleeParryChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL" selected="selected">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL" selected="selected">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_MeleeParryXP" value="0" readonly />
@@ -15844,16 +15844,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_MeleePolearmChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL" selected="selected">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL" selected="selected">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_MeleePolearmXP" value="0" readonly />
@@ -15944,16 +15944,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_MeleeTwoHandedChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL" selected="selected">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL" selected="selected">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_MeleeTwoHandedXP" value="0" readonly />
@@ -16044,16 +16044,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_NavigationChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE" selected="selected">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE" selected="selected">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_NavigationXP" value="0" readonly />
@@ -16141,16 +16141,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_OutdoorSurvivalChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_OutdoorSurvivalXP" value="0" readonly />
@@ -16238,16 +16238,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_PerceptionChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE" selected="selected">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE" selected="selected">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_PerceptionXP" value="0" readonly />
@@ -16335,16 +16335,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_RideChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
@@ -16437,16 +16437,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_RideSpecializationChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 										</select>
 									</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -16541,16 +16541,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_RideSpecializationChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 										</select>
 									</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -16641,16 +16641,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_RowChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH" selected="selected">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH" selected="selected">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_RowXP" value="0" readonly />
@@ -16738,16 +16738,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_StealthChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
@@ -16839,16 +16839,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_StealthSpecializationChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 										</select>
 									</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -16941,16 +16941,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_StealthSpecializationChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 										</select>
 									</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -17062,16 +17062,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_AnimalCareChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_AnimalCareXP" value="0" readonly />
@@ -17176,16 +17176,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_AnimalTrainingChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 										</select>
 									</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -17283,16 +17283,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_AnimalTrainingChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 										</select>
 									</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -17513,16 +17513,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_ChannellingFireChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_ChannellingFireXP" value="0" readonly />
@@ -17618,16 +17618,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_ChannellingHeavensChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_ChannellingHeavensXP" value="0" readonly />
@@ -17723,16 +17723,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_ChannellingMetalChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_ChannellingMetalXP" value="0" readonly />
@@ -17828,16 +17828,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_ChannellingBeastsChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_ChannellingBeastsXP" value="0" readonly />
@@ -17933,16 +17933,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_ChannellingLifeChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_ChannellingLifeXP" value="0" readonly />
@@ -18038,16 +18038,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_ChannellingLightChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_ChannellingLightXP" value="0" readonly />
@@ -18143,16 +18143,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_ChannellingDeathChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_ChannellingDeathXP" value="0" readonly />
@@ -18248,16 +18248,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_ChannellingShadowsChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_ChannellingShadowsXP" value="0" readonly />
@@ -18352,16 +18352,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_ChannellingWitchChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_ChannellingWitchXP" value="0" readonly />
@@ -18457,16 +18457,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_ChannellingDarkChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_ChannellingDarkXP" value="0" readonly />
@@ -18562,16 +18562,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_ChannellingChaosChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_ChannellingChaosXP" value="0" readonly />
@@ -18666,16 +18666,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_ChannellingMiscChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER" selected="selected">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_ChannellingMiscXP" value="0" readonly />
@@ -18771,16 +18771,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_EvaluateChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_EvaluateXP" value="0" readonly />
@@ -18872,16 +18872,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_HealChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_HealXP" value="0" readonly />
@@ -18987,16 +18987,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_LangMagickChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_LangMagickXP" value="0" readonly />
@@ -19094,16 +19094,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_LanguageChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 										</select>
 									</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -19197,16 +19197,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_LanguageChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 										</select>
 									</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -19309,16 +19309,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_LoreChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 										</select>
 									</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -19410,16 +19410,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_LoreChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 										</select>
 									</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -19520,16 +19520,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_PerformChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 										</select>
 									</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -19621,16 +19621,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_PerformChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 										</select>
 									</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -19722,16 +19722,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_PickLockChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY" selected="selected">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY" selected="selected">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_PickLockXP" value="0" readonly />
@@ -19830,16 +19830,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_PlaySpecializationChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY" selected="selected">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY" selected="selected">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 										</select>
 									</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -19931,16 +19931,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_PlayChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY" selected="selected">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY" selected="selected">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 										</select>
 									</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -20034,16 +20034,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_PrayChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP" selected="selected">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP" selected="selected">Fel</option>
 								</select>
 							</div>
 							<input class="sheet-hidden" type="number" name="attr_PrayXP" value="0" readonly />
@@ -20219,16 +20219,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_RangedBlackpowderChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL" selected="selected">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL" selected="selected">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
@@ -20319,16 +20319,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_RangedBowChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL" selected="selected">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL" selected="selected">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
@@ -20419,16 +20419,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_RangedCrossbowChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL" selected="selected">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL" selected="selected">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
@@ -20521,16 +20521,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_RangedEngineeringChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL" selected="selected">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL" selected="selected">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
@@ -20623,16 +20623,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_RangedEntanglingChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL" selected="selected">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL" selected="selected">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
@@ -20725,16 +20725,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_RangedExplosivesChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL" selected="selected">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL" selected="selected">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
@@ -20829,16 +20829,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_RangedSlingChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL" selected="selected">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL" selected="selected">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
@@ -20931,16 +20931,16 @@
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 								<select class="sheet-select-no-arrow-center" name="attr_RangedThrowingChar">
-									<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-									<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL" selected="selected">BS</option>
-									<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-									<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-									<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-									<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-									<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-									<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-									<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-									<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+									<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+									<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL" selected="selected">BS</option>
+									<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+									<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+									<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+									<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+									<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+									<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+									<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+									<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 								</select>
 							</div>
 							<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
@@ -21036,16 +21036,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_ResearchChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_ResearchXP" value="0" readonly />
@@ -21145,16 +21145,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_SailSpecializationChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 										</select>
 									</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -21251,16 +21251,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_SailChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 										</select>
 									</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -21366,16 +21366,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_SecretSignsChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 										</select>
 									</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -21472,16 +21472,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_SecretSignsChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE" selected="selected">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 										</select>
 									</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -21576,16 +21576,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_SetTrapChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY" selected="selected">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY" selected="selected">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_SetTrapXP" value="0" readonly />
@@ -21675,16 +21675,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_SleightofHandChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY" selected="selected">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY" selected="selected">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_SleightofHandXP" value="0" readonly />
@@ -21775,16 +21775,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_SwimChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH" selected="selected">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH" selected="selected">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_SwimXP" value="0" readonly />
@@ -21875,16 +21875,16 @@
 						</div>
 						<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 							<select class="sheet-select-no-arrow-center" name="attr_TrackChar">
-								<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-								<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-								<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-								<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-								<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE" selected="selected">I</option>
-								<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-								<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-								<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-								<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-								<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+								<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+								<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+								<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+								<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+								<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE" selected="selected">I</option>
+								<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+								<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
+								<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+								<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+								<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 							</select>
 						</div>
 							<input class="sheet-hidden" type="number" name="attr_TrackXP" value="0" readonly />
@@ -21985,16 +21985,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_TradeSpecializationChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY" selected="selected">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY" selected="selected">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 										</select>
 									</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />
@@ -22091,16 +22091,16 @@
 									</div>
 									<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm sheet-vert-middle">
 										<select class="sheet-select-no-arrow-center" name="attr_TradeChar">
-											<option value="(@{WeaponSkill}+@{WeaponSkillMod})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-											<option value="(@{BallisticSkill}+@{BallisticSkillMod})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-											<option value="(@{Strength}+@{StrengthMod})" data-i18n="ABBREVIATE-STRENGTH">S</option>
-											<option value="(@{Toughness}+@{ToughnessMod})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-											<option value="(@{Initiative}+@{InitiativeMod})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-											<option value="(@{Agility}+@{AgilityMod})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
-											<option value="(@{Dexterity}+@{DexterityMod})" data-i18n="ABBREVIATE-DEXTERITY" selected="selected">Dex</option>
-											<option value="(@{Intelligence}+@{IntelligenceMod})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-											<option value="(@{WillPower}+@{WillPowerMod})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-											<option value="(@{Fellowship}+@{FellowshipMod})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
+											<option value="(@{WeaponSkill})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
+											<option value="(@{BallisticSkill})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
+											<option value="(@{Strength})" data-i18n="ABBREVIATE-STRENGTH">S</option>
+											<option value="(@{Toughness})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
+											<option value="(@{Initiative})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
+											<option value="(@{Agility})" data-i18n="ABBREVIATE-AGILITY">Ag</option>
+											<option value="(@{Dexterity})" data-i18n="ABBREVIATE-DEXTERITY" selected="selected">Dex</option>
+											<option value="(@{Intelligence})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
+											<option value="(@{WillPower})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
+											<option value="(@{Fellowship})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
 										</select>
 									</div>
 								<input class="sheet-hidden" type="textarea" name="attr_Skill_rep_ID" />


### PR DESCRIPTION
## Changes / Comments

- Fix for Characteristics modifier which was adding twice on the skill target display in rolls.
- Resolved issue with Custom Spell Advantage rule (which basic removed advantage modifier from casting), this will now also disable Advantage for Langange Magick skill roll aswell as spellbook rolls. And removes the gold star indicator when disabled too.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
