### PR TITLE
[Warhammer 4e Character Sheet] 2H fix

### DIFF
--- a/Warhammer 4e Character Sheet/README.md
+++ b/Warhammer 4e Character Sheet/README.md
@@ -75,6 +75,7 @@ Note conditions are not intended for out of combat situations, GM simply makes t
 
 January 3rd 2022 v1.53.2
 
+- Fixed issue where Twohanded weapons when selected would show offhand penality added to the target value of the specific weapon. This did not effect the Roll itself.
 - Fix for Characteristics modifier which was adding twice on the skill target display in rolls.
 - Resolved issue with Custom Spell Advantage rule (which basic removed advantage modifier from casting), this will now also disable Advantage for Langange Magick skill roll aswell as spellbook rolls. And removes the gold star indicator when disabled too.
 

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -28261,9 +28261,16 @@
 							<div class="sheet-col-4-100 sheet-pad-r-sm">
 								<input type="number" name="attr_MeleeBonus" value="0" />
 							</div>
+							
+		<input type="checkbox" name="attr_UsedTwoHanded" class="sheet-hidden sheet-hider" value="0" />	
 							<div class="sheet-col-4-100 sheet-center sheet-pad-r-sm">
 								<input type="value" class="sheet-center" name="attr_targetmelee" value="(@{MeleeWeaponSkill}+@{MeleeBonus}+(@{Advantage}*10))+(@{UsedDefense}*(-20+(10*@{Talent_AmbidextrousLvl})))+(@{condgen_see_move}*-1)" disabled />
 							</div>
+		<input type="checkbox" name="attr_UsedTwoHanded" class="sheet-hidden sheet-hider" value="1" />	
+							<div class="sheet-col-4-100 sheet-center sheet-pad-r-sm">
+								<input type="value" class="sheet-center" name="attr_targetmelee" value="(@{MeleeWeaponSkill}+@{MeleeBonus}+(@{Advantage}*10))+(@{condgen_see_move}*-1)" disabled />
+							</div>
+							
 							<div class="sheet-col-1-30 sheet-center sheet-vert-middle"  style="padding-left: 8px">
 								<input type="checkbox" name="attr_UsedWeapon" value="1" />
 							</div>


### PR DESCRIPTION
## Changes / Comments

- Fixed issue where Twohanded weapons when selected would show offhand penality added to the target value of the specific weapon. This did not effect the Roll itself.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
