### PR TITLE
[StarTrekAdventures] damageCalc() update

### DIFF
--- a/Star Trek Adventures by Roll20/Star Trek Adventures by Roll20.html
+++ b/Star Trek Adventures by Roll20/Star Trek Adventures by Roll20.html
@@ -173,7 +173,7 @@
 						<input type="hidden" name="attr_damageRoll" value="" />
 						<div class="weapon-row">
 							<span data-i18n="name-type" class="label-capsule-weapon">NAME/TYPE</span><input type="text" class="weapon-name" name="attr_weapon_name" spellcheck="false" />
-							<button class="weapon-button" type="roll" name="PcDamageRoll" value="@{whispertype} &{template:strek}@{damageRoll}{{attribute=@{weapon_quality}}}{{discipline=@{weapon_effect}}}{{rollname=@{weapon_name}}}" title="Security + Weapon Damage">
+							<button class="weapon-button" type="roll" name="PcDamageRoll" value="@{whispertype} &{template:strek}@{damageRoll}{{attribute=@{weapon_quality}}}{{discipline=@{weapon_effect}}}{{rollname=@{weapon_name}}}" title="Weapon Damage">
 								<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Star%20Trek%20Adventures%20by%20Roll20/images/STA_starfleet_insignia_full.png" />
 							</button>
 							<input type="number" class="capsule" name="attr_weapon_damage" value="0" title="Weapon Damage" />
@@ -710,7 +710,7 @@
 						<div class="weapon-row">
 							<span data-i18n="name-type-s" class="label-capsule-weapon">NAME/TYPE</span>
 							<input type="text" class="weapon-name" name="attr_weapon_name" spellcheck="false" spellcheck="false"/>
-							<button class="weapon-button" type="roll" name="ShipDamageRoll" value="@{whispertype} &{template:strek}{{attribute=@{weapon_quality}}}{{discipline=@{weapon_effect}}}{{rollname=@{weapon_name}}}@{damageRoll}" title="Security + Weapon Damage">
+							<button class="weapon-button" type="roll" name="ShipDamageRoll" value="@{whispertype} &{template:strek}{{attribute=@{weapon_quality}}}{{discipline=@{weapon_effect}}}{{rollname=@{weapon_name}}}@{damageRoll}" title="Weapon Damage">
 								<img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Star%20Trek%20Adventures%20by%20Roll20/images/STA_starfleet_insignia_full.png" />
 							</button>
 							<input type="number" class="capsule" name="attr_weapon_damage" title="Weapon Damage" value="0" />
@@ -1333,29 +1333,14 @@
 	//Configure weapon damage
 	on("change:repeating_weapons:weapon_damage", () => {
 		getAttrs(["repeating_weapons_weapon_damage", "security"], (v) => {
-			setAttrs({"repeating_weapons_damageRoll": calcDamageRoll(v.repeating_weapons_weapon_damage, "",v.security,0)});
-		});
-	});
-	on("change:security", () => {
-		getSectionIDs("repeating_weapons", (ids) => {
-			if(ids.length) {
-				let fields = ["security"];
-				fields.push(...ids.map((id) => `repeating_weapons_${id}_weapon_damage`));
-				getAttrs(fields, (v) => {
-					let update = {};
-					_.each(ids, (id) => {
-						update[`repeating_weapons_${id}_damageRoll`] = calcDamageRoll(v[`repeating_ship_${id}_weapon_damage`],"",v.security,0);
-					});
-					setAttrs(update);
-				});
-			}
+			setAttrs({"repeating_weapons_damageRoll": calcDamageRoll(v.repeating_weapons_weapon_damage, "",0)});
 		});
 	});
 
 	//Configure damage for ships
 	on("change:repeating_ship:weapon_damage change:repeating_ship:weapon_type", () => {
 		getAttrs(["repeating_ship_weapon_damage","repeating_ship_weapon_type", "ship_security" ,"ship_scale"], (v) => {
-			setAttrs({"repeating_ship_damageRoll": calcDamageRoll(v.repeating_ship_weapon_damage,v.repeating_ship_weapon_type,v.ship_security,v.ship_scale)});
+			setAttrs({"repeating_ship_damageRoll": calcDamageRoll(v.repeating_ship_weapon_damage,v.repeating_ship_weapon_type,v.ship_scale)});
 		});
 	});
 	on("change:ship_security change:ship_scale", () => {
@@ -1372,15 +1357,15 @@
 				getAttrs(fields, (v) => {
 					let update = {};
 					_.each(ids, (id) => {
-						update[`repeating_ship_${id}_damageRoll`] = calcDamageRoll(v[`repeating_ship_${id}_weapon_damage`],v[`repeating_ship_${id}_weapon_type`],v.ship_security,v.ship_scale);
+						update[`repeating_ship_${id}_damageRoll`] = calcDamageRoll(v[`repeating_ship_${id}_weapon_damage`],v[`repeating_ship_${id}_weapon_type`],v.ship_scale);
 					});
 					setAttrs(update);
 				});
 			}
 		});
 	};
-	const calcDamageRoll = function(damage, type, security, scale) {
-		let roll = "", total = 0 + (parseInt(damage) || 0) + (parseInt(security) || 0) + ((type || "Energy").toLowerCase() == "energy" ? (parseInt(scale) || 0) : 0);
+	const calcDamageRoll = function(damage, type, scale) {
+		let roll = "", total = 0 + (parseInt(damage) || 0) + ((type || "Energy").toLowerCase() == "energy" ? (parseInt(scale) || 0) : 0);
 		if(total) {
 			for(let i = 1; i <= total; i++) {
 				roll += `{{cdice${i}=[[1d6]]}}`;

--- a/Star Trek Adventures by Roll20/Star Trek Adventures by Roll20.html
+++ b/Star Trek Adventures by Roll20/Star Trek Adventures by Roll20.html
@@ -1101,7 +1101,7 @@
 <!--Sheet Worker-->
 <script type="text/worker">
 	// Global variables
-	const staglobals_currentversion = 1.5;
+	const staglobals_currentversion = 1.6;
 
     // Check for default attributes and disciplines (system and department for ships) and rolls, if not set
     on("sheet:opened", () => {
@@ -1332,24 +1332,22 @@
 
 	//Configure weapon damage
 	on("change:repeating_weapons:weapon_damage", () => {
-		getAttrs(["repeating_weapons_weapon_damage", "security"], (v) => {
-			setAttrs({"repeating_weapons_damageRoll": calcDamageRoll(v.repeating_weapons_weapon_damage, "",0)});
-		});
+		updateWeaponsAll();
 	});
 
 	//Configure damage for ships
 	on("change:repeating_ship:weapon_damage change:repeating_ship:weapon_type", () => {
-		getAttrs(["repeating_ship_weapon_damage","repeating_ship_weapon_type", "ship_security" ,"ship_scale"], (v) => {
+		getAttrs(["repeating_ship_weapon_damage","repeating_ship_weapon_type", "ship_scale"], (v) => {
 			setAttrs({"repeating_ship_damageRoll": calcDamageRoll(v.repeating_ship_weapon_damage,v.repeating_ship_weapon_type,v.ship_scale)});
 		});
 	});
-	on("change:ship_security change:ship_scale", () => {
+	on("change:ship_scale", () => {
 		updateShipWeaponsAll();
 	});
 	const updateShipWeaponsAll = function() {
 		getSectionIDs("repeating_ship", (ids) => {
 			if(ids.length) {
-				let fields = ["ship_security", "ship_scale"];
+				let fields = ["ship_scale"];
 				fields.push(
 					...ids.map((id) => `repeating_ship_${id}_weapon_damage`)
 					, ...ids.map((id) => `repeating_ship_${id}_weapon_type`)
@@ -1364,6 +1362,11 @@
 			}
 		});
 	};
+    const updateWeaponsAll = function() {
+        getAttrs(["repeating_weapons_weapon_damage"], (v) => {
+			setAttrs({"repeating_weapons_damageRoll": calcDamageRoll(v.repeating_weapons_weapon_damage, "",0)});
+		});
+    };
 	const calcDamageRoll = function(damage, type, scale) {
 		let roll = "", total = 0 + (parseInt(damage) || 0) + ((type || "Energy").toLowerCase() == "energy" ? (parseInt(scale) || 0) : 0);
 		if(total) {
@@ -1380,10 +1383,11 @@
 			let vrs = parseFloat(v["version"]) || 0.0;
 			if (vrs === staglobals_currentversion) {
 				console.log("Star Trek Adventures by Roll20 v" + vrs);
-			} else if (vrs < 1.5) {
-				console.log("UPDATING TO 1.5");
-				updateShipWeaponsAll();
-				setAttrs({"version": "1.5"}, {silent: true}, () => {
+            } else if (vrs < 1.6) {
+				console.log("UPDATING TO 1.6");
+				updateWeaponsAll();
+                updateShipWeaponsAll();
+				setAttrs({"version": "1.6"}, {silent: true}, () => {
 					versioning();
 				});
 			} else {


### PR DESCRIPTION
## Changes / Comments
Star Trek Adventures by Roll20.html

Removed code to add Security stat with Damage dice to align with game rules. Cited by Eric Albion (https://app.roll20.net/forum/post/10600448/star-trek-adventures-weapon-roll-issue).

Added upgrade to version 1.6 function to recalculate both character/npc and ship weapons and remove their respective security stat from weapon rolls.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
