### PR TITLE
[The Fantasy Trip] Changed roll template weapon adjust color into a lightning superscript

### DIFF
--- a/The Fantasy Trip/TFT.css
+++ b/The Fantasy Trip/TFT.css
@@ -337,6 +337,12 @@
 	margin-bottom: .4em;
 }
 
+.sheet-rolltemplate-attack .sheet-template-weaponadj .inlinerollresult,
+.sheet-rolltemplate-cast-spell .sheet-template-weaponadj .inlinerollresult
+{
+	color: rgb(150, 1, 150);
+}
+
 .sheet-rolltemplate-stat-check .sheet-success,
 .sheet-rolltemplate-attack .sheet-success,
 .sheet-rolltemplate-shield-rush .sheet-success,
@@ -573,3 +579,5 @@
 	color: black;
 	opacity: .3;
  }
+
+

--- a/The Fantasy Trip/TFT.css
+++ b/The Fantasy Trip/TFT.css
@@ -337,23 +337,11 @@
 	margin-bottom: .4em;
 }
 
-.sheet-rolltemplate-attack .sheet-template-weaponadj .inlinerollresult,
-.sheet-rolltemplate-cast-spell .sheet-template-weaponadj .inlinerollresult
+.sheet-rolltemplate-attack .sheet-template-weaponadj .inlinerollresult::before,
+.sheet-rolltemplate-cast-spell .sheet-template-weaponadj .inlinerollresult::before
 {
-/*	font-family: dicefontd6;*/
-	/*font-size: 2.5em;*/
-	background-color: white;
-	background-color: hsl(167, 100%, 90%);
-	/*border-style: none;*/
-	/*position: relative;*/
-	/*top: .2em;*/
-	/*margin-bottom: .4em;*/
+	content: "⚔ ";
 }
-/*
-	color: rgb(150, 1, 150);
-}	background-color: white;
-*/
-
 
 .sheet-rolltemplate-stat-check .sheet-success,
 .sheet-rolltemplate-attack .sheet-success,

--- a/The Fantasy Trip/TFT.css
+++ b/The Fantasy Trip/TFT.css
@@ -340,8 +340,20 @@
 .sheet-rolltemplate-attack .sheet-template-weaponadj .inlinerollresult,
 .sheet-rolltemplate-cast-spell .sheet-template-weaponadj .inlinerollresult
 {
-	color: rgb(150, 1, 150);
+/*	font-family: dicefontd6;*/
+	/*font-size: 2.5em;*/
+	background-color: white;
+	background-color: hsl(167, 100%, 90%);
+	/*border-style: none;*/
+	/*position: relative;*/
+	/*top: .2em;*/
+	/*margin-bottom: .4em;*/
 }
+/*
+	color: rgb(150, 1, 150);
+}	background-color: white;
+*/
+
 
 .sheet-rolltemplate-stat-check .sheet-success,
 .sheet-rolltemplate-attack .sheet-success,

--- a/The Fantasy Trip/TFT.html
+++ b/The Fantasy Trip/TFT.html
@@ -572,7 +572,7 @@
 <!-- For casting a spell -->
 <rolltemplate class="sheet-rolltemplate-cast-spell">
 	<div class=container>
-		<div><h1>{{character_name}} casts <span class=capitalize>{{spellname}}</span>!</h1></div>
+		<div><h1>{{character_name}} casts <span class=capitalize>{{spellname}}</span>.</h1></div>
 		{{#defending}}
 			<div><h2>Opponent is defending/dodging</h2></div>
 		{{/defending}}

--- a/The Fantasy Trip/TFT.html
+++ b/The Fantasy Trip/TFT.html
@@ -522,7 +522,7 @@
 					<div>
 						{{dx}}
 						{{#weaponadj}}
-						<span> + <span style='color: rgb(150, 1, 150);'>{{weaponadj}}</span></span>
+						<span> + <span class=template-weaponadj>{{weaponadj}}</span></span>
 						{{/weaponadj}}
 						{{#tohitadj}}
 						<span> + {{tohitadj}}</span>
@@ -593,7 +593,7 @@
 					<div>
 						{{dx}}
 						{{#spelladj}}
-						<span> + <span style='color: rgb(150, 0, 150);'>{{spelladj}}</span></span>
+						<span> + <span class=template-weaponadj>{{spelladj}}</span></span>
 						{{/spelladj}}
 						{{#tohitadj}}
 						<span> + {{tohitadj}}</span>


### PR DESCRIPTION
## Changes / Comments

I didn't like the dark purple font color of the weapon adjust component of the to hit number in the roll template.  I tried coloring the background a light purple, which was legible, but added too many different colors to the already colorful roll template.  So I stuck with the yellow background but added a lightning superscript.  Being a superscript it invites mouseover which will show you the weapon_adj or spell_adj inline roll tooltip.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [x] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
