### PR TITLE
[Exalted 3] dots layout adjustment

### DIFF
--- a/Exalted 3/Exalted3-Sheet.css
+++ b/Exalted 3/Exalted3-Sheet.css
@@ -143,7 +143,7 @@ span.attribute{
   font-size: 15px;  
 }
 span.dotattribute {
-	font-size: 14px;
+	font-size: 16px;
 }
 
 button.button-top {
@@ -378,7 +378,7 @@ select.sheetweaponselect {
 	grid-template-columns: 33% 33% 33%;
 	width: 880px;
 	margin-left: 5px;
-	padding-left: 5px;
+	padding-left: 0px;
 }
 
 .sheet-dots-header{ 
@@ -399,14 +399,14 @@ select.sheetweaponselect {
 	grid-row-end: span 1;
 	grid-template-rows: 40px 400px;
 	grid-template-columns: 33% 33% 33%;
-	width: 880px;
+	width: 873px;
 	margin-left: 5px;
 	padding-left: 8px;
 }
 
 .sheet-dot-abilities-rownew1 {
 	display: grid;
-	grid-template-columns: 20px 100px 80px 50px 35px;
+	grid-template-columns: 20px 93px 87px 45px 35px;
 	grid-template-rows: 100%;
 	align-items: center;
 	margin-bottom: 3px;
@@ -425,7 +425,7 @@ select.sheetweaponselect {
 	margin-left: 5px;
 	margin-top: 10px;
 	padding-left: 8px;
-	width: 880px;
+	width: 873px;
 }
 
 .sheet-dot-essence-main {
@@ -447,15 +447,15 @@ select.sheetweaponselect {
 .radiocontainer {
   display: flex;
   margin: 2px;
-  gap: 3px;
+  gap: 4px;
 }
 
 .radiocontainer2 {
 	display: grid;
-	gap: 2px;
+	gap: 4px;
 	grid-template-columns: 20% 20% 20% 20% 20%;
-	grid-template-rows: 50% 50%;
-	margin-right: 15px;
+	grid-template-rows: 100%;
+	margin-right: 20px;
 }
 
 .radiobox {
@@ -463,10 +463,10 @@ select.sheetweaponselect {
   border: 1px solid black;
   border-radius: 50%;
   background: black;
-  min-height: 12px;
-  min-width: 12px;
-  max-height: 12px;
-  max-width: 12px;
+  min-height: 14px;
+  min-width: 14px;
+  max-height: 14px;
+  max-width: 14px;
   -moz-appearance: none;
   -webkit-appearance: none;
   cursor: pointer;
@@ -492,6 +492,11 @@ select.sheetweaponselect {
 	flex-direction: column;
 }
 
+.sheet-dots-attribute-col {
+	padding-left: 15px;
+}
+
+
 .sheet-attribute-toprow{
 	font-size: 20px;
 	display: grid;
@@ -502,7 +507,7 @@ select.sheetweaponselect {
 .sheet-dots-attribute-rownew {
 	align-items: center;
 	display: grid;
-	grid-template-columns: 15px 93px 150px 30px;
+	grid-template-columns: 25px 110px 100px 40px;
 	grid-template-rows: 100%;
 	margin-bottom: 4px;
 }
@@ -1242,6 +1247,8 @@ div.sheet-charm-description,
 	width: 300px;
 }
 
+
+
 .sheet-martialartsside1 {
 	display: flex;
 	flex-direction: column;
@@ -1256,6 +1263,15 @@ div.sheet-charm-description,
 	justify-content: space-around;
 	font-size: 13px;
 	align-items: center;
+}
+
+.sheet-martial-art-dots {
+	display: grid;
+	grid-template-rows: 100%;
+	grid-template-columns: 35px 153px 47px 75px;
+	align-items: center;
+	font-size: 13px;
+	margin-bottom: 3px;
 }
 
 .sheet-martialartsinner {

--- a/Exalted 3/Exalted3-Sheet.html
+++ b/Exalted 3/Exalted3-Sheet.html
@@ -67,11 +67,6 @@
 					<input class="radiobox" type="radio" name="attr_strength" value="3" style="border-radius: 50%;">
 					<input class="radiobox" type="radio" name="attr_strength" value="4" style="border-radius: 50%;">
 					<input class="radiobox" type="radio" name="attr_strength" value="5" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_strength" value="6" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_strength" value="7" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_strength" value="8" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_strength" value="9" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_strength" value="10" style="border-radius: 50%;">
 				</div>
 				<button type="roll" value="/em rolls Strength with [[(@{strength} + ?{Bonuses|0} + @{wound-penalty})d10>?{Doubles?|Tens,10|Nines,9|Eights,8|Sevens,7|None,11}f<6s + (@{strength} + ?{Bonuses|0} + @{wound-penalty})+?{automatic successes|0}]] sucesses" name="roll_strengthcheck"></button>
 			</div>
@@ -85,11 +80,6 @@
 					<input class="radiobox" type="radio" name="attr_dexterity" value="3" style="border-radius: 50%;">
 					<input class="radiobox" type="radio" name="attr_dexterity" value="4" style="border-radius: 50%;">
 					<input class="radiobox" type="radio" name="attr_dexterity" value="5" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_dexterity" value="6" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_dexterity" value="7" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_dexterity" value="8" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_dexterity" value="9" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_dexterity" value="10" style="border-radius: 50%;">
 				</div>
 				<button type="roll" value="/em rolls Dexterity with [[(@{dexterity} + ?{Bonuses|0} + @{wound-penalty})d10>?{Doubles?|Tens,10|Nines,9|Eights,8|Sevens,7|None,11}f<6s + (@{dexterity} + ?{Bonuses|0} + @{wound-penalty})+?{automatic successes|0}]] sucesses" name="roll_dexteritycheck"></button>
 
@@ -104,11 +94,6 @@
 					<input class="radiobox" type="radio" name="attr_stamina" value="3" style="border-radius: 50%;">
 					<input class="radiobox" type="radio" name="attr_stamina" value="4" style="border-radius: 50%;">
 					<input class="radiobox" type="radio" name="attr_stamina" value="5" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_stamina" value="6" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_stamina" value="7" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_stamina" value="8" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_stamina" value="9" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_stamina" value="10" style="border-radius: 50%;">
 				</div>
 				<button type="roll" value="/em rolls Stamina with [[(@{stamina} + ?{Bonuses|0} + @{wound-penalty})d10>?{Doubles?|Tens,10|Nines,9|Eights,8|Sevens,7|None,11}f<6s + (@{stamina} + ?{Bonuses|0} + @{wound-penalty})+?{automatic successes|0}]] sucesses" name="roll_staminacheck"></button>
 			</div>
@@ -124,11 +109,6 @@
 					<input class="radiobox" type="radio" name="attr_charisma" value="3" style="border-radius: 50%;">
 					<input class="radiobox" type="radio" name="attr_charisma" value="4" style="border-radius: 50%;">
 					<input class="radiobox" type="radio" name="attr_charisma" value="5" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_charisma" value="6" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_charisma" value="7" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_charisma" value="8" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_charisma" value="9" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_charisma" value="10" style="border-radius: 50%;">
 				</div>
 				<button type="roll" value="/em rolls Charisma with [[(@{charisma} + ?{Bonuses|0} + @{wound-penalty})d10>?{Doubles?|Tens,10|Nines,9|Eights,8|Sevens,7|None,11}f<6s + (@{charisma} + ?{Bonuses|0} + @{wound-penalty})+?{automatic successes|0}]] sucesses" name="roll_charismacheck"></button>
 			</div>
@@ -142,11 +122,6 @@
 					<input class="radiobox" type="radio" name="attr_manipulation" value="3" style="border-radius: 50%;">
 					<input class="radiobox" type="radio" name="attr_manipulation" value="4" style="border-radius: 50%;">
 					<input class="radiobox" type="radio" name="attr_manipulation" value="5" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_manipulation" value="6" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_manipulation" value="7" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_manipulation" value="8" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_manipulation" value="9" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_manipulation" value="10" style="border-radius: 50%;">
 				</div>
 				<button type="roll" value="/em rolls Manipulation with [[(@{manipulation} + ?{Bonuses|0} + @{wound-penalty})d10>?{Doubles?|Tens,10|Nines,9|Eights,8|Sevens,7|None,11}f<6s + (@{manipulation} + ?{Bonuses|0} + @{wound-penalty})+?{automatic successes|0}]] sucesses" name="roll_manipulationcheck"></button>
 			</div>
@@ -160,11 +135,6 @@
 					<input class="radiobox" type="radio" name="attr_appearance" value="3" style="border-radius: 50%;">
 					<input class="radiobox" type="radio" name="attr_appearance" value="4" style="border-radius: 50%;">
 					<input class="radiobox" type="radio" name="attr_appearance" value="5" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_appearance" value="6" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_appearance" value="7" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_appearance" value="8" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_appearance" value="9" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_appearance" value="10" style="border-radius: 50%;">
 				</div>
 				<button type="roll" value="/em rolls Appearance with [[(@{appearance} + ?{Bonuses|0} + @{wound-penalty})d10>?{Doubles?|Tens,10|Nines,9|Eights,8|Sevens,7|None,11}f<6s + (@{appearance} + ?{Bonuses|0} + @{wound-penalty})+?{automatic successes|0}]] sucesses" name="roll_appearancecheck"></button>
 			</div>
@@ -180,11 +150,6 @@
 					<input class="radiobox" type="radio" name="attr_perception" value="3" style="border-radius: 50%;">
 					<input class="radiobox" type="radio" name="attr_perception" value="4" style="border-radius: 50%;">
 					<input class="radiobox" type="radio" name="attr_perception" value="5" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_perception" value="6" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_perception" value="7" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_perception" value="8" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_perception" value="9" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_perception" value="10" style="border-radius: 50%;">
 				</div>
 				<button type="roll" value="/em rolls Perception with [[(@{perception} + ?{Bonuses|0} + @{wound-penalty})d10>?{Doubles?|Tens,10|Nines,9|Eights,8|Sevens,7|None,11}f<6s + (@{perception} + ?{Bonuses|0} + @{wound-penalty})+?{automatic successes|0}]] sucesses" name="roll_perceptioncheck"></button>
 			</div>
@@ -198,11 +163,6 @@
 					<input class="radiobox" type="radio" name="attr_intelligence" value="3" style="border-radius: 50%;">
 					<input class="radiobox" type="radio" name="attr_intelligence" value="4" style="border-radius: 50%;">
 					<input class="radiobox" type="radio" name="attr_intelligence" value="5" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_intelligence" value="6" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_intelligence" value="7" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_intelligence" value="8" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_intelligence" value="9" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_intelligence" value="10" style="border-radius: 50%;">
 				</div>
 				<button type="roll" value="/em rolls Intelligence with [[(@{intelligence} + ?{Bonuses|0} + @{wound-penalty})d10>?{Doubles?|Tens,10|Nines,9|Eights,8|Sevens,7|None,11}f<6s + (@{intelligence} + ?{Bonuses|0} + @{wound-penalty})+?{automatic successes|0}]] sucesses" name="roll_intelligencecheck"></button>
 			</div>
@@ -216,11 +176,6 @@
 					<input class="radiobox" type="radio" name="attr_wits" value="3" style="border-radius: 50%;">
 					<input class="radiobox" type="radio" name="attr_wits" value="4" style="border-radius: 50%;">
 					<input class="radiobox" type="radio" name="attr_wits" value="5" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_wits" value="6" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_wits" value="7" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_wits" value="8" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_wits" value="9" style="border-radius: 50%;">
-					<input class="radiobox" type="radio" name="attr_wits" value="10" style="border-radius: 50%;">
 				</div>
 				<button type="roll" value="/em rolls Wits with [[(@{wits} + ?{Bonuses|0} + @{wound-penalty})d10>?{Doubles?|Tens,10|Nines,9|Eights,8|Sevens,7|None,11}f<6s + (@{wits} + ?{Bonuses|0} + @{wound-penalty})+?{automatic successes|0}]] sucesses" name="roll_witscheck"></button>
 			</div>
@@ -240,11 +195,6 @@
 						<input class="radiobox" type="radio" name="attr_archery" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_archery" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_archery" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_archery" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_archery" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_archery" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_archery" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_archery" value="10" style="border-radius: 50%;">
 					</div>
 					<select class="sheetselect" name="attr_arch_attr">
 						<option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -269,11 +219,7 @@
 						<input class="radiobox" type="radio" name="attr_athletics" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_athletics" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_athletics" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_athletics" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_athletics" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_athletics" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_athletics" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_athletics" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_athletics_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -298,11 +244,7 @@
 						<input class="radiobox" type="radio" name="attr_awareness" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_awareness" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_awareness" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_awareness" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_awareness" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_awareness" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_awareness" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_awareness" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_awareness_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -327,11 +269,7 @@
 						<input class="radiobox" type="radio" name="attr_brawl" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_brawl" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_brawl" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_brawl" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_brawl" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_brawl" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_brawl" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_brawl" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_brawl_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -356,11 +294,7 @@
 						<input class="radiobox" type="radio" name="attr_bureaucracy" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_bureaucracy" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_bureaucracy" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_bureaucracy" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_bureaucracy" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_bureaucracy" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_bureaucracy" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_bureaucracy" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_bureaucracy_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -385,7 +319,7 @@
 							<div class="sheet-martialartsside2">
 								<div class="sheet-headtext"><span data-i18n="craft-list-u">Craft</span>
 								</div>
-								<div class="sheet-martial-art">
+								<div class="sheet-martial-art-dots">
 									<span data-i18n="name-u">Name:</span>
 									<input type="text" name="attr_craft_name_1" placeholder="Craft Name 1" class="sheet-martial-art-text" data-i18n-placeholder="craft-name-1-place">
 									<span data-i18n="rating-u">Rating:</span>
@@ -396,14 +330,10 @@
 										<input class="radiobox" type="radio" name="attr_craft_1" value="3" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_craft_1" value="4" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_craft_1" value="5" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_1" value="6" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_1" value="7" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_1" value="8" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_1" value="9" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_1" value="10" style="border-radius: 50%;">
+
 									</div>
 								</div>
-								<div class="sheet-martial-art">
+								<div class="sheet-martial-art-dots">
 									<span data-i18n="name-u">Name:</span>
 									<input type="text" name="attr_craft_name_2" placeholder="Craft Name 2" class="sheet-martial-art-text" data-i18n-placeholder="craft-name-2-place">
 									<span data-i18n="rating-u">Rating:</span>
@@ -414,14 +344,10 @@
 										<input class="radiobox" type="radio" name="attr_craft_2" value="3" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_craft_2" value="4" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_craft_2" value="5" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_2" value="6" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_2" value="7" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_2" value="8" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_2" value="9" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_2" value="10" style="border-radius: 50%;">
+
 									</div>
 								</div>
-								<div class="sheet-martial-art">
+								<div class="sheet-martial-art-dots">
 									<span data-i18n="name-u">Name:</span>
 									<input type="text" name="attr_craft_name_3" placeholder="Craft Name 3" class="sheet-martial-art-text" data-i18n-placeholder="craft-name-3-place">
 									<span data-i18n="rating-u">Rating:</span>
@@ -432,14 +358,10 @@
 										<input class="radiobox" type="radio" name="attr_craft_3" value="3" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_craft_3" value="4" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_craft_3" value="5" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_3" value="6" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_3" value="7" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_3" value="8" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_3" value="9" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_3" value="10" style="border-radius: 50%;">
+
 									</div>
 								</div>
-								<div class="sheet-martial-art">
+								<div class="sheet-martial-art-dots">
 									<span data-i18n="name-u">Name:</span>
 									<input type="text" name="attr_craft_name_4" placeholder="Craft Name 4" class="sheet-martial-art-text" data-i18n-placeholder="craft-name-4-place">
 									<span data-i18n="rating-u">Rating:</span>
@@ -450,14 +372,10 @@
 										<input class="radiobox" type="radio" name="attr_craft_4" value="3" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_craft_4" value="4" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_craft_4" value="5" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_4" value="6" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_4" value="7" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_4" value="8" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_4" value="9" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_4" value="10" style="border-radius: 50%;">
+
 									</div>
 								</div>
-								<div class="sheet-martial-art">
+								<div class="sheet-martial-art-dots">
 									<span data-i18n="name-u">Name:</span>
 									<input type="text" name="attr_craft_name_5" placeholder="Craft Name 5" class="sheet-martial-art-text" data-i18n-placeholder="craft-name-5-place">
 									<span data-i18n="rating-u">Rating:</span>
@@ -468,14 +386,10 @@
 										<input class="radiobox" type="radio" name="attr_craft_5" value="3" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_craft_5" value="4" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_craft_5" value="5" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_5" value="6" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_5" value="7" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_5" value="8" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_5" value="9" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_5" value="10" style="border-radius: 50%;">
+
 									</div>
 								</div>
-								<div class="sheet-martial-art">
+								<div class="sheet-martial-art-dots">
 									<span data-i18n="name-u">Name:</span>
 									<input type="text" name="attr_craft_name_6" placeholder="Craft Name 6" class="sheet-martial-art-text" data-i18n-placeholder="craft-name-6-place">
 									<span data-i18n="rating-u">Rating:</span>
@@ -486,14 +400,10 @@
 										<input class="radiobox" type="radio" name="attr_craft_6" value="3" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_craft_6" value="4" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_craft_6" value="5" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_6" value="6" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_6" value="7" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_6" value="8" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_6" value="9" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_6" value="10" style="border-radius: 50%;">
+
 									</div>
 								</div>
-								<div class="sheet-martial-art">
+								<div class="sheet-martial-art-dots">
 									<span data-i18n="name-u">Name:</span>
 									<input type="text" name="attr_craft_name_7" placeholder="Craft Name 7" class="sheet-martial-art-text" data-i18n-placeholder="craft-name-7-place">
 									<span data-i18n="rating-u">Rating:</span>
@@ -504,14 +414,10 @@
 										<input class="radiobox" type="radio" name="attr_craft_7" value="3" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_craft_7" value="4" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_craft_7" value="5" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_7" value="6" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_7" value="7" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_7" value="8" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_7" value="9" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_7" value="10" style="border-radius: 50%;">
+
 									</div>
 								</div>
-								<div class="sheet-martial-art">
+								<div class="sheet-martial-art-dots">
 									<span data-i18n="name-u">Name:</span>
 									<input type="text" name="attr_craft_name_8" placeholder="Craft Name 8" class="sheet-martial-art-text" data-i18n-placeholder="craft-name-8-place">
 									<span data-i18n="rating-u">Rating:</span>
@@ -522,14 +428,10 @@
 										<input class="radiobox" type="radio" name="attr_craft_8" value="3" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_craft_8" value="4" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_craft_8" value="5" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_8" value="6" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_8" value="7" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_8" value="8" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_8" value="9" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_8" value="10" style="border-radius: 50%;">
+
 									</div>
 								</div>
-								<div class="sheet-martial-art">
+								<div class="sheet-martial-art-dots">
 									<span data-i18n="name-u">Name:</span>
 									<input type="text" name="attr_craft_name_9" placeholder="Craft Name 9" class="sheet-martial-art-text" data-i18n-placeholder="craft-name-9-place">
 									<span data-i18n="rating-u">Rating:</span>
@@ -540,14 +442,10 @@
 										<input class="radiobox" type="radio" name="attr_craft_9" value="3" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_craft_9" value="4" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_craft_9" value="5" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_9" value="6" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_9" value="7" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_9" value="8" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_9" value="9" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_9" value="10" style="border-radius: 50%;">
+
 									</div>
 								</div>
-								<div class="sheet-martial-art">
+								<div class="sheet-martial-art-dots">
 									<span data-i18n="name-u">Name:</span>
 									<input type="text" name="attr_craft_name_10" placeholder="Craft Name 10" class="sheet-martial-art-text" data-i18n-placeholder="craft-name-10-place">
 									<span data-i18n="rating-u">Rating:</span>
@@ -558,11 +456,7 @@
 										<input class="radiobox" type="radio" name="attr_craft_10" value="3" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_craft_10" value="4" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_craft_10" value="5" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_10" value="6" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_10" value="7" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_10" value="8" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_10" value="9" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_craft_10" value="10" style="border-radius: 50%;">
+
 									</div>
 								</div>
 							</div>
@@ -604,11 +498,7 @@
 						<input class="radiobox" type="radio" name="attr_dodge" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_dodge" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_dodge" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_dodge" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_dodge" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_dodge" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_dodge" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_dodge" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_dodge_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -633,11 +523,7 @@
 						<input class="radiobox" type="radio" name="attr_integrity" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_integrity" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_integrity" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_integrity" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_integrity" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_integrity" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_integrity" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_integrity" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_integrity_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -662,11 +548,6 @@
 						<input class="radiobox" type="radio" name="attr_investigation" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_investigation" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_investigation" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_investigation" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_investigation" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_investigation" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_investigation" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_investigation" value="10" style="border-radius: 50%;">
 					</div>
 					<select class="sheetselect" name="attr_investigation_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -693,11 +574,7 @@
 						<input class="radiobox" type="radio" name="attr_larceny" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_larceny" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_larceny" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_larceny" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_larceny" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_larceny" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_larceny" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_larceny" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_larceny_attr">
 						<option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -722,11 +599,6 @@
 						<input class="radiobox" type="radio" name="attr_linguistics" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_linguistics" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_linguistics" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_linguistics" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_linguistics" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_linguistics" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_linguistics" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_linguistics" value="10" style="border-radius: 50%;">
 					</div>
 					<select class="sheetselect" name="attr_linguistics_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -751,11 +623,7 @@
 						<input class="radiobox" type="radio" name="attr_lore" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_lore" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_lore" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_lore" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_lore" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_lore" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_lore" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_lore" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_lore_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -780,7 +648,7 @@
 							<div class="sheet-martialartsside1">
 								<div class="sheet-headtext"><span data-il8n="martial-arts-list" data-i18n="martial-arts-u">Martial Arts</span>
 								</div>
-								<div class="sheet-martial-art">
+								<div class="sheet-martial-art-dots">
 									<span data-i18n="name-u">Name:</span>
 									<input type="text" name="attr_martial_arts_name_1" placeholder="Martial Art Name 1" class="sheet-martial-art-text" data-i18n-placeholder="martial-art-name-1-place">
 									<span data-i18n="rating-u">Rating:</span>
@@ -791,14 +659,10 @@
 										<input class="radiobox" type="radio" name="attr_martial_arts_1" value="3" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_martial_arts_1" value="4" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_martial_arts_1" value="5" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_1" value="6" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_1" value="7" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_1" value="8" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_1" value="9" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_1" value="10" style="border-radius: 50%;">
+
 									</div>
 								</div>
-								<div class="sheet-martial-art">
+								<div class="sheet-martial-art-dots">
 									<span data-i18n="name-u">Name:</span>
 									<input type="text" name="attr_martial_arts_name_2" placeholder="Martial Art Name 2" class="sheet-martial-art-text" data-i18n-placeholder="martial-art-name-2-place">
 									<span data-i18n="rating-u">Rating:</span>
@@ -809,14 +673,10 @@
 										<input class="radiobox" type="radio" name="attr_martial_arts_2" value="3" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_martial_arts_2" value="4" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_martial_arts_2" value="5" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_2" value="6" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_2" value="7" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_2" value="8" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_2" value="9" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_2" value="10" style="border-radius: 50%;">
+
 									</div>
 								</div>
-								<div class="sheet-martial-art">
+								<div class="sheet-martial-art-dots">
 									<span data-i18n="name-u">Name:</span>
 									<input type="text" name="attr_martial_arts_name_3" placeholder="Martial Art Name 3" class="sheet-martial-art-text" data-i18n-placeholder="martial-art-name-3-place">
 									<span data-i18n="rating-u">Rating:</span>
@@ -827,14 +687,10 @@
 										<input class="radiobox" type="radio" name="attr_martial_arts_3" value="3" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_martial_arts_3" value="4" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_martial_arts_3" value="5" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_3" value="6" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_3" value="7" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_3" value="8" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_3" value="9" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_3" value="10" style="border-radius: 50%;">
+
 									</div>
 								</div>
-								<div class="sheet-martial-art">
+								<div class="sheet-martial-art-dots">
 									<span data-i18n="name-u">Name:</span>
 									<input type="text" name="attr_martial_arts_name_4" placeholder="Martial Art Name 4" class="sheet-martial-art-text" data-i18n-placeholder="martial-art-name-4-place">
 									<span data-i18n="rating-u">Rating:</span>
@@ -845,14 +701,10 @@
 										<input class="radiobox" type="radio" name="attr_martial_arts_4" value="3" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_martial_arts_4" value="4" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_martial_arts_4" value="5" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_4" value="6" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_4" value="7" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_4" value="8" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_4" value="9" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_4" value="10" style="border-radius: 50%;">
+
 									</div>
 								</div>
-								<div class="sheet-martial-art">
+								<div class="sheet-martial-art-dots">
 									<span data-i18n="name-u">Name:</span>
 									<input type="text" name="attr_martial_arts_name_5" placeholder="Martial Art Name 5" class="sheet-martial-art-text" data-i18n-placeholder="martial-art-name-5-place">
 									<span data-i18n="rating-u">Rating:</span>
@@ -863,14 +715,10 @@
 										<input class="radiobox" type="radio" name="attr_martial_arts_5" value="3" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_martial_arts_5" value="4" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_martial_arts_5" value="5" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_5" value="6" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_5" value="7" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_5" value="8" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_5" value="9" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_5" value="10" style="border-radius: 50%;">
+
 									</div>
 								</div>
-								<div class="sheet-martial-art">
+								<div class="sheet-martial-art-dots">
 									<span data-i18n="name-u">Name:</span>
 									<input type="text" name="attr_martial_arts_name_6" placeholder="Martial Art Name 6" class="sheet-martial-art-text" data-i18n-placeholder="martial-art-name-6-place">
 									<span data-i18n="rating-u">Rating:</span>
@@ -881,14 +729,10 @@
 										<input class="radiobox" type="radio" name="attr_martial_arts_6" value="3" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_martial_arts_6" value="4" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_martial_arts_6" value="5" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_6" value="6" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_6" value="7" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_6" value="8" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_6" value="9" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_6" value="10" style="border-radius: 50%;">
+
 									</div>
 								</div>
-								<div class="sheet-martial-art">
+								<div class="sheet-martial-art-dots">
 									<span data-i18n="name-u">Name:</span>
 									<input type="text" name="attr_martial_arts_name_7" placeholder="Martial Art Name 7" class="sheet-martial-art-text" data-i18n-placeholder="martial-art-name-7-place">
 									<span data-i18n="rating-u">Rating:</span>
@@ -899,14 +743,10 @@
 										<input class="radiobox" type="radio" name="attr_martial_arts_7" value="3" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_martial_arts_7" value="4" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_martial_arts_7" value="5" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_7" value="6" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_7" value="7" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_7" value="8" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_7" value="9" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_7" value="10" style="border-radius: 50%;">
+
 									</div>
 								</div>
-								<div class="sheet-martial-art">
+								<div class="sheet-martial-art-dots">
 									<span data-i18n="name-u">Name:</span>
 									<input type="text" name="attr_martial_arts_name_8" placeholder="Martial Art Name 8" class="sheet-martial-art-text" data-i18n-placeholder="martial-art-name-8-place">
 									<span data-i18n="rating-u">Rating:</span>
@@ -917,14 +757,10 @@
 										<input class="radiobox" type="radio" name="attr_martial_arts_8" value="3" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_martial_arts_8" value="4" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_martial_arts_8" value="5" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_8" value="6" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_8" value="7" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_8" value="8" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_8" value="9" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_8" value="10" style="border-radius: 50%;">
+
 									</div>
 								</div>
-								<div class="sheet-martial-art">
+								<div class="sheet-martial-art-dots">
 									<span data-i18n="name-u">Name:</span>
 									<input type="text" name="attr_martial_arts_name_9" placeholder="Martial Art Name 9" class="sheet-martial-art-text" data-i18n-placeholder="martial-art-name-9-place">
 									<span data-i18n="rating-u">Rating:</span>
@@ -935,14 +771,10 @@
 										<input class="radiobox" type="radio" name="attr_martial_arts_9" value="3" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_martial_arts_9" value="4" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_martial_arts_9" value="5" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_9" value="6" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_9" value="7" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_9" value="8" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_9" value="9" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_9" value="10" style="border-radius: 50%;">
+
 									</div>
 								</div>
-								<div class="sheet-martial-art">
+								<div class="sheet-martial-art-dots">
 									<span data-i18n="name-u">Name:</span>
 									<input type="text" name="attr_martial_arts_name_10" placeholder="Martial Art Name 10" class="sheet-martial-art-text" data-i18n-placeholder="martial-art-name-10-place">
 									<span data-i18n="rating-u">Rating:</span>
@@ -953,11 +785,7 @@
 										<input class="radiobox" type="radio" name="attr_martial_arts_10" value="3" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_martial_arts_10" value="4" style="border-radius: 50%;">
 										<input class="radiobox" type="radio" name="attr_martial_arts_10" value="5" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_10" value="6" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_10" value="7" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_10" value="8" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_10" value="9" style="border-radius: 50%;">
-										<input class="radiobox" type="radio" name="attr_martial_arts_10" value="10" style="border-radius: 50%;">
+
 									</div>
 								</div>
 							</div>
@@ -1000,11 +828,7 @@
 						<input class="radiobox" type="radio" name="attr_medicine" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_medicine" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_medicine" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_medicine" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_medicine" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_medicine" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_medicine" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_medicine" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_medicine_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -1029,11 +853,7 @@
 						<input class="radiobox" type="radio" name="attr_melee" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_melee" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_melee" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_melee" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_melee" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_melee" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_melee" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_melee" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_melee_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -1058,11 +878,7 @@
 						<input class="radiobox" type="radio" name="attr_occult" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_occult" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_occult" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_occult" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_occult" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_occult" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_occult" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_occult" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_occult_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -1087,11 +903,7 @@
 						<input class="radiobox" type="radio" name="attr_performance" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_performance" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_performance" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_performance" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_performance" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_performance" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_performance" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_performance" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_performance_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -1116,11 +928,7 @@
 						<input class="radiobox" type="radio" name="attr_presence" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_presence" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_presence" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_presence" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_presence" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_presence" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_presence" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_presence" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_presence_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -1147,11 +955,7 @@
 						<input class="radiobox" type="radio" name="attr_resistance" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_resistance" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_resistance" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_resistance" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_resistance" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_resistance" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_resistance" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_resistance" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_resistance_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -1176,11 +980,7 @@
 						<input class="radiobox" type="radio" name="attr_ride" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_ride" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_ride" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_ride" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_ride" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_ride" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_ride" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_ride" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_ride_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -1205,11 +1005,7 @@
 						<input class="radiobox" type="radio" name="attr_sail" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_sail" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_sail" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_sail" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_sail" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_sail" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_sail" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_sail" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_sail_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -1234,11 +1030,7 @@
 						<input class="radiobox" type="radio" name="attr_socialize" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_socialize" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_socialize" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_socialize" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_socialize" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_socialize" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_socialize" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_socialize" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_socialize_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -1263,11 +1055,7 @@
 						<input class="radiobox" type="radio" name="attr_stealth" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_stealth" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_stealth" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_stealth" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_stealth" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_stealth" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_stealth" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_stealth" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_stealth_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -1292,11 +1080,7 @@
 						<input class="radiobox" type="radio" name="attr_survival" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_survival" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_survival" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_survival" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_survival" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_survival" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_survival" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_survival" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_survival_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -1321,11 +1105,7 @@
 						<input class="radiobox" type="radio" name="attr_thrown" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_thrown" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_thrown" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_thrown" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_thrown" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_thrown" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_thrown" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_thrown" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_thrown_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -1350,11 +1130,6 @@
 						<input class="radiobox" type="radio" name="attr_war" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_war" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_war" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_war" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_war" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_war" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_war" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_war" value="10" style="border-radius: 50%;">
 					</div>
 					<select class="sheetselect" name="attr_war_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -1379,11 +1154,7 @@
 						<input class="radiobox" type="radio" name="attr_extra" value="3" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_extra" value="4" style="border-radius: 50%;">
 						<input class="radiobox" type="radio" name="attr_extra" value="5" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_extra" value="6" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_extra" value="7" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_extra" value="8" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_extra" value="9" style="border-radius: 50%;">
-						<input class="radiobox" type="radio" name="attr_extra" value="10" style="border-radius: 50%;">
+
 					</div>
 					<select class="sheetselect" name="attr_extra_attr">
 					  <option value="@{strength}" data-i18n="strength-u">STR</option>
@@ -3903,7 +3674,7 @@
 					<input type="number" name="attr_repqcattackdice">
 					<button type="roll" value="/em rolls to attack with [[ (@{repqcattackdice})d10>?{Doubles?|Tens,10|Nines,9|Eights,8|Sevens,7|None,11}f<6s + @{repqcattackdice} + ?{automatic successes|0}]] successes" name="roll_repattackroll"></button>
 					<input type="number" name="attr_repqcattackdamage">
-					<button type="roll" value="/em rolls damage with [[ (@{repqcattackdamage})d10>?{Doubles?|Tens,10|Nines,9|Eights,8|Sevens,7|None,11}f<6s + @{repqcattackdamage} + ?{automatic successes|0}]] successes" name="roll_repdamageroll"></button>
+					<button type="roll" value="/em rolls damage with [[ (@{repqcattackdamage} - ?{Enemy Soak|0})d10>?{Doubles?|Tens,10|Nines,9|Eights,8|Sevens,7|None,11}f<6s + (@{repqcattackdamage}  - ?{Enemy Soak|0} + ?{automatic successes|0})]] successes" name="roll_repdamageroll"></button>
 				</div>
 			</fieldset>
 			<span class="sheet-misctext" data-i18n="qcdefense-u">Defenses</span>


### PR DESCRIPTION
## Changes / Comments

Adjusted the dot-based layout of the sheet to have 5 dots per ability/attribute rather than 10, as those stats have a normal maximum of 5. 

Added an enemy soak prompt to the quick pools damage roll so the damage pools don't have to be adjusted each time.

Made a couple of touch-ups to the dot layout to make better use of the space and align the sections better.


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
