### PR TITLE
[Dnd4e] Bugfix for Header Color of Monster Powers

### DIFF
--- a/D&D_4E/D&D_4E.css
+++ b/D&D_4E/D&D_4E.css
@@ -742,10 +742,10 @@
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-monster {
-	background-color: -webkit-linear-gradient(left, darkgreen , chartreuse); /* For Safari 5.1 to 6.0 */
-    background-color: -o-linear-gradient(right, darkgreen, chartreuse); /* For Opera 11.1 to 12.0 */
-    background-color: -moz-linear-gradient(right, darkgreen, chartreuse); /* For Firefox 3.6 to 15 */
-    background-color: linear-gradient(to right, darkgreen , chartreuse); /* Standard syntax (must be last) */
+    background: -webkit-linear-gradient(left, darkgreen, chartreuse); /* For Safari 5.1 to 6.0 */
+    background: -o-linear-gradient(right, darkgreen, chartreuse); /* For Opera 11.1 to 12.0 */
+    background: -moz-linear-gradient(right, darkgreen, chartreuse); /* For Firefox 3.6 to 15 */
+    background: linear-gradient(to right, darkgreen , chartreuse); /* Standard syntax (must be last) */
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-subheader-alignright {


### PR DESCRIPTION
## Changes / Comments
* Corrected CSS so that linear-gradient is a background property instead of background-color. Before this change, monster stat block headers had a default background. Now they will be green/chartreuse (as intended).

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name. **Yep**
- [x] Is this a bug fix? **Yep**
- [ ] Does this add functional enhancements (new features or extending existing features) ? **Nope**
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ?  **Yep**, kinda
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data? **N/A**
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards] (https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository)? **N/A**

If you do not know English. Please leave a comment in your native language.
