### PR TITLE
[The One Ring 2e] 2.2.1 - next try to fix the css roll template bug

### DIFF
--- a/The One Ring 2e/release-notes.md
+++ b/The One Ring 2e/release-notes.md
@@ -1,36 +1,58 @@
 # Release Notes
+
 This is a rewrite based on the early 2e (basic) and 1e edition that also includes a 2e sheet for adversaries. It features correct handling of favoured rolls, weary/miserable state, bonus dice and stance related bonus changes to attack rating, parry, protection and damage.
 
 # Release History
+
+## 02.02.01 (Build 7)
+
+### CSS fixes
+
+- removed font imports and font-face declarations
+- added two missing .sheet prefixes in roll-template
+- added two missing .charsheet prefixes in the pc css
+- fixed a typo in the roll-template css
+
 ## 02.02.00 (Build 6)
--  The macro bar is now available for parsed rolls (which is not easy to achieve as parsed roll buttons are action buttons and need special treatment to be available for the macro bar). You can drag / drop attack and protection rolls from the sheet into the macro bar and click those actions directly without opening the sheet. This is especially useful in conjunction with targeted attacks and will smooth and speed up battles.
+
+- The macro bar is now available for parsed rolls (which is not easy to achieve as parsed roll buttons are action buttons and need special treatment to be available for the macro bar). You can drag / drop attack and protection rolls from the sheet into the macro bar and click those actions directly without opening the sheet. This is especially useful in conjunction with targeted attacks and will smooth and speed up battles.
+
 ### Bugfixes
-- bugfix miserable 
+
+- bugfix miserable
 - bugfix favourill not initialized
 - css cleanup
 - fixing two issues that might have had an impact on the roll-template issue! (fingers crossed)
 
 ## 02.01.00 (Build 5)
+
 ### Features
+
 - changed stance values from "Forward/Open/Defensive/Rearward" to "1/2/3/4" because this opens the way for players to easily toggle stance by using the token bar
-- stance changes toggle the stance attack bonus automatically (forward:1/open:0/defensive:-1/rearward:0). The checkbox now only effects the attack damage bonus and is automatically activated when in forward stance (this can be used for Beorning with GREAT STRENGTH virtue to get +1 damage bonus in forward stance). 
+- stance changes toggle the stance attack bonus automatically (forward:1/open:0/defensive:-1/rearward:0). The checkbox now only effects the attack damage bonus and is automatically activated when in forward stance (this can be used for Beorning with GREAT STRENGTH virtue to get +1 damage bonus in forward stance).
 - adversary targeted attack will take the opponent's stance into account and modify the success dice with +1/0/-1 automatically.
 - favoured protection rolls (e.g. due to dwarf virtue "stone hard")
+
 ### Bugfixes
-- CM checkbox not clickable (armour with cunning make), https://trello.com/c/lM1rrRA9
+
+- CM checkbox not clickable (armour with cunning make), <https://trello.com/c/lM1rrRA9>
 - swapped position of Valour and Wisdom
+
 ## 02.00.01 (Build 4)
+
 - rename Advancement Points -> Adventure Points
 
 ## 02.00.00 (Build 3)
+
 - integrate roll parsing to get rid of custom roll tables.
 - integration of armour qualities in the layout (cunning make and close fitting)
 - favoured/ill-favoured rolls for adversaries
-- integrate roll-templates 
+- integrate roll-templates
 - numerous layout optimizations and UI improvments
 
 ## 01.01.00 (Build 2)
-- added sheet worker to set the skill rolls on every update of the favoured skill state or global favoured state. This replaces the static switches in the rolls that were hard to read for players. 
+
+- added sheet worker to set the skill rolls on every update of the favoured skill state or global favoured state. This replaces the static switches in the rolls that were hard to read for players.
 
 ## 01.00.00 (Build 1)
 
@@ -46,7 +68,7 @@ This is a rewrite based on the early 2e (basic) and 1e edition that also include
 
 - Added total parry and protection calculation
 
-- Added selected adversary parry bonus integration into attack rolls 
+- Added selected adversary parry bonus integration into attack rolls
 
 **Data Migrations**
 

--- a/The One Ring 2e/sheet.css
+++ b/The One Ring 2e/sheet.css
@@ -1,3 +1,4 @@
+/*
 @import url('https://fonts.cdnfonts.com/css/aniron');
 @font-face {
     font-family: 'AnorinFace';
@@ -19,6 +20,7 @@
     url("//db.onlinewebfonts.com/t/767cb11dc1ee01154718463adc3a1d1e.ttf") format("truetype"), 
     url("//db.onlinewebfonts.com/t/767cb11dc1ee01154718463adc3a1d1e.svg#Aniron") format("svg"); 
 }
+*/
 /* reset all
 .ui-dialog .charsheet select,
 .ui-dialog .charsheet textarea,
@@ -38,6 +40,7 @@
     /* Define CSS variables */
     --red: rgb(176, 33, 30); 
     --gray: rgb(104, 104, 104);
+    --yellow: rgb(254, 252, 240);
     --solidborder: 1px solid var(--gray);
     --borderred: url('https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/The%20One%20Ring%202e/assets/boxline-border-red.png');
     --borderbrown: url('https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/The%20One%20Ring%202e/assets/boxline-border-brown.png');
@@ -50,7 +53,7 @@
     display: none;
     position: relative;
     background: var(--background);
-    background-color: #FEFCF0;
+    background-color: var(--yellow);
     border: 8px solid transparent;
     border-image-source: var(--borderred);
     border-image-slice: 8 8 8 8;
@@ -71,19 +74,18 @@
 }
 /* Generic element styles */
 .charsheet :is(h1,h2,h3){
-    font-family: "Aniron", "Palatino Linotype", "Book Antiqua", Palatino, serif, sans-serif;
-    font-weight: normal;
+    font-family: Papyrus, "Palatino Linotype", "Book Antiqua", Palatino, serif, sans-serif;
+    font-weight: bolder;
     line-height: 1;
     color: var(--red);
     text-transform: uppercase;
     font-size: smaller; 
-    font-weight: bold;
     line-height: 25px;
 	text-align: center;
 }
 .charsheet :is(h2,h3) {
     color: var(--gray);
-    font-weight: normal;
+    font-weight: bold;
 }
 .charsheet h2 {
     font-size: x-small;
@@ -169,14 +171,14 @@
 .charsheet :is(#skill-strength,#skill-heart,#skill-wits,#virtues,#rewards,#protection) input[type="checkbox"]:checked + span {
     text-decoration: underline;
 }
-input[type='checkbox'],
-input[type='radio'] {
+.charsheet input[type='checkbox'],
+.charsheet input[type='radio'] {
 	accent-color: #AC4637;
 }
 
 /* Dots*/
 .charsheet .sheet-dots {
-    display: inline-block;
+    display: block;
     float: right;
     top: 2px;
     right: 0;
@@ -194,7 +196,7 @@ input[type='radio'] {
     z-index: 1;
 	transform: rotate(45deg);
 }
-.sheet-dots input[type="radio"] + span {
+.charsheet .sheet-dots input[type="radio"] + span {
 	margin: 5px 5px 0px -5px;
     line-height: 5px;
     font-size: 7px;
@@ -221,15 +223,15 @@ input[type='radio'] {
 	border: 0.5px solid grey;
 	border-radius: 50%;
 	margin-right: 8px;
-	font-family: "Aniron", "Palatino Linotype", "Book Antiqua", Palatino, serif, sans-serif;
+	font-family: Papyrus, "Palatino Linotype", "Book Antiqua", Palatino, serif, sans-serif;
 }
-.sheet-dots input[type='radio']:checked ~ input[type='radio'] + span:before {
+.charsheet .sheet-dots input[type='radio']:checked ~ input[type='radio'] + span:before {
     background-size:100%;
 	border: 2px solid #AC4637;
 	background-color: transparent; 
 	transform: rotate(45deg);
 }
-.sheet-dots input[type="radio"]:not([value="0"]) + span:before {
+.charsheet .sheet-dots input[type="radio"]:not([value="0"]) + span:before {
     background-size:100%;
 	border: 2px solid #AC4637;
 	background-color: #AC4637; 
@@ -697,7 +699,7 @@ input[type='radio'] {
     text-align: center;
 }
 .charsheet #notes{
-    background-color: #fefcf0;
+    background-color: var(--yellow);
     grid-area: stre;
     grid-column: 1 / span 12;
     grid-row: 4 / span 2;
@@ -869,16 +871,16 @@ input[type='radio'] {
     background: transparent;
 }
 .sheet-rolltemplate-tor div,
-.sheet-rolltemaplte-tor span {	  
+.sheet-rolltemplate-tor span {	  
     font-family: Papyrus, 'Book Antiqua', Palatino, serif, sans-serif;
     font-weight: bold;
 }
-.withoutavatars .sheet-rolltemplate-tor {
+.sheet-rolltemplate-tor {
     margin-left: -7px;
 }
 .sheet-rolltemplate-tor .sheet-container {
     background: var(--background);
-    background-color: #FEFCF0;
+    background-color: var(--yellow);
     border: 5px solid transparent;
     border-image-source: var(--borderred);
     border-image-slice: 8 8 8 8;
@@ -958,7 +960,7 @@ input[type='radio'] {
     justify-content: center;
     justify-self: center;
     border: 4px solid transparent;
-    background-color: #FEFCF0;
+    background-color: var(--yellow);
     border-image-source: var(--borderbrown);
     /*border-image-source: url('https://raw.githubusercontent.com/bhuesemann/roll20-character-sheets/tor2e_02-00-00/The%20One%20Ring%202e/images/box-border-brown-rttd.png');*/
     /*border-image-source: url('https://raw.githubusercontent.com/roll20/roll20-character-sheets/master/The%20One%20Ring%202e/images/box-border-brown-rttd.png');*/
@@ -970,7 +972,7 @@ input[type='radio'] {
     /*transform: rotate(45deg);*/
 }
 .sheet-rolltemplate-tor div.sheet-die-result span.sheet-rotated-box span {
-    background-color: #FEFCF0;
+    background-color: var(--yellow);
     transform: rotate(-45deg);
     /*transform: rotate(-45deg);*/
     border: 0; 
@@ -981,7 +983,7 @@ input[type='radio'] {
 } 
 .sheet-rolltemplate-tor .sheet-target-number .sheet-rotated-box,
 .sheet-rolltemplate-tor .sheet-roll-total .sheet-rotated-box {
-    background-color: #FEFCF0;
+    background-color: var(--yellow);
 }
 .sheet-rolltemplate-tor .sheet-target-number .sheet-rotated-box span,
 .sheet-rolltemplate-tor .sheet-roll-total .sheet-rotated-box span {
@@ -1018,8 +1020,8 @@ input[type='radio'] {
 .sheet-rolltemplate-tor div.sheet-success-die span.sheet-rotated-box span {
     font-size: 20px;
 }
-.sheet-rolltemplate-tor div.sheet-feat-die span.sheet-rotated-box span.fullcrit,
-.sheet-rolltemplate-tor div.sheet-feat-die span.sheet-rotated-box span.fullfail,
+.sheet-rolltemplate-tor div.sheet-feat-die span.sheet-rotated-box span.sheet-fullcrit,
+.sheet-rolltemplate-tor div.sheet-feat-die span.sheet-rotated-box span.sheet-fullfail,
 .sheet-rolltemplate-tor div.sheet-feat-die span.sheet-rotated-box span.sheet-gandalf,
 .sheet-rolltemplate-tor div.sheet-feat-die span.sheet-rotated-box span.sheet-eye {
     opacity: 0;
@@ -1044,11 +1046,13 @@ input[type='radio'] {
     background-position-y: center;
 }
 .sheet-rolltemplate-tor div.sheet-feat-die span.sheet-rotated-box.sheet-fullcrit + span.sheet-gandalf {
+    background-color: var(--yellow);
     background-image: url('https://raw.githubusercontent.com/roll20/roll20-character-sheets/master/The%20One%20Ring%202e/images/gandalf2.png');
 }
 .sheet-rolltemplate-tor div.sheet-feat-die span.sheet-rotated-box.sheet-fullfail + span.sheet-eye {
     right: 25px;
     width: 2.5em;
+    background-color: var(--yellow);
     background-image: url('https://raw.githubusercontent.com/roll20/roll20-character-sheets/master/The%20One%20Ring%202e/images/eye2.png');
 }
 .sheet-rolltemplate-tor .sheet-feat-label {

--- a/The One Ring 2e/sheet.html
+++ b/The One Ring 2e/sheet.html
@@ -1,4 +1,4 @@
-<input type="hidden" name="attr_version" value="02-02-00" />
+<input type="hidden" name="attr_version" value="02-02-01" />
 <input type="hidden" class="sheet-tabstoggle" name="attr_sheetTab" />
 <input type="checkbox" name="attr_parsedrolls" value="1" class="hidden config-parsed-rolls" checked="checked" hidden
     readonly />


### PR DESCRIPTION
## Changes / Comments

### CSS fixes

- removed font imports and font-face declarations
- added two missing .sheet prefixes in roll-template
- added two missing .charsheet prefixes in the pc css
- fixed a typo in the roll-template css

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
