### PR TITLE
[Alien RPG] Fixed ship armament rolls

### DIFF
--- a/Alien Roleplaying Game/Alien-Roleplaying-Game.html
+++ b/Alien Roleplaying Game/Alien-Roleplaying-Game.html
@@ -1892,7 +1892,7 @@
              -->
              <div class="grid-item-black span-one-thru-six cover-100-flex flex-content-right">
                 <div class="grid-item clip-edges w120 h-fit marg-right">
-                    <span class="centered bold">v3.03 <br/>(2022-02-04)</span>
+                    <span class="centered bold">v3.03 <br/>(2022-02-09)</span>
                 </div>  
                 <div class="cover-75 flex-content-right flex-column">               
                     <div class="grid-item clip-edges align-left marg-right pad-left pad-right">

--- a/Alien Roleplaying Game/Alien-Roleplaying-Game.html
+++ b/Alien Roleplaying Game/Alien-Roleplaying-Game.html
@@ -8,6 +8,7 @@
         v3.00 Richard W: Added encumbrance and list tab indicators, API dice rolls
         v3.01 Richard W: Fixed roll names to make macros work
         v3.02 Richard W: Fixed armament roll rangemod to calculate on load
+        v3.03 Richard W: Fixed armament 3 roll button, changed armament roll name to support API, and changed armor rolls to not use API
 -->
 
 <input type="hidden" name="attr_sheetversion" value="3.02">
@@ -720,10 +721,10 @@
         </div> <!-- END OF ROW 11 -->
         
         <div class="grid-item span-five-six"> <!-- START OF ROW 12 -->
-            <button type="roll" name="armor" class="button-skill roll-rolltemplate" value="@{secret_roll} &{template:alien} {{character-name=@{character_name} }} {{roll-name=Armor Check }} {{base-dice=[[@{armor} + ?{Modifiers|0} ]] }} {{base-roll-one=[[1d6]] }} {{base-roll-two=[[1d6]] }} {{base-roll-three=[[1d6]] }} {{base-roll-four=[[1d6]] }} {{base-roll-five=[[1d6]] }}  {{base-roll-six=[[1d6]] }} {{base-roll-seven=[[1d6]] }} {{base-roll-eight=[[1d6]] }} {{base-roll-nine=[[1d6]] }} {{base-roll-ten=[[1d6]] }} {{base-roll-eleven=[[1d6]] }} {{base-roll-twelve=[[1d6]] }} {{base-roll-thirteen=[[1d6]] }} {{base-roll-fourteen=[[1d6]] }} {{base-roll-fifteen=[[1d6]] }} {{base-roll-sixteen=[[1d6]] }} {{base-roll-seventeen=[[1d6]] }} {{base-roll-eighteen=[[1d6]] }}" data-i18n="armor-u">Armor</button>
-            <button type="roll" name="armor_api" class="button-skill roll-api" data-i18n="armor-u" value="@{roll_command} [Armor] [[(@{armor}+?{Modifiers|0})d6]] [[0d6]] --runas|@{character_name}" title="Roll API Dice!">
+            <button type="roll" name="armor" class="button-skill roll-rolltemplate roll-api" value="@{secret_roll} &{template:alien} {{character-name=@{character_name} }} {{roll-name=Armor Roll }} {{base-dice=[[@{armor} + ?{Modifiers|0} ]] }} {{base-roll-one=[[1d6]] }} {{base-roll-two=[[1d6]] }} {{base-roll-three=[[1d6]] }} {{base-roll-four=[[1d6]] }} {{base-roll-five=[[1d6]] }}  {{base-roll-six=[[1d6]] }} {{base-roll-seven=[[1d6]] }} {{base-roll-eight=[[1d6]] }} {{base-roll-nine=[[1d6]] }} {{base-roll-ten=[[1d6]] }} {{base-roll-eleven=[[1d6]] }} {{base-roll-twelve=[[1d6]] }} {{base-roll-thirteen=[[1d6]] }} {{base-roll-fourteen=[[1d6]] }} {{base-roll-fifteen=[[1d6]] }} {{base-roll-sixteen=[[1d6]] }} {{base-roll-seventeen=[[1d6]] }} {{base-roll-eighteen=[[1d6]] }}" data-i18n="armor-u">Armor</button>
+            <!-- <button type="roll" name="armor_api" class="button-skill roll-api" data-i18n="armor-u" value="@{roll_command} [Armor] [[(@{armor}+?{Modifiers|0})d6]] [[0d6]] --runas|@{character_name}" title="Roll API Dice!">
                 &nbsp;<span >Armor</span>&nbsp;
-            </button>
+            </button> -->
             <div class="float-right">
                 <input type="number" name="attr_armor" value="0" class="no-spin-input optional-spinner-input" title="@{armor}" />
             </div>
@@ -1237,10 +1238,10 @@
             <div class="dark-teal-header some-padding pad-left" data-i18n="ship-hull-u">Hull</div>
         </div>
         <div class="grid-item span-eight-thru-ten span-row7 flex-row flex-content-end flex-items-align-center clip-edges w50pc">
-            <button type="roll" name="ship_armor" class="button-skill pad-right roll-rolltemplate" value="@{secret_roll} &{template:alien} {{character-name=@{ship-name} }} {{roll-name=Ship Armor }} {{base-dice=[[@{ship_armor} + ?{Modifiers|0} ]] }} {{base-roll-one=[[1d6]] }} {{base-roll-two=[[1d6]] }} {{base-roll-three=[[1d6]] }} {{base-roll-four=[[1d6]] }} {{base-roll-five=[[1d6]] }}  {{base-roll-six=[[1d6]] }} {{base-roll-seven=[[1d6]] }} {{base-roll-eight=[[1d6]] }} {{base-roll-nine=[[1d6]] }} {{base-roll-ten=[[1d6]] }} {{base-roll-eleven=[[1d6]] }} {{base-roll-twelve=[[1d6]] }} {{base-roll-thirteen=[[1d6]] }} {{base-roll-fourteen=[[1d6]] }} {{base-roll-fifteen=[[1d6]] }} {{base-roll-sixteen=[[1d6]] }} {{base-roll-seventeen=[[1d6]] }} {{base-roll-eighteen=[[1d6]] }} " data-i18n="ship-armor-u" >Armor</button>
-            <button type="roll" name="ship_armor_api" class="button-skill pad-right roll-api" data-i18n="ship-armor-u" value="@{roll_command} [Ship Armor] [[(@{ship_armor}+?{Modifiers|0})d6]] [[0d6]] --runas|@{character_name}" title="Roll API Dice!">
+            <button type="roll" name="ship_armor" class="button-skill pad-right roll-rolltemplate roll-api" value="@{secret_roll} &{template:alien} {{character-name=@{ship-name} }} {{roll-name=Ship Armor }} {{base-dice=[[@{ship_armor} + ?{Modifiers|0} ]] }} {{base-roll-one=[[1d6]] }} {{base-roll-two=[[1d6]] }} {{base-roll-three=[[1d6]] }} {{base-roll-four=[[1d6]] }} {{base-roll-five=[[1d6]] }}  {{base-roll-six=[[1d6]] }} {{base-roll-seven=[[1d6]] }} {{base-roll-eight=[[1d6]] }} {{base-roll-nine=[[1d6]] }} {{base-roll-ten=[[1d6]] }} {{base-roll-eleven=[[1d6]] }} {{base-roll-twelve=[[1d6]] }} {{base-roll-thirteen=[[1d6]] }} {{base-roll-fourteen=[[1d6]] }} {{base-roll-fifteen=[[1d6]] }} {{base-roll-sixteen=[[1d6]] }} {{base-roll-seventeen=[[1d6]] }} {{base-roll-eighteen=[[1d6]] }} " data-i18n="ship-armor-u" >Armor</button>
+            <!-- <button type="roll" name="ship_armor_api" class="button-skill pad-right roll-api" data-i18n="ship-armor-u" value="@{roll_command} [Ship Armor] [[(@{ship_armor}+?{Modifiers|0})d6]] [[0d6]] --runas|@{character_name}" title="Roll API Dice!">
                 &nbsp;<span >Armor</span>&nbsp;
-            </button>
+            </button> -->
             <div class="some-padding">
                 <input type="number" name="attr_ship_armor" value="0" class="no-spin-input optional-spinner-input" title="@{ship_armor}" />
             </div>
@@ -1502,7 +1503,7 @@
                     <div class="grid-item weapon-item type">
                         <input type="hidden" name="attr_armament1_rangemod" readonly hidden />
                         <button type="roll" name="armament1" class="button-skill roll-rolltemplate" value="@{secret_roll} &{template:alien} {{character-name=@{ship-name}}} {{roll-name=@{armament1_name}}} {{roll-type=@{armament1_type}}} {{base-dice=[[ @{armament1_bonus} + @{armament1_ranged} + @{armament1_rangemod} + ?{Modifiers|0} ]] }} {{base-roll-one=[[1d6]] }} {{base-roll-two=[[1d6]] }} {{base-roll-three=[[1d6]] }} {{base-roll-four=[[1d6]] }} {{base-roll-five=[[1d6]] }}  {{base-roll-six=[[1d6]] }} {{base-roll-seven=[[1d6]] }} {{base-roll-eight=[[1d6]] }} {{base-roll-nine=[[1d6]] }} {{base-roll-ten=[[1d6]] }} {{base-roll-eleven=[[1d6]] }} {{base-roll-twelve=[[1d6]] }} {{base-roll-thirteen=[[1d6]] }} {{base-roll-fourteen=[[1d6]] }} {{base-roll-fifteen=[[1d6]] }} {{base-roll-sixteen=[[1d6]] }} {{base-roll-seventeen=[[1d6]] }} {{base-roll-eighteen=[[1d6]] }}  {{stress-dice=[[@{armament1_stress}]] }} {{stress-roll-one=[[1d6]] }} {{stress-roll-two=[[1d6]] }} {{stress-roll-three=[[1d6]] }} {{stress-roll-four=[[1d6]] }} {{stress-roll-five=[[1d6]] }} {{stress-roll-six=[[1d6]] }} {{stress-roll-seven=[[1d6]] }} {{stress-roll-eight=[[1d6]] }} {{stress-roll-nine=[[1d6]] }} {{stress-roll-ten=[[1d6]] }} {{current-bonus=@{armament1_bonus} }} {{current-damage=@{armament1_damage} }} {{current-range=@{armament1_targetrange} }} {{current-comment=@{armament1_comment} }}" data-i18n="attack-u">Attack</button>
-                        <button type="roll" name="armament1_api" class="button-skill roll-api" data-i18n="attack-u" value="@{roll_command} [@{armament1_type}: @{armament1_name}] [[(@{armament1_bonus}+@{armament1_ranged}+@{armament1_rangemod}+?{Modifiers|0})d6]] [[@{armament1_stress}d6]] --runas|@{ship-name} --|Skill @{armament1_ranged}+@{armament1_bonus}, Damage @{armament1_damage}, @{armament1_targetrange} Range --|@{armament1_comment}" title="Roll API Dice!">
+                        <button type="roll" name="armament1_api" class="button-skill roll-api" data-i18n="attack-u" value="@{roll_command} [@{armament1_name}] [[(@{armament1_bonus}+@{armament1_ranged}+@{armament1_rangemod}+?{Modifiers|0})d6]] [[@{armament1_stress}d6]] --runas|@{ship-name} --|Skill @{armament1_ranged}+@{armament1_bonus}, Damage @{armament1_damage}, @{armament1_targetrange} Range --|@{armament1_comment}" title="Roll API Dice!">
                             &nbsp;<span >Attack</span>&nbsp;
                         </button>
                     </div>
@@ -1563,7 +1564,7 @@
                     <div class="grid-item weapon-item type">
                         <input type="hidden" name="attr_armament2_rangemod" readonly hidden />
                         <button type="roll" name="armament2" class="button-skill roll-rolltemplate" value="@{secret_roll} &{template:alien} {{character-name=@{ship-name}}} {{roll-name=@{armament2_name}}} {{roll-type=@{armament2_type}}} {{base-dice=[[ @{armament2_bonus} + @{armament2_ranged} + @{armament2_rangemod} + ?{Modifiers|0} ]] }} {{base-roll-one=[[1d6]] }} {{base-roll-two=[[1d6]] }} {{base-roll-three=[[1d6]] }} {{base-roll-four=[[1d6]] }} {{base-roll-five=[[1d6]] }}  {{base-roll-six=[[1d6]] }} {{base-roll-seven=[[1d6]] }} {{base-roll-eight=[[1d6]] }} {{base-roll-nine=[[1d6]] }} {{base-roll-ten=[[1d6]] }} {{base-roll-eleven=[[1d6]] }} {{base-roll-twelve=[[1d6]] }} {{base-roll-thirteen=[[1d6]] }} {{base-roll-fourteen=[[1d6]] }} {{base-roll-fifteen=[[1d6]] }} {{base-roll-sixteen=[[1d6]] }} {{base-roll-seventeen=[[1d6]] }} {{base-roll-eighteen=[[1d6]] }}  {{stress-dice=[[@{armament2_stress}]] }} {{stress-roll-one=[[1d6]] }} {{stress-roll-two=[[1d6]] }} {{stress-roll-three=[[1d6]] }} {{stress-roll-four=[[1d6]] }} {{stress-roll-five=[[1d6]] }} {{stress-roll-six=[[1d6]] }} {{stress-roll-seven=[[1d6]] }} {{stress-roll-eight=[[1d6]] }} {{stress-roll-nine=[[1d6]] }} {{stress-roll-ten=[[1d6]] }} {{current-bonus=@{armament2_bonus} }} {{current-damage=@{armament2_damage} }} {{current-range=@{armament2_targetrange} }} {{current-comment=@{armament2_comment} }}" data-i18n="attack-u">Attack</button>
-                        <button type="roll" name="armament2_api" class="button-skill roll-api" data-i18n="attack-u" value="@{roll_command} [@{armament2_type}: @{armament2_name}] [[(@{armament2_bonus}+@{armament2_ranged}+@{armament2_rangemod}+?{Modifiers|0})d6]] [[@{armament2_stress}d6]] --runas|@{ship-name} --|Skill @{armament2_ranged}+@{armament2_bonus}, Damage @{armament2_damage}, @{armament2_targetrange} Range --|@{armament2_comment}" title="Roll API Dice!">
+                        <button type="roll" name="armament2_api" class="button-skill roll-api" data-i18n="attack-u" value="@{roll_command} [@{armament2_name}] [[(@{armament2_bonus}+@{armament2_ranged}+@{armament2_rangemod}+?{Modifiers|0})d6]] [[@{armament2_stress}d6]] --runas|@{ship-name} --|Skill @{armament2_ranged}+@{armament2_bonus}, Damage @{armament2_damage}, @{armament2_targetrange} Range --|@{armament2_comment}" title="Roll API Dice!">
                             &nbsp;<span >Attack</span>&nbsp;
                         </button>
                    </div>
@@ -1623,8 +1624,8 @@
                     </div>
                     <div class="grid-item weapon-item type">
                         <input type="hidden" name="attr_armament3_rangemod" readonly hidden />
-                        <button type="roll" name="armament3" class="button-skill roll-template" value="@{secret_roll} &{template:alien} {{character-name=@{ship-name}}} {{roll-name=@{armament3_name}}} {{roll-type=@{armament3_type}}} {{base-dice=[[@{armament3_bonus} + @{armament3_ranged} + @{armament3_rangemod} + ?{Modifiers|0} ]] }} {{base-roll-one=[[1d6]] }} {{base-roll-two=[[1d6]] }} {{base-roll-three=[[1d6]] }} {{base-roll-four=[[1d6]] }} {{base-roll-five=[[1d6]] }}  {{base-roll-six=[[1d6]] }} {{base-roll-seven=[[1d6]] }} {{base-roll-eight=[[1d6]] }} {{base-roll-nine=[[1d6]] }} {{base-roll-ten=[[1d6]] }} {{base-roll-eleven=[[1d6]] }} {{base-roll-twelve=[[1d6]] }} {{base-roll-thirteen=[[1d6]] }} {{base-roll-fourteen=[[1d6]] }} {{base-roll-fifteen=[[1d6]] }} {{base-roll-sixteen=[[1d6]] }} {{base-roll-seventeen=[[1d6]] }} {{base-roll-eighteen=[[1d6]] }}  {{stress-dice=[[@{armament3_stress}]] }} {{stress-roll-one=[[1d6]] }} {{stress-roll-two=[[1d6]] }} {{stress-roll-three=[[1d6]] }} {{stress-roll-four=[[1d6]] }} {{stress-roll-five=[[1d6]] }} {{stress-roll-six=[[1d6]] }} {{stress-roll-seven=[[1d6]] }} {{stress-roll-eight=[[1d6]] }} {{stress-roll-nine=[[1d6]] }} {{stress-roll-ten=[[1d6]] }} {{current-bonus=@{armament3_bonus} }} {{current-damage=@{armament3_damage} }} {{current-range=@{armament3_targetrange} }} {{current-comment=@{armament3_comment} }}" data-i18n="attack-u">Attack</button>
-                        <button type="roll" name="armament3_api" class="button-skill roll-api" data-i18n="attack-u" value="@{roll_command} [@{armament3_type}: @{armament3_name}] [[(@{armament3_bonus}+@{armament3_ranged}+@{armament3_rangemod}+?{Modifiers|0})d6]] [[@{armament3_stress}d6]] --runas|@{ship-name} --|Skill @{armament3_ranged}+@{armament3_bonus}, Damage @{armament3_damage}, @{armament3_targetrange} Range --|@{armament3_comment}" title="Roll API Dice!">
+                        <button type="roll" name="armament3" class="button-skill roll-rolltemplate" value="@{secret_roll} &{template:alien} {{character-name=@{ship-name}}} {{roll-name=@{armament3_name}}} {{roll-type=@{armament3_type}}} {{base-dice=[[@{armament3_bonus} + @{armament3_ranged} + @{armament3_rangemod} + ?{Modifiers|0} ]] }} {{base-roll-one=[[1d6]] }} {{base-roll-two=[[1d6]] }} {{base-roll-three=[[1d6]] }} {{base-roll-four=[[1d6]] }} {{base-roll-five=[[1d6]] }}  {{base-roll-six=[[1d6]] }} {{base-roll-seven=[[1d6]] }} {{base-roll-eight=[[1d6]] }} {{base-roll-nine=[[1d6]] }} {{base-roll-ten=[[1d6]] }} {{base-roll-eleven=[[1d6]] }} {{base-roll-twelve=[[1d6]] }} {{base-roll-thirteen=[[1d6]] }} {{base-roll-fourteen=[[1d6]] }} {{base-roll-fifteen=[[1d6]] }} {{base-roll-sixteen=[[1d6]] }} {{base-roll-seventeen=[[1d6]] }} {{base-roll-eighteen=[[1d6]] }}  {{stress-dice=[[@{armament3_stress}]] }} {{stress-roll-one=[[1d6]] }} {{stress-roll-two=[[1d6]] }} {{stress-roll-three=[[1d6]] }} {{stress-roll-four=[[1d6]] }} {{stress-roll-five=[[1d6]] }} {{stress-roll-six=[[1d6]] }} {{stress-roll-seven=[[1d6]] }} {{stress-roll-eight=[[1d6]] }} {{stress-roll-nine=[[1d6]] }} {{stress-roll-ten=[[1d6]] }} {{current-bonus=@{armament3_bonus} }} {{current-damage=@{armament3_damage} }} {{current-range=@{armament3_targetrange} }} {{current-comment=@{armament3_comment} }}" data-i18n="attack-u">Attack</button>
+                        <button type="roll" name="armament3_api" class="button-skill roll-api" data-i18n="attack-u" value="@{roll_command} [@{armament3_name}] [[(@{armament3_bonus}+@{armament3_ranged}+@{armament3_rangemod}+?{Modifiers|0})d6]] [[@{armament3_stress}d6]] --runas|@{ship-name} --|Skill @{armament3_ranged}+@{armament3_bonus}, Damage @{armament3_damage}, @{armament3_targetrange} Range --|@{armament3_comment}" title="Roll API Dice!">
                             &nbsp;<span >Attack</span>&nbsp;
                         </button>
                    </div>
@@ -1685,7 +1686,7 @@
                     <div class="grid-item weapon-item type">
                         <input type="hidden" name="attr_armament4_rangemod" readonly hidden />
                         <button type="roll" name="armament4" class="button-skill roll-rolltemplate" value="@{secret_roll} &{template:alien} {{character-name=@{ship-name}}} {{roll-name=@{armament4_name}}} {{roll-type=@{armament4_type}}} {{base-dice=[[@{armament4_bonus} + @{armament4_ranged} + @{armament4_rangemod} + ?{Modifiers|0} ]] }} {{base-roll-one=[[1d6]] }} {{base-roll-two=[[1d6]] }} {{base-roll-three=[[1d6]] }} {{base-roll-four=[[1d6]] }} {{base-roll-five=[[1d6]] }}  {{base-roll-six=[[1d6]] }} {{base-roll-seven=[[1d6]] }} {{base-roll-eight=[[1d6]] }} {{base-roll-nine=[[1d6]] }} {{base-roll-ten=[[1d6]] }} {{base-roll-eleven=[[1d6]] }} {{base-roll-twelve=[[1d6]] }} {{base-roll-thirteen=[[1d6]] }} {{base-roll-fourteen=[[1d6]] }} {{base-roll-fifteen=[[1d6]] }} {{base-roll-sixteen=[[1d6]] }} {{base-roll-seventeen=[[1d6]] }} {{base-roll-eighteen=[[1d6]] }}  {{stress-dice=[[@{armament4_stress}]] }} {{stress-roll-one=[[1d6]] }} {{stress-roll-two=[[1d6]] }} {{stress-roll-three=[[1d6]] }} {{stress-roll-four=[[1d6]] }} {{stress-roll-five=[[1d6]] }} {{stress-roll-six=[[1d6]] }} {{stress-roll-seven=[[1d6]] }} {{stress-roll-eight=[[1d6]] }} {{stress-roll-nine=[[1d6]] }} {{stress-roll-ten=[[1d6]] }} {{current-bonus=@{armament4_bonus} }} {{current-damage=@{armament4_damage} }} {{current-range=@{armament4_targetrange} }} {{current-comment=@{armament4_comment} }}" data-i18n="attack-u">Attack</button>
-                        <button type="roll" name="armament4_api" class="button-skill roll-api" data-i18n="attack-u" value="@{roll_command} [@{armament4_type}: @{armament4_name}] [[(@{armament4_bonus}+@{armament4_ranged}+@{armament4_rangemod}+?{Modifiers|0})d6]] [[@{armament4_stress}d6]] --runas|@{ship-name} --|Skill @{armament4_ranged}+@{armament4_bonus}, Damage @{armament4_damage}, @{armament4_targetrange} Range --|@{armament4_comment}" title="Roll API Dice!">
+                        <button type="roll" name="armament4_api" class="button-skill roll-api" data-i18n="attack-u" value="@{roll_command} [@{armament4_name}] [[(@{armament4_bonus}+@{armament4_ranged}+@{armament4_rangemod}+?{Modifiers|0})d6]] [[@{armament4_stress}d6]] --runas|@{ship-name} --|Skill @{armament4_ranged}+@{armament4_bonus}, Damage @{armament4_damage}, @{armament4_targetrange} Range --|@{armament4_comment}" title="Roll API Dice!">
                             &nbsp;<span >Attack</span>&nbsp;
                         </button>
                    </div>
@@ -1746,7 +1747,7 @@
                     <div class="grid-item weapon-item type">
                         <input type="hidden" name="attr_armament5_rangemod" readonly hidden />
                         <button type="roll" name="armament5" class="button-skill roll-rolltemplate" value="@{secret_roll} &{template:alien} {{character-name=@{ship-name}}} {{roll-name=@{armament5_name}}} {{roll-type=@{armament5_type}}} {{base-dice=[[@{armament5_bonus} + @{armament5_ranged} + @{armament5_rangemod} + ?{Modifiers|0} ]] }} {{base-roll-one=[[1d6]] }} {{base-roll-two=[[1d6]] }} {{base-roll-three=[[1d6]] }} {{base-roll-four=[[1d6]] }} {{base-roll-five=[[1d6]] }}  {{base-roll-six=[[1d6]] }} {{base-roll-seven=[[1d6]] }} {{base-roll-eight=[[1d6]] }} {{base-roll-nine=[[1d6]] }} {{base-roll-ten=[[1d6]] }} {{base-roll-eleven=[[1d6]] }} {{base-roll-twelve=[[1d6]] }} {{base-roll-thirteen=[[1d6]] }} {{base-roll-fourteen=[[1d6]] }} {{base-roll-fifteen=[[1d6]] }} {{base-roll-sixteen=[[1d6]] }} {{base-roll-seventeen=[[1d6]] }} {{base-roll-eighteen=[[1d6]] }}  {{stress-dice=[[@{armament5_stress}]] }} {{stress-roll-one=[[1d6]] }} {{stress-roll-two=[[1d6]] }} {{stress-roll-three=[[1d6]] }} {{stress-roll-four=[[1d6]] }} {{stress-roll-five=[[1d6]] }} {{stress-roll-six=[[1d6]] }} {{stress-roll-seven=[[1d6]] }} {{stress-roll-eight=[[1d6]] }} {{stress-roll-nine=[[1d6]] }} {{stress-roll-ten=[[1d6]] }} {{current-bonus=@{armament5_bonus} }} {{current-damage=@{armament5_damage} }} {{current-range=@{armament5_targetrange} }} {{current-comment=@{armament5_comment} }}" data-i18n="attack-u">Attack</button>
-                        <button type="roll" name="armament5_api" class="button-skill roll-api" data-i18n="attack-u" value="@{roll_command} [@{armament5_type}: @{armament5_name}] [[(@{armament5_bonus}+@{armament5_ranged}+@{armament5_rangemod}+?{Modifiers|0})d6]] [[@{armament5_stress}d6]] --runas|@{ship-name} --|Skill @{armament5_ranged}+@{armament5_bonus}, Damage @{armament5_damage}, @{armament5_targetrange} Range --|@{armament5_comment}" title="Roll API Dice!">
+                        <button type="roll" name="armament5_api" class="button-skill roll-api" data-i18n="attack-u" value="@{roll_command} [@{armament5_name}] [[(@{armament5_bonus}+@{armament5_ranged}+@{armament5_rangemod}+?{Modifiers|0})d6]] [[@{armament5_stress}d6]] --runas|@{ship-name} --|Skill @{armament5_ranged}+@{armament5_bonus}, Damage @{armament5_damage}, @{armament5_targetrange} Range --|@{armament5_comment}" title="Roll API Dice!">
                             &nbsp;<span >Attack</span>&nbsp;
                         </button>
                    </div>
@@ -1891,14 +1892,24 @@
              -->
              <div class="grid-item-black span-one-thru-six cover-100-flex flex-content-right">
                 <div class="grid-item clip-edges w120 h-fit marg-right">
-                    <span class="centered bold">v3.02 <br/>(2022-01-19)</span>
+                    <span class="centered bold">v3.03 <br/>(2022-02-04)</span>
                 </div>  
                 <div class="cover-75 flex-content-right flex-column">               
                     <div class="grid-item clip-edges align-left marg-right pad-left pad-right">
-                        <span class="text-input cover-100 align-left" title="">Fixed armament roll issue by calculating rangemod at sheet load. </span>
+                        <span class="text-input cover-100 align-left" title="">Fixed armament 3 roll button, changed armament roll name to support API, and changed armor rolls to not use API. </span>
                     </div>   
                 </div> 
             </div>
+            <div class="grid-item-black span-one-thru-six cover-100-flex flex-content-right">
+               <div class="grid-item clip-edges w120 h-fit marg-right">
+                   <span class="centered bold">v3.02 <br/>(2022-01-19)</span>
+               </div>  
+               <div class="cover-75 flex-content-right flex-column">               
+                   <div class="grid-item clip-edges align-left marg-right pad-left pad-right">
+                       <span class="text-input cover-100 align-left" title="">Fixed armament roll issue by calculating rangemod at sheet load. </span>
+                   </div>   
+               </div> 
+           </div>
             <div class="grid-item-black span-one-thru-six cover-100-flex flex-content-right">
                <div class="grid-item clip-edges w120 h-fit marg-right">
                    <span class="centered bold">v3.01 <br/>(2022-01-10)</span>
@@ -3020,7 +3031,7 @@
     // CALCULATE STRESS - HEALTH - RADIATION - VALUE FROM CHECKBOXES OR ATTRIBUTE
     const variableAttributes = ["stress","health","radiation"];
     variableAttributes.forEach(function (variableAttribute) {
-        // create an array of the checkbox names. the array(12) sets how many checkboxes there are - change to match.
+        // create an array of the checkbox names. the array(10) sets how many checkboxes there are - change to match.
         const variableAttributeChecks = Array(10).fill().map((_, index) => `${variableAttribute}_${index +1}`);
         on(`change:${variableAttribute} change:${variableAttributeChecks.join(' change:')}`, function (eventinfo) {
             getAttrs(variableAttributeChecks.concat([variableAttribute, variableAttribute + "_max"]), function (values) {


### PR DESCRIPTION
## Changes / Comments
Fixed the Ships armament rolls to support the next version of the API Dice Roller. 
Fixed the Armor rolls to not use the API Dice Roller (armor rolls cannot be pushed).

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
