### PR TITLE
[World-of-the-Storytellers-WoS] fix: try to fix rolltemplate css error (2)

### DIFF
--- a/World-of-the-Storytellers-WoS/wos.css
+++ b/World-of-the-Storytellers-WoS/wos.css
@@ -1,4 +1,4 @@
-@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard-dynamic-subset.css");
+@import url("https://fonts.googleapis.com/css?family=Noto+Sans+KR:wght@100;300;400;500;700;900");
 .displaynone {
   display: none;
 }
@@ -29,7 +29,7 @@
 .charsheet {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
-  font-family: 'Pretendard', 'Noto Sans KR', sans-serif;
+  font-family: 'Noto Sans KR', sans-serif;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
@@ -103,7 +103,7 @@ button[type="roll"] {
 
 h2 {
   font-size: 2.5rem;
-  font-weight: 800;
+  font-weight: 900;
   color: #F2EDE9;
   background: #A65851;
   position: relative;
@@ -177,7 +177,7 @@ h2::after {
 .section-info input[name='attr_character_name'] {
   background: transparent;
   font-size: 3rem;
-  font-weight: 800;
+  font-weight: 900;
   width: 100%;
   color: #0F1D26;
 }
@@ -1613,3 +1613,4 @@ input[type="text"]:hover, input[type="text"]:active, input[type="text"]:focus, t
     width: 400px;
   }
 }
+/*# sourceMappingURL=wos.css.map */


### PR DESCRIPTION
## Changes / Comments

I'm trying to fix the error **again** that rolltemplate styling isn't work... 

Change font to google font.

I hope to solve the problem this time. please...






## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
