### PR TITLE
[Monster of the Week Official] Bug fix

### DIFF
--- a/Monster of the Week Official/MotWHTML.html
+++ b/Monster of the Week Official/MotWHTML.html
@@ -6218,7 +6218,7 @@
 										<input type="checkbox" class="sheet-checkbox" name="attr_Moves-Searcher1"><span class="sheet-mainbox"></span>
 										<span class="sheet-grayable">
 											<span data-i18n="searcher-move1"><b>Prepared to Defend</b>: Even truth-seekers need to fight sometimes. Whenever you suffer harm when you <i>kick some ass</i> or <i>protect someone</i>, you suffer 1 harm less.</span>
-											<button class="sheet-broadcast-button" type="roll" name="roll_Show" value="&{template:motw-moveshare} {{CharName=@{character_name}}} {{movekey=searcher-fixed-move1.1}}" data-i18n-title="send_details_to_chat"></button>
+											<button class="sheet-broadcast-button" type="roll" name="roll_Show" value="&{template:motw-moveshare} {{CharName=@{character_name}}} {{movekey=searcher-move1}}" data-i18n-title="send_details_to_chat"></button>
 										</span>
 									</div>
 									<div class="sheet-move">


### PR DESCRIPTION
Incorrect text key was fed to the move displayer for the Searcher's Prepared to Defend move. Fixed.

## Changes / Comments

Fixed a small bug with the move-sharer button for one of the Searcher's moves. Single line. No impact beyond making the displayed text more correct expected.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
