### PR TITLE
[World-of-the-Storytellers-WoS] Remove duplicate images

### DIFF
--- a/World-of-the-Storytellers-WoS/wos.css
+++ b/World-of-the-Storytellers-WoS/wos.css
@@ -842,7 +842,6 @@ input[type="text"]:hover, input[type="text"]:active, input[type="text"]:focus, t
 .sheet-rolltemplate-wos_story .sheet-arrow {
   width: 30px;
   height: 30px;
-  background-image: url("https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/World-of-the-Storytellers-WoS/img/icon-right.svg");
   display: inline-block;
   -webkit-box-ordinal-group: 0;
       -ms-flex-order: -1;
@@ -991,7 +990,6 @@ input[type="text"]:hover, input[type="text"]:active, input[type="text"]:focus, t
 .sheet-rolltemplate-wos_stat .sheet-arrow {
   width: 30px;
   height: 30px;
-  background-image: url("https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/World-of-the-Storytellers-WoS/img/icon-right.svg");
   display: inline-block;
   -webkit-box-ordinal-group: 0;
       -ms-flex-order: -1;
@@ -1224,7 +1222,6 @@ input[type="text"]:hover, input[type="text"]:active, input[type="text"]:focus, t
 .sheet-rolltemplate-wos_luck .sheet-arrow {
   width: 30px;
   height: 30px;
-  background-image: url("https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/World-of-the-Storytellers-WoS/img/icon-right.svg");
   display: inline-block;
   -webkit-box-ordinal-group: 0;
       -ms-flex-order: -1;
@@ -1337,7 +1334,6 @@ input[type="text"]:hover, input[type="text"]:active, input[type="text"]:focus, t
 .sheet-rolltemplate-wos_luck .sheet-template-dices > .sheet-dice-result .sheet-arrow {
   width: 30px;
   height: 30px;
-  background-image: url("https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/World-of-the-Storytellers-WoS/img/icon-right.svg");
   display: inline-block;
   -webkit-box-ordinal-group: 0;
       -ms-flex-order: -1;
@@ -1491,7 +1487,6 @@ input[type="text"]:hover, input[type="text"]:active, input[type="text"]:focus, t
 .sheet-rolltemplate-wos_roll .sheet-arrow {
   width: 30px;
   height: 30px;
-  background-image: url("https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/World-of-the-Storytellers-WoS/img/icon-right.svg");
   display: inline-block;
   -webkit-box-ordinal-group: 0;
       -ms-flex-order: -1;
@@ -1613,4 +1608,3 @@ input[type="text"]:hover, input[type="text"]:active, input[type="text"]:focus, t
     width: 400px;
   }
 }
-/*# sourceMappingURL=wos.css.map */


### PR DESCRIPTION
## Changes / Comments

Remove duplicate images (remove background-image)




## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
