### PR TITLE
[Symbaroum] Add total corruption hidden input for use in token bar

### DIFF
--- a/Symbaroum/symbaroum.html
+++ b/Symbaroum/symbaroum.html
@@ -98,6 +98,7 @@
     <label class="center" data-i18n-title="corruption threshold" title="corruption threshold">
       <input class="center" name="attr_corruption_threshold" title="@{corruption_threshold}" type="number" value="ceil(@{resolute}/2)" disabled="true"/>
     </label><span class="center" data-i18n="threshold">Threshold</span>
+    <input type="hidden" name="attr_corruption_total" title="@{corruption_total}" value="@{corruption_permanent}+@{corruption}"/>
   </div>
   <div class="grid attacks section-pc1">
     <div class="grid section-header">


### PR DESCRIPTION
## Changes / Comments

Add an hidden input in corruption section to compute attr_corruption_total as (corruption+corruption_premanent).
This is to be able to use [corruption_total / resolute] as a token bar.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
