### PR TITLE
[Warhammer 4e Character Sheet] Ogres & Fixes

### DIFF
--- a/Warhammer 4e Character Sheet/README.md
+++ b/Warhammer 4e Character Sheet/README.md
@@ -73,6 +73,11 @@ Note conditions are not intended for out of combat situations, GM simply makes t
  
 ///// ============ Change Log ============ /////  
 
+January 3rd 2022 v1.53.3
+
+- Added Ogre to the race list race with stats from Archives of the Empire vol 2
+- Fix for melee weapons list target display for any weapon except 2H
+
 January 3rd 2022 v1.53.2
 
 - Fixed issue where Twohanded weapons when selected would show offhand penality added to the target value of the specific weapon. This did not effect the Roll itself.

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -33734,7 +33734,7 @@
 		<div class="sheet-spacer-xl"></div>
 		<!-- FOOTER -->
 		<div class="sheet-row sheet-footer">
-			<div class="sheet-col-1 sheet-small-label sheet-center">Sheet version 1.53.1 : December 6th 2021 | by Djjus & Pote</div>
+			<div class="sheet-col-1 sheet-small-label sheet-center">Sheet version 1.53.3 : February 25th 2022 | by Djjus & Pote</div>
 		</div>
 		</div>
 	</div>		

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -36,6 +36,7 @@
 									<option value="Dwarf" data-i18n="DWARF">Dwarf</option>
 									<option value="Halfling" data-i18n="HALFLING">Halfling</option>
 									<option value="Gnome" data-i18n="GNOME">Gnome</option>
+									<option value="Ogre" data-i18n="OGRE">Ogre</option>
 								</select>
 								<div class="sheet-wrap-box-label sheet-center">
 									<span data-i18n="RACE">Race</span>
@@ -42699,6 +42700,9 @@ on("change:strengthbonus change:toughnessbonus change:willpowerbonus change:race
 		}
 		if(race === 'gnome') {
 		wounds -= str;
+		}
+		if(race === 'ogre') {
+		wounds = (str + tou*2 + wil)*2;
 		}
 		setAttrs({
 		Wounds: wounds

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -32410,7 +32410,7 @@
 				</div>			
 
 				<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm">
-					<input type="number" name="attr_MaxEnc" value="[[@{StrengthBonus}+@{ToughnessBonus}+@{Talent_StrongBackLvl}+(@{Talent_SturdyLvl}*2)]]" disabled="true" />
+					<input type="number" name="attr_MaxEnc" value="(@{StrengthBonus}*@{LargeEnc})+(@{ToughnessBonus}*@{LargeEnc})+@{Talent_StrongBackLvl}+(@{Talent_SturdyLvl}*2)" disabled />
 				</div>				
 				<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm">
 					<input type="hidden" name="attr_OverEncCal" value="[[@{TotalEnc}]]" />			
@@ -42682,6 +42682,7 @@ on("change:strengthbonus change:toughnessbonus change:willpowerbonus change:race
 		const wil = +w.WillPowerBonus || 0;
 		const race = w.Race.toLowerCase();
 		let wounds = str + tou*2 + wil;
+		let lenc = 1;
 		if(race === 'halfling') {
 		wounds -= str;
 		}
@@ -42690,9 +42691,11 @@ on("change:strengthbonus change:toughnessbonus change:willpowerbonus change:race
 		}
 		if(race === 'ogre') {
 		wounds = (str + tou*2 + wil)*2;
+		lenc = 2;
 		}
 		setAttrs({
-		Wounds: wounds
+		Wounds: wounds,
+		LargeEnc: lenc
 		});
 		});
 		});

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -27307,25 +27307,12 @@
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-talents-border">
 								<span data-i18n="ABBREVIATE-STRENGTH"></span>
-								<input class="sheet-center" type="hidden" name="attr_Talent_RiposteChar" value="(@{AgilityBonus})" readonly />
-								<select class="sheet-hidden" name="attr_Talent_ShieldsmanChar">
-										<option value="(@{WeaponSkillBonus})" data-i18n="ABBREVIATE-WEAPON-SKILL">WS</option>
-										<option value="(@{BallisticSkillBonus})" data-i18n="ABBREVIATE-BALLISTIC-SKILL">BS</option>
-										<option value="(@{StrengthBonus})" data-i18n="ABBREVIATE-STRENGTH" selected="selected">S</option>
-										<option value="(@{ToughnessBonus})" data-i18n="ABBREVIATE-TOUGHNESS">T</option>
-										<option value="(@{InitiativeBonus})" data-i18n="ABBREVIATE-INITIATIVE">I</option>
-										<option value="(@{AgilityBonus})" data-i18n="ABBREVIATE-AGILITY" selected="selected">Ag</option>
-										<option value="(@{DexterityBonus})" data-i18n="ABBREVIATE-DEXTERITY">Dex</option>
-										<option value="(@{IntelligenceBonus})" data-i18n="ABBREVIATE-INTELLIGENCE">Int</option>
-										<option value="(@{WillPowerBonus})" data-i18n="ABBREVIATE-WILL-POWER">Wp</option>
-										<option value="(@{FellowshipBonus})" data-i18n="ABBREVIATE-FELLOWSHIP">Fel</option>
-								</select>
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-vert-middle">
 								<input class="sheet-center" type="number" name="attr_Talent_ShieldsmanLvl" value="0" min="0" />
 							</div>
 							<div class="sheet-col-8-100 sheet-center sheet-vert-middle">
-								<input class="sheet-center" type="number" name="attr_Talent_ShieldsmanMax" value="@{Talent_ShieldsmanChar}" disabled />
+								<input class="sheet-center" type="number" name="attr_Talent_ShieldsmanMax" value="@{StrengthBonus}" disabled />
 							</div>
 							<button class="sheet-right" type="compendium" value="Talents:Shieldsman" data-i18n-title="COMPENDIUM-LINK"></button>
 							<span style="font-family: pictos; color: #55b800;" data-i18n-title="SHEET-INTEGRATION" >j</span>

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -28262,7 +28262,7 @@
 								<input type="number" name="attr_MeleeBonus" value="0" />
 							</div>
 							
-		<input type="checkbox" name="attr_UsedTwoHanded" class="sheet-hidden sheet-hider" value="0" />	
+		<input type="checkbox" name="attr_UsedTwoHanded" class="sheet-hidden sheet-hider" value="0" checked/>	
 							<div class="sheet-col-4-100 sheet-center sheet-pad-r-sm">
 								<input type="value" class="sheet-center" name="attr_targetmelee" value="(@{MeleeWeaponSkill}+@{MeleeBonus}+(@{Advantage}*10))+(@{UsedDefense}*(-20+(10*@{Talent_AmbidextrousLvl})))+(@{condgen_see_move}*-1)" disabled />
 							</div>
@@ -28309,7 +28309,7 @@
 					</div>
 					<div class="sheet-row">
 						<div class="sheet-col-1-8 sheet-center sheet-pad-r-sm">
-							<input type="checkbox" name="attr_UsedTwoHanded" value="0" />
+							<input type="checkbox" name="attr_UsedTwoHanded" value="0" checked/>
 						</div>
 						<div class="sheet-col-1-8 sheet-center sheet-pad-r-sm">
 							<input type="checkbox" name="attr_UsedTwoHanded" value="1" />

--- a/Warhammer 4e Character Sheet/translation.json
+++ b/Warhammer 4e Character Sheet/translation.json
@@ -90,6 +90,7 @@
 	"ENC-PENALTY": "Enc Penalty",
 	"COND-RESET": "Clear Conditions",
 	"RESET": "Reset",
+	"OGRE": "Ogre",
 	"YOU": "You",
 	"DMG": "Dmg",
 	"+DMG": "+Dmg",


### PR DESCRIPTION
## Changes / Comments

- Added Ogre to the race list race with x2 human HP and Enc as from Archives of the Empire vol 2
- Fix for melee weapons list target display for any weapon except 2H

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
