### PR TITLE
[CWOD-V20] Fix typo in translation and i18n key

### DIFF
--- a/CWOD-V20/V20.html
+++ b/CWOD-V20/V20.html
@@ -1443,7 +1443,7 @@
 		<td style="width:70%;height:14%">
 		<select class="sheet-text-fronth2" name="attr_virtueConsName" style="width:100px" text-align:left>
 			<option value="Conscience" selected data-i18n="conscience-u">Conscience</option>
-			<option value="Conviction" data-i18n="convinction-u">Conviction</option>
+			<option value="Conviction" data-i18n="conviction-u">Conviction</option>
 		</select>
 		</td>
 		<td style="width:30%">

--- a/CWOD-V20/translations/af.json
+++ b/CWOD-V20/translations/af.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Backgrounds",
 	"virtues-u": "Virtues",
 	"conscience-u": "Conscience",
-	"convinction-u": "Convinction",
+	"conviction-u": "Conviction",
 	"selfcontrol-u": "Self-Control",
 	"instinct-u": "Instinct",
 	"courage-u": "Courage",

--- a/CWOD-V20/translations/ca.json
+++ b/CWOD-V20/translations/ca.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Backgrounds",
 	"virtues-u": "Virtues",
 	"conscience-u": "Conscience",
-	"convinction-u": "Convinction",
+	"conviction-u": "Conviction",
 	"selfcontrol-u": "Self-Control",
 	"instinct-u": "Instinct",
 	"courage-u": "Courage",

--- a/CWOD-V20/translations/cs.json
+++ b/CWOD-V20/translations/cs.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Backgrounds",
 	"virtues-u": "Virtues",
 	"conscience-u": "Conscience",
-	"convinction-u": "Convinction",
+	"conviction-u": "Conviction",
 	"selfcontrol-u": "Self-Control",
 	"instinct-u": "Instinct",
 	"courage-u": "Courage",

--- a/CWOD-V20/translations/da.json
+++ b/CWOD-V20/translations/da.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Backgrounds",
 	"virtues-u": "Virtues",
 	"conscience-u": "Conscience",
-	"convinction-u": "Convinction",
+	"conviction-u": "Conviction",
 	"selfcontrol-u": "Self-Control",
 	"instinct-u": "Instinct",
 	"courage-u": "Courage",

--- a/CWOD-V20/translations/de.json
+++ b/CWOD-V20/translations/de.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Hintergründe",
 	"virtues-u": "Tugenden",
 	"conscience-u": "Gewissen",
-	"convinction-u": "Überzeugung",
+	"conviction-u": "Überzeugung",
 	"selfcontrol-u": "Selbstbeherrschung",
 	"instinct-u": "Instinkt",
 	"courage-u": "Mut",

--- a/CWOD-V20/translations/el.json
+++ b/CWOD-V20/translations/el.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Backgrounds",
 	"virtues-u": "Virtues",
 	"conscience-u": "Conscience",
-	"convinction-u": "Convinction",
+	"conviction-u": "Conviction",
 	"selfcontrol-u": "Self-Control",
 	"instinct-u": "Instinct",
 	"courage-u": "Courage",

--- a/CWOD-V20/translations/en.json
+++ b/CWOD-V20/translations/en.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Backgrounds",
 	"virtues-u": "Virtues",
 	"conscience-u": "Conscience",
-	"convinction-u": "Convinction",
+	"conviction-u": "Conviction",
 	"selfcontrol-u": "Self-Control",
 	"instinct-u": "Instinct",
 	"courage-u": "Courage",

--- a/CWOD-V20/translations/es.json
+++ b/CWOD-V20/translations/es.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Trasfondos",
 	"virtues-u": "Virtudes",
 	"conscience-u": "Conciencia",
-	"convinction-u": "Convicción",
+	"conviction-u": "Convicción",
 	"selfcontrol-u": "Autocontrol",
 	"instinct-u": "Instinto",
 	"courage-u": "Coraje",

--- a/CWOD-V20/translations/fi.json
+++ b/CWOD-V20/translations/fi.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Backgrounds",
 	"virtues-u": "Virtues",
 	"conscience-u": "Conscience",
-	"convinction-u": "Convinction",
+	"conviction-u": "Conviction",
 	"selfcontrol-u": "Self-Control",
 	"instinct-u": "Instinct",
 	"courage-u": "Courage",

--- a/CWOD-V20/translations/fr.json
+++ b/CWOD-V20/translations/fr.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Historiques",
 	"virtues-u": "Vertus",
 	"conscience-u": "Conscience",
-	"convinction-u": "Conviction",
+	"conviction-u": "Conviction",
 	"selfcontrol-u": "Maîtrise de soi",
 	"instinct-u": "Instinct",
 	"courage-u": "Courage",

--- a/CWOD-V20/translations/he.json
+++ b/CWOD-V20/translations/he.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Backgrounds",
 	"virtues-u": "Virtues",
 	"conscience-u": "Conscience",
-	"convinction-u": "Convinction",
+	"conviction-u": "Conviction",
 	"selfcontrol-u": "Self-Control",
 	"instinct-u": "Instinct",
 	"courage-u": "Courage",

--- a/CWOD-V20/translations/hu.json
+++ b/CWOD-V20/translations/hu.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Backgrounds",
 	"virtues-u": "Virtues",
 	"conscience-u": "Conscience",
-	"convinction-u": "Convinction",
+	"conviction-u": "Conviction",
 	"selfcontrol-u": "Self-Control",
 	"instinct-u": "Instinct",
 	"courage-u": "Courage",

--- a/CWOD-V20/translations/it.json
+++ b/CWOD-V20/translations/it.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Backgrounds",
 	"virtues-u": "Virtù",
 	"conscience-u": "Coscienza",
-	"convinction-u": "Convinzione",
+	"conviction-u": "Convinzione",
 	"selfcontrol-u": "Autocontrollo",
 	"instinct-u": "Istinto",
 	"courage-u": "Coraggio",

--- a/CWOD-V20/translations/ja.json
+++ b/CWOD-V20/translations/ja.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Backgrounds",
 	"virtues-u": "Virtues",
 	"conscience-u": "Conscience",
-	"convinction-u": "Convinction",
+	"conviction-u": "Conviction",
 	"selfcontrol-u": "Self-Control",
 	"instinct-u": "Instinct",
 	"courage-u": "Courage",

--- a/CWOD-V20/translations/ko.json
+++ b/CWOD-V20/translations/ko.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "배경점수",
 	"virtues-u": "미덕",
 	"conscience-u": "양심",
-	"convinction-u": "신념",
+	"conviction-u": "신념",
 	"selfcontrol-u": "자제력",
 	"instinct-u": "본능",
 	"courage-u": "용기",

--- a/CWOD-V20/translations/nl.json
+++ b/CWOD-V20/translations/nl.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Backgrounds",
 	"virtues-u": "Virtues",
 	"conscience-u": "Conscience",
-	"convinction-u": "Convinction",
+	"conviction-u": "Conviction",
 	"selfcontrol-u": "Self-Control",
 	"instinct-u": "Instinct",
 	"courage-u": "Courage",

--- a/CWOD-V20/translations/pl.json
+++ b/CWOD-V20/translations/pl.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Backgrounds",
 	"virtues-u": "Virtues",
 	"conscience-u": "Conscience",
-	"convinction-u": "Convinction",
+	"conviction-u": "Conviction",
 	"selfcontrol-u": "Self-Control",
 	"instinct-u": "Instinct",
 	"courage-u": "Courage",

--- a/CWOD-V20/translations/pt.json
+++ b/CWOD-V20/translations/pt.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Antecedentes",
 	"virtues-u": "Virtudes",
 	"conscience-u": "Consciência",
-	"convinction-u": "Convicção",
+	"conviction-u": "Convicção",
 	"selfcontrol-u": "Autocontrole",
 	"instinct-u": "Instinto",
 	"courage-u": "Coragem",

--- a/CWOD-V20/translations/ru.json
+++ b/CWOD-V20/translations/ru.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Дополнения",
 	"virtues-u": "Добродетели",
 	"conscience-u": "Сознательность",
-	"convinction-u": "Убежденность",
+	"conviction-u": "Убежденность",
 	"selfcontrol-u": "Самоконтроль",
 	"instinct-u": "Инстинкты",
 	"courage-u": "Храбрость",

--- a/CWOD-V20/translations/sl.json
+++ b/CWOD-V20/translations/sl.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Backgrounds",
 	"virtues-u": "Virtues",
 	"conscience-u": "Conscience",
-	"convinction-u": "Convinction",
+	"conviction-u": "Conviction",
 	"selfcontrol-u": "Self-Control",
 	"instinct-u": "Instinct",
 	"courage-u": "Courage",

--- a/CWOD-V20/translations/sv.json
+++ b/CWOD-V20/translations/sv.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Backgrounds",
 	"virtues-u": "Virtues",
 	"conscience-u": "Conscience",
-	"convinction-u": "Convinction",
+	"conviction-u": "Conviction",
 	"selfcontrol-u": "Self-Control",
 	"instinct-u": "Instinct",
 	"courage-u": "Courage",

--- a/CWOD-V20/translations/tr.json
+++ b/CWOD-V20/translations/tr.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Backgrounds",
 	"virtues-u": "Virtues",
 	"conscience-u": "Conscience",
-	"convinction-u": "Convinction",
+	"conviction-u": "Conviction",
 	"selfcontrol-u": "Self-Control",
 	"instinct-u": "Instinct",
 	"courage-u": "Courage",

--- a/CWOD-V20/translations/uk.json
+++ b/CWOD-V20/translations/uk.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Backgrounds",
 	"virtues-u": "Virtues",
 	"conscience-u": "Conscience",
-	"convinction-u": "Convinction",
+	"conviction-u": "Conviction",
 	"selfcontrol-u": "Self-Control",
 	"instinct-u": "Instinct",
 	"courage-u": "Courage",

--- a/CWOD-V20/translations/zh.json
+++ b/CWOD-V20/translations/zh.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "背景",
 	"virtues-u": "Virtues",
 	"conscience-u": "Conscience",
-	"convinction-u": "Convinction",
+	"conviction-u": "Conviction",
 	"selfcontrol-u": "Self-Control",
 	"instinct-u": "Instinct",
 	"courage-u": "Courage",

--- a/CWOD-V20/translations/zu.json
+++ b/CWOD-V20/translations/zu.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "crwdns58281:0crwdne58281:0",
 	"virtues-u": "crwdns58282:0crwdne58282:0",
 	"conscience-u": "crwdns58283:0crwdne58283:0",
-	"convinction-u": "crwdns58284:0crwdne58284:0",
+	"conviction-u": "crwdns58284:0crwdne58284:0",
 	"selfcontrol-u": "crwdns58285:0crwdne58285:0",
 	"instinct-u": "crwdns58286:0crwdne58286:0",
 	"courage-u": "crwdns58287:0crwdne58287:0",


### PR DESCRIPTION
## Changes / Comments
Fixed the spelling of the word "Conviction" in the actual translations and in the i18n key as well.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?

If you do not know English. Please leave a comment in your native language.
