### PR TITLE
[D&D_4E] Fix emote text color on dark theme in powers

### DIFF
--- a/D&D_4E/D&D_4E.css
+++ b/D&D_4E/D&D_4E.css
@@ -696,7 +696,7 @@
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-emote {
-    color: #000000;
+    color: inherit;
     padding-left: 5px;
     padding-bottom: 5px;
     line-height: 1em;


### PR DESCRIPTION
When using a power template, the "emote" part of the power looks like it was intended to be on a light background and was hard-coded to black. This made it nearly impossible to read on the dark theme. Changing this `.sheet-emote` rule to set color to inherit causes it to inherit the color that normal chat text gets, which is correctly adjusted for the dark theme.

## Changes / Comments

Before (dark theme, unreadable):
![image](https://user-images.githubusercontent.com/196973/156707489-52269df5-858e-4e02-869f-5fb998206ec1.png)

Before (light theme, readable):
![image](https://user-images.githubusercontent.com/196973/156707667-62e63f52-b360-48b3-aaa4-7185f8d07917.png)


After (dark theme, readable):
![image](https://user-images.githubusercontent.com/196973/156707592-16d1d952-bc41-4048-9655-27eb745d7819.png)

After (light theme, readable, looks almost the same):
![image](https://user-images.githubusercontent.com/196973/156707756-ee79d1d9-e81a-454e-a8b4-5bcfca42e543.png)

In light theme, the inherited color is `#404040`, very dark grey, which is slightly different from the current sheet's hard-coded black. I don't see any reason it needs to be different from the inherited color but maybe someone disagrees. 

The reason for `inherit` instead of removing the color prop is that this text is in a `<caption>` tag which does have its own color from base.css which is significantly lighter (`#777`).  It works because it's about half way between white and black, but looks much different and I was trying to keep things mostly the same.


