### PR TITLE
[Classified] fixed ammo/notes for squad members

### DIFF
--- a/Classified/Classified.html
+++ b/Classified/Classified.html
@@ -5565,7 +5565,7 @@ Ammo: xx/xx  #x
 										<input type='text' style="display:none" value='1000' name='attr_h2hDfSqd2' />
 									</div>									
 								</div>
-<textarea name="attr_squadAmmoNotes">Ammo:  xx/xx #x
+<textarea name="attr_squadAmmoNotes2">Ammo:  xx/xx #x
 Ammo: xx/xx  #x
 </textarea>
 									<div class="sheet-squadbuttonsGrid">
@@ -5617,7 +5617,7 @@ Ammo: xx/xx  #x
 										<input type='text' style="display:none" value='1000' name='attr_h2hDfSqd3' />
 									</div>									
 								</div>
-<textarea name="attr_squadAmmoNotes">Ammo:  xx/xx #x							
+<textarea name="attr_squadAmmoNotes3">Ammo:  xx/xx #x							
 Ammo: xx/xx  #x							
 </textarea>
 									<div class="sheet-squadbuttonsGrid">
@@ -5669,7 +5669,7 @@ Ammo: xx/xx  #x
 										<input type='text' style="display:none" value='1000' name='attr_h2hDfSqd4' />
 									</div>									
 								</div>
-<textarea name="attr_squadAmmoNotes">Ammo:  xx/xx #x
+<textarea name="attr_squadAmmoNotes4">Ammo:  xx/xx #x
 Ammo: xx/xx  #x
 </textarea>
 									<div class="sheet-squadbuttonsGrid">
@@ -5722,7 +5722,7 @@ Ammo: xx/xx  #x
 									<input type='text' style="display:none" value='1000' name='attr_h2hDfSqd5' />
 								</div>									
 							</div>
-<textarea name="attr_squadAmmoNotes">Ammo:  xx/xx #x
+<textarea name="attr_squadAmmoNotes5">Ammo:  xx/xx #x
 Ammo: xx/xx  #x
 </textarea>
 								<div class="sheet-squadbuttonsGrid">
@@ -5773,7 +5773,7 @@ Ammo: xx/xx  #x
 										<input type='text' style="display:none" value='1000' name='attr_h2hDfSqd6' />
 									</div>									
 								</div>
-<textarea name="attr_squadAmmoNotes">Ammo:  xx/xx #x
+<textarea name="attr_squadAmmoNotes6">Ammo:  xx/xx #x
 Ammo: xx/xx  #x
 </textarea>
 									<div class="sheet-squadbuttonsGrid">
@@ -5825,7 +5825,7 @@ Ammo: xx/xx  #x
 										<input type='text' style="display:none" value='1000' name='attr_h2hDfSqd7' />
 									</div>									
 								</div>
-<textarea name="attr_squadAmmoNotes">Ammo:  xx/xx #x
+<textarea name="attr_squadAmmoNotes7">Ammo:  xx/xx #x
 Ammo: xx/xx  #x
 </textarea>
 									<div class="sheet-squadbuttonsGrid">
@@ -5877,7 +5877,7 @@ Ammo: xx/xx  #x
 										<input type='text' style="display:none" value='1000' name='attr_h2hDfSqd8' />
 									</div>									
 								</div>
-<textarea name="attr_squadAmmoNotes">Ammo:  xx/xx #x
+<textarea name="attr_squadAmmoNotes8">Ammo:  xx/xx #x
 Ammo: xx/xx  #x
 </textarea>
 									<div class="sheet-squadbuttonsGrid">
@@ -5930,7 +5930,7 @@ Ammo: xx/xx  #x
 											<input type='text' style="display:none" value='1000' name='attr_h2hDfSqd9' />
 										</div>									
 									</div>
-<textarea name="attr_squadAmmoNotes">Ammo:  xx/xx #x
+<textarea name="attr_squadAmmoNotes9">Ammo:  xx/xx #x
 Ammo: xx/xx  #x
 </textarea>
 										<div class="sheet-squadbuttonsGrid">
@@ -5981,7 +5981,7 @@ Ammo: xx/xx  #x
 												<input type='text' style="display:none" value='1000' name='attr_h2hDfSqd10' />
 											</div>									
 										</div>
-<textarea name="attr_squadAmmoNotes">Ammo:  xx/xx #x
+<textarea name="attr_squadAmmoNotes10">Ammo:  xx/xx #x
 Ammo: xx/xx  #x
 </textarea>
 											<div class="sheet-squadbuttonsGrid">
@@ -6033,7 +6033,7 @@ Ammo: xx/xx  #x
 												<input type='text' style="display:none" value='1000' name='attr_h2hDfSqd11' />
 											</div>									
 										</div>
-<textarea name="attr_squadAmmoNotes">Ammo:  xx/xx #x
+<textarea name="attr_squadAmmoNotes11">Ammo:  xx/xx #x
 Ammo: xx/xx  #x
 </textarea>
 											<div class="sheet-squadbuttonsGrid">
@@ -6085,7 +6085,7 @@ Ammo: xx/xx  #x
 												<input type='text' style="display:none" value='1000' name='attr_h2hDfSqd12' />
 											</div>									
 										</div>
-<textarea name="attr_squadAmmoNotes">Ammo:  xx/xx #x							
+<textarea name="attr_squadAmmoNotes12">Ammo:  xx/xx #x							
 Ammo: xx/xx  #x							
 </textarea>
 											<div class="sheet-squadbuttonsGrid">


### PR DESCRIPTION
## Changes / Comments
Ammo/notes for squad members were pointing at the same Roll20 attribute.





## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
