### PR TITLE
[Red Giant] - update image links to github

### DIFF
--- a/Red Giant/RedGiant.css
+++ b/Red Giant/RedGiant.css
@@ -177,8 +177,9 @@ label.sheet-big-label-title {
 
 .sheet-gamename {
   grid-area: gamename;
-  background-image: url("https://i.ibb.co/yy2gL1K/red-giant-logo.png"); /*Red Giant logo, used with publisher permission*/
-  /*background-image: url("https://github.com/Roll20/roll20-character-sheets/blob/master/Red%20Giant/red_giant_logo.PNG?raw=true");*/
+  
+  background-image: url("https://github.com/Roll20/roll20-character-sheets/blob/master/Red%20Giant/red_giant_logo.PNG?raw=true"); /*Red Giant logo, used with publisher permission*/
+  
   background-size: contain;
   align-items: center;
   justify-items: center;
@@ -1332,8 +1333,7 @@ input.sheet-specials-inputs{
 }
 
 .sheet-rolltemplate-attribute .sheet-attribute-roll-header .sheet-attribute-roll-result {
-    background-image: url("https://i.ibb.co/vx2jYHc/red-moon-transparent.png"); /*Red moon*/
-    /*background-image: url("https://github.com/Roll20/roll20-character-sheets/blob/master/Red%20Giant/red-moon-transparent.png?raw=true");*/
+    background-image: url("https://github.com/Roll20/roll20-character-sheets/blob/master/Red%20Giant/red-moon-transparent.png?raw=true"); /*Red moon*/
 	background-size: 60%;
 	align-items: center;
 	justify-items: center;	


### PR DESCRIPTION
## Changes / Comments
Updated image links to github from the temporary image hosting.
The logo isn't showing up right in chrome for some reason, but I've submitted a bug report for that.
(Does not image usability of the sheet).
It works in Firefox though.


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
