### PR TITLE
[CWOD-V20] Fix typo in translation and i18n key for "Conviction"

### DIFF
--- a/CWOD-V20/V20.html
+++ b/CWOD-V20/V20.html
@@ -1443,7 +1443,7 @@
 		<td style="width:70%;height:14%">
 		<select class="sheet-text-fronth2" name="attr_virtueConsName" style="width:100px" text-align:left>
 			<option value="Conscience" selected data-i18n="conscience-u">Conscience</option>
-			<option value="Conviction" data-i18n="convinction-u">Conviction</option>
+			<option value="Conviction" data-i18n="conviction-u">Conviction</option>
 		</select>
 		</td>
 		<td style="width:30%">

--- a/CWOD-V20/translation.json
+++ b/CWOD-V20/translation.json
@@ -109,7 +109,7 @@
 	"backgrounds-u": "Backgrounds",
 	"virtues-u": "Virtues",
 	"conscience-u": "Conscience",
-	"convinction-u": "Convinction",
+	"conviction-u": "Conviction",
 	"selfcontrol-u": "Self-Control",
 	"instinct-u": "Instinct",
 	"courage-u": "Courage",


### PR DESCRIPTION
## Changes / Comments
Fixed the spelling of the word "Conviction" in `translation.json` and in the name of the i18n key as well.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?

If you do not know English. Please leave a comment in your native language.