### PR TITLE
[Fate] Darkmode Support + Moved CSS off Legacy

### DIFF
--- a/Fate/FateOmni.css
+++ b/Fate/FateOmni.css
@@ -1,40 +1,64 @@
-.sheet-Wrapper {
+/* Strip off all the unwanted bells and whistles Roll20 saddles us with */
+
+.btn, .btn::before {
+	background-image: none;
+	text-shadow: none;
+	box-shadow: none;
+}
+
+/* Darkmode broad recoloring up top */
+
+.sheet-darkmode .tab-content .charsheet .btn,
+.sheet-darkmode .tab-content .charsheet .btn:hover,
+.sheet-darkmode .tab-content .charsheet button,
+.sheet-darkmode .tab-content .charsheet input,
+.sheet-darkmode .tab-content .charsheet select,
+.sheet-darkmode .tab-content .charsheet textarea,
+.sheet-darkmode .tab-content .charsheet
+{
+	background-color: #1f1f1f;
+	color: #eee;
+}
+
+/* I should really add more comments to this some day */
+
+.Wrapper {
 	font-size: 11pt;
 }
 
-.sheet-listcount {
+.listcount {
 	font-weight: normal;
 	font-size: 80%;
 	text-align: right;
 	display: none;
 }
 
-.sheet-squat {
+.squat {
 	height: 30px;
 	max-height: 60px;
 }
 
-.sheet-space-below {
+.space-below {
 	margin-bottom: 6px;
 }
 
-.sheet-SectionHeader:hover .sheet-listcount {
+.SectionHeader:hover .listcount {
 	display: initial;
 }
 
-.sheet-listcount::before {
+.listcount::before {
 	content: "(";
 }
 
-.sheet-listcount::after {
+.listcount::after {
 	content: ")";
 }
 
-.sheet-highlight input[type="button"] {
+.charsheet .highlight input[type="button"] {
 	margin-bottom: 0px;
 }
 
-.sheet-charname {
+.charname {
 	border: 0px;
 	font-size: 36px;
 	font-weight: bold;
@@ -44,22 +68,22 @@
 }
 
 
-.sheet-pronouns {
+.pronouns {
 	border: 0px;
 	font-size: 18px;
 	padding: 0px;
 	margin-left: 0px;
 }
 
-.sheet-floatright {
+.floatright {
 	float: right;
 }
 
-input[type="checkbox"].sheet-triggerbox:checked + .sheet-specific {
+input[type="checkbox"].triggerbox:checked + .specific {
 	display: flex;
 }
 
-.sheet-specific {
+.specific {
 	display: flex;
 	flex-flow: row-reverse;
 	justify-content: flex-end;
@@ -67,7 +91,7 @@ input[type="checkbox"].sheet-triggerbox:checked + .sheet-specific {
 	width: 100%;
 }
 
-.sheet-specific input[type="text"] {
+.specific input[type="text"] {
 	width: 100%;
 	flex-grow: 1;
 	border: 0px;
@@ -76,26 +100,26 @@ input[type="checkbox"].sheet-triggerbox:checked + .sheet-specific {
 	background: transparent;
 }
 
-.sheet-recovery .sheet-label {
+.recovery .label {
 	font-size: 80%;
 	text-transform: uppercase;
 	opacity: 0.25;
 }
 
-input[type="checkbox"]:checked + .sheet-recovery .sheet-label {
+input[type="checkbox"]:checked + .recovery .label {
 	opacity: 1.0;
 	font-weight: bold;
 }
 
-.sheet-aspect .sheet-boxes {
+.aspect .boxes {
 	margin-left: 12px;
 }
 
-input[type="checkbox"].sheet-triggerbox:checked + .sheet-optbar {
+input[type="checkbox"].triggerbox:checked + .optbar {
 	display: flex;
 }
 
-.sheet-optbar {
+.optbar {
 	vertical-align: middle;
 	width: 100%;
 	display: flex;
@@ -106,7 +130,7 @@ input[type="checkbox"].sheet-triggerbox:checked + .sheet-optbar {
 	margin-right: 10px;
 }
 
-.sheet-optbar > span {
+.optbar > span {
 	margin-right: 10px;
 	height: 18px;
 	white-space: nowrap;
@@ -116,7 +140,7 @@ input[type="checkbox"].sheet-triggerbox:checked + .sheet-optbar {
 	border-radius: 6px;
 }
 
-.sheet-optbar select {
+.optbar select {
 	background: transparent;
 	border: none;
 	margin: none;
@@ -124,44 +148,44 @@ input[type="checkbox"].sheet-triggerbox:checked + .sheet-optbar {
 	height: 24px;
 }
 
-.sheet-limited-width {
+.limited-width {
 	max-width: 250px;
 }
 
-input.sheet-compact,
-select.sheet-compact {
+input.compact,
+select.compact {
 	max-width: 85px;
 }
 
-input.sheet-ultracompact,
-select.sheet-ultracompact {
+input.ultracompact,
+select.ultracompact {
 	max-width: 40px;
 }
 
-input.sheet-maxcompact,
-select.sheet-maxcompact {
+input.maxcompact,
+select.maxcompact {
 	max-width: 30px;
 }
 
-.sheet-smalltext {
+.smalltext {
 	font-size: 75%;
 }
-.sheet-clipped {
+.clipped {
 	overflow: hidden;
 }
 
-.sheet-nowrap {
+.nowrap {
 	white-space: nowrap;
 }
 
-.sheet-SheetFlex {
+.SheetFlex {
 	display: flex;
 	flex-direction: row;
 	justify-content: flex-start;
 	width: 100%;
 }
 
-.sheet-SheetCol {
+.SheetCol {
 	min-width: 260px;
 	margin-left: 12px;
 	flex-grow: 1;
@@ -171,20 +195,22 @@ select.sheet-maxcompact {
 	align-items: stretch;
 }
 
-.sheet-SheetCol:first-child {
+.SheetCol:first-child {
 	margin-left: 0px;
 	flex-grow: 3;
 }
 
-.sheet-boxcorner {
+.SectionHeader .boxcorner {
 	text-align: right;
+	flex-grow: 0;
+	display: inherit;
 }
 
-.sheet-SheetCol:first-child .sheet-boxcorner { /* To maintain consistency of position in left col vs right */
+.SectionHeader .SheetCol:first-child .boxcorner { /* To maintain consistency of position in left col vs right */
 	margin-right: 4px;
 }
 
-.sheet-SectionHeader {
+.SectionHeader {
 	font-weight: bold;
 	text-transform: uppercase;
 	font-size: 21px;
@@ -195,18 +221,18 @@ select.sheet-maxcompact {
 	align-items: flex-end;
 }
 
-.sheet-SectionHeader > * {
+.SectionHeader > * {
 	flex-grow: 1;
 }
 
-.sheet-SectionHeader ~ div {
+.SectionHeader ~ div {
 	min-width: 272px;
 	border-radius: 12px;
 }
 
 /* Extras stuff */
 
-span.sheet-icon {
+span.icon {
 	background: black;
 	border-radius: 3px;
 	color: white;
@@ -221,128 +247,128 @@ span.sheet-icon {
 	vertical-align: middle;
 }
 
-input.sheet-icon[value="plus"] + span.sheet-icon::before {
+input.icon[value="plus"] + span.icon::before {
 	content: "+";
 }
 
-input.sheet-icon[value="minus"] + span.sheet-icon::before {
+input.icon[value="minus"] + span.icon::before {
 	content: "–";
 }
 
-input.sheet-icon[value="blank"] + span.sheet-icon::before {
+input.icon[value="blank"] + span.icon::before {
 	content: " ";
 }
 
-.sheet-clear-all {
+.clear-all {
 	clear: both;
 }
 
-.sheet-indented {
+.indented {
 	padding-left: 10px;
 }
 
-.sheet-rolltemplate-share .sheet-space-above,
-.sheet-space-above {
+.rolltemplate-share .space-above,
+.space-above {
 	padding-top: 12px;
 }
 
-.sheet-ExtraDisplay .repcontainer .repitem:first-child .sheet-space-above {
+.ExtraDisplay .repcontainer .repitem:first-child .space-above {
 	padding-top: 0px;
 }
 
-.sheet-hideUnlessNull + * {
+.hideUnlessNull + * {
 	display: none;
 }
 
-.sheet-hideUnlessNull[value=""] + * {
+.hideUnlessNull[value=""] + * {
 	display: initial;
 }
 
-.sheet-element ~ div {
+.element ~ div {
 	display: none;
 }
 
-.sheet-element[value="title"] ~ .repcontainer .repitem > div {
+.element[value="title"] ~ .repcontainer .repitem > div {
 }
 
-.sheet-element[value="title"] ~ div.sheet-title {
+.element[value="title"] ~ div.title {
 	display: block;
 	font-weight: bold;
 	font-size: 120%;
 }
 
-.sheet-element[value="title"] ~ div.sheet-title > input[type=text] {
+.element[value="title"] ~ div.title > input[type=text] {
 	font-weight: bold;
 	font-size: 120%;
 	border: 0px;
 }
 
-.sheet-element[value="permissions"] ~ div.sheet-permissions {
+.element[value="permissions"] ~ div.permissions {
 	display: block;
 }
 
-.sheet-element[value="cost"] ~ div.sheet-cost {
+.element[value="cost"] ~ div.cost {
 	display: block;
 }
 
-.sheet-element[value="aspect"] ~ div.sheet-aspect {
+.element[value="aspect"] ~ div.aspect {
 	display: block;
 }
 
-.sheet-element[value="aspect"] ~ div.sheet-aspect span.sheet-aspect {
+.element[value="aspect"] ~ div.aspect span.aspect {
 	font-weight: bold;
 	font-style: italic;
 	text-transform: capitalize;
 }
 
-.sheet-element[value="skill"] ~ div.sheet-skill {
+.element[value="skill"] ~ div.skill {
 	display: block;
 }
 
-.sheet-element[value="stunt"] ~ div.sheet-stunt {
+.element[value="stunt"] ~ div.stunt {
 	display: block;
 }
 
-.sheet-element[value="track"] ~ div.sheet-track {
+.element[value="track"] ~ div.track {
 	display: block;
 }
 
-.sheet-element[value="rating"] ~ div.sheet-rating {
+.element[value="rating"] ~ div.rating {
 	display: block;
 }
 
-.sheet-element[value="note"] ~ div.sheet-note {
+.element[value="note"] ~ div.note {
 	display: block;
 }
 
 /* End Extras Stuff */
 
-.sheet-AspectFrame,
-.sheet-TrackFrame,
-.sheet-StuntFrame,
-.sheet-PowerFrame,
-.sheet-NoteFrame,
-.sheet-ExtraFrame,
-.sheet-SkillFrame {
+.AspectFrame,
+.TrackFrame,
+.StuntFrame,
+.PowerFrame,
+.NoteFrame,
+.ExtraFrame,
+.SkillFrame {
 	display: flex;
 }
 
-.sheet-StuntFrame,
-.sheet-PowerFrame,
-.sheet-NoteFrame,
-.sheet-ExtraFrame,
-.sheet-SkillFrame {
+.StuntFrame,
+.PowerFrame,
+.NoteFrame,
+.ExtraFrame,
+.SkillFrame {
 	flex-direction: row;
 	justify-content: flex-start;
 }
 
-.sheet-TrackFrame,
-.sheet-AspectFrame {
+.TrackFrame,
+.AspectFrame {
 	flex-direction: column;
 	justify-content: stretch;
 }
 
-.sheet-fieldlabel {
+.charsheet .fieldlabel {
 	font-weight: bold;
 	font-size: 80%;
 	text-transform: uppercase;
@@ -351,23 +377,27 @@ input.sheet-icon[value="blank"] + span.sheet-icon::before {
 	padding-left: 1px;
 	padding-right: 2px;
 	text-shadow: 0px 0px 2px white;
-	background-image: linear-gradient(to bottom,rgba(255,255,255,0),rgba(255,255,255,.16),rgba(255,255,255,.5))
+	/* background-image: linear-gradient(to bottom,rgba(255,255,255,0),rgba(255,255,255,.16),rgba(255,255,255,.5)) */
 }
 
-.sheet-OptionsEdit {
+.sheet-darkmode .tab-content .charsheet .fieldlabel {
+	/* background-image: linear-gradient(to bottom,rgba(16,16,16,0),rgba(16,16,16,.16),rgba(16,16,16,.5)) */
+}
+
+.OptionsEdit {
 	padding: 6px;
 	border-radius: 6px;
 	font-size: 80%;
 	margin-bottom: 6px;
 }
 
-.sheet-TrackEdit,
-.sheet-AspectEdit,
-.sheet-NoteEdit,
-.sheet-ExtraEdit,
-.sheet-PowerEdit,
-.sheet-StuntEdit,
-.sheet-SkillEdit {
+.TrackEdit,
+.AspectEdit,
+.NoteEdit,
+.ExtraEdit,
+.PowerEdit,
+.StuntEdit,
+.SkillEdit {
 	order: -1;
 	min-width: 248px;
 	margin: 6px;
@@ -375,48 +405,48 @@ input.sheet-icon[value="blank"] + span.sheet-icon::before {
 	border-radius: 6px;
 }
 
-.sheet-AspectEdit > .repcontainer,
-.sheet-TrackEdit > .repcontainer,
-.sheet-StuntEdit > .repcontainer,
-.sheet-PowerEdit > .repcontainer,
-.sheet-NoteEdit > .repcontainer,
-.sheet-ExtraEdit > .repcontainer,
-.sheet-SkillEdit > .repcontainer {
+.AspectEdit > .repcontainer,
+.TrackEdit > .repcontainer,
+.StuntEdit > .repcontainer,
+.PowerEdit > .repcontainer,
+.NoteEdit > .repcontainer,
+.ExtraEdit > .repcontainer,
+.SkillEdit > .repcontainer {
 	padding-top: 6px;
 	padding-right: 10px;
 }
 
-.sheet-TrackEdit input[type="text"],
-.sheet-AspectEdit input[type="text"],
-.sheet-NoteEdit input[type="text"],
-.sheet-ExtraEdit input[type="text"],
-.sheet-StuntEdit input[type="text"],
-.sheet-PowerEdit input[type="text"] {
+.TrackEdit input[type="text"],
+.AspectEdit input[type="text"],
+.NoteEdit input[type="text"],
+.ExtraEdit input[type="text"],
+.StuntEdit input[type="text"],
+.PowerEdit input[type="text"] {
 	width: 100%;
 }
 
-.sheet-AspectEdit textarea,
-.sheet-TrackEdit textarea,
-.sheet-NoteEdit textarea,
-.sheet-ExtraEdit textarea,
-.sheet-PowerEdit textarea,
-.sheet-StuntEdit textarea {
+.AspectEdit textarea,
+.TrackEdit textarea,
+.NoteEdit textarea,
+.ExtraEdit textarea,
+.PowerEdit textarea,
+.StuntEdit textarea {
 	width: calc(100% - 10px);
 }
 
-.sheet-AspectEdit > div,
-.sheet-TrackEdit > div,
-.sheet-StuntEdit > div,
-.sheet-PowerEdit > div,
-.sheet-NoteEdit > div,
-.sheet-ExtraEdit > div,
-.sheet-SkillEdit > div {
+.AspectEdit > div,
+.TrackEdit > div,
+.StuntEdit > div,
+.PowerEdit > div,
+.NoteEdit > div,
+.ExtraEdit > div,
+.SkillEdit > div {
 	padding-bottom: 6px;
 	padding-left: 6px;
 	padding-right: 6px;
 }
 
-.sheet-SkillEditRow {
+.SkillEditRow {
 	display: flex;
 	flex-direction: row;
 	flex-flow: nowrap;
@@ -425,79 +455,79 @@ input.sheet-icon[value="blank"] + span.sheet-icon::before {
 	align-items: center;
 }
 
-.sheet-SkillEditRow > *:last-child {
+.SkillEditRow > *:last-child {
 	margin-right: 0px;
 }
 
-.sheet-SkillEditRow > * {
+.SkillEditRow > * {
 	flex-grow: 1;
 	margin-right: 6px;
 	height: 24px;
 }
 
-.sheet-AspectSeparator {
+.AspectSeparator {
 	padding: 6px;
 	margin-bottom: 10px;
 }
 
-.sheet-SkillDisplay {
+.SkillDisplay {
 	order: 0;
 	min-width: 260px;
 	padding: 10px;
 	flex-grow: 1;
 }
 
-.sheet-PowerDisplay,
-.sheet-StuntDisplay {
+.PowerDisplay,
+.StuntDisplay {
 	flex-grow: 1;
 	padding: 10px;
 }
 
-.sheet-NoteDisplay {
+.NoteDisplay {
 	flex-grow: 1;
 	padding: 10px;
 }
 
-.sheet-ExtraDisplay {
+.ExtraDisplay {
 	flex-grow: 1;
 	padding: 10px;
 }
 
-.sheet-TrackDisplay,
-.sheet-AspectDisplay {
+.TrackDisplay,
+.AspectDisplay {
 	padding: 10px;
 }
 
-.sheet-ComboColumn .repcontrol,
-.sheet-AspectDisplay .repcontrol,
-.sheet-TrackDisplay .repcontrol,
-.sheet-StuntDisplay .repcontrol,
-.sheet-PowerDisplay .repcontrol,
-.sheet-NoteDisplay .repcontrol,
-.sheet-ExtraDisplay .repcontrol,
-.sheet-SkillDisplay .repcontrol {
+.ComboColumn .repcontrol,
+.AspectDisplay .repcontrol,
+.TrackDisplay .repcontrol,
+.StuntDisplay .repcontrol,
+.PowerDisplay .repcontrol,
+.NoteDisplay .repcontrol,
+.ExtraDisplay .repcontrol,
+.SkillDisplay .repcontrol {
 	display: none;
 }
 
-.sheet-stunt {
+.stunt {
 	margin-bottom: 6px;
 	text-indent: -10px;
 	margin-left: 10px;
 }
 
-.sheet-stunt .sheet-name {
+.stunt .name {
 	font-weight: bold;
 }
 
-.sheet-stunt .sheet-name::after {
+.stunt .name::after {
 	content: ': ';
 }
 
-.sheet-power {
+.power {
 	margin-bottom: 6px;
 }
 
-.sheet-powerflex {
+.powerflex {
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
@@ -505,48 +535,48 @@ input.sheet-icon[value="blank"] + span.sheet-icon::before {
 	margin-bottom: 3px;
 }
 
-.sheet-power .sheet-name {
+.power .name {
 	font-weight: bold;
 	display: inline-block;
 }
 
-.sheet-power .sheet-cost {
+.power .cost {
 	flex-grow: 0;
 	text-align: right;
 }
 
-.sheet-power .sheet-desc {
+.power .desc {
 	margin-left: 0px;
 	text-indent: 0px;
 }
 
-.sheet-power .sheet-field {
+.power .field {
 	text-indent: -6px;
 	margin-left: 12px;
 }
 
-.sheet-note {
+.note {
 	margin-bottom: 6px;
 }
 
-.sheet-note .sheet-name {
+.note .name {
 	font-weight: bold;
 }
 
-.sheet-note .sheet-desc {
+.note .desc {
 	margin-left: 10px;
 }
 
-.sheet-track,
-.sheet-aspect {
+.track,
+.aspect {
 	margin-bottom: 6px;
 }
 
-.sheet-track .sheet-boxes {
+.track .boxes {
 	margin-left: 6px;
 }
 
-.sheet-topwrap {
+.topwrap {
 	display: flex;
 	flex-flow: row-reverse;
 	width: 100%;
@@ -554,18 +584,18 @@ input.sheet-icon[value="blank"] + span.sheet-icon::before {
 	align-items: flex-end;
 }
 
-.sheet-topwrap > div:last-child {
+.topwrap > div:last-child {
 	flex-grow: 1;
 }
 
-.sheet-Bar {
+.Bar {
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
 	align-items: center;
 }
 
-.sheet-fpbox {
+.fpbox {
 	float: right;
 	display: flex;
 	flex-direction: row;
@@ -576,27 +606,27 @@ input.sheet-icon[value="blank"] + span.sheet-icon::before {
 	margin-left: 20px;
 }
 
-.sheet-pronounbox div,
-.sheet-fpbox div {
+.pronounbox div,
+.fpbox div {
 	text-align: center;
 	vertical-align: bottom;
 	white-space: nowrap;
 	margin-left: 10px;
 }
 
-.sheet-pronounbox > div > div,
-.sheet-fpbox > div > div {
+.pronounbox > div > div,
+.fpbox > div > div {
 	display: block;
 }
 
-.sheet-pronounbox > div > div + div,
-.sheet-fpbox > div > div + div {
+.pronounbox > div > div + div,
+.fpbox > div > div + div {
 	font-weight: bold;
 	font-size: 90%;
 	text-transform: uppercase;
 }
 
-.sheet-fpbox input[type=number] {
+.fpbox input[type=number] {
 	border: 0px;
 	font-size: 30px;
 	font-weight: bold;
@@ -605,125 +635,125 @@ input.sheet-icon[value="blank"] + span.sheet-icon::before {
 	text-align: center;
 }
 
-.sheet-pronounbox input {
+.pronounbox input {
 	text-align: center;
 	max-width: 96px;
 }
 
-.sheet-Bar div {
+.Bar div {
 	display: inline-block;
 	margin-left: 10px;
 }
 
-.sheet-Bar div:first-child {
+.Bar div:first-child {
 	flex-grow: 1;
 	margin-left: 0px;
 }
 
-.sheet-AspectLabelBar {
+.AspectLabelBar {
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
 }
 
-.sheet-aspect:hover .sheet-label {
+.aspect:hover .label {
 	font-weight: bold;
 }
 
-.sheet-aspect .sheet-label {
+.aspect .label {
 	text-transform: uppercase;
 	opacity: 0.75;
 	font-size: 80%;
 	display: block;
 }
 
-.sheet-aspect-category {
+.aspect-category {
 	text-transform: uppercase;
 	font-size: 90%;
 	display: block;
 	font-weight: bold;
 }
 
-.sheet-track .sheet-name {
+.track .name {
 	text-transform: capitalize;
 	font-weight: bold;
 }
 
-.sheet-aspect .sheet-name {
+.aspect .name {
 	text-transform: capitalize;
 	font-weight: bold;
 	font-style: italic;
 	margin-left: 6px;
 }
 
-.sheet-aspect .sheet-notes {
+.aspect .notes {
 	margin-left: 12px;
 	padding-right: 6px;
 	max-width: 250px;
 	font-size: 80%;
 }
 
-.sheet-track .sheet-notes {
+.track .notes {
 	margin-left: 6px;
 	padding-right: 6px;
 	max-width: 250px;
 	font-size: 80%;
 }
 
-.sheet-SkillCell .sheet-rating::before {
+.SkillCell .rating::before {
 	content: '+';
 }
 
-.sheet-signmaker[value="-4"] + .sheet-rating::before,
-.sheet-signmaker[value="-3"] + .sheet-rating::before,
-.sheet-signmaker[value="-2"] + .sheet-rating::before,
-.sheet-signmaker[value="-1"] + .sheet-rating::before {
+.signmaker[value="-4"] + .rating::before,
+.signmaker[value="-3"] + .rating::before,
+.signmaker[value="-2"] + .rating::before,
+.signmaker[value="-1"] + .rating::before {
 	content: '';
 }
 
-.sheet-hideIfNull + div {
+.hideIfNull + div {
 	display: block;
 }
 
-.sheet-hideIfNull[value=""] + * {
+.hideIfNull[value=""] + * {
 	display: none;
 }
 
-.sheet-SkillColumnFirst,
-.sheet-SkillColumnSecond,
-.sheet-SkillColumnThird,
-.sheet-SkillNone,
-.sheet-SkillList,
-.sheet-SkillGrid {
+.SkillColumnFirst,
+.SkillColumnSecond,
+.SkillColumnThird,
+.SkillNone,
+.SkillList,
+.SkillGrid {
 	display: none;
 }
 
-input[value=""] + .sheet-SkillColumnFirst,
-input[value="1"] + .sheet-SkillColumnFirst {
+input[value=""] + .SkillColumnFirst,
+input[value="1"] + .SkillColumnFirst {
 	display: initial;
 }
 
-input[value="2"] + .sheet-SkillColumnSecond {
+input[value="2"] + .SkillColumnSecond {
 	display: initial;
 }
 
-input[value="3"] + .sheet-SkillColumnThird {
+input[value="3"] + .SkillColumnThird {
 	display: initial;
 }
 
-input[value="none"] ~ .sheet-SkillNone {
+input[value="none"] ~ .SkillNone {
 	display: block;
 }
 
-input[value="pyramid"] ~ .sheet-SkillGrid {
+input[value="pyramid"] ~ .SkillGrid {
 	display: block;
 }
 
-input[value="list"] ~ .sheet-SkillList {
+input[value="list"] ~ .SkillList {
 	display: block;
 }
 
-.sheet-SkillGrid > div {
+.SkillGrid > div {
 	display: flex;
 	flex-direction: row;
 	flex-wrap: nowrap;
@@ -732,11 +762,11 @@ input[value="list"] ~ .sheet-SkillList {
 	transition: background 0.25s ease;
 }
 
-.sheet-SkillGrid button[type="roll"] {
+.charsheet .SkillGrid button[type="roll"] {
 	font-weight: bold;
 }
 
-.sheet-SkillList > .repcontainer {
+.SkillList > .repcontainer {
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;
@@ -744,20 +774,20 @@ input[value="list"] ~ .sheet-SkillList {
 	align-items: flex-start;
 }
 
-.sheet-SkillList > .repcontainer > .repitem {
+.SkillList > .repcontainer > .repitem {
 	flex: none;
 }
 
-.sheet-ExtraDisplay button[type="roll"].sheet-roll::before,
-.sheet-StuntDisplay button[type="roll"].sheet-roll::before,
-.sheet-SkillDisplay button[type="action"]::before,
-.sheet-SkillDisplay button[type="roll"]::before {
+.charsheet .ExtraDisplay button[type="roll"].sheet-roll::before,
+.charsheet .StuntDisplay button[type="roll"].sheet-roll::before,
+.charsheet .SkillDisplay button[type="action"]::before,
+.charsheet .SkillDisplay button[type="roll"]::before {
 	content: "";
 }
 
-.sheet-StuntDisplay button[type="roll"].sheet-roll,
-.sheet-SkillDisplay button[type="action"],
-.sheet-SkillDisplay button[type="roll"] {
+.charsheet .StuntDisplay button[type="roll"].sheet-roll,
+.charsheet .SkillDisplay button[type="action"],
+.charsheet .SkillDisplay button[type="roll"] {
 	text-align: left;
 	padding-left: 6px;
 	padding-right: 6px;
@@ -774,17 +804,25 @@ input[value="list"] ~ .sheet-SkillList {
 	transition: background 0.25s ease, color 0.25s ease;
 }
 
-.sheet-ExtraDisplay .sheet-track {
+.sheet-darkmode .tab-content .charsheet .StuntDisplay button[type="roll"].sheet-roll,
+.sheet-darkmode .tab-content .charsheet .SkillDisplay button[type="action"],
+.sheet-darkmode .tab-content .charsheet .SkillDisplay button[type="roll"] {
+	text-shadow: 0 0 2px black;
+	color: #eee;
+	background-color: #1f1f1f;
+}
+
+.ExtraDisplay .track {
 	clear: both;
 }
 
-.sheet-ExtraDisplay .sheet-track .sheet-float-left {
+.ExtraDisplay .track .float-left {
 	float: left;
 	padding-right: 6px;
 	padding-bottom: 6px;
 }
 
-.sheet-ExtraDisplay button[type="roll"].sheet-roll {
+.charsheet .ExtraDisplay button[type="roll"].sheet-roll {
 	float: left; 
 	z-index: 2;
 	position: relative;
@@ -805,37 +843,43 @@ input[value="list"] ~ .sheet-SkillList {
 	transition: background 0.25s ease, color 0.25s ease;
 }
 
-.sheet-ExtraDisplay button[type="roll"].sheet-roll:active,
-.sheet-StuntDisplay button[type="roll"].sheet-roll:active,
-.sheet-SkillDisplay button[type="action"]:active,
-.sheet-SkillDisplay button[type="roll"]:active {
+.sheet-darkmode .tab-content .charsheet .ExtraDisplay button[type="roll"].sheet-roll {
+	color: #eee;
+	background-color: #1f1f1f;
+	text-shadow: 0 0 2px black;
+}
+
+.charsheet .ExtraDisplay button[type="roll"].sheet-roll:active,
+.charsheet .StuntDisplay button[type="roll"].sheet-roll:active,
+.charsheet .SkillDisplay button[type="action"]:active,
+.charsheet .SkillDisplay button[type="roll"]:active {
 	color: white;
 	text-shadow: 0 0 2px white;
 }
 
-.sheet-ExtraDisplay button[type="roll"].sheet-roll:hover,
-.sheet-StuntDisplay button[type="roll"].sheet-roll:hover,
-.sheet-SkillDisplay button[type="action"]:hover,
-.sheet-SkillDisplay button[type="roll"]:hover {
+.charsheet .ExtraDisplay button[type="roll"].sheet-roll:hover,
+.charsheet .StuntDisplay button[type="roll"].sheet-roll:hover,
+.charsheet .SkillDisplay button[type="action"]:hover,
+.charsheet .SkillDisplay button[type="roll"]:hover {
 	color: white;
 	text-shadow: 0 0 2px black;
 }
 
-.sheet-ExtraDisplay button[type="roll"].sheet-roll,
-.sheet-StuntDisplay button[type="roll"].sheet-roll,
-.sheet-SkillDisplay button[type="action"],
-.sheet-SkillDisplay button[type="roll"] {
+.charsheet .ExtraDisplay button[type="roll"].sheet-roll,
+.charsheet .StuntDisplay button[type="roll"].sheet-roll,
+.charsheet .SkillDisplay button[type="action"],
+.charsheet .SkillDisplay button[type="roll"] {
 	font-size: 14px;
 }
 
-.sheet-SkillDisplay .sheet-SkillList button[type="action"],
-.sheet-SkillDisplay .sheet-SkillList button[type="roll"] {
+.charsheet .SkillDisplay .SkillList button[type="action"],
+.charsheet .SkillDisplay .SkillList button[type="roll"] {
 	min-width: 225px;
 }
 
 /* Not sure this one's even in use */
 
-.sheet-SkillGrid div > span {
+.SkillGrid div > span {
 	display: inline-block;
 	min-width: 100px;
 	min-height: 15px; 
@@ -845,22 +889,26 @@ input[value="list"] ~ .sheet-SkillList {
 	border-radius: 6px;
 }
 
-.sheet-SkillGrid div > span[value=""] {
+.SkillGrid div > span[value=""] {
 	display: none;
 }
 
-.sheet-SkillGridRating {
+.SkillGridRating {
 	text-align: right;
 	min-width: 100px;
 	padding-right: 10px;
 	padding-top: 6px;
 }
 
-.sheet-align-right {
+.align-right {
 	text-align: right;
 }
 
-.sheet-OptionsTitleBar {
+.align-left {
+	text-align: left;
+}
+
+.OptionsTitleBar {
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
@@ -870,7 +918,7 @@ input[value="list"] ~ .sheet-SkillList {
 	vertical-align: bottom;
 }
 
-.sheet-EditTitleBar {
+.EditTitleBar {
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
@@ -884,20 +932,25 @@ input[value="list"] ~ .sheet-SkillList {
 
 /* Checkbox Tricks */
 
-input[type="checkbox"].sheet-checkbox {
+input[type="checkbox"].checkbox {
 	opacity: 0.0;
 	width: 20px;
 	height: 20px;
 	position: relative;
-	top: -3px;
-	left: 9px;
+	top: 0px; /* was -3px for legacy; */
+	left: 10px; /* 9px; */
 	margin: -10px;
 	cursor: pointer;
 	z-index: 1;
 	vertical-align: middle;
+	display: inline-block;
 }
 
-input[type="checkbox"].sheet-checkbox + span.sheet-pencilbox::before {
+.SectionHeader .boxcorner input[type="checkbox"].checkbox {
+	top: 14px;
+}
+
+input[type="checkbox"].checkbox + span.pencilbox::before {
 	margin-right: 0px;
 	margin-left: 3px;
 	line-height: 18px;
@@ -912,29 +965,34 @@ input[type="checkbox"].sheet-checkbox + span.sheet-pencilbox::before {
 	font-size: 18px;
 }
 
-input[type="checkbox"].sheet-checkbox:checked + span.sheet-pencilbox::before {
+input[type="checkbox"].checkbox:checked + span.pencilbox::before {
 	content: "D";
 	text-transform: uppercase; /* To enforce uppercase D */
 }
 
-.sheet-pencilbox,
-.sheet-optionsbox {
+.pencilbox,
+.optionsbox {
 	opacity: 0.25;
 	transition: opacity 0.5s ease;
 }
 
-.sheet-EditTitleBar .sheet-pencilbox,
-.sheet-EditTitleBar .sheet-optionsbox,
-.sheet-OptionsTitleBar .sheet-pencilbox,
-.sheet-OptionsTitleBar .sheet-optionsbox,
-input[type="checkbox"].sheet-checkbox:hover + .sheet-pencilbox,
-.sheet-pencilbox:hover,
-input[type="checkbox"].sheet-checkbox:hover + .sheet-optionsbox,
-.sheet-optionsbox:hover {
+.sheet-darkmode .tab-content .charsheet .pencilbox,
+.sheet-darkmode .tab-content .charsheet .optionsbox {
+	opacity: 0.4;
+}
+
+.EditTitleBar .pencilbox,
+.EditTitleBar .optionsbox,
+.OptionsTitleBar .pencilbox,
+.OptionsTitleBar .optionsbox,
+input[type="checkbox"].checkbox:hover + .pencilbox,
+.pencilbox:hover,
+input[type="checkbox"].checkbox:hover + .optionsbox,
+.optionsbox:hover {
 	opacity: 1.0; 
 }
 
-input[type="checkbox"].sheet-checkbox + span.sheet-optionsbox::before {
+input[type="checkbox"].checkbox + span.optionsbox::before {
 	margin-right: 0px;
 	margin-left: 3px;
 	line-height: 18px;
@@ -949,12 +1007,12 @@ input[type="checkbox"].sheet-checkbox + span.sheet-optionsbox::before {
 	font-size: 18px;
 }
 
-input[type="checkbox"].sheet-checkbox:checked + span.sheet-optionsbox::before {
+input[type="checkbox"].checkbox:checked + span.optionsbox::before {
 	content: "2";
 	font-style: normal;
 }
 
-input[type="checkbox"].sheet-checkbox + span.sheet-checker::before {
+input[type="checkbox"].checkbox + span.checker::before {
 	margin-right: 0px;
 	margin-left: 3px;
 	line-height: 18px;
@@ -970,15 +1028,15 @@ input[type="checkbox"].sheet-checkbox + span.sheet-checker::before {
 	font-size: 18px;
 }
 
-input[type="checkbox"].sheet-checkbox:checked + span.sheet-checker::before {
+input[type="checkbox"].checkbox:checked + span.checker::before {
 	content: "2";
 }
 
-input[type="text"].sheet-tracker {
+input[type="text"].tracker {
 	width: 1.67em;
 }
 
-input[type="checkbox"].sheet-checkbox + span.sheet-tracker {
+input[type="checkbox"].checkbox + span.tracker {
 	margin-right: 0px;
 	margin-left: 0px;
 	line-height: 18px;
@@ -997,25 +1055,25 @@ input[type="checkbox"].sheet-checkbox + span.sheet-tracker {
 	transition: background 0.3s ease, color 0.3s ease;
 }
 
-input[type="checkbox"].sheet-checkbox:checked + span.sheet-tracker {
+input[type="checkbox"].checkbox:checked + span.tracker {
 	border: 1px solid black;
 	color: white;
 }
 
-input[type="checkbox"].sheet-checkbox:checked + span.sheet-checkmark::before {
+input[type="checkbox"].checkbox:checked + span.checkmark::before {
 	content: "2";
 	opacity: 1.0;
 }
 
-input[type="checkbox"].sheet-checkbox:hover + span.sheet-checkmark::before {
+input[type="checkbox"].checkbox:hover + span.checkmark::before {
 	opacity: 0.5;
 }
 
-input[type="checkbox"].sheet-checkbox:checked:hover + span.sheet-checkmark::before {
+input[type="checkbox"].checkbox:checked:hover + span.checkmark::before {
 	opacity: 1.0;
 }
 
-input[type="checkbox"].sheet-checkbox + span.sheet-checkmark::before {
+input[type="checkbox"].checkbox + span.checkmark::before {
 	margin-right: 0px;
 	margin-left: 3px;
 	line-height: 18px;
@@ -1031,41 +1089,41 @@ input[type="checkbox"].sheet-checkbox + span.sheet-checkmark::before {
 	font-size: 18px;
 }
 
-input[type="checkbox"].sheet-hidebox, 
-input[type="checkbox"].sheet-hidebox:checked, 
-input[type="checkbox"].sheet-triggerbox, 
-input[type="checkbox"].sheet-triggerbox:checked {
+input[type="checkbox"].hidebox, 
+input[type="checkbox"].hidebox:checked, 
+input[type="checkbox"].triggerbox, 
+input[type="checkbox"].triggerbox:checked {
 	display: none;
 }
 
-input[type="checkbox"].sheet-triggerbox + * {
+input[type="checkbox"].triggerbox + * {
 	display: none;
 }
 
-input[type="checkbox"].sheet-triggerbox:checked + * {
+input[type="checkbox"].triggerbox:checked + * {
 	display: initial;
 }
 
-input[type="checkbox"].sheet-deeptrigger, 
-input[type="checkbox"].sheet-deeptrigger:checked {
+input[type="checkbox"].deeptrigger, 
+input[type="checkbox"].deeptrigger:checked {
 	display: none;
 }
 
-.sheet-deeptrigger ~ * .sheet-deeptriggered {
+.deeptrigger ~ * .deeptriggered {
 	display: none;
 }
 
-input[type="checkbox"].sheet-deeptrigger:checked ~ * .sheet-deeptriggered {
+input[type="checkbox"].deeptrigger:checked ~ * .deeptriggered {
 	display: initial;
 }
 
 /* Skill Combo Columns */
 
-.sheet-ComboColumns {
+.ComboColumns {
 	display: flex;
 }
 
-.sheet-ComboColumn {
+.ComboColumn {
 	flex-flow: column;
 	padding-right: 6px;
 	padding-left: 6px;
@@ -1074,11 +1132,11 @@ input[type="checkbox"].sheet-deeptrigger:checked ~ * .sheet-deeptriggered {
 
 /* Corruption */
 
-.sheet-CorrClock {
+.CorrClock {
 	min-height: 150px;
 }
 
-.sheet-CorrClock > div {
+.CorrClock > div {
 	background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Fate/pics/Clock0.png);
 	background-repeat: no-repeat;
 	background-position: center;
@@ -1093,27 +1151,27 @@ input[type="checkbox"].sheet-deeptrigger:checked ~ * .sheet-deeptriggered {
 	justify-content: center;
 }
 
-input.sheet-corruptor[value="0"] + .sheet-CorrClock > div {
+input.corruptor[value="0"] + .CorrClock > div {
 	background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Fate/pics/Clock0.png);
 }
 
-input.sheet-corruptor[value="1"] + .sheet-CorrClock > div {
+input.corruptor[value="1"] + .CorrClock > div {
 	background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Fate/pics/Clock1.png);
 }
 
-input.sheet-corruptor[value="2"] + .sheet-CorrClock > div {
+input.corruptor[value="2"] + .CorrClock > div {
 	background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Fate/pics/Clock2.png);
 }
 
-input.sheet-corruptor[value="3"] + .sheet-CorrClock > div {
+input.corruptor[value="3"] + .CorrClock > div {
 	background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Fate/pics/Clock3.png);
 }
 
-input.sheet-corruptor[value="4"] + .sheet-CorrClock > div {
+input.corruptor[value="4"] + .CorrClock > div {
 	background-image: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Fate/pics/Clock4.png);
 }
 
-.sheet-CorrClock > div > input[type=number] {
+.CorrClock > div > input[type=number] {
 	background: rgba(0,0,0,0.5);
 	width: 0em;
 	opacity: 0;
@@ -1127,130 +1185,130 @@ input.sheet-corruptor[value="4"] + .sheet-CorrClock > div {
 	text-align: center;
 }
 
-.sheet-CorrClock:hover > div > input[type=number] {
+.CorrClock:hover > div > input[type=number] {
 	opacity: 1;
 	width: 2em;
 }
 
 /* Insane, but it does the job */
 
-input.sheet-hideAllBut ~ * {
+input.hideAllBut ~ * {
 	display: none;
 }
 
-input.sheet-hideAllBut[value="10"] + * + * + * + * + * + * + * + * + * + *,
-input.sheet-hideAllBut[value="10"] + * + * + * + * + * + * + * + * + *,
-input.sheet-hideAllBut[value="10"] + * + * + * + * + * + * + * + *,
-input.sheet-hideAllBut[value="10"] + * + * + * + * + * + * + *,
-input.sheet-hideAllBut[value="10"] + * + * + * + * + * + *,
-input.sheet-hideAllBut[value="10"] + * + * + * + * + *,
-input.sheet-hideAllBut[value="10"] + * + * + * + *,
-input.sheet-hideAllBut[value="10"] + * + * + *,
-input.sheet-hideAllBut[value="10"] + * + *,
-input.sheet-hideAllBut[value="10"] + *,
-input.sheet-hideAllBut[value="9"] + * + * + * + * + * + * + * + * + *,
-input.sheet-hideAllBut[value="9"] + * + * + * + * + * + * + * + *,
-input.sheet-hideAllBut[value="9"] + * + * + * + * + * + * + *,
-input.sheet-hideAllBut[value="9"] + * + * + * + * + * + *,
-input.sheet-hideAllBut[value="9"] + * + * + * + * + *,
-input.sheet-hideAllBut[value="9"] + * + * + * + *,
-input.sheet-hideAllBut[value="9"] + * + * + *,
-input.sheet-hideAllBut[value="9"] + * + *,
-input.sheet-hideAllBut[value="9"] + *,
-input.sheet-hideAllBut[value="8"] + * + * + * + * + * + * + * + *,
-input.sheet-hideAllBut[value="8"] + * + * + * + * + * + * + *,
-input.sheet-hideAllBut[value="8"] + * + * + * + * + * + *,
-input.sheet-hideAllBut[value="8"] + * + * + * + * + *,
-input.sheet-hideAllBut[value="8"] + * + * + * + *,
-input.sheet-hideAllBut[value="8"] + * + * + *,
-input.sheet-hideAllBut[value="8"] + * + *,
-input.sheet-hideAllBut[value="8"] + *,
-input.sheet-hideAllBut[value="7"] + * + * + * + * + * + * + *,
-input.sheet-hideAllBut[value="7"] + * + * + * + * + * + *,
-input.sheet-hideAllBut[value="7"] + * + * + * + * + *,
-input.sheet-hideAllBut[value="7"] + * + * + * + *,
-input.sheet-hideAllBut[value="7"] + * + * + *,
-input.sheet-hideAllBut[value="7"] + * + *,
-input.sheet-hideAllBut[value="7"] + *,
-input.sheet-hideAllBut[value="6"] + * + * + * + * + * + *,
-input.sheet-hideAllBut[value="6"] + * + * + * + * + *,
-input.sheet-hideAllBut[value="6"] + * + * + * + *,
-input.sheet-hideAllBut[value="6"] + * + * + *,
-input.sheet-hideAllBut[value="6"] + * + *,
-input.sheet-hideAllBut[value="6"] + *,
-input.sheet-hideAllBut[value="5"] + * + * + * + * + *,
-input.sheet-hideAllBut[value="5"] + * + * + * + *,
-input.sheet-hideAllBut[value="5"] + * + * + *,
-input.sheet-hideAllBut[value="5"] + * + *,
-input.sheet-hideAllBut[value="5"] + *,
-input.sheet-hideAllBut[value="4"] + * + * + * + *,
-input.sheet-hideAllBut[value="4"] + * + * + *,
-input.sheet-hideAllBut[value="4"] + * + *,
-input.sheet-hideAllBut[value="4"] + *,
-input.sheet-hideAllBut[value="3"] + * + * + *,
-input.sheet-hideAllBut[value="3"] + * + *,
-input.sheet-hideAllBut[value="3"] + *,
-input.sheet-hideAllBut[value="2"] + * + *,
-input.sheet-hideAllBut[value="2"] + *,
-input.sheet-hideAllBut[value="1"] + * {
+input.hideAllBut[value="10"] + * + * + * + * + * + * + * + * + * + *,
+input.hideAllBut[value="10"] + * + * + * + * + * + * + * + * + *,
+input.hideAllBut[value="10"] + * + * + * + * + * + * + * + *,
+input.hideAllBut[value="10"] + * + * + * + * + * + * + *,
+input.hideAllBut[value="10"] + * + * + * + * + * + *,
+input.hideAllBut[value="10"] + * + * + * + * + *,
+input.hideAllBut[value="10"] + * + * + * + *,
+input.hideAllBut[value="10"] + * + * + *,
+input.hideAllBut[value="10"] + * + *,
+input.hideAllBut[value="10"] + *,
+input.hideAllBut[value="9"] + * + * + * + * + * + * + * + * + *,
+input.hideAllBut[value="9"] + * + * + * + * + * + * + * + *,
+input.hideAllBut[value="9"] + * + * + * + * + * + * + *,
+input.hideAllBut[value="9"] + * + * + * + * + * + *,
+input.hideAllBut[value="9"] + * + * + * + * + *,
+input.hideAllBut[value="9"] + * + * + * + *,
+input.hideAllBut[value="9"] + * + * + *,
+input.hideAllBut[value="9"] + * + *,
+input.hideAllBut[value="9"] + *,
+input.hideAllBut[value="8"] + * + * + * + * + * + * + * + *,
+input.hideAllBut[value="8"] + * + * + * + * + * + * + *,
+input.hideAllBut[value="8"] + * + * + * + * + * + *,
+input.hideAllBut[value="8"] + * + * + * + * + *,
+input.hideAllBut[value="8"] + * + * + * + *,
+input.hideAllBut[value="8"] + * + * + *,
+input.hideAllBut[value="8"] + * + *,
+input.hideAllBut[value="8"] + *,
+input.hideAllBut[value="7"] + * + * + * + * + * + * + *,
+input.hideAllBut[value="7"] + * + * + * + * + * + *,
+input.hideAllBut[value="7"] + * + * + * + * + *,
+input.hideAllBut[value="7"] + * + * + * + *,
+input.hideAllBut[value="7"] + * + * + *,
+input.hideAllBut[value="7"] + * + *,
+input.hideAllBut[value="7"] + *,
+input.hideAllBut[value="6"] + * + * + * + * + * + *,
+input.hideAllBut[value="6"] + * + * + * + * + *,
+input.hideAllBut[value="6"] + * + * + * + *,
+input.hideAllBut[value="6"] + * + * + *,
+input.hideAllBut[value="6"] + * + *,
+input.hideAllBut[value="6"] + *,
+input.hideAllBut[value="5"] + * + * + * + * + *,
+input.hideAllBut[value="5"] + * + * + * + *,
+input.hideAllBut[value="5"] + * + * + *,
+input.hideAllBut[value="5"] + * + *,
+input.hideAllBut[value="5"] + *,
+input.hideAllBut[value="4"] + * + * + * + *,
+input.hideAllBut[value="4"] + * + * + *,
+input.hideAllBut[value="4"] + * + *,
+input.hideAllBut[value="4"] + *,
+input.hideAllBut[value="3"] + * + * + *,
+input.hideAllBut[value="3"] + * + *,
+input.hideAllBut[value="3"] + *,
+input.hideAllBut[value="2"] + * + *,
+input.hideAllBut[value="2"] + *,
+input.hideAllBut[value="1"] + * {
 	display: initial;
 }
 
-input.sheet-hideAllBut[value="10"] + * + * + * + * + * + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="10"] + * + * + * + * + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="10"] + * + * + * + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="10"] + * + * + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="10"] + * + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="10"] + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="10"] + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="10"] + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="10"] + * + .sheet-iblock,
-input.sheet-hideAllBut[value="10"] + .sheet-iblock,
-input.sheet-hideAllBut[value="9"] + * + * + * + * + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="9"] + * + * + * + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="9"] + * + * + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="9"] + * + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="9"] + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="9"] + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="9"] + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="9"] + * + .sheet-iblock,
-input.sheet-hideAllBut[value="9"] + .sheet-iblock,
-input.sheet-hideAllBut[value="8"] + * + * + * + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="8"] + * + * + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="8"] + * + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="8"] + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="8"] + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="8"] + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="8"] + * + .sheet-iblock,
-input.sheet-hideAllBut[value="8"] + .sheet-iblock,
-input.sheet-hideAllBut[value="7"] + * + * + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="7"] + * + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="7"] + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="7"] + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="7"] + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="7"] + * + .sheet-iblock,
-input.sheet-hideAllBut[value="7"] + .sheet-iblock,
-input.sheet-hideAllBut[value="6"] + * + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="6"] + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="6"] + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="6"] + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="6"] + * + .sheet-iblock,
-input.sheet-hideAllBut[value="6"] + .sheet-iblock,
-input.sheet-hideAllBut[value="5"] + * + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="5"] + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="5"] + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="5"] + * + .sheet-iblock,
-input.sheet-hideAllBut[value="5"] + .sheet-iblock,
-input.sheet-hideAllBut[value="4"] + * + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="4"] + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="4"] + * + .sheet-iblock,
-input.sheet-hideAllBut[value="4"] + .sheet-iblock,
-input.sheet-hideAllBut[value="3"] + * + * + .sheet-iblock,
-input.sheet-hideAllBut[value="3"] + * + .sheet-iblock,
-input.sheet-hideAllBut[value="3"] + .sheet-iblock,
-input.sheet-hideAllBut[value="2"] + * + .sheet-iblock,
-input.sheet-hideAllBut[value="2"] + .sheet-iblock,
-input.sheet-hideAllBut[value="1"] + .sheet-iblock {
+input.hideAllBut[value="10"] + * + * + * + * + * + * + * + * + * + .iblock,
+input.hideAllBut[value="10"] + * + * + * + * + * + * + * + * + .iblock,
+input.hideAllBut[value="10"] + * + * + * + * + * + * + * + .iblock,
+input.hideAllBut[value="10"] + * + * + * + * + * + * + .iblock,
+input.hideAllBut[value="10"] + * + * + * + * + * + .iblock,
+input.hideAllBut[value="10"] + * + * + * + * + .iblock,
+input.hideAllBut[value="10"] + * + * + * + .iblock,
+input.hideAllBut[value="10"] + * + * + .iblock,
+input.hideAllBut[value="10"] + * + .iblock,
+input.hideAllBut[value="10"] + .iblock,
+input.hideAllBut[value="9"] + * + * + * + * + * + * + * + * + .iblock,
+input.hideAllBut[value="9"] + * + * + * + * + * + * + * + .iblock,
+input.hideAllBut[value="9"] + * + * + * + * + * + * + .iblock,
+input.hideAllBut[value="9"] + * + * + * + * + * + .iblock,
+input.hideAllBut[value="9"] + * + * + * + * + .iblock,
+input.hideAllBut[value="9"] + * + * + * + .iblock,
+input.hideAllBut[value="9"] + * + * + .iblock,
+input.hideAllBut[value="9"] + * + .iblock,
+input.hideAllBut[value="9"] + .iblock,
+input.hideAllBut[value="8"] + * + * + * + * + * + * + * + .iblock,
+input.hideAllBut[value="8"] + * + * + * + * + * + * + .iblock,
+input.hideAllBut[value="8"] + * + * + * + * + * + .iblock,
+input.hideAllBut[value="8"] + * + * + * + * + .iblock,
+input.hideAllBut[value="8"] + * + * + * + .iblock,
+input.hideAllBut[value="8"] + * + * + .iblock,
+input.hideAllBut[value="8"] + * + .iblock,
+input.hideAllBut[value="8"] + .iblock,
+input.hideAllBut[value="7"] + * + * + * + * + * + * + .iblock,
+input.hideAllBut[value="7"] + * + * + * + * + * + .iblock,
+input.hideAllBut[value="7"] + * + * + * + * + .iblock,
+input.hideAllBut[value="7"] + * + * + * + .iblock,
+input.hideAllBut[value="7"] + * + * + .iblock,
+input.hideAllBut[value="7"] + * + .iblock,
+input.hideAllBut[value="7"] + .iblock,
+input.hideAllBut[value="6"] + * + * + * + * + * + .iblock,
+input.hideAllBut[value="6"] + * + * + * + * + .iblock,
+input.hideAllBut[value="6"] + * + * + * + .iblock,
+input.hideAllBut[value="6"] + * + * + .iblock,
+input.hideAllBut[value="6"] + * + .iblock,
+input.hideAllBut[value="6"] + .iblock,
+input.hideAllBut[value="5"] + * + * + * + * + .iblock,
+input.hideAllBut[value="5"] + * + * + * + .iblock,
+input.hideAllBut[value="5"] + * + * + .iblock,
+input.hideAllBut[value="5"] + * + .iblock,
+input.hideAllBut[value="5"] + .iblock,
+input.hideAllBut[value="4"] + * + * + * + .iblock,
+input.hideAllBut[value="4"] + * + * + .iblock,
+input.hideAllBut[value="4"] + * + .iblock,
+input.hideAllBut[value="4"] + .iblock,
+input.hideAllBut[value="3"] + * + * + .iblock,
+input.hideAllBut[value="3"] + * + .iblock,
+input.hideAllBut[value="3"] + .iblock,
+input.hideAllBut[value="2"] + * + .iblock,
+input.hideAllBut[value="2"] + .iblock,
+input.hideAllBut[value="1"] + .iblock {
 	display: inline-block;
 }
 
@@ -1285,7 +1343,7 @@ input.sheet-hideAllBut[value="1"] + .sheet-iblock {
 	min-height: 50px;
 }
 
-.sheet-rolltemplate-fateroll .sheet-roll .inlinerollresult {
+.sheet-rolltemplate-fateroll .sheet-roll .sheet-inlinerollresult {
 	display: inline-block;
 	color: white;
 	font-weight: bold;
@@ -1339,7 +1397,7 @@ input.sheet-hideAllBut[value="1"] + .sheet-iblock {
 	display: block;
 }
 
-button[type="roll"].sheet-share:before {
+.charsheet button[type="roll"].share:before {
 	font-family: "Pictos";
 	font-style: normal;
 	text-transform: uppercase;
@@ -1347,16 +1405,21 @@ button[type="roll"].sheet-share:before {
 	content: 'R';
 }
 
-button[type="roll"].sheet-share:hover {
+.charsheet button[type="roll"].share:hover {
 	opacity: 100%;
 }
 
-button[type="roll"].sheet-share {
+.charsheet button[type="roll"].share {
 	opacity: 25%;
 	background: transparent;
 	border-style: none;
 	margin: 0px;
 	padding: 0px;
+	transition: opacity 0.5s ease;
+}
+
+.sheet-darkmode .tab-content .charsheet button[type="roll"].share {
+	opacity: 40%;
 }
 
 /* Color Theme Shenanigans */
@@ -1379,122 +1442,175 @@ button[type="roll"].sheet-share {
 	background-image: url("https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Fate/pics/RollingDice.jpg");
 }
 
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-share,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-optionsbox,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-OptionsTitleBar,
-input[value="blue"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-checker::before,
-input[value="blue"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-checkmark::before,
-input[value="blue"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox + span.sheet-checkmark::before,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-Bar,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-pronounbox,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-fpbox,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-fpbox input[type=number],
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-optwrap,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-AspectLabelBar,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-aspect .sheet-label,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-specific input[type="text"],
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-track .sheet-optionsbox,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-recovery .sheet-label,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-charname {
+input[value="blue"].theme + .Wrapper .share,
+input[value="blue"].theme + .Wrapper .optionsbox,
+input[value="blue"].theme + .Wrapper .OptionsTitleBar,
+input[value="blue"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checker::before,
+input[value="blue"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checkmark::before,
+input[value="blue"].theme + .Wrapper input[type="checkbox"].checkbox + span.checkmark::before,
+input[value="blue"].theme + .Wrapper .SectionHeader,
+input[value="blue"].theme + .Wrapper .Bar,
+input[value="blue"].theme + .Wrapper .pronounbox,
+input[value="blue"].theme + .Wrapper .fpbox,
+input[value="blue"].theme + .Wrapper .fpbox input[type=number],
+input[value="blue"].theme + .Wrapper .optwrap,
+input[value="blue"].theme + .Wrapper .AspectLabelBar,
+input[value="blue"].theme + .Wrapper .aspect .label,
+/* input[value="blue"].theme + .Wrapper .specific input[type="text"], */
+input[value="blue"].theme + .Wrapper .track .optionsbox,
+input[value="blue"].theme + .Wrapper .recovery .label,
+input[value="blue"].theme + .Wrapper .charname {
 	color: #1b75bb;
 }
 
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-icon,
-input[value="blue"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-tracker,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-EditTitleBar {
+input[value="blue"].theme + .Wrapper .icon,
+input[value="blue"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.tracker,
+input[value="blue"].theme + .Wrapper .EditTitleBar {
 	background: #1b75bb;
 }
 
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-powerflex,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-specific input[type="text"] {
+input[value="blue"].theme + .Wrapper .powerflex,
+input[value="blue"].theme + .Wrapper .specific input[type="text"] {
 	border-bottom: 1px solid #1b75bb;
 }
 
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid div > span,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="blue"].theme + .Wrapper .SkillGrid div > span,
+input[value="blue"].theme + .Wrapper .TrackEdit,
+input[value="blue"].theme + .Wrapper .AspectEdit,
+input[value="blue"].theme + .Wrapper .NoteEdit,
+input[value="blue"].theme + .Wrapper .ExtraEdit,
+input[value="blue"].theme + .Wrapper .StuntEdit,
+input[value="blue"].theme + .Wrapper .PowerEdit,
+input[value="blue"].theme + .Wrapper .SkillEdit,
+input[value="blue"].theme + .Wrapper .OptionsEdit,
+input[value="blue"].theme + .Wrapper .SectionHeader ~ div,
+input[value="blue"].theme + .Wrapper .optbar > span {
 	border: 1px solid #1b75bb;
 }
 
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="blue"].theme + .Wrapper .TrackEdit,
+input[value="blue"].theme + .Wrapper .AspectEdit,
+input[value="blue"].theme + .Wrapper .NoteEdit,
+input[value="blue"].theme + .Wrapper .ExtraEdit,
+input[value="blue"].theme + .Wrapper .StuntEdit,
+input[value="blue"].theme + .Wrapper .PowerEdit,
+input[value="blue"].theme + .Wrapper .SkillEdit,
+input[value="blue"].theme + .Wrapper .OptionsEdit,
+input[value="blue"].theme + .Wrapper .SectionHeader ~ div,
+input[value="blue"].theme + .Wrapper .optbar > span {
 	box-shadow: 2px 2px 6px #1b75bb;
 }
 
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:active,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:active,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:active,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:active,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:hover,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:hover,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:hover,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:hover {
+.charsheet input[value="blue"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll:active,
+.charsheet input[value="blue"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll:active,
+.charsheet input[value="blue"].theme + .Wrapper .SkillDisplay button[type="action"]:active,
+.charsheet input[value="blue"].theme + .Wrapper .SkillDisplay button[type="roll"]:active,
+.charsheet input[value="blue"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll:hover,
+.charsheet input[value="blue"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll:hover,
+.charsheet input[value="blue"].theme + .Wrapper .SkillDisplay button[type="action"]:hover,
+.charsheet input[value="blue"].theme + .Wrapper .SkillDisplay button[type="roll"]:hover {
 	background: #1b75bb;
 }
 
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid > div:hover {
+input[value="blue"].theme + .Wrapper .SkillGrid > div:hover {
 	background: #dde8ff;
 }
 
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-AspectSeparator {
+input[value="blue"].theme + .Wrapper .AspectSeparator {
 	border: 1px solid #dde8ff;
 	box-shadow: 2px 2px 6px #dde8ff;
 }
 
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid > div {
+input[value="blue"].theme + .Wrapper .SkillGrid > div {
 	border-bottom: 1px solid #dde8ff;
 }
 
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid div > span,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-AspectSeparator,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="blue"].theme + .Wrapper .SkillGrid div > span,
+input[value="blue"].theme + .Wrapper .AspectSeparator,
+input[value="blue"].theme + .Wrapper .TrackEdit,
+input[value="blue"].theme + .Wrapper .AspectEdit,
+input[value="blue"].theme + .Wrapper .NoteEdit,
+input[value="blue"].theme + .Wrapper .ExtraEdit,
+input[value="blue"].theme + .Wrapper .StuntEdit,
+input[value="blue"].theme + .Wrapper .PowerEdit,
+input[value="blue"].theme + .Wrapper .SkillEdit,
+input[value="blue"].theme + .Wrapper .OptionsEdit,
+input[value="blue"].theme + .Wrapper .optbar > span {
 	background: #eef8ff;
 }
 
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"],
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"] {
+.charsheet input[value="blue"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll,
+.charsheet input[value="blue"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll,
+.charsheet input[value="blue"].theme + .Wrapper .SkillDisplay button[type="action"],
+.charsheet input[value="blue"].theme + .Wrapper .SkillDisplay button[type="roll"] {
 	border: 1px solid #eef8ff;
 }
 
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div {
+input[value="blue"].theme + .Wrapper .SectionHeader ~ div {
 	background-image: linear-gradient(to bottom,#eef8ff,white,white,white,#eef8ff);
 }
 
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit > .repcontainer,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit > .repcontainer,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit > .repcontainer,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit > .repcontainer,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit > .repcontainer,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit > .repcontainer,
-input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit > .repcontainer {
+input[value="blue"].theme + .Wrapper .AspectEdit > .repcontainer,
+input[value="blue"].theme + .Wrapper .TrackEdit > .repcontainer,
+input[value="blue"].theme + .Wrapper .StuntEdit > .repcontainer,
+input[value="blue"].theme + .Wrapper .PowerEdit > .repcontainer,
+input[value="blue"].theme + .Wrapper .NoteEdit > .repcontainer,
+input[value="blue"].theme + .Wrapper .ExtraEdit > .repcontainer,
+input[value="blue"].theme + .Wrapper .SkillEdit > .repcontainer {
 	background-image: linear-gradient(to bottom,white,#eef8ff);
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .SkillGrid > div:hover {
+	background: #00181f;
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .SkillGrid div > span,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .AspectSeparator,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .TrackEdit,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .AspectEdit,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .NoteEdit,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .ExtraEdit,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .StuntEdit,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .PowerEdit,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .SkillEdit,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .OptionsEdit,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .optbar > span {
+	background: #00181f;
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .SectionHeader ~ div {
+	background-image: linear-gradient(to bottom,#00181f,black,black,black,#00181f);
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .AspectEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .TrackEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .StuntEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .PowerEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .NoteEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .ExtraEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .SkillEdit > .repcontainer {
+	background-image: linear-gradient(to bottom,black,#00181f);
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .share,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .optionsbox,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .OptionsTitleBar,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checker::before,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checkmark::before,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper input[type="checkbox"].checkbox + span.checkmark::before,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .SectionHeader,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .Bar,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .pronounbox,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .fpbox,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .fpbox input[type=number],
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .optwrap,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .AspectLabelBar,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .aspect .label,
+/* input[value="blue"].theme + .Wrapper .specific input[type="text"], */
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .track .optionsbox,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .recovery .label,
+.sheet-darkmode .tab-content .charsheet input[value="blue"].theme + .Wrapper .charname {
+	color: #208cdf;
 }
 
 /* Green theme */
@@ -1515,123 +1631,177 @@ input[value="blue"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit > .repcontaine
 	border: 1px solid #356e45;
 }
 
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-share,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-optionsbox,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-OptionsTitleBar,
-input[value="green"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-checker::before,
-input[value="green"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-checkmark::before,
-input[value="green"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox + span.sheet-checkmark::before,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-Bar,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-pronounbox,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-fpbox,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-fpbox input[type=number],
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-optwrap,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-AspectLabelBar,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-aspect .sheet-label,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-specific input[type="text"],
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-track .sheet-optionsbox,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-recovery .sheet-label,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-charname {
+input[value="green"].theme + .Wrapper .share,
+input[value="green"].theme + .Wrapper .optionsbox,
+input[value="green"].theme + .Wrapper .OptionsTitleBar,
+input[value="green"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checker::before,
+input[value="green"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checkmark::before,
+input[value="green"].theme + .Wrapper input[type="checkbox"].checkbox + span.checkmark::before,
+input[value="green"].theme + .Wrapper .SectionHeader,
+input[value="green"].theme + .Wrapper .Bar,
+input[value="green"].theme + .Wrapper .pronounbox,
+input[value="green"].theme + .Wrapper .fpbox,
+input[value="green"].theme + .Wrapper .fpbox input[type=number],
+input[value="green"].theme + .Wrapper .optwrap,
+input[value="green"].theme + .Wrapper .AspectLabelBar,
+input[value="green"].theme + .Wrapper .aspect .label,
+/* input[value="green"].theme + .Wrapper .specific input[type="text"], */
+input[value="green"].theme + .Wrapper .track .optionsbox,
+input[value="green"].theme + .Wrapper .recovery .label,
+input[value="green"].theme + .Wrapper .charname {
 	color: #356e45;
 }
 
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-icon,
-input[value="green"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-tracker,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-EditTitleBar {
+input[value="green"].theme + .Wrapper .icon,
+input[value="green"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.tracker,
+input[value="green"].theme + .Wrapper .EditTitleBar {
 	background: #356e45;
 }
 
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-powerflex,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-specific input[type="text"] {
+input[value="green"].theme + .Wrapper .powerflex,
+input[value="green"].theme + .Wrapper .specific input[type="text"] {
 	border-bottom: 1px solid #356e45;
 }
 
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid div > span,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="green"].theme + .Wrapper .SkillGrid div > span,
+input[value="green"].theme + .Wrapper .TrackEdit,
+input[value="green"].theme + .Wrapper .AspectEdit,
+input[value="green"].theme + .Wrapper .NoteEdit,
+input[value="green"].theme + .Wrapper .ExtraEdit,
+input[value="green"].theme + .Wrapper .StuntEdit,
+input[value="green"].theme + .Wrapper .PowerEdit,
+input[value="green"].theme + .Wrapper .SkillEdit,
+input[value="green"].theme + .Wrapper .OptionsEdit,
+input[value="green"].theme + .Wrapper .SectionHeader ~ div,
+input[value="green"].theme + .Wrapper .optbar > span {
 	border: 1px solid #356e45;
 }
 
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="green"].theme + .Wrapper .TrackEdit,
+input[value="green"].theme + .Wrapper .AspectEdit,
+input[value="green"].theme + .Wrapper .NoteEdit,
+input[value="green"].theme + .Wrapper .ExtraEdit,
+input[value="green"].theme + .Wrapper .StuntEdit,
+input[value="green"].theme + .Wrapper .PowerEdit,
+input[value="green"].theme + .Wrapper .SkillEdit,
+input[value="green"].theme + .Wrapper .OptionsEdit,
+input[value="green"].theme + .Wrapper .SectionHeader ~ div,
+input[value="green"].theme + .Wrapper .optbar > span {
 	box-shadow: 2px 2px 6px #356e45;
 }
 
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:active,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:active,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:active,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:active,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:hover,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:hover,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:hover,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:hover {
+.charsheet input[value="green"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll:active,
+.charsheet input[value="green"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll:active,
+.charsheet input[value="green"].theme + .Wrapper .SkillDisplay button[type="action"]:active,
+.charsheet input[value="green"].theme + .Wrapper .SkillDisplay button[type="roll"]:active,
+.charsheet input[value="green"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll:hover,
+.charsheet input[value="green"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll:hover,
+.charsheet input[value="green"].theme + .Wrapper .SkillDisplay button[type="action"]:hover,
+.charsheet input[value="green"].theme + .Wrapper .SkillDisplay button[type="roll"]:hover {
 	background: #356e45;
 }
 
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid > div:hover {
+input[value="green"].theme + .Wrapper .SkillGrid > div:hover {
 	background: #ddffd5;
 }
 
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-AspectSeparator {
+input[value="green"].theme + .Wrapper .AspectSeparator {
 	border: 1px solid #ddffd5;
 	box-shadow: 2px 2px 6px #ddffd5;
 }
 
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid > div {
+input[value="green"].theme + .Wrapper .SkillGrid > div {
 	border-bottom: 1px solid #ddffd5;
 }
 
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid div > span,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-AspectSeparator,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="green"].theme + .Wrapper .SkillGrid div > span,
+input[value="green"].theme + .Wrapper .AspectSeparator,
+input[value="green"].theme + .Wrapper .TrackEdit,
+input[value="green"].theme + .Wrapper .AspectEdit,
+input[value="green"].theme + .Wrapper .NoteEdit,
+input[value="green"].theme + .Wrapper .ExtraEdit,
+input[value="green"].theme + .Wrapper .StuntEdit,
+input[value="green"].theme + .Wrapper .PowerEdit,
+input[value="green"].theme + .Wrapper .SkillEdit,
+input[value="green"].theme + .Wrapper .OptionsEdit,
+input[value="green"].theme + .Wrapper .optbar > span {
 	background: #eeffe5;
 }
 
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"],
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"] {
+.charsheet input[value="green"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll,
+.charsheet input[value="green"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll,
+.charsheet input[value="green"].theme + .Wrapper .SkillDisplay button[type="action"],
+.charsheet input[value="green"].theme + .Wrapper .SkillDisplay button[type="roll"] {
 	border: 1px solid #eeffe5;
 }
 
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div {
+input[value="green"].theme + .Wrapper .SectionHeader ~ div {
 	background-image: linear-gradient(to bottom,#eeffe5,white,white,white,#eeffe5);
 }
 
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit > .repcontainer,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit > .repcontainer,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit > .repcontainer,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit > .repcontainer,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit > .repcontainer,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit > .repcontainer,
-input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit > .repcontainer {
+input[value="green"].theme + .Wrapper .AspectEdit > .repcontainer,
+input[value="green"].theme + .Wrapper .TrackEdit > .repcontainer,
+input[value="green"].theme + .Wrapper .StuntEdit > .repcontainer,
+input[value="green"].theme + .Wrapper .PowerEdit > .repcontainer,
+input[value="green"].theme + .Wrapper .NoteEdit > .repcontainer,
+input[value="green"].theme + .Wrapper .ExtraEdit > .repcontainer,
+input[value="green"].theme + .Wrapper .SkillEdit > .repcontainer {
 	background-image: linear-gradient(to bottom,white,#eeffe5);
 }
+
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .SkillGrid > div:hover {
+	background: #001f05;
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .SkillGrid div > span,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .AspectSeparator,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .TrackEdit,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .AspectEdit,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .NoteEdit,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .ExtraEdit,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .StuntEdit,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .PowerEdit,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .SkillEdit,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .OptionsEdit,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .optbar > span {
+	background: #001f05;
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .SectionHeader ~ div {
+	background-image: linear-gradient(to bottom,#001f05,black,black,black,#001f05);
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .AspectEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .TrackEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .StuntEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .PowerEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .NoteEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .ExtraEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .SkillEdit > .repcontainer {
+	background-image: linear-gradient(to bottom,black,#001f05);
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .share,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .optionsbox,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .OptionsTitleBar,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checker::before,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checkmark::before,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper input[type="checkbox"].checkbox + span.checkmark::before,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .SectionHeader,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .Bar,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .pronounbox,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .fpbox,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .fpbox input[type=number],
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .optwrap,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .AspectLabelBar,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .aspect .label,
+/* input[value="green"].theme + .Wrapper .specific input[type="text"], */
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .track .optionsbox,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .recovery .label,
+.sheet-darkmode .tab-content .charsheet input[value="green"].theme + .Wrapper .charname {
+	color: #49975f;
+}
+
 
 /* Purple theme */
 
@@ -1651,123 +1821,177 @@ input[value="green"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit > .repcontain
 	border: 1px solid #3c1e5f;
 }
 
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-share,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-optionsbox,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-OptionsTitleBar,
-input[value="purple"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-checker::before,
-input[value="purple"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-checkmark::before,
-input[value="purple"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox + span.sheet-checkmark::before,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-Bar,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-pronounbox,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-fpbox,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-fpbox input[type=number],
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-optwrap,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-AspectLabelBar,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-aspect .sheet-label,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-specific input[type="text"],
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-track .sheet-optionsbox,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-recovery .sheet-label,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-charname {
+input[value="purple"].theme + .Wrapper .share,
+input[value="purple"].theme + .Wrapper .optionsbox,
+input[value="purple"].theme + .Wrapper .OptionsTitleBar,
+input[value="purple"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checker::before,
+input[value="purple"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checkmark::before,
+input[value="purple"].theme + .Wrapper input[type="checkbox"].checkbox + span.checkmark::before,
+input[value="purple"].theme + .Wrapper .SectionHeader,
+input[value="purple"].theme + .Wrapper .Bar,
+input[value="purple"].theme + .Wrapper .pronounbox,
+input[value="purple"].theme + .Wrapper .fpbox,
+input[value="purple"].theme + .Wrapper .fpbox input[type=number],
+input[value="purple"].theme + .Wrapper .optwrap,
+input[value="purple"].theme + .Wrapper .AspectLabelBar,
+input[value="purple"].theme + .Wrapper .aspect .label,
+/* input[value="purple"].theme + .Wrapper .specific input[type="text"], */
+input[value="purple"].theme + .Wrapper .track .optionsbox,
+input[value="purple"].theme + .Wrapper .recovery .label,
+input[value="purple"].theme + .Wrapper .charname {
 	color: #3c1e5f;
 }
 
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-icon,
-input[value="purple"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-tracker,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-EditTitleBar {
+input[value="purple"].theme + .Wrapper .icon,
+input[value="purple"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.tracker,
+input[value="purple"].theme + .Wrapper .EditTitleBar {
 	background: #3c1e5f;
 }
 
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-powerflex,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-specific input[type="text"] {
+input[value="purple"].theme + .Wrapper .powerflex,
+input[value="purple"].theme + .Wrapper .specific input[type="text"] {
 	border-bottom: 1px solid #3c1e5f;
 }
 
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid div > span,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="purple"].theme + .Wrapper .SkillGrid div > span,
+input[value="purple"].theme + .Wrapper .TrackEdit,
+input[value="purple"].theme + .Wrapper .AspectEdit,
+input[value="purple"].theme + .Wrapper .NoteEdit,
+input[value="purple"].theme + .Wrapper .ExtraEdit,
+input[value="purple"].theme + .Wrapper .StuntEdit,
+input[value="purple"].theme + .Wrapper .PowerEdit,
+input[value="purple"].theme + .Wrapper .SkillEdit,
+input[value="purple"].theme + .Wrapper .OptionsEdit,
+input[value="purple"].theme + .Wrapper .SectionHeader ~ div,
+input[value="purple"].theme + .Wrapper .optbar > span {
 	border: 1px solid #3c1e5f;
 }
 
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="purple"].theme + .Wrapper .TrackEdit,
+input[value="purple"].theme + .Wrapper .AspectEdit,
+input[value="purple"].theme + .Wrapper .NoteEdit,
+input[value="purple"].theme + .Wrapper .ExtraEdit,
+input[value="purple"].theme + .Wrapper .StuntEdit,
+input[value="purple"].theme + .Wrapper .PowerEdit,
+input[value="purple"].theme + .Wrapper .SkillEdit,
+input[value="purple"].theme + .Wrapper .OptionsEdit,
+input[value="purple"].theme + .Wrapper .SectionHeader ~ div,
+input[value="purple"].theme + .Wrapper .optbar > span {
 	box-shadow: 2px 2px 6px #3c1e5f;
 }
 
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:active,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:active,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:active,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:active,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:hover,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:hover,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:hover,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:hover {
+.charsheet input[value="purple"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll:active,
+.charsheet input[value="purple"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll:active,
+.charsheet input[value="purple"].theme + .Wrapper .SkillDisplay button[type="action"]:active,
+.charsheet input[value="purple"].theme + .Wrapper .SkillDisplay button[type="roll"]:active,
+.charsheet input[value="purple"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll:hover,
+.charsheet input[value="purple"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll:hover,
+.charsheet input[value="purple"].theme + .Wrapper .SkillDisplay button[type="action"]:hover,
+.charsheet input[value="purple"].theme + .Wrapper .SkillDisplay button[type="roll"]:hover {
 	background: #3c1e5f;
 }
 
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid > div:hover {
+input[value="purple"].theme + .Wrapper .SkillGrid > div:hover {
 	background: #e8ddee;
 }
 
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-AspectSeparator {
+input[value="purple"].theme + .Wrapper .AspectSeparator {
 	border: 1px solid #e8ddee;
 	box-shadow: 2px 2px 6px #e8ddee;
 }
 
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid > div {
+input[value="purple"].theme + .Wrapper .SkillGrid > div {
 	border-bottom: 1px solid #e8ddee;
 }
 
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid div > span,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-AspectSeparator,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="purple"].theme + .Wrapper .SkillGrid div > span,
+input[value="purple"].theme + .Wrapper .AspectSeparator,
+input[value="purple"].theme + .Wrapper .TrackEdit,
+input[value="purple"].theme + .Wrapper .AspectEdit,
+input[value="purple"].theme + .Wrapper .NoteEdit,
+input[value="purple"].theme + .Wrapper .ExtraEdit,
+input[value="purple"].theme + .Wrapper .StuntEdit,
+input[value="purple"].theme + .Wrapper .PowerEdit,
+input[value="purple"].theme + .Wrapper .SkillEdit,
+input[value="purple"].theme + .Wrapper .OptionsEdit,
+input[value="purple"].theme + .Wrapper .optbar > span {
 	background: #f8eeff;
 }
 
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"],
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"] {
+.charsheet input[value="purple"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll,
+.charsheet input[value="purple"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll,
+.charsheet input[value="purple"].theme + .Wrapper .SkillDisplay button[type="action"],
+.charsheet input[value="purple"].theme + .Wrapper .SkillDisplay button[type="roll"] {
 	border: 1px solid #f8eeff;
 }
 
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div {
+input[value="purple"].theme + .Wrapper .SectionHeader ~ div {
 	background-image: linear-gradient(to bottom,#f8eeff,white,white,white,#f8eeff);
 }
 
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit > .repcontainer,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit > .repcontainer,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit > .repcontainer,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit > .repcontainer,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit > .repcontainer,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit > .repcontainer,
-input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit > .repcontainer {
+input[value="purple"].theme + .Wrapper .AspectEdit > .repcontainer,
+input[value="purple"].theme + .Wrapper .TrackEdit > .repcontainer,
+input[value="purple"].theme + .Wrapper .StuntEdit > .repcontainer,
+input[value="purple"].theme + .Wrapper .PowerEdit > .repcontainer,
+input[value="purple"].theme + .Wrapper .NoteEdit > .repcontainer,
+input[value="purple"].theme + .Wrapper .ExtraEdit > .repcontainer,
+input[value="purple"].theme + .Wrapper .SkillEdit > .repcontainer {
 	background-image: linear-gradient(to bottom,white,#f8eeff);
 }
+
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .SkillGrid > div:hover {
+	background: #18001f;
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .SkillGrid div > span,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .AspectSeparator,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .TrackEdit,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .AspectEdit,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .NoteEdit,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .ExtraEdit,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .StuntEdit,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .PowerEdit,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .SkillEdit,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .OptionsEdit,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .optbar > span {
+	background: #18001f;
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .SectionHeader ~ div {
+	background-image: linear-gradient(to bottom,#18001f,black,black,black,#18001f);
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .AspectEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .TrackEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .StuntEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .PowerEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .NoteEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .ExtraEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .SkillEdit > .repcontainer {
+	background-image: linear-gradient(to bottom,black,#18001f);
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .share,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .optionsbox,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .OptionsTitleBar,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checker::before,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checkmark::before,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper input[type="checkbox"].checkbox + span.checkmark::before,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .SectionHeader,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .Bar,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .pronounbox,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .fpbox,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .fpbox input[type=number],
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .optwrap,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .AspectLabelBar,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .aspect .label,
+/* input[value="purple"].theme + .Wrapper .specific input[type="text"], */
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .track .optionsbox,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .recovery .label,
+.sheet-darkmode .tab-content .charsheet input[value="purple"].theme + .Wrapper .charname {
+	color: #aa61ff;
+}
+
 
 /* Cthulhu theme */
 
@@ -1787,123 +2011,177 @@ input[value="purple"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit > .repcontai
 	border: 1px solid #3a5224;
 }
 
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-share,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-optionsbox,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-OptionsTitleBar,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-checker::before,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-checkmark::before,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox + span.sheet-checkmark::before,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-Bar,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-pronounbox,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-fpbox,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-fpbox input[type=number],
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-optwrap,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-AspectLabelBar,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-aspect .sheet-label,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-specific input[type="text"],
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-track .sheet-optionsbox,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-recovery .sheet-label,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-charname {
+input[value="cthulhu"].theme + .Wrapper .share,
+input[value="cthulhu"].theme + .Wrapper .optionsbox,
+input[value="cthulhu"].theme + .Wrapper .OptionsTitleBar,
+input[value="cthulhu"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checker::before,
+input[value="cthulhu"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checkmark::before,
+input[value="cthulhu"].theme + .Wrapper input[type="checkbox"].checkbox + span.checkmark::before,
+input[value="cthulhu"].theme + .Wrapper .SectionHeader,
+input[value="cthulhu"].theme + .Wrapper .Bar,
+input[value="cthulhu"].theme + .Wrapper .pronounbox,
+input[value="cthulhu"].theme + .Wrapper .fpbox,
+input[value="cthulhu"].theme + .Wrapper .fpbox input[type=number],
+input[value="cthulhu"].theme + .Wrapper .optwrap,
+input[value="cthulhu"].theme + .Wrapper .AspectLabelBar,
+input[value="cthulhu"].theme + .Wrapper .aspect .label,
+/* input[value="cthulhu"].theme + .Wrapper .specific input[type="text"], */
+input[value="cthulhu"].theme + .Wrapper .track .optionsbox,
+input[value="cthulhu"].theme + .Wrapper .recovery .label,
+input[value="cthulhu"].theme + .Wrapper .charname {
 	color: #3a5224;
 }
 
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-icon,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-tracker,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-EditTitleBar {
+input[value="cthulhu"].theme + .Wrapper .icon,
+input[value="cthulhu"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.tracker,
+input[value="cthulhu"].theme + .Wrapper .EditTitleBar {
 	background: #3a5224;
 }
 
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-powerflex,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-specific input[type="text"] {
+input[value="cthulhu"].theme + .Wrapper .powerflex,
+input[value="cthulhu"].theme + .Wrapper .specific input[type="text"] {
 	border-bottom: 1px solid #3a5224;
 }
 
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid div > span,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="cthulhu"].theme + .Wrapper .SkillGrid div > span,
+input[value="cthulhu"].theme + .Wrapper .TrackEdit,
+input[value="cthulhu"].theme + .Wrapper .AspectEdit,
+input[value="cthulhu"].theme + .Wrapper .NoteEdit,
+input[value="cthulhu"].theme + .Wrapper .ExtraEdit,
+input[value="cthulhu"].theme + .Wrapper .StuntEdit,
+input[value="cthulhu"].theme + .Wrapper .PowerEdit,
+input[value="cthulhu"].theme + .Wrapper .SkillEdit,
+input[value="cthulhu"].theme + .Wrapper .OptionsEdit,
+input[value="cthulhu"].theme + .Wrapper .SectionHeader ~ div,
+input[value="cthulhu"].theme + .Wrapper .optbar > span {
 	border: 1px solid #3a5224;
 }
 
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="cthulhu"].theme + .Wrapper .TrackEdit,
+input[value="cthulhu"].theme + .Wrapper .AspectEdit,
+input[value="cthulhu"].theme + .Wrapper .NoteEdit,
+input[value="cthulhu"].theme + .Wrapper .ExtraEdit,
+input[value="cthulhu"].theme + .Wrapper .StuntEdit,
+input[value="cthulhu"].theme + .Wrapper .PowerEdit,
+input[value="cthulhu"].theme + .Wrapper .SkillEdit,
+input[value="cthulhu"].theme + .Wrapper .OptionsEdit,
+input[value="cthulhu"].theme + .Wrapper .SectionHeader ~ div,
+input[value="cthulhu"].theme + .Wrapper .optbar > span {
 	box-shadow: 2px 2px 6px #3a5224;
 }
 
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:active,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:active,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:active,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:active,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:hover,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:hover,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:hover,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:hover {
+.charsheet input[value="cthulhu"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll:active,
+.charsheet input[value="cthulhu"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll:active,
+.charsheet input[value="cthulhu"].theme + .Wrapper .SkillDisplay button[type="action"]:active,
+.charsheet input[value="cthulhu"].theme + .Wrapper .SkillDisplay button[type="roll"]:active,
+.charsheet input[value="cthulhu"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll:hover,
+.charsheet input[value="cthulhu"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll:hover,
+.charsheet input[value="cthulhu"].theme + .Wrapper .SkillDisplay button[type="action"]:hover,
+.charsheet input[value="cthulhu"].theme + .Wrapper .SkillDisplay button[type="roll"]:hover {
 	background: #3a5224;
 }
 
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid > div:hover {
+input[value="cthulhu"].theme + .Wrapper .SkillGrid > div:hover {
 	background: #a9c591;
 }
 
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-AspectSeparator {
+input[value="cthulhu"].theme + .Wrapper .AspectSeparator {
 	border: 1px solid #a9c591;
 	box-shadow: 2px 2px 6px #a9c591;
 }
 
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid > div {
+input[value="cthulhu"].theme + .Wrapper .SkillGrid > div {
 	border-bottom: 1px solid #a9c591;
 }
 
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid div > span,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-AspectSeparator,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="cthulhu"].theme + .Wrapper .SkillGrid div > span,
+input[value="cthulhu"].theme + .Wrapper .AspectSeparator,
+input[value="cthulhu"].theme + .Wrapper .TrackEdit,
+input[value="cthulhu"].theme + .Wrapper .AspectEdit,
+input[value="cthulhu"].theme + .Wrapper .NoteEdit,
+input[value="cthulhu"].theme + .Wrapper .ExtraEdit,
+input[value="cthulhu"].theme + .Wrapper .StuntEdit,
+input[value="cthulhu"].theme + .Wrapper .PowerEdit,
+input[value="cthulhu"].theme + .Wrapper .SkillEdit,
+input[value="cthulhu"].theme + .Wrapper .OptionsEdit,
+input[value="cthulhu"].theme + .Wrapper .optbar > span {
 	background: #d9e0d3;
 }
 
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"],
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"] {
+.charsheet input[value="cthulhu"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll,
+.charsheet input[value="cthulhu"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll,
+.charsheet input[value="cthulhu"].theme + .Wrapper .SkillDisplay button[type="action"],
+.charsheet input[value="cthulhu"].theme + .Wrapper .SkillDisplay button[type="roll"] {
 	border: 1px solid #d9e0d3;
 }
 
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div {
+input[value="cthulhu"].theme + .Wrapper .SectionHeader ~ div {
 	background-image: linear-gradient(to bottom,#d9e0d3,white,white,white,#d9e0d3);
 }
 
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit > .repcontainer,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit > .repcontainer,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit > .repcontainer,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit > .repcontainer,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit > .repcontainer,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit > .repcontainer,
-input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit > .repcontainer {
+input[value="cthulhu"].theme + .Wrapper .AspectEdit > .repcontainer,
+input[value="cthulhu"].theme + .Wrapper .TrackEdit > .repcontainer,
+input[value="cthulhu"].theme + .Wrapper .StuntEdit > .repcontainer,
+input[value="cthulhu"].theme + .Wrapper .PowerEdit > .repcontainer,
+input[value="cthulhu"].theme + .Wrapper .NoteEdit > .repcontainer,
+input[value="cthulhu"].theme + .Wrapper .ExtraEdit > .repcontainer,
+input[value="cthulhu"].theme + .Wrapper .SkillEdit > .repcontainer {
 	background-image: linear-gradient(to bottom,white,#d9e0d3);
 }
+
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .SkillGrid > div:hover {
+	background: #091003;
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .SkillGrid div > span,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .AspectSeparator,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .TrackEdit,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .AspectEdit,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .NoteEdit,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .ExtraEdit,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .StuntEdit,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .PowerEdit,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .SkillEdit,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .OptionsEdit,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .optbar > span {
+	background: #091003;
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .SectionHeader ~ div {
+	background-image: linear-gradient(to bottom,#001f05,black,black,black,#091003);
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .AspectEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .TrackEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .StuntEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .PowerEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .NoteEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .ExtraEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .SkillEdit > .repcontainer {
+	background-image: linear-gradient(to bottom,black,#091003);
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .share,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .optionsbox,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .OptionsTitleBar,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checker::before,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checkmark::before,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper input[type="checkbox"].checkbox + span.checkmark::before,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .SectionHeader,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .Bar,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .pronounbox,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .fpbox,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .fpbox input[type=number],
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .optwrap,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .AspectLabelBar,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .aspect .label,
+/* input[value="cthulhu"].theme + .Wrapper .specific input[type="text"], */
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .track .optionsbox,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .recovery .label,
+.sheet-darkmode .tab-content .charsheet input[value="cthulhu"].theme + .Wrapper .charname {
+	color: #689341;
+}
+
 
 /* Evil Hat theme */
 
@@ -1923,127 +2201,181 @@ input[value="cthulhu"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit > .repconta
 	border: 1px solid #000000;
 }
 
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-share,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-optionsbox,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-OptionsTitleBar,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-checker::before,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-checkmark::before,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox + span.sheet-checkmark::before,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-Bar,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-pronounbox,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-fpbox,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-fpbox input[type=number],
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-optwrap,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-AspectLabelBar,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-aspect .sheet-label,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-specific input[type="text"],
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-track .sheet-optionsbox,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-recovery .sheet-label,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-charname {
+input[value="evilhat"].theme + .Wrapper .share,
+input[value="evilhat"].theme + .Wrapper .optionsbox,
+input[value="evilhat"].theme + .Wrapper .OptionsTitleBar,
+input[value="evilhat"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checker::before,
+input[value="evilhat"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checkmark::before,
+input[value="evilhat"].theme + .Wrapper input[type="checkbox"].checkbox + span.checkmark::before,
+input[value="evilhat"].theme + .Wrapper .SectionHeader,
+input[value="evilhat"].theme + .Wrapper .Bar,
+input[value="evilhat"].theme + .Wrapper .pronounbox,
+input[value="evilhat"].theme + .Wrapper .fpbox,
+input[value="evilhat"].theme + .Wrapper .fpbox input[type=number],
+input[value="evilhat"].theme + .Wrapper .optwrap,
+input[value="evilhat"].theme + .Wrapper .AspectLabelBar,
+input[value="evilhat"].theme + .Wrapper .aspect .label,
+/* input[value="evilhat"].theme + .Wrapper .specific input[type="text"], */
+input[value="evilhat"].theme + .Wrapper .track .optionsbox,
+input[value="evilhat"].theme + .Wrapper .recovery .label,
+input[value="evilhat"].theme + .Wrapper .charname {
 	color: #990000;
 }
 
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-icon,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-tracker,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-EditTitleBar {
+input[value="evilhat"].theme + .Wrapper .icon,
+input[value="evilhat"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.tracker,
+input[value="evilhat"].theme + .Wrapper .EditTitleBar {
 	background: #990000;
 }
 
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-powerflex,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-EditTitleBar {
+input[value="evilhat"].theme + .Wrapper .powerflex,
+input[value="evilhat"].theme + .Wrapper .EditTitleBar {
 	border-bottom: 1px solid #000000;
 }
 
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-specific input[type="text"] {
+input[value="evilhat"].theme + .Wrapper .specific input[type="text"] {
 	border-bottom: 1px solid #000000;
 }
 
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid div > span,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="evilhat"].theme + .Wrapper .SkillGrid div > span,
+input[value="evilhat"].theme + .Wrapper .TrackEdit,
+input[value="evilhat"].theme + .Wrapper .AspectEdit,
+input[value="evilhat"].theme + .Wrapper .NoteEdit,
+input[value="evilhat"].theme + .Wrapper .ExtraEdit,
+input[value="evilhat"].theme + .Wrapper .StuntEdit,
+input[value="evilhat"].theme + .Wrapper .PowerEdit,
+input[value="evilhat"].theme + .Wrapper .SkillEdit,
+input[value="evilhat"].theme + .Wrapper .OptionsEdit,
+input[value="evilhat"].theme + .Wrapper .SectionHeader ~ div,
+input[value="evilhat"].theme + .Wrapper .optbar > span {
 	border: 1px solid #000000;
 }
 
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="evilhat"].theme + .Wrapper .TrackEdit,
+input[value="evilhat"].theme + .Wrapper .AspectEdit,
+input[value="evilhat"].theme + .Wrapper .NoteEdit,
+input[value="evilhat"].theme + .Wrapper .ExtraEdit,
+input[value="evilhat"].theme + .Wrapper .StuntEdit,
+input[value="evilhat"].theme + .Wrapper .PowerEdit,
+input[value="evilhat"].theme + .Wrapper .SkillEdit,
+input[value="evilhat"].theme + .Wrapper .OptionsEdit,
+input[value="evilhat"].theme + .Wrapper .SectionHeader ~ div,
+input[value="evilhat"].theme + .Wrapper .optbar > span {
 	box-shadow: 2px 2px 6px #990000;
 }
 
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:active,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:active,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:active,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:active,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:hover,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:hover,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:hover,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:hover {
+.charsheet input[value="evilhat"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll:active,
+.charsheet input[value="evilhat"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll:active,
+.charsheet input[value="evilhat"].theme + .Wrapper .SkillDisplay button[type="action"]:active,
+.charsheet input[value="evilhat"].theme + .Wrapper .SkillDisplay button[type="roll"]:active,
+.charsheet input[value="evilhat"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll:hover,
+.charsheet input[value="evilhat"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll:hover,
+.charsheet input[value="evilhat"].theme + .Wrapper .SkillDisplay button[type="action"]:hover,
+.charsheet input[value="evilhat"].theme + .Wrapper .SkillDisplay button[type="roll"]:hover {
 	background: #990000;
 }
 
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid > div:hover {
+input[value="evilhat"].theme + .Wrapper .SkillGrid > div:hover {
 	background: #e8dddd;
 }
 
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-AspectSeparator {
+input[value="evilhat"].theme + .Wrapper .AspectSeparator {
 	border: 1px solid #e8dddd;
 	box-shadow: 2px 2px 6px #990000;
 }
 
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid > div {
+input[value="evilhat"].theme + .Wrapper .SkillGrid > div {
 	border-bottom: 1px solid #990000;
 }
 
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid div > span,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-AspectSeparator,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="evilhat"].theme + .Wrapper .SkillGrid div > span,
+input[value="evilhat"].theme + .Wrapper .AspectSeparator,
+input[value="evilhat"].theme + .Wrapper .TrackEdit,
+input[value="evilhat"].theme + .Wrapper .AspectEdit,
+input[value="evilhat"].theme + .Wrapper .NoteEdit,
+input[value="evilhat"].theme + .Wrapper .ExtraEdit,
+input[value="evilhat"].theme + .Wrapper .StuntEdit,
+input[value="evilhat"].theme + .Wrapper .PowerEdit,
+input[value="evilhat"].theme + .Wrapper .SkillEdit,
+input[value="evilhat"].theme + .Wrapper .OptionsEdit,
+input[value="evilhat"].theme + .Wrapper .optbar > span {
 	background: #eeeeee;
 }
 
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"],
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"] {
+.charsheet input[value="evilhat"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll,
+.charsheet input[value="evilhat"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll,
+.charsheet input[value="evilhat"].theme + .Wrapper .SkillDisplay button[type="action"],
+.charsheet input[value="evilhat"].theme + .Wrapper .SkillDisplay button[type="roll"] {
 	border: 1px solid #eeeeee;
 }
 
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div {
+input[value="evilhat"].theme + .Wrapper .SectionHeader ~ div {
 	background-image: linear-gradient(to bottom,#eeeeee,white,white,white,#eeeeee);
 }
 
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit > .repcontainer,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit > .repcontainer,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit > .repcontainer,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit > .repcontainer,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit > .repcontainer,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit > .repcontainer,
-input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit > .repcontainer {
+input[value="evilhat"].theme + .Wrapper .AspectEdit > .repcontainer,
+input[value="evilhat"].theme + .Wrapper .TrackEdit > .repcontainer,
+input[value="evilhat"].theme + .Wrapper .StuntEdit > .repcontainer,
+input[value="evilhat"].theme + .Wrapper .PowerEdit > .repcontainer,
+input[value="evilhat"].theme + .Wrapper .NoteEdit > .repcontainer,
+input[value="evilhat"].theme + .Wrapper .ExtraEdit > .repcontainer,
+input[value="evilhat"].theme + .Wrapper .SkillEdit > .repcontainer {
 	background-image: linear-gradient(to bottom,white,#eeeeee);
 }
+
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .SkillGrid > div:hover {
+	background: #111111;
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .SkillGrid div > span,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .AspectSeparator,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .TrackEdit,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .AspectEdit,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .NoteEdit,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .ExtraEdit,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .StuntEdit,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .PowerEdit,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .SkillEdit,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .OptionsEdit,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .optbar > span {
+	background: #111111;
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .SectionHeader ~ div {
+	background-image: linear-gradient(to bottom,#111111,black,black,black,#111111);
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .AspectEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .TrackEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .StuntEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .PowerEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .NoteEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .ExtraEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .SkillEdit > .repcontainer {
+	background-image: linear-gradient(to bottom,black,#111111);
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .share,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .optionsbox,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .OptionsTitleBar,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checker::before,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checkmark::before,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper input[type="checkbox"].checkbox + span.checkmark::before,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .SectionHeader,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .Bar,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .pronounbox,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .fpbox,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .fpbox input[type=number],
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .optwrap,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .AspectLabelBar,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .aspect .label,
+/* input[value="evilhat"].theme + .Wrapper .specific input[type="text"], */
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .track .optionsbox,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .recovery .label,
+.sheet-darkmode .tab-content .charsheet input[value="evilhat"].theme + .Wrapper .charname {
+	color: #d90000;
+}
+
 
 /* Gray theme */
 
@@ -2063,122 +2395,175 @@ input[value="evilhat"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit > .repconta
 	border: 1px solid #000000;
 }
 
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-share,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-optionsbox,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-OptionsTitleBar,
-input[value="gray"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-checker::before,
-input[value="gray"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-checkmark::before,
-input[value="gray"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox + span.sheet-checkmark::before,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-Bar,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-pronounbox,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-fpbox,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-fpbox input[type=number],
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-optwrap,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-AspectLabelBar,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-aspect .sheet-label,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-specific input[type="text"],
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-track .sheet-optionsbox,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-recovery .sheet-label,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-charname {
+input[value="gray"].theme + .Wrapper .share,
+input[value="gray"].theme + .Wrapper .optionsbox,
+input[value="gray"].theme + .Wrapper .OptionsTitleBar,
+input[value="gray"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checker::before,
+input[value="gray"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checkmark::before,
+input[value="gray"].theme + .Wrapper input[type="checkbox"].checkbox + span.checkmark::before,
+input[value="gray"].theme + .Wrapper .SectionHeader,
+input[value="gray"].theme + .Wrapper .Bar,
+input[value="gray"].theme + .Wrapper .pronounbox,
+input[value="gray"].theme + .Wrapper .fpbox,
+input[value="gray"].theme + .Wrapper .fpbox input[type=number],
+input[value="gray"].theme + .Wrapper .optwrap,
+input[value="gray"].theme + .Wrapper .AspectLabelBar,
+input[value="gray"].theme + .Wrapper .aspect .label,
+/* input[value="gray"].theme + .Wrapper .specific input[type="text"], */
+input[value="gray"].theme + .Wrapper .track .optionsbox,
+input[value="gray"].theme + .Wrapper .recovery .label,
+input[value="gray"].theme + .Wrapper .charname {
 	color: #000000;
 }
 
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-icon,
-input[value="gray"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-tracker,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-EditTitleBar {
+input[value="gray"].theme + .Wrapper .icon,
+input[value="gray"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.tracker,
+input[value="gray"].theme + .Wrapper .EditTitleBar {
 	background: #000000;
 }
 
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-powerflex,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-specific input[type="text"] {
+input[value="gray"].theme + .Wrapper .powerflex,
+input[value="gray"].theme + .Wrapper .specific input[type="text"] {
 	border-bottom: 1px solid #000000;
 }
 
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid div > span,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="gray"].theme + .Wrapper .SkillGrid div > span,
+input[value="gray"].theme + .Wrapper .TrackEdit,
+input[value="gray"].theme + .Wrapper .AspectEdit,
+input[value="gray"].theme + .Wrapper .NoteEdit,
+input[value="gray"].theme + .Wrapper .ExtraEdit,
+input[value="gray"].theme + .Wrapper .StuntEdit,
+input[value="gray"].theme + .Wrapper .PowerEdit,
+input[value="gray"].theme + .Wrapper .SkillEdit,
+input[value="gray"].theme + .Wrapper .OptionsEdit,
+input[value="gray"].theme + .Wrapper .SectionHeader ~ div,
+input[value="gray"].theme + .Wrapper .optbar > span {
 	border: 1px solid #000000;
 }
 
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="gray"].theme + .Wrapper .TrackEdit,
+input[value="gray"].theme + .Wrapper .AspectEdit,
+input[value="gray"].theme + .Wrapper .NoteEdit,
+input[value="gray"].theme + .Wrapper .ExtraEdit,
+input[value="gray"].theme + .Wrapper .StuntEdit,
+input[value="gray"].theme + .Wrapper .PowerEdit,
+input[value="gray"].theme + .Wrapper .SkillEdit,
+input[value="gray"].theme + .Wrapper .OptionsEdit,
+input[value="gray"].theme + .Wrapper .SectionHeader ~ div,
+input[value="gray"].theme + .Wrapper .optbar > span {
 	box-shadow: 2px 2px 6px #000000;
 }
 
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:active,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:active,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:active,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:active,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:hover,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:hover,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:hover,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:hover {
+.charsheet input[value="gray"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll:active,
+.charsheet input[value="gray"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll:active,
+.charsheet input[value="gray"].theme + .Wrapper .SkillDisplay button[type="action"]:active,
+.charsheet input[value="gray"].theme + .Wrapper .SkillDisplay button[type="roll"]:active,
+.charsheet input[value="gray"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll:hover,
+.charsheet input[value="gray"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll:hover,
+.charsheet input[value="gray"].theme + .Wrapper .SkillDisplay button[type="action"]:hover,
+.charsheet input[value="gray"].theme + .Wrapper .SkillDisplay button[type="roll"]:hover {
 	background: #000000;
 }
 
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid > div:hover {
+input[value="gray"].theme + .Wrapper .SkillGrid > div:hover {
 	background: #dddddd;
 }
 
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-AspectSeparator {
+input[value="gray"].theme + .Wrapper .AspectSeparator {
 	border: 1px solid #dddddd;
 	box-shadow: 2px 2px 6px #dddddd;
 }
 
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid > div {
+input[value="gray"].theme + .Wrapper .SkillGrid > div {
 	border-bottom: 1px solid #dddddd;
 }
 
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid div > span,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-AspectSeparator,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="gray"].theme + .Wrapper .SkillGrid div > span,
+input[value="gray"].theme + .Wrapper .AspectSeparator,
+input[value="gray"].theme + .Wrapper .TrackEdit,
+input[value="gray"].theme + .Wrapper .AspectEdit,
+input[value="gray"].theme + .Wrapper .NoteEdit,
+input[value="gray"].theme + .Wrapper .ExtraEdit,
+input[value="gray"].theme + .Wrapper .StuntEdit,
+input[value="gray"].theme + .Wrapper .PowerEdit,
+input[value="gray"].theme + .Wrapper .SkillEdit,
+input[value="gray"].theme + .Wrapper .OptionsEdit,
+input[value="gray"].theme + .Wrapper .optbar > span {
 	background: #eeeeee;
 }
 
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"],
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"] {
+.charsheet input[value="gray"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll,
+.charsheet input[value="gray"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll,
+.charsheet input[value="gray"].theme + .Wrapper .SkillDisplay button[type="action"],
+.charsheet input[value="gray"].theme + .Wrapper .SkillDisplay button[type="roll"] {
 	border: 1px solid #eeeeee;
 }
 
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div {
+input[value="gray"].theme + .Wrapper .SectionHeader ~ div {
 	background-image: linear-gradient(to bottom,#eeeeee,white,white,white,#eeeeee);
 }
 
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit > .repcontainer,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit > .repcontainer,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit > .repcontainer,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit > .repcontainer,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit > .repcontainer,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit > .repcontainer,
-input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit > .repcontainer {
+input[value="gray"].theme + .Wrapper .AspectEdit > .repcontainer,
+input[value="gray"].theme + .Wrapper .TrackEdit > .repcontainer,
+input[value="gray"].theme + .Wrapper .StuntEdit > .repcontainer,
+input[value="gray"].theme + .Wrapper .PowerEdit > .repcontainer,
+input[value="gray"].theme + .Wrapper .NoteEdit > .repcontainer,
+input[value="gray"].theme + .Wrapper .ExtraEdit > .repcontainer,
+input[value="gray"].theme + .Wrapper .SkillEdit > .repcontainer {
 	background-image: linear-gradient(to bottom,white,#eeeeee);
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .SkillGrid > div:hover {
+	background: #111111;
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .SkillGrid div > span,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .AspectSeparator,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .TrackEdit,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .AspectEdit,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .NoteEdit,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .ExtraEdit,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .StuntEdit,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .PowerEdit,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .SkillEdit,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .OptionsEdit,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .optbar > span {
+	background: #111111;
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .SectionHeader ~ div {
+	background-image: linear-gradient(to bottom,#111111,black,black,black,#111111);
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .AspectEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .TrackEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .StuntEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .PowerEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .NoteEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .ExtraEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .SkillEdit > .repcontainer {
+	background-image: linear-gradient(to bottom,black,#111111);
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .share,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .optionsbox,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .OptionsTitleBar,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checker::before,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checkmark::before,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper input[type="checkbox"].checkbox + span.checkmark::before,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .SectionHeader,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .Bar,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .pronounbox,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .fpbox,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .fpbox input[type=number],
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .optwrap,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .AspectLabelBar,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .aspect .label,
+/* input[value="gray"].theme + .Wrapper .specific input[type="text"], */
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .track .optionsbox,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .recovery .label,
+.sheet-darkmode .tab-content .charsheet input[value="gray"].theme + .Wrapper .charname {
+	color: #aaaaaa;
 }
 
 /* Shadow of the Century theme */
@@ -2201,123 +2586,177 @@ input[value="gray"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit > .repcontaine
 	border: 1px solid #007da4;
 }
 
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-share,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-optionsbox,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-OptionsTitleBar,
-input[value="shotc"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-checker::before,
-input[value="shotc"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-checkmark::before,
-input[value="shotc"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox + span.sheet-checkmark::before,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-Bar,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-pronounbox,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-fpbox,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-fpbox input[type=number],
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-optwrap,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-AspectLabelBar,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-aspect .sheet-label,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-specific input[type="text"],
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-track .sheet-optionsbox,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-recovery .sheet-label,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-charname {
+input[value="shotc"].theme + .Wrapper .share,
+input[value="shotc"].theme + .Wrapper .optionsbox,
+input[value="shotc"].theme + .Wrapper .OptionsTitleBar,
+input[value="shotc"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checker::before,
+input[value="shotc"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checkmark::before,
+input[value="shotc"].theme + .Wrapper input[type="checkbox"].checkbox + span.checkmark::before,
+input[value="shotc"].theme + .Wrapper .SectionHeader,
+input[value="shotc"].theme + .Wrapper .Bar,
+input[value="shotc"].theme + .Wrapper .pronounbox,
+input[value="shotc"].theme + .Wrapper .fpbox,
+input[value="shotc"].theme + .Wrapper .fpbox input[type=number],
+input[value="shotc"].theme + .Wrapper .optwrap,
+input[value="shotc"].theme + .Wrapper .AspectLabelBar,
+input[value="shotc"].theme + .Wrapper .aspect .label,
+/* input[value="shotc"].theme + .Wrapper .specific input[type="text"], */
+input[value="shotc"].theme + .Wrapper .track .optionsbox,
+input[value="shotc"].theme + .Wrapper .recovery .label,
+input[value="shotc"].theme + .Wrapper .charname {
 	color: #007da4;
 }
 
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-icon,
-input[value="shotc"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-tracker,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-EditTitleBar {
+input[value="shotc"].theme + .Wrapper .icon,
+input[value="shotc"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.tracker,
+input[value="shotc"].theme + .Wrapper .EditTitleBar {
 	background: #ec008b;
 }
 
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-powerflex,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-specific input[type="text"] {
+input[value="shotc"].theme + .Wrapper .powerflex,
+input[value="shotc"].theme + .Wrapper .specific input[type="text"] {
 	border-bottom: 1px solid #ec008b;
 }
 
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid div > span,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="shotc"].theme + .Wrapper .SkillGrid div > span,
+input[value="shotc"].theme + .Wrapper .TrackEdit,
+input[value="shotc"].theme + .Wrapper .AspectEdit,
+input[value="shotc"].theme + .Wrapper .NoteEdit,
+input[value="shotc"].theme + .Wrapper .ExtraEdit,
+input[value="shotc"].theme + .Wrapper .StuntEdit,
+input[value="shotc"].theme + .Wrapper .PowerEdit,
+input[value="shotc"].theme + .Wrapper .SkillEdit,
+input[value="shotc"].theme + .Wrapper .OptionsEdit,
+input[value="shotc"].theme + .Wrapper .SectionHeader ~ div,
+input[value="shotc"].theme + .Wrapper .optbar > span {
 	border: 1px solid #007da4;
 }
 
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="shotc"].theme + .Wrapper .TrackEdit,
+input[value="shotc"].theme + .Wrapper .AspectEdit,
+input[value="shotc"].theme + .Wrapper .NoteEdit,
+input[value="shotc"].theme + .Wrapper .ExtraEdit,
+input[value="shotc"].theme + .Wrapper .StuntEdit,
+input[value="shotc"].theme + .Wrapper .PowerEdit,
+input[value="shotc"].theme + .Wrapper .SkillEdit,
+input[value="shotc"].theme + .Wrapper .OptionsEdit,
+input[value="shotc"].theme + .Wrapper .SectionHeader ~ div,
+input[value="shotc"].theme + .Wrapper .optbar > span {
 	box-shadow: 2px 2px 6px #ec008b;
 }
 
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:active,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:active,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:active,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:active,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:hover,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:hover,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:hover,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:hover {
+.charsheet input[value="shotc"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll:active,
+.charsheet input[value="shotc"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll:active,
+.charsheet input[value="shotc"].theme + .Wrapper .SkillDisplay button[type="action"]:active,
+.charsheet input[value="shotc"].theme + .Wrapper .SkillDisplay button[type="roll"]:active,
+.charsheet input[value="shotc"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll:hover,
+.charsheet input[value="shotc"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll:hover,
+.charsheet input[value="shotc"].theme + .Wrapper .SkillDisplay button[type="action"]:hover,
+.charsheet input[value="shotc"].theme + .Wrapper .SkillDisplay button[type="roll"]:hover {
 	background: #007da4;
 }
 
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid > div:hover {
+input[value="shotc"].theme + .Wrapper .SkillGrid > div:hover {
 	background: #ddeeff;
 }
 
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-AspectSeparator {
+input[value="shotc"].theme + .Wrapper .AspectSeparator {
 	border: 1px solid #ddeeff;
 	box-shadow: 2px 2px 6px #ddeeff;
 }
 
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid > div {
+input[value="shotc"].theme + .Wrapper .SkillGrid > div {
 	border-bottom: 1px solid #ddeeff;
 }
 
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid div > span,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-AspectSeparator,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="shotc"].theme + .Wrapper .SkillGrid div > span,
+input[value="shotc"].theme + .Wrapper .AspectSeparator,
+input[value="shotc"].theme + .Wrapper .TrackEdit,
+input[value="shotc"].theme + .Wrapper .AspectEdit,
+input[value="shotc"].theme + .Wrapper .NoteEdit,
+input[value="shotc"].theme + .Wrapper .ExtraEdit,
+input[value="shotc"].theme + .Wrapper .StuntEdit,
+input[value="shotc"].theme + .Wrapper .PowerEdit,
+input[value="shotc"].theme + .Wrapper .SkillEdit,
+input[value="shotc"].theme + .Wrapper .OptionsEdit,
+input[value="shotc"].theme + .Wrapper .optbar > span {
 	background: #eef8ff;
 }
 
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"],
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"] {
+.charsheet input[value="shotc"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll,
+.charsheet input[value="shotc"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll,
+.charsheet input[value="shotc"].theme + .Wrapper .SkillDisplay button[type="action"],
+.charsheet input[value="shotc"].theme + .Wrapper .SkillDisplay button[type="roll"] {
 	border: 1px solid #eef8ff;
 }
 
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div {
+input[value="shotc"].theme + .Wrapper .SectionHeader ~ div {
 	background-image: linear-gradient(to bottom,#eef8ff,white,white,white,#eef8ff);
 }
 
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit > .repcontainer,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit > .repcontainer,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit > .repcontainer,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit > .repcontainer,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit > .repcontainer,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit > .repcontainer,
-input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit > .repcontainer {
+input[value="shotc"].theme + .Wrapper .AspectEdit > .repcontainer,
+input[value="shotc"].theme + .Wrapper .TrackEdit > .repcontainer,
+input[value="shotc"].theme + .Wrapper .StuntEdit > .repcontainer,
+input[value="shotc"].theme + .Wrapper .PowerEdit > .repcontainer,
+input[value="shotc"].theme + .Wrapper .NoteEdit > .repcontainer,
+input[value="shotc"].theme + .Wrapper .ExtraEdit > .repcontainer,
+input[value="shotc"].theme + .Wrapper .SkillEdit > .repcontainer {
 	background-image: linear-gradient(to bottom,white,#eef8ff);
 }
+
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .SkillGrid > div:hover {
+	background: #00181f;
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .SkillGrid div > span,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .AspectSeparator,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .TrackEdit,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .AspectEdit,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .NoteEdit,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .ExtraEdit,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .StuntEdit,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .PowerEdit,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .SkillEdit,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .OptionsEdit,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .optbar > span {
+	background: #00181f;
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .SectionHeader ~ div {
+	background-image: linear-gradient(to bottom,#00181f,black,black,black,#00181f);
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .AspectEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .TrackEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .StuntEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .PowerEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .NoteEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .ExtraEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .SkillEdit > .repcontainer {
+	background-image: linear-gradient(to bottom,black,#00181f);
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .share,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .optionsbox,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .OptionsTitleBar,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checker::before,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checkmark::before,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper input[type="checkbox"].checkbox + span.checkmark::before,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .SectionHeader,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .Bar,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .pronounbox,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .fpbox,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .fpbox input[type=number],
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .optwrap,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .AspectLabelBar,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .aspect .label,
+/* input[value="shotc"].theme + .Wrapper .specific input[type="text"], */
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .track .optionsbox,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .recovery .label,
+.sheet-darkmode .tab-content .charsheet input[value="shotc"].theme + .Wrapper .charname {
+	color: #0092bf;
+}
+
 
 /* Orange (Golden) theme */
 
@@ -2337,120 +2776,173 @@ input[value="shotc"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit > .repcontain
 	border: 1px solid #e3ac24;
 }
 
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-share,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-optionsbox,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-OptionsTitleBar,
-input[value="orange"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-checker::before,
-input[value="orange"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-checkmark::before,
-input[value="orange"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox + span.sheet-checkmark::before,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-Bar,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-pronounbox,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-fpbox,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-fpbox input[type=number],
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-optwrap,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-AspectLabelBar,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-aspect .sheet-label,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-specific input[type="text"],
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-track .sheet-optionsbox,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-recovery .sheet-label,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-charname {
+input[value="orange"].theme + .Wrapper .share,
+input[value="orange"].theme + .Wrapper .optionsbox,
+input[value="orange"].theme + .Wrapper .OptionsTitleBar,
+input[value="orange"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checker::before,
+input[value="orange"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checkmark::before,
+input[value="orange"].theme + .Wrapper input[type="checkbox"].checkbox + span.checkmark::before,
+input[value="orange"].theme + .Wrapper .SectionHeader,
+input[value="orange"].theme + .Wrapper .Bar,
+input[value="orange"].theme + .Wrapper .pronounbox,
+input[value="orange"].theme + .Wrapper .fpbox,
+input[value="orange"].theme + .Wrapper .fpbox input[type=number],
+input[value="orange"].theme + .Wrapper .optwrap,
+input[value="orange"].theme + .Wrapper .AspectLabelBar,
+input[value="orange"].theme + .Wrapper .aspect .label,
+/* input[value="orange"].theme + .Wrapper .specific input[type="text"], */
+input[value="orange"].theme + .Wrapper .track .optionsbox,
+input[value="orange"].theme + .Wrapper .recovery .label,
+input[value="orange"].theme + .Wrapper .charname {
 	color: #e3ac24;
 }
 
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-icon,
-input[value="orange"].sheet-theme + .sheet-Wrapper input[type="checkbox"].sheet-checkbox:checked + span.sheet-tracker,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-EditTitleBar {
+input[value="orange"].theme + .Wrapper .icon,
+input[value="orange"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.tracker,
+input[value="orange"].theme + .Wrapper .EditTitleBar {
 	background: #e3ac24;
 }
 
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-powerflex,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-specific input[type="text"] {
+input[value="orange"].theme + .Wrapper .powerflex,
+input[value="orange"].theme + .Wrapper .specific input[type="text"] {
 	border-bottom: 1px solid #e3ac24;
 }
 
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid div > span,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="orange"].theme + .Wrapper .SkillGrid div > span,
+input[value="orange"].theme + .Wrapper .TrackEdit,
+input[value="orange"].theme + .Wrapper .AspectEdit,
+input[value="orange"].theme + .Wrapper .NoteEdit,
+input[value="orange"].theme + .Wrapper .ExtraEdit,
+input[value="orange"].theme + .Wrapper .StuntEdit,
+input[value="orange"].theme + .Wrapper .PowerEdit,
+input[value="orange"].theme + .Wrapper .SkillEdit,
+input[value="orange"].theme + .Wrapper .OptionsEdit,
+input[value="orange"].theme + .Wrapper .SectionHeader ~ div,
+input[value="orange"].theme + .Wrapper .optbar > span {
 	border: 1px solid #e3ac24;
 }
 
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="orange"].theme + .Wrapper .TrackEdit,
+input[value="orange"].theme + .Wrapper .AspectEdit,
+input[value="orange"].theme + .Wrapper .NoteEdit,
+input[value="orange"].theme + .Wrapper .ExtraEdit,
+input[value="orange"].theme + .Wrapper .StuntEdit,
+input[value="orange"].theme + .Wrapper .PowerEdit,
+input[value="orange"].theme + .Wrapper .SkillEdit,
+input[value="orange"].theme + .Wrapper .OptionsEdit,
+input[value="orange"].theme + .Wrapper .SectionHeader ~ div,
+input[value="orange"].theme + .Wrapper .optbar > span {
 	box-shadow: 2px 2px 6px #e3ac24;
 }
 
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:active,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:active,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:active,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:active,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll:hover,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll:hover,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"]:hover,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"]:hover {
+.charsheet input[value="orange"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll:active,
+.charsheet input[value="orange"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll:active,
+.charsheet input[value="orange"].theme + .Wrapper .SkillDisplay button[type="action"]:active,
+.charsheet input[value="orange"].theme + .Wrapper .SkillDisplay button[type="roll"]:active,
+.charsheet input[value="orange"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll:hover,
+.charsheet input[value="orange"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll:hover,
+.charsheet input[value="orange"].theme + .Wrapper .SkillDisplay button[type="action"]:hover,
+.charsheet input[value="orange"].theme + .Wrapper .SkillDisplay button[type="roll"]:hover {
 	background: #e3ac24;
 }
 
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid > div:hover {
+input[value="orange"].theme + .Wrapper .SkillGrid > div:hover {
 	background: #eee8dd;
 }
 
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-AspectSeparator {
+input[value="orange"].theme + .Wrapper .AspectSeparator {
 	border: 1px solid #eee8dd;
 	box-shadow: 2px 2px 6px #eee8dd;
 }
 
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid > div {
+input[value="orange"].theme + .Wrapper .SkillGrid > div {
 	border-bottom: 1px solid #eee8dd;
 }
 
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SkillGrid div > span,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-AspectSeparator,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-OptionsEdit,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-optbar > span {
+input[value="orange"].theme + .Wrapper .SkillGrid div > span,
+input[value="orange"].theme + .Wrapper .AspectSeparator,
+input[value="orange"].theme + .Wrapper .TrackEdit,
+input[value="orange"].theme + .Wrapper .AspectEdit,
+input[value="orange"].theme + .Wrapper .NoteEdit,
+input[value="orange"].theme + .Wrapper .ExtraEdit,
+input[value="orange"].theme + .Wrapper .StuntEdit,
+input[value="orange"].theme + .Wrapper .PowerEdit,
+input[value="orange"].theme + .Wrapper .SkillEdit,
+input[value="orange"].theme + .Wrapper .OptionsEdit,
+input[value="orange"].theme + .Wrapper .optbar > span {
 	background: #fff8ee;
 }
 
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-StuntDisplay button[type="roll"].sheet-roll,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-ExtraDisplay button[type="roll"].sheet-roll,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="action"],
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SkillDisplay button[type="roll"] {
+.charsheet input[value="orange"].theme + .Wrapper .StuntDisplay button[type="roll"].sheet-roll,
+.charsheet input[value="orange"].theme + .Wrapper .ExtraDisplay button[type="roll"].sheet-roll,
+.charsheet input[value="orange"].theme + .Wrapper .SkillDisplay button[type="action"],
+.charsheet input[value="orange"].theme + .Wrapper .SkillDisplay button[type="roll"] {
 	border: 1px solid #fff8ee;
 }
 
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SectionHeader ~ div {
+input[value="orange"].theme + .Wrapper .SectionHeader ~ div {
 	background-image: linear-gradient(to bottom,#fff8ee,white,white,white,#fff8ee);
 }
 
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-AspectEdit > .repcontainer,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-TrackEdit > .repcontainer,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-StuntEdit > .repcontainer,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-PowerEdit > .repcontainer,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-NoteEdit > .repcontainer,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-ExtraEdit > .repcontainer,
-input[value="orange"].sheet-theme + .sheet-Wrapper .sheet-SkillEdit > .repcontainer {
+input[value="orange"].theme + .Wrapper .AspectEdit > .repcontainer,
+input[value="orange"].theme + .Wrapper .TrackEdit > .repcontainer,
+input[value="orange"].theme + .Wrapper .StuntEdit > .repcontainer,
+input[value="orange"].theme + .Wrapper .PowerEdit > .repcontainer,
+input[value="orange"].theme + .Wrapper .NoteEdit > .repcontainer,
+input[value="orange"].theme + .Wrapper .ExtraEdit > .repcontainer,
+input[value="orange"].theme + .Wrapper .SkillEdit > .repcontainer {
 	background-image: linear-gradient(to bottom,white,#fff8ee);
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .SkillGrid > div:hover {
+	background: #1f1800;
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .SkillGrid div > span,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .AspectSeparator,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .TrackEdit,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .AspectEdit,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .NoteEdit,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .ExtraEdit,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .StuntEdit,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .PowerEdit,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .SkillEdit,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .OptionsEdit,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .optbar > span {
+	background: #1f1800;
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .SectionHeader ~ div {
+	background-image: linear-gradient(to bottom,#1f1800,black,black,black,#1f1800);
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .AspectEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .TrackEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .StuntEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .PowerEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .NoteEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .ExtraEdit > .repcontainer,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .SkillEdit > .repcontainer {
+	background-image: linear-gradient(to bottom,black,#1f1800);
+}
+
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .share,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .optionsbox,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .OptionsTitleBar,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checker::before,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper input[type="checkbox"].checkbox:checked + span.checkmark::before,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper input[type="checkbox"].checkbox + span.checkmark::before,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .SectionHeader,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .Bar,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .pronounbox,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .fpbox,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .fpbox input[type=number],
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .optwrap,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .AspectLabelBar,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .aspect .label,
+/* input[value="orange"].theme + .Wrapper .specific input[type="text"], */
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .track .optionsbox,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .recovery .label,
+.sheet-darkmode .tab-content .charsheet input[value="orange"].theme + .Wrapper .charname {
+	color: #e3ac24;
 }

--- a/Fate/FateOmni.html
+++ b/Fate/FateOmni.html
@@ -179,7 +179,8 @@
 			<input type="checkbox" class="triggerbox" name="attr_Show-Modes" value="1">
 			<div class="ModeCell">
 				<div class="SectionHeader">
-					<span><span data-i18n="modes">Modes</span> <span class="boxcorner"><input type="checkbox" class="checkbox" name="attr_EditModes" value="1" checked><span class="pencilbox"/></span></span>
+					<span data-i18n="modes">Modes</span> 
+					<span class="boxcorner"><input type="checkbox" class="checkbox" name="attr_EditModes" value="1" checked><span class="pencilbox"/></span></span>
 				</div>
 				<div class="SkillFrame">
 					<input type="checkbox" class="triggerbox" name="attr_EditModes" value="1" checked>
@@ -258,7 +259,7 @@
 			<input type="checkbox" class="triggerbox" name="attr_Show-Roles" value="1">
 			<div class="RoleCell">
 				<div class="SectionHeader">
-					<span><span data-i18n="roles">Roles</span> <span class="boxcorner"><input type="checkbox" class="checkbox" name="attr_EditRoles" value="1" checked><span class="pencilbox"/></span></span>
+					<span data-i18n="roles">Roles</span> <span class="boxcorner"><input type="checkbox" class="checkbox" name="attr_EditRoles" value="1" checked><span class="pencilbox"/></span>
 				</div>
 				<div class="SkillFrame">
 					<input type="checkbox" class="triggerbox" name="attr_EditRoles" value="1" checked>
@@ -316,7 +317,7 @@
 			<input type="checkbox" class="triggerbox" name="attr_Show-Skillswaps" value="1">
 			<div class="SkillCell">
 				<div class="SectionHeader">
-					<span><span data-i18n="swap-skills">Swappable Skillsets</span> <span name="attr_lastswapped"></span> <span class="boxcorner"><input type="checkbox" class="checkbox" name="attr_EditSwaps" value="1" checked><span class="pencilbox"/></span></span>
+					<span data-i18n="swap-skills">Swappable Skillsets</span> <span name="attr_lastswapped"></span> <span class="boxcorner"><input type="checkbox" class="checkbox" name="attr_EditSwaps" value="1" checked><span class="pencilbox"/></span>
 				</div>
 				<div class="SkillFrame">
 					<input type="checkbox" class="triggerbox" name="attr_EditSwaps" value="1" checked>
@@ -354,7 +355,7 @@
 			<input type="checkbox" class="triggerbox" name="attr_Show-Combinable" value="1">
 			<div class="SkillCell">
 				<div class="SectionHeader">
-					<span><span data-i18n="combine-skills">Combinable Skills</span> <span class="boxcorner"><input type="checkbox" class="checkbox" name="attr_EditCombos" value="1" checked><span class="pencilbox"/></span></span>
+					<span data-i18n="combine-skills">Combinable Skills</span> <span class="boxcorner"><input type="checkbox" class="checkbox" name="attr_EditCombos" value="1" checked><span class="pencilbox"/></span>
 				</div>
 				<div class="SkillFrame">
 					<input type="checkbox" class="triggerbox" name="attr_EditCombos" value="1" checked>
@@ -974,7 +975,7 @@
 			<input type="checkbox" class="triggerbox" name="attr_Show-Packages" value="1">
 			<div class="RoleCell"> 
 				<div class="SectionHeader">
-					<span><span data-i18n="packages">Packages</span> <span class="boxcorner"><input type="checkbox" class="checkbox" name="attr_EditPackages" value="1" checked><span class="pencilbox"/></span></span>
+					<span data-i18n="packages">Packages</span> <span class="boxcorner"><input type="checkbox" class="checkbox" name="attr_EditPackages" value="1" checked><span class="pencilbox"/></span>
 				</div>
 				<div class="StuntFrame">
 					<input type="checkbox" class="triggerbox" name="attr_EditPackages" value="1" checked>
@@ -1462,7 +1463,7 @@
 							<input type="hidden" name="attr_category" value="" class="hideIfNull"><div class="aspect-category"><span name="attr_category"></span></div>
 							<div class="aspect">
 								<input type="hidden" value="" name="attr_label" class="hideIfNull"><div class="AspectLabelBar">
-									<span class="label">
+									<span class="label align-left">
 										<span name="attr_label"></span>
 									</span>
 								</div>
@@ -1932,31 +1933,31 @@
 </div> <!-- /Wrapper -->
 
 <rolltemplate class="sheet-rolltemplate-share">
-	<div {{#theme}}class="theme-{{theme}}"{{/theme}}>
+	<div {{#theme}}class="sheet-theme-{{theme}}"{{/theme}}>
 		{{#name}}
-			<div class="roll-name"><b>{{name}}</b></div>
+			<div class="sheet-roll-name"><b>{{name}}</b></div>
 		{{/name}}
 		{{#text}}
-			<div class="text">{{text}}</div>
+			<div class="sheet-text">{{text}}</div>
 		{{/text}}
 		{{#breaks}}
-			<div class="breaks">{{breaks}}</div>
+			<div class="sheet-breaks">{{breaks}}</div>
 		{{/breaks}}
 		{{#allprops() name text theme breaks}}
-			<div class="space-above">**{{key}}:** {{value}} </div>
+			<div class="sheet-space-above">**{{key}}:** {{value}} </div>
 		{{/allprops() name text theme breaks}}
 	</div>
 </rolltemplate>
 
 <rolltemplate class="sheet-rolltemplate-fateroll">
-	<div {{#theme}}class="theme-{{theme}}"{{/theme}}>
+	<div {{#theme}}class="sheet-theme-{{theme}}"{{/theme}}>
 		{{#name}}
-			<div class="roll-name"><b>{{name}}</b></div>
+			<div class="sheet-roll-name"><b>{{name}}</b></div>
 		{{/name}}
 		{{#roll}}
-			<div class="roll">
+			<div class="sheet-roll">
 				{{roll}}
-				<div class="word">
+				<div class="sheet-word">
 					{{#rollGreater() roll 16}}
 						<span data-i18n="beyond">Beyond</span>
 						<span data-i18n="rating-word8">Legendary</span>

--- a/Fate/sheet.json
+++ b/Fate/sheet.json
@@ -296,5 +296,5 @@
 			"descriptiontranslationkey": "custom-conditions-desc"
 		}
 	],
-	"legacy": true
+	"legacy": false
 }


### PR DESCRIPTION
## Changes / Comments

- CSS changed to support moving to the new model (legacy: false now in sheet.json)
- Added darkmode support for all sheet themes

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
