### PR TITLE
[Harnmaster3] Merge dark theme into vtt dark mode

### DIFF
--- a/HarnMaster3/harnsheet.html
+++ b/HarnMaster3/harnsheet.html
@@ -11,10 +11,6 @@
 	<img class='avatarimage' name='attr_character_avatar' alt="Character Avatar">
 </div>
 
-<!-- toggle themes -->
-<input type='hidden' class='themeactivator' name='attr_colorthemeselector' value='light' >
-<input type='hidden' class='characterviewer' name='attr_colorthemeselector' value='light' >
-
 <!-- buttons to select desired tab -->
 <div class="tab-buttons">
    <button id=chartab type="action" name="act_character" >Character<span class="buttonicon">&nbsp;U </span></button>
@@ -430,9 +426,8 @@
     		<label for=mountedtoggle>Mounted?</label>
     		  <input id=mountedtoggle type="checkbox" name="attr_is_mounted" value="1">	
 				<input type="hidden" name="attr_is_mounted" class="display-mounted-status"> <!-- this is filled with the value set by the is carried checkbox above-->
-				<input type='hidden' class='themeactivator' name='attr_colorthemeselector' value='light' >
-    			<div class="mounted-display full-width themeactivator"> <img class="full-width" src="https://github.com/olafvantol/roll20-character-sheets/blob/77eb88aea6fe38651e24c68cfae1b6f3ab5f4c60/HarnMaster3_v2/mounted-icon-v2.png?raw=true" /> </div>
-				<div class="unmounted-display full-width themeactivator"> <img class="full-width" src="https://github.com/olafvantol/roll20-character-sheets/blob/77eb88aea6fe38651e24c68cfae1b6f3ab5f4c60/HarnMaster3_v2/on-foot-icon-v2.png?raw=true" />  </div>
+				<div class="mounted-display full-width"> <img class="full-width" src="https://github.com/olafvantol/roll20-character-sheets/blob/77eb88aea6fe38651e24c68cfae1b6f3ab5f4c60/HarnMaster3_v2/mounted-icon-v2.png?raw=true" /> </div>
+				<div class="unmounted-display full-width"> <img class="full-width" src="https://github.com/olafvantol/roll20-character-sheets/blob/77eb88aea6fe38651e24c68cfae1b6f3ab5f4c60/HarnMaster3_v2/on-foot-icon-v2.png?raw=true" />  </div>
 				
     	</div>    
         <div class='character-grid-section penalties penalties-grid colored-grid'>
@@ -1578,12 +1573,7 @@
 			<input name="attr_fumblestumblepenalty" type="hidden" value="0"> <!-- provide a default value in case someone rolls before either the option or any penalty is set --> 
     	</div>
     	<div class='settings-grid-section settingsgroup colored-grid'>
-    	    <div class="skill-section-title">Sheet settings</div>
-			<div class="full-width skill-header">Theme</div>
-			<select class="colorselector full-width" name="attr_colorthemeselector"> 
-               <option value="light" id="theme-light">Light theme</option>
-               <option value="dark" id="theme-dark">Dark theme</option>			
-			</select>
+			<div class="skill-section-title">Sheet settings</div> 
 			<div class="full-width skill-header">Custom section control</div>
 			<label for=showhorsetoggle>Show Horse on sheet?</label>
 			<input id=showhorsetoggle name="attr_hrhorseonsheet" type="checkbox" value="1" checked>
@@ -1596,13 +1586,19 @@
 			<input id=legacycharname name="attr_name" type="text" class="full-width" readonly>
 			<div class="full-width skill-header">Sheet version</div>
 			<div class="full-width">
-			  <input name="attr_character_sheet_version" type="number" value="20220303" readonly>
+			  <input name="attr_character_sheet_version" type="number" value="20220312" readonly>
 			  <input type="hidden" name="attr_data_version" value="" readonly>
 			</div>
     	</div>
 	</div>
 	<div class="changelog">
 		<h2>Changelog</h2>
+		<h3>20220312 - Version 2.7</h3>
+		<details>
+			<summary class="changelog-summary">
+				<p class="changelog-summary">Removed themes from sheet and merged dark styling with VTT darkmode</p>
+			</summary>
+		</details>
 		<h3>20220303 - Version 2.6</h3>
 		<details>
 			<summary class="changelog-summary">

--- a/HarnMaster3/harnstyle.css
+++ b/HarnMaster3/harnstyle.css
@@ -27,10 +27,7 @@
   --bbg-dark: #e4e4e4;
 }
 
-.themeactivator[value="light"] ~ div.character,
-.themeactivator[value="light"] ~ div.inventory,
-.themeactivator[value="light"] ~ div.settings,
-.themeactivator[value="light"] ~ div.tab-buttons {
+body {
   --background-sheet: var(--bgs-light);
   --background-dark: var(--bgd-light); /* TODO rename variable, unclear now */
   --background-input: var(--bgi-light);
@@ -43,10 +40,8 @@
   --button-background: var(--bbg-light);
 }
 
-.themeactivator[value="dark"] ~ div.character,
-.themeactivator[value="dark"] ~ div.inventory,
-.themeactivator[value="dark"] ~ div.settings,
-.themeactivator[value="dark"] ~ div.tab-buttons  {
+/* VTT dark mode styling (from previous dark theme) */
+body.sheet-darkmode  {
   --background-sheet: var(--bgs-dark);
   --background-dark: var(--bgd-dark); /* TODO rename variable, unclear now */
   --background-input: var(--bgi-dark);
@@ -59,12 +54,40 @@
   --button-background: var(--bbg-dark);
 }
 
-.themeactivator[value="dark"] ~ div img {
+body.sheet-darkmode ~ div img {
 	filter: invert(100%);
 }
 
-.charsheet {
-	margin-left: 13px;
+body.sheet-darkmode .unmounted-display img,
+body.sheet-darkmode .mounted-display img {
+	filter: invert(85%);
+}
+
+body.sheet-darkmode .sheetform {
+	background-color: transparent;
+}
+
+body.sheet-darkmode .characterviewer {
+	/* background-image: none; */
+	background-image: url(https://github.com/olafvantol/roll20-character-sheets/blob/4850f0511913bbe0a9b0fdb6e58a7f83f53d1d3d/HarnMaster3_v2/holmgang_by_noiseman433_d2xrib.jpg?raw=true); 
+	background-blend-mode: color-burn;
+	background-color: #000000cc;
+}
+
+body.sheet-darkmode .nav-tabs {
+	background-color: transparent;
+}
+
+body.sheet-darkmode .characterviewer .nav-tabs>li>a {
+	background-color: #ffffff21;
+}
+
+body.sheet-darkmode h3 {
+	color: var(--textcolor-dark);
+}
+
+body.sheet-darkmode button.btn {
+	filter: invert(1);
 }
 
 /* coloring some elements outside the basis character sheet */ 
@@ -87,26 +110,12 @@
 	background-color: var(--bgs-light);
 }
 
-/* add darkmode compatibility */
+/* end color schemes */
 
-body.sheet-darkmode .characterviewer {
-	/* background-image: none; */
-	background-image: url(https://github.com/olafvantol/roll20-character-sheets/blob/4850f0511913bbe0a9b0fdb6e58a7f83f53d1d3d/HarnMaster3_v2/holmgang_by_noiseman433_d2xrib.jpg?raw=true); 
-	background-blend-mode: color-burn;
-	background-color: #000000cc;
+.charsheet {
+	margin-left: 13px;
 }
 
-body.sheet-darkmode .nav-tabs {
-	background-color: transparent;
-}
-
-body.sheet-darkmode .characterviewer .nav-tabs>li>a {
-	background-color: #ffffff21;
-}
-
-body.sheet-darkmode h3 {
-	color: var(--textcolor-dark);
-}
 
 /*Configure the tab buttons*/
 
@@ -1199,6 +1208,7 @@ button.dismissnotification {
   border: 1px solid;
   /* by default, the border is the same color as the header. You can change this here, e.g. to black */
   border-color: var(--custom-border-color);
+  color: #121212;
 }
 
 /* Smaller margins - remove these if you want the huge default left margin */
@@ -1252,6 +1262,12 @@ button.dismissnotification {
   --custom-border-color: #00000000;
   --highlight-text-color: #0087ff;
   --highlight-row-bg: #ffffd7;
+}
+
+/* VTT dark mode support (make roll results legible) */
+
+.sheet-rolltemplate-custom .sheet-container .sheet-value {
+	color: var(--dark-primarytext);
 }
 
 /* Allprops part */


### PR DESCRIPTION
Remove theme selector and move dark styling to trigger when VTT dark mode is enabled

## Changes / Comments

Removed theme support from sheet and merge dark theme styling into VTT dark mode.


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name. Yes
- [x] Is this a bug fix? No
- [x] Does this add functional enhancements (new features or extending existing features) ? No
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ?  Yes
- [x] If changing or removing attributes, what steps have you taken, if any, to preserve player data ? N/a
- [x] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ? n/a


