### PR TITLE
[Blades in the Dark] Minor tweak to blades.css to prevent invisible text during dark mode

### DIFF
--- a/Blades in the Dark/blades.css
+++ b/Blades in the Dark/blades.css
@@ -37,6 +37,7 @@
   padding: 0;
   display: flex;
   width: auto;
+  --dark-secondarytext: #333; /* setting this variable here takes care of the text color getting overridden in dark mode, which causes some of the label text (that's also on a background the same color as the initial dark-secondarytext value) to go invisible! */
   color: #333;
   font: inherit;
 }


### PR DESCRIPTION
## Changes / Comments

Added a different value for the --dark-secondarytext in the label styling; the background of some labels on this sheet is the same color as the initial value of --dark-secondarytext so it's making the text invisible. It'll be a much more significant undertaking to modify the sheet to fully take advantage of dark mode, but this should at least allow things to function as they should without full toggle support.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [ ] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [x] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
