### PR TITLE
[StarWars5e] Workaround for attribs not being set on sheet open

### DIFF
--- a/StarWars5E/README.md
+++ b/StarWars5E/README.md
@@ -8,6 +8,9 @@ More Information
 - [Star Wars 5e Discord](https://discord.gg/zYcPYTu)
 
 # Changelog
+
+## 2022-03-17
+* Put in a check against a new behavior that began today sheet attributes are not being set on sheet open even when defined with a value in hidden attributes.  This caused HP and Shield calcs to fail until the related modifiers were changed at least once.  I have added a NaN check against this at least for the ship portion of the sheet.
 ## 2022-03-14
 * Fix for CSS for issue where new sheet tab selectors were covered when Advantage Toggle was on
 * Fix for Hull and Shield Dice calculation that was not including the con or str mod with the first die

--- a/StarWars5E/StarWars5E_HTML.html
+++ b/StarWars5E/StarWars5E_HTML.html
@@ -11133,6 +11133,8 @@
                 var tierDieMultiplier = 0;
                 var shipPwrDie = 0;
                 var sTier = isNaN(parseInt(attrs.base_ship_tier)) == false ? parseInt(attrs.base_ship_tier) : 0;
+                var localCon = isNaN(parseInt(attrs.constitution_mod)) == false ? parseInt(attrs.constitution_mod) : 0;
+                var localStr = isNaN(parseInt(attrs.strength_mod)) == false ? parseInt(attrs.strength_mod) : 0;
     
                 switch(attrs.ship_size) {
                     case "Tiny":
@@ -11243,8 +11245,8 @@
                 
                 
                 var adjustedTierDies = shipSizeDiceMax + (sTier * tierDieMultiplier);
-                shipSizeHullPoints = shipSizeDie + attrs.constitution_mod + ((adjustedTierDies-1) * shipHullPointsAfterFirst) + ((adjustedTierDies-1) * attrs.constitution_mod) + (adjustedTierDies * armorHpPerHitDieMod);
-                shipSizeShieldPoints = Math.floor(((shipSizeDie + attrs.strength_mod) + ((adjustedTierDies-1) * shipHullPointsAfterFirst) + ((adjustedTierDies-1) * attrs.strength_mod)) * shieldCapacity);
+                shipSizeHullPoints = shipSizeDie + localCon + ((adjustedTierDies-1) * shipHullPointsAfterFirst) + ((adjustedTierDies-1) * localCon) + (adjustedTierDies * armorHpPerHitDieMod);
+                shipSizeShieldPoints = Math.floor(((shipSizeDie + localStr) + ((adjustedTierDies-1) * shipHullPointsAfterFirst) + ((adjustedTierDies-1) * localStr)) * shieldCapacity);
                 var shipSizeShieldRegen = Math.floor(shipSizeDie * shieldRegenRate);
     
                 setAttrs({hulldie_final: shipSizeDie}, {silent: true});


### PR DESCRIPTION
## Changes / Comments

## 2022-03-17
* Put in a check against a new behavior that began today 3-17 where sheet attributes are not being set on sheet open even when defined with a value in hidden attributes.  This caused HP and Shield calcs to fail until the related modifiers were changed at least once.  I have added a NaN check against this at least for the ship portion of the sheet.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [ ] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
