### PR TITLE
[StarWars5e] Bug Fix - repeating section defaults New Feature - add ship save mods

### DIFF
--- a/StarWars5E/README.md
+++ b/StarWars5E/README.md
@@ -8,9 +8,11 @@ More Information
 - [Star Wars 5e Discord](https://discord.gg/zYcPYTu)
 
 # Changelog
-
+## 2022-03-19
+* Bug Fix - It was identified that because the default to-hit modifier had been changed from DEX to WIS on the Ship Sheet, sheets upgrading from 2.4 were over-riding any PC weapons to WIS that had not been EXPLICITLY set to DEX, because the weapon attacks on PC and Ship share the same repeating fieldset.  This is a documented Roll20 *feature*.  We have set the default back to DEX on the Ship Weapons for now as a fix for anyone else that still needs to upgrade.  In addition, the defaults between the SHIP and PC defaults have been aligned.  In version 2.4 the PC sheet set the defaults to STR, the SHIP to DEX and we have confirmed that once a name was placed in the 2.4 attack section the defaults would change to DEX.  This should now keep both attack sections in line and avoid a potential future upgrade where one set of defaults writes back over the other. *Ideally in the future the ship weapons will be separated into their own repeating fieldset.*
+* Copied the Save modifiers from the PC sheet to the Ship sheet 
 ## 2022-03-17
-* Put in a check against a new behavior that began today sheet attributes are not being set on sheet open even when defined with a value in hidden attributes.  This caused HP and Shield calcs to fail until the related modifiers were changed at least once.  I have added a NaN check against this at least for the ship portion of the sheet.
+* Put in a check against a new behavior that began today sheet attributes are not being set on sheet open even when defined with a value in hidden attributes.  This caused HP and Shield calcs to fail until the related modifiers were not changed at least once.  Added a NaN check against this at least for the ship portion of the sheet.
 ## 2022-03-14
 * Fix for CSS for issue where new sheet tab selectors were covered when Advantage Toggle was on
 * Fix for Hull and Shield Dice calculation that was not including the con or str mod with the first die

--- a/StarWars5E/StarWars5E_HTML.html
+++ b/StarWars5E/StarWars5E_HTML.html
@@ -1467,8 +1467,8 @@
                                     <input type="checkbox" name="attr_atkflag" value="{{attack=1}}" checked="checked">
                                     <span data-i18n="attack:-u">ATTACK:</span>
                                     <select name="attr_atkattr_base">
-                                        <option value="@{strength_mod}" selected="selected" data-i18n="str-u">STR</option>
-                                        <option value="@{dexterity_mod}" data-i18n="dex-u">DEX</option>
+                                        <option value="@{strength_mod}" data-i18n="str-u">STR</option>
+                                        <option value="@{dexterity_mod}" selected="selected" data-i18n="dex-u">DEX</option>
                                         <option value="@{constitution_mod}" data-i18n="con-u">CON</option>
                                         <option value="@{intelligence_mod}" data-i18n="int-u">INT</option>
                                         <option value="@{wisdom_mod}" data-i18n="wis-u">WIS</option>
@@ -1498,8 +1498,8 @@
                                     <input type="text" name="attr_dmgbase" placeholder="1d6" style="width: 50px;">
                                     <span>+</span>
                                     <select name="attr_dmgattr">
-                                        <option value="@{strength_mod}" selected="selected" data-i18n="str-u">STR</option>
-                                        <option value="@{dexterity_mod}" data-i18n="dex-u">DEX</option>
+                                        <option value="@{strength_mod}" data-i18n="str-u">STR</option>
+                                        <option value="@{dexterity_mod}" selected="selected" data-i18n="dex-u">DEX</option>
                                         <option value="@{constitution_mod}" data-i18n="con-u">CON</option>
                                         <option value="@{intelligence_mod}" data-i18n="int-u">INT</option>
                                         <option value="@{wisdom_mod}" data-i18n="wis-u">WIS</option>
@@ -1544,8 +1544,8 @@
                                     <input type="checkbox" name="attr_saveflag" value="{{save=1}} {{saveattr=@{saveattr}}} {{savedesc=@{saveeffect}}} {{savedc=[[[[@{savedc}]][SAVE]]]}}">
                                     <span data-i18n="saving-throw:-u">SAVING THROW:</span>
                                     <select name="attr_saveattr">
-                                        <option value="Strength" selected="selected" data-i18n="str-u">STR</option>
-                                        <option value="Dexterity" data-i18n="dex-u">DEX</option>
+                                        <option value="Strength" data-i18n="str-u">STR</option>
+                                        <option value="Dexterity" selected="selected" data-i18n="dex-u">DEX</option>
                                         <option value="Constitution" data-i18n="con-u">CON</option>
                                         <option value="Intelligence" data-i18n="int-u">INT</option>
                                         <option value="Wisdom" data-i18n="wis-u">WIS</option>
@@ -5224,10 +5224,10 @@
                                     <span data-i18n="attack:-u">ATTACK:</span>
                                     <select name="attr_atkattr_base">
                                         <option value="@{strength_mod}" data-i18n="str-u">STR</option>
-                                        <option value="@{dexterity_mod}" data-i18n="dex-u">DEX</option>
+                                        <option value="@{dexterity_mod}" selected="selected" data-i18n="dex-u">DEX</option>
                                         <option value="@{constitution_mod}" data-i18n="con-u">CON</option>
                                         <option value="@{intelligence_mod}" data-i18n="int-u">INT</option>
-                                        <option value="@{wisdom_mod}" selected="selected" data-i18n="wis-u">WIS</option>
+                                        <option value="@{wisdom_mod}" data-i18n="wis-u">WIS</option>
                                         <option value="@{charisma_mod}" data-i18n="cha-u">CHA</option>
                                         <option value="power" data-i18n="power-u">POWER</option>
                                         <option value="0">-</option>
@@ -5305,14 +5305,14 @@
                                     </select>
                                     <span data-i18n="vs-dc:-u">VS DC:</span>
                                     <select name="attr_savedc">
-                                        <option value="(@{power_save_dc})" data-i18n="power-u">POWER</option>
+                                        <option value="(@{power_save_dc})" selected="selected" data-i18n="power-u">POWER</option>
                                         <option value="(@{strength_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="str-u">STR</option>
                                         <option value="(@{dexterity_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="dex-u">DEX</option>
                                         <option value="(@{constitution_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="con-u">CON</option>
                                         <option value="(@{intelligence_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="int-u">INT</option>
                                         <option value="(@{wisdom_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="wis-u">WIS</option>
                                         <option value="(@{charisma_mod}+8+@{power_dc_mod}+@{pb})" data-i18n="cha-u">CHA</option>
-                                        <option value="(@{saveflat})" selected="selected" data-i18n="flat-u">FLAT</option>
+                                        <option value="(@{saveflat})" data-i18n="flat-u">FLAT</option>
                                     </select>
                                     <input class="flatflag" type="hidden" name="attr_savedc" value="saveflat">
                                     <input class="num flat" type="text" name="attr_saveflat" placeholder="8" value="8">
@@ -5655,6 +5655,43 @@
                 </div>
             </div>
             <div class="col">
+                <div class="save_options" style="width: 234px;">
+                    <div class="row skill">
+                        <span data-i18n="strength-save-u">Strength Save</span>
+                        <span>+</span><input type="text" class="num" name="attr_strength_save_mod" value="0" placeholder="0" title="@{strength_save_mod}">
+                    </div>
+                    <div class="row skill">
+                        <span data-i18n="dexterity-save-u">Dexterity Save</span>
+                        <span>+</span><input type="text" class="num" name="attr_dexterity_save_mod" value="0" placeholder="0" title="@{dexterity_save_mod}">
+                    </div>
+                    <div class="row skill">
+                        <span data-i18n="constitution-save-u">Constitution Save</span>
+                        <span>+</span><input type="text" class="num" name="attr_constitution_save_mod" value="0" placeholder="0" title="@{constitution_save_mod}">
+                    </div>
+                    <div class="row skill">
+                        <span data-i18n="intelligence-save-u">Intelligence Save</span>
+                        <span>+</span><input type="text" class="num" name="attr_intelligence_save_mod" value="0" placeholder="0" title="@{intelligence_save_mod}">
+                    </div>
+                    <div class="row skill">
+                        <span data-i18n="wisdom-save-u">Wisdom Save</span>
+                        <span>+</span><input type="text" class="num" name="attr_wisdom_save_mod" value="0" placeholder="0" title="@{wisdom_save_mod}">
+                    </div>
+                    <div class="row skill">
+                        <span data-i18n="charisma-save-u">Charisma Save</span>
+                        <span>+</span><input type="text" class="num" name="attr_charisma_save_mod" value="0" placeholder="0" title="@{charisma_save_mod}">
+                    </div>
+                    <div class="row">
+                        <span data-i18n="death-save-mod:-u">DEATH SAVE MODIFIER:</span>
+                        <input type="text" class="num" name="attr_death_save_mod" placeholder="0" value="0">
+                    </div>
+                    <div class="row">
+                        <span data-i18n="glob-saving-mod:-u">GLOBAL SAVING THROW MODIFIER:</span>
+                        <input type="text" class="num" name="attr_globalsavemod" placeholder="0" value="0">
+                    </div>
+                    <div class="row title">
+                        <span data-i18n="save-opts-u">SAVE OPTIONS</span>
+                    </div>
+                </div>
                 <div class="skill_options" style="width: 234px;">
                     <div data-i18n-list="skills-list">
                         <div class="row skill" data-i18n-list-item="ship_boost">
@@ -13174,10 +13211,10 @@
             }
             else if(v["version"] === "2.4") {
                 console.log("UPGRADING TO v2.5");
-                upgrade_to_2_4(function() {
-                    setAttrs({version: "2.5"});
-                    versioning(finished);
+                setAttrs({version: "2.5"}, function(){
+                    finished();
                 });
+                console.log("5th Edition OGL by Roll20 v" + v["version"]);
             }
             else if(v["version"] === "2.3") {
                 console.log("UPGRADING TO v2.4");


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

## 2022-03-19
* Bug Fix - It was identified that because the default to-hit modifier had been changed from DEX to WIS on the Ship Sheet, sheets upgrading from 2.4 were over-riding any PC weapons to WIS that had not been EXPLICITLY set to DEX, because the weapon attacks on PC and Ship share the same repeating fieldset.  This is a documented Roll20 *feature*.  We have set the default back to DEX on the Ship Weapons for now as a fix for anyone else that still needs to upgrade.  In addition, the defaults between the SHIP and PC defaults have been aligned.  In version 2.4 the PC sheet set the defaults to STR, the SHIP to DEX and we have confirmed that once a name was placed in the 2.4 attack section the defaults would change to DEX.  This should now keep both attack sections in line and avoid a potential future upgrade where one set of defaults writes back over the other. *Ideally in the future the ship weapons will be separated into their own repeating fieldset.*
* Copied the Save modifiers from the PC sheet to the Ship sheet 


