### PR TITLE
[HârnMaster 3] styling - Dark mode for roll templates

### DIFF
--- a/HarnMaster3/harnstyle.css
+++ b/HarnMaster3/harnstyle.css
@@ -1225,12 +1225,41 @@ button.dismissnotification {
 
 /* ROLL TEMPLATES */
 
+/* RT colour schemes */
+.sheet-rolltemplate-custom .sheet-container.sheet-color-harn {
+  --header-bg-color: #a27800;
+  --header-text-color: #FFF;
+  --main-text-color:#586e75;
+  --content-bg-color: #fdf6e3;
+  --custom-border-color: #a27800;
+  --highlight-text-color: #0087ff;
+  --highlight-row-bg: #ffffd7;
+  --even-row-bg: #eee8d5;
+}
+
+ .sheet-rolltemplate-custom.sheet-rolltemplate-darkmode .sheet-container.sheet-color-harn {
+  --header-bg-color: #6c71c4;
+  --header-text-color: #FFF;
+  --main-text-color:#93a1a1;
+  --content-bg-color: #002b36;
+  --custom-border-color: #6c71c4;
+  --highlight-text-color: #0087ff;
+  --highlight-row-bg: #002b36;
+  --even-row-bg: #073642;
+}
+
+/* VTT dark mode support (make roll results legible) */
+
+.sheet-rolltemplate-custom .sheet-container .sheet-value {
+	color: var(--dark-primarytext);
+}
+
+/* other RT styling and layout */
+
 .sheet-rolltemplate-custom .sheet-container {
   width: 100%;	
   border: 1px solid;
-  /* by default, the border is the same color as the header. You can change this here, e.g. to black */
   border-color: var(--custom-border-color);
-  color: #121212;
 }
 
 /* Smaller margins - remove these if you want the huge default left margin */
@@ -1261,41 +1290,11 @@ button.dismissnotification {
   font-size:.9em;
 }
 
-/* example colors */
-.sheet-rolltemplate-custom .sheet-container {
-  /* this is the default color */
-  --header-bg-color: rgba(112,32,130,1);
-  --header-text-color: #FFF;
-  --content-bg-color: #FFF;
-  --custom-border-color: #000;
-}
-.sheet-rolltemplate-custom .sheet-container.sheet-color-red {
-  --header-bg-color: #F00;
-}
-.sheet-rolltemplate-custom .sheet-container.sheet-color-green {
-  --header-bg-color: #0F0;
-  --header-text-color: #000;
-}
-
-.sheet-rolltemplate-custom .sheet-container.sheet-color-harn {
-  --header-bg-color: #a27800;
-  --header-text-color: #FFF;
-  --content-bg-color: #FFFAF0;
-  --custom-border-color: #00000000;
-  --highlight-text-color: #0087ff;
-  --highlight-row-bg: #ffffd7;
-}
-
-/* VTT dark mode support (make roll results legible) */
-
-.sheet-rolltemplate-custom .sheet-container .sheet-value {
-	color: var(--dark-primarytext);
-}
 
 /* Allprops part */
 .sheet-rolltemplate-custom .sheet-content {
   display: grid;
-  /* background: #FFF; */
+  color: var(--main-text-color);
   background-color: var(--content-bg-color);
   /* Header formatting - modify the column layout below */
   grid-template-columns: auto auto;
@@ -1358,7 +1357,7 @@ button.dismissnotification {
 .sheet-rolltemplate-custom .sheet-crit-failure {
     grid-column: span 2;
 	border: 2px solid #990000;
-    background-color: #CC0000 !important;
+    background-color: #dc322f !important;
 	color: #FFF;
     text-align: center;
     font-weight: bold;
@@ -1380,7 +1379,7 @@ button.dismissnotification {
 /* Make even-numbered rows grey */
 .sheet-rolltemplate-custom .sheet-content :nth-child(4n+3),
 .sheet-rolltemplate-custom .sheet-content :nth-child(4n) {
-  background:#EEE;
+  background: var(--even-row-bg);
 }
 
 /* Description field */
@@ -1388,5 +1387,6 @@ button.dismissnotification {
   grid-column: span 2;
   padding: 5px;
   text-align: center;
+  font-weight: bold;
 }
 


### PR DESCRIPTION
Use new css class to target separate dark mode styling. Also minor changes to light mode style to add a border and bring it more in line with solarized.

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

## New Sheet Details


# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->
Title is descriptive: add styling for dark mode roll templates



