### PR TITLE
[ADnD 2E Revised] Bugfix useroptions

### DIFF
--- a/ADnD 2E Revised/2ESheet.html
+++ b/ADnD 2E Revised/2ESheet.html
@@ -45861,14 +45861,11 @@ const fixQuotes = function (currentValue, attribute, event) {
 }
 
 on(BOOK_FIELDS.map(b => `change:${b}`).join(' '), function (eventInfo) {
-    let attribute = eventInfo.sourceAttribute;
-    let currentValue = eventInfo.newValue;
-    if (currentValue) {
-        fixQuotes(currentValue, attribute, "eventInfo.newValue");
+    if (eventInfo.newValue) {
+        fixQuotes(eventInfo.newValue, eventInfo.sourceAttribute, "eventInfo.newValue");
     } else {
-        getAttrs([attribute], function (values) {
-            currentValue = values[attribute];
-            fixQuotes(currentValue, attribute, "getAttrs");
+        getAttrs([eventInfo.sourceAttribute], function (values) {
+            fixQuotes(values[eventInfo.sourceAttribute], eventInfo.sourceAttribute, "getAttrs");
         });
     }
 });

--- a/ADnD 2E Revised/2ESheet.html
+++ b/ADnD 2E Revised/2ESheet.html
@@ -45857,6 +45857,7 @@ on(BOOK_FIELDS.map(b => `change:${b}`).join(' '), function (eventInfo) {
     if (currentValue) {
         if (currentValue.includes('’')) {
             newValue[eventInfo.sourceAttribute] = currentValue.replaceAll('’', '\'');
+            console.log(`${eventInfo.sourceAttribute} was updated via eventInfo.newValue`);
             setAttrs(newValue,{silent:true});
         }
         return;
@@ -45866,6 +45867,7 @@ on(BOOK_FIELDS.map(b => `change:${b}`).join(' '), function (eventInfo) {
         currentValue = values[eventInfo.sourceAttribute];
         if (currentValue.includes('’')) {
             newValue[eventInfo.sourceAttribute] = currentValue.replaceAll('’', '\'');
+            console.log(`${eventInfo.sourceAttribute} was updated via getAttrs`);
             setAttrs(newValue,{silent:true});
         }
     })

--- a/ADnD 2E Revised/2ESheet.html
+++ b/ADnD 2E Revised/2ESheet.html
@@ -45852,12 +45852,26 @@ on('sheet:opened', function () {
 
 // Fix for Roll20 not handling quotes correctly from sheet.json
 on(BOOK_FIELDS.map(b => `change:${b}`).join(' '), function (eventInfo) {
-    console.log(eventInfo);
-    if (eventInfo.newValue && eventInfo.newValue.includes('’')) {
-        let newValue = {};
-        newValue[eventInfo.sourceAttribute] = eventInfo.newValue.replaceAll('’', '\'');
-        setAttrs(newValue,{silent:true});
+    let currentValue = eventInfo.newValue;
+    let newValue = {};
+    if (currentValue) {
+        if (currentValue.includes('’')) {
+            newValue[eventInfo.sourceAttribute] = currentValue.replaceAll('’', '\'');
+            console.log(`${eventInfo.sourceAttribute} was updated from eventInfo.newValue`)
+            setAttrs(newValue,{silent:true});
+        }
+        return;
     }
+
+    getAttrs([eventInfo.sourceAttribute], function(values) {
+        console.log(values);
+        currentValue = values[eventInfo.sourceAttribute];
+        if (currentValue.includes('’')) {
+            newValue[eventInfo.sourceAttribute] = currentValue.replaceAll('’', '\'');
+            console.log(`${eventInfo.sourceAttribute} was updated from getAttrs`)
+            setAttrs(newValue,{silent:true});
+        }
+    })
 });
 
 // --- ALL SHEET WORKERS END --- //
@@ -45865,7 +45879,7 @@ on(BOOK_FIELDS.map(b => `change:${b}`).join(' '), function (eventInfo) {
 // --- Version change start --- //
 
 const SHEET_NAME = 'AD&D 2E Revised';
-const SHEET_VERSION = '4.7.1';
+const SHEET_VERSION = '4.7.2';
 
 on('sheet:opened', function(){
     getAttrs(['character_sheet'],function(attrs){

--- a/ADnD 2E Revised/2ESheet.html
+++ b/ADnD 2E Revised/2ESheet.html
@@ -45851,26 +45851,26 @@ on('sheet:opened', function () {
 });
 
 // Fix for Roll20 not handling quotes correctly from sheet.json
-on(BOOK_FIELDS.map(b => `change:${b}`).join(' '), function (eventInfo) {
-    let currentValue = eventInfo.newValue;
-    let newValue = {};
-    if (currentValue) {
-        if (currentValue.includes('’')) {
-            newValue[eventInfo.sourceAttribute] = currentValue.replaceAll('’', '\'');
-            console.log(`${eventInfo.sourceAttribute} was updated via eventInfo.newValue`);
-            setAttrs(newValue,{silent:true});
-        }
-        return;
+const fixQuotes = function (currentValue, attribute, event) {
+    if (currentValue.includes('’')) {
+        let newValue = {};
+        newValue[attribute] = currentValue.replaceAll('’', '\'');
+        console.log(`${attribute} was updated via ${event}`);
+        setAttrs(newValue,{silent:true});
     }
+}
 
-    getAttrs([eventInfo.sourceAttribute], function (values) {
-        currentValue = values[eventInfo.sourceAttribute];
-        if (currentValue.includes('’')) {
-            newValue[eventInfo.sourceAttribute] = currentValue.replaceAll('’', '\'');
-            console.log(`${eventInfo.sourceAttribute} was updated via getAttrs`);
-            setAttrs(newValue,{silent:true});
-        }
-    })
+on(BOOK_FIELDS.map(b => `change:${b}`).join(' '), function (eventInfo) {
+    let attribute = eventInfo.sourceAttribute;
+    let currentValue = eventInfo.newValue;
+    if (currentValue) {
+        fixQuotes(currentValue, attribute, "eventInfo.newValue");
+    } else {
+        getAttrs([attribute], function (values) {
+            currentValue = values[attribute];
+            fixQuotes(currentValue, attribute, "getAttrs");
+        });
+    }
 });
 
 // --- ALL SHEET WORKERS END --- //

--- a/ADnD 2E Revised/2ESheet.html
+++ b/ADnD 2E Revised/2ESheet.html
@@ -45857,18 +45857,15 @@ on(BOOK_FIELDS.map(b => `change:${b}`).join(' '), function (eventInfo) {
     if (currentValue) {
         if (currentValue.includes('’')) {
             newValue[eventInfo.sourceAttribute] = currentValue.replaceAll('’', '\'');
-            console.log(`${eventInfo.sourceAttribute} was updated from eventInfo.newValue`)
             setAttrs(newValue,{silent:true});
         }
         return;
     }
 
-    getAttrs([eventInfo.sourceAttribute], function(values) {
-        console.log(values);
+    getAttrs([eventInfo.sourceAttribute], function (values) {
         currentValue = values[eventInfo.sourceAttribute];
         if (currentValue.includes('’')) {
             newValue[eventInfo.sourceAttribute] = currentValue.replaceAll('’', '\'');
-            console.log(`${eventInfo.sourceAttribute} was updated from getAttrs`)
             setAttrs(newValue,{silent:true});
         }
     })

--- a/ADnD 2E Revised/javascript/sheetWorkers.js
+++ b/ADnD 2E Revised/javascript/sheetWorkers.js
@@ -1583,6 +1583,7 @@ on(BOOK_FIELDS.map(b => `change:${b}`).join(' '), function (eventInfo) {
     if (currentValue) {
         if (currentValue.includes('’')) {
             newValue[eventInfo.sourceAttribute] = currentValue.replaceAll('’', '\'');
+            console.log(`${eventInfo.sourceAttribute} was updated via eventInfo.newValue`);
             setAttrs(newValue,{silent:true});
         }
         return;
@@ -1592,6 +1593,7 @@ on(BOOK_FIELDS.map(b => `change:${b}`).join(' '), function (eventInfo) {
         currentValue = values[eventInfo.sourceAttribute];
         if (currentValue.includes('’')) {
             newValue[eventInfo.sourceAttribute] = currentValue.replaceAll('’', '\'');
+            console.log(`${eventInfo.sourceAttribute} was updated via getAttrs`);
             setAttrs(newValue,{silent:true});
         }
     })

--- a/ADnD 2E Revised/javascript/sheetWorkers.js
+++ b/ADnD 2E Revised/javascript/sheetWorkers.js
@@ -1578,12 +1578,26 @@ on('sheet:opened', function () {
 
 // Fix for Roll20 not handling quotes correctly from sheet.json
 on(BOOK_FIELDS.map(b => `change:${b}`).join(' '), function (eventInfo) {
-    console.log(eventInfo);
-    if (eventInfo.newValue && eventInfo.newValue.includes('’')) {
-        let newValue = {};
-        newValue[eventInfo.sourceAttribute] = eventInfo.newValue.replaceAll('’', '\'');
-        setAttrs(newValue,{silent:true});
+    let currentValue = eventInfo.newValue;
+    let newValue = {};
+    if (currentValue) {
+        if (currentValue.includes('’')) {
+            newValue[eventInfo.sourceAttribute] = currentValue.replaceAll('’', '\'');
+            console.log(`${eventInfo.sourceAttribute} was updated from eventInfo.newValue`)
+            setAttrs(newValue,{silent:true});
+        }
+        return;
     }
+
+    getAttrs([eventInfo.sourceAttribute], function(values) {
+        console.log(values);
+        currentValue = values[eventInfo.sourceAttribute];
+        if (currentValue.includes('’')) {
+            newValue[eventInfo.sourceAttribute] = currentValue.replaceAll('’', '\'');
+            console.log(`${eventInfo.sourceAttribute} was updated from getAttrs`)
+            setAttrs(newValue,{silent:true});
+        }
+    })
 });
 
 // --- ALL SHEET WORKERS END --- //

--- a/ADnD 2E Revised/javascript/sheetWorkers.js
+++ b/ADnD 2E Revised/javascript/sheetWorkers.js
@@ -1583,18 +1583,15 @@ on(BOOK_FIELDS.map(b => `change:${b}`).join(' '), function (eventInfo) {
     if (currentValue) {
         if (currentValue.includes('’')) {
             newValue[eventInfo.sourceAttribute] = currentValue.replaceAll('’', '\'');
-            console.log(`${eventInfo.sourceAttribute} was updated from eventInfo.newValue`)
             setAttrs(newValue,{silent:true});
         }
         return;
     }
 
-    getAttrs([eventInfo.sourceAttribute], function(values) {
-        console.log(values);
+    getAttrs([eventInfo.sourceAttribute], function (values) {
         currentValue = values[eventInfo.sourceAttribute];
         if (currentValue.includes('’')) {
             newValue[eventInfo.sourceAttribute] = currentValue.replaceAll('’', '\'');
-            console.log(`${eventInfo.sourceAttribute} was updated from getAttrs`)
             setAttrs(newValue,{silent:true});
         }
     })

--- a/ADnD 2E Revised/javascript/sheetWorkers.js
+++ b/ADnD 2E Revised/javascript/sheetWorkers.js
@@ -1577,26 +1577,23 @@ on('sheet:opened', function () {
 });
 
 // Fix for Roll20 not handling quotes correctly from sheet.json
-on(BOOK_FIELDS.map(b => `change:${b}`).join(' '), function (eventInfo) {
-    let currentValue = eventInfo.newValue;
-    let newValue = {};
-    if (currentValue) {
-        if (currentValue.includes('’')) {
-            newValue[eventInfo.sourceAttribute] = currentValue.replaceAll('’', '\'');
-            console.log(`${eventInfo.sourceAttribute} was updated via eventInfo.newValue`);
-            setAttrs(newValue,{silent:true});
-        }
-        return;
+const fixQuotes = function (currentValue, attribute, event) {
+    if (currentValue.includes('’')) {
+        let newValue = {};
+        newValue[attribute] = currentValue.replaceAll('’', '\'');
+        console.log(`${attribute} was updated via ${event}`);
+        setAttrs(newValue,{silent:true});
     }
+}
 
-    getAttrs([eventInfo.sourceAttribute], function (values) {
-        currentValue = values[eventInfo.sourceAttribute];
-        if (currentValue.includes('’')) {
-            newValue[eventInfo.sourceAttribute] = currentValue.replaceAll('’', '\'');
-            console.log(`${eventInfo.sourceAttribute} was updated via getAttrs`);
-            setAttrs(newValue,{silent:true});
-        }
-    })
+on(BOOK_FIELDS.map(b => `change:${b}`).join(' '), function (eventInfo) {
+    if (eventInfo.newValue) {
+        fixQuotes(eventInfo.newValue, eventInfo.sourceAttribute, "eventInfo.newValue");
+    } else {
+        getAttrs([eventInfo.sourceAttribute], function (values) {
+            fixQuotes(values[eventInfo.sourceAttribute], eventInfo.sourceAttribute, "getAttrs");
+        });
+    }
 });
 
 // --- ALL SHEET WORKERS END --- //

--- a/ADnD 2E Revised/javascript/version.js
+++ b/ADnD 2E Revised/javascript/version.js
@@ -1,7 +1,7 @@
 // --- Version change start --- //
 
 const SHEET_NAME = 'AD&D 2E Revised';
-const SHEET_VERSION = '4.7.1';
+const SHEET_VERSION = '4.7.2';
 
 on('sheet:opened', function(){
     getAttrs(['character_sheet'],function(attrs){


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [X] The pull request title clearly contains the name of the sheet I am editing.
- [X] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [X] The pull request makes changes to files in only one sub-folder.
- [X] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

Improved the handling of quotes from the Default Sheet Settings. The previous solution worked for new sheets, but not for old sheets when the GM uses the "Apply Default Settings" button from the menu.




