### PR TITLE
[Coeurs Vaillants] New Features and Bugfixes - use template for rolls and other updates

### DIFF
--- a/CoeursVaillants/CoeursVaillants.html
+++ b/CoeursVaillants/CoeursVaillants.html
@@ -7,7 +7,7 @@
         <label>Peuple <input type="text" name="attr_peuple"> Poids <input type="text" name="attr_poids"></label>
     </div>
     <div class="sheet-logo sheet-block">
-        <img class="sheet-logo" title="Version 1.00 - 10/12/2021" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/CoeursVaillants/images/Logo.png" width="100%" />
+        <img class="sheet-logo" title="Version 1.01 - 13/04/2022" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/CoeursVaillants/images/Logo.png" width="100%" />
     </div>
     <div class="sheet-lvl sheet-block">
         <label>Niveau <input type="number" name="attr_niveau" class='sheet-extrashort' value='1'>
@@ -17,126 +17,100 @@
         <label class="sheet-avent2">3XP x Niveau : gain de niveau</label>
     </div>
     <div class="sheet-stat sheet-block">
-        <h2>Caractéristiques</h2>
+        <h2>Caractéristiques <button type='roll' name='roll_testfor' title='Tirer une nouvelle série de caracs' value='&{template:default} {{name=Tirage de Caractéristiques}} {{Série 1=[[3d6cs<1cf>6]] [[3d6cs<1cf>6]] [[3d6cs<1cf>6]] [[3d6cs<1cf>6]] [[3d6cs<1cf>6]] [[3d6cs<1cf>6]]}} {{Série 2=[[3d6cs<1cf>6]] [[3d6cs<1cf>6]] [[3d6cs<1cf>6]] [[3d6cs<1cf>6]] [[3d6cs<1cf>6]] [[3d6cs<1cf>6]]}} {{note=Plus c’est bas mieux c’est !}}'></button></h2>
         <label>
-            <button type='roll' name='roll_testfor' value='/em realise un jet de [[2d20kh1]] contre Caracteristique' class='sheet-greenbutton'></button>
-            <button type='roll' name='roll_testfor' value='/em realise un jet de [[1d20]] contre Caracteristique'></button>
-            <button type='roll' name='roll_testfor' value='/em realise un jet de [[2d20kl1]] contre Caracteristique' class='sheet-redbutton'></button>
+            <button type='roll' name='roll_testfor' value='&{template:default} {{name=Jet de Caractéristique (Av.)}} {{Résultat=[[2d20kh1+?{Métier ?|Aucun métier,0|Artisan,@{artisan}|Courtisan,@{courtisan}|Voyageur,@{voyageur}|Érudit,@{erudit}}]]}}' class='sheet-greenbutton'></button>
+            <button type='roll' name='roll_testfor' value='&{template:default} {{name=Jet de Caractéristique}} {{Résultat=[[1d20+?{Métier ?|Aucun métier,0|Artisan,@{artisan}|Courtisan,@{courtisan}|Voyageur,@{voyageur}|Érudit,@{erudit}}]]}}'></button>
+            <button type='roll' name='roll_testfor' value='&{template:default} {{name=Jet de Caractéristique (Des.)}} {{Résultat=[[2d20kl1+?{Métier ?|Aucun métier,0|Artisan,@{artisan}|Courtisan,@{courtisan}|Voyageur,@{voyageur}|Érudit,@{erudit}}]]}}' class='sheet-redbutton'></button>
         </label>
-        <label>FOR <input type="number" name="attr_for" class='sheet-short' value='0'></label>
-        <label>CON <input type="number" name="attr_con" class='sheet-short' value='0'></label>
-        <label>DEX <input type="number" name="attr_dex" class='sheet-short' value='0'></label>
-        <label>INT <input type="number" name="attr_int" class='sheet-short' value='0'></label>
-        <label>SAG <input type="number" name="attr_sag" class='sheet-short' value='0'></label>
-        <label>CHA <input type="number" name="attr_cha" class='sheet-short' value='0'></label>
+        <label><h3>FOR <input type="number" name="attr_for" class='sheet-short' value='0'></h3></label>
+        <label><h3>INT <input type="number" name="attr_int" class='sheet-short' value='0'></h3></label>
+        <label><h3>SAG <input type="number" name="attr_sag" class='sheet-short' value='0'></h3></label>
+        <label><h3>DEX <input type="number" name="attr_dex" class='sheet-short' value='0'></h3></label>
+        <label><h3>CON <input type="number" name="attr_con" class='sheet-short' value='0'></h3></label>
+        <label><h3>CHA <input type="number" name="attr_cha" class='sheet-short' value='0'></h3></label>
     </div>
     <div class="sheet-skill sheet-block">
         <label>
             Mouvement (pas) <input type="number" name="attr_mvt" class='sheet-extrashort' value='12'>
-            Dés de vie <input type="text" name="attr_dv" class='sheet-extrashort'>
-            Repit <button type='roll' name='roll_testRepit' value='/em souffle un bon coup, il récupère [[@{niveau}d4]] PV'></button>
+            Dés de vie <input type="text" name="attr_dv" class='sheet-short' value='1d8'>
+			<button type='roll' name='roll_jetdv' value='&{template:default} {{name=Nouveaux PV}} {{Résultat=[[@{dv}+8]]}}'></button>
+            Répit <button type='roll' name='roll_testRepit' value='&{template:default} {{name=Répit}} {{Récupération=[[@{niveau}d4]] PV}}'></button>
         </label>
         <label>
-            Initiative <input type="text" name="attr_initiative" class='sheet-short'>
-            <button type='roll' name='roll_testinit' value='/em obtient une initiative de [[@{initiative} &{tracker}]]'></button>
-            Manoeuvre <input type="number" name="attr_manoeuvre" class='sheet-short' value='0'>
-            <button type='roll' name='roll_testmanoeuvreadv' value='/em obtient un jet de manoeuvre de [[2d20kh1}]] contre difficulté @{manoeuvre}' class='sheet-greenbutton'></button>
-            <button type='roll' name='roll_testmanoeuvre' value='/em obtient un jet de manoeuvre de [[1d20}]] contre difficulté @{manoeuvre}'></button>
-            <button type='roll' name='roll_testmanoeuvredisadv' value='/em obtient un jet de manoeuvre de [[2d20kl1}]] contre difficulté @{manoeuvre}' class='sheet-redbutton'></button>
+            Initiative <input type="text" name="attr_initiative" class='sheet-short' value='1d8'>
+            <button type='roll' name='roll_testinit' value='&{template:default} {{name=Jet d’Initiative}} {{Résultat=[[@{initiative}+@{niveau} &{tracker}]]}}'></button>
+            Manoeuvre <input type="number" name="attr_manoeuvre" class='sheet-short' value='10'>
+            <button type='roll' name='roll_testmanoeuvreadv' value='&{template:default} {{name=Jet de Manœuvre (Av.)}} {{Résultat=[[{2d20kh1+?{Métier ?|Aucun métier,0|Artisan,@{artisan}|Courtisan,@{courtisan}|Voyageur,@{voyageur}|Érudit,@{erudit}}}>@{manoeuvre}]] Succès}}' class='sheet-greenbutton'></button>
+            <button type='roll' name='roll_testmanoeuvre' value='&{template:default} {{name=Jet de Manœuvre}} {{Résultat=[[{1d20+?{Métier ?|Aucun métier,0|Artisan,@{artisan}|Courtisan,@{courtisan}|Voyageur,@{voyageur}|Érudit,@{erudit}}}>@{manoeuvre}]] Succès}}'></button>
+            <button type='roll' name='roll_testmanoeuvredisadv' value='&{template:default} {{name=Jet de Manœuvre (Des.)}} {{Résultat=[[{2d20kl1+?{Métier ?|Aucun métier,0|Artisan,@{artisan}|Courtisan,@{courtisan}|Voyageur,@{voyageur}|Érudit,@{erudit}}}>@{manoeuvre}]] Succès}}' class='sheet-redbutton'></button>
         </label>
     </div>
     <div class="sheet-combat sheet-block">
-        <h2>Combat (Trucs 
-            <button type='roll' name='roll_testtruc' value='/em realise un truc de combat de [[2d20kh1 + @{bc}]] contre caracteristique' class='sheet-greenbutton'></button>
-            <button type='roll' name='roll_testtruc' value='/em realise un truc de combat de [[1d20 + @{bc}]] contre caracteristique'></button>
-            <button type='roll' name='roll_testtruc' value='/em realise un truc de combat de [[2d20kl1 + @{bc}]] contre caracteristique' class='sheet-redbutton'></button>)
-        </h2>
+			<h2>Combat – Trucs de combat 
+            <button type='roll' name='roll_testtruc' value='&{template:default} {{name=Truc de combat (Av.)}} {{Résultat=[[2d20kh1+@{bc}]]}}' class='sheet-greenbutton'></button>
+            <button type='roll' name='roll_testtruc' value='&{template:default} {{name=Truc de combat}} {{Résultat=[[1d20+@{bc}]]}}'></button>
+            <button type='roll' name='roll_testtruc' value='&{template:default} {{name=Truc de combat (Des.)}} {{Résultat=[[2d20kl1+@{bc}]]}}' class='sheet-redbutton'></button></h2>
         <label>
             <input type="text" name="attr_arm1" value="Arme/Attaque">
             <input type="number" name="attr_bonusarm1" value="0" class='sheet-short'>
             <input type="text" name="attr_dmgarm1" value="DMG" class='sheet-medium'>
-            <button type='roll' name='roll_testcombat1' value='/em realise un jet d&#39;attaque de [[2d20kh1 + @{bonusarm1}]] contre CA et inflige [[@{dmgarm1}]] dommages' class='sheet-greenbutton'></button>
-            <button type='roll' name='roll_testcombat1' value='/em realise un jet d&#39;attaque de [[1d20 + @{bonusarm1}]] contre CA et inflige [[@{dmgarm1}]] dommages'></button>
-            <button type='roll' name='roll_testcombat1' value='/em realise un jet d&#39;attaque de [[2d20kl1 + @{bonusarm1}]] contre CA et inflige [[@{dmgarm1}]] dommages' class='sheet-redbutton'></button>
+            <button type='roll' name='roll_testcombat1' value='&{template:default} {{name=Attaque avec @{arm1} (Av.)}} {{Résultat=[[2d20kh1[D20]+@{bc}[BC]+@{bonusarm1}[Bonus arme]]]}} {{Contusion=[[{@{dmgarm1}}>1]] dégâts}} {{Blessure=[[@{dmgarm1}]] dégâts}}' class='sheet-greenbutton'></button>
+            <button type='roll' name='roll_testcombat1' value='&{template:default} {{name=Attaque avec @{arm1}}} {{Résultat=[[1d20[D20]+@{bc}[BC]+@{bonusarm1}[Bonus arme]]]}} {{Contusion=[[{@{dmgarm1}}>1]] dégâts}} {{Blessure=[[@{dmgarm1}]] dégâts}}'></button>
+            <button type='roll' name='roll_testcombat1' value='&{template:default} {{name=Attaque avec @{arm1} (Des.)}} {{Résultat=[[2d20kl1[D20]+@{bc}[BC]+@{bonusarm1}[Bonus arme]]]}} {{Contusion=[[{@{dmgarm1}}>1]] dégâts}} {{Blessure=[[@{dmgarm1}]] dégâts}}' class='sheet-redbutton'></button>
         </label>
         <label>
             <input type="text" name="attr_arm2" value="Arme/Attaque">
             <input type="number" name="attr_bonusarm2" value="0" class='sheet-short'>
             <input type="text" name="attr_dmgarm2" value="DMG" class='sheet-medium'>
-            <button type='roll' name='roll_testcombat2' value='/em realise un jet d&#39;attaque de [[2d20kh1 + @{bonusarm2}]] contre CA et inflige [[@{dmgarm2}]] dommages' class='sheet-greenbutton'></button>
-            <button type='roll' name='roll_testcombat2' value='/em realise un jet d&#39;attaque de [[1d20 + @{bonusarm2}]] contre CA et inflige [[@{dmgarm2}]] dommages'></button>
-            <button type='roll' name='roll_testcombat2' value='/em realise un jet d&#39;attaque de [[2d20kl1 + @{bonusarm2}]] contre CA et inflige [[@{dmgarm2}]] dommages' class='sheet-redbutton'></button>
+            <button type='roll' name='roll_testcombat2' value='&{template:default} {{name=Attaque avec @{arm2} (Av.)}} {{Résultat=[[2d20kh1[D20]+@{bc}[BC]+@{bonusarm2}[Bonus arme]]]}} {{Contusion=[[{@{dmgarm2}}>1]] dégâts}} {{Blessure=[[@{dmgarm2}]] dégâts}}' class='sheet-greenbutton'></button>
+            <button type='roll' name='roll_testcombat2' value='&{template:default} {{name=Attaque avec @{arm2}}} {{Résultat=[[1d20[D20]+@{bc}[BC]+@{bonusarm2}[Bonus arme]]]}} {{Contusion=[[{@{dmgarm2}}>1]] dégâts}} {{Blessure=[[@{dmgarm2}]] dégâts}}'></button>
+            <button type='roll' name='roll_testcombat2' value='&{template:default} {{name=Attaque avec @{arm2} (Des.)}} {{Résultat=[[2d20kl1[D20]+@{bc}[BC]+@{bonusarm2}[Bonus arme]]]}} {{Contusion=[[{@{dmgarm2}}>1]] dégâts}} {{Blessure=[[@{dmgarm2}]] dégâts}}' class='sheet-redbutton'></button>
         </label>
         <label>
             <input type="text" name="attr_arm3" value="Arme/Attaque">
             <input type="number" name="attr_bonusarm3" value="0" class='sheet-short'>
             <input type="text" name="attr_dmgarm3" value="DMG" class='sheet-medium'>
-            <button type='roll' name='roll_testcombat3' value='/em realise un jet d&#39;attaque de [[2d20kh1 + @{bonusarm3}]] contre CA et inflige [[@{dmgarm3}]] dommages' class='sheet-greenbutton'></button>
-            <button type='roll' name='roll_testcombat3' value='/em realise un jet d&#39;attaque de [[1d20 + @{bonusarm3}]] contre CA et inflige [[@{dmgarm3}]] dommages'></button>
-            <button type='roll' name='roll_testcombat3' value='/em realise un jet d&#39;attaque de [[2d20kl1 + @{bonusarm3}]] contre CA et inflige [[@{dmgarm3}]] dommages' class='sheet-redbutton'></button>
+            <button type='roll' name='roll_testcombat3' value='&{template:default} {{name=Attaque avec @{arm3} (Av.)}} {{Résultat=[[2d20kh1[D20]+@{bc}[BC]+@{bonusarm3}[Bonus arme]]]}} {{Contusion=[[{@{dmgarm3}}>1]] dégâts}} {{Blessure=[[@{dmgarm3}]] dégâts}}' class='sheet-greenbutton'></button>
+            <button type='roll' name='roll_testcombat3' value='&{template:default} {{name=Attaque avec @{arm3}}} {{Résultat=[[1d20[D20]+@{bc}[BC]+@{bonusarm3}[Bonus arme]]]}} {{Contusion=[[{@{dmgarm3}}>1]] dégâts}} {{Blessure=[[@{dmgarm3}]] dégâts}}'></button>
+            <button type='roll' name='roll_testcombat3' value='&{template:default} {{name=Attaque avec @{arm3} (Des.)}} {{Résultat=[[2d20kl1[D20]+@{bc}[BC]+@{bonusarm3}[Bonus arme]]]}} {{Contusion=[[{@{dmgarm3}}>1]] dégâts}} {{Blessure=[[@{dmgarm3}]] dégâts}}' class='sheet-redbutton'></button>
         </label>
     </div>
     <div class="sheet-equip sheet-block">
         <h2>Equipement</h2>
         <textarea name="attr_equip" class='sheet-text2col'></textarea>
-        <label>Richesses <input type="text" name="attr_po" class='sheet-short' value='0po'>
+        <label>Richesses <input type="text" name="attr_po" class='sheet-short' value='0 po'>
     </div>
     <div class="sheet-meca sheet-block">
         <h2>Mécaniques</h2>
-        <label>CA <input type="number" name="attr_ca" class='sheet-short' value='0'></label>
+        <label>CA <input type="number" name="attr_ca" class='sheet-short' value='10'></label>
         <label>PV <input type="number" name="attr_pv" class='sheet-extrashort' value='0'> / <input type="number" name="attr_pvmax" class='sheet-extrashort' value='0'></label>
         <label>BC <input type="number" name="attr_bc" class='sheet-short' value='0'></label>
         <label>Svg <input type="number" name="attr_svg" class='sheet-short' value='0'>
-            <button type='roll' name='roll_testsvg' value='/em realise un jet de sauvegarde de [[2d20kh1]] contre @{svg}' class='sheet-greenbutton'></button>
-            <button type='roll' name='roll_testsvg' value='/em realise un jet de sauvegarde de [[1d20]] contre @{svg}'></button>
-            <button type='roll' name='roll_testsvg' value='/em realise un jet de sauvegarde de [[2d20kl1]] contre @{svg}' class='sheet-redbutton'></button>
+            <button type='roll' name='roll_testsvg' value='&{template:default} {{name=Jet de Sauvegarde (Av.)}} {{Résultat=[[{2d20kh1+?{Sauvegarde ?|Aucune,0|Souffles,@{souffle}|Mort,@{mort}|Magie,@{magie}|Poisons,@{poison}}}>@{svg}]] Succès}}' class='sheet-greenbutton'></button>
+            <button type='roll' name='roll_testsvg' value='&{template:default} {{name=Jet de Sauvegarde}} {{Résultat=[[{1d20+?{Sauvegarde ?|Aucune,0|Souffles,@{souffle}|Mort,@{mort}|Magie,@{magie}|Poisons,@{poison}}}>@{svg}]] Succès}}'></button>
+            <button type='roll' name='roll_testsvg' value='&{template:default} {{name=Jet de Sauvegarde (Des.)}} {{Résultat=[[{2d20kl1+?{Sauvegarde ?|Aucune,0|Souffles,@{souffle}|Mort,@{mort}|Magie,@{magie}|Poisons,@{poison}}}>@{svg}]] Succès}}' class='sheet-redbutton'></button>
         </label>
     </div>
     <div class="sheet-comp sheet-block">
         <h2>Métiers</h2>
-        <label>Artisan <input type="number" name="attr_artisan" class='sheet-extrashort' value='0'>
-        <button type='roll' name='roll_testartisan' value='/em realise un jet de [[2d20kh1 + @{artisan}]] d&#39;artisan contre caracteristique ou CA/DEX' class='sheet-greenbutton'></button>
-        <button type='roll' name='roll_testartisan' value='/em realise un jet de [[1d20 + @{artisan}]] d&#39;artisan contre caracteristique ou CA/DEX'></button>
-        <button type='roll' name='roll_testartisan' value='/em realise un jet de [[2d20kl1 + @{artisan}]] d&#39;artisan contre caracteristique ou CA/DEX' class='sheet-redbutton'></button></label>
-        <label>Courtisan <input type="number" name="attr_courtisan" class='sheet-extrashort' value='0'>
-        <button type='roll' name='roll_testcourtisan' value='/em realise un jet de [[2d20kh1 + @{courtisan}]] de courtisan contre caracteristique ou CA/DEX' class='sheet-greenbutton'></button>
-        <button type='roll' name='roll_testcourtisan' value='/em realise un jet de [[1d20 + @{courtisan}]] de courtisan contre caracteristique ou CA/DEX'></button>
-        <button type='roll' name='roll_testcourtisan' value='/em realise un jet de [[2d20kl1 + @{courtisan}]] de courtisan contre caracteristique ou CA/DEX' class='sheet-redbutton'></button></label>
-        <label>Voyageur <input type="number" name="attr_voyageur" class='sheet-extrashort' value='0'>
-        <button type='roll' name='roll_testvoyageur' value='/em realise un jet de [[2d20kh1 + @{voyageur}]]de voyageur contre caracteristique ou CA/DEX' class='sheet-greenbutton'></button>
-        <button type='roll' name='roll_testvoyageur' value='/em realise un jet de [[1d20 + @{voyageur}]]de voyageur contre caracteristique ou CA/DEX'></button>
-        <button type='roll' name='roll_testvoyageur' value='/em realise un jet de [[2d20kl1 + @{voyageur}]]de voyageur contre caracteristique ou CA/DEX' class='sheet-redbutton'></button></label>
-        <label>Erudit <input type="number" name="attr_erudit" class='sheet-extrashort' value='0'>
-        <button type='roll' name='roll_testerudit' value='/em realise un jet de [[2d20kh1 + @{erudit}]] d&#39;erudit contre caracteristique ou CA/DEX' class='sheet-greenbutton'></button>
-        <button type='roll' name='roll_testerudit' value='/em realise un jet de [[1d20 + @{erudit}]] d&#39;erudit contre caracteristique ou CA/DEX'></button>
-        <button type='roll' name='roll_testerudit' value='/em realise un jet de [[2d20kl1 + @{erudit}]] d&#39;erudit contre caracteristique ou CA/DEX' class='sheet-redbutton'></button></label>
+        <label>Artisan <input type="number" name="attr_artisan" class='sheet-extrashort' value='0'></label>
+        <label>Courtisan <input type="number" name="attr_courtisan" class='sheet-extrashort' value='0'></label>
+        <label>Voyageur <input type="number" name="attr_voyageur" class='sheet-extrashort' value='0'></label>
+        <label>Erudit <input type="number" name="attr_erudit" class='sheet-extrashort' value='0'></label>
     </div>
     <div class="sheet-svg sheet-block">
         <h2>Sauvegardes</h2>
-        <label>Souffle <input type="number" name="attr_souffle" class='sheet-extrashort' value='0'>
-        <button type='roll' name='roll_testsouffle' value='/em realise un jet de sauvegarde de Souffle de [[2d20kh1 + @{souffle}]] contre @{svg}' class='sheet-greenbutton'></button>
-        <button type='roll' name='roll_testsouffle' value='/em realise un jet de sauvegarde de Souffle de [[1d20 + @{souffle}]] contre @{svg}'></button>
-        <button type='roll' name='roll_testsouffle' value='/em realise un jet de sauvegarde de Souffle de [[2d20kl1 + @{souffle}]] contre @{svg}' class='sheet-redbutton'></button></label>
-        <label>Mort <input type="number" name="attr_mort" class='sheet-extrashort' value='0'>
-        <button type='roll' name='roll_testmort' value='/em realise un jet de sauvegarde de Mort de [[2d20kh1 + @{mort}]] contre @{svg}' class='sheet-greenbutton'></button>
-        <button type='roll' name='roll_testmort' value='/em realise un jet de sauvegarde de Mort de [[1d20 + @{mort}]] contre @{svg}'></button>
-        <button type='roll' name='roll_testmort' value='/em realise un jet de sauvegarde de Mort de [[2d20kl1 + @{mort}]] contre @{svg}' class='sheet-redbutton'></button></label>
-        <label>Magie <input type="number" name="attr_magie" class='sheet-extrashort' value='0'>
-        <button type='roll' name='roll_testmagie' value='/em realise un jet de sauvegarde de Magie de [[2d20kh1 + @{magie}]] contre @{svg}' class='sheet-greenbutton'></button>
-        <button type='roll' name='roll_testmagie' value='/em realise un jet de sauvegarde de Magie de [[1d20 + @{magie}]] contre @{svg}'></button>
-        <button type='roll' name='roll_testmagie' value='/em realise un jet de sauvegarde de Magie de [[2d20kl1 + @{magie}]] contre @{svg}' class='sheet-redbutton'></button></label>
-        <label>Poison <input type="number" name="attr_poison" class='sheet-extrashort' value='0'>
-        <button type='roll' name='roll_testpoison' value='/em realise un jet de sauvegarde de Poison de [[2d20kh1 + @{poison}]] contre @{svg}' class='sheet-greenbutton'></button>
-        <button type='roll' name='roll_testpoison' value='/em realise un jet de sauvegarde de Poison de [[1d20 + @{poison}]] contre @{svg}'></button>
-        <button type='roll' name='roll_testpoison' value='/em realise un jet de sauvegarde de Poison de [[2d20kl1 + @{poison}]] contre @{svg}' class='sheet-redbutton'></button></label>
+        <label>Souffle <input type="number" name="attr_souffle" class='sheet-extrashort' value='0'></label>
+        <label>Mort <input type="number" name="attr_mort" class='sheet-extrashort' value='0'></label>
+        <label>Magie <input type="number" name="attr_magie" class='sheet-extrashort' value='0'></label>
+        <label>Poison <input type="number" name="attr_poison" class='sheet-extrashort' value='0'></label>
     </div>
     <div class="sheet-avent sheet-block">
         <label>Points d'Aventure <input type="number" name="attr_aventure" class='sheet-extrashort' value='1'></label>
-    </div>
-    <div class="sheet-block">
         <label class="sheet-avent2">Avantage sur un jet (à déclarer avant le jet).</label>
         <label class="sheet-avent2">Une action supplémentaire en combat.</label>
-        <label class="sheet-avent2">Retrouver 1d8 + niveau points de vie. <button type='roll' name='roll_testAvPV' value='/em trouve un second souffle, il récupère [[1d8+@{niveau}]] PV'></label>
+        <label class="sheet-avent2">Retrouver 1d8 + niveau points de vie. <button type='roll' name='roll_testAvPV' value='&{template:default} {{name=Second souffle}} {{Récupération=[[@{niveau}d8]] PV}}'></label>
         <label class="sheet-avent2">Prier une divinité.</label>
     </div>
     <div class="sheet-bonus sheet-block">
@@ -145,28 +119,28 @@
     </div>
     <div class="sheet-mat1 sheet-block">
         <label>Matrices de niveau 1</label>
-        <label><input type="number" name="attr_mat1" class='sheet-extrashort'></label>
+        <label><input type="number" name="attr_mat1" class='sheet-extrashort'> / <input type="number" name="attr_maxmat1" class='sheet-extrashort'></label>
     </div>
     <div class="sheet-cercle1 sheet-block">
         <textarea name="attr_cercle1" class='sheet-text2col'>Sorts de Cercle 1</textarea>
     </div>
     <div class="sheet-mat2 sheet-block">
         <label>Matrices de niveau 2</label>
-        <label><input type="number" name="attr_mat2" class='sheet-extrashort'></label>
+        <label><input type="number" name="attr_mat2" class='sheet-extrashort'> / <input type="number" name="attr_maxmat2" class='sheet-extrashort'></label>
     </div>
     <div class="sheet-cercle2 sheet-block">
         <textarea name="attr_cercle2" class='sheet-text2col'>Sorts de Cercle 2</textarea>
     </div>
     <div class="sheet-mat3 sheet-block">
         <label>Matrices de niveau 3</label>
-        <label><input type="number" name="attr_mat3" class='sheet-extrashort'></label>
+        <label><input type="number" name="attr_mat3" class='sheet-extrashort'> / <input type="number" name="attr_maxmat3" class='sheet-extrashort'></label>
     </div>
     <div class="sheet-cercle3 sheet-block">
         <textarea name="attr_cercle3" class='sheet-text2col'>Sorts de Cercle 3</textarea>
     </div>
     <div class="sheet-mat4 sheet-block">
         <label>Matrices de niveau 4</label>
-        <label><input type="number" name="attr_mat4" class='sheet-extrashort'></label>
+        <label><input type="number" name="attr_mat4" class='sheet-extrashort'> / <input type="number" name="attr_maxmat4" class='sheet-extrashort'></label>
     </div>
     <div class="sheet-cercle4 sheet-block">
         <textarea name="attr_cercle4" class='sheet-text2col'>Sorts de Cercle 4</textarea>
@@ -178,8 +152,10 @@
 <div class="sheet-block_b">
     <div class="sheet-block">
         <label>NOM <input type="text" name="attr_character_name" class='sheet-long'></label>
-        <label>CA <input type="number" name="attr_pnjca" class='sheet-short' value='0'>
-        DV  <select name="attr_pnjdv" class="sheet-short">
+        <label>CA <input type="number" name="attr_pnjca" class='sheet-short' value='10'>
+        MVT <input type="number" name="attr_pnjmvt" class='sheet-short' value='12'>
+        PV <input type="number" name="attr_pnjpv" class='sheet-extrashort' value='0'> / <input type="number" name="attr_pnjpvmax" class='sheet-extrashort' value='0'></label>
+        <label>DV  <select name="attr_pnjdv" class="sheet-short">
                 <option value="1-1">1-1</option>
                 <option value="1" selected="selected">1</option>
                 <option value="2">2</option>
@@ -197,26 +173,25 @@
                 <option value="14">14</option>
                 <option value="15">15</option>
             </select>
-        PV <input type="number" name="attr_pnjpv" class='sheet-extrashort' value='0'> / <input type="number" name="attr_pnjpvmax" class='sheet-extrashort' value='0'>
-        Svg <input type="number" name="attr_pnjsvg" class='sheet-short' value='0'>
-        MVT <input type="number" name="attr_pnjmvt" class='sheet-short' value='0'>
-        Initiative <input type="text" name="attr_initiative" class='sheet-short'>
-        <button type='roll' name='roll_testinit' value='/em obtient une initiative de [[@{initiative} &{tracker}]]'></button></label>
+			<button type='roll' name='roll_jetpvpnj' value='/w gm &{template:default} {{name=PV du PNJ}} {{Résultat=[[{@{pnjdv}d8,1d4}kh1]]}}'></button>
+			Svg <input type="number" name="attr_pnjsvg" class='sheet-short' value='14'>
+			<button type='roll' name='roll_jetsvgpnj' value='/w gm &{template:default} {{name=Sauvegarde PNJ}} {{Résultat=[[1d20>@{pnjsvg}]] Succès}}'></button>
+			Initiative <input type="text" name="attr_initiative" class='sheet-short'>
+			<button type='roll' name='roll_testinit' value='/w gm &{template:default} {{name=Initiative PNJ}} {{Résultat=[[@{initiative}+@{pnjdv} &{tracker}]]}}'></button>
+		</label>
         <label>
             <input type="text" name="attr_pnjarm1" value="Arme/Attaque">
-            <input type="number" name="attr_pnjbonusarm1" value="0" class='sheet-short'>
             <input type="text" name="attr_pnjdmgarm1" value="DMG" class='sheet-medium'>
-            <button type='roll' name='roll_testpnjcombat1' value='/em realise un jet d&#39;attaque de [[2d20kh1 + @{pnjbonusarm1}]] contre CA et inflige [[@{pnjdmgarm1}]] dommages' class='sheet-greenbutton'></button>
-            <button type='roll' name='roll_testpnjcombat1' value='/em realise un jet d&#39;attaque de [[1d20 + @{pnjbonusarm1}]] contre CA et inflige [[@{pnjdmgarm1}]] dommages'></button>
-            <button type='roll' name='roll_testpnjcombat1' value='/em realise un jet d&#39;attaque de [[2d20kl1 + @{pnjbonusarm1}]] contre CA et inflige [[@{pnjdmgarm1}]] dommages' class='sheet-redbutton'></button>
+            <button type='roll' name='roll_testpnjcombat1' value='/w gm &{template:default} {{name=Attaque avec @{pnjarm1} (Av.)}} {{Résultat=[[2d20kh1+[[{ {@{pnjdv}}, {12}}kl1]]]]}} {{Contusion=[[{@{pnjdmgarm1}}>1]] dégâts}} {{Blessure=[[@{pnjdmgarm1}]] dégâts}}' class='sheet-greenbutton'></button>
+            <button type='roll' name='roll_testpnjcombat1' value='/w gm &{template:default} {{name=Attaque avec @{pnjarm1}}} {{Résultat=[[1d20+[[{ {@{pnjdv}}, {12}}kl1]]]]}} {{Contusion=[[{@{pnjdmgarm1}}>1]] dégâts}} {{Blessure=[[@{pnjdmgarm1}]] dégâts}}'></button>
+            <button type='roll' name='roll_testpnjcombat1' value='/w gm &{template:default} {{name=Attaque avec @{pnjarm1} (Des.)}} {{Résultat=[[2d20kl1+[[{ {@{pnjdv}}, {12}}kl1]]]]}} {{Contusion=[[{@{pnjdmgarm1}}>1]] dégâts}} {{Blessure=[[@{pnjdmgarm1}]] dégâts}}' class='sheet-redbutton'></button>
         </label>
         <label>
             <input type="text" name="attr_pnjarm2" value="Arme/Attaque">
-            <input type="number" name="attr_pnjbonusarm2" value="0" class='sheet-short'>
             <input type="text" name="attr_pnjdmgarm2" value="DMG" class='sheet-medium'>
-            <button type='roll' name='roll_testpnjcombat2' value='/em realise un jet d&#39;attaque de [[2d20kh1 + @{pnjbonusarm2}]] contre CA et inflige [[@{pnjdmgarm2}]] dommages' class='sheet-greenbutton'></button>
-            <button type='roll' name='roll_testpnjcombat2' value='/em realise un jet d&#39;attaque de [[1d20 + @{pnjbonusarm2}]] contre CA et inflige [[@{pnjdmgarm2}]] dommages'></button>
-            <button type='roll' name='roll_testpnjcombat2' value='/em realise un jet d&#39;attaque de [[2d20kl1 + @{pnjbonusarm2}]] contre CA et inflige [[@{pnjdmgarm2}]] dommages' class='sheet-redbutton'></button>
+            <button type='roll' name='roll_testpnjcombat2' value='/w gm &{template:default} {{name=Attaque avec @{pnjarm2} (Av.)}} {{Résultat=[[2d20kh1+[[{ {@{pnjdv}}, {12}}kl1]]]]}} {{Contusion=[[{@{pnjdmgarm2}}>1]] dégâts}} {{Blessure=[[@{pnjdmgarm2}]] dégâts}}' class='sheet-greenbutton'></button>
+            <button type='roll' name='roll_testpnjcombat2' value='/w gm &{template:default} {{name=Attaque avec @{pnjarm2}}} {{Résultat=[[1d20+[[{ {@{pnjdv}}, {12}}kl1]]]]}} {{Contusion=[[{@{pnjdmgarm2}}>1]] dégâts}} {{Blessure=[[@{pnjdmgarm2}]] dégâts}}'></button>
+            <button type='roll' name='roll_testpnjcombat2' value='/w gm &{template:default} {{name=Attaque avec @{pnjarm2} (Des.)}} {{Résultat=[[2d20kl1+[[{ {@{pnjdv}}, {12}}kl1]]]]}} {{Contusion=[[{@{pnjdmgarm2}}>1]] dégâts}} {{Blessure=[[@{pnjdmgarm2}]] dégâts}}' class='sheet-redbutton'></button>
         </label>
         <label>
             <textarea name="attr_pnjspecial" class='sheet-text3col'>Capacités spéciales</textarea>


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

## New Sheet Details

<!-- If you are submitting a new sheet to the repository, please fill in any empty spaces indicated by < >. -->

- The name of this game is: <   >  _(i.e. Dungeons & Dragons 5th Edition, The Dresden Files RPG)_
- The publisher of this game is: <   > _(i.e. Wizards of the Coast, Evil Hat)_
- The name of this game system/family is: <   > _(i.e. Dungeons & Dragons, FATE)_

- [ ] I have followed the [Character Sheets Standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) when building this sheet.

<!-- Please check any that apply: -->

- [ ] This sheet has been made on behalf of, or by, the game's publisher.
- [ ] This game is not a traditionally published game, but a copy of the game rules can be purchased/downloaded/found at: <   >
- [ ] This sheet is for an unofficial fan game, modification to an existing game, or a homebrew system.

# Changes / Description

Following updates have been done:
 - use default template on all rolls.
 - add prompt to choose the 'métier' or the 'sauvegarde' to use.
 - remove unecessary buttons thanks to that prompt.
 - add a button to roll 2 series of characteristics.
 - weapon roll now automatically adds the 'BC'.
 - add a number input for maximum 'matrice' for each level.
 - on 'fiche PNJ', automaticaly take the 'DV' amount to add to combat rolls (with +12 cap).
 - add a button to roll a new hit points total (PJ and PNJ).
 - correct the mistake on 'répit' roll. Was 1d4+level, but it is 1d4 per level in the rules.

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->




