### PR TITLE
[PokemonTabletopAdventures_v3] Update: Changes default values to allow easier use

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -6,10 +6,11 @@
     <button class="sheet-page-selection-option" name="act_configuration-page" type="action">Configuration</button>
   </div>
 
-  <input class="sheet-selected-page" name="attr_selected-page" type="hidden" value="character-page" />
+  <input class="sheet-selected-page" name="attr_selected-page" type="hidden" value="configuration-page" />
 
+  <!-- CHARACTER PAGE -->
   <div class="sheet-character-page">
-    <input class="sheet-character-type" name="attr_character-type" type="hidden" value="trainer" />
+    <input class="sheet-character-type" name="attr_character-type" type="hidden" value="pokemon" />
 
     <p class="sheet-logo">
       <img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/PokemonTabletopAdventures_v3/images/PTA3SmallLogo.png" />
@@ -76,12 +77,12 @@
               <option value="grass">Grass</option>
               <option value="ground">Ground</option>
               <option value="ice">Ice</option>
-              <option value="normal" selected>Normal</option>
+              <option value="normal">Normal</option>
               <option value="poison">Poison</option>
               <option value="psychic">Psychic</option>
               <option value="rock">Rock</option>
               <option value="steel">Steel</option>
-              <option value="typeless">Typeless</option>
+              <option value="typeless" selected>Typeless</option>
               <option value="water">Water</option>
             </select>
             <select class="sheet-half-text sheet-no-dropdown" name="attr_type2" title="Attribute: type2">
@@ -226,12 +227,12 @@
               <option value="grass">Grass</option>
               <option value="ground">Ground</option>
               <option value="ice">Ice</option>
-              <option value="normal" selected>Normal</option>
+              <option value="normal">Normal</option>
               <option value="poison">Poison</option>
               <option value="psychic">Psychic</option>
               <option value="rock">Rock</option>
               <option value="steel">Steel</option>
-              <option value="typeless">Typeless</option>
+              <option value="typeless" selected>Typeless</option>
               <option value="water">Water</option>
             </select>
             <select class="sheet-half-text sheet-no-dropdown" name="attr_type2" title="type2">
@@ -936,7 +937,7 @@
     <b>Moves</b>
     <fieldset class="repeating_moves">
       <input name="attr_move_category_defense" type="hidden" />
-      <input class="sheet-color-setting-move" name="attr_move_type" type="hidden" value="normal" />
+      <input class="sheet-color-setting-move" name="attr_move_type" type="hidden" value="typeless" />
       <div class="sheet-pokemon-move">
         <input checked class="sheet-options-flag" name="attr_options_flag" type="checkbox" />
         <span name="attr_flag">-</span>
@@ -1016,12 +1017,12 @@
               <option value="grass">Grass</option>
               <option value="ground">Ground</option>
               <option value="ice">Ice</option>
-              <option value="normal" selected>Normal</option>
+              <option value="normal">Normal</option>
               <option value="poison">Poison</option>
               <option value="psychic">Psychic</option>
               <option value="rock">Rock</option>
               <option value="steel">Steel</option>
-              <option value="typeless">Typeless</option>
+              <option value="typeless" selected>Typeless</option>
               <option value="water">Water</option>
             </select>
             <select class="sheet-move-text sheet-no-dropdown" name="attr_move_category" title="Attribute: move_category">
@@ -1171,6 +1172,7 @@
     <textarea name="attr_notes" spellcheck="false" title="Attribute: notes"></textarea>
   </div>
 
+  <!-- CONFIGURATION PAGE -->
   <div class="sheet-configuration-page">
     <h2>Configuration Options</h2>
     <div class="sheet-configuration-grid sheet-text-background">
@@ -1178,8 +1180,8 @@
         <b title="Default value: Trainer">Character Type:</b>
         <b class="sheet-info-tooltip" title="Default value: Trainer"> ℹ </b>
         <select class="sheet-character-type sheet-no-dropdown" name="attr_character-type" title="Attribute: character-type">
-          <option value="trainer" selected>Trainer</option>
-          <option value="pokemon">Pokémon</option>
+          <option value="trainer">Trainer</option>
+          <option value="pokemon" selected>Pokémon</option>
           <option value="hybrid">Pokémon (Character Class)</option>
         </select>
         <p class="sheet-dark-text">
@@ -1232,7 +1234,7 @@
       <div class="sheet-initiative-breaker">
         <b title="Default value: [[d20]]">Initiative Tie Breaker:</b>
         <b class="sheet-info-tooltip" title="Default value: [[d20]]"> ℹ </b>
-        <input name="attr_initiative-tie-breaker" title="Attribute: initiative-tie-breaker" type="text" value="[[d20]]" /><br />
+        <input name="attr_initiative-tie-breaker" title="Attribute: initiative-tie-breaker" type="text" value="[[d100-1]]" /><br />
         <p class="sheet-dark-text">
           This is included so that you can, if you wish, add it to the character's speed when determining their initiative order.
           (Note this isn't an official rule, but it's helpful when characters have the same speed!)

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -24,6 +24,12 @@ Things we want to add to the character sheet, presented in no particular order o
 
 ## Changelog
 
+### May 12, 2022
+- Fixed a bug where the pokemon and hybrid character pages would default to the normal type selection rather than typeless if this value isn't modified
+  - Also sets the default type for a newly created move to typeless rather than normal
+- Updated the default values so that a new character opens to the configuration page with the character type set as pokemon
+- Updated the default initiative tie breaker to allow a full range of decimal values
+
 ### May 7, 2022
 - Add support for importing character sheets by using the VTTES tool
   - Community member used this to create every Pokemon, so this lets others take advantage of that work even if they can't use that tool


### PR DESCRIPTION
# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description
- Updates the default page for PTA3 character sheets to the configuration page
- Updates the default character type to pokemon rather than trainer as the more commonly used type
- Updates the default tie breaker initiative to allow a full range of decimal values
- Updates the default type selection for new moves to typeless
- Resolves an issue where pokemon- and hybrid-type characters were showing "Normal" for their primary type instead of "Typeless" if it was not updated
