### PR TITLE
[The One Ring 2e] - 2.13 - increased contrast of roll buttons

### DIFF
--- a/The One Ring 2e/release-notes.md
+++ b/The One Ring 2e/release-notes.md
@@ -4,6 +4,10 @@ This is a rewrite based on the early 2e (basic) and 1e edition that also include
 
 # Release History
 
+## 02.13.00 (Build 17)
+### CSS
+- enhanced contrast of roll buttons
+
 ## 02.12.01 (Build 16)
 ### Bugfixes
 - Fixed stance damagebonus should be dependent on the stance damage active checkbox (error was introduced with the grievous selectbox) 

--- a/The One Ring 2e/sheet.css
+++ b/The One Ring 2e/sheet.css
@@ -887,13 +887,15 @@
 .ui-dialog .charsheet :is(button[type="roll"],
     button[type="roll"][class~="table-rolls"],
     button[type="action"][class~="parsed-rolls"]) {
+    color: rgb(40,40,40);
+    font-weight: bold;
     font-size: 1.3em;
     background: transparent;
     border: none;
     -webkit-box-shadow: none;
     -moz-box-shadow: none;
     box-shadow: none;
-    opacity: 1;
+    opacity: 0.8;
     padding: 0px;
     margin: 0px 0px;
     outline: none;
@@ -911,8 +913,10 @@
     /* change D12 to target-appropriate crosshairs */
     font-family: "Pictos Custom" !important;
     content: "[" !important;
-    color: inherit;
-    opacity: 0.3;
+    font-size: 1.1em;
+    color: rgb(40,40,40);
+    font-weight: normal;
+    opacity: 0.8;
 }
 
 .ui-dialog .charsheet :is(button[type="roll"][class~="table-rolls"],
@@ -1069,7 +1073,7 @@
     background-color: var(--yellow);
     border: 5px solid transparent;
     border-image-source: var(--borderred);
-    border-image-slice: 24 24 24 24;
+    border-image-slice: 20 20 20 20;
     border-image-repeat: repeat;
 }
 

--- a/The One Ring 2e/sheet.html
+++ b/The One Ring 2e/sheet.html
@@ -1,4 +1,4 @@
-<input type="hidden" name="attr_version" value="02-12-01" />
+<input type="hidden" name="attr_version" value="02-13-00" />
 <input type="hidden" class="sheet-tabstoggle" name="attr_sheetTab" />
 <input type="checkbox" name="attr_parsedrolls" value="1" class="hidden config-parsed-rolls" checked="checked" hidden
     readonly />
@@ -2539,6 +2539,25 @@
                         hlog(`
 ### Bugfixes
 - Fixed stance damagebonus should be dependent on the stance damage active checkbox (error was introduced with the grievous selectbox)
+                        `, releaselog);
+                        hlog("==============", releaselog);
+                        attrs['releaselog'] =  releaselog.msg + values['releaselog'];
+                        if (Object.keys(attrs).length) {
+                            setAttrs(attrs);
+                        }
+                    });
+                }
+            }
+
+            if (build < 17) {
+                attrs["build"] = 17;
+                let releaselog = {msg:""};
+                hlog(`Release 02.13.00 - ${new Date().toLocaleString()}`, releaselog);
+                if (v.sheettab === "isPC"){
+                    getAttrs(['releaselog'], function(values){
+                        hlog(`
+### CSS
+- enhanced contrast of roll buttons
                         `, releaselog);
                         hlog("==============", releaselog);
                         attrs['releaselog'] =  releaselog.msg + values['releaselog'];


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

## New Sheet Details

<!-- If you are submitting a new sheet to the repository, please fill in any empty spaces indicated by < >. -->

- The name of this game is: <   >  _(i.e. Dungeons & Dragons 5th Edition, The Dresden Files RPG)_
- The publisher of this game is: <   > _(i.e. Wizards of the Coast, Evil Hat)_
- The name of this game system/family is: <   > _(i.e. Dungeons & Dragons, FATE)_

- [ ] I have followed the [Character Sheets Standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) when building this sheet.

<!-- Please check any that apply: -->

- [ ] This sheet has been made on behalf of, or by, the game's publisher.
- [ ] This game is not a traditionally published game, but a copy of the game rules can be purchased/downloaded/found at: <   >
- [ ] This sheet is for an unofficial fan game, modification to an existing game, or a homebrew system.

# Changes / Description

### CSS
- enhanced contrast of roll buttons




