### PR TITLE
[PokemonTabletopAdventures_v3] New Feature: Adds a toggle button for rolling publicly or to the gm

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -5,7 +5,7 @@
     <button class="sheet-page-selection-option" name="act_character-page" type="action">Character</button>
     <button class="sheet-page-selection-option" name="act_configuration-page" type="action">Configuration</button>
     <input name="attr_publicity_label" type="hidden" value="Rolling Publicly" />
-    <input name="attr_publicity_roll" type="hidden" value="public" />
+    <input name="attr_publicity_roll" type="hidden" value="" />
     <button class="sheet-page-selection-option" name="act_toggle-roll-publicity" type="action"><span name="attr_publicity_label"></span></button>
   </div>
 
@@ -2173,7 +2173,7 @@
 
       if (publicity == publicityLabel) {
         publicityLabel = "Rolling to GM";
-        var publicityRoll = "/w gm ";
+        publicityRoll = "/w gm ";
       }
 
       setAttrs({

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -4,6 +4,9 @@
   <div class="sheet-page-selection">
     <button class="sheet-page-selection-option" name="act_character-page" type="action">Character</button>
     <button class="sheet-page-selection-option" name="act_configuration-page" type="action">Configuration</button>
+    <input name="attr_publicity_label" type="hidden" value="Rolling Publicly" />
+    <input name="attr_publicity_roll" type="hidden" value="public" />
+    <button class="sheet-page-selection-option" name="act_toggle-roll-publicity" type="action"><span name="attr_publicity_label"></span></button>
   </div>
 
   <input class="sheet-selected-page" name="attr_selected-page" type="hidden" value="configuration-page" />
@@ -292,7 +295,7 @@
           <b class="sheet-hide-on-mobile">Attack<br /></b>
           <input class="sheet-stat-ball-color" name="attr_ATK" title="Attribute: ATK" type="number" readonly /><br />
           <button class="sheet-stat-roller" name="roll_attack_check" type="roll"
-            value="&{template:skill-roll} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Attack Check}} {{skill-roll=[[ 1d20 + [[ @{ATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Attack Check}} {{skill-roll=[[ 1d20 + [[ @{ATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
             <span name="attr_ATKMOD" title="Attribute: ATKMOD"></span>
           </button>
           <br />
@@ -302,7 +305,7 @@
           <b class="sheet-hide-on-mobile">Defense<br /></b>
           <input class="sheet-stat-ball-color" name="attr_DEF" title="Attribute: DEF" type="number" readonly /><br />
           <button class="sheet-stat-roller" name="roll_defense_check" type="roll"
-            value="&{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Defense Check}} {{skill-roll=[[ 1d20 + [[ @{DEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Defense Check}} {{skill-roll=[[ 1d20 + [[ @{DEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
             <span name="attr_DEFMOD" title="Attribute: DEFMOD"></span>
           </button>
           <br />
@@ -315,7 +318,7 @@
           <b class="sheet-hide-on-mobile">Special Attack<br /></b>
           <input class="sheet-stat-ball-color" name="attr_SPATK" title="Attribute: SPATK" type="number" readonly /><br />
           <button class="sheet-stat-roller" name="roll_special_attack_check" type="roll"
-            value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Attack Check}} {{skill-roll=[[ 1d20 + [[ @{SPATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Attack Check}} {{skill-roll=[[ 1d20 + [[ @{SPATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
             <span name="attr_SPATKMOD" title="Attribute: SPATKMOD"></span>
           </button>
           <br />
@@ -325,7 +328,7 @@
           <b class="sheet-hide-on-mobile">Special Defense<br /></b>
           <input class="sheet-stat-ball-color" name="attr_SPDEF" title="Attribute: SPDEF" type="number" readonly /><br />
           <button class="sheet-stat-roller" name="roll_special_defense_check" type="roll"
-            value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Defense Check}} {{skill-roll=[[ 1d20 + [[ @{SPDEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Defense Check}} {{skill-roll=[[ 1d20 + [[ @{SPDEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
             <span name="attr_SPDEFMOD" title="Attribute: SPDEFMOD"></span>
           </button>
           <br />
@@ -335,7 +338,7 @@
           <b class="sheet-hide-on-mobile">Speed<br /></b>
           <input class="sheet-stat-ball-color" name="attr_SPD" title="Attribute: SPD" type="number" readonly /><br />
           <button class="sheet-stat-roller" name="roll_speed_check" type="roll"
-            value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Speed Check}} {{skill-roll=[[ 1d20 + [[ @{SPDMOD} + ?{Temp Modifier|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Speed Check}} {{skill-roll=[[ 1d20 + [[ @{SPDMOD} + ?{Temp Modifier|0} ]] ]]}}">
             <span name="attr_SPDMOD" title="Attribute: SPDMOD"></span>
           </button>
           <br />
@@ -524,7 +527,7 @@
           <input class="sheet-skill-color-setting" name="attr_acrobatics_ability_mod" type="hidden" value="SPD" />
           <input class="sheet-skill-total" name="attr_acrobatics_total" readonly title="Attribute: acrobatics_total" type="number" />
           <button class="sheet-skill-roller" name="roll_acrobaticscheck" type="roll"
-            value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Acrobatics}} {{skill-roll=[[ 1d20!kh2 + [[ @{acrobatics_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Acrobatics}} {{skill-roll=[[ 1d20!kh2 + [[ @{acrobatics_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Acrobatics (<span name="attr_acrobatics_ability_mod"></span>)
           </button>
           <input name="attr_acrobaticstalent1" value="2" title="Attribute: acrobaticstalent1" type="checkbox" />
@@ -533,7 +536,7 @@
           <input class="sheet-skill-color-setting" name="attr_athletics_ability_mod" type="hidden" value="ATK" />
           <input class="sheet-skill-total" name="attr_athletics_total" readonly title="Attribute: athletics_total" type="number" />
           <button class="sheet-skill-roller" name="roll_athleticscheck" type="roll"
-            value="&{template:skill-roll} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Athletics}} {{skill-roll=[[ 1d20!kh2 + [[ @{athletics_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Athletics}} {{skill-roll=[[ 1d20!kh2 + [[ @{athletics_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Athletics (<span name="attr_athletics_ability_mod"></span>)
           </button>
           <input name="attr_athleticstalent1" value="2" title="Attribute: athleticstalent1" type="checkbox" />
@@ -542,7 +545,7 @@
           <input class="sheet-skill-color-setting" name="attr_bluff_ability_mod" type="hidden" value="SPDEF" />
           <input class="sheet-skill-total" name="attr_bluff_total" readonly title="Attribute: bluff_total" type="number" />
           <button class="sheet-skill-roller" name="roll_bluffcheck" type="roll"
-            value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Bluff/Deception}} {{skill-roll=[[ 1d20!kh2 + [[ @{bluff_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Bluff/Deception}} {{skill-roll=[[ 1d20!kh2 + [[ @{bluff_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Bluff/Deception (<span name="attr_bluff_ability_mod"></span>)
           </button>
           <input name="attr_blufftalent1" value="2" title="Attribute: blufftalent1" type="checkbox" />
@@ -551,7 +554,7 @@
           <input class="sheet-skill-color-setting" name="attr_concentration_ability_mod" type="hidden" value="DEF" />
           <input class="sheet-skill-total" name="attr_concentration_total" readonly title="Attribute: concentration_total" type="number" />
           <button class="sheet-skill-roller" name="roll_concentrationcheck" type="roll"
-            value="&{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Concentration}} {{skill-roll=[[ 1d20!kh2 + [[ @{concentration_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Concentration}} {{skill-roll=[[ 1d20!kh2 + [[ @{concentration_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Concentration (<span name="attr_concentration_ability_mod"></span>)
           </button>
           <input name="attr_concentrationtalent1" value="2" title="Attribute: concentrationtalent1" type="checkbox" />
@@ -560,7 +563,7 @@
           <input class="sheet-skill-color-setting" name="attr_constitution_ability_mod" type="hidden" value="DEF" />
           <input class="sheet-skill-total" name="attr_constitution_total" readonly title="Attribute: constitution_total" type="number" />
           <button class="sheet-skill-roller" name="roll_constitutioncheck" type="roll"
-            value="&{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Constitution}} {{skill-roll=[[ 1d20!kh2 + [[ @{constitution_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Constitution}} {{skill-roll=[[ 1d20!kh2 + [[ @{constitution_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Constitution (<span name="attr_constitution_ability_mod"></span>)
           </button>
           <input name="attr_constitutiontalent1" value="2" title="Attribute: constitutiontalent1" type="checkbox" />
@@ -569,7 +572,7 @@
           <input class="sheet-skill-color-setting" name="attr_diplomacy_ability_mod" type="hidden" value="SPDEF" />
           <input class="sheet-skill-total" name="attr_diplomacy_total" readonly title="Attribute: diplomacy_total" type="number" />
           <button class="sheet-skill-roller" name="roll_diplomacycheck" type="roll"
-            value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Diplomacy/Persuasion}} {{skill-roll=[[ 1d20!kh2 + [[ @{diplomacy_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Diplomacy/Persuasion}} {{skill-roll=[[ 1d20!kh2 + [[ @{diplomacy_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Diplomacy/Persuasion (<span name="attr_diplomacy_ability_mod"></span>)
           </button>
           <input name="attr_diplomacytalent1" value="2" title="Attribute: diplomacytalent1" type="checkbox" />
@@ -578,7 +581,7 @@
           <input class="sheet-skill-color-setting" name="attr_engineering_ability_mod" type="hidden" value="SPATK" />
           <input class="sheet-skill-total" name="attr_engineering_total" readonly title="Attribute: engineering_total" type="number" />
           <button class="sheet-skill-roller" name="roll_engineeringcheck" type="roll"
-            value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Engineering/Operation}} {{skill-roll=[[ 1d20!kh2 + [[ @{engineering_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Engineering/Operation}} {{skill-roll=[[ 1d20!kh2 + [[ @{engineering_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Engineering/Operation (<span name="attr_engineering_ability_mod"></span>)
           </button>
           <input name="attr_engineeringtalent1" value="2" title="Attribute: engineeringtalent1" type="checkbox" />
@@ -587,7 +590,7 @@
           <input class="sheet-skill-color-setting" name="attr_history_ability_mod" type="hidden" value="SPATK" />
           <input class="sheet-skill-total" name="attr_history_total" readonly title="Attribute: history_total" type="number" />
           <button class="sheet-skill-roller" name="roll_historycheck" type="roll"
-            value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=History}} {{skill-roll=[[ 1d20!kh2 + [[ @{history_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=History}} {{skill-roll=[[ 1d20!kh2 + [[ @{history_total} + ?{Temporary Bonus|0} ]] ]]}}">
             History (<span name="attr_history_ability_mod"></span>)
           </button>
           <input name="attr_historytalent1" value="2" title="Attribute: historytalent1" type="checkbox" />
@@ -596,7 +599,7 @@
           <input class="sheet-skill-color-setting" name="attr_insight_ability_mod" type="hidden" value="SPDEF" />
           <input class="sheet-skill-total" name="attr_insight_total" readonly title="Attribute: insight_total" type="number" />
           <button class="sheet-skill-roller" name="roll_insightcheck" type="roll"
-            value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Insight}} {{skill-roll=[[ 1d20!kh2 + [[ @{insight_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Insight}} {{skill-roll=[[ 1d20!kh2 + [[ @{insight_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Insight (<span name="attr_insight_ability_mod"></span>)
           </button>
           <input name="attr_insighttalent1" value="2" title="Attribute: insighttalent1" type="checkbox" />
@@ -607,7 +610,7 @@
           <input class="sheet-skill-color-setting" name="attr_investigate_ability_mod" type="hidden" value="SPATK" />
           <input class="sheet-skill-total" name="attr_investigate_total" readonly title="Attribute: investigate_total" type="number" />
           <button class="sheet-skill-roller" name="roll_investigatecheck" type="roll"
-            value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Investigate}} {{skill-roll=[[ 1d20!kh2 + [[ @{investigate_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Investigate}} {{skill-roll=[[ 1d20!kh2 + [[ @{investigate_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Investigate (<span name="attr_investigate_ability_mod"></span>)
           </button>
           <input name="attr_investigatetalent1" value="2" title="Attribute: investigatetalent1" type="checkbox" />
@@ -616,7 +619,7 @@
           <input class="sheet-skill-color-setting" name="attr_medicine_ability_mod" type="hidden" value="SPATK" />
           <input class="sheet-skill-total" name="attr_medicine_total" readonly title="Attribute: medicine_total" type="number" />
           <button class="sheet-skill-roller" name="roll_medicinecheck" type="roll"
-            value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Medicine}} {{skill-roll=[[ 1d20!kh2 + [[ @{medicine_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Medicine}} {{skill-roll=[[ 1d20!kh2 + [[ @{medicine_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Medicine (<span name="attr_medicine_ability_mod"></span>)
           </button>
           <input name="attr_medicinetalent1" value="2" title="Attribute: medicinetalent1" type="checkbox" />
@@ -625,7 +628,7 @@
           <input class="sheet-skill-color-setting" name="attr_nature_ability_mod" type="hidden" value="SPATK" />
           <input class="sheet-skill-total" name="attr_nature_total" readonly title="Attribute: nature_total" type="number" />
           <button class="sheet-skill-roller" name="roll_naturecheck" type="roll"
-            value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Nature}} {{skill-roll=[[ 1d20!kh2 + [[ @{nature_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Nature}} {{skill-roll=[[ 1d20!kh2 + [[ @{nature_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Nature (<span name="attr_nature_ability_mod"></span>)
           </button>
           <input name="attr_naturetalent1" value="2" title="Attribute: naturetalent1" type="checkbox" />
@@ -634,7 +637,7 @@
           <input class="sheet-skill-color-setting" name="attr_perception_ability_mod" type="hidden" value="SPDEF" />
           <input class="sheet-skill-total" name="attr_perception_total" readonly title="Attribute: perception_total" type="number" />
           <button class="sheet-skill-roller" name="roll_perceptioncheck" type="roll"
-            value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perception}} {{skill-roll=[[ 1d20!kh2 + [[ @{perception_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perception}} {{skill-roll=[[ 1d20!kh2 + [[ @{perception_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Perception (<span name="attr_perception_ability_mod"></span>)
           </button>
           <input name="attr_perceptiontalent1" value="2" title="Attribute: perceptiontalent1" type="checkbox" />
@@ -643,7 +646,7 @@
           <input class="sheet-skill-color-setting" name="attr_perform_ability_mod" type="hidden" value="SPDEF" />
           <input class="sheet-skill-total" name="attr_perform_total" readonly title="Attribute: perform_total" type="number" />
           <button class="sheet-skill-roller" name="roll_performcheck" type="roll"
-            value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perform}} {{skill-roll=[[ 1d20!kh2 + [[ @{perform_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perform}} {{skill-roll=[[ 1d20!kh2 + [[ @{perform_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Perform (<span name="attr_perform_ability_mod"></span>)
           </button>
           <input name="attr_performtalent1" value="2" title="Attribute: performtalent1" type="checkbox" />
@@ -652,7 +655,7 @@
           <input class="sheet-skill-color-setting" name="attr_handling_ability_mod" type="hidden" value="SPDEF" />
           <input class="sheet-skill-total" name="attr_handling_total" readonly title="Attribute: handling_total" type="number" />
           <button class="sheet-skill-roller" name="roll_handlingcheck" type="roll"
-            value="&{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Pokemon Handling}} {{skill-roll=[[ 1d20!kh2 + [[ @{handling_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Pokemon Handling}} {{skill-roll=[[ 1d20!kh2 + [[ @{handling_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Pokémon Handling (<span name="attr_handling_ability_mod"></span>)
           </button>
           <input name="attr_handlingtalent1" value="2" title="Attribute: handlingtalent1" type="checkbox" />
@@ -660,7 +663,7 @@
           <input name="attr_handling" value="0" title="Attribute: handling" type="number" />
           <input class="sheet-skill-color-setting" name="attr_programming_ability_mod" type="hidden" value="SPATK" />
           <input class="sheet-skill-total" name="attr_programming_total" readonly title="Attribute: programming_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_programmingcheck" type="roll" value="&{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Programming}} {{skill-roll=[[ 1d20!kh2 + [[ @{programming_total} + ?{Temporary Bonus|0} ]] ]]}}">
+          <button class="sheet-skill-roller" name="roll_programmingcheck" type="roll" value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Programming}} {{skill-roll=[[ 1d20!kh2 + [[ @{programming_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Programming (<span name="attr_programming_ability_mod"></span>)
           </button>
           <input name="attr_programmingtalent1" value="2" title="Attribute: programmingtalent1" type="checkbox" />
@@ -669,7 +672,7 @@
           <input class="sheet-skill-color-setting" name="attr_sleight_ability_mod" type="hidden" value="SPD" />
           <input class="sheet-skill-total" name="attr_sleightofhand_total" readonly title="Attribute: sleightofhand_total" type="number" />
           <button class="sheet-skill-roller" name="roll_sleightofhandcheck" type="roll"
-            value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Sleight of Hand}} {{skill-roll=[[ 1d20!kh2 + [[ @{sleightofhand_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Sleight of Hand}} {{skill-roll=[[ 1d20!kh2 + [[ @{sleightofhand_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Sleight of Hand (<span name="attr_sleight_ability_mod"></span>)
           </button>
           <input name="attr_sleightofhandtalent1" value="2" title="Attribute: sleightofhandtalent1" type="checkbox" />
@@ -678,7 +681,7 @@
           <input class="sheet-skill-color-setting" name="attr_stealth_ability_mod" type="hidden" value="SPD" />
           <input class="sheet-skill-total" name="attr_stealth_total" readonly title="Attribute: stealth_total" type="number" />
           <button class="sheet-skill-roller" name="roll_stealthcheck" type="roll"
-            value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Stealth}} {{skill-roll=[[ 1d20!kh2 + [[ @{stealth_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Stealth}} {{skill-roll=[[ 1d20!kh2 + [[ @{stealth_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Stealth (<span name="attr_stealth_ability_mod"></span>)
           </button>
           <input name="attr_stealthtalent1" value="2" title="Attribute: stealthtalent1" type="checkbox" />
@@ -697,7 +700,7 @@
           <input class="sheet-skill-total" name="attr_capture_total" readonly title="The value added to your skill check to hit a Pokémon with a Pokéball. Note - this can be ignored if the target Pokémon is at or below half of their max HP.
           Attribute: capture_total" type="number" />
           <button class="sheet-skill-roller" name="roll_capturecheck" type="roll"
-            value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Capture Pokémon}} {{skill-roll=[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 @{ball_capture_modifier} + @{capture_roll_bonus} ]] }}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Capture Pokémon}} {{skill-roll=[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 @{ball_capture_modifier} + @{capture_roll_bonus} ]] }}">
             Capture Pokémon (<span name="attr_capture_ability_mod"></span>)
           </button>
           <input name="attr_capture_default_custom_modifier" type="hidden" value="0" />
@@ -752,7 +755,7 @@
           <input class="sheet-skill-total" name="attr_capture_total" readonly title="The value added to your skill check to hit a Pokémon with a Pokéball. Note - this can be ignored if the target Pokémon is at or below half of their max HP.
           Attribute: capture_total" type="number" />
           <button class="sheet-skill-roller" name="roll_capturecheck" type="roll"
-            value="&{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Capture Pokémon}} {{skill-roll=[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 @{ball_capture_modifier} + @{capture_roll_bonus} ]] }}">
+            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Capture Pokémon}} {{skill-roll=[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 @{ball_capture_modifier} + @{capture_roll_bonus} ]] }}">
             Capture Pokémon (<span name="attr_capture_ability_mod"></span>)
           </button>
           <input name="attr_capture_roll_bonus" title="Use this field to assign a static modifier to your capture rolls - things like a Capture Specialist's Capture Point feature.
@@ -816,7 +819,7 @@
           <div class="sheet-pokemon-move-info-header">
             <span class="sheet-fill-space">
               <button class="sheet-inline-roller sheet-skill-roller" name="roll-origin-feature-output" title="Click this to send this feature to the chat log. Click the Plus to allow editing the information." type="roll"
-              value="&{template:feature-output} {{type-color=@{type1}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{feature-name=@{originfeaturename}}} {{feature-text=@{originfeaturedesc}}}">
+              value="@{publicity_roll} &{template:feature-output} {{type-color=@{type1}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{feature-name=@{originfeaturename}}} {{feature-text=@{originfeaturedesc}}}">
                 <span name="attr_originfeaturename"></span>
               </button>
               <b class="sheet-info-tooltip" title="Click this to send this feature to the chat log. Click the Plus to allow editing the information.">ℹ</b>
@@ -834,7 +837,7 @@
             <input name="attr_originfeaturename" placeholder="Feature Name" spellcheck="false" type="text" />
             <span class="sheet-fill-space sheet-hide-on-mobile">
               <button class="sheet-inline-roller sheet-skill-roller" name="roll-origin-feature-output" title="Click this to send this feature to the chat log." type="roll"
-              value="&{template:feature-output} {{type-color=@{type1}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{feature-name=@{originfeaturename}}} {{feature-text=@{originfeaturedesc}}}">
+              value="@{publicity_roll} &{template:feature-output} {{type-color=@{type1}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{feature-name=@{originfeaturename}}} {{feature-text=@{originfeaturedesc}}}">
                   Send to Chat
                 </button>
                 <b class="sheet-info-tooltip" title="Click this to send this feature to the chat log.">ℹ</b>
@@ -860,7 +863,7 @@
             <div class="sheet-pokemon-move-info-header">
               <span class="sheet-fill-space">
                 <button class="sheet-inline-roller sheet-skill-roller" name="roll-class-feature-output" title="Click this to send this feature to the chat log. Click the Plus to allow editing the information." type="roll"
-                value="&{template:feature-output} {{type-color=@{type1}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{feature-name=@{classfeaturename}}} {{feature-text=@{classfeaturedesc}}}">
+                value="@{publicity_roll} &{template:feature-output} {{type-color=@{type1}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{feature-name=@{classfeaturename}}} {{feature-text=@{classfeaturedesc}}}">
                   <span name="attr_classfeaturename"></span>
                 </button>
                 <b class="sheet-info-tooltip" title="Click this to send this feature to the chat log. Click the Plus to allow editing the information.">ℹ</b>
@@ -878,7 +881,7 @@
               <input name="attr_classfeaturename" placeholder="Feature Name" spellcheck="false" type="text" />
               <span class="sheet-fill-space sheet-hide-on-mobile">
                 <button class="sheet-inline-roller sheet-skill-roller" name="roll-class-feature-output" title="Click this to send this feature to the chat log." type="roll"
-                value="&{template:feature-output} {{type-color=@{type1}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{feature-name=@{classfeaturename}}} {{feature-text=@{classfeaturedesc}}}">
+                value="@{publicity_roll} &{template:feature-output} {{type-color=@{type1}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{feature-name=@{classfeaturename}}} {{feature-text=@{classfeaturedesc}}}">
                     Send to Chat
                   </button>
                   <b class="sheet-info-tooltip" title="Click this to send this feature to the chat log.">ℹ</b>
@@ -945,7 +948,7 @@
           <div class="sheet-pokemon-move-info-header">
             <span class="sheet-fill-space">
               <button class="sheet-inline-roller sheet-skill-roller" name="roll-movetemplate" title="Click this to roll this attack with the option of choosing temporary modifiers or effectiveness." type="roll"
-                value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} ]]}} {{damage-2=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-3=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-4=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-5=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}}">
+                value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} ]]}} {{damage-2=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-3=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-4=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-5=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}}">
                 <span name="attr_move_name"></span>
               </button>
               <b class="sheet-info-tooltip" title="Click this to roll this attack with the option of choosing temporary modifiers or effectiveness.">ℹ</b>
@@ -953,7 +956,7 @@
 
             <span class="sheet-fill-space sheet-hide-on-mobile">
               <button class="sheet-inline-roller sheet-skill-roller" name="roll-quick-move" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers." type="roll"
-                value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{effectiveness-roll=[[2]]}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} {{damage-2=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-3=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-4=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-5=[[ @{move_dicenumber}d@{damage_dice} ]]}}">
+                value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{effectiveness-roll=[[2]]}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} {{damage-2=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-3=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-4=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-5=[[ @{move_dicenumber}d@{damage_dice} ]]}}">
                 Quick Roll
               </button>
               <b class="sheet-info-tooltip" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers.">ℹ</b>
@@ -988,7 +991,7 @@
 
             <span class="sheet-fill-space sheet-hide-on-mobile">
               <button class="sheet-inline-roller sheet-skill-roller" name="roll-quick-move" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers." type="roll"
-                value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{effectiveness-roll=[[2]]}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} {{damage-2=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-3=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-4=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-5=[[ @{move_dicenumber}d@{damage_dice} ]]}}">
+                value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{effectiveness-roll=[[2]]}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} {{damage-2=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-3=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-4=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-5=[[ @{move_dicenumber}d@{damage_dice} ]]}}">
                 Quick Roll
               </button>
               <b class="sheet-info-tooltip" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers.">ℹ</b>
@@ -1146,7 +1149,7 @@
           <div class="sheet-move-notes-roller">
             <textarea class="sheet-3row-textarea" name="attr_move_effect" placeholder="Additional Effect Notes" spellcheck="false" title="Attribute: move_effect"></textarea>
             <button class="sheet-move-roller" name="roll-movetemplate" type="roll"
-              value="&{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} ]]}} {{damage-2=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-3=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-4=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-5=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}}">
+              value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} ]]}} {{damage-2=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-3=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-4=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-5=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}}">
               T
             </button>
           </div>
@@ -1229,7 +1232,7 @@
         </p>
         <!-- This is super not supported so be warned that it might break one day -->
         <button class="tokenaction sheet-hidden-setting" type="roll" name="attr_Initiative" title="Initiative"
-          value="@{character_name}'s Initiative: [[@{initiative-macro}&{tracker}]]"></button>
+          value="@{publicity_roll} @{character_name}'s Initiative: [[@{initiative-macro}&{tracker}]]"></button>
       </div>
       <div class="sheet-initiative-breaker">
         <b title="Default value: [[d20]]">Initiative Tie Breaker:</b>
@@ -2159,6 +2162,24 @@
   pageButtons.forEach((page) => {
     on(`clicked:${page}`, function () {
       setAttrs({ "selected-page": page });
+    });
+  });
+
+  on(`clicked:toggle-roll-publicity`, function () {
+    getAttrs(["publicity_label"], function (values) {
+      const publicity = values["publicity_label"];
+      var publicityLabel = "Rolling Publicly";
+      var publicityRoll = "";
+
+      if (publicity == publicityLabel) {
+        publicityLabel = "Rolling to GM";
+        var publicityRoll = "/w gm ";
+      }
+
+      setAttrs({
+        publicity_label: publicityLabel,
+        publicity_roll: publicityRoll,
+      });
     });
   });
 


### PR DESCRIPTION

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

- Adds a button with an attribute-backed-span along with some inputs to hold the attribute
- Adds a sheet worker to toggle the publicity values when the button is pressed
- Updates all roll buttons to utilise the `publicity_roll` attribute when sending rolls to chat



