### PR TITLE
[Das_Schwarze_Auge_4-1] Fix Mixed Up Spells

### DIFF
--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -13779,6 +13779,15 @@
             <input type="text" class="sheet-selectable-text" style="width: 52em" value="https://www.youtube.com/watch?v=l2SCwz51T9g&list=PLGBXxa8pcNCqzNe4CrKvy-_QgjfgLDOZ-" />
         </p>
 
+		<h4>Update auf Version 20220524</h4>
+		<div>
+			<p>Fehlerbehebungen
+				<ul>
+					<li>Die Funktionen der Würfelknöpfe für &bdquo;Kraft des Erzes&ldquo;, &bdquo;Kraft des Humus&ldquo; und &bdquo;Krähenruf&ldquo; sind nicht länger vertauscht.</li>
+				</ul>
+			</p>
+		</div>
+
 		<h4>Update auf Version 20220226</h4>
 			<p>Neue Features
 				<ul>
@@ -14587,7 +14596,7 @@
     </div>
 
 
-    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20220226"><input type="hidden" class="sheet-stat-immutable sheet-stat-immutable-version" readonly="readonly" name="attr_data_version" value=""></b>
+    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20220524"><input type="hidden" class="sheet-stat-immutable sheet-stat-immutable-version" readonly="readonly" name="attr_data_version" value=""></b>
     </table>
 </div>
 <rolltemplate class="sheet-rolltemplate-check">

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -8680,9 +8680,9 @@
                 </div>
                 <input class="sheet-talent-zauber-elementarkraft-erz sheet-default-hide" type="checkbox" name="attr_zauber_kraft" value="1">
                 <div class="sheet-zauber">
-					<button type="action" name="act_z_kraehenruf-action" class="sheet-default-hide"></button>
-					<input type="hidden" name="attr_z_kraehenruf_action" value="">
-                    <div class="sheet-talent-cell sheet-talent-name"><button type="roll" name="roll_z_kraehenruf" value="@{z_kraehenruf_action}"> <span>Kraft des Erzes</span></button></div>
+					<button type="action" name="act_z_kraftdeserzes-action" class="sheet-default-hide"></button>
+					<input type="hidden" name="attr_z_kraftdeserzes_action" value="">
+                    <div class="sheet-talent-cell sheet-talent-name"><button type="roll" name="roll_z_kraftdeserzes" value="@{z_kraftdeserzes_action}"> <span>Kraft des Erzes</span></button></div>
                     <div class="sheet-talent-cell sheet-talent-eigenschaften">KL/KO/KK</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_kraft">
                     <input type="number" class="sheet-talent-taw" name="attr_ZfW_kraft" min="0" value="0">
@@ -8692,9 +8692,9 @@
                 </div>
                 <input class="sheet-talent-zauber-elementarkraft-humus sheet-default-hide" type="checkbox" name="attr_zauber_kraft_humus" value="1">
                 <div class="sheet-zauber">
-					<button type="action" name="act_z_kraftdeserzes-action" class="sheet-default-hide"></button>
-					<input type="hidden" name="attr_z_kraftdeserzes_action" value="">
-                    <div class="sheet-talent-cell sheet-talent-name"><button type="roll" name="roll_z_kraftdeserzes" value="@{z_kraftdeserzes_action}"> <span>Kraft des Humus</span></button></div>
+					<button type="action" name="act_z_kraftdeshumus-action" class="sheet-default-hide"></button>
+					<input type="hidden" name="attr_z_kraftdeshumus_action" value="">
+                    <div class="sheet-talent-cell sheet-talent-name"><button type="roll" name="roll_z_kraftdeshumus" value="@{z_kraftdeshumus_action}"> <span>Kraft des Humus</span></button></div>
                     <div class="sheet-talent-cell sheet-talent-eigenschaften">IN/CH/KO</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_kraft_humus">
                     <input type="number" class="sheet-talent-taw" name="attr_ZfW_kraft_humus" min="0" value="0">
@@ -8704,9 +8704,9 @@
                 </div>
                 <input class="sheet-talent-zauber-krahenruf sheet-default-hide" type="checkbox" name="attr_zauber_krahenruf" value="1">
                 <div class="sheet-zauber">
-					<button type="action" name="act_z_kraftdeshumus-action" class="sheet-default-hide"></button>
-					<input type="hidden" name="attr_z_kraftdeshumus_action" value="">
-                    <div class="sheet-talent-cell sheet-talent-name"><button type="roll" name="roll_z_kraftdeshumus" value="@{z_kraftdeshumus_action}"> <span>Krähenruf</span></button></div>
+					<button type="action" name="act_z_kraehenruf-action" class="sheet-default-hide"></button>
+					<input type="hidden" name="attr_z_kraehenruf_action" value="">
+                    <div class="sheet-talent-cell sheet-talent-name"><button type="roll" name="roll_z_kraehenruf" value="@{z_kraehenruf_action}"> <span>Krähenruf</span></button></div>
                     <div class="sheet-talent-cell sheet-talent-eigenschaften">MU/CH/CH</div>
                     <input type="text" class="sheet-talent-spez" name="attr_Spez_krahenruf">
                     <input type="number" class="sheet-talent-taw" name="attr_ZfW_krahenruf" min="0" value="0">
@@ -14107,9 +14107,9 @@
 				<button name="komm" type="roll" value="@{z_kommkoboldkomm_action}"> <span>Komm Kobold Komm</span></button>
 				<button name="koerperlose" type="roll" value="@{z_koerperlosereise_action}"> <span>Körperlose Reise</span></button>
 				<button name="krabbelnder" type="roll" value="@{z_krabbelnderschrecken_action}"> <span>Krabbelnder Schrecken</span></button>
-				<button name="kraft" type="roll" value="@{z_kraehenruf_action}"> <span>Kraft des Erzes</span></button>
-				<button name="kraft_humus" type="roll" value="@{z_kraftdeserzes_action}"> <span>Kraft des Humus</span></button>
-				<button name="krahenruf" type="roll" value="@{z_kraftdeshumus_action}"> <span>Krähenruf</span></button>
+				<button name="kraft" type="roll" value="@{z_kraftdeserzes_action}"> <span>Kraft des Erzes</span></button>
+				<button name="kraft_humus" type="roll" value="@{z_kraftdeshumus_action}"> <span>Kraft des Humus</span></button>
+				<button name="krahenruf" type="roll" value="@{z_kraehenruf_action}"> <span>Krähenruf</span></button>
 				<button name="krotensprung" type="roll" value="@{z_kroetensprung_action}"> <span>Krötensprung</span></button>
 				<button name="kulminatio" type="roll" value="@{z_kulminatio_action}"> <span>Kulminatio Kugelblitz</span></button>
 				<button name="kusch" type="roll" value="@{z_kusch_action}"> <span>Kusch!</span></button>


### PR DESCRIPTION
# Submission Checklist
## Required

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description
* **Fixes**
  * Fix: Function of roll buttons of spells 'Kraft des Erzes', 'Kraft des Humus' and 'Krähenruf' are no longer swapped (2b290269e2d2ecd54abba596b830745b07c2b3cb)
* **Miscellaneous**
  * Bump version number (7cc62be78781b3ebb62ce614f6a889c93bc80fe2)
  * Info on the latest version/changes (7cc62be78781b3ebb62ce614f6a889c93bc80fe2)




