### PR TITLE
[Das_Schwarze_Auge_4-1] Fix Spell Spelling (Internal and External)

### DIFF
--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
@@ -1283,7 +1283,7 @@ p + p {
 .charsheet .sheet-talent-zauber-verstandigung:checked + div.sheet-zauber,
 .charsheet .sheet-talent-zauber-verwandlung:checked + div.sheet-zauber,
 .charsheet .sheet-talent-zauber-vipernblick:checked + div.sheet-zauber,
-.charsheet .sheet-talent-zauber-visibli:checked + div.sheet-zauber,
+.charsheet .sheet-talent-zauber-visibili:checked + div.sheet-zauber,
 .charsheet .sheet-talent-zauber-vocolimbo:checked + div.sheet-zauber,
 .charsheet .sheet-talent-zauber-vogelzwitschern:checked + div.sheet-zauber,
 .charsheet .sheet-talent-zauber-warmes-blut:checked + div.sheet-zauber,

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -10370,16 +10370,16 @@
                     <button name="vipernblickSpez" type="roll" value="@{gm_roll_opt} &{template:DSA-Zauber} {{name=Vipernblick (@{spez_vipernblick})}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{ZfW_vipernblick} + 2]]}} {{stat1=[[@{MU}]]}} {{stat2=[[@{MU}]]}} {{stat3=[[@{CH}]]}} {{Talent=[[ { [[{0d1 + @{ZfW_vipernblick} + 2 - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - (@{ZfW_vipernblick} + 2), 0d1}kh1]] - @{MU}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - (@{ZfW_vipernblick} + 2), 0d1}kh1]] - @{MU}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - (@{ZfW_vipernblick} + 2), 0d1}kh1]] - @{CH}, 0d1}kh1, 0d1 + @{ZfW_vipernblick} + 2}dh1]]}}">Spez</button>
                     <br>
                 </div>
-                <input class="sheet-talent-zauber-visibli sheet-default-hide" type="checkbox" name="attr_zauber_visibli" value="1">
+                <input class="sheet-talent-zauber-visibili sheet-default-hide" type="checkbox" name="attr_zauber_visibili" value="1">
                 <div class="sheet-zauber">
-					<button type="action" name="act_z_visibli-action" class="sheet-default-hide"></button>
-					<input type="hidden" name="attr_z_visibli_action" value="">
-                    <div class="sheet-talent-cell sheet-talent-name"><button type="roll" name="roll_z_visibli" value="@{z_visibli_action}"> <span>Visibli Vanitar</span></button></div>
+					<button type="action" name="act_z_visibili-action" class="sheet-default-hide"></button>
+					<input type="hidden" name="attr_z_visibili_action" value="">
+                    <div class="sheet-talent-cell sheet-talent-name"><button type="roll" name="roll_z_visibili" value="@{z_visibili_action}"> <span>Visibili Vanitar</span></button></div>
                     <div class="sheet-talent-cell sheet-talent-eigenschaften">KL/IN/GE</div>
-                    <input type="text" class="sheet-talent-spez" name="attr_Spez_visibli">
-                    <input type="number" class="sheet-talent-taw" name="attr_ZfW_visibli" min="0" value="0">
+                    <input type="text" class="sheet-talent-spez" name="attr_Spez_visibili">
+                    <input type="number" class="sheet-talent-taw" name="attr_ZfW_visibili" min="0" value="0">
                     <div class="sheet-talent-cell sheet-talent-taw">272</div>
-                    <button name="visibliSpez" type="roll" value="@{gm_roll_opt} &{template:DSA-Zauber} {{name=Visibli Vanitar (@{spez_visibli})}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{ZfW_visibli} + 2]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{GE}]]}} {{Talent=[[ { [[{0d1 + @{ZfW_visibli} + 2 - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - (@{ZfW_visibli} + 2), 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - (@{ZfW_visibli} + 2), 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - (@{ZfW_visibli} + 2), 0d1}kh1]] - @{GE}, 0d1}kh1, 0d1 + @{ZfW_visibli} + 2}dh1]]}}">Spez</button>
+                    <button name="visibiliSpez" type="roll" value="@{gm_roll_opt} &{template:DSA-Zauber} {{name=Visibili Vanitar (@{spez_visibili})}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{ZfW_visibili} + 2]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{GE}]]}} {{Talent=[[ { [[{0d1 + @{ZfW_visibili} + 2 - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - (@{ZfW_visibili} + 2), 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - (@{ZfW_visibili} + 2), 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - (@{ZfW_visibili} + 2), 0d1}kh1]] - @{GE}, 0d1}kh1, 0d1 + @{ZfW_visibili} + 2}dh1]]}}">Spez</button>
                     <br>
                 </div>
                 <input class="sheet-talent-zauber-vocolimbo sheet-default-hide" type="checkbox" name="attr_zauber_vocolimbo" value="1">
@@ -11044,7 +11044,7 @@
                                         <label><input type="checkbox" name="attr_zauber_verstandigung" value="1">Verständigung stören</label>
                                         <label><input type="checkbox" name="attr_zauber_verwandlung" value="1">Verwandlung beenden</label>
                                         <label><input type="checkbox" name="attr_zauber_vipernblick" value="1">Vipernblick</label>
-                                        <label><input type="checkbox" name="attr_zauber_visibli" value="1">Visibli Vanitar</label>
+                                        <label><input type="checkbox" name="attr_zauber_visibili" value="1">Visibili Vanitar</label>
                                         <label><input type="checkbox" name="attr_zauber_vocolimbo" value="1">Vocolimbo hohler Klang</label>
                                         <label><input type="checkbox" name="attr_zauber_vogelzwitschern" value="1">Vogelzwitschern Glockenspiel</label>
                                         <label><input type="checkbox" name="attr_zauber_wandausdornen" value="1">Wand aus Dornen</label>
@@ -13779,6 +13779,23 @@
             <input type="text" class="sheet-selectable-text" style="width: 52em" value="https://www.youtube.com/watch?v=l2SCwz51T9g&list=PLGBXxa8pcNCqzNe4CrKvy-_QgjfgLDOZ-" />
         </p>
 
+		<h4>Update auf Version 20220604</h4>
+		<div>
+			<p>Fehlerbehebungen
+				<ul>
+					<li>Der interne Name des &bdquo;Visibili Vanitar&ldquo; wurde korrigiert. Da auch der Name der (internen) Attribute falsch war, wurden die Daten intern auf neue Namen migriert (umgeschrieben). Alte Würfelknöpfe in beispielsweise Makroleisten sollten weiterhin funktionieren.</li>
+				</ul>
+			</p>
+		</div>
+		<!-- Legacy Buttons, DO NOT REMOVE -->
+		<p class="sheet-default-hide">
+            <div class="sheet-zauber">
+                <div class="sheet-talent-cell sheet-talent-name"><button type="roll" name="roll_z_visibli" value="@{z_visibili_action}"> <span>Visibili Vanitar</span></button></div>
+                <button name="visibliSpez" type="roll" value="@{gm_roll_opt} &{template:DSA-Zauber} {{name=Visibili Vanitar (@{spez_visibili})}} {{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} {{taw=[[@{ZfW_visibili} + 2]]}} {{stat1=[[@{KL}]]}} {{stat2=[[@{IN}]]}} {{stat3=[[@{GE}]]}} {{Talent=[[ { [[{0d1 + @{ZfW_visibili} + 2 - (?{Erleichterung (−) oder Erschwernis (+)|0}), 0d1}kh1]] - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - (@{ZfW_visibili} + 2), 0d1}kh1]] - @{KL}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - (@{ZfW_visibili} + 2), 0d1}kh1]] - @{IN}, 0d1}kh1 - {1d20cs1cf20 + [[{0d1 + (?{Erleichterung (−) oder Erschwernis (+)|0}) - (@{ZfW_visibili} + 2), 0d1}kh1]] - @{GE}, 0d1}kh1, 0d1 + @{ZfW_visibili} + 2}dh1]]}}">Spez</button>
+                <br>
+            </div>
+		</p>
+
 		<h4>Update auf Version 20220524</h4>
 		<div>
 			<p>Fehlerbehebungen
@@ -14257,7 +14274,7 @@
 				<button name="verstandigung" type="roll" value="@{z_verstaendigungstoeren_action}"> <span>Verständigung stören</span></button>
 				<button name="verwandlung" type="roll" value="@{z_verwandlungbeenden_action}"> <span>Verwandlung beenden</span></button>
 				<button name="vipernblick" type="roll" value="@{z_vipernblick_action}"> <span>Vipernblick</span></button>
-				<button name="visibli" type="roll" value="@{z_visibli_action}"> <span>Visibli Vanitar</span></button>
+				<button name="visibli" type="roll" value="@{z_visibili_action}"> <span>Visibili Vanitar</span></button>
 				<button name="vocolimbo" type="roll" value="@{z_vocolimbo_action}"> <span>Vocolimbo Hohler Klang</span></button>
 				<button name="vogelzwitschern" type="roll" value="@{z_vogelzwitschern_action}"> <span>Vogelzwitschern Glockenspiel</span></button>
 				<button name="Wand_aus_Flammen" type="roll" value="@{z_wandausflammen_action}"> <span>Wand aus Flammen</span></button>
@@ -18057,6 +18074,7 @@ Relevant character sheet versions
 * 20210718: Reorganisation of encumbrance
 * 20211010: Clearer attribute names for life energy, astral energy etc.
 * 20220116: New roll buttons
+* 20220604: Visibili Vanitar spelling fixes
 */
 function migrationCheck() {
     safeGetAttrs(["character_sheet_version", "data_version"], function(v) {
@@ -18132,7 +18150,8 @@ var versionsWithMigrations = [
     20210413,
     20210718,
     20211010,
-    20220116
+    20220116,
+    20220604
 ]
 
 /*
@@ -18682,6 +18701,49 @@ function migrateTo20220116(migrationChain) {
 		}
 
 		attrsToChange["eidsegen_action"] = "%{" + v["character_name"] + "|eidsegen-action}";
+
+		debugLog(caller, attrsToChange);
+		safeSetAttrs(attrsToChange, {}, function(){
+			callNextMigration(migrationChain);
+		});
+	});
+}
+
+/*
+	Migration steps:
+	- Use new attributes for spell "Visibili Vanitar"
+*/
+function migrateTo20220604(migrationChain) {
+	var caller = "migrateTo20220604";
+	debugLog(caller, "Invoked.");
+
+	var attrsToGet = [
+		"zauber_visibli",
+		"z_visibli_action",
+		"Spez_visibli",
+		"ZfW_visibli"
+	];
+
+	var attrsToChange = {};
+
+	safeGetAttrs(attrsToGet, function(v) {
+		for (attr of attrsToGet)
+		{
+			if (attr.match("visibli"))
+			{
+				var newAttr = attr.replace(/visibli/gm, "visibili");
+				if (attr.match("z_visibli_action"))
+				{
+					attrsToChange[newAttr] = v[attr].replace(/visibli/gm, "visibili");
+				} else {
+					attrsToChange[newAttr] = v[attr];
+				}
+				if (attr.match("Spez_visibli") && v[attr] === 0)
+				{
+					attrsToChange[newAttr] = "";
+				}					
+			}
+		}
 
 		debugLog(caller, attrsToChange);
 		safeSetAttrs(attrsToChange, {}, function(){
@@ -20815,7 +20877,7 @@ const spells = [
 	'z_verstaendigungstoeren',
 	'z_verwandlungbeenden',
 	'z_vipernblick',
-	'z_visibli',
+	'z_visibili',
 	'z_vocolimbo',
 	'z_vogelzwitschern',
 	'z_wandausdornen',
@@ -21346,7 +21408,7 @@ const spellsData = {
 	'z_verstaendigungstoeren': {'internal': "verstandigung", 'ui': "Verständigung stören", 'stats': ['KL', 'KL', 'IN']},
 	'z_verwandlungbeenden': {'internal': "verwandlung", 'ui': "Verwandlung beenden", 'stats': ['KL', 'CH', 'FF']},
 	'z_vipernblick': {'internal': "vipernblick", 'ui': "Vipernblick", 'stats': ['MU', 'MU', 'CH']},
-	'z_visibli': {'internal': "visibli", 'ui': "Visibli Vanitar", 'stats': ['KL', 'IN', 'GE']},
+	'z_visibili': {'internal': "visibili", 'ui': "Visibili Vanitar", 'stats': ['KL', 'IN', 'GE']},
 	'z_vocolimbo': {'internal': "vocolimbo", 'ui': "Vocolimbo hohler Klang", 'stats': ['KL', 'CH', 'FF']},
 	'z_vogelzwitschern': {'internal': "vogelzwitschern", 'ui': "Vogelzwitschern Glockenspiel", 'stats': ['MU', 'IN', 'GE']},
 	'z_wandausdornen': {'internal': "wandausdornen", 'ui': "Wand aus Dornen", 'stats': ['MU', 'KL', 'CH']},

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -18055,6 +18055,8 @@ Relevant character sheet versions
 *           INI mod from main weapon
 *           wound mods
 * 20210718: Reorganisation of encumbrance
+* 20211010: Clearer attribute names for life energy, astral energy etc.
+* 20220116: New roll buttons
 */
 function migrationCheck() {
     safeGetAttrs(["character_sheet_version", "data_version"], function(v) {

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -14613,7 +14613,7 @@
     </div>
 
 
-    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20220524"><input type="hidden" class="sheet-stat-immutable sheet-stat-immutable-version" readonly="readonly" name="attr_data_version" value=""></b>
+    <b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="sheet-stat-immutable sheet-stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20220604"><input type="hidden" class="sheet-stat-immutable sheet-stat-immutable-version" readonly="readonly" name="attr_data_version" value=""></b>
     </table>
 </div>
 <rolltemplate class="sheet-rolltemplate-check">


### PR DESCRIPTION
# Submission Checklist
## Required

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description
* ''Fixes''
  * Fix external and internal spelling of the spell 'Visibili Vanitar' (5634696ced8f4a442a1cb15df8c41fda6f198160)
    * Old attributes and roll buttons are kept, new attributes are migrated on sheet-open
* Miscellaneous
  * Add comments on previous two sheet versions with migrations (0d91259d4eefc38bdb80d8dff12f9bd5f57f00da)
  * Bump version number (24937e5625698df7c66d560f2a34380e5cda246e)

## Attributes & Co.
* Old attributes (unused after migration)
  * `zauber_visibli`, `z_visibli_action`, `Spez_visibli`, `ZfW_visibli`
  * Old roll buttons (same naming issue) will continue to exist for macro compatibility, but will use the new attributes and are hidden from the user to prevent future use
* New attributes
  * `zauber_visibili`, `z_visibili_action`, `Spez_visibili`, `ZfW_visibili`