### PR TITLE
[HeroSystem6eHeroic] Added option for 'Takes No STUN' power effects

### DIFF
--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -1290,7 +1290,7 @@ select:focus + .focus {
 	background-color: #fff990;
 	margin: 5px;
 	width: 450px;
-	max-height: 203px;
+	height: 213px;
 	margin: 0px;
 	border: solid 2px goldenrod;
 	border-radius: 3px;

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -4467,6 +4467,14 @@
 				</label>
 				<h1>Use Hit Location System</h1>
 			</div>
+			
+			<div class="item-options-row">
+				<label class="container-checkbox">
+					<input type="checkbox" name="attr_optionTakesNoSTUN">
+					<span class="checkmark"></span>
+				</label>
+				<h1>Takes No STUN</h1>
+			</div>
 		</div>
 	</div>
 </div>
@@ -4493,6 +4501,9 @@
 	  	<span><input class="tally" type="number" value="0" min="0" name=attr_totalCharacterCost readonly="true" tabindex="-1"/></span>
 	</div>
 </div>
+
+<!-- Hidden variables to protect characteristics during option changes -->
+<input type="hidden" name="attr_hiddenSTUN"  value="20"/>
 
 <!-- Some hidden variables to help simplify skill point calculations -->
 <input type="hidden" name="attr_hiddenSet1SkillsCost"  value="0"/>
@@ -4811,22 +4822,36 @@
 	
 	// Add 1 to currentSTUN
 	on("clicked:currentSTUNplus", function () {
-		getAttrs(["currentSTUN"], function(values) {
-			const currentValue = parseInt(values.currentSTUN)||0;
+		getAttrs(["currentSTUN", "optionTakesNoSTUN"], function(values) {
+			let currentValue = parseInt(values.currentSTUN)||0;
+			const takesNoSTUN = values.optionTakesNoSTUN;
 			
+			if (takesNoSTUN != 0) {
+				currentValue = 0;
+			} else {
+				currentValue = currentValue+1;
+			}
+					
 			setAttrs({
-				"currentSTUN":currentValue+1
+				"currentSTUN":currentValue
 			});
 		});
 	});
 	
 	// Subtract 1 from currentSTUN
 	on("clicked:currentSTUNminus", function () {
-		getAttrs(["currentSTUN"], function(values) {
-			const currentValue = parseInt(values.currentSTUN)||0;
+		getAttrs(["currentSTUN", "optionTakesNoSTUN"], function(values) {
+			let currentValue = parseInt(values.currentSTUN)||0;
+			const takesNoSTUN = values.optionTakesNoSTUN;
 			
+			if (takesNoSTUN != 0) {
+				currentValue = 0;
+			} else {
+				currentValue = currentValue-1;
+			}
+					
 			setAttrs({
-				"currentSTUN":currentValue-1
+				"currentSTUN":currentValue
 			});
 		});
 	});
@@ -4906,22 +4931,36 @@
 	
 	// Add 1 to gearCurrentSTUN
 	on("clicked:gearCurrentSTUNplus", function () {
-		getAttrs(["gearCurrentSTUN"], function(values) {
-			const currentValue = parseInt(values.gearCurrentSTUN)||0;
+		getAttrs(["gearCurrentSTUN", "optionTakesNoSTUN"], function(values) {
+			let currentValue = parseInt(values.gearCurrentSTUN)||0;
+			const takesNoSTUN = values.optionTakesNoSTUN;
+			
+			if (takesNoSTUN != 0) {
+				currentValue = 0;
+			} else {
+				currentValue = currentValue +1;
+			}
 			
 			setAttrs({
-				"gearCurrentSTUN":currentValue+1
+				"gearCurrentSTUN":currentValue
 			});
 		});
 	});
 	
 	// Subtract 1 from gearCurrentSTUN
 	on("clicked:gearCurrentSTUNminus", function () {
-		getAttrs(["gearCurrentSTUN"], function(values) {
-			const currentValue = parseInt(values.gearCurrentSTUN)||0;
+		getAttrs(["gearCurrentSTUN", "optionTakesNoSTUN"], function(values) {
+			let currentValue = parseInt(values.gearCurrentSTUN)||0;
+			const takesNoSTUN = values.optionTakesNoSTUN;
 			
+			if (takesNoSTUN != 0) {
+				currentValue = 0;
+			} else {
+				currentValue = currentValue -1;
+			}
+					
 			setAttrs({
-				"gearCurrentSTUN":currentValue-1
+				"gearCurrentSTUN":currentValue
 			});
 		});
 	});
@@ -5414,18 +5453,24 @@
 	});
 	
 	// Update hidden attribute currentDCV
-	on("change:dcv change:weightDexDCVPenalty change:shieldDCV change:bonusDCVmodifier change:useCharacteristicMaximums", function () {
-		getAttrs(["dcv","useCharacteristicMaximums","currentDCV","weightDexDCVPenalty","shieldDCV","bonusDCVmodifier"], function(values) {
+	on("change:dcv change:weightDexDCVPenalty change:shieldDCV change:bonusDCVmodifier change:useCharacteristicMaximums change:optionTakesNoSTUN", function () {
+		getAttrs(["dcv","useCharacteristicMaximums","currentDCV","weightDexDCVPenalty","shieldDCV","bonusDCVmodifier", "optionTakesNoSTUN"], function(values) {
 		  
 			const statValue = parseInt(values.dcv)||0;
 			const shieldBonus = parseInt(values.shieldDCV)||0;
 			const weightPenalty = parseInt(values.weightDexDCVPenalty)||0;
 			const bonusModifier = parseInt(values.bonusDCVmodifier)||0;
 			const useMaximums = values.useCharacteristicMaximums;
-			const baseStat = 3;
+			const takesNoSTUN = values.optionTakesNoSTUN;
+			let baseStat = 3;
 			const maxStat = 8;
-			const costStat = 5;
+			let costStat = 5;
 			let statCP = 0;
+			
+			// Automaton defenses cost triple.
+			if (takesNoSTUN != 0) {
+				costStat = costStat*3;
+			}
 	
 			if ( (statValue>maxStat) && (useMaximums != 0) ) {
 				statCP=(statValue-maxStat)*costStat+(statValue-baseStat)*costStat;
@@ -5472,15 +5517,21 @@
 	});
 	
 	// Update Mental Defensive Combat Value
-	on("change:dmcv change:useCharacteristicMaximums", function () {
-		getAttrs(["dmcv","useCharacteristicMaximums"], function(values) {
+	on("change:dmcv change:useCharacteristicMaximums change:optionTakesNoSTUN", function () {
+		getAttrs(["dmcv","useCharacteristicMaximums", "optionTakesNoSTUN"], function(values) {
 		  
 			const statValue = parseInt(values.dmcv)||0;
 			const useMaximums = values.useCharacteristicMaximums;
+			const takesNoSTUN = values.optionTakesNoSTUN;
 			const baseStat = 3;
 			const maxStat = 8;
-			const costStat = 3;
+			let costStat = 3;
 			let statCP = 0;
+			
+			// Automaton defenses cost triple.
+			if (takesNoSTUN != 0) {
+				costStat = costStat*3;
+			}
 	
 			if ( (statValue>maxStat) && (useMaximums != 0) ) {
 				statCP=(statValue-maxStat)*costStat+(statValue-baseStat)*costStat;
@@ -5646,15 +5697,22 @@
 	});
 	
 	// Update Physical Defense
-	on("change:pd change:useCharacteristicMaximums", function () {
-		getAttrs(["pd","useCharacteristicMaximums"], function(values) {
+	on("change:pd change:useCharacteristicMaximums change:optionTakesNoSTUN", function () {
+		getAttrs(["pd","useCharacteristicMaximums", "optionTakesNoSTUN"], function(values) {
 		  
 			const statValue = parseInt(values.pd)||0;
 			const useMaximums = values.useCharacteristicMaximums;
-			const baseStat = 2;
+			const takesNoSTUN = values.optionTakesNoSTUN;
+			let baseStat = 2;
 			const maxStat = 8;
-			const costStat = 1;
+			let costStat = 1;
 			let statCP = 0;
+			
+			// Automaton defenses cost triple.
+			if (takesNoSTUN != 0) {
+				costStat = costStat*3;
+				baseState = 1;
+			}
 	
 			if ( (statValue>maxStat) && (useMaximums != 0) ) {
 				statCP=(statValue-maxStat)*costStat+(statValue-baseStat)*costStat;
@@ -5673,15 +5731,22 @@
 	});
 	
 	// Update Energy Defense
-	on("change:ed change:useCharacteristicMaximums", function () {
-		getAttrs(["ed","useCharacteristicMaximums"], function(values) {
+	on("change:ed change:useCharacteristicMaximums change:optionTakesNoSTUN", function () {
+		getAttrs(["ed","useCharacteristicMaximums", "optionTakesNoSTUN"], function(values) {
 		  
 			const statValue = parseInt(values.ed)||0;
 			const useMaximums = values.useCharacteristicMaximums;
-			const baseStat = 2;
+			const takesNoSTUN = values.optionTakesNoSTUN;
+			let baseStat = 2;
 			const maxStat = 8;
-			const costStat = 1;
+			let costStat = 1;
 			let statCP = 0;
+			
+			// Automaton defenses cost triple.
+			if (takesNoSTUN != 0) {
+				costStat = costStat*3;
+				baseState = 1;
+			}
 	
 			if ( (statValue>maxStat) && (useMaximums != 0) ) {
 				statCP=(statValue-maxStat)*costStat+(statValue-baseStat)*costStat;
@@ -5726,27 +5791,69 @@
 		});
 	});
 	
+	// Handle STUN data when optionTakesNoSTUN is checked.
+	on("change:optionTakesNoSTUN", function () {
+		getAttrs(["optionTakesNoSTUN", "stun", "hiddenSTUN"], function(values) {
+		  
+			const takesNoSTUN = values.optionTakesNoSTUN;
+			let statValue = values.stun;
+	
+			// Store STUN in hiddenSTUN and then set it to zero.
+			if (takesNoSTUN != 0) {
+				savedStatValue = statValue;
+				statValue = 0;
+			} else {
+				statValue = savedStatValue;
+			}
+			
+			// Update character. Reset health status.
+			setAttrs({
+				"hiddenSTUN":savedStatValue,
+				"stun":statValue,
+				"currentSTUN":statValue,
+				"gearCurrentSTUN":statValue
+			});
+			
+			// Update characteristics cost
+			sumCharacteristicPoints();
+		});
+	});
+	
 	// Update STUN
-	on("change:stun change:useCharacteristicMaximums", function () {
-		getAttrs(["stun","useCharacteristicMaximums"], function(values) {
+	on("change:stun change:useCharacteristicMaximums change:optionTakesNoSTUN", function () {
+		getAttrs(["stun","useCharacteristicMaximums", "hiddenSTUN", "optionTakesNoSTUN"], function(values) {
 		  
 			const statValue = parseInt(values.stun)||0;
 			const useMaximums = values.useCharacteristicMaximums;
-			const baseStat = 20;
+			const takesNoSTUN = values.optionTakesNoSTUN;
+			let baseStat = 20;
 			const maxStat = 50;
 			const costStat = 0.5;
 			let statCP = 0;
-	
-			if ( (statValue>maxStat) && (useMaximums != 0) ) {
-				statCP=(statValue-maxStat)*costStat+(statValue-baseStat)*costStat;
-			} else {
-				statCP=(statValue-baseStat)*costStat;
-			}	
 			
-			// Update cost	
-			setAttrs({
-				"stunCP":heroRoundLow(statCP)
-			});
+			// If option takesNoSTUN is not checked. Save the new value of STUN.
+			if (takesNoSTUN != 0) {
+				
+				// Reset STUN and cost to zero.
+				setAttrs({
+					"stun":0,
+					"stunCP":0
+				});
+				
+			} else {
+				
+				// Calculate costs, save stun to hiddenSTUN, and calculate cost.
+				if ( (statValue>maxStat) && (useMaximums != 0) ) {
+					statCP=(statValue-maxStat)*costStat+(statValue-baseStat)*costStat;
+				} else {
+					statCP=(statValue-baseStat)*costStat;
+				}
+				
+				setAttrs({
+					"hiddenSTUN":statValue,
+					"stunCP":heroRoundLow(statCP)
+				});
+			}	
 			
 			// Update costs
 			sumCharacteristicPoints();
@@ -5806,6 +5913,7 @@
 			sumCharacteristicPoints();
 		});
 	});
+	
 	
 	// Movement abilities
 	


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [X] The pull request title clearly contains the name of the sheet I am editing.
- [X] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [X] The pull request makes changes to files in only one sub-folder.
- [X] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

## New Sheet Details

<!-- If you are submitting a new sheet to the repository, please fill in any empty spaces indicated by < >. -->

- The name of this game is: <   >  _(i.e. Dungeons & Dragons 5th Edition, The Dresden Files RPG)_
- The publisher of this game is: <   > _(i.e. Wizards of the Coast, Evil Hat)_
- The name of this game system/family is: <   > _(i.e. Dungeons & Dragons, FATE)_

- [ ] I have followed the [Character Sheets Standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) when building this sheet.

<!-- Please check any that apply: -->

- [ ] This sheet has been made on behalf of, or by, the game's publisher.
- [ ] This game is not a traditionally published game, but a copy of the game rules can be purchased/downloaded/found at: <   >
- [ ] This sheet is for an unofficial fan game, modification to an existing game, or a homebrew system.

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

Added 'Takes No STUN' power effects to the list of options. This feature would be typically used for undead, robots, golems, and other types of automaton NPCs. With the option set, STUN no longer counts towards character costs and cannot be recovered through healing or aid.




