### PR TITLE
Update V20.html - Minor Style Fix to Path Sins

### DIFF
--- a/CWOD-V20/V20.html
+++ b/CWOD-V20/V20.html
@@ -1501,16 +1501,16 @@
 <div class="sheet-col" style="width:33% ">
 <div class="sheet-col" style="width:100%; text-align:center"><span class="sheet-text-fronth3" data-i18n="pathsins-u">Path Sins</span></div><div class="sheet-line-behindh3" ></div>
     <div class="sheet-col" style="width:260px">
-        <h5>10<textarea type="text" name="attr_MoralPath10" style="width:235px; height:36px"/></textarea></h5>
-        <h5>9 <textarea type="text" name="attr_MoralPath9" style="width:235px; height:36px"/></textarea></h5>
-        <h5>8 <textarea type="text" name="attr_MoralPath8" style="width:235px; height:36px"/></textarea></h5>
-		<h5>7 <textarea type="text" name="attr_MoralPath7" style="width:235px; height:36px"/></textarea></h5>
-		<h5>6 <textarea type="text" name="attr_MoralPath6" style="width:235px; height:36px"/></textarea></h5>
-		<h5>5 <textarea type="text" name="attr_MoralPath5" style="width:235px; height:36px"/></textarea></h5>
-		<h5>4 <textarea type="text" name="attr_MoralPath4" style="width:235px; height:36px"/></textarea></h5>
-		<h5>3 <textarea type="text" name="attr_MoralPath3" style="width:235px; height:36px"/></textarea></h5>
-		<h5>2 <textarea type="text" name="attr_MoralPath2" style="width:235px; height:36px"/></textarea></h5>
-		<h5>1 <textarea type="text" name="attr_MoralPath1" style="width:235px; height:36px"/></textarea></h5>        
+        <h5>10<textarea type="text" name="attr_MoralPath10" style="width:234px; height:36px; vertical-align:top"/></textarea></h5>
+        <h5>9 <textarea type="text" name="attr_MoralPath9" style="width:235px; height:36px; vertical-align:top"/></textarea></h5>
+        <h5>8 <textarea type="text" name="attr_MoralPath8" style="width:235px; height:36px; vertical-align:top"/></textarea></h5>
+		<h5>7 <textarea type="text" name="attr_MoralPath7" style="width:235px; height:36px; vertical-align:top"/></textarea></h5>
+		<h5>6 <textarea type="text" name="attr_MoralPath6" style="width:235px; height:36px; vertical-align:top"/></textarea></h5>
+		<h5>5 <textarea type="text" name="attr_MoralPath5" style="width:235px; height:36px; vertical-align:top"/></textarea></h5>
+		<h5>4 <textarea type="text" name="attr_MoralPath4" style="width:235px; height:36px; vertical-align:top"/></textarea></h5>
+		<h5>3 <textarea type="text" name="attr_MoralPath3" style="width:235px; height:36px; vertical-align:top"/></textarea></h5>
+		<h5>2 <textarea type="text" name="attr_MoralPath2" style="width:235px; height:36px; vertical-align:top"/></textarea></h5>
+		<h5>1 <textarea type="text" name="attr_MoralPath1" style="width:235px; height:36px; vertical-align:top"/></textarea></h5>        
     </div>
 </div>
 


### PR DESCRIPTION
Minor adjustment to styling of Path Sins, making it a bit more readable. Before, the number beside the textbox was below the textbox, making it a little unclear which one it was associated to.

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

This is a minor HTML styling change to the Path Sins block. The number denoting what text block was associated to which sin tier was a little unclear, because the number was BELOW the text block. I changed this to align to the top of the box instead. Also, since 10 is one pixel wider than the other numbers, I reduced the initial width of the first text block by one pixel so it lined up better on the right-hand side.




