### PR TITLE
[CoeursVaillants] fix: replace "em" width of number input in css

### DIFF
--- a/CoeursVaillants/CoeursVaillants.css
+++ b/CoeursVaillants/CoeursVaillants.css
@@ -207,8 +207,8 @@ input[type="number"].sheet-inpnum2c{
     width: 35px;
 }
 input[type="number"].sheet-inpnum2cbig{
-    width: 1em;
-    font-size: 1.4em;
+    width: 35px;
+    font-size: 140%;
 	/* margin-bottom: 4px; */
 }
 input[type="number"].sheet-inpnum2cboxed{


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [ ] The pull request title clearly contains the name of the sheet I am editing.
- [ ] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [ ] The pull request makes changes to files in only one sub-folder.
- [ ] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

<!-- Please check any that apply: -->

- [ ] This sheet has been made on behalf of, or by, the game's publisher.
- [ ] This game is not a traditionally published game, but a copy of the game rules can be purchased/downloaded/found at: <   >
- [ ] This sheet is for an unofficial fan game, modification to an existing game, or a homebrew system.

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

Small fix to replace width and size from "em" to pixel and percentile for a particular CSS component. For an unknown reason it is causing issues in real sheets that can’t be reproduce in sandbox.


