### PR TITLE
[Haunted West] Bugfix - Fixed trained skills calculation

### DIFF
--- a/Haunted-West-Character-Sheet/haunted_west.html
+++ b/Haunted-West-Character-Sheet/haunted_west.html
@@ -266,16 +266,16 @@
                     <div class="skillattvalue"><input type="number" name="attr_longarms2" value="@{awareness}+@{longarms2_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
-                    <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{awareness}+@{navigation_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Navigation}}" name="Navigation"><span class="icond10">00</span> Navigation</button></div>
-					<div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_navigation_type"></div>
+                    <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{awareness}/5)+@{navigation_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Navigation}}" name="Navigation"><span class="icond10">00</span> Navigation*</button></div>
+		    <div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_navigation_type"></div>
                     <div class="skillvalue"><input type="number" name="attr_navigation_val"> </div>
-                    <div class="skillattvalue"><input type="number" name="attr_navigation" value="@{awareness}+@{navigation_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"><input type="number" name="attr_navigation" value="floor(@{awareness}/5)+@{navigation_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
-                    <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{awareness}+@{navigation2_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Navigation}}" name="Navigation2"><span class="icond10">00</span> Navigation</button></div>
-					<div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_navigation2_type"></div>
+                    <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{awareness}/5)+@{navigation2_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Navigation}}" name="Navigation2"><span class="icond10">00</span> Navigation*</button></div>
+		    <div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_navigation2_type"></div>
                     <div class="skillvalue"><input type="number" name="attr_navigation2_val"> </div>
-                    <div class="skillattvalue"><input type="number" name="attr_navigation2" value="@{awareness}+@{navigation2_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"><input type="number" name="attr_navigation2" value="floor(@{awareness}/5)+@{navigation2_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
                     <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{awareness}+@{observation_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Observation}}" name="Observation"><span class="icond10">00</span> Observation</button></div>
@@ -288,16 +288,16 @@
                     <div class="skillattvalue"><input type="number" name="attr_psychology" value="@{awareness}+@{psychology_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
-                    <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{awareness}+@{tactics_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Tactics}}" name="Tactics"><span class="icond10">00</span> Tactics</button></div>
-					<div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_tactics_type"></div>
+                    <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{awareness}/5)+@{tactics_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Tactics}}" name="Tactics"><span class="icond10">00</span> Tactics*</button></div>
+	            <div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_tactics_type"></div>
                     <div class="skillvalue"><input type="number" name="attr_tactics_val"> </div>
-                    <div class="skillattvalue"><input type="number" name="attr_tactics" value="@{awareness}+@{tactics_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"><input type="number" name="attr_tactics" value="floor(@{awareness}/5)+@{tactics_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
-                    <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{awareness}+@{tactics2_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Tactics}}" name="tactics2"><span class="icond10">00</span> Tactics</button></div>
-					<div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_tactics2_type"></div>
+                    <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{awareness}/5)+@{tactics2_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Tactics}}" name="tactics2"><span class="icond10">00</span> Tactics*</button></div>
+		    <div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_tactics2_type"></div>
                     <div class="skillvalue"><input type="number" name="attr_tactics2_val"> </div>
-                    <div class="skillattvalue"><input type="number" name="attr_tactics2" value="@{awareness}+@{tactics2_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"><input type="number" name="attr_tactics2" value="floor(@{awareness}/5)+@{tactics2_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
                     <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{awareness}+@{tracking_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Tracking}}" name="Tracking"><span class="icond10">00</span> Tracking</button></div>
@@ -370,10 +370,11 @@
                     <div class="titleskillrawattvalue"><input type="number" name="attr_reflexesvalue" value="@{reflexes}" disabled="true" /></div>
                 </div>
                 <div class="skillrow">
-                    <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{reflexes}+@{acrobatics_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Acrobatics}}" name="Acrobatics*"><span class="icond10">00</span> Acrobatics*</button></div>
+                    <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{reflexes}/5)+@{acrobatics_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Acrobatics}}" name="Acrobatics*"><span class="icond10">00</span> Acrobatics*</button></div>
                     <div class="skillvalue"><input type="number" name="attr_acrobatics_val"></div>
-                    <div class="skillattvalue"><input type="number" name="attr_acrobatics" value="@{reflexes}+@{acrobatics_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"><input type="number" name="attr_acrobatics" value="floor(@{reflexes}/5)+@{acrobatics_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
+		
                 <div class="skillrow">
                     <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{reflexes}+@{dodge_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Dodge}}" name="Dodge"><span class="icond10">00</span> Dodge</button></div>
                     <div class="skillvalue"><input type="number" name="attr_dodge_val"></div>
@@ -447,16 +448,16 @@
                     <div class="titleskillrawattvalue"><input type="number" name="attr_personalityvalue" value="@{personality}" disabled="true" /></div>
                 </div>
                 <div class="skillrow">
-                    <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{personality}+@{thearts_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Arts*}}" name="The Arts"><span class="icond10">00</span> Arts*</button></div>
+                    <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{personality}/5)+@{thearts_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Arts*}}" name="The Arts"><span class="icond10">00</span> Arts*</button></div>
                     <div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_thearts_type"></div>
 					<div class="skillvalue"><input type="number" name="attr_thearts_val"></div>
-                    <div class="skillattvalue"><input type="number" name="attr_thearts" value="@{personality}+@{thearts_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"><input type="number" name="attr_thearts" value="floor(@{personality}/5)+@{thearts_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
-                    <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{personality}+@{thearts2_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Arts*}}" name="The Arts2"><span class="icond10">00</span> Arts*</button></div>
+                    <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{personality}/5)+@{thearts2_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Arts*}}" name="The Arts2"><span class="icond10">00</span> Arts*</button></div>
                     <div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_thearts2_type"></div>
 					<div class="skillvalue"><input type="number" name="attr_thearts2_val"></div>
-                    <div class="skillattvalue"><input type="number" name="attr_thearts2" value="@{personality}+@{thearts2_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"><input type="number" name="attr_thearts2" value="floor(@{personality}/5)+@{thearts2_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
                     <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{personality}+@{bluff_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Bluff}}" name="Bluff"><span class="icond10">00</span> Bluff+</button></div>
@@ -511,21 +512,21 @@
                     <div class="titleskillrawattvalue"><input type="number" name="attr_technologyvalue" value="@{technology}" disabled="true" /></div>
                 </div>
                 <div class="skillrow">
-                    <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{technology}+@{craft_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Craft}}" name="Craft"><span class="icond10">00</span> Craft</button></div>
+                    <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{technology}/5)+@{craft_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Craft}}" name="Craft"><span class="icond10">00</span> Craft*</button></div>
                     <div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_craft_type"></div>
 					<div class="skillvalue"><input type="number" name="attr_craft_val"></div>
-                    <div class="skillattvalue"><input type="number" name="attr_craft" value="@{technology}+@{craft_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"><input type="number" name="attr_craft" value="floor(@{technology}/5)+@{craft_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
-                    <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{technology}+@{craft2_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Craft}}" name="craft2"><span class="icond10">00</span> Craft</button></div>
+                    <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{technology}/5)+@{craft2_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Craft}}" name="craft2"><span class="icond10">00</span> Craft*</button></div>
                     <div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_craft2_type"></div>
 					<div class="skillvalue"><input type="number" name="attr_craft2_val"></div>
-                    <div class="skillattvalue"><input type="number" name="attr_craft2" value="@{technology}+@{craft2_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"><input type="number" name="attr_craft2" value="floor(@{technology}/5)+@{craft2_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
-                    <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{technology}+@{electronics_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Electrics}}" name="Electrics*"><span class="icond10">00</span> Electrics*</button></div>
+                    <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{technology}/5)+@{electronics_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Electrics}}" name="Electrics*"><span class="icond10">00</span> Electrics*</button></div>
                     <div class="skillvalue"><input type="number" name="attr_electronics_val"></div>
-                    <div class="skillattvalue"><input type="number" name="attr_electronics" value="@{technology}+@{electronics_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"><input type="number" name="attr_electronics" value="floor(@{technology}/5)+@{electronics_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
                     <div class="skilllabel"><button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{technology}+@{lockpicking_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Lockpicking}}" name="Lockpicking"><span class="icond10">00</span> Lockpicking</button></div>
@@ -533,9 +534,9 @@
                     <div class="skillattvalue"> <input type="number" name="attr_lockpicking" value="@{technology}+@{lockpicking_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
-                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{technology}+@{mechanics_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Mechanics*}}" name="Mechanics*"><span class="icond10">00</span> Mechanics*</button></div>
+                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{technology}/5)+@{mechanics_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Mechanics*}}" name="Mechanics*"><span class="icond10">00</span> Mechanics*</button></div>
                     <div class="skillvalue"> <input type="number" name="attr_mechanics_val"></div>
-                    <div class="skillattvalue"> <input type="number" name="attr_mechanics" value="@{technology}+@{mechanics_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"> <input type="number" name="attr_mechanics" value="floor(@{technology}/5)+@{mechanics_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
                     <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{technology}+@{pilot_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Pilot (Type)}}" name="Pilot"><span class="icond10">00</span> Pilot</button></div>
@@ -550,9 +551,9 @@
                     <div class="skillattvalue"> <input type="number" name="attr_pilot2" value="@{technology}+@{pilot2_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
-                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{technology}+@{repair_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Repair}}" name="Repair*"><span class="icond10">00</span> Repair*</button></div>
+                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{technology}/5)+@{repair_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Repair}}" name="Repair*"><span class="icond10">00</span> Repair*</button></div>
                     <div class="skillvalue"> <input type="number" name="attr_repair_val"></div>
-                    <div class="skillattvalue"> <input type="number" name="attr_repair" value="@{technology}+@{repair_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"> <input type="number" name="attr_repair" value="floor(@{technology}/5)+@{repair_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
                     <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{technology}+@{tinker_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Tinker}}" name="Tinker"><span class="icond10">00</span> Tinker</button></div>
@@ -573,9 +574,9 @@
                     <div class="titleskillrawattvalue"> <input type="number" name="attr_knowledgevalue" value="@{knowledge}" disabled="true" /></div>
                 </div>
                 <div class="skillrow">
-                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{knowledge}+@{counterfeiting_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Counterfeiting}}" name="Counterfeiting*"><span class="icond10">00</span> Counterfeiting*</button></div>
+                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{knowledge}/5)+@{counterfeiting_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Counterfeiting}}" name="Counterfeiting*"><span class="icond10">00</span> Counterfeiting*</button></div>
                     <div class="skillvalue"> <input type="number" name="attr_counterfeiting_val"></div>
-                    <div class="skillattvalue"> <input type="number" name="attr_counterfeiting" value="@{knowledge}+@{counterfeiting_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"> <input type="number" name="attr_counterfeiting" value="floor(@{knowledge}/5)+@{counterfeiting_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
                     <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{knowledge}+@{firstiaid_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=First Aid}}" name="First Aid"><span class="icond10">00</span> First Aid</button></div>
@@ -583,21 +584,21 @@
                     <div class="skillattvalue"> <input type="number" name="attr_firstiaid" value="@{knowledge}+@{firstaid_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
-                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{knowledge}+@{medicine_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Medicine}}" name="Medicine*"><span class="icond10">00</span> Medicine*</button></div>
+                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{knowledge}/5)+@{medicine_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Medicine}}" name="Medicine*"><span class="icond10">00</span> Medicine*</button></div>
                     <div class="skillvalue"> <input type="number" name="attr_medicine_val"></div>
-                    <div class="skillattvalue"> <input type="number" name="attr_medicine" value="@{knowledge}+@{medicine_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"> <input type="number" name="attr_medicine" value="floor(@{knowledge}/5)+@{medicine_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
-                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{knowledge}+@{language_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Language}}" name="Language"><span class="icond10">00</span> Language*</button></div>
+                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{knowledge}/5)+@{language_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Language}}" name="Language"><span class="icond10">00</span> Language*</button></div>
                     <div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_language_type"></div>
                     <div class="skillvalue"> <input type="number" name="attr_language_val"></div>
-                    <div class="skillattvalue"> <input type="number" name="attr_language" value="@{knowledge}+@{language_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"> <input type="number" name="attr_language" value="floor(@{knowledge}/5)+@{language_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
-				<div class="skillrow">
-                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{knowledge}+@{language2_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Language}}" name="language2*"><span class="icond10">00</span> Language*</button></div>
+		<div class="skillrow">
+                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{knowledge}/5)+@{language2_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Language}}" name="language2*"><span class="icond10">00</span> Language*</button></div>
                     <div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_language2_type"></div>
                     <div class="skillvalue"> <input type="number" name="attr_language2_val"></div>
-                    <div class="skillattvalue"> <input type="number" name="attr_language2" value="@{knowledge}+@{language2_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"> <input type="number" name="attr_language2" value="floor(@{knowledge}/5)+@{language2_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
                     <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{knowledge}+@{logic_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Logic}}" name="Logic"><span class="icond10">00</span> Logic</button></div>
@@ -618,28 +619,28 @@
                 </div>
 
                 <div class="skillrow">
-                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{knowledge}+@{science_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Science}}" name="Science"><span class="icond10">00</span> Science*</button></div>
-					<div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_science_type"></div>
+                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{knowledge}/5)+@{science_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Science}}" name="Science"><span class="icond10">00</span> Science*</button></div>
+		    <div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_science_type"></div>
                     <div class="skillvalue"> <input type="number" name="attr_science_val"></div>
-                    <div class="skillattvalue"> <input type="number" name="attr_science" value="@{knowledge}+@{science_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"> <input type="number" name="attr_science" value="floor(@{knowledge}/5)+@{science_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
-                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{knowledge}+@{science2_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Science}}" name="Science2"><span class="icond10">00</span> Science*</button></div>
+                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{knowledge}/5)+@{science2_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Science}}" name="Science2"><span class="icond10">00</span> Science*</button></div>
 					<div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_science2_type"></div>
                     <div class="skillvalue"> <input type="number" name="attr_science2_val"></div>
-                    <div class="skillattvalue"> <input type="number" name="attr_science2" value="@{knowledge}+@{science2_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"> <input type="number" name="attr_science2" value="floor(@{knowledge}/5)+@{science2_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
-                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{knowledge}+@{trade_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Trade}}" name="Trade"><span class="icond10">00</span> Trade</button></div>
-					<div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_trade_type"></div>
+                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{knowledge}/5)+@{trade_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Trade}}" name="Trade"><span class="icond10">00</span> Trade*</button></div>
+		    <div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_trade_type"></div>
                     <div class="skillvalue"> <input type="number" name="attr_trade_val"></div>
-                    <div class="skillattvalue"> <input type="number" name="attr_trade" value="@{knowledge}+@{trade_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"> <input type="number" name="attr_trade" value="floor(@{knowledge}/5)+@{trade_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
-                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{knowledge}+@{trade2_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Trade}}" name="Trade2"><span class="icond10">00</span> Trade</button></div>
-					<div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_trade2_type"></div>
+                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{knowledge}/5)+@{trade2_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Trade}}" name="Trade2"><span class="icond10">00</span> Trade*</button></div>
+		    <div class="skilltypebox"><input class="withtype" type="text" spellcheck="false" name="attr_trade2_type"></div>
                     <div class="skillvalue"> <input type="number" name="attr_trade2_val"></div>
-                    <div class="skillattvalue"> <input type="number" name="attr_trade2" value="@{knowledge}+@{trade2_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"> <input type="number" name="attr_trade2" value="floor(@{knowledge}/5)+@{trade2_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
             </div>
         </div> <!-- end sec2-->
@@ -661,9 +662,9 @@
                     <div class="skillattvalue"> <input type="number" name="attr_commands" value="@{resolve}+@{commands_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
-                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{resolve}+@{explosive_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Explosive}}" name="Explosive*"><span class="icond10">00</span> Explosive*</button></div>
+                    <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[floor(@{resolve}/5)+@{explosive_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Explosive}}" name="Explosive*"><span class="icond10">00</span> Explosive*</button></div>
                     <div class="skillvalue"> <input type="number" name="attr_explosive_val"></div>
-                    <div class="skillattvalue"> <input type="number" name="attr_explosive" value="@{resolve}+@{explosive_val}" disabled="true" class="attr_skillattvalue"></div>
+                    <div class="skillattvalue"> <input type="number" name="attr_explosive" value="floor(@{resolve}/5)+@{explosive_val}" disabled="true" class="attr_skillattvalue"></div>
                 </div>
                 <div class="skillrow">
                     <div class="skilllabel"> <button type="roll" class="txtbutton" value="&{template:custom} [[ floor([[ [[@{resolve}+@{negotiations_val}]] - [[1d100+@{modifier}*-1]] ]] / 10) ]] {{target=$[[0]]}} {{rawroll=$[[1]]}} {{difference=$[[2]]}} {{jacks=$[[3]]}} {{name=Negotiations}}" name="Negotiations"><span class="icond10">00</span> Negotiations</button></div>


### PR DESCRIPTION
# Submission Checklist
## Required

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

Page 242 mentions:
> Trained skills (denoted by a *) ... These skills’ base value is one-fifth of their linked Traits

Sheet was treating them as 100% the linked trait.

Changed relevant calculations (any skill with a `*`) from `...@stat...` to `...floor(@stat/5)...`, marked a couple more skills as trained based on the Haunted West PDF from drivethrurpg. I didn't see any erratas or FAQ that may have changed what skills are trained or how they're calculated.
