### PR TITLE
[Torchbearer-2E] [Bug Fix] Inline roll background color overridden in dark mode

### DIFF
--- a/Torchbearer 2E/torchbearer.css
+++ b/Torchbearer 2E/torchbearer.css
@@ -1380,8 +1380,8 @@ button[type="roll"].sheet-complex-roll-button span {
 .sheet-rolltemplate-complex .inlinerollresult.fullcrit,
 .sheet-rolltemplate-complex .inlinerollresult.fullfail,
 .sheet-rolltemplate-complex .inlinerollresult.importantroll {
-  background: none;
-  border: none;
+  background: none !important;
+  border: none !important;
 }
 
 .sheet-rolltemplate-simple .sheet-caps,


### PR DESCRIPTION
The new dark mode feature was overriding the css on the roll card causing a purple background and border. Added the important tag to prevent this override.

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

The new dark mode feature causes an override to the inline roll result background color. I have added the important tag to prevent this override.

Screen cap of bug with dark mode enabled.
<img width="202" alt="image" src="https://user-images.githubusercontent.com/11466834/181269478-4e399c50-632b-43eb-8bab-14e52aabe770.png">

Screen cap of fix with dark mode enabled.
![image](https://user-images.githubusercontent.com/11466834/181270142-cd8970a1-2f61-4547-b175-fc08e7585be6.png)

Screen cap of fix with dark mode disabled.
<img width="226" alt="image" src="https://user-images.githubusercontent.com/11466834/181270320-b0cbe54a-df60-4149-81d5-f41e13a79dce.png">






