### PR TITLE
The Fantasy Trip: styling, round the 4d and 5d combat radio buttons, add stat check radio buttons for dice count.

### DIFF
--- a/The Fantasy Trip/TFT.css
+++ b/The Fantasy Trip/TFT.css
@@ -159,7 +159,7 @@ body.sheet-darkmode .charsheet {
 	position:relative;
 	top:.17em;
 	text-align: center;
-	/* It's a fade intheinthe original */
+	/* It's a fade in the original */
 	margin-top: 0em;
 	padding-left: .125em;
 	padding-right: .125em;
@@ -167,7 +167,7 @@ body.sheet-darkmode .charsheet {
 }
 
 .sheet-dice-button::before {
-	content: "t";
+	content: "0";
 	font-family: "dicefontd20";
 	font-size: 1.4em;
 	font-weight: normal;

--- a/The Fantasy Trip/TFT.css
+++ b/The Fantasy Trip/TFT.css
@@ -145,7 +145,7 @@ body.sheet-darkmode .charsheet {
 	text-align: center;
 	align-self: center;
 	font-weight: bold;
-	border-radius: .2rem;
+	border-radius: 1.5rem;
 	border-width: 1px;
 }
 

--- a/The Fantasy Trip/TFT.html
+++ b/The Fantasy Trip/TFT.html
@@ -97,7 +97,7 @@
 						<button class=sheet-caption-button title="Roll 8d6 for next Stat or Health Check." type="action" name="act_save8d">8d</button>
 					</span>
 					<span title="Blank check, provided for the criticals.  Success on roll &le; the number.">
-							<button class=sheet-dice-button type="action" title="Blank Stat Check" name="act_blank_check"></button>
+						<button class=sheet-dice-button type="action" title="Blank Stat Check" name="act_blank_check"></button>
 					</span>
 				</div>
 				<!-- MA -->

--- a/The Fantasy Trip/TFT.html
+++ b/The Fantasy Trip/TFT.html
@@ -30,6 +30,7 @@
 		</div>
 		<div class="sheet-stats sheet-block">
 			<div> <!-- To prevent them from vertically spreading out -->
+				<!-- ST -->
 				<div class=sheet-flex-centered>
 					<span>
 						<span  title="Base Strength">
@@ -46,6 +47,7 @@
 						<button class=sheet-dice-button type="action" title="4d6 Strength Check" name="act_st_check4">4</button>
 					</span>
 				</div>
+				<!-- DX -->
 				<div class=sheet-flex-centered>
 					<span>
 						<span title="Base Dexterity">
@@ -62,6 +64,7 @@
 						<button class=sheet-dice-button type="action" title="4d6 Strength Check" name="act_dx_check4">4</button>
 					</span>
 				</div>
+				<!-- IQ -->
 				<div class=sheet-flex-centered>
 					<span>
 						<span title="Base IQ">
@@ -78,6 +81,7 @@
 						<button class=sheet-dice-button type="action" title="4d6 IQ Check" name="act_iq_check4">4</button>
 					</span>
 				</div>
+				<!-- MA -->
 				<div class=sheet-flex-centered>
 					<span>
 						<span title="Movement Allowance.">
@@ -100,6 +104,7 @@
 					<span>&nbsp;</span>
 					<span class='sheet-label sheet-nowrap' title="Weight penalties, automatically applied." name="attr_mapenalty"></span>
 				</div>
+				<!-- MANA -->
 				<div class=sheet-flex-centered>
 					<span>
 						<span title="Max Staff Mana.">
@@ -112,6 +117,7 @@
 						<span class=sheet-computed-value title="Remaining Mana." type=number name="attr_mana"></span>
 					</span>
 				</div>
+				<!-- SAVES -->
 				<div class=sheet-flex-centered>
 					<span title="Blank saves, provided for the criticals.  Success on roll &le; the stat.">
 						<span class=sheet-stat-label>Saves</span>

--- a/The Fantasy Trip/TFT.html
+++ b/The Fantasy Trip/TFT.html
@@ -97,7 +97,7 @@
 						<button class=sheet-caption-button title="Roll 8d6 for next Stat or Health Check." type="action" name="act_save8d">8d</button>
 					</span>
 					<span title="Blank check, provided for the criticals.  Success on roll &le; the number.">
-							<button class=sheet-dice-button type="action" title="Blank stat check" name="act_blank_check"></button>
+							<button class=sheet-dice-button type="action" title="Blank Stat Check" name="act_blank_check"></button>
 					</span>
 				</div>
 				<!-- MA -->

--- a/The Fantasy Trip/TFT.html
+++ b/The Fantasy Trip/TFT.html
@@ -81,6 +81,22 @@
 						<button class=sheet-dice-button type="action" title="4d6 IQ Check" name="act_iq_check4">4</button>
 					</span>
 				</div>
+				<!-- SAVES -->
+				<div class=sheet-flex-centered>
+					<span title="Blank saves, provided for the criticals.  Success on roll &le; the stat.">
+						<span class=sheet-stat-label>Saves</span>
+					</span>
+					<span>
+						<button class=sheet-dice-button type="action" title="2d6 Save" name="act_save2">2</button>
+						<button class=sheet-dice-button type="action" title="2d6 Save" name="act_save3">3</button >
+						<button class=sheet-dice-button type="action" title="2d6 Save" name="act_save4">4</button>
+						<button class=sheet-dice-button type="action" title="5d6 Save" name="act_save5">5</button>
+						<button class=sheet-dice-button type="action" title="6d6 Save" name="act_save6">6</button>
+						<button class=sheet-dice-button type="action" title="7d6 Save" name="act_save7">7</button>
+						<button class=sheet-dice-button type="action" title="8d6 Save" name="act_save8">8</button>
+					</span>
+				</div>
+
 				<!-- MA -->
 				<div class=sheet-flex-centered>
 					<span>
@@ -117,33 +133,19 @@
 						<span class=sheet-computed-value title="Remaining Mana." type=number name="attr_mana"></span>
 					</span>
 				</div>
-				<!-- SAVES -->
-				<div class=sheet-flex-centered>
-					<span title="Blank saves, provided for the criticals.  Success on roll &le; the stat.">
-						<span class=sheet-stat-label>Saves</span>
-					</span>
-					<span>
-						<button class=sheet-dice-button type="action" title="2d6 Save" name="act_save2">2</button>
-						<button class=sheet-dice-button type="action" title="2d6 Save" name="act_save3">3</button >
-						<button class=sheet-dice-button type="action" title="2d6 Save" name="act_save4">4</button>
-						<button class=sheet-dice-button type="action" title="5d6 Save" name="act_save5">5</button>
-						<button class=sheet-dice-button type="action" title="6d6 Save" name="act_save6">6</button>
-						<button class=sheet-dice-button type="action" title="7d6 Save" name="act_save7">7</button>
-						<button class=sheet-dice-button type="action" title="8d6 Save" name="act_save8">8</button>
-					</span>
-				</div>
 			</div>
 		</div>
 		<div class="sheet-combat sheet-block">
 			<div> <!-- stops from stretching -->
+				<!-- Turn Order -->
 				<div class=sheet-flex-centered style='margin-bottom: .5rem'>
 					<button class=sheet-dice-button type="action" title="Add yourself to Turn Order, select your Token first." name="act_turnorder">Turn Order</button>
 					<span>
 						<button class=sheet-dice-button type="action" title="Roll team Initiative." name="act_initiative">Initiative</button>
 						<input class=sheet-onechar-input type=text title="Bonus to Initiative, as for Tactics or Strategist." name="attr_initiative_adj"/>
 					</span>
-
 				</div>
+				<!-- Health -->
 				<div class=sheet-flex-centered>
 					<span title="Wounded ST, current Strength reduced by Wounds and Fatigue.">
 						<span class='sheet-label sheet-first-word' style='width: 5rem'>Health </span>
@@ -154,6 +156,7 @@
 						<button class=sheet-dice-button type="action" title="4d6 Health Check" name="act_health_check4">4</button>
 					</span>
 				</div>
+				<!-- Wounds -->
 				<div class=sheet-flex-centered>
 					<span title="Damage done to your Health, must be healed.">
 						<span class=sheet-label style='width: 5rem;'>Wounds </span>
@@ -161,6 +164,7 @@
 					</span>
 					<button class=sheet-dice-button type="action" title="Reaction to attacker initiating Hand to Hand Combat." style='width: 4.6rem' name="act_hthreaction">HTH</button>
 				</div>
+				<!-- Fatigue -->
 				<div class=sheet-flex-centered>
 					<span title="Temporary damage done to your Health as for spellcasting.">
 						<span class=sheet-label style='width: 5rem'>Fatigue </span>
@@ -171,6 +175,7 @@
 						<button class=sheet-dice-button type="action" title="Shield Rush Save vs equal or stronger (unwounded strength) rusher." style='width: 4.6rem' name="act_shieldrushstronger">SRS</button>
 					</span>
 				</div>
+				<!-- Minus to Hit -->
 				<div class=sheet-flex-centered>
 					<span title="Subtract from enemy DX when attacking you.">
 						<span class=sheet-label style='width: 8rem' >Minus to Hit </span>
@@ -181,6 +186,7 @@
 						<span class=sheet-computed-value name="attr_minustohit"/>
 					</span>
 				</div>
+				<!-- Hits Blocked -->
 				<div class=sheet-flex-centered>
 					<span title="Hits blocked per attack by your armor/shields/abilities.">
 						<span class=sheet-label>Hits Blocked</span>

--- a/The Fantasy Trip/TFT.html
+++ b/The Fantasy Trip/TFT.html
@@ -33,8 +33,8 @@
 				<!-- ST -->
 				<div class=sheet-flex-centered>
 					<span>
-						<span  title="Base Strength">
-							<span class=sheet-stat-label>ST</span>
+						<span title="Base Strength">
+							<span class=sheet-stat-label >ST</span>
 							<input class=sheet-tiny-input type=text name="attr_ST_max" value="8"/>
 						</span>
 						<span class=sheet-stat-plus>+</span>
@@ -43,15 +43,14 @@
 						<span class=sheet-computed-value title="Final Strength.  Base plus Adjustments, not counting Wounds or Fatigue." name="attr_ST"/>
 					</span>
 					<span>
-						<button class=sheet-dice-button type="action" title="3d6 Strength Check" name="act_st_check3">3</button>
-						<button class=sheet-dice-button type="action" title="4d6 Strength Check" name="act_st_check4">4</button>
+						<button class=sheet-dice-button type="action" title="Strength Check" name="act_st_check"></button>
 					</span>
 				</div>
 				<!-- DX -->
 				<div class=sheet-flex-centered>
 					<span>
 						<span title="Base Dexterity">
-							<span class=sheet-stat-label>DX</span>
+							<span class=sheet-stat-label >DX</span>
 							<input class=sheet-tiny-input type=text name="attr_DX_max" value="8"/>
 						</span>
 						<span class=sheet-stat-plus>+</span>
@@ -60,8 +59,7 @@
 						<span class=sheet-computed-value title="Final Dexterity.  Base plus Adjustments minus Armor Penalties." name="attr_DX"/>
 					</span>
 					<span>
-						<button class=sheet-dice-button type="action" title="3d6 Dexterity Check" name="act_dx_check3">3</button>
-						<button class=sheet-dice-button type="action" title="4d6 Strength Check" name="act_dx_check4">4</button>
+						<button class=sheet-dice-button type="action" title="Dexterity Check" name="act_dx_check"></button>
 					</span>
 				</div>
 				<!-- IQ -->
@@ -77,26 +75,31 @@
 						<span class=sheet-computed-value title="Final IQ.  Base plus Adjustments." name="attr_IQ"/>
 					</span>
 					<span>
-						<button class=sheet-dice-button type="action" title="3d6 IQ Check" name="act_iq_check3">3</button>
-						<button class=sheet-dice-button type="action" title="4d6 IQ Check" name="act_iq_check4">4</button>
+						<button class=sheet-dice-button type="action" title="IQ Check" name="act_iq_check"></button>
 					</span>
 				</div>
 				<!-- SAVES -->
 				<div class=sheet-flex-centered>
-					<span title="Blank saves, provided for the criticals.  Success on roll &le; the stat.">
-						<span class=sheet-stat-label>Saves</span>
-					</span>
 					<span>
-						<button class=sheet-dice-button type="action" title="2d6 Save" name="act_save2">2</button>
-						<button class=sheet-dice-button type="action" title="2d6 Save" name="act_save3">3</button >
-						<button class=sheet-dice-button type="action" title="2d6 Save" name="act_save4">4</button>
-						<button class=sheet-dice-button type="action" title="5d6 Save" name="act_save5">5</button>
-						<button class=sheet-dice-button type="action" title="6d6 Save" name="act_save6">6</button>
-						<button class=sheet-dice-button type="action" title="7d6 Save" name="act_save7">7</button>
-						<button class=sheet-dice-button type="action" title="8d6 Save" name="act_save8">8</button>
+						<input type=checkbox name=attr_save2d class=sheet-caption-checkbox hidden>
+						<button class=sheet-caption-button title="Roll 2d6 for next Stat or Health Check." type="action" name="act_save2d">2d</button>
+						<input type=checkbox name=attr_save3d class=sheet-caption-checkbox value='on' hidden>
+						<button class=sheet-caption-button title="Roll 3d6 for next Stat or Health Check." type="action" name="act_save3d">3d</button>
+						<input type=checkbox name=attr_save4d class=sheet-caption-checkbox hidden>
+						<button class=sheet-caption-button title="Roll 4d6 for next Stat or Health Check." type="action" name="act_save4d">4d</button>
+						<input type=checkbox name=attr_save5d class=sheet-caption-checkbox hidden>
+						<button class=sheet-caption-button title="Roll 5d6 for next Stat or Health Check." type="action" name="act_save5d">5d</button>
+						<input type=checkbox name=attr_save6d class=sheet-caption-checkbox value='on'hidden>
+						<button class=sheet-caption-button title="Roll 6d6 for next Stat or Health Check." type="action" name="act_save6d">6d</button>
+						<input type=checkbox name=attr_save7d class=sheet-caption-checkbox hidden>
+						<button class=sheet-caption-button title="Roll 7d6 for next Stat or Health Check." type="action" name="act_save7d">7d</button>
+						<input type=checkbox name=attr_save8d class=sheet-caption-checkbox hidden>
+						<button class=sheet-caption-button title="Roll 8d6 for next Stat or Health Check." type="action" name="act_save8d">8d</button>
+					</span>
+					<span title="Blank check, provided for the criticals.  Success on roll &le; the number.">
+							<button class=sheet-dice-button type="action" title="Blank stat check" name="act_blank_check"></button>
 					</span>
 				</div>
-
 				<!-- MA -->
 				<div class=sheet-flex-centered>
 					<span>
@@ -152,8 +155,7 @@
 						<span class=sheet-computed-value name="attr_health"/>
 					</span>
 					<span>
-						<button class=sheet-dice-button type="action" title="3d6 Health Check" name="act_health_check3">3</button>
-						<button class=sheet-dice-button type="action" title="4d6 Health Check" name="act_health_check4">4</button>
+						<button class=sheet-dice-button type="action" title="Health Check" name="act_health_check"></button>
 					</span>
 				</div>
 				<!-- Wounds -->
@@ -926,7 +928,7 @@
 	const diceArrayToString = function(rolls) {
 		let diceString = '';
 		if (rolls) {
-			for (i = 0; i < rolls.length; ++i) {
+			for (let i = 0; i < rolls.length; ++i) {
 				let roll = rolls[i];
 				if (roll == 1) diceString += 'a';
 				else if (roll == 2) diceString += 'b';
@@ -1030,17 +1032,9 @@
 
 		let selected = id ? (id + '_' + attrName).toLowerCase() : attrName;
 
-		console.log('toggling', selected)
-
 		getAttrs([selected], function(values) {
 			let oldValue = values[selected];
-
-			console.log('old value is', oldValue)
-
 			let newValue = (oldValue == 'on' ? 0 : 'on');
-
-			console.log('new value is', oldValue)
-
 			let valueMap = {};
 			// toggle this one, turn off the rest.
 			valueMap[selected] = newValue;
@@ -1218,52 +1212,42 @@
 		});
 	}
 
-	on('clicked:st_check3', (info) => {
-		doSaveRoll("&{template:stat-check} {{stat_a=a}} {{stat_name=strength}} {{stat=[[@{st}[STR]]]}} {{roll1=[[3d6]]}}");
-	});
-	on('clicked:st_check4', (info) => {
-		doSaveRoll("&{template:stat-check} {{stat_a=a}} {{stat_name=strength}} {{stat=[[@{st}[STR]]]}} {{roll1=[[4d6]]}}");
-	});
-	on('clicked:dx_check3', (info) => {
-		doSaveRoll("&{template:stat-check} {{stat_a=a}} {{stat_name=dexterity}} {{stat=[[@{dx}[DEX]]]}} {{roll1=[[3d6]]}}");
-	});
-	on('clicked:dx_check4', (info) => {
-		doSaveRoll("&{template:stat-check} {{stat_a=a}} {{stat_name=dexterity}} {{stat=[[@{dx}[DEX]]]}} {{roll1=[[4d6]]}}");
-	});
-	on('clicked:iq_check3', (info) => {
-		doSaveRoll("&{template:stat-check} {{stat_a=an}} {{stat_name=IQ}} {{stat=[[@{iq}[IQ]]]}} {{roll1=[[3d6]]}}");
-	});
-	on('clicked:iq_check4', (info) => {
-		doSaveRoll("&{template:stat-check} {{stat_a=an}} {{stat_name=IQ}} {{stat=[[@{iq}[IQ]]]}} {{roll1=[[4d6]]}}");
-	});
-	on('clicked:health_check3', (info) => {
-		doSaveRoll("&{template:stat-check} {{stat_a=a}} {{stat_name=health}} {{stat=[[@{health}[HEALTH]]]}} {{roll1=[[3d6]]}}");
-	});
-	on('clicked:health_check4', (info) => {
-		doSaveRoll("&{template:stat-check} {{stat_a=a}} {{stat_name=health}} {{stat=[[@{health}[HEALTH]]]}} {{roll1=[[4d6]]}}");
-	});
-	on('clicked:save2', (info) => {
-		doSaveRoll("&{template:stat-check} {{stat_a=a}} {{stat_name=}} {{stat=...}} {{roll1=[[2d6]]}}");
-	});
-	on('clicked:save3', (info) => {
-		doSaveRoll("&{template:stat-check} {{stat_a=a}} {{stat_name=}} {{stat=...}} {{roll1=[[3d6]]}}");
-	});
-	on('clicked:save4', (info) => {
-		doSaveRoll("&{template:stat-check} {{stat_a=a}} {{stat_name=}} {{stat=...}} {{roll1=[[4d6]]}}");
-	});
-	on('clicked:save5', (info) => {
-		doSaveRoll("&{template:stat-check} {{stat_a=a}} {{stat_name=}} {{stat=...}} {{roll1=[[5d6]]}}");
-	});
-	on('clicked:save6', (info) => {
-		doSaveRoll("&{template:stat-check} {{stat_a=a}} {{stat_name=}} {{stat=...}} {{roll1=[[6d6]]}}");
-	});
-	on('clicked:save7', (info) => {
-		doSaveRoll("&{template:stat-check} {{stat_a=a}} {{stat_name=}} {{stat=...}} {{roll1=[[7d6]]}}");
-	});
-	on('clicked:save8', (info) => {
-		doSaveRoll("&{template:stat-check} {{stat_a=a}} {{stat_name=}} {{stat=...}} {{roll1=[[8d6]]}}");
-	});
+	// attr is actual attribute st
+	// name is the friendly name like strength
+	// label is to show in the template, so like STR
+	// a is whether to save a <name> roll or an <name> roll.
+	const doStatRoll = function(attr, name, label, an = 'a') {
+		getAttrs(saveDiceAttrs(), function(values) {
+			let dice = getSaveDiceValue(values)
+			s = "&{template:stat-check} {{stat_a=" + an + "}} {{stat_name=" + name + "}} {{stat=[[@{" + attr + "}[" + label + "]]]}} {{roll1=[[" + dice + "d6]]}}";
+			doSaveRoll(s);
+			// since we've baked dice into the string we are save.
+			// We do this because that's the most common value.
+			setSaveDice(3);
+		});
+	}
 
+	on('clicked:st_check', (info) => {
+		doStatRoll('st', 'strength', 'STR');
+	});
+	on('clicked:dx_check', (info) => {
+		doStatRoll('dx', 'dexterity', 'DEX');
+	});
+	on('clicked:iq_check', (info) => {
+		doStatRoll('iq', 'IQ', 'IQ', 'an');
+	});
+	on('clicked:blank_check', (info) => {
+		getAttrs(saveDiceAttrs(), function(values) {
+			let dice = getSaveDiceValue(values)
+			s = "&{template:stat-check} {{stat_a=a}} {{stat_name=}} {{stat=...}} {{roll1=[[" + dice + "d6]]}}";
+			doSaveRoll(s);
+			setSaveDice(3);
+		});
+	});
+	on('clicked:health_check', (info) => {
+		doStatRoll('health', 'health', 'HEALTH');
+//		doSaveRoll("&{template:stat-check} {{stat_a=a}} {{stat_name=health}} {{stat=[[@{health}[HEALTH]]]}} {{roll1=[[3d6]]}}");
+	});
 
 	on('clicked:initiative', (info) => {
 		let initiativeAdjName = 'initiative_adj';
@@ -1582,7 +1566,7 @@
 		});
 	});
 
-	// Toggleable attack buttons.
+	// Radio/Toggle attack buttons.
 	on(' clicked:attack5d', (info) => {
 		toggleCheckbox('', 'defending2');
 		clearCheckbox('defending');
@@ -1592,6 +1576,55 @@
 		clearCheckbox('defending2');
 	});
 
+	// Returns the save dice attribute name
+	// give the dice.
+	const saveDiceAttr = function(dice) {
+		return 'save' + dice + 'd';
+	}
+
+	// returns an array of save dice attrs.
+	const saveDiceAttrs = function() {
+		let attrs = []
+		for (let i = 2; i < 9; ++i) {
+			attrs.push(saveDiceAttr(i));
+		}
+		return attrs;
+	}
+
+	// Given a value map, returns the number of dice.
+	const getSaveDiceValue = function(values) {
+		for (let i = 2; i < 9; ++i) {
+			if (values[saveDiceAttr(i)] != 0) {
+				return i;
+			}
+		}
+		// default.
+		return 3;
+	}
+
+	// Tell it how many dice to use, it sets the radio
+	// button.
+	const setSaveDice = function(dice) {
+		// Seems like you have to set attrs from a get attrs.
+		getAttrs(saveDiceAttrs(), function(values) {
+			for (let i = 2; i < 9; ++i) {
+				values[saveDiceAttr(i)] = (i == dice) ? 'on' : 0;
+			}
+			setAttrs(values);
+		});
+	}
+
+	// Radio save buttons.
+	on('clicked:save2d'
+		+ ' clicked:save3d'
+		+ ' clicked:save4d'
+		+ ' clicked:save5d'
+		+ ' clicked:save6d'
+		+ ' clicked:save7d'
+		+' clicked:save8d', (info) => {
+
+		setSaveDice(parseInt(info.triggerName.substring(12)) || 3);
+	});
 
 	// Weapons Select/Expand/Describe/NC
 	on('clicked:repeating_weapons', (info) => {


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

- Round the 4d and 5d Attack radio buttons, to make the fact that they are radio buttons more clear.
- Remove the bottom clunky "Saves" row and replace with radio buttons for how many dice to roll
- Replace 3 and 4 dice stat saves with just one button which references the radio buttons