### PR TITLE
Update HeroSystem6e,html to improve generic attack button

### DIFF
--- a/HeroSystem6e/HeroSystem6e.html
+++ b/HeroSystem6e/HeroSystem6e.html
@@ -125,8 +125,7 @@
 							<button type="roll" class="edit-hide tooltip" name="roll_Attack_Roll" value="@{ocv_formula}"></button>
 							<span class="tooltiptext">Attack&nbsp;Roll</span>
 						</div>
-						<input type="hidden" name="attr_ocv_formula" value="&{template:hero6template} {{charname=@{character_name}}} {{action=Attack Roll}} {{attack=[[3d6]]}} {{ocv=@{OCV}}} {{hitlocation=[[3d6]]}} {{damage=[[@{hth} @{preview_damage}]]}} {{type=STUN}} {{count=BODY}}" />
-						<!--<input type="hidden" name="attr_ocv_formula" value="&{template:hero6template} {{charname=@{character_name}}} {{action=Attack Roll}} {{attack=[[3d6]]}} {{ocv=@{OCV}}}" /> -->
+						<input type="hidden" name="attr_ocv_formula" value="&{template:hero6template} {{charname=@{character_name}}} {{action=Attack Roll}} {{attack=[[3d6]]}} {{ocv=@{OCV}}} {{hitlocation=[[@{hit_location_roll}]]}} {{damage=[[@{hth} @{preview_damage}]]}} {{type=STUN}} {{count=BODY}}" />
 					</div>
 					<div class="line">
 						<div class="in3">DCV</div>
@@ -551,8 +550,7 @@
 							<button type="roll" class="edit-hide tooltip" name="roll_Attack_Roll" value="@{ocv_formula}"></button>
 							<span class="tooltiptext">Attack&nbsp;Roll</span>
 						</div>
-						<input type="hidden" name="attr_ocv_formula" value="&{template:hero6template} {{charname=@{character_name}}} {{action=Attack Roll}} {{attack=[[3d6]]}} {{ocv=@{OCV}}} {{hitlocation=[[3d6]]}} {{damage=[[@{hth} @{preview_damage}]]}} {{type=STUN}} {{count=BODY}}" />
-						<!--<input type="hidden" name="attr_ocv_formula" value="&{template:hero6template} {{charname=@{character_name}}} {{action=Attack Roll}} {{attack=[[3d6]]}} {{ocv=@{OCV}}}" /> -->
+						<input type="hidden" name="attr_ocv_formula" value="&{template:hero6template} {{charname=@{character_name}}} {{action=Attack Roll}} {{attack=[[3d6]]}} {{ocv=@{OCV}}} {{hitlocation=[[@{hit_location_roll}]]}} {{damage=[[@{hth} @{preview_damage}]]}} {{type=STUN}} {{count=BODY}}" />
 					</div>
 					<div class="line">
 						<div class="in3">DCV</div>
@@ -5050,7 +5048,7 @@ var setCombatModifiers = function() {
 		switch( v[ "radio_target" ]) {
 		case "-1":     /* none */
 			modifier = 0;
-			roll = "";
+			roll = "0";
 			break;
 		case "1":     /* normal */
 			modifier = 0;
@@ -5058,7 +5056,7 @@ var setCombatModifiers = function() {
 			break;
 		case "2":     /* focus */
 			modifier = (-4);
-			roll = "";
+			roll = "1";
 			break;
 		case "3":     /* head shot (head to shoulders) */
 			modifier = (-4);
@@ -5118,7 +5116,7 @@ var setCombatModifiers = function() {
 			break;
 		default:
 			modifier = 0;
-			roll = "";
+			roll = "0";
 		}
 
 		setAttrs({ ocv_modifiers: modifier, hit_location_roll: roll });

--- a/HeroSystem6e/HeroSystem6e.html
+++ b/HeroSystem6e/HeroSystem6e.html
@@ -925,6 +925,7 @@
 						<div class="cp2">Half</div>
 						<div class="cp3">Final</div>
 						<div class="cp4">Damage</div>
+						<div class="cp2"></div>
 					</div>
 					<div class="line">
 						<div class="cp1">OCV</div>
@@ -940,8 +941,11 @@
 						<span class="cp2 field" name="attr_preview_half_ocv" disabled="true"></span>
 						<span class="cp3 field heads" name="attr_preview_final_ocv" disabled="true"></span>
 						<span class="cp4 field" name="attr_preview_damage" disabled="true"></span>
-						<button type="roll" class="edit-hide tooltip" name="roll_Attack_Roll" value="@{ocv_formula}"></button>
-
+						<div class="cp2 button">
+						    <span class="sheet-stat-button sheet-flash" name="attr_preview_atkbtn" disabled="true">Roll</span>
+    						<button type="roll" class="edit-hide tooltip" name="roll_Attack_Roll" value="@{ocv_formula}"></button>
+    					    <span class="tooltiptext">Attack&nbsp;Roll</span>
+		                </div>
 					</div>
 					<div class="line">
 						<div class="cp1">DCV</div>
@@ -956,6 +960,8 @@
 						<span class="cp2 field" name="attr_preview_psl_dcv" disabled="true"></span>
 						<span class="cp2 field" name="attr_preview_half_dcv" disabled="true"></span>
 						<span class="cp3 field heads" name="attr_preview_final_dcv" disabled="true"></span>
+						<div class="cp4"></div>
+						<div class="cp2"></div>
 					</div>
 				</div><!-- end subsection -->
 

--- a/HeroSystem6e/HeroSystem6e.html
+++ b/HeroSystem6e/HeroSystem6e.html
@@ -125,7 +125,8 @@
 							<button type="roll" class="edit-hide tooltip" name="roll_Attack_Roll" value="@{ocv_formula}"></button>
 							<span class="tooltiptext">Attack&nbsp;Roll</span>
 						</div>
-						<input type="hidden" name="attr_ocv_formula" value="&{template:hero6template} {{charname=@{character_name}}} {{action=Attack Roll}} {{attack=[[3d6]]}} {{ocv=@{OCV}}}" />
+						<input type="hidden" name="attr_ocv_formula" value="&{template:hero6template} {{charname=@{character_name}}} {{action=Attack Roll}} {{attack=[[3d6]]}} {{ocv=@{OCV}}} {{hitlocation=[[3d6]]}} {{damage=[[@{hth} @{preview_damage}]]}} {{type=STUN}} {{count=BODY}}" />
+						<!--<input type="hidden" name="attr_ocv_formula" value="&{template:hero6template} {{charname=@{character_name}}} {{action=Attack Roll}} {{attack=[[3d6]]}} {{ocv=@{OCV}}}" /> -->
 					</div>
 					<div class="line">
 						<div class="in3">DCV</div>
@@ -550,7 +551,8 @@
 							<button type="roll" class="edit-hide tooltip" name="roll_Attack_Roll" value="@{ocv_formula}"></button>
 							<span class="tooltiptext">Attack&nbsp;Roll</span>
 						</div>
-						<input type="hidden" name="attr_ocv_formula" value="&{template:hero6template} {{charname=@{character_name}}} {{action=Attack Roll}} {{attack=[[3d6]]}} {{ocv=@{OCV}}}" />
+						<input type="hidden" name="attr_ocv_formula" value="&{template:hero6template} {{charname=@{character_name}}} {{action=Attack Roll}} {{attack=[[3d6]]}} {{ocv=@{OCV}}} {{hitlocation=[[3d6]]}} {{damage=[[@{hth} @{preview_damage}]]}} {{type=STUN}} {{count=BODY}}" />
+						<!--<input type="hidden" name="attr_ocv_formula" value="&{template:hero6template} {{charname=@{character_name}}} {{action=Attack Roll}} {{attack=[[3d6]]}} {{ocv=@{OCV}}}" /> -->
 					</div>
 					<div class="line">
 						<div class="in3">DCV</div>
@@ -940,6 +942,8 @@
 						<span class="cp2 field" name="attr_preview_half_ocv" disabled="true"></span>
 						<span class="cp3 field heads" name="attr_preview_final_ocv" disabled="true"></span>
 						<span class="cp4 field" name="attr_preview_damage" disabled="true"></span>
+						<button type="roll" class="edit-hide tooltip" name="roll_Attack_Roll" value="@{ocv_formula}"></button>
+
 					</div>
 					<div class="line">
 						<div class="cp1">DCV</div>


### PR DESCRIPTION
- Made generic attack button on OCV provide hit location and body count as powers do
- Added a button to do the same thing at the end of the OCV line of the combat preview table

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

The generic attack button provided very barebones attack roll info.  With this update it adds hit location and body calculation so that it is as complete as attack rolls for powers.  Additionally, I've added an intuitive attack roll button in the combat preview table at the end of the OCV row.


