### PR TITLE
Update HeroSystem6e.html to store proper dice in hth

### DIFF
--- a/HeroSystem6e/HeroSystem6e.html
+++ b/HeroSystem6e/HeroSystem6e.html
@@ -2970,7 +2970,7 @@ var setSTR = function() {
 			STR: strength,
 			str_roll_show: 9 + bonus + v[ "str_roll_pow" ] + "-",
 			str_roll_formula: formula,
-			hth: getDice( strength, 5, "text" ),
+			hth: getDice( strength, 5, "dice" ),
 			lift: getLift( strength ),
 			str_reduced_end: str_reduced_end,
 			str_end: str_end


### PR DESCRIPTION
The "hth" field was using traditional human notation for half dice, which was not properly parsed when passed to a dice roll.  By switching it to "dice" format instead of "text" format, we get dice annotation that roll20 can parse.

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

The character sheet previously displayed human-friendly damage dice in the "hth" attribute (e.g., 5½d6).  This occasionally made this attribute unusable for Roll20 dice rolls.  By changing the function call that populates the attribute to use "dice" format instead of "text" format, this issue is resolved.
