### PR TITLE
[Warhammer 4e Character Sheet] Cast Lore/Staff fixes

### DIFF
--- a/Warhammer 4e Character Sheet/README.md
+++ b/Warhammer 4e Character Sheet/README.md
@@ -81,6 +81,11 @@ Note conditions are not intended for out of combat situations, GM simply makes t
  
 ///// ============ Change Log ============ /////  
 
+August 8th 2022 v1.6a
+
+- Fixed Enchanted Staff CN mod when casting. Should now add -1 appropriatly for all Lore's.
+- Fixed used with Characteristics Mod add reseting undere certain circumstances.
+
 
 July 11th 2022 v1.6
 

--- a/Warhammer 4e Character Sheet/README.md
+++ b/Warhammer 4e Character Sheet/README.md
@@ -85,6 +85,7 @@ August 8th 2022 v1.6a
 
 - Fixed Enchanted Staff CN mod when casting. Should now add -1 appropriatly for all Lore's.
 - Fixed used with Characteristics Mod add reseting undere certain circumstances.
+- Channeling rolls from the Skill tab will now add Accu Ext SL to spells and rituals of the same Lore.
 
 
 July 11th 2022 v1.6

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -25106,19 +25106,19 @@
 								</div>
 								<select class="sheet-select-no-arrow-center" name="attr_ExtChannellingLore">
 									<option data-i18n="SELECT" selected="selected">Select</option>
-									<option value="(@{ChannellingFire})" data-i18n="FIRE">Fire</option>
-									<option value="(@{ChannellingHeavens})" data-i18n="HEAVENS">Heavens</option>
-									<option value="(@{ChannellingMetal})" data-i18n="METAL">Metal</option>
-                                    <option value="(@{ChannellingBeasts})" data-i18n="BEASTS">Beasts</option>
-									<option value="(@{ChannellingLife})" data-i18n="LIFE">Life</option>
-									<option value="(@{ChannellingLight})" data-i18n="LIGHT">Light</option>
-									<option value="(@{ChannellingDeath})" data-i18n="DEATH">Death</option>
-									<option value="(@{ChannellingShadows})" data-i18n="SHADOWS">Shadows</option>
-									<option value="(@{ChannellingWitch})" data-i18n="WITCH">Witch</option>
-									<option value="(@{ChannellingDark})" data-i18n="DARK">Dark</option>
-									<option value="(@{ChannellingChaos})" data-i18n="CHAOS">Chaos</option>
-									<option value="(@{ChannellingGreatMaw})" data-i18n="GREAT-MAW">Great Maw</option>
-									<option value="(@{ChannellingMisc})" data-i18n="MISC">Misc</option>
+									<option value="(@{ChannellingFire}) [Fire]" data-i18n="FIRE">Fire</option>
+									<option value="(@{ChannellingHeavens}) [Heavens]" data-i18n="HEAVENS">Heavens</option>
+									<option value="(@{ChannellingMetal}) [Metal]" data-i18n="METAL">Metal</option>
+                                    <option value="(@{ChannellingBeasts}) [Beasts]" data-i18n="BEASTS">Beasts</option>
+									<option value="(@{ChannellingLife}) [Life]" data-i18n="LIFE">Life</option>
+									<option value="(@{ChannellingLight}) [Light]" data-i18n="LIGHT">Light</option>
+									<option value="(@{ChannellingDeath}) [Death]" data-i18n="DEATH">Death</option>
+									<option value="(@{ChannellingShadows}) [Shadows]" data-i18n="SHADOWS">Shadows</option>
+									<option value="(@{ChannellingWitch}) [Witch]" data-i18n="WITCH">Witch</option>
+									<option value="(@{ChannellingDark}) [Dark]" data-i18n="DARK">Dark</option>
+									<option value="(@{ChannellingChaos}) [Chaos]" data-i18n="CHAOS">Chaos</option>
+									<option value="(@{ChannellingGreatMaw}) [GreatMaw]" data-i18n="GREAT-MAW">Great Maw</option>
+									<option value="(@{ChannellingMisc}) [Misc]" data-i18n="MISC">Misc</option>
 								</select>
 							</div>
 	<input type="checkbox" name="attr_talentmode" class="sheet-hidden sheet-hider" value="2" />
@@ -25469,19 +25469,19 @@
 								</div>
 								<select class="sheet-select-no-arrow-center" name="attr_ExtChannellingLore">
 									<option data-i18n="SELECT" selected="selected">Select</option>
-									<option value="(@{ChannellingFire})" data-i18n="FIRE">Fire</option>
-									<option value="(@{ChannellingHeavens})" data-i18n="HEAVENS">Heavens</option>
-									<option value="(@{ChannellingMetal})" data-i18n="METAL">Metal</option>
-                                    <option value="(@{ChannellingBeasts})" data-i18n="BEASTS">Beasts</option>
-									<option value="(@{ChannellingLife})" data-i18n="LIFE">Life</option>
-									<option value="(@{ChannellingLight})" data-i18n="LIGHT">Light</option>
-									<option value="(@{ChannellingDeath})" data-i18n="DEATH">Death</option>
-									<option value="(@{ChannellingShadows})" data-i18n="SHADOWS">Shadows</option>
-									<option value="(@{ChannellingWitch})" data-i18n="WITCH">Witch</option>
-									<option value="(@{ChannellingDark})" data-i18n="DARK">Dark</option>
-									<option value="(@{ChannellingChaos})" data-i18n="CHAOS">Chaos</option>
-									<option value="(@{ChannellingGreatMaw})" data-i18n="GREAT-MAW">Great Maw</option>
-									<option value="(@{ChannellingMisc})" data-i18n="MISC">Misc</option>
+									<option value="(@{ChannellingFire}) [Fire]" data-i18n="FIRE">Fire</option>
+									<option value="(@{ChannellingHeavens}) [Heavens]" data-i18n="HEAVENS">Heavens</option>
+									<option value="(@{ChannellingMetal}) [Metal]" data-i18n="METAL">Metal</option>
+                                    <option value="(@{ChannellingBeasts}) [Beasts]" data-i18n="BEASTS">Beasts</option>
+									<option value="(@{ChannellingLife}) [Life]" data-i18n="LIFE">Life</option>
+									<option value="(@{ChannellingLight}) [Light]" data-i18n="LIGHT">Light</option>
+									<option value="(@{ChannellingDeath}) [Death]" data-i18n="DEATH">Death</option>
+									<option value="(@{ChannellingShadows}) [Shadows]" data-i18n="SHADOWS">Shadows</option>
+									<option value="(@{ChannellingWitch}) [Witch]" data-i18n="WITCH">Witch</option>
+									<option value="(@{ChannellingDark}) [Dark]" data-i18n="DARK">Dark</option>
+									<option value="(@{ChannellingChaos}) [Chaos]" data-i18n="CHAOS">Chaos</option>
+									<option value="(@{ChannellingGreatMaw}) [GreatMaw]" data-i18n="GREAT-MAW">Great Maw</option>
+									<option value="(@{ChannellingMisc}) [Misc]" data-i18n="MISC">Misc</option>
 								</select>
 							</div>
 							</div>
@@ -25517,7 +25517,7 @@
 								<div class="sheet-center sheet-small-label sheet-pad-b-sm">
 									<span data-i18n="CASTING-NUMBER">CN</span> <span style="color: red">x4</span>
 								</div>
-		<input type="checkbox" name="attr_Spellmem" class="sheet-hidden sheet-hider" value="1" checked />
+		<input type="checkbox" name="attr_Spellmem" class="sheet-hidden sheet-hider" value="1" />
 								<div class="sheet-center sheet-small-label sheet-pad-b-sm">
 									<span data-i18n="CASTING-NUMBER">CN</span>
 								</div>
@@ -27655,7 +27655,7 @@
 		<div class="sheet-spacer-xl"></div>
 		<!-- FOOTER -->
 		<div class="sheet-row sheet-footer">
-			<div class="sheet-col-1 sheet-small-label sheet-center">Sheet version 1.6 : July 11th 2022 | by Djjus & Pote</div>
+			<div class="sheet-col-1 sheet-small-label sheet-center">Sheet version 1.6a : August 8th 2022 | by Djjus & Pote</div>
 		</div>
 		</div>
 	</div>
@@ -39830,41 +39830,41 @@ on('change:repeating_spellbookarcane:ExtChannellingLore', function(event) {
                 // get the row id that the player clicked. the id is always between the second and third '_'
 				const playerclickedid = event.sourceAttribute.split('_')[2] || '';				
 	
-				getAttrs(["repeating_spellbookarcane_ExtChannellingLore"], function(v) {
-				
-				if (v.repeating_spellbookarcane_ExtChannellingLore == "(@{ChannellingFire})") {lore = 1;}
-				if (v.repeating_spellbookarcane_ExtChannellingLore == "(@{ChannellingHeavens})") {lore = 2;}
-				if (v.repeating_spellbookarcane_ExtChannellingLore == "(@{ChannellingMetal})") {lore = 3;}
-				if (v.repeating_spellbookarcane_ExtChannellingLore == "(@{ChannellingBeasts})") {lore = 4;}
-				if (v.repeating_spellbookarcane_ExtChannellingLore == "(@{ChannellingLife})") {lore = 5;}
-				if (v.repeating_spellbookarcane_ExtChannellingLore == "(@{ChannellingLight})") {lore = 6;}
-				if (v.repeating_spellbookarcane_ExtChannellingLore == "(@{ChannellingDeath})") {lore = 7;}
-				if (v.repeating_spellbookarcane_ExtChannellingLore == "(@{ChannellingShadows})") {lore = 8;}
-				if (v.repeating_spellbookarcane_ExtChannellingLore == "(@{ChannellingWitch})") {lore = 9;}
-				if (v.repeating_spellbookarcane_ExtChannellingLore == "(@{ChannellingDark})") {lore = 10;}
-				if (v.repeating_spellbookarcane_ExtChannellingLore == "(@{ChannellingChaos})") {lore = 11;}
-				if (v.repeating_spellbookarcane_ExtChannellingLore == "(@{ChannellingGreatMaw})") {lore = 12;}
-				if (v.repeating_spellbookarcane_ExtChannellingLore == "(@{ChannellingMisc})") {lore = 13;}
-				
-	console.log("spelllore change");
-	console.log(lore);
-	
-			   	
 				getSectionIDs("repeating_spellbookarcane", function (ids) {
                 if (playerclickedid == ids.toLowerCase) return;
                     // create an object to hold all the attributes we are bout to change
                     const output = {};
                     // loop through the row ids
                     ids.forEach(id => {
+					
+					getAttrs([`repeating_spellbookarcane_${id}_ExtChannellingLore`], function(t) {
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingFire}) [Fire]") {lore = 1;} else  {checklore = 0;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingHeavens}) [Heavens]") {lore = 2;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingMetal}) [Metal]") {lore = 3;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingBeasts}) [Beasts]") {lore = 4;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingLife}) [Life]") {lore = 5;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingLight}) [Light]") {lore = 6;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingDeath}) [Death]") {lore = 7;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingShadows}) [Shadows]") {lore = 8;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingWitch}) [Witch]") {lore = 9;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingDark}) [Dark]") {lore = 10;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingChaos}) [Chaos]") {lore = 11;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingGreatMaw}) [GreatMaw]") {lore = 12;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingMisc}) [Misc]") {lore = 13;}
+				
+	console.log("spelllore change");
+	console.log(lore);
+						
+					
                         // check if the id is the one the player clicked; if not, set to 0, if it is, set to 1.
                         let playerId = playerclickedid.toLowerCase();
 						if(playerId == id.toLowerCase()) {
 						output[`repeating_spellbookarcane_${id}_MagicLore`]  = lore;
 						output[`repeating_spellbookarcane_${id}_spellchannelsl`]  = 0;
+						setAttrs(output, {silent: true});
 						}
                     });
-                    setAttrs(output, {silent: true});
-	});
+			});
 	});
 });
 
@@ -39929,19 +39929,19 @@ on('change:repeating_spellbookrituals:ExtChannellingLore', function(event) {
 	
 				getAttrs(["repeating_spellbookrituals_ExtChannellingLore"], function(v) {
 				
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingFire})") {lore = 1;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingHeavens})") {lore = 2;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingMetal})") {lore = 3;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingBeasts})") {lore = 4;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingLife})") {lore = 5;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingLight})") {lore = 6;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingDeath})") {lore = 7;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingShadows})") {lore = 8;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingWitch})") {lore = 9;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingDark})") {lore = 10;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingChaos})") {lore = 11;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingGreatMaw})") {lore = 12;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingMisc})") {lore = 13;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingFire}) [Fire]") {lore = 1;} else  {lore = 0;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingHeavens}) [Heavens]") {lore = 2;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingMetal}) [Metal]") {lore = 3;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingBeasts}) [Beasts]") {lore = 4;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingLife}) [Life]") {lore = 5;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingLight}) [Light]") {lore = 6;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingDeath}) [Death]") {lore = 7;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingShadows}) [Shadows]") {lore = 8;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingWitch}) [Witch]") {lore = 9;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingDark}) [Dark]") {lore = 10;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingChaos}) [Chaos]") {lore = 11;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingGreatMaw}) [GreatMaw]") {lore = 12;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingMisc}) [Misc]") {lore = 13;}
 				
 	console.log("spelllore change");
 	console.log(lore);
@@ -40106,7 +40106,7 @@ on('sheet:opened change:repeating_inventory', function(event) {
 });
 
 
-on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexesLvl change:Talent_SavvyLvl change:Talent_SuaveLvl change:Talent_WarriorBornLvl change:Talent_MarksmanLvl change:Talent_SharpLvl change:Talent_NimbleFingersLvl change:Talent_VeryResilientLvl change:Talent_VeryStrongLvl', function(event){
+on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexesLvl change:Talent_SavvyLvl change:Talent_SuaveLvl change:Talent_WarriorBornLvl change:Talent_MarksmanLvl change:Talent_SharpLvl change:Talent_NimbleFingersLvl change:Talent_VeryResilientLvl change:Talent_VeryStrongLvl change:WillPowerTalents change:AgilityTalents change:BallisticSkillTalents change:IntelligenceTalents change:InitiativeTalents change:InitiativeTalents change:FellowshipTalents change:WeaponSkillTalentsD change:DexterityTalents change:ToughnessTalents change:StrengthTalents', function(event){
 
         if (event.sourceType === 'sheetworker') return;
                console.log("Test char talents");	
@@ -40122,15 +40122,15 @@ on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexe
 		getAttrs([`${stat}Start`, `${stat}Talents`, `${stat}TalentsD`, `${stat}Adv`, `${stat}Mod`, `${stat}BonusMod`, 'Agility', 'encpenalty', 'talentmode'], function (v) {
 		const charStart   = +v[`${stat}Start`] || 0;
 		
-		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`] || 0;}
+		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`];}
 		
-		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] || 0 * v.talentmode;} else {charTalentsD = 0;}
+		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] * v.talentmode;} else {charTalentsD = 0;}
 		
 		const charAdv     = +v[`${stat}Adv`] || 0;	
 		const charMod     = +v[`${stat}Mod`] || 0;	
 		const pen = +v.encpenalty || 0;	
 		
-		var charScore   = charStart + charTalents + charTalentsD + charAdv;	
+		var charScore   = charStart + charTalents + charTalentsD + charAdv + charMod;	
 		
 		const bonusStart  = Math.floor(charScore / 10);
 		setAttrs({
@@ -40156,15 +40156,15 @@ on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexe
 		getAttrs([`${stat}Start`, `${stat}Talents`, `${stat}TalentsD`, `${stat}Adv`, `${stat}Mod`, `${stat}BonusMod`, 'Agility', 'encpenalty', 'talentmode'], function (v) {
 		const charStart   = +v[`${stat}Start`] || 0;
 		
-		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`] || 0;}
+		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`];}
 		
-		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] || 0 * v.talentmode;} else {charTalentsD = 0;}
+		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] * v.talentmode;} else {charTalentsD = 0;}
 		
 		const charAdv     = +v[`${stat}Adv`] || 0;	
 		const charMod     = +v[`${stat}Mod`] || 0;	
 		const pen = +v.encpenalty || 0;	
 		
-		var charScore   = charStart + charTalents + charTalentsD + charAdv;	
+		var charScore   = charStart + charTalents + charTalentsD + charAdv + charMod;	
 		
 		
 		const bonusStart  = Math.floor(charScore / 10);
@@ -40191,16 +40191,16 @@ on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexe
 		getAttrs([`${stat}Start`, `${stat}Talents`, `${stat}TalentsD`, `${stat}Adv`, `${stat}Mod`, `${stat}BonusMod`, 'Agility', 'encpenalty', 'talentmode'], function (v) {
 		const charStart   = +v[`${stat}Start`] || 0;
 		
-		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`] || 0;}
+		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`];}
 		
-		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] || 0 * v.talentmode;} else {charTalentsD = 0;}
+		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] * v.talentmode;} else {charTalentsD = 0;}
 		
 		const charAdv     = +v[`${stat}Adv`] || 0;	
 		const charMod     = +v[`${stat}Mod`] || 0;	
 		const pen = +v.encpenalty || 0;	
 		
 		if ( `${stat}` == 'Agility' ) {
-		var charScorePre   = charStart + charTalents + charAdv;
+		var charScorePre   = charStart + charTalents + charTalentsD + charAdv + charMod;
 		var penmod = charScorePre - pen*10;
         if (penmod < 10) { var charScore = 10; }
         if (penmod > 10) { var charScore = penmod }
@@ -40229,16 +40229,16 @@ on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexe
 		getAttrs([`${stat}Start`, `${stat}Talents`, `${stat}TalentsD`, `${stat}Adv`, `${stat}Mod`, `${stat}BonusMod`, 'Agility', 'encpenalty', 'talentmode'], function (v) {
 		const charStart   = +v[`${stat}Start`] || 0;
 		
-		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`] || 0;}
+		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`];}
 		
-		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] || 0 * v.talentmode;} else {charTalentsD = 0;}
+		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] * v.talentmode;} else {charTalentsD = 0;}
 		
 		const charAdv     = +v[`${stat}Adv`] || 0;	
 		const charMod     = +v[`${stat}Mod`] || 0;	
 		const pen = +v.encpenalty || 0;	
 		
 		if ( `${stat}` == 'Agility' ) {
-		var charScorePre   = charStart + charTalents + charAdv;
+		var charScorePre   = charStart + charTalents + charTalentsD + charAdv + charMod;
 		var penmod = charScorePre - pen*10;
         if (penmod < 10) { var charScore = 10; }
         if (penmod > 10) { var charScore = penmod }
@@ -40269,15 +40269,15 @@ on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexe
 		getAttrs([`${stat}Start`, `${stat}Talents`, `${stat}TalentsD`, `${stat}Adv`, `${stat}Mod`, `${stat}BonusMod`, 'Agility', 'encpenalty', 'talentmode'], function (v) {
 		const charStart   = +v[`${stat}Start`] || 0;
 		
-		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`] || 0;}
+		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`];}
 		
-		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] || 0 * v.talentmode;} else {charTalentsD = 0;}
+		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] * v.talentmode;} else {charTalentsD = 0;}
 		
 		const charAdv     = +v[`${stat}Adv`] || 0;	
 		const charMod     = +v[`${stat}Mod`] || 0;	
 		const pen = +v.encpenalty || 0;	
 		
-		var charScore   = charStart + charTalents + charTalentsD + charAdv;
+		var charScore   = charStart + charTalents + charTalentsD + charAdv + charMod;
 		
 		const bonusStart  = Math.floor(charScore / 10);
 		setAttrs({
@@ -40301,15 +40301,15 @@ on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexe
 		getAttrs([`${stat}Start`, `${stat}Talents`, `${stat}TalentsD`, `${stat}Adv`, `${stat}Mod`, `${stat}BonusMod`, 'Agility', 'encpenalty', 'talentmode'], function (v) {
 		const charStart   = +v[`${stat}Start`] || 0;
 		
-		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`] || 0;}
+		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`];}
 		
-		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] || 0 * v.talentmode;} else {charTalentsD = 0;}
+		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] * v.talentmode;} else {charTalentsD = 0;}
 		
 		const charAdv     = +v[`${stat}Adv`] || 0;	
 		const charMod     = +v[`${stat}Mod`] || 0;	
 		const pen = +v.encpenalty || 0;	
 		
-		var charScore   = charStart + charTalents + charTalentsD + charAdv;
+		var charScore   = charStart + charTalents + charTalentsD + charAdv + charMod;
 		
 		const bonusStart  = Math.floor(charScore / 10);
 		setAttrs({
@@ -40335,22 +40335,22 @@ on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexe
 		getAttrs([`${stat}Start`, `${stat}Talents`, `${stat}TalentsD`, `${stat}Adv`, `${stat}Mod`, `${stat}BonusMod`, 'Agility', 'encpenalty', 'talentmode'], function (v) {
 		const charStart   = +v[`${stat}Start`] || 0;
 		
-		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`] || 0;}
+		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`];}
 		
-		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] || 0 * v.talentmode;} else {charTalentsD = 0;}
+		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] * v.talentmode;} else {charTalentsD = 0;}
 		
 		const charAdv     = +v[`${stat}Adv`] || 0;	
 		const charMod     = +v[`${stat}Mod`] || 0;	
 		const pen = +v.encpenalty || 0;	
 		
-		var charScore   = charStart + charTalents + charTalentsD + charAdv;	
+		var charScore   = charStart + charTalents + charTalentsD + charAdv + charMod;	
 		
 		const bonusStart  = Math.floor(charScore / 10);
 		setAttrs({
 		[stat]: charScore,
 		[`${stat}BonusStart`]: bonusStart
 		});
-		
+
 		const bonusMod = +v[`${stat}BonusMod`] || 0;
 		const bonus    = bonusStart + bonusMod;
 		setAttrs({
@@ -40367,15 +40367,15 @@ on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexe
 		getAttrs([`${stat}Start`, `${stat}Talents`, `${stat}TalentsD`, `${stat}Adv`, `${stat}Mod`, `${stat}BonusMod`, 'Agility', 'encpenalty', 'talentmode'], function (v) {
 		const charStart   = +v[`${stat}Start`] || 0;
 		
-		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`] || 0;}
+		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`];}
 		
-		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] || 0 * v.talentmode;} else {charTalentsD = 0;}
+		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] * v.talentmode;} else {charTalentsD = 0;}
 		
 		const charAdv     = +v[`${stat}Adv`] || 0;	
 		const charMod     = +v[`${stat}Mod`] || 0;	
 		const pen = +v.encpenalty || 0;	
 		
-		var charScore   = charStart + charTalents + charTalentsD + charAdv;	
+		var charScore   = charStart + charTalents + charTalentsD + charAdv + charMod;	
 		
 		const bonusStart  = Math.floor(charScore / 10);
 		setAttrs({
@@ -40401,15 +40401,15 @@ on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexe
 		getAttrs([`${stat}Start`, `${stat}Talents`, `${stat}TalentsD`, `${stat}Adv`, `${stat}Mod`, `${stat}BonusMod`, 'Agility', 'encpenalty', 'talentmode'], function (v) {
 		const charStart   = +v[`${stat}Start`] || 0;
 		
-		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`] || 0;}
+		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`];}
 		
-		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] || 0 * v.talentmode;} else {charTalentsD = 0;}
+		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] * v.talentmode;} else {charTalentsD = 0;}
 		
 		const charAdv     = +v[`${stat}Adv`] || 0;	
 		const charMod     = +v[`${stat}Mod`] || 0;	
 		const pen = +v.encpenalty || 0;	
 		
-		var charScore   = charStart + charTalents + charTalentsD + charAdv;	
+		var charScore   = charStart + charTalents + charTalentsD + charAdv + charMod;	
 		
 		const bonusStart  = Math.floor(charScore / 10);
 		setAttrs({
@@ -40433,15 +40433,15 @@ on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexe
 		getAttrs([`${stat}Start`, `${stat}Talents`, `${stat}TalentsD`, `${stat}Adv`, `${stat}Mod`, `${stat}BonusMod`, 'Agility', 'encpenalty', 'talentmode'], function (v) {
 		const charStart   = +v[`${stat}Start`] || 0;
 		
-		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`] || 0;}
+		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`];}
 		
-		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] || 0 * v.talentmode;} else {charTalentsD = 0;}
+		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] * v.talentmode;} else {charTalentsD = 0;}
 		
 		const charAdv     = +v[`${stat}Adv`] || 0;	
 		const charMod     = +v[`${stat}Mod`] || 0;	
 		const pen = +v.encpenalty || 0;	
 		
-		var charScore   = charStart + charTalents + charTalentsD + charAdv;	
+		var charScore   = charStart + charTalents + charTalentsD + charAdv + charMod;	
 		
 		const bonusStart  = Math.floor(charScore / 10);
 		setAttrs({
@@ -40467,15 +40467,15 @@ on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexe
 		getAttrs([`${stat}Start`, `${stat}Talents`, `${stat}TalentsD`, `${stat}Adv`, `${stat}Mod`, `${stat}BonusMod`, 'Agility', 'encpenalty', 'talentmode'], function (v) {
 		const charStart   = +v[`${stat}Start`] || 0;
 		
-		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`] || 0;}
+		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`];}
 		
-		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] || 0 * v.talentmode;} else {charTalentsD = 0;}
+		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] * v.talentmode;} else {charTalentsD = 0;}
 		
 		const charAdv     = +v[`${stat}Adv`] || 0;	
 		const charMod     = +v[`${stat}Mod`] || 0;	
 		const pen = +v.encpenalty || 0;	
 		
-		var charScore   = charStart + charTalents + charTalentsD + charAdv;	
+		var charScore   = charStart + charTalents + charTalentsD + charAdv + charMod;	
 		
 		const bonusStart  = Math.floor(charScore / 10);
 		setAttrs({
@@ -40499,15 +40499,15 @@ on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexe
 		getAttrs([`${stat}Start`, `${stat}Talents`, `${stat}TalentsD`, `${stat}Adv`, `${stat}Mod`, `${stat}BonusMod`, 'Agility', 'encpenalty', 'talentmode'], function (v) {
 		const charStart   = +v[`${stat}Start`] || 0;
 		
-		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`] || 0;}
+		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`];}
 		
-		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] || 0 * v.talentmode;} else {charTalentsD = 0;}
+		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] * v.talentmode;} else {charTalentsD = 0;}
 		
 		const charAdv     = +v[`${stat}Adv`] || 0;	
 		const charMod     = +v[`${stat}Mod`] || 0;	
 		const pen = +v.encpenalty || 0;	
 		
-		var charScore   = charStart + charTalents + charTalentsD + charAdv;	
+		var charScore   = charStart + charTalents + charTalentsD + charAdv + charMod;	
 		
 		const bonusStart  = Math.floor(charScore / 10);
 		setAttrs({
@@ -40533,15 +40533,15 @@ on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexe
 		getAttrs([`${stat}Start`, `${stat}Talents`, `${stat}TalentsD`, `${stat}Adv`, `${stat}Mod`, `${stat}BonusMod`, 'Agility', 'encpenalty', 'talentmode'], function (v) {
 		const charStart   = +v[`${stat}Start`] || 0;
 		
-		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`] || 0;}
+		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`];}
 		
-		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] || 0 * v.talentmode;} else {charTalentsD = 0;}
+		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] * v.talentmode;} else {charTalentsD = 0;}
 		
 		const charAdv     = +v[`${stat}Adv`] || 0;	
 		const charMod     = +v[`${stat}Mod`] || 0;	
 		const pen = +v.encpenalty || 0;	
 		
-		var charScore   = charStart + charTalents + charTalentsD + charAdv;	
+		var charScore   = charStart + charTalents + charTalentsD + charAdv + charMod;	
 		
 		const bonusStart  = Math.floor(charScore / 10);
 		setAttrs({
@@ -40565,15 +40565,15 @@ on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexe
 		getAttrs([`${stat}Start`, `${stat}Talents`, `${stat}TalentsD`, `${stat}Adv`, `${stat}Mod`, `${stat}BonusMod`, 'Agility', 'encpenalty', 'talentmode'], function (v) {
 		const charStart   = +v[`${stat}Start`] || 0;
 		
-		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`] || 0;}
+		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`];}
 		
-		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] || 0 * v.talentmode;} else {charTalentsD = 0;}
+		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] * v.talentmode;} else {charTalentsD = 0;}
 		
 		const charAdv     = +v[`${stat}Adv`] || 0;	
 		const charMod     = +v[`${stat}Mod`] || 0;	
 		const pen = +v.encpenalty || 0;	
 		
-		var charScore   = charStart + charTalents + charTalentsD + charAdv;	
+		var charScore   = charStart + charTalents + charTalentsD + charAdv + charMod;	
 		
 		const bonusStart  = Math.floor(charScore / 10);
 		setAttrs({
@@ -40599,15 +40599,15 @@ on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexe
 		getAttrs([`${stat}Start`, `${stat}Talents`, `${stat}TalentsD`, `${stat}Adv`, `${stat}Mod`, `${stat}BonusMod`, 'Agility', 'encpenalty', 'talentmode'], function (v) {
 		const charStart   = +v[`${stat}Start`] || 0;
 		
-		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`] || 0;}
+		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`];}
 		
-		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] || 0 * v.talentmode;} else {charTalentsD = 0;}
+		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] * v.talentmode;} else {charTalentsD = 0;}
 		
 		const charAdv     = +v[`${stat}Adv`] || 0;	
 		const charMod     = +v[`${stat}Mod`] || 0;	
 		const pen = +v.encpenalty || 0;	
 		
-		var charScore   = charStart + charTalents + charTalentsD + charAdv;	
+		var charScore   = charStart + charTalents + charTalentsD + charAdv + charMod;	
 		
 		const bonusStart  = Math.floor(charScore / 10);
 		setAttrs({
@@ -40631,9 +40631,9 @@ on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexe
 		getAttrs([`${stat}Start`, `${stat}Talents`, `${stat}TalentsD`, `${stat}Adv`, `${stat}Mod`, `${stat}BonusMod`, 'Agility', 'encpenalty', 'talentmode'], function (v) {
 		const charStart   = +v[`${stat}Start`] || 0;
 		
-		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`] || 0;}
+		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`];}
 		
-		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] || 0 * v.talentmode;} else {charTalentsD = 0;}
+		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] * v.talentmode;} else {charTalentsD = 0;}
 		
 		const charAdv     = +v[`${stat}Adv`] || 0;	
 		const charMod     = +v[`${stat}Mod`] || 0;	
@@ -40665,15 +40665,15 @@ on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexe
 		getAttrs([`${stat}Start`, `${stat}Talents`, `${stat}TalentsD`, `${stat}Adv`, `${stat}Mod`, `${stat}BonusMod`, 'Agility', 'encpenalty', 'talentmode'], function (v) {
 		const charStart   = +v[`${stat}Start`] || 0;
 		
-		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`] || 0;}
+		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`];}
 		
-		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] || 0 * v.talentmode;} else {charTalentsD = 0;}
+		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] * v.talentmode;} else {charTalentsD = 0;}
 		
 		const charAdv     = +v[`${stat}Adv`] || 0;	
 		const charMod     = +v[`${stat}Mod`] || 0;	
 		const pen = +v.encpenalty || 0;	
 		
-		var charScore   = charStart + charTalents + charTalentsD + charAdv;	
+		var charScore   = charStart + charTalents + charTalentsD + charAdv + charMod;	
 		
 		const bonusStart  = Math.floor(charScore / 10);
 		setAttrs({
@@ -40697,15 +40697,15 @@ on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexe
 		getAttrs([`${stat}Start`, `${stat}Talents`, `${stat}TalentsD`, `${stat}Adv`, `${stat}Mod`, `${stat}BonusMod`, 'Agility', 'encpenalty', 'talentmode'], function (v) {
 		const charStart   = +v[`${stat}Start`] || 0;
 		
-		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`] || 0;}
+		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`];}
 		
-		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] || 0 * v.talentmode;} else {charTalentsD = 0;}
+		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] * v.talentmode;} else {charTalentsD = 0;}
 		
 		const charAdv     = +v[`${stat}Adv`] || 0;	
 		const charMod     = +v[`${stat}Mod`] || 0;	
 		const pen = +v.encpenalty || 0;	
 		
-		var charScore   = charStart + charTalents + charTalentsD + charAdv;	
+		var charScore   = charStart + charTalents + charTalentsD + charAdv + charMod;	
 		
 		const bonusStart  = Math.floor(charScore / 10);
 		setAttrs({
@@ -40731,15 +40731,15 @@ on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexe
 		getAttrs([`${stat}Start`, `${stat}Talents`, `${stat}TalentsD`, `${stat}Adv`, `${stat}Mod`, `${stat}BonusMod`, 'Agility', 'encpenalty', 'talentmode'], function (v) {
 		const charStart   = +v[`${stat}Start`] || 0;
 		
-		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`] || 0;}
+		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`];}
 		
-		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] || 0 * v.talentmode;} else {charTalentsD = 0;}
+		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] * v.talentmode;} else {charTalentsD = 0;}
 		
 		const charAdv     = +v[`${stat}Adv`] || 0;	
 		const charMod     = +v[`${stat}Mod`] || 0;	
 		const pen = +v.encpenalty || 0;	
 		
-		var charScore   = charStart + charTalents + charTalentsD + charAdv;	
+		var charScore   = charStart + charTalents + charTalentsD + charAdv + charMod;	
 		
 		const bonusStart  = Math.floor(charScore / 10);
 		setAttrs({
@@ -40763,15 +40763,15 @@ on('change:talentmode change:Talent_CoolheadedLvl change:Talent_LightningReflexe
 		getAttrs([`${stat}Start`, `${stat}Talents`, `${stat}TalentsD`, `${stat}Adv`, `${stat}Mod`, `${stat}BonusMod`, 'Agility', 'encpenalty', 'talentmode'], function (v) {
 		const charStart   = +v[`${stat}Start`] || 0;
 		
-		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`] || 0;}
+		if (v.talentmode== 1) {charTalents = 0;} else {charTalents = +v[`${stat}Talents`];}
 		
-		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] || 0 * v.talentmode;} else {charTalentsD = 0;}
+		if (v.talentmode== 1) {charTalentsD = +v[`${stat}TalentsD`] * v.talentmode;} else {charTalentsD = 0;}
 		
 		const charAdv     = +v[`${stat}Adv`] || 0;	
 		const charMod     = +v[`${stat}Mod`] || 0;	
 		const pen = +v.encpenalty || 0;	
 		
-		var charScore   = charStart + charTalents + charTalentsD + charAdv;	
+		var charScore   = charStart + charTalents + charTalentsD + charAdv + charMod;	
 		
 		const bonusStart  = Math.floor(charScore / 10);
 		setAttrs({
@@ -42200,9 +42200,6 @@ on('clicked:repeating_spellbookpetty:spellcast clicked:repeating_spellbookpetty:
     });
 
 on('clicked:repeating_spellbookarcane:spellcast clicked:repeating_spellbookarcane:spellcastdmg clicked:repeating_spellbookarcane:spellcastreroll clicked:repeating_spellbookarcane:spellcastdmgreroll', (eventInfo) => {
-	getAttrs(["initiative_houserule", "OverChannel", "LastRollAccuExtSL", "Talent_SuffusedWithAqshyLvl", "Talent_SuffusedWithAzyrLvl", "Talent_SuffusedWithChamonLvl", "Talent_SuffusedWithGhurLvl", "Talent_SuffusedWithGhyranLvl", "Talent_SuffusedWithHyshLvl", "Talent_SuffusedWithShiyshLvl", "Talent_SuffusedWithUgluLvl"], function(v) {
-	
-   let roll = '{{sl=[[0 [Roll SL]]]}} {{slbonus=[[@{Talent_InstinctiveDictionLvl}+@{Talent_PerfectPitchLvl} [SL TOTAL]]]}} {{slbonusatk=[[@{slbonusCast}]]}} {{sladd=[[0]]}} {{modvalue=[[?{@{translation_modifier}|@{prefix2-_SpellMod}}]]}} {{accuchanexlsl=[[Accu-]]}} {{title=@{prefix2-_spellname}}} {{character_name=@{character_name}}} {{advantage=[[@{Advantage}*10*@{Advantage_casting}]]}} {{unconscious=[[@{UnconsciousMod}]]}} {{cond=[[@{condgen_see}-@{DrunkMod}]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{spelltype=^{ARCANE-SPELL}}} {{spellrange=Range: @{prefix2-_spellrange}}} {{spelltarget=Targets: @{prefix2-_spelltarget}}} {{spellduration=Duration: @{prefix2-_spellduration}}} {{target=[[ [[(@{condgen_see}*-1)]] [COND] + [[{@{LangMagick}}]] [SKILL] + ?{@{translation_modifier}|0} [MOD] + [[@{Advantage}*10*@{Advantage_casting}]] [ADV] ]]}} {{spelldescription=@{prefix2-_spelldesc}}} {{test=[[@{roll_rule}]]}} {{SLmod=[[?{SL Modifier|0}]]}} {{spelltest=[[1d10]]}} {{arcanetest=true}} {{rolltype=[[6]]}} {{spellcastingnumber=[[@{prefix2-_cn-sl-mod}+(@{prefix2-_spellcastingnumber}*((@{prefix2-_Spellmem}-1)*-1))]]}} {{mod1type=[[@{prefix2-_ArcaneSpell_modtype1}]]}} {{mod1=@{prefix2-_ArcaneSpell_mod1}}} {{mod2type=[[@{prefix2-_ArcaneSpell_modtype2}]]}} {{mod2=@{prefix2-_ArcaneSpell_mod2}}} {{mod3type=[[@{prefix2-_ArcaneSpell_modtype3}]]}} {{mod3=@{prefix2-_ArcaneSpell_mod3}}} {{NPC=[[0]]}} {{RTminor=@{RT-minor}}} {{RTmajor=@{RT-major}}} {{RTgrim=@{RT-grim}}} {{sptal2=[[@{Talent_InstinctiveDictionLvl}]]}} {{sptal3=[[@{Talent_PerfectPitchLvl}]]}} {{sptal23=[[@{Talent_InstinctiveandPitch}]]}} {{spellmem=[[@{prefix2-_Spellmem}]]}} {{lore=[[@{prefix2-_MagicLore}]]}} {{usedenchstaff=[[@{prefix2-_Used_Enchanted_Staff_show}]]}} {{cnsl=[[?{Accumulated Extended Channelling SL (Start at 0)|@{prefix2-_spellchannelsl}}-(@{prefix2-_spellcastingnumber}+(@{prefix2-_spellcastingnumber}*((@{prefix2-_Spellmem}-1)*-1)))]]}} {{testoutcome=[[0]]}}';
    var trigger = eventInfo.triggerName.slice(8);
    var skillpre = trigger.split('_');
    var skill = skillpre[3];
@@ -42219,10 +42216,39 @@ on('clicked:repeating_spellbookarcane:spellcast clicked:repeating_spellbookarcan
    var accumod = '@{LastRollAccuExtSL}';
    var prefix = eventInfo.triggerName.slice(8, -19);}
    
+   
+	getAttrs(["initiative_houserule", "OverChannel", "LastRollAccuExtSL", "Talent_SuffusedWithAqshyLvl", "Talent_SuffusedWithAzyrLvl", "Talent_SuffusedWithChamonLvl", "Talent_SuffusedWithGhurLvl", "Talent_SuffusedWithGhyranLvl", "Talent_SuffusedWithHyshLvl", "Talent_SuffusedWithShiyshLvl", "Talent_SuffusedWithUgluLvl", "Used_Enchanted_Staff", `@{prefix}_MagicLore`], function(v) {
+
+				cnlore = 0;
+				const playerclickedid = eventInfo.sourceAttribute.split('_')[2] || '';				
+
+				getSectionIDs("repeating_spellbookarcane", function (ids) {
+                if (playerclickedid == ids.toLowerCase) return;
+                    // create an object to hold all the attributes we are bout to change
+                    const output = {};
+                    // loop through the row ids
+                    ids.forEach(id => {
+					
+						let playerId = playerclickedid.toLowerCase();
+						if(playerId == id.toLowerCase()) {
+					getAttrs([`repeating_spellbookarcane_${id}_MagicLore`], function(t) {
+
+							etest = v.Used_Enchanted_Staff*1;
+							e2test = t[`repeating_spellbookarcane_${id}_MagicLore`];
+		
+							if (etest === e2test) {cnlore += 1;}
+							if (etest === 14) {cnlore += 1;}
+					
+	
+   let roll = '{{sl=[[0 [Roll SL]]]}} {{slbonus=[[@{Talent_InstinctiveDictionLvl}+@{Talent_PerfectPitchLvl} [SL TOTAL]]]}} {{slbonusatk=[[@{slbonusCast}]]}} {{sladd=[[0]]}} {{modvalue=[[?{@{translation_modifier}|@{prefix2-_SpellMod}}]]}} {{accuchanexlsl=[[Accu-]]}} {{title=@{prefix2-_spellname}}} {{character_name=@{character_name}}} {{advantage=[[@{Advantage}*10*@{Advantage_casting}]]}} {{unconscious=[[@{UnconsciousMod}]]}} {{cond=[[@{condgen_see}-@{DrunkMod}]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{spelltype=^{ARCANE-SPELL}}} {{spellrange=Range: @{prefix2-_spellrange}}} {{spelltarget=Targets: @{prefix2-_spelltarget}}} {{spellduration=Duration: @{prefix2-_spellduration}}} {{target=[[ [[(@{condgen_see}*-1)]] [COND] + [[{@{LangMagick}}]] [SKILL] + ?{@{translation_modifier}|0} [MOD] + [[@{Advantage}*10*@{Advantage_casting}]] [ADV] ]]}} {{spelldescription=@{prefix2-_spelldesc}}} {{test=[[@{roll_rule}]]}} {{SLmod=[[?{SL Modifier|0}]]}} {{spelltest=[[1d10]]}} {{arcanetest=true}} {{rolltype=[[6]]}} {{spellcastingnumber=[[@{prefix2-_spellcastingnumber}-[cnlore]+(@{prefix2-_spellcastingnumber}*((@{prefix2-_Spellmem}-1)*-1))]]}} {{mod1type=[[@{prefix2-_ArcaneSpell_modtype1}]]}} {{mod1=@{prefix2-_ArcaneSpell_mod1}}} {{mod2type=[[@{prefix2-_ArcaneSpell_modtype2}]]}} {{mod2=@{prefix2-_ArcaneSpell_mod2}}} {{mod3type=[[@{prefix2-_ArcaneSpell_modtype3}]]}} {{mod3=@{prefix2-_ArcaneSpell_mod3}}} {{NPC=[[0]]}} {{RTminor=@{RT-minor}}} {{RTmajor=@{RT-major}}} {{RTgrim=@{RT-grim}}} {{sptal2=[[@{Talent_InstinctiveDictionLvl}]]}} {{sptal3=[[@{Talent_PerfectPitchLvl}]]}} {{sptal23=[[@{Talent_InstinctiveandPitch}]]}} {{spellmem=[[@{prefix2-_Spellmem}]]}} {{lore=[[@{prefix2-_MagicLore}]]}} {{usedenchstaff=[[@{prefix2-_Used_Enchanted_Staff_show}]]}} {{cnsl=[[?{Accumulated Extended Channelling SL (Start at 0)|@{prefix2-_spellchannelsl}}-(@{prefix2-_spellcastingnumber}+(@{prefix2-_spellcastingnumber}*((@{prefix2-_Spellmem}-1)*-1)))]]}} {{testoutcome=[[0]]}}';
+   
    let rollBegins = '@{Whisper} &{template:whfrp2e}';
    
+               console.log(" TEST ");
+               console.log(cnlore);
+   
    let rollDmg = rollDmgPart.replaceAll('prefix2-', `${prefix}`);
-   let rollPart = roll.replaceAll('Accu-', accumod).replaceAll('prefix2-', `${prefix}`);
+   let rollPart = roll.replaceAll('Accu-', accumod).replaceAll('prefix2-', `${prefix}`).replaceAll('[cnlore]', cnlore);
    
                console.log(rollPart);	
 				
@@ -42328,6 +42354,10 @@ on('clicked:repeating_spellbookarcane:spellcast clicked:repeating_spellbookarcan
 					
                 });
         });
+                    });
+						}
+					});
+					});
 	});
 		
     });
@@ -42500,9 +42530,7 @@ on('clicked:repeating_spellbookarcane:channelreset', (eventInfo) => {
 	
 	
 on('clicked:repeating_spellbookrituals:spellcast  clicked:repeating_spellbookrituals:spellcastdmg clicked:repeating_spellbookrituals:spellcastreroll  clicked:repeating_spellbookrituals:spellcastdmgreroll', (eventInfo) => {
-	getAttrs(["initiative_houserule", "OverChannel", "LastRollAccuExtSL"], function(v) {
-	
-   let roll = '{{sl=[[0 [Roll SL]]]}} {{slbonus=[[@{Talent_InstinctiveDictionLvl}+@{Talent_PerfectPitchLvl} [SL TOTAL]]]}} {{slbonusatk=[[@{slbonusCast}]]}} {{sladd=[[0]]}} {{modvalue=[[?{@{translation_modifier}|@{prefix2-_SpellMod}}]]}} {{accuchanexlsl=[[Accu-]]}} {{title=@{prefix2-_spellname}}} {{character_name=@{character_name}}} {{advantage=[[@{Advantage}*10*@{Advantage_casting}]]}} {{unconscious=[[@{UnconsciousMod}]]}} {{cond=[[@{condgen_see}-@{DrunkMod}]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{spelltype=^{RITUALS}}} {{target=[[ [[(@{condgen_see}*-1)]] [COND] + [[{@{LangMagick}}]] [SKILL] + ?{@{translation_modifier}|0} [MOD] + [[@{Advantage}*10*@{Advantage_casting}]] [ADV] ]]}} {{consequence=@{prefix2-_ritualcons}}} {{spelldescription=@{prefix2-_spelldesc}}} {{test=[[@{roll_rule}]]}} {{SLmod=[[?{SL Modifier|0}]]}} {{spelltest=[[1d10]]}} {{arcanetest=true}} {{rolltype=[[6]]}} {{spellcastingnumber=[[@{prefix2-_cn-sl-mod}+(3*(@{prefix2-_spellcastingnumber}*((@{prefix2-_Spellmem}-1)*-1)))]]}} {{mod1type=[[@{prefix2-_ArcaneSpell_modtype1}]]}} {{mod1=@{prefix2-_ArcaneSpell_mod1}}} {{mod2type=[[@{prefix2-_ArcaneSpell_modtype2}]]}} {{mod2=@{prefix2-_ArcaneSpell_mod2}}} {{mod3type=[[@{prefix2-_ArcaneSpell_modtype3}]]}} {{mod3=@{prefix2-_ArcaneSpell_mod3}}} {{NPC=[[0]]}} {{RTminor=@{RT-minor}}} {{RTmajor=@{RT-major}}} {{RTgrim=@{RT-grim}}} {{sptal2=[[@{Talent_InstinctiveDictionLvl}]]}} {{sptal3=[[@{Talent_PerfectPitchLvl}]]}} {{sptal23=[[@{Talent_InstinctiveandPitch}]]}} {{spellmem=[[@{prefix2-_Spellmem}]]}} {{lore=[[@{prefix2-_MagicLore}]]}} {{cnsl=[[?{Accumulated Extended Channelling SL (Start at 0)|@{prefix2-_spellchannelsl}}-(@{prefix2-_spellcastingnumber}+(@{prefix2-_spellcastingnumber}*((@{prefix2-_Spellmem}-1)*-1)))]]}} {{testoutcome=[[0]]}}';
+
    var trigger = eventInfo.triggerName.slice(8);
    var skillpre = trigger.split('_');
    var skill = skillpre[3];
@@ -42518,6 +42546,10 @@ on('clicked:repeating_spellbookrituals:spellcast  clicked:repeating_spellbookrit
    if (skill === "spellcastdmgreroll") {rollDmgPart = ' {{hitlocation=true}} {{spelldamage=[[@{prefix2-_spelldamage}+@{prefix2-_spelldamagewb}]]}} {{RTcrit=@{RT-critical}}} {{reroll=[1](~@{character_name}|prefix2-_spellcastdmgreroll)}}';
    var accumod = '@{LastRollAccuExtSL}';
    var prefix = eventInfo.triggerName.slice(8, -19);}
+
+	getAttrs(["initiative_houserule", "OverChannel", "LastRollAccuExtSL"], function(v) {
+	
+   let roll = '{{sl=[[0 [Roll SL]]]}} {{slbonus=[[@{Talent_InstinctiveDictionLvl}+@{Talent_PerfectPitchLvl} [SL TOTAL]]]}} {{slbonusatk=[[@{slbonusCast}]]}} {{sladd=[[0]]}} {{modvalue=[[?{@{translation_modifier}|@{prefix2-_SpellMod}}]]}} {{accuchanexlsl=[[Accu-]]}} {{title=@{prefix2-_spellname}}} {{character_name=@{character_name}}} {{advantage=[[@{Advantage}*10*@{Advantage_casting}]]}} {{unconscious=[[@{UnconsciousMod}]]}} {{cond=[[@{condgen_see}-@{DrunkMod}]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{spelltype=^{RITUALS}}} {{target=[[ [[(@{condgen_see}*-1)]] [COND] + [[{@{LangMagick}}]] [SKILL] + ?{@{translation_modifier}|0} [MOD] + [[@{Advantage}*10*@{Advantage_casting}]] [ADV] ]]}} {{consequence=@{prefix2-_ritualcons}}} {{spelldescription=@{prefix2-_spelldesc}}} {{test=[[@{roll_rule}]]}} {{SLmod=[[?{SL Modifier|0}]]}} {{spelltest=[[1d10]]}} {{arcanetest=true}} {{rolltype=[[6]]}} {{spellcastingnumber=[[@{prefix2-_cn-sl-mod}+(3*(@{prefix2-_spellcastingnumber}*((@{prefix2-_Spellmem}-1)*-1)))]]}} {{mod1type=[[@{prefix2-_ArcaneSpell_modtype1}]]}} {{mod1=@{prefix2-_ArcaneSpell_mod1}}} {{mod2type=[[@{prefix2-_ArcaneSpell_modtype2}]]}} {{mod2=@{prefix2-_ArcaneSpell_mod2}}} {{mod3type=[[@{prefix2-_ArcaneSpell_modtype3}]]}} {{mod3=@{prefix2-_ArcaneSpell_mod3}}} {{NPC=[[0]]}} {{RTminor=@{RT-minor}}} {{RTmajor=@{RT-major}}} {{RTgrim=@{RT-grim}}} {{sptal2=[[@{Talent_InstinctiveDictionLvl}]]}} {{sptal3=[[@{Talent_PerfectPitchLvl}]]}} {{sptal23=[[@{Talent_InstinctiveandPitch}]]}} {{spellmem=[[@{prefix2-_Spellmem}]]}} {{lore=[[@{prefix2-_MagicLore}]]}} {{cnsl=[[?{Accumulated Extended Channelling SL (Start at 0)|@{prefix2-_spellchannelsl}}-(@{prefix2-_spellcastingnumber}+(@{prefix2-_spellcastingnumber}*((@{prefix2-_Spellmem}-1)*-1)))]]}} {{testoutcome=[[0]]}}';
    
    let rollBegins = '@{Whisper} &{template:whfrp2e}';
    
@@ -44547,19 +44579,19 @@ on('change:Used_Enchanted_Staff change:repeating_spellbookarcane:ExtChannellingL
 			ids.forEach(id => {
 				const output = {};
 					getAttrs([`repeating_spellbookarcane_${id}_ExtChannellingLore`], function(t) {
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingFire})") {checklore = 1;} else  {checklore = 0;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingHeavens})") {checklore = 2;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingMetal})") {checklore = 3;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingBeasts})") {checklore = 4;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingLife})") {checklore = 5;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingLight})") {checklore = 6;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingDeath})") {checklore = 7;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingShadows})") {checklore = 8;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingWitch})") {checklore = 9;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingDark})") {checklore = 10;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingChaos})") {checklore = 11;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingGreatMaw})") {checklore = 12;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingMisc})") {checklore = 13;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingFire}) [Fire]") {checklore = 1;} else  {checklore = 0;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingHeavens}) [Heavens]") {checklore = 2;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingMetal}) [Metal]") {checklore = 3;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingBeasts}) [Beasts]") {checklore = 4;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingLife}) [Life]") {checklore = 5;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingLight}) [Light]") {checklore = 6;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingDeath}) [Death]") {checklore = 7;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingShadows}) [Shadows]") {checklore = 8;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingWitch}) [Witch]") {checklore = 9;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingDark}) [Dark]") {checklore = 10;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingChaos}) [Chaos]") {checklore = 11;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingGreatMaw}) [GreatMaw]") {checklore = 12;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingMisc}) [Misc]") {checklore = 13;}
 					
 						if (lorestaff === checklore) {
 						output[`repeating_spellbookarcane_${id}_Used_Enchanted_Staff_show`] = 1, setAttrs(output, {silent: true})
@@ -44665,20 +44697,19 @@ on("change:repeating_spellbookarcane:UsedSpell1 change:repeating_spellbookarcane
             let name = v.repeating_spellbookarcane_spellname;	
 			let lore = v.Used_Enchanted_Staff*1;
 
-					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingFire})") {checklore = 1;} else  {checklore = 0;}
-					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingHeavens})") {checklore = 2;}
-					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingMetal})") {checklore = 3;}
-					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingBeasts})") {checklore = 4;}
-					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingLife})") {checklore = 5;}
-					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingLight})") {checklore = 6;}
-					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingDeath})") {checklore = 7;}
-					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingShadows})") {checklore = 8;}
-					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingWitch})") {checklore = 9;}
-					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingDark})") {checklore = 10;}
-					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingChaos})") {checklore = 11;}
-					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingGreatMaw})") {checklore = 12;}
-					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingMisc})") {checklore = 13;}
-					
+					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingFire}) [Fire]") {checklore = 1;} else  {checklore = 0;}
+					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingHeavens}) [Heavens]") {checklore = 2;}
+					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingMetal}) [Metal]") {checklore = 3;}
+					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingBeasts}) [Beasts]") {checklore = 4;}
+					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingLife}) [Life]") {checklore = 5;}
+					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingLight}) [Light]") {checklore = 6;}
+					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingDeath}) [Death]") {checklore = 7;}
+					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingShadows}) [Shadows]") {checklore = 8;}
+					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingWitch}) [Witch]") {checklore = 9;}
+					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingDark}) [Dark]") {checklore = 10;}
+					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingChaos}) [Chaos]") {checklore = 11;}
+					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingGreatMaw}) [GreatMaw]") {checklore = 12;}
+					if(v.repeating_spellbookarcane_ExtChannellingLore === "(@{ChannellingMisc}) [Misc]") {checklore = 13;}
 			
 						if (lore === checklore) {
 						cnmod = 1;

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -25106,19 +25106,19 @@
 								</div>
 								<select class="sheet-select-no-arrow-center" name="attr_ExtChannellingLore">
 									<option data-i18n="SELECT" selected="selected">Select</option>
-									<option value="(@{ChannellingFire}) [Fire]" data-i18n="FIRE">Fire</option>
-									<option value="(@{ChannellingHeavens}) [Heavens]" data-i18n="HEAVENS">Heavens</option>
-									<option value="(@{ChannellingMetal}) [Metal]" data-i18n="METAL">Metal</option>
-                                    <option value="(@{ChannellingBeasts}) [Beasts]" data-i18n="BEASTS">Beasts</option>
-									<option value="(@{ChannellingLife}) [Life]" data-i18n="LIFE">Life</option>
-									<option value="(@{ChannellingLight}) [Light]" data-i18n="LIGHT">Light</option>
-									<option value="(@{ChannellingDeath}) [Death]" data-i18n="DEATH">Death</option>
-									<option value="(@{ChannellingShadows}) [Shadows]" data-i18n="SHADOWS">Shadows</option>
-									<option value="(@{ChannellingWitch}) [Witch]" data-i18n="WITCH">Witch</option>
-									<option value="(@{ChannellingDark}) [Dark]" data-i18n="DARK">Dark</option>
-									<option value="(@{ChannellingChaos}) [Chaos]" data-i18n="CHAOS">Chaos</option>
-									<option value="(@{ChannellingGreatMaw}) [GreatMaw]" data-i18n="GREAT-MAW">Great Maw</option>
-									<option value="(@{ChannellingMisc}) [Misc]" data-i18n="MISC">Misc</option>
+									<option value="(@{ChannellingFire})" data-i18n="FIRE">Fire</option>
+									<option value="(@{ChannellingHeavens})" data-i18n="HEAVENS">Heavens</option>
+									<option value="(@{ChannellingMetal})" data-i18n="METAL">Metal</option>
+                                    <option value="(@{ChannellingBeasts})" data-i18n="BEASTS">Beasts</option>
+									<option value="(@{ChannellingLife})" data-i18n="LIFE">Life</option>
+									<option value="(@{ChannellingLight})" data-i18n="LIGHT">Light</option>
+									<option value="(@{ChannellingDeath})" data-i18n="DEATH">Death</option>
+									<option value="(@{ChannellingShadows})" data-i18n="SHADOWS">Shadows</option>
+									<option value="(@{ChannellingWitch})" data-i18n="WITCH">Witch</option>
+									<option value="(@{ChannellingDark})" data-i18n="DARK">Dark</option>
+									<option value="(@{ChannellingChaos})" data-i18n="CHAOS">Chaos</option>
+									<option value="(@{ChannellingGreatMaw})" data-i18n="GREAT-MAW">Great Maw</option>
+									<option value="(@{ChannellingMisc})" data-i18n="MISC">Misc</option>
 								</select>
 							</div>
 	<input type="checkbox" name="attr_talentmode" class="sheet-hidden sheet-hider" value="2" />
@@ -25233,15 +25233,14 @@
 							</div>
 							<input type="checkbox" name="attr_SpellDmg" class="sheet-hidden sheet-hider" value="0" checked="checked" />
 							<div class="sheet-col-1-12 sheet-center sheet-pad-r-sm">
-								<button type="action" class="sheet-roll-flex" name="act_spellcast" value="@{Whisper} &{template:whfrp2e} {{modvalue=[[?{@{translation_modifier}|@{SpellMod}}]]}} {{title=@{spellname}}} {{character_name=@{character_name}}} {{advantage=[[@{Advantage}*10*@{Advantage_casting}]]}}{{unconscious=[[@{UnconsciousMod}]]}} {{cond=[[@{condgen_see}-@{DrunkMod}]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{spelltype=^{ARCANE-SPELL}}} {{spellrange=Range: @{spellrange}}} {{spelltarget=Targets: @{spelltarget}}} {{spellduration=Duration: @{spellduration}}} {{target=[[ [[(@{condgen_see}*-1)]] [COND] + [[{@{LangMagick}}]] [SKILL] + ?{@{translation_modifier}|0} [MOD] + [[@{Advantage}*10*@{Advantage_casting}]] [ADV] ]]}} {{spellcastingnumber=[[@{spellcastingnumber}*(2*((@{Spellmem}-1)*1))]]}} {{accuchanexlsl=[[@{spellchannelsl}]]}} {{spelldescription=@{spelldesc}}} {{test=[[@{roll_rule}]]}} {{SLmod=[[?{SL Modifier|0}]]}} {{spelltest=[[1d10]]}} {{arcanetest=true}} {{rolltype=[[5]]}} {{mod1type=[[@{ArcaneSpell_modtype1}]]}} {{mod1=@{ArcaneSpell_mod1}}} {{mod2type=[[@{ArcaneSpell_modtype2}]]}} {{mod2=@{ArcaneSpell_mod2}}} {{mod3type=[[@{ArcaneSpell_modtype3}]]}} {{mod3=@{ArcaneSpell_mod3}}} {{NPC=[[0]]}} {{RTcrit=@{RT-crit}}} {{RTminor=@{RT-minor}}} {{RTmajor=@{RT-major}}} {{reroll=@{RR-rep}SpellCast)}} {{sptal2=[[@{Talent_InstinctiveDictionLvl}]]}} {{sptal3=[[@{Talent_PerfectPitchLvl}]]}} {{sptal23=[[@{Talent_InstinctiveandPitch}]]}}">
+								<button type="action" class="sheet-roll-flex" name="act_spellcast">
 									<span data-i18n="CAST">Cast</span>
 								</button>
 					<button type="action" class="sheet-hidden" name="act_spellcastreroll"></button>
 							</div>
 							<input type="checkbox" name="attr_SpellDmg" class="sheet-hidden sheet-hider" value="1" />
 							<div class="sheet-col-1-12 sheet-center sheet-pad-r-sm">
-								<button type="action" class="sheet-roll-flex" name="act_spellcastdmg"
-                                        value="@{Whisper} &{template:whfrp2e} {{modvalue=[[?{@{translation_modifier}|@{SpellMod}}]]}} {{title=@{spellname}}} {{character_name=@{character_name}}} {{advantage=[[@{Advantage}*10*@{Advantage_casting}]]}} {{unconscious=[[@{UnconsciousMod}]]}} {{cond=[[@{condgen_see}-@{DrunkMod}]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{spelltype=^{ARCANE-SPELL}}} {{spellrange=Range: @{spellrange}}} {{spelltarget=Targets: @{spelltarget}}} {{spellduration=Duration: @{spellduration}}} {{target=[[ [[(@{condgen_see}*-1)]] [COND] + [[{@{LangMagick}}]] [SKILL] + ?{@{translation_modifier}|0} [MOD] + [[@{Advantage}*10*@{Advantage_casting}]] [ADV] ]]}} {{spellcastingnumber=[[@{spellcastingnumber}]]}} {{accuchanexlsl=[[@{spellchannelsl}]]}} {{spelldescription=@{spelldesc}}} {{test=[[@{roll_rule}]]}} {{SLmod=[[?{SL Modifier|0}]]}} {{spelltest=[[1d10]]}} {{hitlocation=true}} {{spelldamage=[[@{spelldamage}+@{spelldamagewb}]]}} {{arcanetest=true}} {{rolltype=[[6]]}} {{mod1type=[[@{ArcaneSpell_modtype1}]]}} {{mod1=@{ArcaneSpell_mod1}}} {{mod2type=[[@{ArcaneSpell_modtype2}]]}} {{mod2=@{ArcaneSpell_mod2}}} {{mod3type=[[@{ArcaneSpell_modtype3}]]}} {{mod3=@{ArcaneSpell_mod3}}} {{NPC=[[0]]}} {{RTcrit=@{RT-crit}}} {{RTminor=@{RT-minor}}} {{RTmajor=@{RT-major}}} {{reroll=@{RR-rep}SpellCastDmg)}} {{sptal2=[[@{Talent_InstinctiveDictionLvl}]]}} {{sptal3=[[@{Talent_PerfectPitchLvl}]]}} {{sptal23=[[@{Talent_InstinctiveandPitch}]]}}">
+								<button type="action" class="sheet-roll-flex" name="act_spellcastdmg">
 									<span data-i18n="CAST">Cast</span>
 								</button>
 					<button type="action" class="sheet-hidden" name="act_spellcastdmgreroll"></button>
@@ -25331,7 +25330,7 @@
 								</button>
 							</div>
 							<div class="sheet-col-1-12 sheet-center sheet-vert-middle">
-								<button type="action" class="sheet-roll-flex" name="act_extchannellingloreroll" value="@{Whisper} &amp&{template:whfrp2e} {{modvalue=[[?{Channeling Roll Modifier|@{ChanMod}}]]}} {{title=@{spellname}}} {{title=^{EXTENDED-CHANNELLING-TEST}}} {{skill=^{ADVANCED-SKILL}}}} {{unconscious=[[@{UnconsciousMod}]]}} {{cond=[[@{condgen_see}-@{DrunkMod}]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{character_name=@{character_name}}} {{target=[[ [[(@{condgen_see}*-1)]] [COND] + @{ExtChannellingLore} [SKILL] + ?{Channeling Roll Modifier|0} [MOD] ]]}} {{skilltest=true}} {{test=[[@{roll_rule}]]}} {{accuchanexlsl=[[?{Accumulated Extended Channelling SL (Start at 0)|@{spellchannelsl}}}} {{SLmod=[[?{SL Modifier|0}]]]]}} {{spellcastingnumber=[[@{spellcastingnumber}]]}} {{SLmod=[[?{SL Modifier|0}]]}} {{rolltype=[[9]]}} {{mod1type=[[@{ExtChannellingLoreRoll_modtype1}]]}} {{mod1=@{ExtChannellingLoreRoll_mod1}}} {{mod2type=[[@{ExtChannellingLoreRoll_modtype2}]]}} {{mod2=@{ExtChannellingLoreRoll_mod2}}} {{mod3type=[[@{ExtChannellingLoreRoll_modtype3}]]}} {{mod3=@{ExtChannellingLoreRoll_mod3}}} {{NPC=[[0]]}} {{RTminor=@{RT-minor}}} {{RTmajor=@{RT-major}}} {{reroll=@{RR-rep}ExtChannellingLoreRoll)}} {{sptal1=[[@{Talent_AethyricAttunementLvl}]]}}">
+								<button type="action" class="sheet-roll-flex" name="act_extchannellingloreroll" >
 									<span data-i18n="CHANNEL">Channel</span>
 								</button>
 							</div>
@@ -25469,19 +25468,19 @@
 								</div>
 								<select class="sheet-select-no-arrow-center" name="attr_ExtChannellingLore">
 									<option data-i18n="SELECT" selected="selected">Select</option>
-									<option value="(@{ChannellingFire}) [Fire]" data-i18n="FIRE">Fire</option>
-									<option value="(@{ChannellingHeavens}) [Heavens]" data-i18n="HEAVENS">Heavens</option>
-									<option value="(@{ChannellingMetal}) [Metal]" data-i18n="METAL">Metal</option>
-                                    <option value="(@{ChannellingBeasts}) [Beasts]" data-i18n="BEASTS">Beasts</option>
-									<option value="(@{ChannellingLife}) [Life]" data-i18n="LIFE">Life</option>
-									<option value="(@{ChannellingLight}) [Light]" data-i18n="LIGHT">Light</option>
-									<option value="(@{ChannellingDeath}) [Death]" data-i18n="DEATH">Death</option>
-									<option value="(@{ChannellingShadows}) [Shadows]" data-i18n="SHADOWS">Shadows</option>
-									<option value="(@{ChannellingWitch}) [Witch]" data-i18n="WITCH">Witch</option>
-									<option value="(@{ChannellingDark}) [Dark]" data-i18n="DARK">Dark</option>
-									<option value="(@{ChannellingChaos}) [Chaos]" data-i18n="CHAOS">Chaos</option>
-									<option value="(@{ChannellingGreatMaw}) [GreatMaw]" data-i18n="GREAT-MAW">Great Maw</option>
-									<option value="(@{ChannellingMisc}) [Misc]" data-i18n="MISC">Misc</option>
+									<option value="(@{ChannellingFire})" data-i18n="FIRE">Fire</option>
+									<option value="(@{ChannellingHeavens})" data-i18n="HEAVENS">Heavens</option>
+									<option value="(@{ChannellingMetal})" data-i18n="METAL">Metal</option>
+                                    <option value="(@{ChannellingBeasts})" data-i18n="BEASTS">Beasts</option>
+									<option value="(@{ChannellingLife})" data-i18n="LIFE">Life</option>
+									<option value="(@{ChannellingLight})" data-i18n="LIGHT">Light</option>
+									<option value="(@{ChannellingDeath})" data-i18n="DEATH">Death</option>
+									<option value="(@{ChannellingShadows})" data-i18n="SHADOWS">Shadows</option>
+									<option value="(@{ChannellingWitch})" data-i18n="WITCH">Witch</option>
+									<option value="(@{ChannellingDark})" data-i18n="DARK">Dark</option>
+									<option value="(@{ChannellingChaos})" data-i18n="CHAOS">Chaos</option>
+									<option value="(@{ChannellingGreatMaw})" data-i18n="GREAT-MAW">Great Maw</option>
+									<option value="(@{ChannellingMisc})" data-i18n="MISC">Misc</option>
 								</select>
 							</div>
 							</div>
@@ -25512,17 +25511,22 @@
 							<input type="hidden" class="sheet-center" name="attr_rep_ID" value="0" />
 						<div class="sheet-row sheet-pad-b-sm" style="display: ruby;">
 						<div class="sheet-col-1-4" style="display: inline; padding-right: 10px;">
-							<div class="sheet-col-1-10 sheet-center sheet-vert-middle sheet-pad-l-sm sheet-pad-r-sm">
+							<div class="sheet-col-1-20 sheet-center sheet-vert-middle sheet-pad-l-sm sheet-pad-r-sm">
 		<input type="checkbox" name="attr_Spellmem" class="sheet-hidden sheet-hider" value="0" checked />
 								<div class="sheet-center sheet-small-label sheet-pad-b-sm">
-									<span data-i18n="CASTING-NUMBER">CN</span> <span style="color: red">x4</span>
+									<span data-i18n="CASTING-NUMBER">CN</span> <span style="color: red">x2</span>
 								</div>
 		<input type="checkbox" name="attr_Spellmem" class="sheet-hidden sheet-hider" value="1" />
 								<div class="sheet-center sheet-small-label sheet-pad-b-sm">
 									<span data-i18n="CASTING-NUMBER">CN</span>
 								</div>
-								<input type="number" class="sheet-center" name="attr_spellcastingnumber" value="0" />
-								<input type="hidden" class="sheet-center" name="attr_cn-sl-mod" value="@{spellcastingnumber}" />
+							<input type="hidden" class="sheet-center" name="attr_Used_Enchanted_Staff_show" value="0"  />
+		<input type="checkbox" name="attr_Used_Enchanted_Staff_show" class="sheet-hidden sheet-hider" value="1" />
+								<div class="sheet-center sheet-pad-b-sm" style="position: absolute;left: 33px;top: 66px;font-size: 8px;">
+									<span style="color: red" unselectable="on">-1</span>
+								</div>
+								<input type="number" class="sheet-center" name="attr_spellcastingnumber"  value="1" min="1" />
+								<input type="hidden" class="sheet-center" name="attr_cn-sl-mod" value="@{spellcastingnumber}-@{Used_Enchanted_Staff}" />
 							</div>
 							</div>
 						<div class="sheet-col-1-3" style="display: inline; padding-right: 10px;">
@@ -25551,7 +25555,7 @@
 								</button>
 							</div>
 							<div class="sheet-col-1-12 sheet-center sheet-vert-middle">
-								<button type="action" class="sheet-roll-flex" name="act_extchannellingloreroll" value="@{Whisper} &amp&{template:whfrp2e} {{modvalue=[[?{Channeling Roll Modifier|@{ChanMod}}]]}} {{title=@{spellname}}} {{title=^{EXTENDED-CHANNELLING-TEST}}} {{skill=^{ADVANCED-SKILL}}}} {{unconscious=[[@{UnconsciousMod}]]}} {{cond=[[@{condgen_see}-@{DrunkMod}]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{character_name=@{character_name}}} {{target=[[ [[(@{condgen_see}*-1)]] [COND] + @{ExtChannellingLore} [SKILL] + ?{Channeling Roll Modifier|0} [MOD] ]]}} {{skilltest=true}} {{test=[[@{roll_rule}]]}} {{accuchanexlsl=[[?{Accumulated Extended Channelling SL (Start at 0)|@{spellchannelsl}}}} {{SLmod=[[?{SL Modifier|0}]]]]}} {{spellcastingnumber=[[@{spellcastingnumber}]]}} {{SLmod=[[?{SL Modifier|0}]]}} {{rolltype=[[9]]}} {{mod1type=[[@{ExtChannellingLoreRoll_modtype1}]]}} {{mod1=@{ExtChannellingLoreRoll_mod1}}} {{mod2type=[[@{ExtChannellingLoreRoll_modtype2}]]}} {{mod2=@{ExtChannellingLoreRoll_mod2}}} {{mod3type=[[@{ExtChannellingLoreRoll_modtype3}]]}} {{mod3=@{ExtChannellingLoreRoll_mod3}}} {{NPC=[[0]]}} {{RTminor=@{RT-minor}}} {{RTmajor=@{RT-major}}} {{reroll=@{RR-rep}ExtChannellingLoreRoll)}} {{sptal1=[[@{Talent_AethyricAttunementLvl}]]}}">
+								<button type="action" class="sheet-roll-flex" name="act_extchannellingloreroll" >
 									<span data-i18n="CHANNEL">Channel</span>
 								</button>
 							</div>
@@ -25576,14 +25580,14 @@
 							</div>
 							<input type="checkbox" name="attr_SpellDmg" class="sheet-hidden sheet-hider" value="0" checked="checked" />
 							<div class="sheet-col-1-15 sheet-center sheet-pad-r-sm">
-								<button type="action" class="sheet-roll-flex" name="act_spellcast" value="@{Whisper} &{template:whfrp2e} {{modvalue=[[?{@{translation_modifier}|@{SpellMod}}]]}} {{title=@{spellname}}} {{character_name=@{character_name}}} {{advantage=[[@{Advantage}*10*@{Advantage_casting}]]}}{{unconscious=[[@{UnconsciousMod}]]}} {{cond=[[@{condgen_see}-@{DrunkMod}]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{spelltype=^{ARCANE-SPELL}}} {{spellrange=Range: @{spellrange}}} {{spelltarget=Targets: @{spelltarget}}} {{spellduration=Duration: @{spellduration}}} {{target=[[ [[(@{condgen_see}*-1)]] [COND] + [[{@{LangMagick}}]] [SKILL] + ?{@{translation_modifier}|0} [MOD] + [[@{Advantage}*10*@{Advantage_casting}]] [ADV] ]]}} {{spellcastingnumber=[[@{spellcastingnumber}*(4*((@{Spellmem}-1)*1))]]}} {{accuchanexlsl=[[@{spellchannelsl}]]}} {{spelldescription=@{spelldesc}}} {{test=[[@{roll_rule}]]}} {{SLmod=[[?{SL Modifier|0}]]}} {{spelltest=[[1d10]]}} {{arcanetest=true}} {{rolltype=[[5]]}} {{mod1type=[[@{ArcaneSpell_modtype1}]]}} {{mod1=@{ArcaneSpell_mod1}}} {{mod2type=[[@{ArcaneSpell_modtype2}]]}} {{mod2=@{ArcaneSpell_mod2}}} {{mod3type=[[@{ArcaneSpell_modtype3}]]}} {{mod3=@{ArcaneSpell_mod3}}} {{NPC=[[0]]}} {{RTcrit=@{RT-crit}}} {{RTminor=@{RT-minor}}} {{RTmajor=@{RT-major}}} {{reroll=@{RR-rep}SpellCast)}} {{sptal2=[[@{Talent_InstinctiveDictionLvl}]]}} {{sptal3=[[@{Talent_PerfectPitchLvl}]]}} {{sptal23=[[@{Talent_InstinctiveandPitch}]]}}">
+								<button type="action" class="sheet-roll-flex" name="act_spellcast" >
 									<span data-i18n="CAST">Cast</span>
 								</button>
 					<button type="action" class="sheet-hidden" name="act_spellcastreroll"></button>
 							</div>
 							<input type="checkbox" name="attr_SpellDmg" class="sheet-hidden sheet-hider" value="1" />
 							<div class="sheet-col-1-15 sheet-center sheet-pad-r-sm">
-								<button type="action" class="sheet-roll-flex" name="act_spellcastdmg" value="@{Whisper} &{template:whfrp2e} {{modvalue=[[?{@{translation_modifier}|@{SpellMod}}]]}} {{title=@{spellname}}} {{character_name=@{character_name}}} {{advantage=[[@{Advantage}*10*@{Advantage_casting}]]}} {{unconscious=[[@{UnconsciousMod}]]}} {{cond=[[@{condgen_see}-@{DrunkMod}]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{spelltype=^{ARCANE-SPELL}}} {{spellrange=Range: @{spellrange}}} {{spelltarget=Targets: @{spelltarget}}} {{spellduration=Duration: @{spellduration}}} {{target=[[ [[(@{condgen_see}*-1)]] [COND] + [[{@{LangMagick}}]] [SKILL] + ?{@{translation_modifier}|0} [MOD] + [[@{Advantage}*10*@{Advantage_casting}]] [ADV] ]]}} {{spellcastingnumber=[[@{spellcastingnumber}]]}} {{accuchanexlsl=[[@{spellchannelsl}]]}} {{spelldescription=@{spelldesc}}} {{test=[[@{roll_rule}]]}} {{SLmod=[[?{SL Modifier|0}]]}} {{spelltest=[[1d10]]}} {{hitlocation=true}} {{spelldamage=[[@{spelldamage}+@{spelldamagewb}]]}} {{arcanetest=true}} {{rolltype=[[6]]}} {{mod1type=[[@{ArcaneSpell_modtype1}]]}} {{mod1=@{ArcaneSpell_mod1}}} {{mod2type=[[@{ArcaneSpell_modtype2}]]}} {{mod2=@{ArcaneSpell_mod2}}} {{mod3type=[[@{ArcaneSpell_modtype3}]]}} {{mod3=@{ArcaneSpell_mod3}}} {{NPC=[[0]]}} {{RTcrit=@{RT-crit}}} {{RTminor=@{RT-minor}}} {{RTmajor=@{RT-major}}} {{reroll=@{RR-rep}SpellCastDmg)}} {{sptal2=[[@{Talent_InstinctiveDictionLvl}]]}} {{sptal3=[[@{Talent_PerfectPitchLvl}]]}} {{sptal23=[[@{Talent_InstinctiveandPitch}]]}}">
+								<button type="action" class="sheet-roll-flex" name="act_spellcastdmg" >
 									<span data-i18n="CAST">Cast</span>
 								</button>
 					<button type="action" class="sheet-hidden" name="act_spellcastdmgreroll"></button>
@@ -39838,19 +39842,19 @@ on('change:repeating_spellbookarcane:ExtChannellingLore', function(event) {
                     ids.forEach(id => {
 					
 					getAttrs([`repeating_spellbookarcane_${id}_ExtChannellingLore`], function(t) {
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingFire}) [Fire]") {lore = 1;} else  {checklore = 0;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingHeavens}) [Heavens]") {lore = 2;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingMetal}) [Metal]") {lore = 3;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingBeasts}) [Beasts]") {lore = 4;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingLife}) [Life]") {lore = 5;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingLight}) [Light]") {lore = 6;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingDeath}) [Death]") {lore = 7;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingShadows}) [Shadows]") {lore = 8;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingWitch}) [Witch]") {lore = 9;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingDark}) [Dark]") {lore = 10;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingChaos}) [Chaos]") {lore = 11;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingGreatMaw}) [GreatMaw]") {lore = 12;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingMisc}) [Misc]") {lore = 13;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingFire})") {lore = 1;} else  {checklore = 0;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingHeavens})") {lore = 2;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingMetal})") {lore = 3;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingBeasts})]") {lore = 4;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingLife})") {lore = 5;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingLight})") {lore = 6;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingDeath})") {lore = 7;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingShadows})") {lore = 8;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingWitch})") {lore = 9;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingDark})") {lore = 10;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingChaos})") {lore = 11;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingGreatMaw})") {lore = 12;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingMisc})") {lore = 13;}
 				
 	console.log("spelllore change");
 	console.log(lore);
@@ -39929,19 +39933,19 @@ on('change:repeating_spellbookrituals:ExtChannellingLore', function(event) {
 	
 				getAttrs(["repeating_spellbookrituals_ExtChannellingLore"], function(v) {
 				
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingFire}) [Fire]") {lore = 1;} else  {lore = 0;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingHeavens}) [Heavens]") {lore = 2;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingMetal}) [Metal]") {lore = 3;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingBeasts}) [Beasts]") {lore = 4;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingLife}) [Life]") {lore = 5;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingLight}) [Light]") {lore = 6;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingDeath}) [Death]") {lore = 7;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingShadows}) [Shadows]") {lore = 8;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingWitch}) [Witch]") {lore = 9;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingDark}) [Dark]") {lore = 10;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingChaos}) [Chaos]") {lore = 11;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingGreatMaw}) [GreatMaw]") {lore = 12;}
-				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingMisc}) [Misc]") {lore = 13;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingFire})") {lore = 1;} else  {lore = 0;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingHeavens})") {lore = 2;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingMetal})") {lore = 3;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingBeasts})") {lore = 4;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingLife})") {lore = 5;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingLight})]") {lore = 6;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingDeath})") {lore = 7;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingShadows})") {lore = 8;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingWitch})") {lore = 9;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingDark})") {lore = 10;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingChaos})") {lore = 11;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingGreatMaw})") {lore = 12;}
+				if (v.repeating_spellbookrituals_ExtChannellingLore == "(@{ChannellingMisc})") {lore = 13;}
 				
 	console.log("spelllore change");
 	console.log(lore);
@@ -42217,7 +42221,7 @@ on('clicked:repeating_spellbookarcane:spellcast clicked:repeating_spellbookarcan
    var prefix = eventInfo.triggerName.slice(8, -19);}
    
    
-	getAttrs(["initiative_houserule", "OverChannel", "LastRollAccuExtSL", "Talent_SuffusedWithAqshyLvl", "Talent_SuffusedWithAzyrLvl", "Talent_SuffusedWithChamonLvl", "Talent_SuffusedWithGhurLvl", "Talent_SuffusedWithGhyranLvl", "Talent_SuffusedWithHyshLvl", "Talent_SuffusedWithShiyshLvl", "Talent_SuffusedWithUgluLvl", "Used_Enchanted_Staff", `@{prefix}_MagicLore`], function(v) {
+	getAttrs(["initiative_houserule", "OverChannel", "LastRollAccuExtSL", "Talent_SuffusedWithAqshyLvl", "Talent_SuffusedWithAzyrLvl", "Talent_SuffusedWithChamonLvl", "Talent_SuffusedWithGhurLvl", "Talent_SuffusedWithGhyranLvl", "Talent_SuffusedWithHyshLvl", "Talent_SuffusedWithShiyshLvl", "Talent_SuffusedWithUgluLvl", "Used_Enchanted_Staff"], function(v) {
 
 				cnlore = 0;
 				const playerclickedid = eventInfo.sourceAttribute.split('_')[2] || '';				
@@ -42531,6 +42535,7 @@ on('clicked:repeating_spellbookarcane:channelreset', (eventInfo) => {
 	
 on('clicked:repeating_spellbookrituals:spellcast  clicked:repeating_spellbookrituals:spellcastdmg clicked:repeating_spellbookrituals:spellcastreroll  clicked:repeating_spellbookrituals:spellcastdmgreroll', (eventInfo) => {
 
+			   
    var trigger = eventInfo.triggerName.slice(8);
    var skillpre = trigger.split('_');
    var skill = skillpre[3];
@@ -42547,9 +42552,34 @@ on('clicked:repeating_spellbookrituals:spellcast  clicked:repeating_spellbookrit
    var accumod = '@{LastRollAccuExtSL}';
    var prefix = eventInfo.triggerName.slice(8, -19);}
 
-	getAttrs(["initiative_houserule", "OverChannel", "LastRollAccuExtSL"], function(v) {
+	getAttrs(["initiative_houserule", "OverChannel", "LastRollAccuExtSL", "Used_Enchanted_Staff"], function(v) {
+
+				cnlore = 0;
+				const playerclickedid = eventInfo.sourceAttribute.split('_')[2] || '';				
+
+				getSectionIDs("repeating_spellbookrituals", function (ids) {
+                if (playerclickedid == ids.toLowerCase) return;
+                    // create an object to hold all the attributes we are bout to change
+                    const output = {};
+                    // loop through the row ids
+                    ids.forEach(id => {
+					
+						let playerId = playerclickedid.toLowerCase();
+						if(playerId == id.toLowerCase()) {
+					getAttrs([`repeating_spellbookrituals_${id}_MagicLore`], function(t) {
+
+							etest = v.Used_Enchanted_Staff*1;
+							e2test = t[`repeating_spellbookrituals_${id}_MagicLore`];
+		
+							if (etest === e2test) {cnlore += 1;}
+							if (etest === 14) {cnlore += 1;}
 	
-   let roll = '{{sl=[[0 [Roll SL]]]}} {{slbonus=[[@{Talent_InstinctiveDictionLvl}+@{Talent_PerfectPitchLvl} [SL TOTAL]]]}} {{slbonusatk=[[@{slbonusCast}]]}} {{sladd=[[0]]}} {{modvalue=[[?{@{translation_modifier}|@{prefix2-_SpellMod}}]]}} {{accuchanexlsl=[[Accu-]]}} {{title=@{prefix2-_spellname}}} {{character_name=@{character_name}}} {{advantage=[[@{Advantage}*10*@{Advantage_casting}]]}} {{unconscious=[[@{UnconsciousMod}]]}} {{cond=[[@{condgen_see}-@{DrunkMod}]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{spelltype=^{RITUALS}}} {{target=[[ [[(@{condgen_see}*-1)]] [COND] + [[{@{LangMagick}}]] [SKILL] + ?{@{translation_modifier}|0} [MOD] + [[@{Advantage}*10*@{Advantage_casting}]] [ADV] ]]}} {{consequence=@{prefix2-_ritualcons}}} {{spelldescription=@{prefix2-_spelldesc}}} {{test=[[@{roll_rule}]]}} {{SLmod=[[?{SL Modifier|0}]]}} {{spelltest=[[1d10]]}} {{arcanetest=true}} {{rolltype=[[6]]}} {{spellcastingnumber=[[@{prefix2-_cn-sl-mod}+(3*(@{prefix2-_spellcastingnumber}*((@{prefix2-_Spellmem}-1)*-1)))]]}} {{mod1type=[[@{prefix2-_ArcaneSpell_modtype1}]]}} {{mod1=@{prefix2-_ArcaneSpell_mod1}}} {{mod2type=[[@{prefix2-_ArcaneSpell_modtype2}]]}} {{mod2=@{prefix2-_ArcaneSpell_mod2}}} {{mod3type=[[@{prefix2-_ArcaneSpell_modtype3}]]}} {{mod3=@{prefix2-_ArcaneSpell_mod3}}} {{NPC=[[0]]}} {{RTminor=@{RT-minor}}} {{RTmajor=@{RT-major}}} {{RTgrim=@{RT-grim}}} {{sptal2=[[@{Talent_InstinctiveDictionLvl}]]}} {{sptal3=[[@{Talent_PerfectPitchLvl}]]}} {{sptal23=[[@{Talent_InstinctiveandPitch}]]}} {{spellmem=[[@{prefix2-_Spellmem}]]}} {{lore=[[@{prefix2-_MagicLore}]]}} {{cnsl=[[?{Accumulated Extended Channelling SL (Start at 0)|@{prefix2-_spellchannelsl}}-(@{prefix2-_spellcastingnumber}+(@{prefix2-_spellcastingnumber}*((@{prefix2-_Spellmem}-1)*-1)))]]}} {{testoutcome=[[0]]}}';
+
+               console.log(etest);
+               console.log(e2test);
+
+	
+   let roll = '{{sl=[[0 [Roll SL]]]}} {{slbonus=[[@{Talent_InstinctiveDictionLvl}+@{Talent_PerfectPitchLvl} [SL TOTAL]]]}} {{slbonusatk=[[@{slbonusCast}]]}} {{sladd=[[0]]}} {{modvalue=[[?{@{translation_modifier}|@{prefix2-_SpellMod}}]]}} {{accuchanexlsl=[[Accu-]]}} {{title=@{prefix2-_spellname}}} {{character_name=@{character_name}}} {{advantage=[[@{Advantage}*10*@{Advantage_casting}]]}} {{unconscious=[[@{UnconsciousMod}]]}} {{cond=[[@{condgen_see}-@{DrunkMod}]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{spelltype=^{RITUALS}}} {{target=[[ [[(@{condgen_see}*-1)]] [COND] + [[{@{LangMagick}}]] [SKILL] + ?{@{translation_modifier}|0} [MOD] + [[@{Advantage}*10*@{Advantage_casting}]] [ADV] ]]}} {{consequence=@{prefix2-_ritualcons}}} {{spelldescription=@{prefix2-_spelldesc}}} {{test=[[@{roll_rule}]]}} {{SLmod=[[?{SL Modifier|0}]]}} {{spelltest=[[1d10]]}} {{arcanetest=true}} {{rolltype=[[6]]}} {{spellcastingnumber=[[@{prefix2-_spellcastingnumber}-[cnlore]+(3*(@{prefix2-_spellcastingnumber}*((@{prefix2-_Spellmem}-1)*-1)))]]}} {{mod1type=[[@{prefix2-_ArcaneSpell_modtype1}]]}} {{mod1=@{prefix2-_ArcaneSpell_mod1}}} {{mod2type=[[@{prefix2-_ArcaneSpell_modtype2}]]}} {{mod2=@{prefix2-_ArcaneSpell_mod2}}} {{mod3type=[[@{prefix2-_ArcaneSpell_modtype3}]]}} {{mod3=@{prefix2-_ArcaneSpell_mod3}}} {{NPC=[[0]]}} {{RTminor=@{RT-minor}}} {{RTmajor=@{RT-major}}} {{RTgrim=@{RT-grim}}} {{sptal2=[[@{Talent_InstinctiveDictionLvl}]]}} {{sptal3=[[@{Talent_PerfectPitchLvl}]]}} {{sptal23=[[@{Talent_InstinctiveandPitch}]]}} {{spellmem=[[@{prefix2-_Spellmem}]]}} {{lore=[[@{prefix2-_MagicLore}]]}} {{usedenchstaff=[[@{prefix2-_Used_Enchanted_Staff_show}]]}} {{cnsl=[[?{Accumulated Extended Channelling SL (Start at 0)|@{prefix2-_spellchannelsl}}-(@{prefix2-_spellcastingnumber}+(@{prefix2-_spellcastingnumber}*((@{prefix2-_Spellmem}-1)*-1)))]]}} {{testoutcome=[[0]]}}';
    
    let rollBegins = '@{Whisper} &{template:whfrp2e}';
    
@@ -42558,7 +42588,7 @@ on('clicked:repeating_spellbookrituals:spellcast  clicked:repeating_spellbookrit
                console.log(accumod);
    
    let rollDmg = rollDmgPart.replaceAll('prefix2-', `${prefix}`);
-   let rollPart = roll.replaceAll('Accu-', accumod).replaceAll('prefix2-', `${prefix}`);
+   let rollPart = roll.replaceAll('Accu-', accumod).replaceAll('prefix2-', `${prefix}`).replaceAll('[cnlore]', cnlore);
    
    	
                console.log(rollPart);	
@@ -42631,6 +42661,10 @@ on('clicked:repeating_spellbookrituals:spellcast  clicked:repeating_spellbookrit
                     });
         });
 	});
+                    });
+						}
+					});
+					});
 		
     });
     });
@@ -44564,7 +44598,7 @@ on('change:armorimpenetrable change:armorweakpoints change:armorpartial change:a
 	});			
 });	
 
-on('change:Used_Enchanted_Staff change:repeating_spellbookarcane:ExtChannellingLore', function(event){
+on('change:Used_Enchanted_Staff change:repeating_spellbookarcane:ExtChannellingLore  change:repeating_spellbookrituals:ExtChannellingLore', function(event){
         if (event.sourceType === 'sheetworker') return;
     console.log("Used_Enchanted_Staff change");	
 	
@@ -44579,19 +44613,19 @@ on('change:Used_Enchanted_Staff change:repeating_spellbookarcane:ExtChannellingL
 			ids.forEach(id => {
 				const output = {};
 					getAttrs([`repeating_spellbookarcane_${id}_ExtChannellingLore`], function(t) {
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingFire}) [Fire]") {checklore = 1;} else  {checklore = 0;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingHeavens}) [Heavens]") {checklore = 2;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingMetal}) [Metal]") {checklore = 3;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingBeasts}) [Beasts]") {checklore = 4;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingLife}) [Life]") {checklore = 5;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingLight}) [Light]") {checklore = 6;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingDeath}) [Death]") {checklore = 7;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingShadows}) [Shadows]") {checklore = 8;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingWitch}) [Witch]") {checklore = 9;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingDark}) [Dark]") {checklore = 10;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingChaos}) [Chaos]") {checklore = 11;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingGreatMaw}) [GreatMaw]") {checklore = 12;}
-					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingMisc}) [Misc]") {checklore = 13;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingFire})") {checklore = 1;} else  {checklore = 0;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingHeavens})") {checklore = 2;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingMetal})") {checklore = 3;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingBeasts})") {checklore = 4;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingLife})") {checklore = 5;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingLight})") {checklore = 6;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingDeath})") {checklore = 7;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingShadows})") {checklore = 8;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingWitch})") {checklore = 9;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingDark})") {checklore = 10;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingChaos})") {checklore = 11;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingGreatMaw})") {checklore = 12;}
+					if(t[`repeating_spellbookarcane_${id}_ExtChannellingLore`] === "(@{ChannellingMisc})") {checklore = 13;}
 					
 						if (lorestaff === checklore) {
 						output[`repeating_spellbookarcane_${id}_Used_Enchanted_Staff_show`] = 1, setAttrs(output, {silent: true})
@@ -44599,6 +44633,37 @@ on('change:Used_Enchanted_Staff change:repeating_spellbookarcane:ExtChannellingL
 						output[`repeating_spellbookarcane_${id}_Used_Enchanted_Staff_show`] = 1, setAttrs(output, {silent: true})
 						} else {
 						output[`repeating_spellbookarcane_${id}_Used_Enchanted_Staff_show`] = 0, setAttrs(output, {silent: true})
+						}
+						
+					});		
+	
+			});	
+		});		
+		
+		getSectionIDs("repeating_spellbookrituals", function (ids) {
+			ids.forEach(id => {
+				const output = {};
+					getAttrs([`repeating_spellbookrituals_${id}_ExtChannellingLore`], function(t) {
+					if(t[`repeating_spellbookrituals_${id}_ExtChannellingLore`] === "(@{ChannellingFire})") {checklore = 1;} else  {checklore = 0;}
+					if(t[`repeating_spellbookrituals_${id}_ExtChannellingLore`] === "(@{ChannellingHeavens})") {checklore = 2;}
+					if(t[`repeating_spellbookrituals_${id}_ExtChannellingLore`] === "(@{ChannellingMetal})") {checklore = 3;}
+					if(t[`repeating_spellbookrituals_${id}_ExtChannellingLore`] === "(@{ChannellingBeasts})") {checklore = 4;}
+					if(t[`repeating_spellbookrituals_${id}_ExtChannellingLore`] === "(@{ChannellingLife})") {checklore = 5;}
+					if(t[`repeating_spellbookrituals_${id}_ExtChannellingLore`] === "(@{ChannellingLight})") {checklore = 6;}
+					if(t[`repeating_spellbookrituals_${id}_ExtChannellingLore`] === "(@{ChannellingDeath})") {checklore = 7;}
+					if(t[`repeating_spellbookrituals_${id}_ExtChannellingLore`] === "(@{ChannellingShadows})") {checklore = 8;}
+					if(t[`repeating_spellbookrituals_${id}_ExtChannellingLore`] === "(@{ChannellingWitch})") {checklore = 9;}
+					if(t[`repeating_spellbookrituals_${id}_ExtChannellingLore`] === "(@{ChannellingDark})") {checklore = 10;}
+					if(t[`repeating_spellbookrituals_${id}_ExtChannellingLore`] === "(@{ChannellingChaos})") {checklore = 11;}
+					if(t[`repeating_spellbookrituals_${id}_ExtChannellingLore`] === "(@{ChannellingGreatMaw})") {checklore = 12;}
+					if(t[`repeating_spellbookrituals_${id}_ExtChannellingLore`] === "(@{ChannellingMisc})") {checklore = 13;}
+					
+						if (lorestaff === checklore) {
+						output[`repeating_spellbookrituals_${id}_Used_Enchanted_Staff_show`] = 1, setAttrs(output, {silent: true})
+						} else if (lorestaff === 14) {
+						output[`repeating_spellbookrituals_${id}_Used_Enchanted_Staff_show`] = 1, setAttrs(output, {silent: true})
+						} else {
+						output[`repeating_spellbookrituals_${id}_Used_Enchanted_Staff_show`] = 0, setAttrs(output, {silent: true})
 						}
 						
 					});		

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -43199,6 +43199,23 @@ on('clicked:repeating_divinemiracles:miracle clicked:repeating_divinemiracles:mi
 			if ( test <= target ) { var computed4 = slbonusatk ;} else  { var computed4 = 0 ;}
 			if ( test <= target ) { var computed5 = slbonusatk + SLmod ;} else  { var computed5 = SLmod ;}
 
+			if ( computed >= computed3 ) {extsl = computed;} else {extsl = computed3;}	
+			if ( test <= target ) {if ( extsl === 0 ) {extsl += 1;}}
+			
+				chancrit = 0;
+							
+			if ( test <= target ) {
+			if ( test === 11 ) {chancrit = 1;}
+			if ( test === 22 ) {chancrit = 1;}
+			if ( test === 33 ) {chancrit = 1;}
+			if ( test === 44 ) {chancrit = 1;}
+			if ( test === 55 ) {chancrit = 1;}
+			if ( test === 66 ) {chancrit = 1;}
+			if ( test === 77 ) {chancrit = 1;}
+			if ( test === 88 ) {chancrit = 1;}
+			if ( test === 99 ) {chancrit = 1;}			
+			}
+			
                console.log(cond);	
                console.log(computed);
                console.log(computed3);
@@ -43215,6 +43232,76 @@ on('clicked:repeating_divinemiracles:miracle clicked:repeating_divinemiracles:mi
                     sladd: computed5,
                 }
             );
+
+		console.log("TEST TEST");
+		console.log(trigger);
+
+		if (trigger === "channellingfire") {lore = 1}
+		if (trigger === "channellingheavens") {lore = 2}
+		if (trigger === "channellingmetal") {lore = 3}
+		if (trigger === "channellingbeasts") {lore = 4}
+		if (trigger === "channellinglife") {lore = 5}
+		if (trigger === "channellinglight") {lore = 6}
+		if (trigger === "channellingdeath") {lore = 7}
+		if (trigger === "channellingshadows") {lore = 8}
+		if (trigger === "channellingwitch") {lore = 9}
+		if (trigger === "channellingdark") {lore = 10}
+		if (trigger === "channellingchaos") {lore = 11}
+		if (trigger === "channellinggreatmaw") {lore = 12}
+		if (trigger === "channellingmisc") {lore = 13}
+		
+		console.log(lore);
+				
+				getSectionIDs("repeating_spellbookarcane", function (ids) {
+                    // create an object to hold all the attributes we are bout to change
+                    const output = {};
+                    // loop through the row ids
+                    ids.forEach(id => {
+					
+						getAttrs([`repeating_spellbookarcane_${id}_MagicLore`, `repeating_spellbookarcane_${id}_spellchannelsl`, "WillPowerBonus"], function(v) {
+						
+							accuchanexlsl = v[`repeating_spellbookarcane_${id}_spellchannelsl`];
+							
+						
+							if(v[`repeating_spellbookarcane_${id}_MagicLore`] == lore)
+							{
+							extslout = accuchanexlsl + extsl;
+							if (extslout < 0) {extslout = 0;}
+							
+							if (chancrit === 1) {extslout += v.WillPowerBonus;}
+							
+							output[`repeating_spellbookarcane_${id}_spellchannelsl`] = extslout, setAttrs(output, {silent: true})
+							}
+						});					
+					
+                    });
+				});
+				
+				getSectionIDs("repeating_spellbookrituals", function (ids) {
+                    // create an object to hold all the attributes we are bout to change
+                    const output = {};
+                    // loop through the row ids
+                    ids.forEach(id => {
+					
+						getAttrs([`repeating_spellbookrituals_${id}_MagicLore`, `repeating_spellbookrituals_${id}_spellchannelsl`, "WillPowerBonus"], function(v) {
+						
+							accuchanexlsl = v[`repeating_spellbookarcane_${id}_spellchannelsl`];
+							
+							if(v[`repeating_spellbookrituals_${id}_MagicLore`] == lore)
+							{
+							extslout = accuchanexlsl + extsl;
+							if (extslout < 0) {extslout = 0;}
+							
+							if (chancrit === 1) {extslout += v.WillPowerBonus;}
+							
+							output[`repeating_spellbookrituals_${id}_spellchannelsl`] = extslout, setAttrs(output, {silent: true})
+							}
+						});					
+					
+                    });
+				});
+			
+			
         });
     });
 	

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -42248,9 +42248,6 @@ on('clicked:repeating_spellbookarcane:spellcast clicked:repeating_spellbookarcan
    
    let rollBegins = '@{Whisper} &{template:whfrp2e}';
    
-               console.log(" TEST ");
-               console.log(cnlore);
-   
    let rollDmg = rollDmgPart.replaceAll('prefix2-', `${prefix}`);
    let rollPart = roll.replaceAll('Accu-', accumod).replaceAll('prefix2-', `${prefix}`).replaceAll('[cnlore]', cnlore);
    
@@ -42284,8 +42281,6 @@ on('clicked:repeating_spellbookarcane:spellcast clicked:repeating_spellbookarcan
 			if (lore === 7) {if (v.Talent_SuffusedWithShiyshLvl == 1) {suffadd = 1; lorecomp = 7;} else {suffadd = 0; lorecomp = 0;}} 
 			if (lore === 8) {if (v.Talent_SuffusedWithAzyrLvl == 1) {suffadd = 1; lorecomp = 8;} else {suffadd = 0; lorecomp = 0;}} 
 			
-               console.log(lore);	
-               console.log(lorecomp);	
 			
 		setAttrs({
             "LastRollAccuExtSL": accuchanexlsl,
@@ -42330,9 +42325,6 @@ on('clicked:repeating_spellbookarcane:spellcast clicked:repeating_spellbookarcan
 							{
 							output[`repeating_spellbookarcane_${id}_spellchannelsl`] = 0, setAttrs(output, {silent: true})
 							
-               console.log("check");	
-               console.log(v[`repeating_spellbookarcane_${id}_UsedSpell1`]);	
-							
 							if(v[`repeating_spellbookarcane_${id}_UsedSpell1`] === 1)
 							{
 							setAttrs({
@@ -42357,6 +42349,22 @@ on('clicked:repeating_spellbookarcane:spellcast clicked:repeating_spellbookarcan
 					});					
 					
                 });
+				getSectionIDs("repeating_spellbookrituals", function (ids) {
+                    // create an object to hold all the attributes we are bout to change
+                    const output = {};
+                    // loop through the row ids
+                    ids.forEach(id => {
+					
+						getAttrs([`repeating_spellbookrituals_${id}_MagicLore`], function(v) {
+						
+							if(v[`repeating_spellbookrituals_${id}_MagicLore`] == lore)
+							{
+							output[`repeating_spellbookrituals_${id}_spellchannelsl`] = 0, setAttrs(output, {silent: true})
+							}
+						});					
+					
+                    });
+				});
         });
                     });
 						}
@@ -42370,7 +42378,7 @@ on('clicked:repeating_spellbookarcane:spellcast clicked:repeating_spellbookarcan
 	
 
 on('clicked:repeating_spellbookarcane:extchannellingloreroll', (eventInfo) => {
-	getAttrs(["initiative_houserule", "WillPowerBonus"], function(v) {	
+	getAttrs(["initiative_houserule"], function(v) {	
 	
    let roll = '{{test=[[@{roll_rule}]]}} {{sl=[[0 [Roll SL]]]}} {{slbonus=[[@{Talent_AethyricAttunementLvl} [SL TOTAL]]]}} {{slbonusatk=[[@{slbonusChannel}]]}} {{sladd=[[0]]}} {{modvalue=[[?{Channeling Roll Modifier|@{prefix2-_ChanMod}}]]}} {{title=^{EXTENDED-CHANNELLING-TEST}}} {{skill=^{ADVANCED-SKILL}}}} {{unconscious=[[@{UnconsciousMod}]]}} {{cond=[[@{condgen_see}-@{DrunkMod}]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{character_name=@{character_name}}} {{target=[[ [[(@{condgen_see}*-1)]] [COND] + @{prefix2-_ExtChannellingLore} [SKILL] + ?{Channeling Roll Modifier|0} [MOD] ]]}} {{skilltest=true}} {{accuchanexlsl=[[?{Accumulated Extended Channelling SL (Start at 0)|@{prefix2-_spellchannelsl}}}} {{SLmod=[[?{SL Modifier|0}]]]]}} {{SLmod=[[?{SL Modifier|0}]]}} {{rolltype=[[9]]}} {{lore=[[@{prefix2-_MagicLore}]]}} {{robes=[[@{Used_Wizard_Robes}]]}} {{mod1type=[[@{prefix2-_ExtChannellingLoreRoll_modtype1}]]}} {{mod1=@{prefix2-_ExtChannellingLoreRoll_mod1}}} {{mod2type=[[@{prefix2-_ExtChannellingLoreRoll_modtype2}]]}} {{mod2=@{prefix2-_ExtChannellingLoreRoll_mod2}}} {{mod3type=[[@{prefix2-_ExtChannellingLoreRoll_modtype3}]]}} {{mod3=@{prefix2-_ExtChannellingLoreRoll_mod3}}} {{NPC=[[0]]}} {{RTminor=@{RT-minor}}} {{RTmajor=@{RT-major}}} {{reroll=[1](~@{character_name}|prefix2-_extchannellingloreroll)}} {{sptal1=[[@{Talent_AethyricAttunementLvl}]]}} {{testoutcome=[[0]]}}';
    var trigger = eventInfo.triggerName.slice(8);
@@ -42450,7 +42458,7 @@ on('clicked:repeating_spellbookarcane:extchannellingloreroll', (eventInfo) => {
                     // loop through the row ids
                     ids.forEach(id => {
 					
-						getAttrs([`repeating_spellbookarcane_${id}_MagicLore`, `repeating_spellbookarcane_${id}_UsedSpell1`, `repeating_spellbookarcane_${id}_UsedSpell2`, `repeating_spellbookarcane_${id}_UsedSpell3`], function(v) {
+						getAttrs([`repeating_spellbookarcane_${id}_MagicLore`, `repeating_spellbookarcane_${id}_UsedSpell1`, `repeating_spellbookarcane_${id}_UsedSpell2`, `repeating_spellbookarcane_${id}_UsedSpell3`, "WillPowerBonus"], function(v) {
 						
 							if(v[`repeating_spellbookarcane_${id}_MagicLore`] == lore)
 							{
@@ -42460,7 +42468,6 @@ on('clicked:repeating_spellbookarcane:extchannellingloreroll', (eventInfo) => {
 							
 							output[`repeating_spellbookarcane_${id}_spellchannelsl`] = extslout, setAttrs(output, {silent: true})			
 	
-							
 							if(v[`repeating_spellbookarcane_${id}_UsedSpell1`] === 1)
 							{
 							setAttrs({
@@ -42482,6 +42489,29 @@ on('clicked:repeating_spellbookarcane:extchannellingloreroll', (eventInfo) => {
 							
 							
 							
+							}
+						});					
+					
+                    });
+				});
+				
+				
+				getSectionIDs("repeating_spellbookrituals", function (ids) {
+                    // create an object to hold all the attributes we are bout to change
+                    const output = {};
+                    // loop through the row ids
+                    ids.forEach(id => {
+					
+						getAttrs([`repeating_spellbookrituals_${id}_MagicLore`, "WillPowerBonus"], function(v) {
+						
+							if(v[`repeating_spellbookrituals_${id}_MagicLore`] == lore)
+							{
+							extslout = accuchanexlsl + extsl;
+							if (extslout < 0) {extslout = 0;}
+							
+							if (chancrit === 1) {extslout += v.WillPowerBonus;}
+							
+							output[`repeating_spellbookrituals_${id}_spellchannelsl`] = extslout, setAttrs(output, {silent: true})
 							}
 						});					
 					
@@ -42524,11 +42554,33 @@ on('clicked:repeating_spellbookarcane:channelreset', (eventInfo) => {
 							if(v[`repeating_spellbookarcane_${id}_MagicLore`] == lore)
 							{
 							output2[`repeating_spellbookarcane_${id}_spellchannelsl`] = 0, setAttrs(output2, {silent: true})
+									   
+				getSectionIDs("repeating_spellbookrituals", function (ids) {
+                    // create an object to hold all the attributes we are bout to change
+                    const output = {};
+                    const output2 = {};
+                    // loop through the row ids
+                    ids.forEach(id => {
+					
+			
+						getAttrs([`repeating_spellbookrituals_${id}_MagicLore`], function(v) {
+						
+							if(v[`repeating_spellbookrituals_${id}_MagicLore`] == lore)
+							{
+							output2[`repeating_spellbookrituals_${id}_spellchannelsl`] = 0, setAttrs(output2, {silent: true})
+							}
+						});					
+					
+                    });
+				});		
 							}
 						});					
 					
                     });
 				});
+				
+				
+				
 
     });
 	
@@ -42574,23 +42626,13 @@ on('clicked:repeating_spellbookrituals:spellcast  clicked:repeating_spellbookrit
 							if (etest === e2test) {cnlore += 1;}
 							if (etest === 14) {cnlore += 1;}
 	
-
-               console.log(etest);
-               console.log(e2test);
-
-	
    let roll = '{{sl=[[0 [Roll SL]]]}} {{slbonus=[[@{Talent_InstinctiveDictionLvl}+@{Talent_PerfectPitchLvl} [SL TOTAL]]]}} {{slbonusatk=[[@{slbonusCast}]]}} {{sladd=[[0]]}} {{modvalue=[[?{@{translation_modifier}|@{prefix2-_SpellMod}}]]}} {{accuchanexlsl=[[Accu-]]}} {{title=@{prefix2-_spellname}}} {{character_name=@{character_name}}} {{advantage=[[@{Advantage}*10*@{Advantage_casting}]]}} {{unconscious=[[@{UnconsciousMod}]]}} {{cond=[[@{condgen_see}-@{DrunkMod}]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{spelltype=^{RITUALS}}} {{target=[[ [[(@{condgen_see}*-1)]] [COND] + [[{@{LangMagick}}]] [SKILL] + ?{@{translation_modifier}|0} [MOD] + [[@{Advantage}*10*@{Advantage_casting}]] [ADV] ]]}} {{consequence=@{prefix2-_ritualcons}}} {{spelldescription=@{prefix2-_spelldesc}}} {{test=[[@{roll_rule}]]}} {{SLmod=[[?{SL Modifier|0}]]}} {{spelltest=[[1d10]]}} {{arcanetest=true}} {{rolltype=[[6]]}} {{spellcastingnumber=[[@{prefix2-_spellcastingnumber}-[cnlore]+(3*(@{prefix2-_spellcastingnumber}*((@{prefix2-_Spellmem}-1)*-1)))]]}} {{mod1type=[[@{prefix2-_ArcaneSpell_modtype1}]]}} {{mod1=@{prefix2-_ArcaneSpell_mod1}}} {{mod2type=[[@{prefix2-_ArcaneSpell_modtype2}]]}} {{mod2=@{prefix2-_ArcaneSpell_mod2}}} {{mod3type=[[@{prefix2-_ArcaneSpell_modtype3}]]}} {{mod3=@{prefix2-_ArcaneSpell_mod3}}} {{NPC=[[0]]}} {{RTminor=@{RT-minor}}} {{RTmajor=@{RT-major}}} {{RTgrim=@{RT-grim}}} {{sptal2=[[@{Talent_InstinctiveDictionLvl}]]}} {{sptal3=[[@{Talent_PerfectPitchLvl}]]}} {{sptal23=[[@{Talent_InstinctiveandPitch}]]}} {{spellmem=[[@{prefix2-_Spellmem}]]}} {{lore=[[@{prefix2-_MagicLore}]]}} {{usedenchstaff=[[@{prefix2-_Used_Enchanted_Staff_show}]]}} {{cnsl=[[?{Accumulated Extended Channelling SL (Start at 0)|@{prefix2-_spellchannelsl}}-(@{prefix2-_spellcastingnumber}+(@{prefix2-_spellcastingnumber}*((@{prefix2-_Spellmem}-1)*-1)))]]}} {{testoutcome=[[0]]}}';
    
    let rollBegins = '@{Whisper} &{template:whfrp2e}';
    
-               console.log(trigger);
-               console.log(skill);
-               console.log(accumod);
-   
    let rollDmg = rollDmgPart.replaceAll('prefix2-', `${prefix}`);
    let rollPart = roll.replaceAll('Accu-', accumod).replaceAll('prefix2-', `${prefix}`).replaceAll('[cnlore]', cnlore);
    
-   	
                console.log(rollPart);	
 				
         startRoll(rollBegins + rollPart + rollDmg, (results) => {
@@ -42643,6 +42685,23 @@ on('clicked:repeating_spellbookrituals:spellcast  clicked:repeating_spellbookrit
 			
 				const playerclickedid = eventInfo.sourceAttribute.split('_')[2] || '';				
 				
+				getSectionIDs("repeating_spellbookarcane", function (ids) {
+                if (playerclickedid == ids.toLowerCase) return;
+                    // create an object to hold all the attributes we are bout to change
+                    const output = {};
+                    // loop through the row ids
+                    ids.forEach(id => {
+					
+						getAttrs([`repeating_spellbookarcane_${id}_MagicLore`], function(v) {
+						
+							if(v[`repeating_spellbookarcane_${id}_MagicLore`] == lore)
+							{
+							output[`repeating_spellbookarcane_${id}_spellchannelsl`] = 0, setAttrs(output, {silent: true})
+							}
+						});					
+					
+                    });
+					});
 				getSectionIDs("repeating_spellbookrituals", function (ids) {
                 if (playerclickedid == ids.toLowerCase) return;
                     // create an object to hold all the attributes we are bout to change
@@ -42659,7 +42718,7 @@ on('clicked:repeating_spellbookrituals:spellcast  clicked:repeating_spellbookrit
 						});					
 					
                     });
-        });
+					});
 	});
                     });
 						}
@@ -42673,7 +42732,7 @@ on('clicked:repeating_spellbookrituals:spellcast  clicked:repeating_spellbookrit
 	
 
 on('clicked:repeating_spellbookrituals:extchannellingloreroll', (eventInfo) => {
-	getAttrs(["initiative_houserule", "WillPowerBonus"], function(v) {	
+	getAttrs(["initiative_houserule"], function(v) {	
 	
    let roll = '{{test=[[@{roll_rule}]]}} {{sl=[[0 [Roll SL]]]}} {{slbonus=[[@{Talent_AethyricAttunementLvl} [SL TOTAL]]]}} {{slbonusatk=[[@{slbonusChannel}]]}} {{sladd=[[0]]}} {{modvalue=[[?{Channeling Roll Modifier|@{prefix2-_ChanMod}}]]}} {{title=^{EXTENDED-CHANNELLING-TEST}}} {{skill=^{ADVANCED-SKILL}}}} {{unconscious=[[@{UnconsciousMod}]]}} {{cond=[[@{condgen_see}-@{DrunkMod}]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[@{ProneMod}]]}} {{entangled=[[@{EntangledMod}]]}} {{blinded=[[@{BlindedMod}]]}} {{deafened=[[0]]}} {{character_name=@{character_name}}} {{target=[[ [[(@{condgen_see}*-1)]] [COND] + @{prefix2-_ExtChannellingLore} [SKILL] + ?{Channeling Roll Modifier|0} [MOD] ]]}} {{skilltest=true}} {{accuchanexlsl=[[?{Accumulated Extended Channelling SL (Start at 0)|@{prefix2-_spellchannelsl}}]]}} {{ritualsacr=@{prefix2-_ritualsacr}}} {{SLmod=[[?{SL Modifier|0}]]}} {{SLmod=[[?{SL Modifier|0}]]}} {{rolltype=[[9]]}} {{lore=[[@{prefix2-_MagicLore}]]}} {{robes=[[@{Used_Wizard_Robes}]]}} {{mod1type=[[@{prefix2-_ExtChannellingLoreRoll_modtype1}]]}} {{mod1=@{prefix2-_ExtChannellingLoreRoll_mod1}}} {{mod2type=[[@{prefix2-_ExtChannellingLoreRoll_modtype2}]]}} {{mod2=@{prefix2-_ExtChannellingLoreRoll_mod2}}} {{mod3type=[[@{prefix2-_ExtChannellingLoreRoll_modtype3}]]}} {{mod3=@{prefix2-_ExtChannellingLoreRoll_mod3}}} {{NPC=[[0]]}} {{RTminor=@{RT-minor}}} {{RTmajor=@{RT-major}}} {{reroll=[1](~@{character_name}|prefix2-_extchannellingloreroll)}} {{sptal1=[[@{Talent_AethyricAttunementLvl}]]}} {{testoutcome=[[0]]}}';
    var trigger = eventInfo.triggerName.slice(8);
@@ -42744,16 +42803,37 @@ on('clicked:repeating_spellbookrituals:extchannellingloreroll', (eventInfo) => {
                     testoutcome: outcome,
                 }
             );
-			
-				const playerclickedid = eventInfo.sourceAttribute.split('_')[2] || '';				
+					
 				
+				getSectionIDs("repeating_spellbookarcane", function (ids) {
+                    // create an object to hold all the attributes we are bout to change
+                    const output = {};
+                    // loop through the row ids
+                    ids.forEach(id => {
+					
+						getAttrs([`repeating_spellbookarcane_${id}_MagicLore`, "WillPowerBonus"], function(v) {
+						
+							if(v[`repeating_spellbookarcane_${id}_MagicLore`] == lore)
+							{
+							extslout = accuchanexlsl + extsl;
+							if (extslout < 0) {extslout = 0;}
+							
+							if (chancrit === 1) {extslout += v.WillPowerBonus;}
+							
+							output[`repeating_spellbookarcane_${id}_spellchannelsl`] = extslout, setAttrs(output, {silent: true})
+							}
+						});					
+					
+                    });
+				});
+
 				getSectionIDs("repeating_spellbookrituals", function (ids) {
                     // create an object to hold all the attributes we are bout to change
                     const output = {};
                     // loop through the row ids
                     ids.forEach(id => {
 					
-						getAttrs([`repeating_spellbookrituals_${id}_MagicLore`], function(v) {
+						getAttrs([`repeating_spellbookrituals_${id}_MagicLore`, "WillPowerBonus"], function(v) {
 						
 							if(v[`repeating_spellbookrituals_${id}_MagicLore`] == lore)
 							{
@@ -42769,7 +42849,6 @@ on('clicked:repeating_spellbookrituals:extchannellingloreroll', (eventInfo) => {
                     });
 				});
 
-
     });
 		
     });
@@ -42781,7 +42860,7 @@ on('clicked:repeating_spellbookrituals:channelreset', (eventInfo) => {
 				
                console.log("channel reset");
 			   lore = '';
-			   
+	   
 				getSectionIDs("repeating_spellbookrituals", function (ids) {
                     // create an object to hold all the attributes we are bout to change
                     const output = {};
@@ -42805,6 +42884,25 @@ on('clicked:repeating_spellbookrituals:channelreset', (eventInfo) => {
 							if(v[`repeating_spellbookrituals_${id}_MagicLore`] == lore)
 							{
 							output2[`repeating_spellbookrituals_${id}_spellchannelsl`] = 0, setAttrs(output2, {silent: true})
+										   
+				getSectionIDs("repeating_spellbookarcane", function (ids) {
+                    // create an object to hold all the attributes we are bout to change
+                    const output = {};
+                    const output2 = {};
+                    // loop through the row ids
+                    ids.forEach(id => {
+					
+			
+						getAttrs([`repeating_spellbookarcane_${id}_MagicLore`], function(v) {
+						
+							if(v[`repeating_spellbookarcane_${id}_MagicLore`] == lore)
+							{
+							output2[`repeating_spellbookarcane_${id}_spellchannelsl`] = 0, setAttrs(output2, {silent: true})
+							}
+						});					
+					
+                    });
+				});		
 							}
 						});					
 					
@@ -43233,9 +43331,6 @@ on('clicked:repeating_divinemiracles:miracle clicked:repeating_divinemiracles:mi
                 }
             );
 
-		console.log("TEST TEST");
-		console.log(trigger);
-
 		if (trigger === "channellingfire") {lore = 1}
 		if (trigger === "channellingheavens") {lore = 2}
 		if (trigger === "channellingmetal") {lore = 3}
@@ -43250,8 +43345,6 @@ on('clicked:repeating_divinemiracles:miracle clicked:repeating_divinemiracles:mi
 		if (trigger === "channellinggreatmaw") {lore = 12}
 		if (trigger === "channellingmisc") {lore = 13}
 		
-		console.log(lore);
-				
 				getSectionIDs("repeating_spellbookarcane", function (ids) {
                     // create an object to hold all the attributes we are bout to change
                     const output = {};
@@ -43285,7 +43378,7 @@ on('clicked:repeating_divinemiracles:miracle clicked:repeating_divinemiracles:mi
 					
 						getAttrs([`repeating_spellbookrituals_${id}_MagicLore`, `repeating_spellbookrituals_${id}_spellchannelsl`, "WillPowerBonus"], function(v) {
 						
-							accuchanexlsl = v[`repeating_spellbookarcane_${id}_spellchannelsl`];
+							accuchanexlsl = v[`repeating_spellbookrituals_${id}_spellchannelsl`];
 							
 							if(v[`repeating_spellbookrituals_${id}_MagicLore`] == lore)
 							{


### PR DESCRIPTION
- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

- Fixed Enchanted Staff CN mod when casting. Should now add -1 appropriately for all Lore's.
- Fixed used with Characteristics Mod add resetting under certain circumstances.
- Channelling rolls from the Skill tab will now add Accu Ext SL to spells and rituals of the same Lore.


