### PR TITLE
The Fantasy Trip:  feature add ready_XXX attributes mirroring the currently selected weapon or spell attributes.

### DIFF
--- a/The Fantasy Trip/TFT.html
+++ b/The Fantasy Trip/TFT.html
@@ -1052,6 +1052,8 @@
 
 
 	// select this weapon or spell, id starts with repeating_[weapon][spell]
+	// it will set attributes ready_name, damage, to_hit, attack, success, failure
+	// so macros can get at them.
 	const selectWeaponOrSpell = function(id) {
 		// get them all, and de check any not me...
 		let selected = (id + "_selection-flag").toLowerCase();
@@ -1061,6 +1063,7 @@
 					let oldValue = values[selected];
 					let newValue = (oldValue == 'on' ? 0 : 'on');
 					let valueMap = {};
+					let readyAttributes = [];
 					// toggle this one, turn off the rest
 					valueMap[selected]  = newValue;
 
@@ -1070,16 +1073,50 @@
 							let propertyName = repeatingPropertyName('weapons', weaponIds[i], 'selection-flag');
 							if (propertyName != selected) {
 								valueMap[propertyName] = 0;
+							} else {
+								let id = weaponIds[i];
+								readyAttributes = [repeatingPropertyName('weapons', id, 'weaponname'),
+									repeatingPropertyName('weapons', id, 'weapondamage'),
+									repeatingPropertyName('weapons', id, 'tohit'),
+									repeatingPropertyName('weapons', id, 'attackflavor'),
+									repeatingPropertyName('weapons', id, 'successflavor'),
+									repeatingPropertyName('weapons', id, 'failureflavor')];
 							}
 						}
 						for (var i = 0; i < spellIds.length; ++i) {
 							let propertyName = repeatingPropertyName('spells', spellIds[i], 'selection-flag');
 							if (propertyName != selected) {
 								valueMap[propertyName] = 0;
+							} else {
+								let id = spellIds[i];
+								readyAttributes = [repeatingPropertyName('spells', id, 'spellname'),
+								repeatingPropertyName('spells', id, 'spelldamage'),
+								repeatingPropertyName('spells', id, 'tohit'),
+								repeatingPropertyName('spells', id, 'attackflavor'),
+								repeatingPropertyName('spells', id, 'successflavor'),
+								repeatingPropertyName('spells', id, 'failureflavor')];
 							}
 						}
 					}
-					setAttrs(valueMap, {silent: true});
+					getAttrs(readyAttributes, function(readyValues) {
+						// convert into ready_ attributes.
+						for (const [key, value] of Object.entries(readyValues)) {
+							if (key.endsWith('name')) {
+								valueMap['ready_name'] = value
+							} else if (key.endsWith('damage')) {
+								valueMap['ready_damage'] = value
+							} else if (key.endsWith('tohit')) {
+								valueMap['ready_tohit'] = value
+							} else if (key.endsWith('attackflavor')) {
+								valueMap['ready_attackflavor'] = value
+							} else if (key.endsWith('successflavor')) {
+								valueMap['ready_successflavor'] = value
+							} else if (key.endsWith('failureflavor')) {
+								valueMap['ready_failureflavor'] = value
+							}
+						}
+						setAttrs(valueMap, {silent: true});
+					})
 				});
 			});
 		});


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

 - When a weapon or spell is selected, attributes beginning with the word "ready" are set to mirror the current selection.  So we have `ready_name`, `ready_damage`, `ready_tohit`, `ready_attackflavor`, `ready_successflavor`, and `ready_failureflavor`  This to make it easier/possible for macro writers to get at the currently selected or "ready" spell or weapon.




