### PR TITLE
[Warhammer 4e Character Sheet] Dual Wield - Crit update

### DIFF
--- a/Warhammer 4e Character Sheet/README.md
+++ b/Warhammer 4e Character Sheet/README.md
@@ -83,7 +83,7 @@ Note conditions are not intended for out of combat situations, GM simply makes t
 
 August 16th 2022 v1.6b
 
-- Adds conditional check when peforming Dual Wield attack, if the Player has just rolled a crit, they now will chose if they want to use main hand or crit result for the DW attack.
+- Adds conditional check when peforming Dual Wield attack, if the Player has just rolled a crit, they now will chose if they want to use main hand or crit result for the DW attack. Crit result DW hits will now remove any modifier on crit roll before reversal, so result stays within 1d100 range.
 
 
 August 8th 2022 v1.6a

--- a/Warhammer 4e Character Sheet/README.md
+++ b/Warhammer 4e Character Sheet/README.md
@@ -81,6 +81,11 @@ Note conditions are not intended for out of combat situations, GM simply makes t
  
 ///// ============ Change Log ============ /////  
 
+August 16th 2022 v1.6b
+
+- Adds conditional check when peforming Dual Wield attack, if the Player has just rolled a crit, they now will chose if they want to use main hand or crit result for the DW attack.
+
+
 August 8th 2022 v1.6a
 
 - Fixed Enchanted Staff CN mod when casting. Should now add -1 appropriatly for all Lore's.

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -41608,7 +41608,7 @@ on('clicked:meleeattackoff clicked:meleechargeoff clicked:furiousassaultoff clic
 	if (trigger == "dualwieldoff") {rollEnd = ' {{berserkcharge=[[0]]}} {{RTfuriousassault=@{RT-furiousassaultoff}}} {{furiousassault=[[@{Talent_FuriousAssaultLvl}]]}} {{reroll=@{RT-reroll}MeleeAttackOff)}} {{dualwield=[[@{Talent_DualWielderLvl}]]}} {{dwuse}}';
 	rollPart2 = roll.replaceAll('>addsl<', '+@{Talent_DualWielderLvl}>addsldf<');
 	if (lastcrit > 0) {	
-	rollPart3 = rollPart2.replaceAll('>test<', `${lastcrit}`);
+	rollPart3 = rollPart2.replaceAll('>test<', '?{Use Crit Result|Yes, ' + `${lastcrit}` + '|No, ' + `${rollrev}` + '}');
 	} else {	
 	rollPart3 = rollPart2.replaceAll('>test<', `${rollrev}`);
 	}

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -43908,10 +43908,11 @@ on('clicked:criticalroll', (eventInfo) => {
                console.log(rollPart);					
         startRoll(rollBegins + rollPart, (results) => {
             const critroll = results.results.critroll.result
+            const modvalue = results.results.modvalue.result
 
 	setAttrs(
 	{
-		"LastCritRoll": critroll
+		"LastCritRoll": critroll - modvalue
 	}, {silent: true});		
 
 						

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -27659,7 +27659,7 @@
 		<div class="sheet-spacer-xl"></div>
 		<!-- FOOTER -->
 		<div class="sheet-row sheet-footer">
-			<div class="sheet-col-1 sheet-small-label sheet-center">Sheet version 1.6a : August 8th 2022 | by Djjus & Pote</div>
+			<div class="sheet-col-1 sheet-small-label sheet-center">Sheet version 1.6b : August 16th 2022 | by Djjus & Pote</div>
 		</div>
 		</div>
 	</div>


### PR DESCRIPTION
- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

- Adds conditional check when performing follow up Dual Wield attack, if the Player has just rolled a crit, they now will chose if they want to use main hand or crit result for the DW attack. Crit result DW hits will now remove any modifier on crit roll before reversal, so result stays within 1d100 range.



