### PR TITLE
Update HeroSystem6e.html to improve the Combat tab

### DIFF
--- a/HeroSystem6e/HeroSystem6e.html
+++ b/HeroSystem6e/HeroSystem6e.html
@@ -125,6 +125,7 @@
 							<button type="roll" class="edit-hide tooltip" name="roll_Attack_Roll" value="@{ocv_formula}"></button>
 							<span class="tooltiptext">Attack&nbsp;Roll</span>
 						</div>
+						<!-- XXX - New code -->
 						<input type="hidden" name="attr_ocv_formula" value="&{template:hero6template} {{charname=@{character_name}}} {{action=Attack Roll}} {{attack=[[3d6]]}} {{ocv=@{OCV}}} {{hitlocation=[[@{hit_location_roll}]]}} {{damage=[[@{hth} @{preview_damage}]]}} {{type=STUN}} {{count=BODY}}" />
 					</div>
 					<div class="line">
@@ -550,6 +551,7 @@
 							<button type="roll" class="edit-hide tooltip" name="roll_Attack_Roll" value="@{ocv_formula}"></button>
 							<span class="tooltiptext">Attack&nbsp;Roll</span>
 						</div>
+            <!-- XXX -->
 						<input type="hidden" name="attr_ocv_formula" value="&{template:hero6template} {{charname=@{character_name}}} {{action=Attack Roll}} {{attack=[[3d6]]}} {{ocv=@{OCV}}} {{hitlocation=[[@{hit_location_roll}]]}} {{damage=[[@{hth} @{preview_damage}]]}} {{type=STUN}} {{count=BODY}}" />
 					</div>
 					<div class="line">
@@ -970,10 +972,76 @@
 		</div><!-- end column-100 -->
 
 		<div class="column-60">
+			<div class="section">
+				<input type="checkbox" class="section-title" value="attr_section_9" checked="checked"/>
+				<span class="section-title">COMBAT SKILL LEVELS</span>
+
+				<div class="subsection">
+
+					<div class="line heads">
+						<div class="cs0"></div>
+						<div class="cs1 indent">Type</div>
+						<div class="cs2">OCV</div>
+						<div class="cs3">DCV</div>
+						<div class="cs4">OMCV</div>
+						<div class="cs5">DMCV</div>
+						<div class="cs6">&frac12;DC</div>
+					</div>
+					<fieldset class="repeating_combatskills">
+						<div class="line">
+							<div class="cs0"><input type="checkbox" name="attr_csl_checkbox" value="1" /></div>
+							<input type="text" class="cs1 edit-show" name="attr_csl_name" value="" />
+							<span class="cs1 field edit-hide" name="attr_csl_name" disabled="true"></span>
+							<div class="cs2"><input type="checkbox" name="attr_radio_csl_ocv" value="1" /></div>
+							<div class="cs3"><input type="checkbox" name="attr_radio_csl_dcv" value="1" /></div>
+							<div class="cs4"><input type="checkbox" name="attr_radio_csl_omcv" value="1" /></div>
+							<div class="cs5"><input type="checkbox" name="attr_radio_csl_dmcv" value="1" /></div>
+							<div class="cs6"><input type="checkbox" name="attr_radio_csl_dc" value="1" /></div>
+						</div>
+					</fieldset>
+				</div><!-- end subsection -->
+
+			</div><!-- end section -->
 
 			<div class="section">
 				<input type="checkbox" class="section-title" value="attr_section_8" checked="checked"/>
-				<span class="section-title">ATTACKS &amp; MANEUVERS</span>
+				<span class="section-title">RANGE ONLY MANEUVERS</span>
+
+				<div class="subsection">
+					<div class="line heads">
+						<div class="am0"></div>
+						<div class="am1">Maneuver</div>
+						<div class="am2">Phs</div>
+						<div class="am2">OCV</div>
+						<div class="am2">DCV</div>
+						<div class="am3">Dmg</div>
+						<div class="am4">Effects</div>
+					</div>
+					<div class="line">
+						<div class="am0"><input type="checkbox" name="attr_radio_maneuver3" value="1" /></div>
+						<div class="am1">Brace</div>
+						<div class="am2">0</div>
+						<div class="am2">+0</div>
+						<div class="am2">&#189;</div>
+						<div class="am3"></div>
+						<div class="am4">+2 RMod (-1 increment)</div>
+					</div>
+					<div class="line">
+						<div class="am0"><input type="checkbox" name="attr_radio_maneuver12" value="1" /></div>
+						<div class="am1">Set</div>
+						<div class="am2">1</div>
+						<div class="am2">+1</div>
+						<div class="am2">+0</div>
+						<div class="am3"></div>
+						<div class="am4">Ranged attacks only</div>
+					</div>
+				</div><!-- end subsection -->
+
+			</div><!-- end section -->
+
+			<div class="section">
+				<input type="checkbox" class="section-title" value="attr_section_8" checked="checked"/>
+				<span class="section-title">GENERAL MANEUVERS</span>
 
 				<div class="subsection">
 					<div class="line heads">
@@ -1002,15 +1070,6 @@
 						<div class="am2">+0</div>
 						<div class="am3"></div>
 						<div class="am4">Block, Abort</div>
-					</div>
-					<div class="line">
-						<div class="am0"><input type="checkbox" name="attr_radio_maneuver3" value="1" /></div>
-						<div class="am1">Brace</div>
-						<div class="am2">0</div>
-						<div class="am2">+0</div>
-						<div class="am2">&#189;</div>
-						<div class="am3"></div>
-						<div class="am4">+2 RMod (-1 increment)</div>
 					</div>
 					<div class="line">
 						<div class="am0"><input type="checkbox" name="attr_radio_maneuver4" value="1" /></div>
@@ -1096,15 +1155,6 @@
 						</div>
 					</div>
 					<div class="line">
-						<div class="am0"><input type="checkbox" name="attr_radio_maneuver12" value="1" /></div>
-						<div class="am1">Set</div>
-						<div class="am2">1</div>
-						<div class="am2">+1</div>
-						<div class="am2">+0</div>
-						<div class="am3"></div>
-						<div class="am4">Ranged attacks only</div>
-					</div>
-					<div class="line">
 						<div class="am0"><input type="checkbox" name="attr_radio_maneuver13" value="1" /></div>
 						<div class="am1">Shove</div>
 						<div class="am2">&#189;</div>
@@ -1139,6 +1189,23 @@
 						<div class="am2">-2</div>
 						<div class="am3"></div>
 						<div class="am4">Knock target prone</div>
+					</div>
+				</div><!-- end subsection -->
+
+			</div><!-- end section -->
+			<div class="section">
+				<input type="checkbox" class="section-title" value="attr_section_8" checked="checked"/>
+				<span class="section-title">MARTIAL MANEUVERS<BR /></span>
+                <span><strong>NOTE:</strong> You must purchase these maneuvers to use them.</span>
+				<div class="subsection">
+					<div class="line heads">
+						<div class="am0"></div>
+						<div class="am1">Maneuver</div>
+						<div class="am2">Phs</div>
+						<div class="am2">OCV</div>
+						<div class="am2">DCV</div>
+						<div class="am3">Dmg</div>
+						<div class="am4">Effects</div>
 					</div>
 					<fieldset class="repeating_maneuvers">
 						<div class="line">
@@ -1206,40 +1273,36 @@
 
 			</div><!-- end section -->
 
+		</div><!-- end column-60 -->
+
+		<div class="column-40">
+
 			<div class="section">
-				<input type="checkbox" class="section-title" value="attr_section_9" checked="checked"/>
-				<span class="section-title">COMBAT SKILL LEVELS</span>
+				<input type="checkbox" class="section-title" value="attr_section_11" checked="checked"/>
+				<span class="section-title">PENALTY SKILL LEVELS</span>
 
 				<div class="subsection">
 
 					<div class="line heads">
-						<div class="cs0"></div>
-						<div class="cs1 indent">Type</div>
-						<div class="cs2">OCV</div>
-						<div class="cs3">DCV</div>
-						<div class="cs4">OMCV</div>
-						<div class="cs5">DMCV</div>
-						<div class="cs6">&frac12;DC</div>
+						<div class="ps0"></div>
+						<div class="ps1 indent">Type</div>
+						<div class="ps2">RMOD</div>
+						<div class="ps2">OCV</div>
+						<div class="ps2">DCV</div>
 					</div>
-					<fieldset class="repeating_combatskills">
+					<fieldset class="repeating_penaltyskills">
 						<div class="line">
-							<div class="cs0"><input type="checkbox" name="attr_csl_checkbox" value="1" /></div>
-							<input type="text" class="cs1 edit-show" name="attr_csl_name" value="" />
-							<span class="cs1 field edit-hide" name="attr_csl_name" disabled="true"></span>
-							<div class="cs2"><input type="checkbox" name="attr_radio_csl_ocv" value="1" /></div>
-							<div class="cs3"><input type="checkbox" name="attr_radio_csl_dcv" value="1" /></div>
-							<div class="cs4"><input type="checkbox" name="attr_radio_csl_omcv" value="1" /></div>
-							<div class="cs5"><input type="checkbox" name="attr_radio_csl_dmcv" value="1" /></div>
-							<div class="cs6"><input type="checkbox" name="attr_radio_csl_dc" value="1" /></div>
+							<div class="ps0"><input type="checkbox" name="attr_psl_checkbox" value="1" /></div>
+							<input type="text" class="ps1 edit-show" name="attr_psl_name" value="" />
+							<span class="ps1 field edit-hide" name="attr_psl_name" disabled="true"></span>
+							<div class="ps2"><input type="checkbox" name="attr_radio_psl_rmod" value="1" /></div>
+							<div class="ps2"><input type="checkbox" name="attr_radio_psl_ocv" value="1" /></div>
+							<div class="ps2"><input type="checkbox" name="attr_radio_psl_dcv" value="1" /></div>
 						</div>
 					</fieldset>
 				</div><!-- end subsection -->
 
 			</div><!-- end section -->
-
-		</div><!-- end column-60 -->
-
-		<div class="column-40">
 
 			<div class="section">
 				<input type="checkbox" class="section-title" value="attr_section_24" checked="checked"/>
@@ -1268,7 +1331,7 @@
 
 			<div class="section">
 				<input type="checkbox" class="section-title" value="attr_section_10" checked="checked"/>
-				<span class="section-title">COMBAT MODIFIERS</span>
+				<span class="section-title">RANGE MODIFIERS</span>
 
 				<div class="subsection">
 					<div class="line">
@@ -1298,8 +1361,15 @@
 						<div class="cm3">-8</div>
 						<div class="cm3">-10</div>
 					</div>
+				</div>
+			</div>
 
-					<div class="line heads cm0">
+			<div class="section">
+				<input type="checkbox" class="section-title" value="attr_section_10" checked="checked"/>
+				<span class="section-title">TARGETING MODIFIERS</span>
+				
+				<div class="subsection">
+					<div class="line heads">
 						<div class="cm4"></div>
 						<div class="cm5"></div>
 						<div class="cm6"></div>
@@ -1307,7 +1377,7 @@
 					</div>
 					<div class="line heads underline">
 						<div class="cm4"></div>
-						<div class="cm5">Shot Targetting</div>
+						<div class="cm5">Shot Target Area</div>
 						<div class="cm6">OCV</div>
 						<div class="cm7">Location</div>
 					</div>
@@ -1328,16 +1398,9 @@
 						    <button type="roll" value="&{template:hero6template} {{charname=@{character_name}}} {{action=Hit Location (normal)}} {{hitlocation=[[3d6]]}}">3d6</button>
 						</div>
 					</div>
-					<div class="line focus">
-						<div class="cm4"><input type="radio" name="attr_radio_target" value="2" /></div>
-						<div class="cm5">Focus</div>
-						<div class="cm6">-4</div>
-						<div class="cm7">Focus</div>
-					</div>
-
 					<div class="line">
 						<div class="cm4"><input type="radio" name="attr_radio_target" value="3" /></div>
-						<div class="cm5">Head Shot (Head to Shoulders)</div>
+						<div class="cm5">Head Area (Head to Shoulders)</div>
 						<div class="cm6">-4</div>
 						<div class="cm7 button">
 				    		<div>1d6+3</div>
@@ -1346,7 +1409,7 @@
 					</div>
 					<div class="line">
 						<div class="cm4"><input type="radio" name="attr_radio_target" value="4" /></div>
-						<div class="cm5">High Shot (Head to Vitals)</div>
+						<div class="cm5">High Area (Head to Vitals)</div>
 						<div class="cm6">-2</div>
 						<div class="cm7 button">
 			    			<div>2d6+1</div>
@@ -1355,7 +1418,7 @@
 					</div>
 					<div class="line">
 						<div class="cm4"><input type="radio" name="attr_radio_target" value="5" /></div>
-						<div class="cm5">Body Shot (Hands to Legs)</div>
+						<div class="cm5">Body Area (Hands to Legs)</div>
 						<div class="cm6">-1</div>
 						<div class="cm7 button">
 		    				<div>2d6+4</div>
@@ -1364,7 +1427,7 @@
 					</div>
 					<div class="line">
 						<div class="cm4"><input type="radio" name="attr_radio_target" value="6" /></div>
-						<div class="cm5">Low Shot (Shoulder to Feet)</div>
+						<div class="cm5">Low Area (Shoulder to Feet)</div>
 						<div class="cm6">-2</div>
 						<div class="cm7 button">
 	    					<div>2d6+7*</div>
@@ -1373,7 +1436,7 @@
 					</div>
 					<div class="line">
 						<div class="cm4"><input type="radio" name="attr_radio_target" value="7" /></div>
-						<div class="cm5">Leg Shot (Vitals to Feet)</div>
+						<div class="cm5">Leg Area (Vitals to Feet)</div>
 						<div class="cm6">-4</div>
 						<div class="cm7 button">
 							<div>1d6+12</div>
@@ -1383,14 +1446,21 @@
 					<div class="line">
 						<div class="cm8">* Treat a 19 as the Feet Location</div>
 					</div>
+				</div>
+			</div>
 
+			<div class="section">
+				<input type="checkbox" class="section-title" value="attr_section_10" checked="checked"/>
+				<span class="section-title">CALLED SHOT MODIFIERS</span>
+				
+				<div class="subsection">
 					<div class="line heads cm-wrap">
 						<div class="cm4">&nbsp;</div>
-						<div class="cm9">Targetting</div>
+						<div class="cm9">Targeting</div>
 						<div class="cm6">OCV</div>
 						<div class="cm-gap">&nbsp;</div>
 						<div class="cm4">&nbsp;</div>
-						<div class="cm9">Targetting</div>
+						<div class="cm9">Targeting</div>
 						<div class="cm6">OCV</div>
 					</div>
 					<div class="line">
@@ -1438,34 +1508,12 @@
 						<div class="cm9">Feet</div>
 						<div class="cm6">-8</div>
 					</div>
-
-				</div><!-- end subsection -->
-
-			</div><!-- end section -->
-
-			<div class="section">
-				<input type="checkbox" class="section-title" value="attr_section_11" checked="checked"/>
-				<span class="section-title">PENALTY SKILL LEVELS</span>
-
-				<div class="subsection">
-
-					<div class="line heads">
-						<div class="ps0"></div>
-						<div class="ps1 indent">Type</div>
-						<div class="ps2">RMOD</div>
-						<div class="ps2">OCV</div>
-						<div class="ps2">DCV</div>
+					<div class="line focus">
+						<div class="cm4"><input type="radio" name="attr_radio_target" value="2" /></div>
+						<div class="cm9">Focus</div>
+						<div class="cm6">-4</div>
 					</div>
-					<fieldset class="repeating_penaltyskills">
-						<div class="line">
-							<div class="ps0"><input type="checkbox" name="attr_psl_checkbox" value="1" /></div>
-							<input type="text" class="ps1 edit-show" name="attr_psl_name" value="" />
-							<span class="ps1 field edit-hide" name="attr_psl_name" disabled="true"></span>
-							<div class="ps2"><input type="checkbox" name="attr_radio_psl_rmod" value="1" /></div>
-							<div class="ps2"><input type="checkbox" name="attr_radio_psl_ocv" value="1" /></div>
-							<div class="ps2"><input type="checkbox" name="attr_radio_psl_dcv" value="1" /></div>
-						</div>
-					</fieldset>
+
 				</div><!-- end subsection -->
 
 			</div><!-- end section -->
@@ -4449,6 +4497,8 @@ on("change:repeating_powers:attack_wizard", function(eventinfo) {
 	});
 });
 
+
+
 var setPowerFormulas = function() {
 	getSectionIDs( "repeating_powers", function(ids) {
 
@@ -4637,6 +4687,8 @@ on("change:radio_maneuver1 change:radio_maneuver2 change:radio_maneuver3 change:
 	for( var i = 1; i <= 16; i++ ) {
 		if( element == ("radio_maneuver" + i) ) {
 			setAttrs({ [ "radio_maneuver" + i ] : value });
+		} else if (3 == i || 12 == i) { 
+		    // Do nothing. Allow these to remain checked. Set and Brace are allowed to combine with other maneuvers.
 		} else {
 			setAttrs({ [ "radio_maneuver" + i ] : 0 });
 		}
@@ -4662,7 +4714,7 @@ on("change:radio_maneuver1 change:radio_maneuver2 change:radio_maneuver3 change:
 
 
 
-/* saves maneuver values to a hidden field for later use */
+/* XXX saves maneuver values to a hidden field for later use */
 var setManeuver = function() {
 
 	getSectionIDs( "repeating_maneuvers", function(ids) {
@@ -4684,8 +4736,8 @@ var setManeuver = function() {
 			});
 		}
 
-	   var onLast = _.after(ids.length+16, function() {
-			saveAll();
+    var onLast = _.after(ids.length+16, function() {
+    saveAll();
 		});
 
 		var checkPreset = function(n) {
@@ -4744,7 +4796,7 @@ var setManeuver = function() {
 						break;
 					case 11:
 						pre_name = "Multiple Attack";
-						/* no pre_ocv.  player will need to use other modifier, -2 x number of targets over first */
+						/* pre_ocv. -2 x number of targets over first */
 						pre_ocv = multiattack_penalty;
 						pre_half_dcv = 1;
 						break;


### PR DESCRIPTION
- Allow set and brace to be used along with another maneuver (e.g., strike or haymaker) as per rules
- Separate the various kinds of combat maneuvers for cleaner look
- Bring Skill Levels to the top so that they are not overlooked
- Separate the range modifiers and called shots from the refined hit location areas
- Move "focus" to called shots

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)




