### PR TITLE
[Warhammer 4e Character Sheet] Chrome Dark Mode fix

### DIFF
--- a/Warhammer 4e Character Sheet/README.md
+++ b/Warhammer 4e Character Sheet/README.md
@@ -11,7 +11,7 @@ I'm a active WFRP player and I plan to further enhance this sheet at time goes o
 
 This sheet attempts to simplify the WFRP 4e Core book rules into a workable mostly automated roll20 sheet, without the need to track too many variables manually. This is accomplished by a combination of detailed manual configuration for each character, as every character is different, and a highly integrated and standardized roll template. Including uptodate offical companion and expansion rule (TEW/UiA/WoM/AotE..), and options for certain custom house rules.
 
-Optional Custom WFRP4e token marker set 3.1 is available @ https://github.com/Djjus/Vault/blob/master/Warhammer%204e%20Character%20Sheet/markers/WFRP4eset3.1.zip. Follow Roll20 Token marker update instructions for your server.
+Optional Custom WFRP4e token marker set 4 is available @ https://github.com/Djjus/Vault/raw/master/Warhammer%204e%20Character%20Sheet/markers/WFRP4eset4.0.zip // UiA Edition @ https://github.com/Djjus/Vault/raw/master/Warhammer%204e%20Character%20Sheet/markers/WFRP4eset4.0%20(UiA).zip. Follow Roll20 Token marker update instructions for your server.
 
 The sheet should work on latest version of Firefox, MS Egde & Chrome. at 110-125% Magnification. 
 
@@ -64,7 +64,7 @@ Please report issues on Github or Discord : Justi#7934
 - NPC tab is intended of quick persistent and contained NPC creation without the need for full character sheets for each of them. With template integration, semi featured with contained Name / Characteristic / Condition / Advantage integration and up to 5 weapons & spells for each NPC, and a collapsible notes section. Good for GMs and players. (I would still recommend separate character sheet for actual NPC bosses/major characters).  
 - Condition Tracking integration into roll template. Option to choose between Advantage +xx showing only on all combat rolls and all (new default v1.3) non-situational roll modifying conditions (e.g. Broken, Fatigued Stunned, Prone..) to be add to appropriate rolls automatically. Includes NPC tab support too.  
 
-This sheet has TokenMod integrated (TokenMod API needs to be install in the game!) buttons which can set/unset conditions, it does requires my custom WFRP4e Tokens v3.1 (download @ https://github.com/Djjus/Vault/blob/master/Warhammer%204e%20Character%20Sheet/markers/WFRP4eset3.1.zip) due to naming convention. 
+This sheet has TokenMod integrated (TokenMod API needs to be install in the game!) buttons which can set/unset conditions, it does requires my custom WFRP4e Tokens v4 @ https://github.com/Djjus/Vault/raw/master/Warhammer%204e%20Character%20Sheet/markers/WFRP4eset4.0.zip // UiA Edition @ https://github.com/Djjus/Vault/raw/master/Warhammer%204e%20Character%20Sheet/markers/WFRP4eset4.0%20(UiA).zip
 
 Condition effects are currently hard coded as follows (updated June 15th 2021): 
 
@@ -85,6 +85,11 @@ August 22th 2022 v1.6b
 
 - Adds conditional check when peforming Dual Wield attack, if the Player has just rolled a crit, they now will chose if they want to use main hand or crit result for the DW attack. Crit result DW hits will now remove any modifier on crit roll before reversal, so result stays within 1d100 range.
 - Fixed recent issue with Darkmode on Chrome based browsers, white text was showing in much of the chat log RT output while in darkmode.
+- Custom WFRP4e token marker set 4.0 released incluides UiA edition with no Advantage markers. Splits into Fear 1/2/3 markers. And a number of usefull custom markers. Url:
+
+https://github.com/Djjus/Vault/raw/master/Warhammer%204e%20Character%20Sheet/markers/WFRP4eset4.0.zip
+
+UiA Edition: https://github.com/Djjus/Vault/raw/master/Warhammer%204e%20Character%20Sheet/markers/WFRP4eset4.0%20(UiA).zip
 
 
 August 8th 2022 v1.6a

--- a/Warhammer 4e Character Sheet/README.md
+++ b/Warhammer 4e Character Sheet/README.md
@@ -81,9 +81,10 @@ Note conditions are not intended for out of combat situations, GM simply makes t
  
 ///// ============ Change Log ============ /////  
 
-August 16th 2022 v1.6b
+August 22th 2022 v1.6b
 
 - Adds conditional check when peforming Dual Wield attack, if the Player has just rolled a crit, they now will chose if they want to use main hand or crit result for the DW attack. Crit result DW hits will now remove any modifier on crit roll before reversal, so result stays within 1d100 range.
+- Fixed recent issue with Darkmode on Chrome based browsers, white text was showing in much of the chat log RT output while in darkmode.
 
 
 August 8th 2022 v1.6a

--- a/Warhammer 4e Character Sheet/README.md
+++ b/Warhammer 4e Character Sheet/README.md
@@ -85,7 +85,7 @@ August 22th 2022 v1.6b
 
 - Adds conditional check when peforming Dual Wield attack, if the Player has just rolled a crit, they now will chose if they want to use main hand or crit result for the DW attack. Crit result DW hits will now remove any modifier on crit roll before reversal, so result stays within 1d100 range.
 - Fixed recent issue with Darkmode on Chrome based browsers, white text was showing in much of the chat log RT output while in darkmode.
-- Custom WFRP4e token marker set 4.0 released incluides UiA edition with no Advantage markers. Splits into Fear 1/2/3 markers. And a number of usefull custom markers. Url:
+- Custom WFRP4e token marker set 4.0 released includes UiA edition with no Advantage markers. Splits Fear into 1/2/3 markers. And a number of usefull custom markers. Url:
 
 https://github.com/Djjus/Vault/raw/master/Warhammer%204e%20Character%20Sheet/markers/WFRP4eset4.0.zip
 

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.css
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.css
@@ -2,6 +2,11 @@
 *, .sheet-rolltemplate-whfrp2e * {
 	box-sizing: border-box;
 }
+
+.sheet-rolltemplate-whfrp2e .sheet-main-content {
+  	color: black;
+}
+
 @font-face {
     font-family: 'WH font';
     src: url(https://fonts.googleapis.com/css?family=EB+Garamond);

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.css
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.css
@@ -7,6 +7,10 @@
   	color: black;
 }
 
+.sheet-rolltemplate-whfrp2e .sheet-main-content .inlinerollresult {
+  	background: yellow;
+}
+
 @font-face {
     font-family: 'WH font';
     src: url(https://fonts.googleapis.com/css?family=EB+Garamond);

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -27659,7 +27659,7 @@
 		<div class="sheet-spacer-xl"></div>
 		<!-- FOOTER -->
 		<div class="sheet-row sheet-footer">
-			<div class="sheet-col-1 sheet-small-label sheet-center">Sheet version 1.6b : August 16th 2022 | by Djjus & Pote</div>
+			<div class="sheet-col-1 sheet-small-label sheet-center">Sheet version 1.6b : August 22th 2022 | by Djjus & Pote</div>
 		</div>
 		</div>
 	</div>


### PR DESCRIPTION
- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

- Fixed recent issue with Dark Mode on Chrome based browsers, illegible white text was showing in much of the chat log RT output.
- Custom WFRP4e token marker set 4.0 released includes UiA edition with no Advantage markers. Splits Fear into 1/2/3 markers. And a number of usefull custom markers.

https://github.com/Djjus/Vault/raw/master/Warhammer%204e%20Character%20Sheet/markers/WFRP4eset4.0.zip

UiA Edition: https://github.com/Djjus/Vault/raw/master/Warhammer%204e%20Character%20Sheet/markers/WFRP4eset4.0%20(UiA).zip