### PR TITLE
Shadowrun Sixth World v.59 - sheet breaking bugfix, minor new feature

### DIFF
--- a/Shadowrun Sixth World/CHANGELOG.md
+++ b/Shadowrun Sixth World/CHANGELOG.md
@@ -2,6 +2,7 @@ Change Log
 ==============================================
 **2022-08-30 ** v.59 Chuz (James Culp)
 	Bugfix - Non-PC sheets were broken anywhere that a textarea (notes style) entry existed you couldn't display it to add or edit the values.
+	New Feature - character_name sanitization.  Sometimes we want to use names with characters that will break roll buttons and other parts of the sheet.  This replaces the bad characters with an asterisk *
 **2022-08-16 ** v.58 Chuz (James Culp)
 	New Feature - Added the ability to change the ammo type in use on Core->Primary Ranged with the AR and DV changes applied.  Default will be Standard.
 	New Feature - Added split rolls for Burst Fire Wide firing mode on the Core->Primary Ranged weapons.  This splits the dicepool (on odd pools the left roll Atk 1 gets the extra die).  If Wild Dice are toggled on a prompt will appear for each attack.  Glitches are calculated for each attack separately.

--- a/Shadowrun Sixth World/CHANGELOG.md
+++ b/Shadowrun Sixth World/CHANGELOG.md
@@ -1,5 +1,7 @@
 Change Log
 ==============================================
+**2022-08-30 ** v.59 Chuz (James Culp)
+	Bugfix - Non-PC sheets were broken anywhere that a textarea (notes style) entry existed you couldn't display it to add or edit the values.
 **2022-08-16 ** v.58 Chuz (James Culp)
 	New Feature - Added the ability to change the ammo type in use on Core->Primary Ranged with the AR and DV changes applied.  Default will be Standard.
 	New Feature - Added split rolls for Burst Fire Wide firing mode on the Core->Primary Ranged weapons.  This splits the dicepool (on odd pools the left roll Atk 1 gets the extra die).  If Wild Dice are toggled on a prompt will appear for each attack.  Glitches are calculated for each attack separately.

--- a/Shadowrun Sixth World/Shadowrun6thEdition.css
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.css
@@ -3697,7 +3697,8 @@ span.d6 {
   /*:+:+:+: NPC BODY :+:+:+:*/
   /*:+:+:+: NPC TEXT BOXES AND REPEATING SECTIONS :+:+:+:*/
   /*:+:+:+: NPC MATRIX :+:+:+:*/
-input[name="attr_stats_toggle"][value="settings"] ~ .body .toggle-display {
+input[name="attr_stats_toggle"][value="settings"] ~ .body .toggle-display,
+input[name="attr_stats_toggle"][value="settings"] ~ .border-box .body .toggle-display {
   display: none !important; }
 
 .npc {
@@ -4602,6 +4603,7 @@ input[name='attr_sheet_type'][value='pc'] ~ .pc,
 .options_toggle[value='rolls'] ~ .rolls, 
 input[name='attr_stats_toggle'][value='settings'] ~ .border-box .attribute .settings,
 input[name='attr_stats_toggle'][value='settings'] ~ .border-box .body .column .rows .settings,
+input[name='attr_stats_toggle'][value='settings'] ~ .border-box .body .textrow .settings, 
 input[name='attr_stats_toggle'][value='settings'] ~ .body .column .settings,
 input[name='attr_stats_toggle'][value='settings'] ~ .body .textrow .settings, 
 input[name='attr_stats_toggle'][value='settings'] ~ .settings,

--- a/Shadowrun Sixth World/Shadowrun6thEdition.html
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.html
@@ -3403,6 +3403,7 @@
 								<span class="changelog-entry">**2022-08-30 ** v.59 Chuz (James Culp)</span>
 								<ul>
 									<li><span class="bullet">A</span><b>Bugfix</b> - Non-PC sheets were broken anywhere that a textarea (notes style) entry existed you couldn't display it to add or edit the values.
+									<li><span class="bullet">F</span><b>New Feature</b> - New Feature - character_name sanitization.  Sometimes we want to use names with characters that will break roll buttons and other parts of the sheet.  This replaces the bad characters with an asterisk *
 								</ul>
 								<span class="changelog-entry">**2022-08-16 ** v.58 Chuz (James Culp)</span>
 								<ul>

--- a/Shadowrun Sixth World/Shadowrun6thEdition.html
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.html
@@ -5914,8 +5914,12 @@ on("sheet:opened", function() {
 					console.log("Data now fits v.57");
 					show_changelog();
 				case (v.data_version < 0.58):
-					_v57_update();
+					_v58_update();
 					console.log("Data now fits v.58");
+				case (v.data_version < 0.59):
+					_v58_update();
+					_v59_update();
+					console.log("Data now fits v.59");
 				default:
 					setAttrs({
 						'data_version': v.sheet_version
@@ -5938,19 +5942,17 @@ var show_changelog = () => {
 };
 
 
+var _v59_update = () => {
+	getAttrs(['character_name'], (v) => {
+console.log(v);
+		set_display_name(v.character_name);
+	});
+};
+
 var _v58_update = () => {
-	getAttrs(['wild_die'], (v) => {
-		if(v.wild_die == 0) {
-			setAttrs({
-				wild_die1: eventInfo.newValue,
-				wild_die2: eventInfo.newValue
-			});
-		} else {
-			setAttrs({
-				wild_die1: "?{Wild Dice for First Roll?|0}",
-				wild_die2: "?{Wild Dice for Second Roll?|0}"
-			});
-		}
+	setAttrs({
+		wild_die1: "?{Wild Dice for First Roll?|0}",
+		wild_die2: "?{Wild Dice for Second Roll?|0}"
 	});
 };
 
@@ -7053,6 +7055,17 @@ console.log(eventInfo);
 	}
 });
 
+
+on("change:character_name", (eventInfo) => {
+	set_display_name(eventInfo.newValue);
+});
+
+var set_display_name = (name) => {
+	character_name = name.replace(/[\}\)\|]/g, '*');
+	setAttrs({
+		character_name: character_name
+	});
+};
 
 var update_attribute = (attr) => {
 	getAttrs([`${attr.key}`], (v) => {

--- a/Shadowrun Sixth World/Shadowrun6thEdition.html
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.html
@@ -3400,7 +3400,10 @@
 						<div class="notes-changelog">
 							<div name="changelog" class="changelog">
 								<h1 class="changelog-header">Most Recent Updates</h1>
-
+								<span class="changelog-entry">**2022-08-30 ** v.59 Chuz (James Culp)</span>
+								<ul>
+									<li><span class="bullet">A</span><b>Bugfix</b> - Non-PC sheets were broken anywhere that a textarea (notes style) entry existed you couldn't display it to add or edit the values.
+								</ul>
 								<span class="changelog-entry">**2022-08-16 ** v.58 Chuz (James Culp)</span>
 								<ul>
 									<li><span class="bullet">F</span><b>New Feature</b> - Added the ability to change the ammo type in use on Core->Primary Ranged with the AR and DV changes applied.  Default will be Standard.
@@ -5856,7 +5859,7 @@
 <input type="hidden" name="attr_wild_die1" value="0" />
 <input type="hidden" name="attr_wild_die2" value="0" />
 
-<input type="hidden" name="attr_sheet_version" value="0.58">
+<input type="hidden" name="attr_sheet_version" value="0.59">
 <input type="hidden" name="attr_data_version" value="0">
 <script type="text/worker">
 


### PR DESCRIPTION
- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

- [x] I have followed the [Character Sheets Standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) when building this sheet.

# Changes / Description

- Bugfix - Non-PC sheets were broken anywhere that a textarea (notes style) entry existed you couldn't display it to add or edit the values.
- New Feature - character_name sanitization.  Sometimes we want to use names with characters that will break roll buttons and other parts of the sheet.  This replaces the bad characters with an asterisk *



