### PR TITLE
[Ironsworn] Fixed roll template selectors not prefixed with template class, and forbidden escape sequence in CSS

### DIFF
--- a/Ironsworn/Ironsworn.css
+++ b/Ironsworn/Ironsworn.css
@@ -165,7 +165,6 @@
 }
 .charsheet .btn {
   display: inline;
-  width: 100%;
   font-weight: bold;
   font-size: 14px;
   padding: 0;
@@ -2806,14 +2805,17 @@
   margin: 0;
   height: auto;
 }
-.sheet-subfooter-momentum {
+.sheet-rolltemplate-ironsworn_moves .sheet-subfooter-momentum {
   text-align: right !important;
   margin-right: 10px;
 }
-.sheet-challenge-dice-title::after,
-.sheet-action-score-title::after,
-.sheet-progress-title::after,
-.sheet-momentum-title::after {
+.sheet-rolltemplate-ironsworn_moves .sheet-challenge-dice-title::after,
+.sheet-rolltemplate-ironsworn_moves .sheet-action-score-title::after,
+.sheet-rolltemplate-ironsworn_moves .sheet-progress-title::after,
+.sheet-rolltemplate-ironsworn_moves .sheet-momentum-title::after,
+.sheet-rolltemplate-ironsworn_progress .sheet-challenge-dice-title::after,
+.sheet-rolltemplate-ironsworn_progress .sheet-action-score-title::after,
+.sheet-rolltemplate-ironsworn_progress .sheet-progress-title::after {
   content: ": ";
 }
 .sheet-rolltemplate-ironsworn_oracles .sheet-result-row,

--- a/Ironsworn/Ironsworn.css
+++ b/Ironsworn/Ironsworn.css
@@ -1654,10 +1654,8 @@
   background: #4c4d4f;
   color: #fff;
   text-transform: uppercase;
-}
-.charsheet .move-roll-shortcut-title::before,
-.charsheet .move-roll-shortcut-title::after {
-  content: "\a0";
+  padding: 0px 5px 0px 5px;
+  width: auto;
 }
 .charsheet .move-roll-shortcut-pay-the-price {
   text-align: center;

--- a/Ironsworn/src/app/Ironsworn.styl
+++ b/Ironsworn/src/app/Ironsworn.styl
@@ -153,7 +153,6 @@
 
   .btn
     display: inline
-    width: 100%
     font-weight: bold
     font-size: 14px
     padding 0

--- a/Ironsworn/src/app/components/moves/moves.styl
+++ b/Ironsworn/src/app/components/moves/moves.styl
@@ -205,8 +205,8 @@ span
   background #4c4d4f
   color #fff
   text-transform uppercase
-  &::before, &::after
-    content "\a0"
+  padding 0px 5px 0px 5px
+  width auto
 
 move-roll-shortcut()
   text-align center

--- a/Ironsworn/src/app/roll-templates/mixins/body.styl
+++ b/Ironsworn/src/app/roll-templates/mixins/body.styl
@@ -1,6 +1,8 @@
-
-.sheet-challenge-dice-title::after,
-.sheet-action-score-title::after,
-.sheet-progress-title::after,
-.sheet-momentum-title::after
+.sheet-rolltemplate-ironsworn_moves .sheet-challenge-dice-title::after,
+.sheet-rolltemplate-ironsworn_moves .sheet-action-score-title::after,
+.sheet-rolltemplate-ironsworn_moves .sheet-progress-title::after,
+.sheet-rolltemplate-ironsworn_moves .sheet-momentum-title::after,
+.sheet-rolltemplate-ironsworn_progress .sheet-challenge-dice-title::after,
+.sheet-rolltemplate-ironsworn_progress .sheet-action-score-title::after,
+.sheet-rolltemplate-ironsworn_progress .sheet-progress-title::after
   content ": "

--- a/Ironsworn/src/app/roll-templates/mixins/outcomes.styl
+++ b/Ironsworn/src/app/roll-templates/mixins/outcomes.styl
@@ -4,6 +4,6 @@ outcome-base(background)
   border-radius 1em
   background-color background
 
-.sheet-subfooter-momentum
+.sheet-rolltemplate-ironsworn_moves .sheet-subfooter-momentum
   text-align right !important
   margin-right 10px


### PR DESCRIPTION
- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

This is a possible fix for the CSS not loading into the chat frame, which completely screws the roll templates.

![image](https://user-images.githubusercontent.com/5169814/187055341-891ca810-78a1-4fba-b4c2-7a478f4a5e1e.png)

See also https://app.roll20.net/forum/post/11059481/roll-template-styles-no-more-applied-on-ironsworn-sheet




