### PR TITLE
[Fate] Bugfix for CSS styling of aspect labels

### DIFF
--- a/Fate/FateOmni.css
+++ b/Fate/FateOmni.css
@@ -668,6 +668,7 @@ input.icon[value="blank"] + span.icon::before {
 	opacity: 0.75;
 	font-size: 80%;
 	display: block;
+	white-space: normal;
 }
 
 .aspect-category {


### PR DESCRIPTION
Unwelcome change in base.css definition of .label style's white-space property caused issues for labels that absolutely needed to wrap in the sheet. Have established a kinder override value for white-space in the relevant situation.

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)