### PR TITLE
GURPS 2.8.4

### DIFF
--- a/GURPS/gurps.html
+++ b/GURPS/gurps.html
@@ -4358,10 +4358,12 @@
 					<input type="text" name="attr_announcement_version" readonly="readonly" value="0" title="GURPS Character Sheet Version" />
 				</h4>
 
-				<!-- current version notes: 2.8.3 -->			
+				<!-- current version notes: 2.8.4 -->			
 				<ul>
+					<li>Options tab. Sheet Options sub-tab. Updated <b>Resync</b> button to change colors when clicked. Thanks to Onyxring's Roll20Async functions!</li>
 					<li>
-						Options Tab. Sheet Options sub-tab. Resync button - made some improvements with data syncing for skills and spells.
+						Repeating Skills, attribute drop-down. The character sheet uses an old method to link skills to an attribute. The old method might not trigger correctly
+						when an attribute like Dexterity is changed. Solved the issue by tricking the system into resyncing skills when an attribute is changed.
 					</li>
 				</ul>
 				
@@ -14026,8 +14028,20 @@ Slam uses either DX, Brawling, or Sumo Wrestling. Note that the -4 to hit and ef
 			<h4>Version: <span name="attr_announcement_version"></span></h4>
 
 			<p>Pull Request: <span name="attr_latest_changes"></span></p>
+			
+			<!-- current version notes: 2.8.4 -->
+			<ul>
+				<li>Options tab. Sheet Options sub-tab. Updated <b>Resync</b> button to change colors when clicked. Thanks to Onyxring's Roll20Async functions!</li>
+				<li>
+					Repeating Skills, attribute drop-down. The character sheet uses an old method to link skills to an attribute. The old method might not trigger correctly
+					when an attribute like Dexterity is changed. Solved the issue by tricking the system into resyncing skills when an attribute is changed.
+				</li>
+			</ul>
 
-			<!-- current version notes: 2.8.3 -->
+			<h4>Version: 2.8.3</h4>
+
+			<p>Pull Request: 9/1/2022</p>	
+
 			<ul>
 				<li>
 					Options Tab. Sheet Options sub-tab. Resync button - when resyncing skills and and spells, it now pulls the latest attribure value. 
@@ -17266,9 +17280,9 @@ Diffuse: Max 2HP (Exception: Area-effect, cone, and explosion attacks cause norm
 	
 	const noop = function () { }; // do nothing callback function.
 	
-	const version = "2.8.3";
+	const version = "2.8.4";
 	
-	const latestChangesDate = "9/1/2022";
+	const latestChangesDate = "9/6/2022";
 	
 	let modCascade = true;
 	
@@ -19235,6 +19249,7 @@ Diffuse: Max 2HP (Exception: Area-effect, cone, and explosion attacks cause norm
 	updateRepeatingSkillValues = () => {
 
 		let fieldValues = [
+			"repeating_skills_name",	//for debugging
 			"repeating_skills_base",
 			"repeating_skills_difficulty",
 			"repeating_skills_bonus",
@@ -23614,6 +23629,8 @@ Diffuse: Max 2HP (Exception: Area-effect, cone, and explosion attacks cause norm
 	// if an attribute is updated, update linked items
 	on("change:strength_display", event => {
 	
+		resyncRepeatingSkills();
+
 		updateSectionSkillsLinkedToUpdatedRow("ST");
 	
 	});
@@ -23626,24 +23643,40 @@ Diffuse: Max 2HP (Exception: Area-effect, cone, and explosion attacks cause norm
 	
 	on("change:dexterity", event => {
 	
+		resyncRepeatingSkills();
+
 		updateSectionSkillsLinkedToUpdatedRow("DX");
 	
 	});
 	
 	on("change:intelligence", event => {
 	
+		resyncRepeatingSkills();
+
 		updateSectionSkillsLinkedToUpdatedRow("IQ");
 	
 	});
 	
 	on("change:willpower", event => {
 	
+		resyncRepeatingSkills();
+
 		updateSectionSkillsLinkedToUpdatedRow("WILL");
+	
+	});
+
+	on("change:perception", event => {
+	
+		resyncRepeatingSkills();
+
+		updateSectionSkillsLinkedToUpdatedRow("PER");
 	
 	});
 	
 	on("change:health", event => {
 	
+		resyncRepeatingSkills();
+
 		updateSectionSkillsLinkedToUpdatedRow("HT");
 	
 	});
@@ -33671,14 +33704,20 @@ Diffuse: Max 2HP (Exception: Area-effect, cone, and explosion attacks cause norm
 
 			resyncRepeatingSpells();
 
+			resetResyncButtonSate();
+
 		});
 
 	});
 
 	resetResyncButtonSate = () => {
 
-		setAttrs({resync_state: "normal"});
+		setTimeout(() => {
 
+			setAttrs({resync_state: "normal"});
+
+		}, 1000);
+		
 	}
 
 	/**
@@ -33829,5 +33868,92 @@ Diffuse: Max 2HP (Exception: Area-effect, cone, and explosion attacks cause norm
 		});
 
 	}
+
+	/* async functions                              */
+	/* see: https://github.com/onyxring/Roll20Async */
+
+	function setActiveCharacterId(charId) {
+        var oldAcid = getActiveCharacterId();
+        var ev = new CustomEvent("message");
+        ev.data = { "id": "0", "type": "setActiveCharacter", "data": charId };
+        self.dispatchEvent(ev);
+        return oldAcid;
+    }
+    var _sIn = setInterval;
+    setInterval = function (callback, timeout) {
+        var acid = getActiveCharacterId();
+        _sIn(
+            function () {
+                var prevAcid = setActiveCharacterId(acid);
+                callback();
+                setActiveCharacterId(prevAcid);
+            }
+            , timeout);
+    }
+    var _sto = setTimeout
+    setTimeout = function (callback, timeout) {
+        var acid = getActiveCharacterId();
+        _sto(
+            function () {
+                var prevAcid = setActiveCharacterId(acid);
+                callback();
+                setActiveCharacterId(prevAcid);
+            }
+            , timeout);
+    }
+    function getAttrsAsync(props) {
+        var acid = getActiveCharacterId(); //save the current activeCharacterID in case it has changed when the promise runs 
+        var prevAcid = null;               //local variable defined here, because it needs to be shared across the promise callbacks defined below
+        return new Promise((resolve, reject) => {
+            prevAcid = setActiveCharacterId(acid);  //in case the activeCharacterId has changed, restore it to what we were expecting and save the current value to restore later
+            try {
+                getAttrs(props, (values) => { resolve(values); });
+            }
+            catch { reject(); }
+        }).finally(() => {
+            setActiveCharacterId(prevAcid); //restore activeCharcterId to what it was when the promise first ran
+        });
+    }
+    //use the same pattern for each of the following...
+    function setAttrsAsync(propObj, options) {
+        var acid = getActiveCharacterId();
+        var prevAcid = null;
+        return new Promise((resolve, reject) => {
+            prevAcid = setActiveCharacterId(acid);
+            try {
+                setAttrs(propObj, options, (values) => { resolve(values); });
+            }
+            catch { reject(); }
+        }).finally(() => {
+            setActiveCharacterId(prevAcid);
+        });
+    }
+
+    function getSectionIDsAsync(sectionName) {
+        var acid = getActiveCharacterId();
+        var prevAcid = null;
+        return new Promise((resolve, reject) => {
+            prevAcid = setActiveCharacterId(acid);
+            try {
+                getSectionIDs(sectionName, (values) => { resolve(values); });
+            }
+            catch { reject(); }
+        }).finally(() => {
+            setActiveCharacterId(prevAcid);
+        });
+    }
+    function getSingleAttrAsync(prop) {
+        var acid = getActiveCharacterId();
+        var prevAcid = null;
+        return new Promise((resolve, reject) => {
+            prevAcid = setActiveCharacterId(acid);
+            try {
+                getAttrs([prop], (values) => { resolve(values[prop]); });
+            }
+            catch { reject(); }
+        }).finally(() => {
+            setActiveCharacterId(prevAcid);
+        });
+    }
 
 </script>


### PR DESCRIPTION
minor revision to resync button and add additional code to update skills linked to an attribute

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

- Options tab. Sheet Options sub-tab. Updated <b>Resync</b> button to change colors when clicked. Thanks to Onyxring's Roll20Async functions!
- Repeating Skills, attribute drop-down. The character sheet uses an old method to link skills to an attribute. The old method might not trigger correctly when an attribute like Dexterity is changed. Solved the issue by tricking the system into resyncing skills when an attribute is changed.
