### PR TITLE
[Warhammer 4e Character Sheet] v1.61 - Armor Tab update

### DIFF
--- a/Warhammer 4e Character Sheet/README.md
+++ b/Warhammer 4e Character Sheet/README.md
@@ -81,6 +81,11 @@ Note conditions are not intended for out of combat situations, GM simply makes t
  
 ///// ============ Change Log ============ /////  
 
+September 24th 2022 v1.61
+
+- Updated Armor Tab - There is now 3 (Light/Medium/Heavy) Equip/unequip buttons at the top of the tab. This allows quicker equiping and unequiping of armor for players. Also all Equip/Unequip and Worn/Unworn actions in this tab now automatally activate or disable the corresponding armor penatlies. 
+
+
 August 22th 2022 v1.6b
 
 - Removed critical rt display for Prayer spells, as they do not get dubs random criticals, only fumbles.

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.css
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.css
@@ -1338,6 +1338,9 @@ span[class*="sheet-tab-npc"] {
 	font-size: 7px;
 	border-radius: 4px 4px 4px 4px;
 }
+span[class*="sheet-tab-armorequip1"],
+span[class*="sheet-tab-armorequip2"],
+span[class*="sheet-tab-armorequip3"],
 span[class*="sheet-tab-otherxp"],
 span[class*="sheet-tab-gmwhisper"] {
 	background: #615c50;
@@ -1823,6 +1826,9 @@ input.sheet-tab-npc99:checked ~ div.sheet-npc-page99 {
 }
 
 input.sheet-tab-gmwhisper:checked ~ span.sheet-tab-gmwhisper,
+input.sheet-tab-armorequip1:checked ~ span.sheet-tab-armorequip1,
+input.sheet-tab-armorequip2:checked ~ span.sheet-tab-armorequip2,
+input.sheet-tab-armorequip3:checked ~ span.sheet-tab-armorequip3,
 input.sheet-tab-otherxp:checked ~ span.sheet-tab-otherxp,
 input.sheet-tab-conditions-button:checked ~ span.sheet-tab-conditions-button,
 input.sheet-tab-npc0:checked ~ span.sheet-tab-npc0,
@@ -1880,6 +1886,26 @@ span.sheet-tab-gmwhisper {
 	top: -2px;
 	background-color: transparent;
 }
+span.sheet-tab-armorequip1,
+span.sheet-tab-armorequip2,
+span.sheet-tab-armorequip3 {
+	display: inline-block;
+	width: 34px;
+	height: 12px;
+	font-size: 8px;
+	text-align: center;
+	line-height: 5px;
+	left: 10px;
+	top: -2px;
+	background-color: transparent;
+}
+input.sheet-tab-armorequip1,
+input.sheet-tab-armorequip2,
+input.sheet-tab-armorequip3 {
+	display: inline-block;
+	width: 34px;
+	height: 13px;
+}
 input.sheet-tab-otherxp,
 span.sheet-tab-otherxp {
 	display: inline-block;
@@ -1898,6 +1924,20 @@ span.sheet-tab-conditions-button,
 span.sheet-tab-gmwhisper {
 	margin-left: -70px;
 }
+span.sheet-tab-armorequip1 {
+	margin-left: -55px;
+}
+span.sheet-tab-armorequip2,
+span.sheet-tab-armorequip3 {
+	margin-left: -38px;
+}
+input.sheet-tab-armorequip1 {
+	right: 8px;
+}
+input.sheet-tab-armorequip2,
+input.sheet-tab-armorequip3 {
+	left: 10px;
+}
 span.sheet-tab-npc {
 	margin-left: -18px;
 	background-color: #d6d4ce;
@@ -1905,6 +1945,9 @@ span.sheet-tab-npc {
 
 input.sheet-tab-conditions-button:checked + span.sheet-tab-conditions-button,
 input.sheet-tab-gmwhisper:checked + span.sheet-tab-gmwhisper,
+input.sheet-tab-armorequip1:checked + span.sheet-tab-armorequip1,
+input.sheet-tab-armorequip2:checked + span.sheet-tab-armorequip2,
+input.sheet-tab-armorequip3:checked + span.sheet-tab-armorequip3,
 input.sheet-tab-otherxp:checked + span.sheet-tab-otherxp,
 input.sheet-tab-npc:checked + span.sheet-tab-npc {
 	background-color: #615c50;

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -23465,10 +23465,32 @@
 				<div class="sheet-col-3-5 sheet-pad-r-md">
 					<div class="sheet-row">
 						<div class="sheet-col-1">
-			<div class="sheet-col-1 sheet-seperator-cap sheet-left sheet-mar-l-md" >
+			<div class="sheet-col-1 sheet-left sheet-mar-l-md" >
+					<div class="sheet-col-1-2 sheet-seperator-cap">
 				<span  style="font-size: 14px" data-i18n="PROTECTIVE-ITEMS">PROTECTIVE ITEMS</span>
 				<span class="sheet-pictos-custom">e</span>
+					</div>
+					<div class="sheet-col-7-25 sheet-wrap-box-2" style="height: 14px; float: right;margin-right: 15px;">
+					<div class="sheet-col-1-5 sheet-pad-l-sm sheet-vert-middle sheet-center">
+							<span style="font-size: 9px; position: relative;bottom: 2.5px;" data-i18n="EQUIP:">Equip:</span>
+					</div>
+					<div class="sheet-col-3-4 sheet-vert-middle sheet-center">
+							<input class="sheet-tab-armorequip1" style="font-size: 9px; position: relative;bottom: 2.5px;" type="checkbox" name="attr_Light_armor_equip" value="1" />
+							<span class="sheet-tab-armorequip1">
+								<span data-i18n="LIGHT" >Light</span>
+							</span>
+							<input class="sheet-tab-armorequip2" style="font-size: 9px; position: relative;bottom: 2.5px;" type="checkbox" name="attr_Medium_armor_equip" value="1" />
+							<span class="sheet-tab-armorequip2">
+								<span data-i18n="MEDIUM" >Medium</span>
+							</span>
+							<input class="sheet-tab-armorequip3" style="font-size: 9px; position: relative;bottom: 2.5px;" type="checkbox" name="attr_Heavy_armor_equip" value="1" />
+							<span class="sheet-tab-armorequip3">
+								<span data-i18n="HEAVY" >Heavy</span>
+							</span>
+					</div>
+					</div>
 			</div>
+			
 			<img src="https://github.com/Djjus/Vault/blob/master/Warhammer%204e%20Character%20Sheet/assets/seperator-center-2-3.png?raw=true">
 								<span style="color:darkgray;font-size:10px;" data-i18n="NOTE-ARMOR-ENC">ENC: Input the full enc of each item (-1 if wron is automatically added)</span>
 						<span class="sheet-spacer"></span>
@@ -23557,10 +23579,12 @@
 						<div class="sheet-col-1-10t sheet-center sheet-vert-middle sheet-pad-r-sm">
 							<span data-i18n="HEAVY">Heavy</span>
 						</div>
-						<div class="sheet-col-7-22 sheet-vert-middle sheet-pad-r-sm">
+						<div class="sheet-col-5-21 sheet-vert-middle sheet-pad-r-sm">
 							<input type="text" name="attr_armornameH3" />
 						</div>
-
+						<div class="sheet-col-2-25 sheet-vert-middle sheet-center sheet-pad-r-sm">
+							<input type="checkbox" name="attr_armorOpenH3" value="1"data-i18n-title="OPEN?" title=" Open? " />
+						</div>
 						<div class="sheet-col-2-25 sheet-vert-middle sheet-pad-r-sm">
 							<input type="number" name="attr_armorEncH3" value="0" min="0" />
 						</div>
@@ -25763,7 +25787,7 @@
 								<select class="sheet-center sheet-spell-name" name="attr_spellname"  style="border: 1px solid #c0c0c0; border-radius: 2px">
 									<option value="" data-i18n="SELECT-BLESSING">Select Blessing</option>
 									<option value="@{customblessname}" data-i18n="SPELL-CUSTOM">Custom Spell Name</option>
-									<option value="Blessing of Battle" data-i18n="BLESSING-BATTLE">Blessing of Battle</option>
+									<option value="@{blessing_of_battle}" data-i18n="BLESSING-BATTLE">Blessing of Battle</option>
 									<option value="Blessing of Breath" data-i18n="BLESSING-BREATH">Blessing of Breath</option>
 									<option value="Blessing of Charisma" data-i18n="BLESSING-CHARISMA">Blessing of Charisma</option>
 									<option value="Blessing of Conscience" data-i18n="BLESSING-CONSCIENCE">Blessing of Conscience</option>
@@ -27659,7 +27683,7 @@
 		<div class="sheet-spacer-xl"></div>
 		<!-- FOOTER -->
 		<div class="sheet-row sheet-footer">
-			<div class="sheet-col-1 sheet-small-label sheet-center">Sheet version 1.6b : August 22th 2022 | by Djjus & Pote</div>
+			<div class="sheet-col-1 sheet-small-label sheet-center">Sheet version 1.61 : September 24th 2022 | by Djjus & Pote</div>
 		</div>
 		</div>
 	</div>
@@ -36247,7 +36271,26 @@
 		setAttrs({
 		translation_targetnumber: getTranslationByKey("TARGET-NUMBER"),
 		translation_modifier: getTranslationByKey("MODIFIER"),
-		translation_roll_modifier: getTranslationByKey("ROLL-MODIFIER")
+		translation_roll_modifier: getTranslationByKey("ROLL-MODIFIER"),
+		blessing_of_battle: getTranslationByKey("BLESSING-BATTLE"),
+		blessing_of_breath: getTranslationByKey("BLESSING-BREATH"),
+		blessing_of_charisma: getTranslationByKey("BLESSING-CHARISMA"),
+		blessing_of_conscience: getTranslationByKey("BLESSING-CONSCIENCE"),
+		blessing_of_courage: getTranslationByKey("BLESSING-COURAGE"),
+		blessing_of_finesse: getTranslationByKey("BLESSING-FINESSE"),
+		blessing_of_fortune: getTranslationByKey("BLESSING-FORTUNE"),
+		blessing_of_grace: getTranslationByKey("BLESSING-GRACE"),
+		blessing_of_hardiness: getTranslationByKey("BLESSING-HARDINESS"),
+		blessing_of_healing: getTranslationByKey("BLESSING-HEALING"),
+		blessing_of_hunt: getTranslationByKey("BLESSING-HUNT"),
+		blessing_of_might: getTranslationByKey("BLESSING-MIGHT"),
+		blessing_of_protection: getTranslationByKey("BLESSING-PROTECTION"),
+		blessing_of_recuperation: getTranslationByKey("BLESSING-RECUPERATION"),
+		blessing_of_righteousness: getTranslationByKey("BLESSING-RIGHTEUSNESS"),
+		blessing_of_savagery: getTranslationByKey("BLESSING-SAVAGERY"),
+		blessing_of_tenacity: getTranslationByKey("BLESSING-TENACITY"),
+		blessing_of_wit: getTranslationByKey("BLESSING-WIT"),
+		blessing_of_wisdom: getTranslationByKey("BLESSING-WISDOM")
 		});
 		});
 
@@ -44996,5 +45039,301 @@ on("change:repeating_spellbookarcane:UsedSpell1 change:repeating_spellbookarcane
 	});			
 });		
 
+
+on('change:armoractiveH1 change:armoractiveH2 change:armoractiveH3 change:armoractiveT1 change:armoractiveT2 change:armoractiveT3 change:armoractiveLA1 change:armoractiveLA2 change:armoractiveLA3 change:armoractiveLL1 change:armoractiveLL2 change:armoractiveLL3 change:armoropenh3', function(event){
+        if (event.sourceType === 'sheetworker') return;
+    console.log("Armor Change");	
+	
+	var trigger = event.triggerName;	
+
+    console.log(trigger);			   
+
+	if (trigger = "armoractiveh1") {
+   getAttrs(["armoractiveh1", "armoractiveh2", "armoractiveh3"], function(v) {	
+
+	ar = v.armoractiveh1*1 + v.armoractiveh2*1 + v.armoractiveh3*1;
+	if (ar > 0) {ar = 1;} else {ar = 0;}
+
+			setAttrs({
+				"Armorpartial": ar,
+			}, {silent: true});	
+
+		});	
+	}
+	if (trigger = "armoractiveh2") {
+   getAttrs(["armoractiveh1", "armoractiveh2", "armoractiveh3"], function(v) {	
+
+	ar = v.armoractiveh1*1 + v.armoractiveh2*1 + v.armoractiveh3*1;
+	if (ar > 0) {ar = 1;} else {ar = 0;}
+	
+			setAttrs({
+				"armorpartial": ar,
+				"armorcoifpenalty": v.armoractiveh2*10,
+			}, {silent: true});	
+
+		});
+   getAttrs(["armoractiveh2", "armoractivet2", "armoractivela2", "armoractivell2"], function(v) {	
+
+	ar2 = v.armoractiveh2*1 + v.armoractivet2*1 + v.armoractivela2*1 + v.armoractivell2*1;
+	if (ar2 > 0) {ar2 = 10;} else {ar2 = 0;}
+
+			setAttrs({
+				"armormailpenalty": ar2,
+			}, {silent: true});	
+
+		});			
+	}
+	
+	if (trigger = "armoractiveh3") {
+   getAttrs(["armoractiveh1", "armoractiveh2", "armoractiveh3", "armoropenh3", "armoractivet3", "armoractivela3", "armoractivell3"], function(v) {	
+
+	ar = v.armoractiveh1*1 + v.armoractiveh2*1 + v.armoractiveh3*1;
+	peq = v.armoractiveh3*1 + v.armoractivet3*1 + v.armoractivela3*1 + v.armoractivell3*1
+	
+	
+	
+	if (ar > 0) {ar = 1;} else {ar = 0;}
+	if (peq > 0) {peq = 1;}
+	if (v.armoropenh3 === "1") { helm = 10; } else { helm = 20; peq = 1; }
+	
+    console.log(peq);
+    console.log("Test");
+	
+			setAttrs({
+				"armorpartial": ar,
+				"armorhelmpenalty": v.armoractiveh3*helm,
+				"armorimpenetrable": peq,
+				"armorweakpoints": peq,
+			}, {silent: true});	
+
+		});
+   getAttrs(["armoractiveh3", "armoractivet3", "armoractivela3", "armoractivell3"], function(v) {	
+
+	ar3 = v.armoractiveh3*1 + v.armoractivet3*1 + v.armoractivela3*1 + v.armoractivell3*1;
+	if (ar3 > 0) {ar3 = 10;} else {ar3 = 0;}
+
+    console.log(ar3);
+    console.log("Test");
+	
+			setAttrs({
+				"armorplatepenalty": ar3,
+			}, {silent: true});	
+
+		});		
+	}
+	if (trigger = "armoropenh3") {
+   getAttrs(["armoractiveh1", "armoractiveh2", "armoractiveh3", "armoropenh3"], function(v) {	
+
+	ar = v.armoractiveh1*1 + v.armoractiveh2*1 + v.armoractiveh3*1;
+	if (ar > 0) {ar = 1;} else {ar = 0;}
+	if (v.armoropenh3 === "1") { helm = 10; } else { helm = 20; }
+	
+			setAttrs({
+				"armorpartial": ar,
+				"armorhelmpenalty": v.armoractiveh3*helm,
+			}, {silent: true});	
+
+		});	
+	}
+	
+	
+	
+	if (trigger = "armoractivet2") {
+   getAttrs(["armoractiveh2", "armoractivet2", "armoractivela2", "armoractivell2"], function(v) {	
+
+	ar = v.armoractiveh2*1 + v.armoractivet2*1 + v.armoractivela2*1 + v.armoractivell2*1;
+	if (ar > 0) {ar = 10;} else {ar = 0;}
+
+			setAttrs({
+				"armormailpenalty": ar,
+			}, {silent: true});	
+
+		});	
+	}	
+	
+	if (trigger = "armoractivet3") {
+   getAttrs(["armoractiveh3", "armoractivet3", "armoractivela3", "armoractivell3", "armoropenh3"], function(v) {	
+
+	ar = v.armoractiveh3*1 + v.armoractivet3*1 + v.armoractivela3*1 + v.armoractivell3*1;
+	helm = (v.armoractiveh3*1-v.armoropenh3);
+	if (helm < 0) {helm = 0;}
+	peq = helm + v.armoractivet3*1 + v.armoractivela3*1 + v.armoractivell3*1;
+	
+	if (ar > 0) {ar = 10;} else {ar = 0;}
+	if (peq > 0) {peq = 1;}
+
+			setAttrs({
+				"armorplatepenalty": ar,
+				"armorimpenetrable": peq,
+				"armorweakpoints": peq,
+			}, {silent: true});	
+
+		});	
+	}	
+	
+	if (trigger = "armoractivell3") {
+   getAttrs(["armoractiveh3", "armoractivet3", "armoractivela3", "armoractivell3", "armoropenh3"], function(v) {	
+
+	ar = v.armoractiveh3*1 + v.armoractivet3*1 + v.armoractivela3*1 + v.armoractivell3*1;
+	helm = (v.armoractiveh3*1-v.armoropenh3);
+	if (helm < 0) {helm = 0;}
+	peq = helm + v.armoractivet3*1 + v.armoractivela3*1 + v.armoractivell3*1;
+	if (ar > 0) {ar = 10;} else {ar = 0;}
+	if (peq > 0) {peq = 1;} else {peq = 0;}
+
+			setAttrs({
+				"armorplatepenalty": ar,
+				"armorplatelegspenalty": v.armoractivell3*10,
+				"armorimpenetrable": peq,
+				"armorweakpoints": peq,
+			}, {silent: true});	
+
+		});	
+	}	
+	
+		
+});	
+
+
+on('change:Light_armor_equip', function(event){
+        if (event.sourceType === 'sheetworker') return;
+   getAttrs(["Light_armor_equip"], function(v) {	
+
+	var trigger = v.Light_armor_equip*1;	
+
+    console.log(trigger);			   
+
+		if (trigger === 0) {
+			console.log("Light Armor Unequip");
+				setAttrs({
+					"armoractiveh1": 0,
+					"armoractivet1": 0,
+					"armoractivela1": 0,
+					"armoractivell1": 0,
+				}, {silent: true});	
+		
+		} else {
+			console.log("Light Armor Equip");
+				setAttrs({
+					"armoractiveh1": 1,
+					"armoractivet1": 1,
+					"armoractivela1": 1,
+					"armoractivell1": 1,
+				}, {silent: true});	
+		
+		}
+		
+	getAttrs(["armoractiveh2", "armoractiveh3"], function(v) {	
+
+	ar = trigger + v.armoractiveh2*1 + v.armoractiveh3*1;
+	if (ar > 0) {ar = 1;} else {ar = 0;}
+
+			setAttrs({
+				"Armorpartial": ar,
+			}, {silent: true});	
+
+		});	
+		
+	
+	});	
+});	
+
+on('change:Medium_armor_equip', function(event){
+        if (event.sourceType === 'sheetworker') return;
+   getAttrs(["Medium_armor_equip"], function(v) {	
+
+	var trigger = v.Medium_armor_equip*1;	
+
+    console.log(trigger);			   
+
+		if (trigger === 0) {
+			console.log("Medium Armor Unequip");
+				setAttrs({
+					"armoractiveh2": 0,
+					"armoractivet2": 0,
+					"armoractivela2": 0,
+					"armoractivell2": 0,
+				}, {silent: true});	
+		
+		} else {
+			console.log("Medium Armor Equip");
+				setAttrs({
+					"armoractiveh2": 1,
+					"armoractivet2": 1,
+					"armoractivela2": 1,
+					"armoractivell2": 1,
+				}, {silent: true});	
+		
+		}
+		
+	getAttrs(["armoractiveh1", "armoractiveh3"], function(v) {	
+
+	ar = trigger + v.armoractiveh1*1 + v.armoractiveh3*1;
+	if (ar > 0) {ar = 1;} else {ar = 0;}
+
+			setAttrs({
+				"Armorpartial": ar,
+				"armorcoifpenalty": trigger*10,
+				"armormailpenalty": trigger*10,
+			}, {silent: true});	
+
+		});	
+		
+	
+	});	
+});	
+
+on('change:Heavy_armor_equip', function(event){
+        if (event.sourceType === 'sheetworker') return;
+   getAttrs(["Heavy_armor_equip"], function(v) {	
+
+	var trigger = v.Heavy_armor_equip*1;	
+
+    console.log(trigger);			   
+
+		if (trigger === 0) {
+			console.log("Heavy Armor Unequip");
+				setAttrs({
+					"armoractiveh3": 0,
+					"armoractivet3": 0,
+					"armoractivela3": 0,
+					"armoractivell3": 0,
+					"armorplatelegspenalty": 0,
+					"armorimpenetrable": 0,
+					"armorweakpoints": 0,
+				}, {silent: true});	
+		
+		} else {
+			console.log("Heavy Armor Equip");
+				setAttrs({
+					"armoractiveh3": 1,
+					"armoractivet3": 1,
+					"armoractivela3": 1,
+					"armoractivell3": 1,
+					"armorplatelegspenalty": 10,
+					"armorimpenetrable": 1,
+					"armorweakpoints": 1,
+				}, {silent: true});	
+		
+		}
+		
+	getAttrs(["armoractiveh1", "armoractiveh2", "armoropenh3"], function(v) {	
+
+	ar = trigger + v.armoractiveh1*1 + v.armoractiveh2*1;
+	if (ar > 0) {ar = 1;} else {ar = 0;}
+	if (v.armoropenh3 === "1") { helm = 10; } else { helm = 20; }
+	
+
+			setAttrs({
+				"Armorpartial": ar,
+				"armorhelmpenalty": trigger*helm,
+				"armorplatepenalty": trigger*10,
+			}, {silent: true});	
+
+		});	
+		
+	
+	});	
+});
 
 </script>

--- a/Warhammer 4e Character Sheet/translation.json
+++ b/Warhammer 4e Character Sheet/translation.json
@@ -1527,6 +1527,8 @@
 
 	"GRIMOIRE-MISCAST": "Grimoire Miscast",
 	"NOT-WORN": "Not Worn",
+	"OPEN?": "Open?",
+	"EQUIP:": "Equip:",
 	"UNEQUIPED": "Unequiped",
 	"ALL-WINDS": "All Winds",
 	"WIZARDS-ROBES": "Wizard’s Robes",


### PR DESCRIPTION

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

- Updated Armor Tab - There is now 3 (Light/Medium/Heavy) Equip/unequip buttons at the top of the tab. This allows quicker equipping and unequipping of Armor for players. Also all Equip/Unequip and Worn/Unworn actions in this tab now automatically activate or disable the corresponding Armor penalties. 


