### PR TITLE
[Chronicles of Darkness] Hide firefox spinner for derived inputs

### DIFF
--- a/Chronicles of Darkness/CofD.css
+++ b/Chronicles of Darkness/CofD.css
@@ -986,6 +986,9 @@ input.sheet-if[value="16"] ~ .sheet-ne-16 {
     margin-bottom: 0px;
 }
 
+.sheet-derived input {
+    -moz-appearance: textfield;
+}
 .sheet-derived input::-webkit-outer-spin-button,
 .sheet-derived input::-webkit-inner-spin-button {
     /* display: none; <- Crashes Chrome on hover */


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

Fixes #10707 

## Root Cause
The inputs are correctly populated, but the value is not seen because it is covered by the Firefox number input spinners (the up and down arrows for number inputs).

## Fix
Hide the Firefox number input spinners for these "derived" inputs.

(Chromium spinners are already hidden with different css rules.)