### PR TITLE
[Star Wars Saga Edition] Update: Changed Initiative tiebreaker to initiative mod

### DIFF
--- a/Star Wars Saga Edition/StarWarsSagaEdition.html
+++ b/Star Wars Saga Edition/StarWarsSagaEdition.html
@@ -192,8 +192,8 @@
 				</div>	
 				<div class="table-row">
 					<span class="table-data">	
-						<button type="roll" name="roll_InitiativeTurn" value="&{template:skill} {{name=Rolling for Turn Order}} {{skill=[[1d20+@{Initiative}+@{InitiativeDecimal}[Dex Decimal]+?{Other Modifiers|0}[Other] &{tracker}]]}}" title="Roll Initiative to Turn Order window %{InitiativeTurn}" ></button>		
-						<label><span data-i18n="initiative">Initiative</span></label>	 <span class="small" style="margin-left:10px;"><input type="checkbox"  value="[[0.01 * @{dex}]]" name="attr_InitiativeDecimal" title="Add Dex Score to roll as a decimal for easier sorting @{InitiativeDecimal}" checked /><span data-i18n="init_dex_decimal" class="sheet-not-sheet-show">Dex Score as Decimal</span>
+						<button type="roll" name="roll_InitiativeTurn" value="&{template:skill} {{name=Rolling for Turn Order}} {{skill=[[1d20+@{Initiative}+@{InitiativeDecimal}[Initiative Decimal]+?{Other Modifiers|0}[Other] &{tracker}]]}}" title="Roll Initiative to Turn Order window %{InitiativeTurn}" ></button>		
+						<label><span data-i18n="initiative">Initiative</span></label>	 <span class="small" style="margin-left:10px;"><input type="checkbox"  value="[[0.01 * @{Initiative}]]" name="attr_InitiativeDecimal" title="Add Initiative Modifier to roll as a decimal for easier sorting @{InitiativeDecimal}" checked /><span data-i18n="init_decimal" class="sheet-not-sheet-show">Initiative as Decimal</span>
 					</span>
 				</div>
 			</div>
@@ -1931,8 +1931,8 @@
 			<button type="roll" name="roll_NPC-PerceptionShort" value="&{template:skill} {{name=Perception}} {{skill=[[1d20+@{Perception}+?{Other Modifiers|0}[Other]]]}}" title="Roll Perception" ></button>
 				<label>Perception </label>		
 			<br />
-			<button type="roll" name="roll_NPC-InitiativeTurn" value="&{template:skill} {{name=Rolling for Turn Order}} {{skill=[[1d20+@{Initiative}+@{InitiativeDecimal}[Dex Decimal]+?{Other Modifiers|0}[Other] &{tracker}]]}}" title="Roll Initiative to Turn Order window %{InitiativeTurn}" ></button>		
-				<label>Initiative</label>	 <span class="small" style="margin-left:10px;"><input type="checkbox" value="[[0.01 * @{dex}]]" name="attr_InitiativeDecimal" title="Add Dex Score to roll as a decimal for easier sorting @{InitiativeDecimal}" checked />Dex Score as Decimal
+			<button type="roll" name="roll_NPC-InitiativeTurn" value="&{template:skill} {{name=Rolling for Turn Order}} {{skill=[[1d20+@{Initiative}+@{InitiativeDecimal}[Initiative Decimal]+?{Other Modifiers|0}[Other] &{tracker}]]}}" title="Roll Initiative to Turn Order window %{InitiativeTurn}" ></button>		
+				<label>Initiative</label>	 <span class="small" style="margin-left:10px;"><input type="checkbox" value="[[0.01 * @{Initiative}]]" name="attr_InitiativeDecimal" title="Add Initiative Modifier to roll as a decimal for easier sorting @{InitiativeDecimal}" checked />Initiative as Decimal
 			<table>
 					<div class="textHead">Grapple</div>
 				<tr>


### PR DESCRIPTION
Tiebreakers for skills in SWSE (including initiative rolls) are determined by the skill modifier, not the score of the ability that it's based on. That has never, ever been a thing.

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)


# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

Tiebreakers for skills in SWSE (including initiative rolls) are determined by the skill modifier, not the score of the ability that it's based on. That has never, ever been a thing.


