### PR TITLE
[Snice] Adjusted result text color in dark theme

### DIFF
--- a/Snice/snice.css
+++ b/Snice/snice.css
@@ -10,6 +10,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     background-position: center;
+    color: #000;
     border: 2px solid #000;
     border-radius: 6px;
     text-align: center;


### PR DESCRIPTION
Adjusted the roll result text color in the Roll20 dark theme. Apparently there was an update not so long ago that made the roll result's text white by default when dark theme is enabled, which then makes it almost invisible on the semi-white backgrounds of the Snice template. Updated the style to set a default text color so it's safe for future updates. (Totally my fault for forgetting this in the initial version as I left the color to the Roll20 defaults)

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

