### PR TITLE
[ADnD_2E_Revised] Bugfix/Fixed magic weapons not updating if the bonus is in the middle of the name

### DIFF
--- a/ADnD_2E_Revised/javascript/sheetWorkers.js
+++ b/ADnD_2E_Revised/javascript/sheetWorkers.js
@@ -1484,8 +1484,9 @@ function setWeaponWithBonus(weaponName, setWeaponFunc, comparer, thac0Field, cat
             if (!match)
                 return;
 
-            let baseWeaponName = weaponName.replace(match[0], ' ').trim();
-            baseWeapons = WEAPONS_TABLE[baseWeaponName];
+            let baseWeaponName1 = weaponName.replace(match[0], '');
+            let baseWeaponName2 = weaponName.replace(match[0], ' ').trim();
+            baseWeapons = WEAPONS_TABLE[baseWeaponName1] || WEAPONS_TABLE[baseWeaponName2];
             if (!baseWeapons)
                 return;
 


### PR DESCRIPTION
# Submission Checklist
## Required

- [X] The pull request title clearly contains the name of the sheet I am editing.
- [X] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [X] The pull request makes changes to files in only one sub-folder.
- [X] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

Fixed magic weapons when placed somewhere without a whitespace, ie
- "Long Sword" becoming "Long +2 Sword" is okay
- "Short bow, Arrow" becoming "Short bow +2, Arrow" was broken