### PR TITLE
[SotS][Bugfix] Lifestyle radio buttons can't store value

### DIFF
--- a/SotS/Swords of the Serpentine.html
+++ b/SotS/Swords of the Serpentine.html
@@ -374,15 +374,16 @@
 <hr style="height:4px;border-width:0;color:gray;background-color:gray"/>
 
 <div class="col">
-	<h2>Wealth</h2>
-	<label class="sheet-wealth2">Current Wealth</label> <input type="number" name="attr_wealth" class="sheet-wealth" min="0" max="100"/><br/>&nbsp;<br/>
-	<label class="sheet-lifestyle">Lifestyle: </label>
-	<input type="radio" name="attr_lifestyle" class="sheet-radio" /><label class="sheet-wealth1">Squalid(-2)</label>
-	<input type="radio" name="attr_lifestyle" class="sheet-radio" /><label class="sheet-wealth2">Struggling(-1)</label>
-	<input type="radio" name="attr_lifestyle" class="sheet-radio" /><label class="sheet-wealth2">Comfortable(0)</label>
-	<input type="radio" name="attr_lifestyle" class="sheet-radio" /><label class="sheet-wealth1">Wealthy(1)</label>
-	<input type="radio" name="attr_lifestyle" class="sheet-radio" /><label class="sheet-wealth1">Opulent(2)</label>
-
+	<form action="">
+		<h2>Wealth</h2>
+		<label class="sheet-wealth2">Current Wealth</label> <input type="number" name="attr_wealth" class="sheet-wealth" min="0" max="100"><br>&nbsp;<br>
+		<label class="sheet-lifestyle">Lifestyle: </label>
+		<input type="radio" name="attr_lifestyle" value="1" class="sheet-radio"><label class="sheet-wealth1">Squalid(-2)</label>
+		<input type="radio" name="attr_lifestyle" value="2" class="sheet-radio"><label class="sheet-wealth2">Struggling(-1)</label>
+		<input type="radio" name="attr_lifestyle" value="3" class="sheet-radio" checked="checked"><label class="sheet-wealth2">Comfortable(0)</label>
+		<input type="radio" name="attr_lifestyle" value="4" class="sheet-radio"><label class="sheet-wealth1">Wealthy(1)</label>
+		<input type="radio" name="attr_lifestyle" value="5" class="sheet-radio"><label class="sheet-wealth1">Opulent(2)</label>
+	</form>
 </div>
 
 

--- a/SotS/Swords of the Serpentine.html
+++ b/SotS/Swords of the Serpentine.html
@@ -374,16 +374,15 @@
 <hr style="height:4px;border-width:0;color:gray;background-color:gray"/>
 
 <div class="col">
-	<form action="">
-		<h2>Wealth</h2>
-		<label class="sheet-wealth2">Current Wealth</label> <input type="number" name="attr_wealth" class="sheet-wealth" min="0" max="100"><br>&nbsp;<br>
-		<label class="sheet-lifestyle">Lifestyle: </label>
-		<input type="radio" name="attr_lifestyle" value="1" class="sheet-radio"><label class="sheet-wealth1">Squalid(-2)</label>
-		<input type="radio" name="attr_lifestyle" value="2" class="sheet-radio"><label class="sheet-wealth2">Struggling(-1)</label>
-		<input type="radio" name="attr_lifestyle" value="3" class="sheet-radio" checked="checked"><label class="sheet-wealth2">Comfortable(0)</label>
-		<input type="radio" name="attr_lifestyle" value="4" class="sheet-radio"><label class="sheet-wealth1">Wealthy(1)</label>
-		<input type="radio" name="attr_lifestyle" value="5" class="sheet-radio"><label class="sheet-wealth1">Opulent(2)</label>
-	</form>
+	<h2>Wealth</h2>
+	<label class="sheet-wealth2">Current Wealth</label> <input type="number" name="attr_wealth" class="sheet-wealth" min="0" max="100"><br>&nbsp;<br>
+	<label class="sheet-lifestyle">Lifestyle: </label>
+	
+	<input type="radio" name="attr_lifestyle" value="1" class="sheet-radio"><label class="sheet-wealth1">Squalid(-2)</label>
+	<input type="radio" name="attr_lifestyle" value="2" class="sheet-radio"><label class="sheet-wealth2">Struggling(-1)</label>
+	<input type="radio" name="attr_lifestyle" value="3" class="sheet-radio" checked="checked"><label class="sheet-wealth2">Comfortable(0)</label>
+	<input type="radio" name="attr_lifestyle" value="4" class="sheet-radio"><label class="sheet-wealth1">Wealthy(1)</label>
+	<input type="radio" name="attr_lifestyle" value="5" class="sheet-radio"><label class="sheet-wealth1">Opulent(2)</label>
 </div>
 
 


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

Love this sheet, thanks for making it for our new favorite game!

Lifestyle radio buttons work OK until the sheet is closed. The next time the sheet is opened, it will always choose the final radio button, Opulent(2), as "on".

Wrapping the radio buttons into a form will allow a default check on Comfortable(0), and maintain the selected value (now an integer) for attr_lifestyle.




