### PR TITLE
[SotS][Bugfix] Lifestyle buttons don't store value

### DIFF
--- a/SotS/Swords of the Serpentine.html
+++ b/SotS/Swords of the Serpentine.html
@@ -377,12 +377,12 @@
 	<h2>Wealth</h2>
 	<label class="sheet-wealth2">Current Wealth</label> <input type="number" name="attr_wealth" class="sheet-wealth" min="0" max="100"/><br/>&nbsp;<br/>
 	<label class="sheet-lifestyle">Lifestyle: </label>
-	<input type="radio" name="attr_lifestyle" class="sheet-radio" /><label class="sheet-wealth1">Squalid(-2)</label>
-	<input type="radio" name="attr_lifestyle" class="sheet-radio" /><label class="sheet-wealth2">Struggling(-1)</label>
-	<input type="radio" name="attr_lifestyle" class="sheet-radio" /><label class="sheet-wealth2">Comfortable(0)</label>
-	<input type="radio" name="attr_lifestyle" class="sheet-radio" /><label class="sheet-wealth1">Wealthy(1)</label>
-	<input type="radio" name="attr_lifestyle" class="sheet-radio" /><label class="sheet-wealth1">Opulent(2)</label>
-
+	<input type="radio" name="attr_lifestyle" class="sheet-radio" value="1" /><label class="sheet-wealth1">Squalid(-2)</label>
+	<input type="radio" name="attr_lifestyle" class="sheet-radio" value="2" /><label class="sheet-wealth2">Struggling(-1)</label>
+	<input type="radio" name="attr_lifestyle" class="sheet-radio" value="3" /><label class="sheet-wealth2">Comfortable(0)</label>
+	<input type="radio" name="attr_lifestyle" class="sheet-radio" value="4" /><label class="sheet-wealth1">Wealthy(1)</label>
+	<input type="radio" name="attr_lifestyle" class="sheet-radio" value="5" /><label class="sheet-wealth1">Opulent(2)</label>
+	
 </div>
 
 


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

- [x] I have followed the [Character Sheets Standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) when building this sheet.

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->
Love this sheet, thanks for making it for our new favorite game!

Lifestyle radio buttons work OK until the sheet is closed. The next time the sheet is opened, it will always choose the final radio button, Opulent(2), as "on".

Giving the radio button selections new numeric values should maintain the selected button for attr_lifestyle.
