### PR TITLE
Updated WHFRP2.html - Bugfixes SB & TB modifier actually used & Melee Weapon 6 & 7 damage rolls use correct name

### DIFF
--- a/Warhammer-Fantasy-Roleplay-2nd-Edition/WHFRP2.html
+++ b/Warhammer-Fantasy-Roleplay-2nd-Edition/WHFRP2.html
@@ -511,10 +511,10 @@
 						<input class="sheet-center" type="number" name="attr_Wounds_max" value="@{WoundsStart}+@{WoundsTalents}+@{WoundsAdv}+@{WoundsMod}" disabled="true"/>
 					</div>
 					<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm">
-						<input class="sheet-center" type="number" name="attr_StrengthBonus" value="floor((@{StrengthStart}+@{StrengthTalents}+@{StrengthAdv}+@{StrengthMod})/10)" disabled="true"/>
+						<input class="sheet-center" type="number" name="attr_StrengthBonus" value="floor((@{StrengthStart}+@{StrengthTalents}+@{StrengthAdv}+@{StrengthMod})/10)+@{StrengthBonusMod}" disabled="true"/>
 					</div>
 					<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm">
-						<input class="sheet-center" type="number" name="attr_ToughnessBonus" value="floor((@{ToughnessStart}+@{ToughnessTalents}+@{ToughnessAdv}+@{ToughnessMod})/10)" disabled="true"/>
+						<input class="sheet-center" type="number" name="attr_ToughnessBonus" value="floor((@{ToughnessStart}+@{ToughnessTalents}+@{ToughnessAdv}+@{ToughnessMod})/10)+@{ToughnessBonusMod}" disabled="true"/>
 					</div>
 					<div class="sheet-col-1-10 sheet-center sheet-pad-r-sm">
 						<input class="sheet-center" type="number" name="attr_Movement" value="@{MovementStart}+@{MovementTalents}+@{MovementAdv}+@{MovementMod}-@{encumbered}-@{armormovepenalty}" disabled="true"/>
@@ -3281,7 +3281,7 @@
 				<button type="roll" class="sheet-roll" name="roll_MeleeAttack6" value="@{Whisper} &{template:whfrp2e} {{title=@{meleeweaponname6}}} {{character_name=@{character_name}}} {{attacktype=^{MELEE}}} {{target=[[@{meleetohit6}+?{@{translation_modifier}|0}]]}} {{attacktest=[[1d100]]}} {{qualities=@{meleequalities6}}}"></button>
 			</div>
 			<div class="sheet-col-4-100 sheet-center sheet-pad-r-sm">
-				<button type="roll" class="sheet-roll" name="roll_MeleeDamage6" value="@{Whisper} &{template:whfrp2e} {{title=@{meleeweaponname1}}} {{character_name=@{character_name}}} {{attacktype=^{DAMAGE}}} {{damage=[[1d10+@{StrengthBonus}+@{meleedmg6}]]}} {{impact=[[@{meleeimpact6}]]}} {{impactdamage=[[1d10+@{StrengthBonus}+@{meleedmg6}]]}} {{qualities=@{meleequalities6}}}"></button>
+				<button type="roll" class="sheet-roll" name="roll_MeleeDamage6" value="@{Whisper} &{template:whfrp2e} {{title=@{meleeweaponname6}}} {{character_name=@{character_name}}} {{attacktype=^{DAMAGE}}} {{damage=[[1d10+@{StrengthBonus}+@{meleedmg6}]]}} {{impact=[[@{meleeimpact6}]]}} {{impactdamage=[[1d10+@{StrengthBonus}+@{meleedmg6}]]}} {{qualities=@{meleequalities6}}}"></button>
 			</div>
 			<div class="sheet-col-4-100 sheet-center sheet-pad-r-sm">
 				<button type="roll" class="sheet-roll" name="roll_MeleeParry6" value="@{Whisper} &{template:whfrp2e} {{title=@{meleeweaponname6}}} {{character_name=@{character_name}}} {{attacktype=^{PARRY}}} {{target=[[@{meleetohit6}+@{meleedefensive6}+?{@{translation_modifier}|0}]]}} {{parrytest=[[1d100]]}} {{qualities=@{meleequalities6}}}"></button>
@@ -3310,7 +3310,7 @@
 				<button type="roll" class="sheet-roll" name="roll_MeleeAttack7" value="@{Whisper} &{template:whfrp2e} {{title=@{meleeweaponname7}}} {{character_name=@{character_name}}} {{attacktype=^{MELEE}}} {{target=[[@{meleetohit7}+?{@{translation_modifier}|0}]]}} {{attacktest=[[1d100]]}} {{qualities=@{meleequalities7}}}"></button>
 			</div>
 			<div class="sheet-col-4-100 sheet-center sheet-pad-r-sm">
-				<button type="roll" class="sheet-roll" name="roll_MeleeDamage7" value="@{Whisper} &{template:whfrp2e} {{title=@{meleeweaponname1}}} {{character_name=@{character_name}}} {{attacktype=^{DAMAGE}}} {{damage=[[1d10+@{StrengthBonus}+@{meleedmg7}]]}} {{impact=[[@{meleeimpact7}]]}} {{impactdamage=[[1d10+@{StrengthBonus}+@{meleedmg7}]]}} {{qualities=@{meleequalities7}}}"></button>
+				<button type="roll" class="sheet-roll" name="roll_MeleeDamage7" value="@{Whisper} &{template:whfrp2e} {{title=@{meleeweaponname7}}} {{character_name=@{character_name}}} {{attacktype=^{DAMAGE}}} {{damage=[[1d10+@{StrengthBonus}+@{meleedmg7}]]}} {{impact=[[@{meleeimpact7}]]}} {{impactdamage=[[1d10+@{StrengthBonus}+@{meleedmg7}]]}} {{qualities=@{meleequalities7}}}"></button>
 			</div>
 			<div class="sheet-col-4-100 sheet-center sheet-pad-r-sm">
 				<button type="roll" class="sheet-roll" name="roll_MeleeParry7" value="@{Whisper} &{template:whfrp2e} {{title=@{meleeweaponname7}}} {{character_name=@{character_name}}} {{attacktype=^{PARRY}}} {{target=[[@{meleetohit7}+@{meleedefensive7}+?{@{translation_modifier}|0}]]}} {{parrytest=[[1d100]]}} {{qualities=@{meleequalities7}}}"></button>


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [X] The pull request title clearly contains the name of the sheet I am editing.
- [X] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [X] The pull request makes changes to files in only one sub-folder.
- [X] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

Updated Warhammer-Fantasy-Roleplay-2nd-Edition fixing the following.
SB & TB (Secondary profile) now actually use their respective BonusMod value for the Current calculation. 
Melee weapon 6 & 7 when rolling damage now use the correct name instead of using meleeweaponname1.




