### PR TITLE
[PokemonTabletopAdventures_v3] Fix: Updates 3D Die Rolling

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -1,8 +1,8 @@
 .charsheet,
 .sheet-rolltemplate-move-roll,
 .sheet-rolltemplate-dual-hit-move-roll,
-.sheet-rolltemplate-dectuple-hit-move-roll,
-.sheet-rolltemplate-quintuple-hit-move-roll,
+.sheet-rolltemplate-ten-hit-move-roll,
+.sheet-rolltemplate-multi-hit-move-roll,
 .sheet-rolltemplate-triple-hit-move-roll,
 .sheet-rolltemplate-feature-output {
   --poke-bug: #c6d16e;
@@ -1130,8 +1130,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll,
 .sheet-rolltemplate-dual-hit-move-roll,
-.sheet-rolltemplate-dectuple-hit-move-roll,
-.sheet-rolltemplate-quintuple-hit-move-roll,
+.sheet-rolltemplate-ten-hit-move-roll,
+.sheet-rolltemplate-multi-hit-move-roll,
 .sheet-rolltemplate-triple-hit-move-roll,
 .sheet-rolltemplate-feature-output {
   --header-text: black;
@@ -1143,8 +1143,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll,
 .sheet-rolltemplate-dual-hit-move-roll,
-.sheet-rolltemplate-dectuple-hit-move-roll,
-.sheet-rolltemplate-quintuple-hit-move-roll,
+.sheet-rolltemplate-ten-hit-move-roll,
+.sheet-rolltemplate-multi-hit-move-roll,
 .sheet-rolltemplate-triple-hit-move-roll,
 .sheet-rolltemplate-skill-roll,
 .sheet-rolltemplate-feature-output {
@@ -1156,8 +1156,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-darkmode.sheet-rolltemplate-move-roll,
 .sheet-rolltemplate-darkmode.sheet-rolltemplate-dual-hit-move-roll,
-.sheet-rolltemplate-darkmode.sheet-rolltemplate-dectuple-hit-move-roll,
-.sheet-rolltemplate-darkmode.sheet-rolltemplate-quintuple-hit-move-roll,
+.sheet-rolltemplate-darkmode.sheet-rolltemplate-ten-hit-move-roll,
+.sheet-rolltemplate-darkmode.sheet-rolltemplate-multi-hit-move-roll,
 .sheet-rolltemplate-darkmode.sheet-rolltemplate-triple-hit-move-roll,
 .sheet-rolltemplate-darkmode.sheet-rolltemplate-feature-output,
 .sheet-rolltemplate-darkmode.sheet-rolltemplate-skill-roll {
@@ -1411,8 +1411,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container hr.sheet-border,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container hr.sheet-border,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container hr.sheet-border,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container hr.sheet-border,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container hr.sheet-border,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container hr.sheet-border,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container hr.sheet-border,
 .sheet-rolltemplate-skill-roll .sheet-container hr.sheet-border,
 .sheet-rolltemplate-feature-output .sheet-container hr.sheet-border {
@@ -1422,8 +1422,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template,
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template,
 .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template {
@@ -1437,8 +1437,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-crit-damage-text,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-crit-damage-text,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-crit-damage-text,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-crit-damage-text,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template .sheet-crit-damage-text,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-crit-damage-text,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .sheet-crit-damage-text {
   font-weight: bold;
   margin-left: 10px;
@@ -1447,8 +1447,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template .sheet-skill-roll .inlinerollresult {
   background: #000000;
@@ -1458,8 +1458,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-notes-text .inlinerollresult,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-notes-text .inlinerollresult,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-notes-text .inlinerollresult,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-notes-text .inlinerollresult,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template .sheet-notes-text .inlinerollresult,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-notes-text .inlinerollresult,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .sheet-notes-text .inlinerollresult,
 .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template .sheet-notes-text .inlinerollresult {
   background: #00000000;
@@ -1470,12 +1470,12 @@ button[type="roll"].sheet-stat-roller:hover {
 }
 
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-damage-roll,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-damage-roll,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-damage-roll,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template .sheet-damage-roll,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-damage-roll,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .sheet-damage-roll {
   text-align: center;
 }
@@ -1491,13 +1491,13 @@ button[type="roll"].sheet-stat-roller:hover {
 /* Varying colour by effectiveness for damage roll and text  */
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-text-color,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-text-color,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-text-color,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-text-color,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-text-color,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-text-color,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-text-color {
   background: #800000;
   border-color: #800000;
@@ -1506,13 +1506,13 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-text-color,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-text-color,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-text-color,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-text-color,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-text-color,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-text-color,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-text-color {
   background: #cf6800;
   border-color: #cf6800;
@@ -1521,23 +1521,23 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-text-color,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-text-color,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-text-color,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-text-color,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-text-color,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-text-color,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-text-color,
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-text-color,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-text-color,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-text-color,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-text-color,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-text-color,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-text-color,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-text-color {
   background: #000000;
   border-color: #000000;
@@ -1546,13 +1546,13 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-text-color,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-text-color,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-text-color,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-text-color,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-text-color,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-text-color,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-text-color {
   background: #000080;
   border-color: #000080;
@@ -1561,13 +1561,13 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-text-color,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-text-color,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-text-color,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-text-color,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-text-color,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-text-color,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-text-color {
   background: #008000;
   border-color: #008000;
@@ -1576,8 +1576,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template a,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template a,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template a,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template a,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template a,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template a,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template a,
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template a,
 .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template a {
@@ -1588,8 +1588,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template td,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template td,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template td,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template td {
   padding: 4px 2px;
 }
@@ -1601,12 +1601,12 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-effectiveness-text,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td.sheet-effectiveness-text,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-effectiveness-text,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-effectiveness-text,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template td.sheet-effectiveness-text,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td.sheet-effectiveness-text,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-effectiveness-text,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td.sheet-targeted-defense,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-targeted-defense,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-targeted-defense,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template td.sheet-targeted-defense,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td.sheet-targeted-defense,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-targeted-defense {
   font-weight: bold;
   line-height: 20px;
@@ -1617,8 +1617,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-label,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td.sheet-label,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-label,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-label,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template td.sheet-label,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td.sheet-label,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-label,
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template td.sheet-label {
   font-weight: bold;
@@ -1629,8 +1629,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
 .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template td.sheet-notes-text {
   font-size: 12px;
@@ -1641,8 +1641,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template td.sheet-subhead,
 .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template td.sheet-subhead {
@@ -1654,8 +1654,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template th,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template th,
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template th,
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template th,
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template th,
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template th,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template th,
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template th,
 .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template th {
@@ -1668,8 +1668,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template tr:nth-child(odd),
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(odd),
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(odd),
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(odd),
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(odd),
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(odd),
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(odd),
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template tr:nth-child(odd),
 .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template tr:nth-child(odd) {
@@ -1678,8 +1678,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
-.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
-.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
+.sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
+.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template tr:nth-child(even),
 .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template tr:nth-child(even) {
@@ -1807,8 +1807,8 @@ button[type="roll"].sheet-inline-roller {
 
   .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template,
   .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template,
-  .sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template,
-  .sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template,
+  .sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template,
+  .sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template,
   .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template,
   .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template,
   .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template {
@@ -1819,8 +1819,8 @@ button[type="roll"].sheet-inline-roller {
   
   .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
   .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
-  .sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
-  .sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
+  .sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
+  .sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
   .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
   .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template td.sheet-notes-text {
     font-size: 16px;

--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -1,7 +1,8 @@
 .charsheet,
 .sheet-rolltemplate-move-roll,
 .sheet-rolltemplate-dual-hit-move-roll,
-.sheet-rolltemplate-multi-hit-move-roll,
+.sheet-rolltemplate-dectuple-hit-move-roll,
+.sheet-rolltemplate-quintuple-hit-move-roll,
 .sheet-rolltemplate-triple-hit-move-roll,
 .sheet-rolltemplate-feature-output {
   --poke-bug: #c6d16e;
@@ -1129,7 +1130,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll,
 .sheet-rolltemplate-dual-hit-move-roll,
-.sheet-rolltemplate-multi-hit-move-roll,
+.sheet-rolltemplate-dectuple-hit-move-roll,
+.sheet-rolltemplate-quintuple-hit-move-roll,
 .sheet-rolltemplate-triple-hit-move-roll,
 .sheet-rolltemplate-feature-output {
   --header-text: black;
@@ -1141,7 +1143,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll,
 .sheet-rolltemplate-dual-hit-move-roll,
-.sheet-rolltemplate-multi-hit-move-roll,
+.sheet-rolltemplate-dectuple-hit-move-roll,
+.sheet-rolltemplate-quintuple-hit-move-roll,
 .sheet-rolltemplate-triple-hit-move-roll,
 .sheet-rolltemplate-skill-roll,
 .sheet-rolltemplate-feature-output {
@@ -1153,7 +1156,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-darkmode.sheet-rolltemplate-move-roll,
 .sheet-rolltemplate-darkmode.sheet-rolltemplate-dual-hit-move-roll,
-.sheet-rolltemplate-darkmode.sheet-rolltemplate-multi-hit-move-roll,
+.sheet-rolltemplate-darkmode.sheet-rolltemplate-dectuple-hit-move-roll,
+.sheet-rolltemplate-darkmode.sheet-rolltemplate-quintuple-hit-move-roll,
 .sheet-rolltemplate-darkmode.sheet-rolltemplate-triple-hit-move-roll,
 .sheet-rolltemplate-darkmode.sheet-rolltemplate-feature-output,
 .sheet-rolltemplate-darkmode.sheet-rolltemplate-skill-roll {
@@ -1407,7 +1411,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container hr.sheet-border,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container hr.sheet-border,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container hr.sheet-border,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container hr.sheet-border,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container hr.sheet-border,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container hr.sheet-border,
 .sheet-rolltemplate-skill-roll .sheet-container hr.sheet-border,
 .sheet-rolltemplate-feature-output .sheet-container hr.sheet-border {
@@ -1417,7 +1422,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template,
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template,
 .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template {
@@ -1431,7 +1437,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-crit-damage-text,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-crit-damage-text,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-crit-damage-text,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-crit-damage-text,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-crit-damage-text,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .sheet-crit-damage-text {
   font-weight: bold;
   margin-left: 10px;
@@ -1440,7 +1447,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll .inlinerollresult,
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template .sheet-skill-roll .inlinerollresult {
   background: #000000;
@@ -1450,7 +1458,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-notes-text .inlinerollresult,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-notes-text .inlinerollresult,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-notes-text .inlinerollresult,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-notes-text .inlinerollresult,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-notes-text .inlinerollresult,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .sheet-notes-text .inlinerollresult,
 .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template .sheet-notes-text .inlinerollresult {
   background: #00000000;
@@ -1461,10 +1470,12 @@ button[type="roll"].sheet-stat-roller:hover {
 }
 
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .sheet-accuracy-roll,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-damage-roll,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-damage-roll,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-damage-roll,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-damage-roll,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .sheet-damage-roll {
   text-align: center;
 }
@@ -1480,11 +1491,13 @@ button[type="roll"].sheet-stat-roller:hover {
 /* Varying colour by effectiveness for damage roll and text  */
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-text-color,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-text-color,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-text-color,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-text-color,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-text-color,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .userscript--2-effectiveness-text-color {
   background: #800000;
   border-color: #800000;
@@ -1493,11 +1506,13 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-text-color,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-text-color,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-text-color,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-text-color,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-text-color,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .userscript--1-effectiveness-text-color {
   background: #cf6800;
   border-color: #cf6800;
@@ -1506,19 +1521,23 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-text-color,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-text-color,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-text-color,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-text-color,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-text-color,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .userscript-0-effectiveness-text-color,
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-text-color,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-text-color,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-text-color,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-text-color,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-text-color,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .sheet-0-effectiveness-text-color {
   background: #000000;
   border-color: #000000;
@@ -1527,11 +1546,13 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-text-color,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-text-color,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-text-color,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-text-color,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-text-color,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .userscript-1-effectiveness-text-color {
   background: #000080;
   border-color: #000080;
@@ -1540,11 +1561,13 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-color .inlinerollresult,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-color .inlinerollresult,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-color .inlinerollresult,
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-text-color,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-text-color,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-text-color,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-text-color,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-text-color,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template .userscript-2-effectiveness-text-color {
   background: #008000;
   border-color: #008000;
@@ -1553,7 +1576,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template a,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template a,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template a,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template a,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template a,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template a,
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template a,
 .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template a {
@@ -1564,7 +1588,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template td,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template td,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template td {
   padding: 4px 2px;
 }
@@ -1576,10 +1601,12 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-effectiveness-text,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td.sheet-effectiveness-text,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td.sheet-effectiveness-text,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-effectiveness-text,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-effectiveness-text,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-effectiveness-text,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td.sheet-targeted-defense,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td.sheet-targeted-defense,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-targeted-defense,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-targeted-defense,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-targeted-defense {
   font-weight: bold;
   line-height: 20px;
@@ -1590,7 +1617,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-label,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td.sheet-label,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td.sheet-label,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-label,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-label,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-label,
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template td.sheet-label {
   font-weight: bold;
@@ -1601,7 +1629,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
 .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template td.sheet-notes-text {
   font-size: 12px;
@@ -1612,7 +1641,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template td.sheet-subhead,
 .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template td.sheet-subhead {
@@ -1624,7 +1654,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template th,
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template th,
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template th,
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template th,
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template th,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template th,
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template th,
 .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template th {
@@ -1637,7 +1668,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template tr:nth-child(odd),
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(odd),
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(odd),
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(odd),
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(odd),
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(odd),
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template tr:nth-child(odd),
 .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template tr:nth-child(odd) {
@@ -1646,7 +1678,8 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
 .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
-.sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
+.sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
+.sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template tr:nth-child(even),
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template tr:nth-child(even),
 .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template tr:nth-child(even) {
@@ -1774,7 +1807,8 @@ button[type="roll"].sheet-inline-roller {
 
   .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template,
   .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template,
-  .sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template,
+  .sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template,
+  .sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template,
   .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template,
   .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template,
   .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template {
@@ -1785,7 +1819,8 @@ button[type="roll"].sheet-inline-roller {
   
   .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
   .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
-  .sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
+  .sheet-rolltemplate-dectuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
+  .sheet-rolltemplate-quintuple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
   .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-notes-text,
   .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template td.sheet-notes-text {
     font-size: 16px;

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -1006,7 +1006,7 @@
           <div class="sheet-pokemon-move-info-header">
             <span class="sheet-fill-space">
               <button class="sheet-inline-roller sheet-skill-roller" name="roll-movetemplate" title="Click this to roll this attack with the option of choosing temporary modifiers or effectiveness." type="roll"
-                value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} ]]}} {{damage-2=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-3=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-4=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-5=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}}">
+                value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{critical-damage-extra=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} ]]}} @{attack_rolls}">
                 <span name="attr_move_name"></span>
               </button>
               <b class="sheet-info-tooltip" title="Click this to roll this attack with the option of choosing temporary modifiers or effectiveness.">ℹ</b>
@@ -1014,7 +1014,7 @@
 
             <span class="sheet-fill-space sheet-hide-on-mobile">
               <button class="sheet-inline-roller sheet-skill-roller" name="roll-quick-move" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers." type="roll"
-                value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{effectiveness-roll=[[2]]}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} {{damage-2=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-3=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-4=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-5=[[ @{move_dicenumber}d@{damage_dice} ]]}}">
+                value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{effectiveness-roll=[[2]]}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} ${quick_attack_rolls}">
                 Quick Roll
               </button>
               <b class="sheet-info-tooltip" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers.">ℹ</b>
@@ -1049,7 +1049,7 @@
 
             <span class="sheet-fill-space sheet-hide-on-mobile">
               <button class="sheet-inline-roller sheet-skill-roller" name="roll-quick-move" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers." type="roll"
-                value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{effectiveness-roll=[[2]]}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} {{damage-2=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-3=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-4=[[ @{move_dicenumber}d@{damage_dice} ]]}} {{damage-5=[[ @{move_dicenumber}d@{damage_dice} ]]}}">
+                value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{effectiveness-roll=[[2]]}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} ${quick_attack_rolls}">
                 Quick Roll
               </button>
               <b class="sheet-info-tooltip" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers.">ℹ</b>
@@ -1131,12 +1131,15 @@
               <b class="sheet-info-tooltip" title="Choose the Scatter type of the attack. This will effect which roll template is used for the chat log output.">ℹ</b>
             </span>
             <span>
+              <input name="attr_attack_rolls" type="hidden" />
+              <input name="attr_quick_attack_rolls" type="hidden" />
               <select class="sheet-move-text" name="attr_move_template" title="Attribute: move_template">
-                <option value="move-roll" selected>None</option>
-                <option value="dual-hit-move-roll">Dual Hit</option>
-                <option value="multi-hit-move-roll">Multi Hit</option>
-                <option value="triple-hit-move-roll">Triple Hit</option>
-              </select>
+                <option value="move-roll" selected>One Hit</option>
+                <option value="dual-hit-move-roll">Two Hits</option>
+                <option value="triple-hit-move-roll">Three Hits</option>
+                <option value="quintuple-hit-move-roll">Up to Five Hits</option>
+                <option value="dectuple-hit-move-roll">Up to Ten Hits</option>
+      </select>
             </span>
 
             <span>
@@ -1207,7 +1210,7 @@
           <div class="sheet-move-notes-roller">
             <textarea class="sheet-3row-textarea" name="attr_move_effect" placeholder="Additional Effect Notes" spellcheck="false" title="Attribute: move_effect"></textarea>
             <button class="sheet-move-roller" name="roll-movetemplate" type="roll"
-              value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{accuracy-2=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-3=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-4=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{accuracy-5=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{critical-damage-extra=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} ]]}} {{damage-2=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-3=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-4=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}} {{damage-5=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}}">
+              value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{critical-damage-extra=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} ]]}} @{attack_rolls}">
               T
             </button>
           </div>
@@ -1666,7 +1669,585 @@
     </div>
   </rolltemplate>
 
-  <rolltemplate class="sheet-rolltemplate-multi-hit-move-roll">
+  <rolltemplate class="sheet-rolltemplate-quintuple-hit-move-roll">
+    <div class="sheet-container sheet-rolltemplate-color-setting-{{move-type}}-move">
+      <table class="sheet-move-template">
+        <tbody>
+          <tr>
+            <th colspan="4">{{move-name}}</th>
+          </tr>
+          <tr class="sheet-hide-on-mobile">
+            <td colspan="4" class="sheet-subhead">[{{character-name}}](https://journal.roll20.net/character/{{character-id}}" name="name-link")</td>
+          </tr>
+
+          <!-- Targeted Defense -->
+          {{#target}}
+          <tr>
+            <td class="sheet-targeted-defense" colspan="4">Attacking against {{target}}</td>
+          </tr>
+          {{/target}}
+
+          <!-- Effectiveness -->
+          {{#^rollTotal() effectiveness-roll 2}}
+          <tr>
+            <!--<td class="sheet-label"><span>Effect:</span></td>-->
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>
+                <!-- Shielded -->
+                {{#rollTotal() effectiveness-roll 0}} It was *really* ineffective... {{/rollTotal() effectiveness-roll 0}}
+                <!-- Resisted -->
+                {{#rollTotal() effectiveness-roll 1}} It wasn't very effective... {{/rollTotal() effectiveness-roll 1}}
+                <!-- Super -->
+                {{#rollTotal() effectiveness-roll 3}} It was super effective! {{/rollTotal() effectiveness-roll 3}}
+                <!-- Extreme -->
+                {{#rollTotal() effectiveness-roll 4}} It was extremely effective! {{/rollTotal() effectiveness-roll 4}}
+              </span>
+            </td>
+          </tr>
+          {{/^rollTotal() effectiveness-roll 2}}
+
+          <!-- Scatter Attack 1 -->
+          <tr>
+            <td class="sheet-label"><span>Accuracy Check:</span></td>
+            <td class="sheet-accuracy-roll">{{accuracy}}</td>
+
+            <!-- Damage Rolls -->
+            <!-- Dice-Based Critical Hit -->
+            {{#rollWasCrit() accuracy}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage}} </span></td>
+            {{/rollWasCrit() accuracy}}
+
+            <!-- Effect-Based Critical Hit -->
+            <!-- Not a Natural Crit, and we deal Critical Damage -->
+            {{#^rollWasCrit() accuracy}}
+
+            <!-- Effect 1 is Critical Hit and we hit the Threshold -->
+            {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage}} </span></td>
+            {{/^rollLess() accuracy effect1_threshold}}
+
+            <!-- Effect 1 is Critical Hit but we missed the Threshold -->
+            {{#rollLess() accuracy effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage}} </span></td>
+            {{/rollLess() accuracy effect1_threshold}} {{/rollTotal() effect1_roll 99}}
+
+            <!-- Regular Hit -->
+            {{#rollLess() effect1_roll 99}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage}} </span></td>
+            {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy}}
+          </tr>
+          <!-- Effect Resoluton  -->
+          <!-- Effect 1 -->
+          {{#rollBetween() effect1_roll 1 10}} {{#^rollLess() accuracy effect1_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect1_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy effect1_threshold}} {{/rollBetween() effect1_roll 1 10}}
+
+          <!-- Effect 2 -->
+          {{#rollBetween() effect2_roll 1 10}} {{#^rollLess() accuracy effect2_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect2_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy effect2_threshold}} {{/rollBetween() effect2_roll 1 10}}
+
+          <!-- Scatter Attack 2 -->
+          <tr>
+            <td class="sheet-label"><span>Accuracy Check:</span></td>
+            <td class="sheet-accuracy-roll">{{accuracy-2}}</td>
+
+            <!-- Damage Rolls -->
+            <!-- Dice-Based Critical Hit -->
+            {{#rollWasCrit() accuracy-2}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/rollWasCrit() accuracy-2}}
+
+            <!-- Effect-Based Critical Hit -->
+            <!-- Not a Natural Crit, and we deal Critical Damage -->
+            {{#^rollWasCrit() accuracy-2}}
+
+            <!-- Effect 1 is Critical Hit and we hit the Threshold -->
+            {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy-2 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/^rollLess() accuracy-2 effect1_threshold}}
+
+            <!-- Effect 1 is Critical Hit but we missed the Threshold -->
+            {{#rollLess() accuracy-2 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-2}} </span></td>
+            {{/rollLess() accuracy-2 effect1_threshold}} {{/rollTotal() effect1_roll 99}}
+
+            <!-- Regular Hit -->
+            {{#rollLess() effect1_roll 99}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-2}} </span></td>
+            {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy-2}}
+          </tr>
+          <!-- Effect Resoluton  -->
+          <!-- Effect 1 -->
+          {{#rollBetween() effect1_roll 1 10}} {{#^rollLess() accuracy-2 effect1_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect1_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-2 effect1_threshold}} {{/rollBetween() effect1_roll 1 10}}
+
+          <!-- Effect 2 -->
+          {{#rollBetween() effect2_roll 1 10}} {{#^rollLess() accuracy-2 effect2_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect2_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-2 effect2_threshold}} {{/rollBetween() effect2_roll 1 10}}
+
+          <!-- Scatter Attack 3 -->
+          <tr>
+            <td class="sheet-label"><span>Accuracy Check:</span></td>
+            <td class="sheet-accuracy-roll">{{accuracy-3}}</td>
+
+            <!-- Damage Rolls -->
+            <!-- Dice-Based Critical Hit -->
+            {{#rollWasCrit() accuracy-3}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/rollWasCrit() accuracy-3}}
+
+            <!-- Effect-Based Critical Hit -->
+            <!-- Not a Natural Crit, and we deal Critical Damage -->
+            {{#^rollWasCrit() accuracy-3}}
+
+            <!-- Effect 1 is Critical Hit and we hit the Threshold -->
+            {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy-3 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/^rollLess() accuracy-3 effect1_threshold}}
+
+            <!-- Effect 1 is Critical Hit but we missed the Threshold -->
+            {{#rollLess() accuracy-3 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-3}} </span></td>
+            {{/rollLess() accuracy-3 effect1_threshold}} {{/rollTotal() effect1_roll 99}}
+
+            <!-- Regular Hit -->
+            {{#rollLess() effect1_roll 99}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-3}} </span></td>
+            {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy-3}}
+          </tr>
+          <!-- Effect Resoluton  -->
+          <!-- Effect 1 -->
+          {{#rollBetween() effect1_roll 1 10}} {{#^rollLess() accuracy-3 effect1_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect1_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-3 effect1_threshold}} {{/rollBetween() effect1_roll 1 10}}
+
+          <!-- Effect 2 -->
+          {{#rollBetween() effect2_roll 1 10}} {{#^rollLess() accuracy-3 effect2_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect2_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-3 effect2_threshold}} {{/rollBetween() effect2_roll 1 10}}
+
+          <!-- Scatter Attack 4 -->
+          <tr>
+            <td class="sheet-label"><span>Accuracy Check:</span></td>
+            <td class="sheet-accuracy-roll">{{accuracy-4}}</td>
+
+            <!-- Damage Rolls -->
+            <!-- Dice-Based Critical Hit -->
+            {{#rollWasCrit() accuracy-4}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/rollWasCrit() accuracy-4}}
+
+            <!-- Effect-Based Critical Hit -->
+            <!-- Not a Natural Crit, and we deal Critical Damage -->
+            {{#^rollWasCrit() accuracy-4}}
+
+            <!-- Effect 1 is Critical Hit and we hit the Threshold -->
+            {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy-4 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/^rollLess() accuracy-4 effect1_threshold}}
+
+            <!-- Effect 1 is Critical Hit but we missed the Threshold -->
+            {{#rollLess() accuracy-4 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-4}} </span></td>
+            {{/rollLess() accuracy-4 effect1_threshold}} {{/rollTotal() effect1_roll 99}}
+
+            <!-- Regular Hit -->
+            {{#rollLess() effect1_roll 99}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-4}} </span></td>
+            {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy-4}}
+          </tr>
+          <!-- Effect Resoluton  -->
+          <!-- Effect 1 -->
+          {{#rollBetween() effect1_roll 1 10}} {{#^rollLess() accuracy-4 effect1_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect1_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-4 effect1_threshold}} {{/rollBetween() effect1_roll 1 10}}
+
+          <!-- Effect 2 -->
+          {{#rollBetween() effect2_roll 1 10}} {{#^rollLess() accuracy-4 effect2_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect2_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-4 effect2_threshold}} {{/rollBetween() effect2_roll 1 10}}
+
+          <!-- Scatter Attack 5 -->
+          <tr>
+            <td class="sheet-label"><span>Accuracy Check:</span></td>
+            <td class="sheet-accuracy-roll">{{accuracy-5}}</td>
+
+            <!-- Damage Rolls -->
+            <!-- Dice-Based Critical Hit -->
+            {{#rollWasCrit() accuracy-5}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/rollWasCrit() accuracy-5}}
+
+            <!-- Effect-Based Critical Hit -->
+            <!-- Not a Natural Crit, and we deal Critical Damage -->
+            {{#^rollWasCrit() accuracy-5}}
+
+            <!-- Effect 1 is Critical Hit and we hit the Threshold -->
+            {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy-5 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/^rollLess() accuracy-5 effect1_threshold}}
+
+            <!-- Effect 1 is Critical Hit but we missed the Threshold -->
+            {{#rollLess() accuracy-5 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-5}} </span></td>
+            {{/rollLess() accuracy-5 effect1_threshold}} {{/rollTotal() effect1_roll 99}}
+
+            <!-- Regular Hit -->
+            {{#rollLess() effect1_roll 99}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-5}} </span></td>
+            {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy-5}}
+          </tr>
+          <!-- Effect Resoluton  -->
+          <!-- Effect 1 -->
+          {{#rollBetween() effect1_roll 1 10}} {{#^rollLess() accuracy-5 effect1_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect1_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-5 effect1_threshold}} {{/rollBetween() effect1_roll 1 10}}
+
+          <!-- Effect 2 -->
+          {{#rollBetween() effect2_roll 1 10}} {{#^rollLess() accuracy-5 effect2_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect2_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-5 effect2_threshold}} {{/rollBetween() effect2_roll 1 10}}
+
+          <!-- Scatter Attack 6 -->
+          <tr>
+            <td class="sheet-label"><span>Accuracy Check:</span></td>
+            <td class="sheet-accuracy-roll">{{accuracy-6}}</td>
+
+            <!-- Damage Rolls -->
+            <!-- Dice-Based Critical Hit -->
+            {{#rollWasCrit() accuracy-6}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/rollWasCrit() accuracy-6}}
+
+            <!-- Effect-Based Critical Hit -->
+            <!-- Not a Natural Crit, and we deal Critical Damage -->
+            {{#^rollWasCrit() accuracy-6}}
+
+            <!-- Effect 1 is Critical Hit and we hit the Threshold -->
+            {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy-6 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/^rollLess() accuracy-6 effect1_threshold}}
+
+            <!-- Effect 1 is Critical Hit but we missed the Threshold -->
+            {{#rollLess() accuracy-6 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-6}} </span></td>
+            {{/rollLess() accuracy-6 effect1_threshold}} {{/rollTotal() effect1_roll 99}}
+
+            <!-- Regular Hit -->
+            {{#rollLess() effect1_roll 99}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-6}} </span></td>
+            {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy-6}}
+          </tr>
+          <!-- Effect Resoluton  -->
+          <!-- Effect 1 -->
+          {{#rollBetween() effect1_roll 1 10}} {{#^rollLess() accuracy-6 effect1_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect1_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-6 effect1_threshold}} {{/rollBetween() effect1_roll 1 10}}
+
+          <!-- Effect 2 -->
+          {{#rollBetween() effect2_roll 1 10}} {{#^rollLess() accuracy-6 effect2_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect2_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-6 effect2_threshold}} {{/rollBetween() effect2_roll 1 10}}
+
+          <!-- Scatter Attack 7 -->
+          <tr>
+            <td class="sheet-label"><span>Accuracy Check:</span></td>
+            <td class="sheet-accuracy-roll">{{accuracy-7}}</td>
+
+            <!-- Damage Rolls -->
+            <!-- Dice-Based Critical Hit -->
+            {{#rollWasCrit() accuracy-7}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/rollWasCrit() accuracy-7}}
+
+            <!-- Effect-Based Critical Hit -->
+            <!-- Not a Natural Crit, and we deal Critical Damage -->
+            {{#^rollWasCrit() accuracy-7}}
+
+            <!-- Effect 1 is Critical Hit and we hit the Threshold -->
+            {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy-7 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/^rollLess() accuracy-7 effect1_threshold}}
+
+            <!-- Effect 1 is Critical Hit but we missed the Threshold -->
+            {{#rollLess() accuracy-7 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-7}} </span></td>
+            {{/rollLess() accuracy-7 effect1_threshold}} {{/rollTotal() effect1_roll 99}}
+
+            <!-- Regular Hit -->
+            {{#rollLess() effect1_roll 99}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-7}} </span></td>
+            {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy-7}}
+          </tr>
+          <!-- Effect Resoluton  -->
+          <!-- Effect 1 -->
+          {{#rollBetween() effect1_roll 1 10}} {{#^rollLess() accuracy-7 effect1_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect1_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-7 effect1_threshold}} {{/rollBetween() effect1_roll 1 10}}
+
+          <!-- Effect 2 -->
+          {{#rollBetween() effect2_roll 1 10}} {{#^rollLess() accuracy-7 effect2_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect2_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-7 effect2_threshold}} {{/rollBetween() effect2_roll 1 10}}
+
+          <!-- Scatter Attack 8 -->
+          <tr>
+            <td class="sheet-label"><span>Accuracy Check:</span></td>
+            <td class="sheet-accuracy-roll">{{accuracy-8}}</td>
+
+            <!-- Damage Rolls -->
+            <!-- Dice-Based Critical Hit -->
+            {{#rollWasCrit() accuracy-8}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/rollWasCrit() accuracy-8}}
+
+            <!-- Effect-Based Critical Hit -->
+            <!-- Not a Natural Crit, and we deal Critical Damage -->
+            {{#^rollWasCrit() accuracy-8}}
+
+            <!-- Effect 1 is Critical Hit and we hit the Threshold -->
+            {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy-8 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/^rollLess() accuracy-8 effect1_threshold}}
+
+            <!-- Effect 1 is Critical Hit but we missed the Threshold -->
+            {{#rollLess() accuracy-8 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-8}} </span></td>
+            {{/rollLess() accuracy-8 effect1_threshold}} {{/rollTotal() effect1_roll 99}}
+
+            <!-- Regular Hit -->
+            {{#rollLess() effect1_roll 99}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-8}} </span></td>
+            {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy-8}}
+          </tr>
+          <!-- Effect Resoluton  -->
+          <!-- Effect 1 -->
+          {{#rollBetween() effect1_roll 1 10}} {{#^rollLess() accuracy-8 effect1_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect1_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-8 effect1_threshold}} {{/rollBetween() effect1_roll 1 10}}
+
+          <!-- Effect 2 -->
+          {{#rollBetween() effect2_roll 1 10}} {{#^rollLess() accuracy-8 effect2_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect2_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-8 effect2_threshold}} {{/rollBetween() effect2_roll 1 10}}
+
+          <!-- Scatter Attack 9 -->
+          <tr>
+            <td class="sheet-label"><span>Accuracy Check:</span></td>
+            <td class="sheet-accuracy-roll">{{accuracy-9}}</td>
+
+            <!-- Damage Rolls -->
+            <!-- Dice-Based Critical Hit -->
+            {{#rollWasCrit() accuracy-9}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/rollWasCrit() accuracy-9}}
+
+            <!-- Effect-Based Critical Hit -->
+            <!-- Not a Natural Crit, and we deal Critical Damage -->
+            {{#^rollWasCrit() accuracy-9}}
+
+            <!-- Effect 1 is Critical Hit and we hit the Threshold -->
+            {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy-9 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/^rollLess() accuracy-9 effect1_threshold}}
+
+            <!-- Effect 1 is Critical Hit but we missed the Threshold -->
+            {{#rollLess() accuracy-9 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-9}} </span></td>
+            {{/rollLess() accuracy-9 effect1_threshold}} {{/rollTotal() effect1_roll 99}}
+
+            <!-- Regular Hit -->
+            {{#rollLess() effect1_roll 99}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-9}} </span></td>
+            {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy-9}}
+          </tr>
+          <!-- Effect Resoluton  -->
+          <!-- Effect 1 -->
+          {{#rollBetween() effect1_roll 1 10}} {{#^rollLess() accuracy-9 effect1_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect1_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-9 effect1_threshold}} {{/rollBetween() effect1_roll 1 10}}
+
+          <!-- Effect 2 -->
+          {{#rollBetween() effect2_roll 1 10}} {{#^rollLess() accuracy-9 effect2_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect2_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-9 effect2_threshold}} {{/rollBetween() effect2_roll 1 10}}
+
+          <!-- Scatter Attack 10 -->
+          <tr>
+            <td class="sheet-label"><span>Accuracy Check:</span></td>
+            <td class="sheet-accuracy-roll">{{accuracy-10}}</td>
+
+            <!-- Damage Rolls -->
+            <!-- Dice-Based Critical Hit -->
+            {{#rollWasCrit() accuracy-10}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/rollWasCrit() accuracy-10}}
+
+            <!-- Effect-Based Critical Hit -->
+            <!-- Not a Natural Crit, and we deal Critical Damage -->
+            {{#^rollWasCrit() accuracy-10}}
+
+            <!-- Effect 1 is Critical Hit and we hit the Threshold -->
+            {{#rollTotal() effect1_roll 99}} {{#^rollLess() accuracy-10 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{critical-damage-extra}} </span></td>
+            {{/^rollLess() accuracy-10 effect1_threshold}}
+
+            <!-- Effect 1 is Critical Hit but we missed the Threshold -->
+            {{#rollLess() accuracy-10 effect1_threshold}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-10}} </span></td>
+            {{/rollLess() accuracy-10 effect1_threshold}} {{/rollTotal() effect1_roll 99}}
+
+            <!-- Regular Hit -->
+            {{#rollLess() effect1_roll 99}}
+            <td class="sheet-label"><span>Damage:</span></td>
+            <td class="sheet-damage-roll"><span class="sheet-damage-roll sheet-{{effectiveness}}-effectiveness-color"> {{damage-10}} </span></td>
+            {{/rollLess() effect1_roll 99}} {{/^rollWasCrit() accuracy-10}}
+          </tr>
+          <!-- Effect Resoluton  -->
+          <!-- Effect 1 -->
+          {{#rollBetween() effect1_roll 1 10}} {{#^rollLess() accuracy-10 effect1_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect1_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-10 effect1_threshold}} {{/rollBetween() effect1_roll 1 10}}
+
+          <!-- Effect 2 -->
+          {{#rollBetween() effect2_roll 1 10}} {{#^rollLess() accuracy-10 effect2_threshold}}
+          <tr>
+            <td class="sheet-effectiveness-text" colspan="4">
+              <span>The opponent was {{effect2_name}}</span>
+            </td>
+          </tr>
+          {{/^rollLess() accuracy-10 effect2_threshold}} {{/rollBetween() effect2_roll 1 10}}
+
+          <!-- Notes -->
+          {{#notes}}
+          <tr>
+            <td class="sheet-notes-text" colspan="4"><span>{{notes}}</span></td>
+          </tr>
+          {{/notes}}
+        </tbody>
+      </table>
+    </div>
+  </rolltemplate>
+
+  <rolltemplate class="sheet-rolltemplate-quintuple-hit-move-roll">
     <div class="sheet-container sheet-rolltemplate-color-setting-{{move-type}}-move">
       <table class="sheet-move-template">
         <tbody>
@@ -2370,7 +2951,7 @@
     });
   });
 
-  on(`change:repeating_moves:move_category`, function (event) {
+  on("change:repeating_moves:move_category", function (event) {
     getAttrs(["repeating_moves_move_name", "repeating_moves_move_category"], function (values) {
       let attrs = {};
       let cat = parseInt(values.repeating_moves_move_category) || 0;
@@ -2378,6 +2959,73 @@
       setAttrs(attrs);
     });
   });
+
+  // Handling Extra Attacks
+  on("sheet:opened", function (_) {
+    getSectionIDs("repeating_moves", function (idArray) {
+      const templates = idArray.map((id) => `repeating_moves_${id}_move_template`);
+      getAttrs([...templates], function (values) {
+        const rows = templates.reduce((obj, template) => {
+          const selection = values[template];
+          
+          if (selection.includes("multi-hit-move-roll")) obj[template] = "quintuple-hit-move-roll";
+          return obj;
+        });
+
+        if (rows) setAttrs(rows);
+      });
+    });
+  });
+
+  on("sheet:opened", function (_) {
+    getSectionIDs("repeating_moves", function (idArray) {
+      const templates = idArray.map((id) => `repeating_moves_${id}_move_template`);
+      const attackRolls = idArray.map((id) => `repeating_moves_${id}_attack_rolls`);
+      const quickAttackRolls = idArray.map((id) => `repeating_moves_${id}_quick_attack_rolls`);
+
+      getAttrs([...templates], function (values) {
+        const rows = templates.reduce((obj, template) => {
+          const selection = values[template];
+          const attackRolls = generateAttackRollsFromScatterSelection(selection);
+          const rowName = template.slice(0,-13);
+
+          obj[`${rowName}_attack_rolls`] = attackRolls[0];
+          obj[`${rowName}_quick_attack_rolls`] = attackRolls[1];
+          return obj;
+        }, {});
+        if (rows) setAttrs(rows);
+      });
+    });
+  });
+
+  on("change:repeating_moves:move_template", function (eventInfo) {
+    const attackRolls = generateAttackRollsFromScatterSelection(eventInfo.newValue);
+    const attrs = {
+        "repeating_moves_attack_rolls": attackRolls[0],
+        "repeating_moves_quick_attack_rolls": attackRolls[1]
+    };
+    setAttrs(attrs);
+  });
+
+  function generateAttackRollsFromScatterSelection(selection) {
+    let extraAttacks = 0;
+    switch (selection) {
+      case "dectuple-hit-move-roll": extraAttacks = 9; break;
+      case "quintuple-hit-move-roll": extraAttacks = 4; break;
+      case "triple-hit-move-roll": extraAttacks = 2; break;
+      case "dual-hit-move-roll": extraAttacks = 1; break;
+    }
+
+    let attackRolls = "{{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}}";
+    let quickAttackRolls = "{{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}}";
+    for (i = 0; i < extraAttacks; i++) {
+      let extraAttack = i+2;
+      attackRolls += ` {{accuracy-${extraAttack}=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} + ?{Temp Accuracy Bonus} ]]}} {{damage-${extraAttack}=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]])d@{damage_dice} ]]}}`;
+      quickAttackRolls += ` {{accuracy-${extraAttack}=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{damage-${extraAttack}=[[ @{move_dicenumber}d@{damage_dice} ]]}}`;
+    }
+
+    return [attackRolls, quickAttackRolls];
+  }
 
   // Handling Move and Feature Usage
   on("clicked:repeating_moves:incrementmoveusage", function () {

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -1014,7 +1014,7 @@
 
             <span class="sheet-fill-space sheet-hide-on-mobile">
               <button class="sheet-inline-roller sheet-skill-roller" name="roll-quick-move" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers." type="roll"
-                value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{effectiveness-roll=[[2]]}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} ${quick_attack_rolls}">
+                value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{effectiveness-roll=[[2]]}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} @{quick_attack_rolls}">
                 Quick Roll
               </button>
               <b class="sheet-info-tooltip" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers.">ℹ</b>
@@ -1049,7 +1049,7 @@
 
             <span class="sheet-fill-space sheet-hide-on-mobile">
               <button class="sheet-inline-roller sheet-skill-roller" name="roll-quick-move" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers." type="roll"
-                value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{effectiveness-roll=[[2]]}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} ${quick_attack_rolls}">
+                value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{effectiveness-roll=[[2]]}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} @{quick_attack_rolls}">
                 Quick Roll
               </button>
               <b class="sheet-info-tooltip" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers.">ℹ</b>
@@ -1669,7 +1669,7 @@
     </div>
   </rolltemplate>
 
-  <rolltemplate class="sheet-rolltemplate-quintuple-hit-move-roll">
+  <rolltemplate class="sheet-rolltemplate-dectuple-hit-move-roll">
     <div class="sheet-container sheet-rolltemplate-color-setting-{{move-type}}-move">
       <table class="sheet-move-template">
         <tbody>

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -1131,14 +1131,14 @@
               <b class="sheet-info-tooltip" title="Choose the Scatter type of the attack. This will effect which roll template is used for the chat log output.">ℹ</b>
             </span>
             <span>
-              <input name="attr_attack_rolls" type="hidden" />
-              <input name="attr_quick_attack_rolls" type="hidden" />
+              <input name="attr_attack_rolls" type="hidden" value="{{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}}"/>
+              <input name="attr_quick_attack_rolls" type="hidden" value="{{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}}" />
               <select class="sheet-move-text" name="attr_move_template" title="Attribute: move_template">
                 <option value="move-roll" selected>One Hit</option>
                 <option value="dual-hit-move-roll">Two Hits</option>
                 <option value="triple-hit-move-roll">Three Hits</option>
-                <option value="quintuple-hit-move-roll">Up to Five Hits</option>
-                <option value="dectuple-hit-move-roll">Up to Ten Hits</option>
+                <option value="multi-hit-move-roll">Up to Five Hits</option>
+                <option value="ten-hit-move-roll">Up to Ten Hits</option>
       </select>
             </span>
 
@@ -1669,7 +1669,7 @@
     </div>
   </rolltemplate>
 
-  <rolltemplate class="sheet-rolltemplate-dectuple-hit-move-roll">
+  <rolltemplate class="sheet-rolltemplate-ten-hit-move-roll">
     <div class="sheet-container sheet-rolltemplate-color-setting-{{move-type}}-move">
       <table class="sheet-move-template">
         <tbody>
@@ -2247,7 +2247,7 @@
     </div>
   </rolltemplate>
 
-  <rolltemplate class="sheet-rolltemplate-quintuple-hit-move-roll">
+  <rolltemplate class="sheet-rolltemplate-multi-hit-move-roll">
     <div class="sheet-container sheet-rolltemplate-color-setting-{{move-type}}-move">
       <table class="sheet-move-template">
         <tbody>
@@ -2964,22 +2964,6 @@
   on("sheet:opened", function (_) {
     getSectionIDs("repeating_moves", function (idArray) {
       const templates = idArray.map((id) => `repeating_moves_${id}_move_template`);
-      getAttrs([...templates], function (values) {
-        const rows = templates.reduce((obj, template) => {
-          const selection = values[template];
-          
-          if (selection.includes("multi-hit-move-roll")) obj[template] = "quintuple-hit-move-roll";
-          return obj;
-        });
-
-        if (rows) setAttrs(rows);
-      });
-    });
-  });
-
-  on("sheet:opened", function (_) {
-    getSectionIDs("repeating_moves", function (idArray) {
-      const templates = idArray.map((id) => `repeating_moves_${id}_move_template`);
       const attackRolls = idArray.map((id) => `repeating_moves_${id}_attack_rolls`);
       const quickAttackRolls = idArray.map((id) => `repeating_moves_${id}_quick_attack_rolls`);
 
@@ -3010,8 +2994,8 @@
   function generateAttackRollsFromScatterSelection(selection) {
     let extraAttacks = 0;
     switch (selection) {
-      case "dectuple-hit-move-roll": extraAttacks = 9; break;
-      case "quintuple-hit-move-roll": extraAttacks = 4; break;
+      case "ten-hit-move-roll": extraAttacks = 9; break;
+      case "multi-hit-move-roll": extraAttacks = 4; break;
       case "triple-hit-move-roll": extraAttacks = 2; break;
       case "dual-hit-move-roll": extraAttacks = 1; break;
     }

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -24,6 +24,12 @@ Things we want to add to the character sheet, presented in no particular order o
 
 ## Changelog
 
+### Feb 14, 2023
+- Gave the attack rolls some love, as befitting the day of the year.
+  - Updated the scatter selection to change the attack rolls, so that lower-hit moves aren't rolling many sets of dice
+  - Added support for scatter attacks that hit up to 10 times
+  - Clarified the intent of each scatter type selection by explicitly stating how many hits are in each roll
+
 ### Aug 11, 2022
 - Implemented the ability to change the background and roll template colours for class and origin features, accessible to Trainer and Hybrid character types
 

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -30,6 +30,9 @@ Things we want to add to the character sheet, presented in no particular order o
   - Added support for scatter attacks that hit up to 10 times
   - Clarified the intent of each scatter type selection by explicitly stating how many hits are in each roll
 
+<details>
+  <summary><u>Expand for 2022 Changes</u></summary>
+  
 ### Aug 11, 2022
 - Implemented the ability to change the background and roll template colours for class and origin features, accessible to Trainer and Hybrid character types
 
@@ -75,6 +78,11 @@ Current mobile bugs that I'm pretty sure are roll20 bugs:
 - HP updates seem to clear out the _max value sometimes?
 - Stat in parenthesis for skill checks doesn't populate
 - The roll20 dice font is not available
+
+</details>
+
+<details>
+  <summary><u>Expand for 2021 Changes</u></summary>
 
 ### Jul 17th, 2021
 - Added a level field to the `hybrid` _(or Pokémon (Character Class))_ character type.
@@ -167,6 +175,11 @@ Current mobile bugs that I'm pretty sure are roll20 bugs:
 - Added a quick roll button that rolls a move without any query boxes for temporary modifiers or effectiveness, rolling with +0/+0/Neutral values
 - Streamlined move displays to show the configuration only when desired via a collapsible control
 
+</details>
+
+<details>
+<summary><u>Expand for 2020 Changes</u></summary>
+
 ### Dec 12, 2020
 
 - Migrated the character sheet style attributes to new fields
@@ -254,3 +267,5 @@ Current mobile bugs that I'm pretty sure are roll20 bugs:
 ### Sept 16, 2020
 
 - Initial Commit
+
+</details>


### PR DESCRIPTION
# Submission Checklist
## Required

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

- Resolves issue where every attack type throws out five sets of attack and damgae dice instead of only the number required
- Adds `attack_rolls` and `quick_attack_rolls` attributes to the repeating moves fieldset to house the accuracy and damage checks for normal rolls - asking for modifiers - and quick rolls - asking for no modifiers
- Updates the scatter type selection field values
- Adds support for updating sheets to use this new value
- Adds support for Population Bomb by adding an "Up to 10 Hits" option for the scatter type
