### PR TITLE
PokemonTabletopUnited - Bugfixes

### DIFF
--- a/PokemonTabletopUnited/ptu.css
+++ b/PokemonTabletopUnited/ptu.css
@@ -1,14 +1,10 @@
 input[type='number']::-webkit-outer-spin-button,
 input[type='number']::-webkit-inner-spin-button,
 input[type='number'] {
-	-webkit-appearance: none;
-	-moz-appearance: textfield !important;
-	margin: 0;
-	} /*Remove arrows from numerical boxes */
-
-#page-wrap {
-  width: 1024px;
-}
+    -webkit-appearance: none;
+    -moz-appearance: textfield !important;
+    margin: 0;
+    } /*Remove arrows from numerical boxes */
 
 input.sheet-oldtab1:not(:checked) ~ .sheet-oldtab1,
 input.sheet-oldtab2:not(:checked) ~ .sheet-oldtab2,
@@ -29,13 +25,17 @@ table.sheet-status-table td:nth-child(even) {
 input.sheet-oldtab {
     width: calc(20% - 4px);
     max-width: 150px;
-    height: 20px;
-    
     outline: none !important;
     position: relative;
     cursor: pointer;
     z-index: 1;
+    -moz-appearance:initial; /* Allows ::before for Firefox Browsers */
 }
+
+.ui-dialog .charsheet input.sheet-oldtab {
+    height: 20px;
+    border: 0px;
+}   /* Necessary to override Roll20 */
 
 input.sheet-oldtab1 {
     margin-left: 1px;

--- a/PokemonTabletopUnited/ptu.css
+++ b/PokemonTabletopUnited/ptu.css
@@ -1,3 +1,11 @@
+input[type='number']::-webkit-outer-spin-button,
+input[type='number']::-webkit-inner-spin-button,
+input[type='number'] {
+	-webkit-appearance: none;
+	-moz-appearance: textfield !important;
+	margin: 0;
+	} /*Remove arrows from numerical boxes */
+
 #page-wrap {
   width: 1024px;
 }


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [X] The pull request title clearly contains the name of the sheet I am editing.
- [X] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [X] The pull request makes changes to files in only one sub-folder.
- [X] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

- Removed spin buttons (up-down arrows) from numerical fields as they would overlap text in several fields.
- Removed page-wrap width as it was breaking the layout on tabbed view
- Added workaround for ::before elements in Firefox
- Added high-specificity height and border setting for tab radio buttons to maintain Firefox layout consistent with Chrome

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->




