### PR TITLE
[Magical Kitties Save the Day!] bugfix: remove attr_character_token img

### DIFF
--- a/Magical-Kitties/Magical-Kitties-Save-the-Day.html
+++ b/Magical-Kitties/Magical-Kitties-Save-the-Day.html
@@ -1,5 +1,5 @@
 <div class="container">
-  <button type="roll" class="button-roll" style="transform: translate(15px, 5px);" value="&{template:default} {{name=**Extra Dice**}} {{ Rolled ?{Extra Dice|1} extra dice.}} {{Successes = [[(?{Extra Dice})d6>?{Task Difficulty|Typical,4|Easy,3|Hard,5|Extreme,6}]] }}" data-i18n="extra-dice-rolls-u" data-i18n-title="extra-dice-rolls-u"></button>
+  <button type="roll" class="button-roll" style="transform: translate(55px, 5px);" value="&{template:default} {{name=**Extra Dice**}} {{ Rolled ?{Extra Dice|1} extra dice.}} {{Successes = [[(?{Extra Dice})d6>?{Task Difficulty|Typical,4|Easy,3|Hard,5|Extreme,6}]] }}" data-i18n="extra-dice-rolls-u" data-i18n-title="extra-dice-rolls-u"></button>
   <div class="masthead">
     <span class="magical-kitties">Magical Kitties</span>
     <span class="save-the-day">Save the Day!</span>

--- a/Magical-Kitties/Magical-Kitties-Save-the-Day.html
+++ b/Magical-Kitties/Magical-Kitties-Save-the-Day.html
@@ -1,6 +1,5 @@
 <div class="container">
   <button type="roll" class="button-roll" style="transform: translate(15px, 5px);" value="&{template:default} {{name=**Extra Dice**}} {{ Rolled ?{Extra Dice|1} extra dice.}} {{Successes = [[(?{Extra Dice})d6>?{Task Difficulty|Typical,4|Easy,3|Hard,5|Extreme,6}]] }}" data-i18n="extra-dice-rolls-u" data-i18n-title="extra-dice-rolls-u"></button>
-  <img class="kitty-token" name="attr_character_token" data-i18n-title="default-token-click-edit-to-update">
   <div class="masthead">
     <span class="magical-kitties">Magical Kitties</span>
     <span class="save-the-day">Save the Day!</span>


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

Once the big changes from the last pull request went live, I naturally discovered a bug in an edge case--if you create a fresh character sheet without a token assigned, attr_character_token doesn't get the default token image, but instead gets no image at all, which makes the top of the character sheet go wonky.

All the solutions I could find for switching to displaying nothing when the image is missing end up being stripped out by Roll20 (e.g. onerror, using wrapping <object> tags).

I don't know whether this is a bug with attr_character_token, but it's easier to take the img tag out than it is to troubleshoot a possible bug there.

Summary of behaviors with `attr_character_token` and `attr_character_avatar`:
1) Works great: Character has token assigned
2) Works great: Character HAD token assigned, then was
   removed--shows the default token image
3) Missing image: Character has never had a token assigned,
   attr_character_token shows a broken image (expected: shows 
   the default token image)

(Tagging other sheet authors @Anduh and @apsalari to keep them up-to-date on changes)
