### PR TITLE
[Warhammer 4e Character Sheet] v1.65b Talent dissplay fix

### DIFF
--- a/Warhammer 4e Character Sheet/README.md
+++ b/Warhammer 4e Character Sheet/README.md
@@ -81,6 +81,11 @@ Note conditions are not intended for out of combat situations, GM simply makes t
  
 ///// ============ Change Log ============ /////  
 
+February 28th 2022 v1.65b
+
+- Fixed Talent Nobleblood test +SL text during leadership rolls, now correctly dislays as situational bonus SL.
+
+
 February 14th 2022 v1.65a
 
 - Fixed some skill rolls not always working due to new Besmirched condition bug

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -48436,8 +48436,8 @@ on('clicked:repeating_divinemiracles:miracle clicked:repeating_divinemiracles:mi
 	sitmods = '+@{Talent_MenacingLvl}+@{Talent_NobleBloodLvl}';
 	rollPart = rollPart2.replaceAll('cond-', `(@{condgen}-@{DrunkMod})`).replaceAll('>sitmod<', sitmods);}
 	else if (trigger === 'leadership') {cond = '{{cond=[[@{condgen}-@{DrunkMod}]]}} {{drunk=[[0]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[0]]}} {{deafened=[[0]]}} {{warleader=[[@{Talent_WarLeaderLvl}]]}} {{commandingpresence=[[@{Talent_CommandingPresenceLvl}]]}} {{inspiring=[[@{Talent_InspiringLvl}]]}} {{nobleblood=[[@{Talent_NobleBloodLvl}]]}} {{masterandcommander=[[@{Talent_MasterAndCommanderLvl}]]}}';
-	addsl = '+@{Talent_CommandingPresenceLvl}+@{Talent_NobleBloodLvl}+@{Talent_MasterAndCommanderLvl}';
-	sitmods = '+@{Talent_WarLeaderLvl}+@{Talent_InspiringLvl}';
+	addsl = '+@{Talent_CommandingPresenceLvl}+@{Talent_MasterAndCommanderLvl}';
+	sitmods = '+@{Talent_WarLeaderLvl}+@{Talent_InspiringLvl}+@{Talent_NobleBloodLvl}';
 	rollPart = rollPart2.replaceAll('cond-', `(@{condgen}-@{DrunkMod})`).replaceAll('>addsl<', addsl).replaceAll('>sitmod<', sitmods);}
 	else if (trigger === 'row') {cond = '{{cond=[[@{condgen}-@{DrunkMod}]]}} {{drunk=[[0]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[0]]}} {{deafened=[[0]]}} {{strongback=[[@{Talent_StrongBackLvl}]]}} {{pilot=[[@{Talent_PilotLvl}]]}}'
 	addsl = '+@{Talent_StrongBackLvl}';


### PR DESCRIPTION

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

- Fixed Talent Nobleblood test +SL text during leadership rolls, now correctly dislays as situational bonus SL.




