### PR TITLE
Shadowrun Sixth World v.78 - 1 bug fix

### DIFF
--- a/Shadowrun Sixth World/CHANGELOG.md
+++ b/Shadowrun Sixth World/CHANGELOG.md
@@ -1,5 +1,7 @@
 Change Log
 ==============================================
+**2023-03-27 ** v.77 Chuz (James Culp)
+	Bugfix - Final(?) fix to Spirit and Vehicle dicepool bug.  Spirit ranged/melee dicepools are set when the spirit is created (when force/type are changed and reset toggle is on).  Vehicle pools are set when the sheet owner sets them.  They will only change now if/when they are in grunt groups and the number of grunts change or the sheet owner changes the dicepool directly.
 **2023-03-20 ** v.77 Chuz (James Culp)
 	Bugfix - (?) Trying to fix some dicepool bugs on NPC and Vehicle sheets tied to grunt groups.
 	Bugfix - Vehicle physical and matrix condition monitors weren't updating right on drag and drop

--- a/Shadowrun Sixth World/Shadowrun6thEdition.css
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.css
@@ -4353,6 +4353,13 @@ input[name="attr_stats_toggle"][value="settings"] ~ .border-box .body .toggle-di
   display: none;
 }
 
+input[name='attr_sheet_type'][value='spirit'] ~ .npc .body div.spirit.weapon-range .atk-dp-mod,
+input[name='attr_sheet_type'][value='vehicle'] ~ .npc .body div.vehicle.weapon-range .atk-dp-mod,
+input[name='attr_sheet_type'][value='spirit'] ~ .npc .body div.spirit.weapon-melee .atk-dp-mod,
+input[name='attr_sheet_type'][value='vehicle'] ~ .npc .body div.vehicle.weapon-melee .atk-dp-mod {
+  display: none;
+}
+
 .npc .body div.weapon-range,
 .npc .body div.weapon-melee {
 width: 100% !important; }

--- a/Shadowrun Sixth World/Shadowrun6thEdition.html
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.html
@@ -3474,6 +3474,10 @@
 						<div class="notes-changelog">
 							<div name="changelog" class="changelog">
 								<h1 class="changelog-header">Most Recent Updates</h1>
+								<span class="changelog-entry">**2023-03-27 ** v.77 Chuz (James Culp)</span>
+								<ul>
+									<li><span class="bullet">A</span><b>Bugfix</b> - Final(?) fix to Spirit and Vehicle dicepool bug.  Spirit ranged/melee dicepools are set when the spirit is created (when force/type are changed and reset toggle is on).  Vehicle pools are set when the sheet owner sets them.  They will only change now if/when they are in grunt groups and the number of grunts change or the sheet owner changes the dicepool directly.
+								</ul>
 								<span class="changelog-entry">**2023-03-20 ** v.77 Chuz (James Culp)</span>
 								<ul>
 									<li><span class="bullet">A</span><b>Bugfix</b> - (?) Trying to fix some dicepool bugs on NPC and Vehicle sheets tied to grunt groups.
@@ -4933,8 +4937,8 @@
 						<label data-i18n-title="modeoptions" title="Mode Options">
 							<input name="attr_firing_modes" placeholder="SS/SA/BF/BW/FA" type="text" title="@{repeating_range_${x}_firing_modes}}"/>
 						</label>
-						<h3 data-i18n="modifier">modifier</h3>
-						<label data-i18n-title="modifier" title="modifier">
+						<h3 class="atk-dp-mod" data-i18n="modifier">modifier</h3>
+						<label class="atk-dp-mod" data-i18n-title="modifier" title="modifier">
 							<input name="attr_dicepool_modifier" title="@{repeating_range_${x}_dicepool_modifier}" type="number" value="0"/>
 						</label>
 					</div>
@@ -5012,7 +5016,7 @@
 				 <label data-i18n-title="extreme" title="Extreme 500+">
 					<input name="attr_extreme_base" placeholder="-" title="@{repeating_melee_${x}_extreme_base}" type="text" value=""/>
 				 </label>
-				 <div class="row">
+				 <div class="row atk-dp-mod">
 					 <h3 data-i18n="modifier">modifier</h3>
 					 <label data-i18n-title="modifier" title="modifier">
 						 <input name="attr_dicepool_modifier" title="@{repeating_range_${x}_dicepool_modifier}" type="number" value="0"/>
@@ -6274,7 +6278,7 @@
 <input type="hidden" name="attr_spellcasting_specialist" value="0" />
 <input type="hidden" name="attr_spellcasting_expert" value="0" />
 
-<input type="hidden" name="attr_sheet_version" value="0.77">
+<input type="hidden" name="attr_sheet_version" value="0.78">
 <input type="hidden" name="attr_data_version" value="0">
 <script type="text/worker">
 // Sheet workers
@@ -6353,7 +6357,6 @@ on("sheet:opened", function() {
 				case (v.data_version < 0.77):
 					_v77_update();
 					console.log("Data now fits v.77");
-break;
 				default:
 					setAttrs({
 						'data_version': v.sheet_version
@@ -9755,7 +9758,7 @@ console.log("updating dicepool_base to: "+v[`${weap}_dicepool`]);
 //			}
 
 			// If this is a vehicle/drone sheet there's nothing more to do
-			if(v.sheet_type == 'vehicle') {
+			if(v.sheet_type == 'vehicle' || v.sheet_type == 'spirit') {
 				return;
 			}
 


### PR DESCRIPTION
- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

- [x] I have followed the [Character Sheets Standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) when building this sheet.


# Changes / Description

	Bugfix - Final(?) fix to Spirit and Vehicle dicepool bug.  Spirit ranged/melee dicepools are set when the spirit is created (when force/type are changed and reset toggle is on).  Vehicle pools are set when the sheet owner sets them.  They will only change now if/when they are in grunt groups and the number of grunts change or the sheet owner changes the dicepool directly.
