### PR TITLE
Coriolis Alternative - Bugfix - Fix fonts in CSS

### DIFF
--- a/Coriolis Alternative/CoriolisAlternative.css
+++ b/Coriolis Alternative/CoriolisAlternative.css
@@ -316,7 +316,7 @@ div.sheet-page {
 }
 
 .sheet-card__panel span{
-    font-family:"Exo";
+    font-family:"Exo", sans-serif;
 }
 
 .sheet-card__panel span,
@@ -442,7 +442,7 @@ span.sheet-signature{
     background: #272626;
     padding: 8px 0px 8px 8px;
     font-size: 14px;
-    font-family:"Exo";
+    font-family:"Exo", sans-serif;
     text-transform: uppercase;
 }
 
@@ -582,7 +582,7 @@ button[type=roll].sheet-action{
     font-size: 16px;
     max-height:40px;
     line-height:18px;
-    font-family:"Exo";
+    font-family:"Exo", sans-serif;
 }
 
 button[type=action].sheet-action{


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

Changed typeface to sans-serif in some classes that missing it so there's no mismatch in fonts throughout the sheet. While the original version of the sheet is displayed correctly, the mismatch can be clearly seen when adding translation. Probably because the font doesn't have cyrillic alphabet, so instead a default font is used that has different typefaces, unlike the Exo font that is sans serif in itself.

An example:
![image](https://user-images.githubusercontent.com/2573283/228963784-820566bd-9be4-43cb-9d80-b1f438f42b1c.png)

Font on the left:
![image](https://user-images.githubusercontent.com/2573283/228966404-2dcb8d56-d38a-46c8-a78b-11586e404b29.png)

Font on the right:
![image](https://user-images.githubusercontent.com/2573283/228966496-e0677028-089c-4946-94c6-4b584939a4ea.png)





