### PR TITLE
[Fate] New feature - Added filtering support for the Extras section

### DIFF
--- a/Fate/FateOmni.css
+++ b/Fate/FateOmni.css
@@ -275,9 +275,15 @@ input.icon[value="blank"] + span.icon::before {
 	padding-top: 12px;
 }
 
-.ExtraDisplay .repcontainer .repitem:first-child .space-above {
-	padding-top: 0px;
+.rule-above {
+	margin-top: 12px;
+	border-top: 1px solid gray;
+	padding-top: 12px;
 }
+
+/* .ExtraDisplay .repcontainer .repitem:first-child .space-above {
+	padding-top: 0px;
+} */ 
 
 .hideUnlessNull + * {
 	display: none;
@@ -359,16 +365,20 @@ input.icon[value="blank"] + span.icon::before {
 .StuntFrame,
 .PowerFrame,
 .NoteFrame,
-.ExtraFrame,
 .SkillFrame {
 	flex-direction: row;
 	justify-content: flex-start;
 }
 
 .TrackFrame,
+.ExtraFrame,
 .AspectFrame {
 	flex-direction: column;
 	justify-content: stretch;
+}
+
+.ExtraFrame .fieldlabel {
+	text-align: left;
 }
 
 .ui-dialog .tab-content .charsheet .fieldlabel {
@@ -714,6 +724,16 @@ input.icon[value="blank"] + span.icon::before {
 .signmaker[value="-1"] + .rating::before {
 	content: '';
 }
+
+
+.hideOnOne + div {
+	display: block;
+}
+
+.hideOnOne[value="1"] + div {
+	display: none;
+}
+
 
 .hideIfNull + div {
 	display: block;

--- a/Fate/FateOmni.html
+++ b/Fate/FateOmni.html
@@ -164,6 +164,7 @@
 		<hr>
 		Click this button to export the entire sheet as a JSON object that can be imported to another sheet using the import area below.
 		<div><button type="action" name="act_exportsheet">Export</button></div>
+		<div><button type="action" name="act_exportsheetextrasonly">Export (Extras Only)</button></div>
 		<div><textarea name="attr_exportsheetdata" style="width: 90%"></textarea></div>
 		<hr>
 		Clicking this button will empty out all the dynamic elements of the sheet. It will leave some attributes untouched, but should blank out aspects, skills, stunts, stress, consequences, conditions, tempaspects, modes, roles, swaps, packages, powers, extras, and notes. 
@@ -1138,8 +1139,15 @@
 							<span><span data-i18n="edit">Edit</span> <span data-i18n="extras">Extras</span></span>
 							<span><input type="checkbox" class="checkbox" name="attr_EditExtras" value="1" checked><span class="pencilbox"/></span>
 						</div>
-						<div data-i18n="extra-desc" class="limited-width">Extras are composed of a series of elements. For each extra, start by adding a title element, then add other elements as needed: permissions, costs, aspects, skills, stunts, tracks, ratings (e.g., weapon:X, armor:X), notes.</div>
+						<div data-i18n="extra-desc">Extras are composed of a series of elements. For each extra, start by adding a title element, then add other elements as needed: permissions, costs, aspects, skills, stunts, tracks, ratings (e.g., weapon:X, armor:X), notes.</div>
+						<div>
+							<span data-i18n="Filter"></span>: <input type="text" name="attr_extrasfilter" value="">
+							<div>
+								<i><span data-i18n="You can use the filter to hide anything that doesn't follow a title element with a matching name."></span></i>
+							</div>
+						</div>
 						<fieldset class="repeating_extras">
+							<input type="hidden" name="attr_hideme" value="0">
 							<input type="hidden" name="attr_element" class="element hideUnlessNull" value="">
 							<select name="attr_element">
 								<option value="" data-i18n="add..."></option>
@@ -1153,103 +1161,108 @@
 								<option value="rating" data-i18n="rating"></option>
 								<option value="note" data-i18n="note"></option>
 							</select>
-							<div class="title AspectSeparator">
-								<input type="text" name="attr_name" value="" data-i18n-placeholder="title" placeholder="title" class="title">
-							</div>
-							<div class="fieldlabel aspect"><span data-i18n="aspects"></span></div>
-							<div class="fieldlabel permissions cost skill track rating note stunt label"><span name="attr_element"></span></div>
-							<div class="aspect note skill stunt rating track">
-								<b style="font-size: 80%;"><span data-i18n="label"></span> (<span data-i18n="optional"></span>):</b>
-								<input type="text" name="attr_label" value="" class="compact">
-							</div>
-							<div class="track">
-								<input type="hidden" class="hideIfNull" name="attr_label" value="">
-								<div>
-									<b style="font-size: 80%;"><span data-i18n="label-icon"></span>:</b>
-									<select class="compact" name="attr_icon">
-										<option value="" data-i18n="none"></option>
-										<option value="plus" data-i18n="plusdie"></option>
-										<option value="blank" data-i18n="blankdie"></option>
-										<option value="minus" data-i18n="minusdie"></option>
-									</select>
+							<input type="hidden" name="attr_hideme" value="0" class="hideOnOne">
+							<div class="tobehiddenornot">
+								<input type="hidden" name="attr_element" class="element" value="">
+								<div class="fieldlabel title"><span data-i18n="title"></span></div>
+								<div class="title AspectSeparator">
+									<input type="text" name="attr_name" value="" data-i18n-placeholder="title" placeholder="title" class="title">
 								</div>
-									<input type="hidden" class="hideIfNull" name="attr_icon" value="">
-								<div>
-									<b style="font-size: 80%;"><span data-i18n="label-icon"></span> 2:</b>
-									<select class="compact" name="attr_icon2">
-										<option value="" data-i18n="none"></option>
-										<option value="plus" data-i18n="plusdie"></option>
-										<option value="blank" data-i18n="blankdie"></option>
-										<option value="minus" data-i18n="minusdie"></option>
-									</select>
+								<div class="fieldlabel aspect"><span data-i18n="aspects"></span></div>
+								<div class="fieldlabel permissions cost skill track rating note stunt label"><span name="attr_element"></span></div>
+								<div class="aspect note skill stunt rating track">
+									<b style="font-size: 80%;"><span data-i18n="label"></span> (<span data-i18n="optional"></span>):</b>
+									<input type="text" name="attr_label" value="" class="compact">
 								</div>
-									<input type="hidden" class="hideIfNull" name="attr_icon2" value="">
-								<div>
-									<b style="font-size: 80%;"><span data-i18n="label-icon"></span> 3:</b>
-									<select class="compact" name="attr_icon3">
-										<option value="" data-i18n="none"></option>
-										<option value="plus" data-i18n="plusdie"></option>
-										<option value="blank" data-i18n="blankdie"></option>
-										<option value="minus" data-i18n="minusdie"></option>
-									</select>
+								<div class="track">
+									<input type="hidden" class="hideIfNull" name="attr_label" value="">
+									<div>
+										<b style="font-size: 80%;"><span data-i18n="label-icon"></span>:</b>
+										<select class="compact" name="attr_icon">
+											<option value="" data-i18n="none"></option>
+											<option value="plus" data-i18n="plusdie"></option>
+											<option value="blank" data-i18n="blankdie"></option>
+											<option value="minus" data-i18n="minusdie"></option>
+										</select>
+									</div>
+										<input type="hidden" class="hideIfNull" name="attr_icon" value="">
+									<div>
+										<b style="font-size: 80%;"><span data-i18n="label-icon"></span> 2:</b>
+										<select class="compact" name="attr_icon2">
+											<option value="" data-i18n="none"></option>
+											<option value="plus" data-i18n="plusdie"></option>
+											<option value="blank" data-i18n="blankdie"></option>
+											<option value="minus" data-i18n="minusdie"></option>
+										</select>
+									</div>
+										<input type="hidden" class="hideIfNull" name="attr_icon2" value="">
+									<div>
+										<b style="font-size: 80%;"><span data-i18n="label-icon"></span> 3:</b>
+										<select class="compact" name="attr_icon3">
+											<option value="" data-i18n="none"></option>
+											<option value="plus" data-i18n="plusdie"></option>
+											<option value="blank" data-i18n="blankdie"></option>
+											<option value="minus" data-i18n="minusdie"></option>
+										</select>
+									</div>
+								</div>
+								<div class="skill">
+									<b style="font-size: 80%;"><span data-i18n="skill"></span>:</b>
+									<input type="text" name="attr_skill" value="" class="compact" data-i18n-placeholder="skill" placeholder="skill">
+								</div>
+								<div class="skill"  style="font-size: 80%;">
+									<b><span data-i18n="rating"></span>:</b>
+									<input type="number" name="attr_rating" value="0" min="-4" max="10" class="compact">
+									<input type="hidden" name="attr_word" value="">
+									<span name="attr_word"></span>
+								</div>
+								<div class="stunt">
+									<b style="font-size: 80%;"><span data-i18n="name"></span>:</b>
+									<input type="text" name="attr_name" value="" class="compact" data-i18n-placeholder="stunt" placeholder="stunt">
+									<div class"fieldlabel"><input type="checkbox" name="attr_rollable" value="1"> <span class="fieldlabel" data-i18n="rollable">Rollable</span></div>
+									<input type="checkbox" class="triggerbox" name="attr_rollable" value="1">
+									<div>
+										<div class="fieldlabel" data-i18n="bonus">Bonus</div>
+										<input name="attr_bonus" type="number" value="0">
+										<div class="fieldlabel" data-i18n="skill">Skill</div>
+										<input name="attr_skill" type="text" value="">
+										<input name="attr_skillvalue" type="hidden" value="0">
+									</div>
+								</div>
+								<div class="rating">
+									<b style="font-size: 80%;"><span data-i18n="name"></span>:</b>
+									<input type="text" name="attr_name" value="" class="compact" data-i18n-placeholder="name" placeholder="name">
+								</div>
+								<div class="rating">
+									<b style="font-size: 80%;"><span data-i18n="rating"></span>:</b>
+									<input type="number" name="attr_rating" value="0" class="compact">
+								</div>
+								<div class="track">
+									<b style="font-size: 80%;"><span data-i18n="name"></span>:</b>
+									<input type="text" name="attr_name" value="" data-i18n-placeholder="optional" placeholder="optional" class="compact">
+								</div>
+								<div class="track">
+									<b style="font-size: 80%;"><span data-i18n="track-length"></span>:</b>
+									<input type="number" name="attr_track" value="1" min="1" max="10" class="compact">
+								</div>
+								<div class="track">
+									<input type="hidden" name="attr_track" value="1" class="hideAllBut">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track1">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track2">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track3">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track4">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track5">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track6">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track7">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track8">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track9">
+									<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track10">
+								</div>
+								<div class="permissions cost aspect note stunt">
+									<textarea name="attr_text" rows=2 class="squat"></textarea>
 								</div>
 							</div>
-							<div class="skill">
-								<b style="font-size: 80%;"><span data-i18n="skill"></span>:</b>
-								<input type="text" name="attr_skill" value="" class="compact" data-i18n-placeholder="skill" placeholder="skill">
-							</div>
-							<div class="skill"  style="font-size: 80%;">
-								<b><span data-i18n="rating"></span>:</b>
-								<input type="number" name="attr_rating" value="0" min="-4" max="10" class="compact">
-								<input type="hidden" name="attr_word" value="">
-								<span name="attr_word"></span>
-							</div>
-							<div class="stunt">
-								<b style="font-size: 80%;"><span data-i18n="name"></span>:</b>
-								<input type="text" name="attr_name" value="" class="compact" data-i18n-placeholder="stunt" placeholder="stunt">
-								<div class"fieldlabel"><input type="checkbox" name="attr_rollable" value="1"> <span class="fieldlabel" data-i18n="rollable">Rollable</span></div>
-								<input type="checkbox" class="triggerbox" name="attr_rollable" value="1">
-								<div>
-									<div class="fieldlabel" data-i18n="bonus">Bonus</div>
-									<input name="attr_bonus" type="number" value="0">
-									<div class="fieldlabel" data-i18n="skill">Skill</div>
-									<input name="attr_skill" type="text" value="">
-									<input name="attr_skillvalue" type="hidden" value="0">
-								</div>
-							</div>
-							<div class="rating">
-								<b style="font-size: 80%;"><span data-i18n="name"></span>:</b>
-								<input type="text" name="attr_name" value="" class="compact" data-i18n-placeholder="name" placeholder="name">
-							</div>
-							<div class="rating">
-								<b style="font-size: 80%;"><span data-i18n="rating"></span>:</b>
-								<input type="number" name="attr_rating" value="0" class="compact">
-							</div>
-							<div class="track">
-								<b style="font-size: 80%;"><span data-i18n="name"></span>:</b>
-								<input type="text" name="attr_name" value="" data-i18n-placeholder="optional" placeholder="optional" class="compact">
-							</div>
-							<div class="track">
-								<b style="font-size: 80%;"><span data-i18n="track-length"></span>:</b>
-								<input type="number" name="attr_track" value="1" min="1" max="10" class="compact">
-							</div>
-							<div class="track">
-								<input type="hidden" name="attr_track" value="1" class="hideAllBut">
-								<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track1">
-								<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track2">
-								<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track3">
-								<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track4">
-								<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track5">
-								<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track6">
-								<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track7">
-								<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track8">
-								<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track9">
-								<input type="text" value="" maxlength="2" size="1" class="tracker" name="attr_track10">
-							</div>
-							<div class="permissions cost aspect note stunt">
-								<textarea name="attr_text" rows=2 class="squat"></textarea>
-							</div>
-						</fieldset>
+						</fieldset> <!-- End of the Extras editing fieldset -->
 						<div>
 							<select name="attr_addextra">
 								<option value="" data-i18n="add...">Add...</option>
@@ -1276,98 +1289,102 @@
 					</div> <!-- /ExtraEdit -->
 					
 					<div class="ExtraDisplay">
+						<span data-i18n="Filter"></span>: <input type="text" name="attr_extrasfilter" value="" data-i18n-title="You can use the filter to hide anything that doesn't follow a title element with a matching name.">
 						<fieldset class="repeating_extras">
-							<input type="hidden" name="attr_element" class="element" value="">
-							<div class="title clear-all space-above" width="100%">
-								<span name="attr_name"></span>
-							</div>
-							<div class="permissions space-below clear-all">
-								<div class="fieldlabel"><b><span data-i18n="permissions"></span></b></div>
-								<div class="indented"><span name="attr_text"></span></div>
-							</div>
-							<div class="cost space-below clear-all">
-								<div class="fieldlabel"><b><span data-i18n="cost"></span></b></div>
-								<div class="indented"><span name="attr_text"></span></div>
-							</div>
-							<div class="aspect space-below clear-all">
-								<!-- input type="hidden" class="hideUnlessNull" name="attr_label" value=""><div class="fieldlabel"><b><span data-i18n="aspects"></span></b></div -->
-								<input type="hidden" class="hideIfNull" name="attr_label" value=""><div class="fieldlabel"><b><span name="attr_label"></span></b></div>
-								<div class="aspect indented">
-									<span name="attr_text" class="aspect"></span>
-									<input type="hidden" name="attr_text" value="">
-									<input type="hidden" name="attr_label" value="">
-									<button type="roll" class="share" value="&{template:share} {{theme=@{theme}}} {{name=@{character_name}: ^{extra} @{label} ^{aspect}}} {{text=***@{text}***}}"></button>
-								</div>
-							</div>
-							<div class="note space-below clear-all">
-								<input type="hidden" class="hideIfNull" name="attr_label" value=""><div class="fieldlabel"><b><span name="attr_label"></span></b></div>
-								<div class="indented">
-									<span name="attr_text"></span>
-									<input type="hidden" name="attr_label" value="">
-									<input type="hidden" name="attr_text" value="">
-									<button type="roll" class="share" value="&{template:share} {{theme=@{theme}}} {{name=@{character_name}: @{label} ^{note}}} {{text=@{text}}}"></button>
-								</div>
-							</div>
-							<div class="skill">
-								<input type="hidden" name="attr_skill" value="">
-								<input type="hidden" name="attr_rating" value="0">
-								<input type="hidden" class="hideIfNull" name="attr_label" value=""><div class="fieldlabel clear-all"><b><span name="attr_label"></span></b></div>
-								<button type="roll" value="@{comstyle} &{template:fateroll} {{theme=@{theme}}} {{name=@{character_name}: @{skill}}} {{roll=[[@{fatedice}+@{rating}+@{Show-Diceprompts}]]}}" name="roll_SkillRoll" class="sheet-roll">
-									<b><span name="attr_skill"></span></b>:
-									<span name="attr_word"></span>
-								</button>
-							</div>
-							<div class="stunt space-below clear-all">
-								<input type="hidden" class="hideIfNull" name="attr_label" value=""><div class="fieldlabel"><b><span name="attr_label"></span></b></div>
-								<div class="stunt">
-									<b><span name="attr_name"></span>:</b>
-									<span name="attr_text"></span>
-									<input type="hidden" name="attr_name" value=""><input type="hidden" name="attr_text" value="">
-									<button type="roll" class="share" value="&{template:share} {{theme=@{theme}}} {{name=@{character_name}: ^{extra} ^{stunt}}} {{text=**@{name}:** @{text}}}"></button>
-									<input type="hidden" name="attr_skill" value="">
-									<input type="hidden" name="attr_skillvalue" value="0">
-									<input type="hidden" name="attr_bonus" value="0">
-									<input type="checkbox" class="triggerbox" name="attr_rollable" value="1">
-									<span><br/><button type="roll" class="sheet-roll" value="@{comstyle} &{template:fateroll} {{theme=@{theme}}} {{name=@{character_name}: @{name} (@{skill})}} {{roll=[[@{fatedice}+@{skillvalue}+@{bonus}+@{Show-Diceprompts}]]}}" name="roll_SkillRoll">
-										<b><span data-i18n="roll"></span>
-										<span name="attr_skill"></span></b> = <span name="attr_skillvalue"></span> + <span name="attr_bonus"></span> &nbsp;
-									</button></span>
-								</div>
-							</div>
-							<div class="rating space-below clear-all">
-								<input type="hidden" class="hideIfNull" name="attr_label" value=""><div class="fieldlabel"><b><span name="attr_label"></span></b></div>
-								<div class="indented">
-									<b><span name="attr_name"></span>:</b>
-									<span name="attr_rating"></span>
-									<input type="hidden" name="attr_name" value="">
-									<input type="hidden" name="attr_rating" value="">
-									<button type="roll" class="share" value="&{template:share} {{theme=@{theme}}} {{name=@{character_name}: ^{extra} ^{rating}}} {{text=**@{name}:** @{rating}}}"></button>
-								</div>
-							</div>
-							<div class="track space-below clear-all">
-								<input type="hidden" class="hideIfNull" name="attr_label" value=""><div class="fieldlabel">
-									<input type="hidden" class="hideIfNull icon" name="attr_icon" value=""><span class="icon"></span>
-									<input type="hidden" class="hideIfNull icon" name="attr_icon2" value=""><span class="icon"></span>
-									<input type="hidden" class="hideIfNull icon" name="attr_icon3" value=""><span class="icon"></span>
-									<b><span name="attr_label"></span></b>
-								</div>
-								<div class="indented">
-									<span class="nowrap float-left">
-										<input type="hidden" name="attr_track" value="1" class="hideAllBut">
-										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check1" value="1"><span class="tracker" name="attr_track1"></span></span>
-										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check2" value="1"><span class="tracker" name="attr_track2"></span></span>
-										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check3" value="1"><span class="tracker" name="attr_track3"></span></span>
-										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check4" value="1"><span class="tracker" name="attr_track4"></span></span>
-										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check5" value="1"><span class="tracker" name="attr_track5"></span></span>
-										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check6" value="1"><span class="tracker" name="attr_track6"></span></span>
-										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check7" value="1"><span class="tracker" name="attr_track7"></span></span>
-										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check8" value="1"><span class="tracker" name="attr_track8"></span></span>
-										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check9" value="1"><span class="tracker" name="attr_track9"></span></span>
-										<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check10" value="1"><span class="tracker" name="attr_track10"></span></span>
-									</span>
+							<input type="hidden" name="attr_hideme" value="0" class="hideOnOne">
+							<div class="tobehiddenornot">
+								<input type="hidden" name="attr_element" class="element" value="">
+								<div class="title clear-all space-above rule-above" width="100%">
 									<span name="attr_name"></span>
 								</div>
-							</div>
+								<div class="permissions space-below clear-all">
+									<div class="fieldlabel"><b><span data-i18n="permissions"></span></b></div>
+									<div class="indented"><span name="attr_text"></span></div>
+								</div>
+								<div class="cost space-below clear-all">
+									<div class="fieldlabel"><b><span data-i18n="cost"></span></b></div>
+									<div class="indented"><span name="attr_text"></span></div>
+								</div>
+								<div class="aspect space-below clear-all">
+									<!-- input type="hidden" class="hideUnlessNull" name="attr_label" value=""><div class="fieldlabel"><b><span data-i18n="aspects"></span></b></div -->
+									<input type="hidden" class="hideIfNull" name="attr_label" value=""><div class="fieldlabel"><b><span name="attr_label"></span></b></div>
+									<div class="aspect indented">
+										<span name="attr_text" class="aspect"></span>
+										<input type="hidden" name="attr_text" value="">
+										<input type="hidden" name="attr_label" value="">
+										<button type="roll" class="share" value="&{template:share} {{theme=@{theme}}} {{name=@{character_name}: ^{extra} @{label} ^{aspect}}} {{text=***@{text}***}}"></button>
+									</div>
+								</div>
+								<div class="note space-below clear-all">
+									<input type="hidden" class="hideIfNull" name="attr_label" value=""><div class="fieldlabel"><b><span name="attr_label"></span></b></div>
+									<div class="indented">
+										<span name="attr_text"></span>
+										<input type="hidden" name="attr_label" value="">
+										<input type="hidden" name="attr_text" value="">
+										<button type="roll" class="share" value="&{template:share} {{theme=@{theme}}} {{name=@{character_name}: @{label} ^{note}}} {{text=@{text}}}"></button>
+									</div>
+								</div>
+								<div class="skill">
+									<input type="hidden" name="attr_skill" value="">
+									<input type="hidden" name="attr_rating" value="0">
+									<input type="hidden" class="hideIfNull" name="attr_label" value=""><div class="fieldlabel clear-all"><b><span name="attr_label"></span></b></div>
+									<button type="roll" value="@{comstyle} &{template:fateroll} {{theme=@{theme}}} {{name=@{character_name}: @{skill}}} {{roll=[[@{fatedice}+@{rating}+@{Show-Diceprompts}]]}}" name="roll_SkillRoll" class="sheet-roll">
+										<b><span name="attr_skill"></span></b>:
+										<span name="attr_word"></span>
+									</button>
+								</div>
+								<div class="stunt space-below clear-all">
+									<input type="hidden" class="hideIfNull" name="attr_label" value=""><div class="fieldlabel"><b><span name="attr_label"></span></b></div>
+									<div class="stunt">
+										<b><span name="attr_name"></span>:</b>
+										<span name="attr_text"></span>
+										<input type="hidden" name="attr_name" value=""><input type="hidden" name="attr_text" value="">
+										<button type="roll" class="share" value="&{template:share} {{theme=@{theme}}} {{name=@{character_name}: ^{extra} ^{stunt}}} {{text=**@{name}:** @{text}}}"></button>
+										<input type="hidden" name="attr_skill" value="">
+										<input type="hidden" name="attr_skillvalue" value="0">
+										<input type="hidden" name="attr_bonus" value="0">
+										<input type="checkbox" class="triggerbox" name="attr_rollable" value="1">
+										<span><br/><button type="roll" class="sheet-roll" value="@{comstyle} &{template:fateroll} {{theme=@{theme}}} {{name=@{character_name}: @{name} (@{skill})}} {{roll=[[@{fatedice}+@{skillvalue}+@{bonus}+@{Show-Diceprompts}]]}}" name="roll_SkillRoll">
+											<b><span data-i18n="roll"></span>
+											<span name="attr_skill"></span></b> = <span name="attr_skillvalue"></span> + <span name="attr_bonus"></span> &nbsp;
+										</button></span>
+									</div>
+								</div>
+								<div class="rating space-below clear-all">
+									<input type="hidden" class="hideIfNull" name="attr_label" value=""><div class="fieldlabel"><b><span name="attr_label"></span></b></div>
+									<div class="indented">
+										<b><span name="attr_name"></span>:</b>
+										<span name="attr_rating"></span>
+										<input type="hidden" name="attr_name" value="">
+										<input type="hidden" name="attr_rating" value="">
+										<button type="roll" class="share" value="&{template:share} {{theme=@{theme}}} {{name=@{character_name}: ^{extra} ^{rating}}} {{text=**@{name}:** @{rating}}}"></button>
+									</div>
+								</div>
+								<div class="track space-below clear-all">
+									<input type="hidden" class="hideIfNull" name="attr_label" value=""><div class="fieldlabel">
+										<input type="hidden" class="hideIfNull icon" name="attr_icon" value=""><span class="icon"></span>
+										<input type="hidden" class="hideIfNull icon" name="attr_icon2" value=""><span class="icon"></span>
+										<input type="hidden" class="hideIfNull icon" name="attr_icon3" value=""><span class="icon"></span>
+										<b><span name="attr_label"></span></b>
+									</div>
+									<div class="indented">
+										<span class="nowrap float-left">
+											<input type="hidden" name="attr_track" value="1" class="hideAllBut">
+											<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check1" value="1"><span class="tracker" name="attr_track1"></span></span>
+											<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check2" value="1"><span class="tracker" name="attr_track2"></span></span>
+											<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check3" value="1"><span class="tracker" name="attr_track3"></span></span>
+											<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check4" value="1"><span class="tracker" name="attr_track4"></span></span>
+											<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check5" value="1"><span class="tracker" name="attr_track5"></span></span>
+											<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check6" value="1"><span class="tracker" name="attr_track6"></span></span>
+											<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check7" value="1"><span class="tracker" name="attr_track7"></span></span>
+											<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check8" value="1"><span class="tracker" name="attr_track8"></span></span>
+											<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check9" value="1"><span class="tracker" name="attr_track9"></span></span>
+											<span class="trackContainer"><input type="checkbox" class="checkbox" name="attr_check10" value="1"><span class="tracker" name="attr_track10"></span></span>
+										</span>
+										<span name="attr_name"></span>
+									</div>
+								</div>
+							</div> <!-- tobehiddenornot -->
 						</fieldset>
 					</div>
 
@@ -4553,6 +4570,74 @@ on("change:repeating_extras:rating", function(e) {
 	}
 });
 
+// A function from wiki.roll20.net/Sheet_Worker_Scripts that gets you section IDs in their order of display
+
+var getSectionIDsOrdered = function (sectionName, callback) {
+  'use strict';
+  getAttrs([`_reporder_${sectionName}`], function (v) {
+    getSectionIDs(sectionName, function (idArray) {
+      let reporderArray = v[`_reporder_${sectionName}`] ? v[`_reporder_${sectionName}`].toLowerCase().split(',') : [],
+        ids = [...new Set(reporderArray.filter(x => idArray.includes(x)).concat(idArray))];
+      callback(ids);
+    });
+  });
+};
+
+// Creating a handler to make sure that extras are divided up by/attached to title elements. ZOD 
+
+on("change:extrasfilter change:repeating_extras sheet:opened", function(e) {
+	getSectionIDsOrdered("extras", function(x) {
+		log("Extras grouping handler activated");
+		// We really only care about these fields: 
+		// - element, which is the type-of-element indicator, and 
+		// - name, which will contain the name of a title element, for filtering purposes
+		// - hideme, which will contain a 1 if it should be hidden and a 0 if it shouldn't, based on filter text
+		// 
+		// hideme = 0 or 1, extrasfilter = <string>
+		log(x);
+		var fieldlist = ['extrasfilter'];
+		for(var i=0; i < x.length; i++) {
+			fieldlist[i*3+1] = "repeating_extras_" + x[i] + "_hideme";
+			fieldlist[i*3+2] = "repeating_extras_" + x[i] + "_element";
+			fieldlist[i*3+3] = "repeating_extras_" + x[i] + "_name";
+		}
+		getAttrs(fieldlist, function(ext) {
+			log(ext);
+			var att = {};
+			var hidestate = 0;
+			const spacetrim = /[ ]*$/;
+			var empty = false;
+			var searcher = '';
+			if( ext['extrasfilter'].replace(spacetrim) == "" ) {
+				empty = true; 
+			} else {
+				searcher = new RegExp(ext['extrasfilter'],'i');
+			}
+			for(var i=0; i < x.length; i++) {
+				if ( empty ) {
+					att['repeating_extras_' + x[i] + "_hideme" ] = "0";
+				} else {
+					var el = ext["repeating_extras_" + x[i] + "_element"];
+					var na = ext["repeating_extras_" + x[i] + "_name"];
+					if ( el == "title" ) {
+						log("title element found " + na);
+						if ( searcher.test(na) ) {
+							log("matches filter");
+							hidestate = 0;
+						} else {
+							log("does not match filter");
+							hidestate = 1;
+						}
+					}
+					att['repeating_extras_' + x[i] + "_hideme" ] = hidestate;
+				}
+			}
+			log(att);
+			setAttrs(att);
+		});
+	});
+});
+
 on("change:repeating_skills:rollthis change:combomulti", function(e) {
 	log("rollthis or combomulti marked in repeating_skills - skill combo feature");
 	log(e);
@@ -4833,8 +4918,14 @@ on("change:importsheetdata sheet:opened", function() {
 		if ( values.importsheetdata !== "" ) { // Then it's gonna get processed.
 			log("importsheetdata: non null importablesheetdata detected");
 			var impsheet = JSON.parse(values.importsheetdata); // Hope this works!
-			var attrs = impsheet.attr; // this should get us the "flat attributes" that are just gonna get overwritten, as our starter object
-			var fsets = impsheet.fieldset; // An array of objects each representing a row in one of the many fieldsets this sheet uses
+			var attrs = {};
+			var fsets = [];
+			if ( typeof(impsheet.attr) !== "undefined" ) {
+				attrs = impsheet.attr; // this should get us the "flat attributes" that are just gonna get overwritten, as our starter object
+			}
+			if ( typeof(impsheet.fieldset) !== "undefined" ) {
+				fsets = impsheet.fieldset; // An array of objects each representing a row in one of the many fieldsets this sheet uses
+			}
 			attrs["importsheetdata"] = ""; // Initialize the import field now that we've read it in.
 			for(var i=0; i < fsets.length; i++) {
 				var row = fsets[i]; // This is an object
@@ -4858,6 +4949,32 @@ on("change:importsheetdata sheet:opened", function() {
 // all the fieldsets so far: 
 // aspects, skills, stunts, stress, consequences, conditions, tempaspects, modes, roles, swaps, packages, powers, extras, notes
 // ZOD
+
+on("clicked:exportsheetextrasonly", function(e) {
+	var exsheet = { "attr": {}, "fieldset": [] };
+	var fields = [];
+	getSectionIDs("extras", function(extrasList) {
+		var flist = fieldsets["extras"];
+		var fnames = [];
+		for(var i=0; i < extrasList.length; i++) {
+			for(var j=0; j < flist.length; j++) {
+				fnames[i*flist.length+j] = "repeating_extras_" + extrasList[i] + "_" + flist[j];
+			}
+		}
+		fields = fields.concat(fnames);
+		getAttrs(fields, function(v) {
+			log(v);
+			for(var i=0; i < extrasList.length; i++) {
+				var thisrow = { "_fieldset": "extras" };
+				for(var j=0; j < fieldsets["extras"].length; j++) {
+					thisrow[fieldsets["extras"][j]] = v["repeating_extras_" + extrasList[i] + "_" + fieldsets["extras"][j]];
+				}
+				exsheet["fieldset"].push(thisrow);
+			}
+			setAttrs({ "exportsheetdata": JSON.stringify(exsheet,null,"\t") });
+		});
+	});
+});
 
 on("clicked:exportsheet", function(e) {
 	var exsheet = { "attr": {}, "fieldset": [] };
@@ -5111,7 +5228,7 @@ on("clicked:exportsheet", function(e) {
 																}
 																
 																// And finally, we stringify the object and set the export field value
-																setAttrs({ "exportsheetdata": JSON.stringify(exsheet) });
+																setAttrs({ "exportsheetdata": JSON.stringify(exsheet,null,"\t") });
 															});
 
 														}); // notes

--- a/Fate/translation.json
+++ b/Fate/translation.json
@@ -454,5 +454,7 @@
 	"Dice Communications": "Dice Communications",
 	"Display sheet's rolls publicly": "Display sheet's rolls publicly", 
 	"Whisper sheet's rolls to GM": "Whisper sheet's rolls to GM",
+	"Filter": "Filter",
+	"You can use the filter to hide anything that doesn't follow a title element with a matching name.": "You can use the filter to hide anything that doesn't follow a title element with a matching name. Just type in a phrase and then click, tap, or tab out of the filter field to apply the filter.",
 	"zzzz-end-of-json": "<!-- End of JSON File -->"
 }


### PR DESCRIPTION
# Submission Checklist
## Required

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

This is a small update for the official Fate sheet created & supported by Evil Hat Productions.

The Extras section of the sheet can get unruly if you have many Extras defined. This update adds a filtering feature; type in a search string, and any element that does NOT follow a title that matches your search will be hidden. Works in both editing and displaying modes.


