### PR TITLE
Fixing Ordem Paranormal Sheet - Missing `sheet-` prefix in CSS file

### DIFF
--- a/Ordem Paranormal/ordemparanormal.css
+++ b/Ordem Paranormal/ordemparanormal.css
@@ -123,27 +123,27 @@ body.sheet-darkmode,
   background-color: var(--background-color) !important;
 }
 
-.main input {
+.sheet-main input {
   color: var(--text-color);
 }
 
-.main input:disabled {
+.sheet-main input:disabled {
   background-color: var(--background-color-disabled) !important;
 }
 
-.main span {
+.sheet-main span {
   color: var(--title-color);
 }
 
-.main div {
+.sheet-main div {
   color: var(--text-color);
 }
 
-.main button {
+.sheet-main button {
   color: var(--title-color);
 }
 
-.main h1,
+.sheet-main h1,
 h2,
 h3,
 h4,
@@ -152,63 +152,63 @@ h6 {
   color: var(--title-color);
 }
 
-.main select,
-.main option {
+.sheet-main select,
+.sheet-main option {
   color: var(--text-color);
   background-color: var(--background-color-secondary);
 }
 
-.main textarea {
+.sheet-main textarea {
   overflow: auto;
   color: var(--text-color);
 }
 
-.main progress {
+.sheet-main progress {
   vertical-align: baseline;
 }
 
-.main button,
-.main input,
-.main optgroup,
-.main select,
-.main textarea {
+.sheet-main button,
+.sheet-main input,
+.sheet-main optgroup,
+.sheet-main select,
+.sheet-main textarea {
   font-family: inherit;
   font-size: 100%;
   line-height: 1.15;
   margin: 0;
 }
 
-.main button,
-.main input {
+.sheet-main button,
+.sheet-main input {
   overflow: visible;
 }
 
-.main img {
+.sheet-main img {
   border-style: none;
 }
 
-.main sub,
-.main sup {
+.sheet-main sub,
+.sheet-main sup {
   font-size: 75%;
   line-height: 0;
   position: relative;
   vertical-align: baseline;
 }
 
-.main sub {
+.sheet-main sub {
   bottom: -0.25em;
 }
 
-.main sup {
+.sheet-main sup {
   top: -0.5em;
 }
 
-.main b,
-.main strong {
+.sheet-main b,
+.sheet-main strong {
   font-weight: bolder;
 }
 
-.main {
+.sheet-main {
   margin: 0 auto;
   font-family: "PT Sans", sans-serif;
   font-size: 13px;
@@ -221,48 +221,48 @@ h6 {
   background-color: var(--background-color);
 }
 
-.main * {
+.sheet-main * {
   box-sizing: border-box;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-.main *::-moz-selection {
+.sheet-main *::-moz-selection {
   color: #4d131a;
   background: var(--highligth-color);
 }
 
-.main *::selection {
+.sheet-main *::selection {
   color: #4d131a;
   background: var(--highligth-color);
 }
 
-.main input,
-.main textarea,
-.main select {
+.sheet-main input,
+.sheet-main textarea,
+.sheet-main select {
   outline: none !important;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 13px;
   border-radius: 0 !important;
 }
 
-.main input {
+.sheet-main input {
   background-color: var(--background-color);
 }
 
-.main input:disabled,
-.main textarea:disabled,
-.main select:disabled {
+.sheet-main input:disabled,
+.sheet-main textarea:disabled,
+.sheet-main select:disabled {
   background-color: var(--background-color-secondary);
 }
 
-.main button {
+.sheet-main button {
   outline: none !important;
 }
 
-.main button[type="roll"],
-.main button[type="roll"].btn,
-.main button[type="roll"].btn {
+.sheet-main button[type="roll"],
+.sheet-main button[type="roll"].btn,
+.sheet-main button[type="roll"].btn {
   background-image: none;
   border-radius: 0 !important;
   padding: 0 !important;
@@ -272,15 +272,15 @@ h6 {
   text-shadow: initial;
 }
 
-.main button[type="roll"]:active,
-.main button[type="roll"]:hover,
-.main button[type="roll"]:focus,
-.main button[type="roll"].btn:active,
-.main button[type="roll"].btn:hover,
-.main button[type="roll"].btn:focus,
-.main button[type="roll"].btn:active,
-.main button[type="roll"].btn:hover,
-.main button[type="roll"].btn:focus {
+.sheet-main button[type="roll"]:active,
+.sheet-main button[type="roll"]:hover,
+.sheet-main button[type="roll"]:focus,
+.sheet-main button[type="roll"].btn:active,
+.sheet-main button[type="roll"].btn:hover,
+.sheet-main button[type="roll"].btn:focus,
+.sheet-main button[type="roll"].btn:active,
+.sheet-main button[type="roll"].btn:hover,
+.sheet-main button[type="roll"].btn:focus {
   background-image: none;
   border-radius: 0 !important;
   padding: 0 !important;
@@ -290,14 +290,14 @@ h6 {
   text-shadow: initial;
 }
 
-.main button[type="roll"]::before,
-.main button[type="roll"].btn::before,
-.main button[type="roll"].btn::before {
+.sheet-main button[type="roll"]::before,
+.sheet-main button[type="roll"].btn::before,
+.sheet-main button[type="roll"].btn::before {
   content: "";
   border-radius: 0 !important;
 }
 
-.main .repcontrol > .btn {
+.sheet-main .repcontrol > .btn {
   background-color: var(--icon-color);
   font-size: 2px;
   border: none;
@@ -315,11 +315,11 @@ h6 {
   position: relative;
 }
 
-.main .repcontrol > .btn:hover {
+.sheet-main .repcontrol > .btn:hover {
   background-color: var(--icon-hover);
 }
 
-.main .repcontrol > .btn.repcontrol_add::before {
+.sheet-main .repcontrol > .btn.repcontrol_add::before {
   position: absolute;
   content: "&";
   font-weight: 0;
@@ -336,7 +336,7 @@ h6 {
   transform: translate(-50%, -50%);
 }
 
-.main .repcontrol > .btn.repcontrol_edit::before {
+.sheet-main .repcontrol > .btn.repcontrol_edit::before {
   position: absolute;
   display: flex;
   align-items: center;
@@ -353,7 +353,7 @@ h6 {
   transform: translate(-50%, -50%);
 }
 
-.main
+.sheet-main
   .repcontainer[data-groupname="repeating_attacks"]
   > .repitem
   .itemcontrol {
@@ -361,7 +361,7 @@ h6 {
   font-family: "Pictos";
 }
 
-.main
+.sheet-main
   .repcontainer[data-groupname="repeating_attacks"]
   > .repitem
   .repcontrol_del {
@@ -374,7 +374,7 @@ h6 {
   right: 0;
 }
 
-.main
+.sheet-main
   .repcontainer[data-groupname="repeating_attacks"]
   > .repitem
   .editmode
@@ -382,7 +382,7 @@ h6 {
   content: "Aplicar";
 }
 
-.main .header-info {
+.sheet-main .sheet-header-info {
   display: grid;
   width: 100%;
   grid-template-columns: 140px 140px auto;
@@ -391,7 +391,7 @@ h6 {
   margin-bottom: 2rem;
 }
 
-.header-info .double-input-container {
+.sheet-header-info .sheet-double-input-container {
   width: 100%;
   display: grid;
   /* height: 155px; */
@@ -399,7 +399,7 @@ h6 {
   column-gap: 10px;
 }
 
-.main .character-attributes {
+.sheet-main .sheet-character-attributes {
   /* margin-top: -20px; */
   width: 100%;
   height: 90px;
@@ -409,8 +409,8 @@ h6 {
   column-gap: 22px;
 }
 
-.main .pseudo-attributes,
-.main .proeficience-container {
+.sheet-main .sheet-pseudo-attributes,
+.sheet-main .sheet-proeficience-container {
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -420,7 +420,7 @@ h6 {
   margin-bottom: 22px;
 }
 
-.main .pseudo-attributes .double-containers {
+.sheet-main .sheet-pseudo-attributes .sheet-double-containers {
   display: grid;
   grid-template-columns: 22rem 22rem;
   column-gap: 2rem;
@@ -428,35 +428,42 @@ h6 {
   margin: 0 auto;
 }
 
-.main .pseudo-attributes .single-container {
+.sheet-main .sheet-pseudo-attributes .sheet-single-container {
   display: flex;
   flex-direction: column;
   width: 22rem;
   margin: 0 auto;
 }
 
-.pseudo-attributes-wrapper {
+.sheet-pseudo-attributes-wrapper {
   display: flex;
   flex-direction: column;
   row-gap: 1rem;
 }
 
-.pseudo-attributes-wrapper .container-title,
-.attacks-container .container-title {
+.sheet-pseudo-attributes-wrapper .sheet-container-title,
+.sheet-attacks-container .sheet-container-title {
   text-align: center;
 }
 
-.main .pseudo-attributes .container-pvs-mps {
+.sheet-main .sheet-pseudo-attributes .container-pvs-mps {
   min-height: 6.5rem;
 }
 
-.main .pseudo-attributes .container-pvs-mps .inside-negative-corner {
+.sheet-main
+  .sheet-pseudo-attributes
+  .container-pvs-mps
+  .sheet-inside-negative-corner {
   display: grid;
   grid-template-columns: 74px auto 74px;
   grid-template-rows: 16px auto 14px;
 }
 
-.main .pseudo-attributes .container-pvs-mps .inside-negative-corner .box-title {
+.sheet-main
+  .sheet-pseudo-attributes
+  .sheet-container-pvs-mps
+  .sheet-inside-negative-corner
+  .sheet-box-title {
   width: 100%;
   display: flex;
   justify-content: center;
@@ -473,43 +480,47 @@ h6 {
   text-transform: uppercase;
 }
 
-.main
-  .pseudo-attributes
-  .container-pvs-mps
-  .inside-negative-corner
-  .border-right {
+.sheet-main
+  .sheet-pseudo-attributes
+  .sheet-container-pvs-mps
+  .sheet-inside-negative-corner
+  .sheet-border-right {
   border: 0;
   border-right: 1px solid var(--accent-color);
 }
 
-.main
-  .pseudo-attributes
-  .container-pvs-mps
-  .inside-negative-corner
-  .border-right
+.sheet-main
+  .sheet-pseudo-attributes
+  .sheet-container-pvs-mps
+  .sheet-inside-negative-corner
+  .sheet-border-right
   input {
   width: 50px;
 }
 
-.main
-  .pseudo-attributes
-  .container-pvs-mps
-  .inside-negative-corner
-  .border-left {
+.sheet-main
+  .sheet-pseudo-attributes
+  .sheet-container-pvs-mps
+  .sheet-inside-negative-corner
+  .sheet-border-left {
   border: 0;
   border-left: 1px solid var(--accent-color);
 }
 
-.main
-  .pseudo-attributes
-  .container-pvs-mps
-  .inside-negative-corner
-  .border-left
+.sheet-main
+  .sheet-pseudo-attributes
+  .sheet-container-pvs-mps
+  .sheet-inside-negative-corner
+  .sheet-border-left
   input {
   width: 50px;
 }
 
-.main .pseudo-attributes .container-pvs-mps .inside-negative-corner input {
+.sheet-main
+  .sheet-pseudo-attributes
+  .sheet-container-pvs-mps
+  .sheet-inside-negative-corner
+  input {
   background-color: transparent;
   border: 0;
   min-width: 40px;
@@ -520,19 +531,19 @@ h6 {
   height: 100%;
 }
 
-.main .left-container {
+.sheet-main .sheet-left-container {
   width: 100%;
   display: flex;
   flex-direction: column;
 }
 
-.main .left-container .attacks-container {
+.sheet-main .sheet-left-container .sheet-attacks-container {
   width: 100%;
   display: block;
   margin-bottom: 22px;
 }
 
-.main .left-container .attacks-container .attacksgrid {
+.sheet-main .sheet-left-container .sheet-attacks-container .sheet-attacksgrid {
   display: grid;
   padding-left: 10px;
   padding-right: 10px;
@@ -541,11 +552,18 @@ h6 {
   grid-template-rows: 24px auto;
 }
 
-.main .left-container .attacks-container .attacksgrid.header {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid.header {
   grid-template-rows: 24px;
 }
 
-.main .left-container .attacks-container .attacksgrid input {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  input {
   display: inline-block;
   height: 24px;
   font-size: 12px;
@@ -556,7 +574,11 @@ h6 {
   width: 100%;
 }
 
-.main .left-container .attacks-container .attacksgrid .buttonrollataque {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-buttonrollataque {
   background-color: transparent;
   font-family: "dicefontd20";
   color: var(--icon-color);
@@ -569,47 +591,59 @@ h6 {
   transition: color 1s;
 }
 
-.buttonrollerro {
+.sheet-buttonrollerro {
   font-family: "dicefontd10" !important;
 }
 
-.buttondicefont {
+.sheet-buttondicefont {
   font-family: "dicefontd20" !important;
   font-size: 20px;
 }
 
-.main .left-container .attacks-container .attacksgrid .buttonrollataque:hover,
-.buttonrollerro:hover {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-buttonrollataque:hover,
+.sheet-buttonrollerro:hover {
   color: var(--dice-hover);
 }
 
-.main .left-container .attacks-container .attacksgrid .buttonrollataque:active,
-.buttonrollerro:active {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-buttonrollataque:active,
+.sheet-buttonrollerro:active {
   font-size: 18px;
 }
 
-.main .left-container .attacks-container .attacksgrid .containercritico {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .containercritico {
   display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: center;
 }
 
-.main
-  .left-container
-  .attacks-container
-  .attacksgrid
-  .containercritico
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-containercritico
   input.margem {
   width: 24px;
 }
 
-.main
-  .left-container
-  .attacks-container
-  .attacksgrid
-  .containercritico
-  .divisor {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-containercritico
+  .sheet-divisor {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 13px;
   display: inline-flex;
@@ -623,27 +657,31 @@ h6 {
   border-bottom: 2px solid transparent;
 }
 
-.main
-  .left-container
-  .attacks-container
-  .attacksgrid
-  .containercritico
-  .divisor
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-containercritico
+  .sheet-divisor
   b {
   font-weight: bold;
 }
 
-.main
-  .left-container
-  .attacks-container
-  .attacksgrid
-  .containercritico
-  input.multiplicador {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-containercritico
+  input.sheet-multiplicador {
   text-align: center;
   width: 16px;
 }
 
-.main .left-container .attacks-container .attacksgrid .moreinfo {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-moreinfo {
   position: relative;
   margin-top: 7px;
   grid-column: 1/8;
@@ -656,12 +694,12 @@ h6 {
   margin-bottom: 7px;
 }
 
-.main
-  .left-container
-  .attacks-container
-  .attacksgrid
-  .moreinfo
-  .containermoreinfo {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-moreinfo
+  .sheet-containermoreinfo {
   width: 100%;
   display: none;
   padding: 7px;
@@ -672,52 +710,52 @@ h6 {
   border: 0;
 }
 
-.main
-  .left-container
-  .attacks-container
-  .attacksgrid
-  .moreinfo
-  .containermoreinfo
-  .inputtextbellow {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-moreinfo
+  .sheet-containermoreinfo
+  .sheet-inputtextbellow {
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
   width: 100%;
 }
 
-.main
-  .left-container
-  .attacks-container
-  .attacksgrid
-  .moreinfo
-  .containermoreinfo
-  .inputtextbellow.descricao {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-moreinfo
+  .sheet-containermoreinfo
+  .sheet-inputtextbellow.descricao {
   grid-column: 1/5;
 }
 
-.pericialuta,
-.tiporolagemtres {
+.sheet-pericialuta,
+.sheet-tiporolagemtres {
   grid-column: 5/7;
 }
 
-.tipodano,
-.tiporolagemum {
+.sheet-tipodano,
+.sheet-tiporolagemum {
   grid-column: 1/3;
 }
 
-.alcance,
-.tiporolagemdois {
+.sheet-alcance,
+.sheet-tiporolagemdois {
   grid-column: 3/5;
 }
 
-.main
-  .left-container
-  .attacks-container
-  .attacksgrid
-  .moreinfo
-  .containermoreinfo
-  .inputtextbellow
-  .title {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-moreinfo
+  .sheet-containermoreinfo
+  .sheet-inputtextbellow
+  .sheet-title {
   width: 100%;
   font-size: 10px;
   line-height: 12px;
@@ -726,12 +764,12 @@ h6 {
   display: block;
 }
 
-.main
-  .left-container
-  .attacks-container
-  .attacksgrid
-  .moreinfo
-  .hiddencheckbox {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-moreinfo
+  .sheet-hiddencheckbox {
   width: 24px;
   height: 24px;
   border: 0;
@@ -744,22 +782,22 @@ h6 {
   cursor: pointer;
 }
 
-.main
-  .left-container
-  .attacks-container
-  .attacksgrid
-  .moreinfo
-  .hiddencheckbox:hover
-  ~ span.hiddencheckboxcover {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-moreinfo
+  .sheet-hiddencheckbox:hover
+  ~ span.sheet-hiddencheckboxcover {
   background-color: var(--icon-hover);
 }
 
-.main
-  .left-container
-  .attacks-container
-  .attacksgrid
-  .moreinfo
-  span.hiddencheckboxcover {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-moreinfo
+  span.sheet-hiddencheckboxcover {
   pointer-events: none;
   display: block;
   width: 24px;
@@ -774,12 +812,12 @@ h6 {
   cursor: pointer;
 }
 
-.main
-  .left-container
-  .attacks-container
-  .attacksgrid
-  .moreinfo
-  span.hiddencheckboxcover::before {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-moreinfo
+  span.sheet-hiddencheckboxcover::before {
   pointer-events: none;
   width: 14px;
   height: 14px;
@@ -798,43 +836,63 @@ h6 {
   transform: translate(-50%, -50%);
 }
 
-.main
-  .left-container
-  .attacks-container
-  .attacksgrid
-  .moreinfo
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-moreinfo
   input:checked
-  ~ span.hiddencheckboxcover::before {
+  ~ span.sheet-hiddencheckboxcover::before {
   content: "▲";
 }
 
-.main
-  .left-container
-  .attacks-container
-  .attacksgrid
-  .moreinfo
-  .hiddencheckbox:checked
-  ~ .containermoreinfo {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-moreinfo
+  .sheet-hiddencheckbox:checked
+  ~ .sheet-containermoreinfo {
   display: grid;
   border: 1px solid var(--icon-color);
 }
 
-.main .left-container .attacks-container .attacksgrid .moreinfo .topline,
-.main .left-container .attacks-container .attacksgrid .moreinfo .bottomline {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-moreinfo
+  .sheet-topline,
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-moreinfo
+  .sheet-bottomline {
   display: none;
   background-color: var(--icon-color);
   height: 2px;
   width: 100%;
 }
 
-.main .left-container .attacks-container .attacksgrid .moreinfo input {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-moreinfo
+  input {
   background-color: transparent;
   border: 0;
   border-bottom: 2px solid var(--icon-color);
   color: var(--icon-color);
 }
 
-.main .left-container .attacks-container .attacksgrid .moreinfo select {
+.sheet-main
+  .sheet-left-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  .sheet-moreinfo
+  select {
   color: var(--accent-color);
   width: 100%;
   height: 24px;
@@ -844,14 +902,14 @@ h6 {
   border-bottom: 2px solid var(--icon-color);
 }
 
-.main .left-container .attacks-container .repeating_attacks {
+.sheet-main .sheet-left-container .sheet-attacks-container .repeating_attacks {
   border: 0;
   padding: 0;
   margin: 0;
   margin-bottom: 35px;
 }
 
-.main .left-container .defense-and-proeficience-container {
+.sheet-main .sheet-left-container .sheet-defense-and-proeficience-container {
   width: 100%;
   display: grid;
   grid-template-columns: 294px auto;
@@ -861,7 +919,7 @@ h6 {
   margin-top: 1.75rem;
 }
 
-.main .left-container .size-and-move-container {
+.sheet-main .sheet-left-container .sheet-size-and-move-container {
   width: 100%;
   display: grid;
   grid-template-columns: 294px auto;
@@ -870,35 +928,48 @@ h6 {
   margin-bottom: 22px;
 }
 
-.main .left-container .defense-and-proeficience-container .box-proficiencies,
-.main .left-container .proeficience-container .box-proficiencies,
-.main .left-container .size-and-move-container .container-size {
+.sheet-main
+  .sheet-left-container
+  .sheet-defense-and-proeficience-container
+  .sheet-box-proficiencies,
+.sheet-main
+  .sheet-left-container
+  .sheet-proeficience-container
+  .box-proficiencies,
+.sheet-main
+  .sheet-left-container
+  .sheet-size-and-move-container
+  .sheet-container-size {
   box-sizing: border-box;
 }
 
-.main
-  .left-container
-  .defense-and-proeficience-container
-  .box-proficiencies
-  .default-title,
-.main
-  .left-container
-  .proeficience-container
-  .box-proficiencies
-  .default-title {
+.sheet-main
+  .sheet-left-container
+  .sheet-defense-and-proeficience-container
+  .sheet-box-proficiencies
+  .sheet-default-title,
+.sheet-main
+  .sheet-left-container
+  .sheet-proeficience-container
+  .sheet-box-proficiencies
+  .sheet-default-title {
   font-size: 11px;
 }
 
-.main
-  .left-container
-  .defense-and-proeficience-container
-  .box-proficiencies
+.sheet-main
+  .sheet-left-container
+  .sheet-defense-and-proeficience-container
+  .sheet-box-proficiencies
   textarea {
   /* width: 190px; */
   height: 150px;
 }
 
-.main .left-container .size-and-move-container .container-size select {
+.sheet-main
+  .sheet-left-container
+  .sheet-size-and-move-container
+  .sheet-container-size
+  select {
   height: 23px;
   font-size: 12px;
   text-align: center;
@@ -911,7 +982,11 @@ h6 {
   width: 100%;
 }
 
-.main .left-container .size-and-move-container .container-move input {
+.sheet-main
+  .sheet-left-container
+  .sheet-size-and-move-container
+  .sheet-container-move
+  input {
   height: 20px;
   font-size: 12px;
   text-align: center;
@@ -927,12 +1002,14 @@ h6 {
   width: 100%;
 }
 
-.main .pseudo-attributes-wrapper .container-defense-armor-shield {
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield {
   display: flex;
   flex-direction: column;
 }
 
-.main .pseudo-attributes-wrapper .double-defense-containers {
+.sheet-main .sheet-pseudo-attributes-wrapper .sheet-double-defense-containers {
   display: grid;
   grid-template-columns: 28rem 28rem;
   column-gap: 2rem;
@@ -940,45 +1017,38 @@ h6 {
   margin: 0 auto;
 }
 
-.main .pseudo-attributes-wrapper .single-defense-container {
+.sheet-main .sheet-pseudo-attributes-wrapper .sheet-single-defense-container {
   display: flex;
   flex-direction: column;
   width: calc(50% - 2rem);
   margin: 0 auto;
 }
 
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense {
-  /* height: 76px; */
-}
-
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense
-  .inside-negative-corner,
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense-nonbased
-  .inside-negative-corner {
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-defense
+  .sheet-inside-negative-corner,
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-defense-nonbased
+  .sheet-inside-negative-corner {
   display: flex;
 }
 
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense
-  .inside-negative-corner
-  .box-title,
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense-nonbased
-  .inside-negative-corner
-  .box-title {
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-defense
+  .sheet-inside-negative-corner
+  .sheet-box-title,
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-defense-nonbased
+  .sheet-inside-negative-corner
+  .sheet-box-title {
   width: 100%;
   display: flex;
   justify-content: center;
@@ -997,12 +1067,12 @@ h6 {
   margin-bottom: 0.5rem;
 }
 
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense
-  .inside-negative-corner
-  .grid-wrapper {
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-defense
+  .sheet-inside-negative-corner
+  .sheet-grid-wrapper {
   padding-bottom: 1rem;
   padding-left: 1rem;
   padding-right: 1rem;
@@ -1012,12 +1082,12 @@ h6 {
   row-gap: 5px;
 }
 
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense-nonbased
-  .inside-negative-corner
-  .grid-wrapper {
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-defense-nonbased
+  .sheet-inside-negative-corner
+  .sheet-grid-wrapper {
   padding-bottom: 1rem;
   padding-left: 1rem;
   padding-right: 1rem;
@@ -1027,11 +1097,11 @@ h6 {
   row-gap: 5px;
 }
 
-.main
-  .left-container
-  .size-and-move-container
-  .container-size
-  .inside-negative-corner {
+.sheet-main
+  .sheet-left-container
+  .sheet-size-and-move-container
+  .sheet-container-size
+  .sheet-inside-negative-corner {
   height: 100%;
   padding-left: 10px;
   padding-right: 10px;
@@ -1039,45 +1109,45 @@ h6 {
   grid-template-columns: auto;
 }
 
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense,
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense-nonbased,
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense
-  .inside-negative-corner,
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense-nonbased
-  .inside-negative-corner {
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-defense,
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-defense-nonbased,
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-defense
+  .sheet-inside-negative-corner,
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-defense-nonbased
+  .sheet-inside-negative-corner {
   height: 100% !important;
 }
 
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense
-  .inside-negative-corner
-  .signal,
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense-nonbased
-  .inside-negative-corner
-  .signal,
-.main
-  .left-container
-  .size-and-move-container
-  .container-size
-  .inside-negative-corner
-  .signal {
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-defense
+  .sheet-inside-negative-corner
+  .sheet-signal,
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-defense-nonbased
+  .sheet-inside-negative-corner
+  .sheet-signal,
+.sheet-main
+  .sheet-left-container
+  .sheet-size-and-move-container
+  .sheet-container-size
+  .sheet-inside-negative-corner
+  .sheet-signal {
   font-family: Arial, Verdana;
   width: 100%;
   height: 26px;
@@ -1088,24 +1158,24 @@ h6 {
   font-size: 10px !important;
 }
 
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense
-  .inside-negative-corner
-  .big-signal,
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense-nonbased
-  .inside-negative-corner
-  .big-signal,
-.main
-  .left-container
-  .size-and-move-container
-  .container-size
-  .inside-negative-corner
-  .big-signal {
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-defense
+  .sheet-inside-negative-corner
+  .sheet-big-signal,
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-defense-nonbased
+  .sheet-inside-negative-corner
+  .sheet-big-signal,
+.sheet-main
+  .sheet-left-container
+  .sheet-size-and-move-container
+  .sheet-container-size
+  .sheet-inside-negative-corner
+  .sheet-big-signal {
   font-size: 14px !important;
   font-family: Arial, Verdana;
   width: 100%;
@@ -1116,17 +1186,17 @@ h6 {
   align-items: center;
 }
 
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense
-  .inside-negative-corner
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-defense
+  .sheet-inside-negative-corner
   input,
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense-nonbased
-  .inside-negative-corner
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-defense-nonbased
+  .sheet-inside-negative-corner
   input {
   height: 26px;
   font-size: 12px;
@@ -1137,17 +1207,17 @@ h6 {
   width: 100%;
 }
 
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense
-  .inside-negative-corner
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-defense
+  .sheet-inside-negative-corner
   select,
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense-nonbased
-  .inside-negative-corner
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-defense-nonbased
+  .sheet-inside-negative-corner
   select {
   height: 26px;
   margin: 0;
@@ -1159,11 +1229,11 @@ h6 {
   border-bottom: 2px solid var(--accent-color);
 }
 
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-move
-  .inside-negative-corner
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-move
+  .sheet-inside-negative-corner
   input {
   height: 20px;
   font-size: 12px;
@@ -1180,18 +1250,18 @@ h6 {
   width: 100%;
 }
 
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense
-  .inside-negative-corner
-  .select_mod_defesa,
-.main
-  .pseudo-attributes-wrapper
-  .container-defense-armor-shield
-  .container-defense-nonbased
-  .inside-negative-corner
-  .select_mod_defesa {
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-defense
+  .sheet-inside-negative-corner
+  .sheet-select_mod_defesa,
+.sheet-main
+  .sheet-pseudo-attributes-wrapper
+  .sheet-container-defense-armor-shield
+  .sheet-container-defense-nonbased
+  .sheet-inside-negative-corner
+  .sheet-select_mod_defesa {
   height: 26px;
   font-size: 10px;
   text-align: center;
@@ -1203,7 +1273,10 @@ h6 {
   font-family: "PT Sans", sans-serif;
 }
 
-.main .left-container .container-armor-shield .inside-negative-corner {
+.sheet-main
+  .sheet-left-container
+  .sheet-container-armor-shield
+  .sheet-inside-negative-corner {
   /* height: 12rem; */
   padding: 1rem 1rem;
   display: grid;
@@ -1215,16 +1288,16 @@ h6 {
   border: 2px var(--accent-color) solid;
 }
 
-.main
-  .left-container
-  .size-and-move-container
-  .container-size
-  .inside-negative-corner,
-.main
-  .left-container
-  .size-and-move-container
-  .container-move
-  .inside-negative-corner {
+.sheet-main
+  .sheet-left-container
+  .sheet-size-and-move-container
+  .sheet-container-size
+  .sheet-inside-negative-corner,
+.sheet-main
+  .sheet-left-container
+  .sheet-size-and-move-container
+  .sheet-container-move
+  .sheet-inside-negative-corner {
   height: 76px;
   padding-left: 10px;
   padding-right: 10px;
@@ -1234,7 +1307,11 @@ h6 {
   grid-template-rows: auto;
 }
 
-.main .left-container .container-armor-shield .inside-negative-corner input {
+.sheet-main
+  .sheet-left-container
+  .sheet-container-armor-shield
+  .sheet-inside-negative-corner
+  input {
   height: 20px;
   font-size: 12px;
   text-align: center;
@@ -1244,24 +1321,36 @@ h6 {
   width: 100%;
 }
 
-.main .left-container .spells {
+.sheet-main .sheet-left-container .sheet-spells {
   width: 100%;
   display: block;
   margin-bottom: 22px;
 }
 
-.main .left-container .spells .inside-negative-corner .content-grid {
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-content-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
 }
 
-.main .left-container .spells .inside-negative-corner .vertical-line {
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-vertical-line {
   width: 1px;
   background-color: var(--accent-color);
   height: 96%;
 }
 
-.main .left-container .spells .inside-negative-corner .spellcolumn {
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-spellcolumn {
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -1271,7 +1360,11 @@ h6 {
   justify-content: flex-start;
 }
 
-.main .left-container .spells .inside-negative-corner .cicloheader {
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-cicloheader {
   width: 100%;
   height: 24px;
   font-size: 11px;
@@ -1288,12 +1381,12 @@ h6 {
   column-gap: 7px;
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .cicloheader
-  .ciclo-title {
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-cicloheader
+  .sheet-ciclo-title {
   height: 100%;
   width: 100%;
   padding-left: 80px;
@@ -1307,7 +1400,12 @@ h6 {
   font-weight: bold;
 }
 
-.main .left-container .spells .inside-negative-corner .cicloheader .ciclo-cost {
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-cicloheader
+  .sheet-ciclo-cost {
   height: 100%;
   width: 100%;
   text-align: center;
@@ -1320,160 +1418,164 @@ h6 {
   justify-content: center;
 }
 
-.main .left-container .spells .inside-negative-corner .containerspelllist {
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist {
   width: 100%;
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"],
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"],
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"],
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"],
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"] {
   width: 100%;
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   .itemcontrol,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   .itemcontrol,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   .itemcontrol,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   .itemcontrol,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   .itemcontrol {
   z-index: 99;
   font-family: "Pictos";
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   > .repitem,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   > .repitem,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   > .repitem,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   > .repitem,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   > .repitem {
   width: 100%;
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   > .repitem
-  .container-single-spell,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   > .repitem
-  .container-single-spell,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   > .repitem
-  .container-single-spell,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   > .repitem
-  .container-single-spell,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   > .repitem
-  .container-single-spell {
+  .sheet-container-single-spell {
   position: relative;
   padding-left: 3px;
   padding-right: 3px;
@@ -1485,95 +1587,95 @@ h6 {
   width: 100%;
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   > .repitem
-  .container-single-spell
+  .sheet-container-single-spell
   input,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   > .repitem
-  .container-single-spell
+  .sheet-container-single-spell
   select,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   > .repitem
-  .container-single-spell
+  .sheet-container-single-spell
   input,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   > .repitem
-  .container-single-spell
+  .sheet-container-single-spell
   select,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   > .repitem
-  .container-single-spell
+  .sheet-container-single-spell
   input,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   > .repitem
-  .container-single-spell
+  .sheet-container-single-spell
   select,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   > .repitem
-  .container-single-spell
+  .sheet-container-single-spell
   input,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   > .repitem
-  .container-single-spell
+  .sheet-container-single-spell
   select,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   > .repitem
-  .container-single-spell
+  .sheet-container-single-spell
   input,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   > .repitem
-  .container-single-spell
+  .sheet-container-single-spell
   select {
   width: 100%;
   background-color: var(--background-color);
@@ -1582,51 +1684,51 @@ h6 {
   border-bottom: 2px solid var(--accent-color);
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   > .repitem
-  .container-single-spell
-  .buttonspell,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-buttonspell,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   > .repitem
-  .container-single-spell
-  .buttonspell,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-buttonspell,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   > .repitem
-  .container-single-spell
-  .buttonspell,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-buttonspell,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   > .repitem
-  .container-single-spell
-  .buttonspell,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-buttonspell,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   > .repitem
-  .container-single-spell
-  .buttonspell {
+  .sheet-container-single-spell
+  .sheet-buttonspell {
   background-color: transparent;
   font-family: "dicefontd20";
   color: var(--icon-color);
@@ -1640,147 +1742,147 @@ h6 {
   transition: color 1s;
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   > .repitem
-  .container-single-spell
-  .buttonspell:hover,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-buttonspell:hover,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   > .repitem
-  .container-single-spell
-  .buttonspell:hover,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-buttonspell:hover,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   > .repitem
-  .container-single-spell
-  .buttonspell:hover,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-buttonspell:hover,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   > .repitem
-  .container-single-spell
-  .buttonspell:hover,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-buttonspell:hover,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   > .repitem
-  .container-single-spell
-  .buttonspell:hover {
+  .sheet-container-single-spell
+  .sheet-buttonspell:hover {
   color: var(--dice-hover);
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   > .repitem
-  .container-single-spell
-  .buttonspell:active,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-buttonspell:active,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   > .repitem
-  .container-single-spell
-  .buttonspell:active,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-buttonspell:active,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   > .repitem
-  .container-single-spell
-  .buttonspell:active,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-buttonspell:active,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   > .repitem
-  .container-single-spell
-  .buttonspell:active,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-buttonspell:active,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   > .repitem
-  .container-single-spell
-  .buttonspell:active {
+  .sheet-container-single-spell
+  .sheet-buttonspell:active {
   font-size: 18px;
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   > .repitem
-  .container-single-spell
-  .hiddencheckbox,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-hiddencheckbox,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   > .repitem
-  .container-single-spell
-  .hiddencheckbox,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-hiddencheckbox,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   > .repitem
-  .container-single-spell
-  .hiddencheckbox,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-hiddencheckbox,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   > .repitem
-  .container-single-spell
-  .hiddencheckbox,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-hiddencheckbox,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   > .repitem
-  .container-single-spell
-  .hiddencheckbox {
+  .sheet-container-single-spell
+  .sheet-hiddencheckbox {
   width: 20px;
   height: 20px;
   border: 0;
@@ -1796,210 +1898,210 @@ h6 {
   transition: color 1s;
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   > .repitem
-  .container-single-spell
-  .hiddencheckbox:checked
-  ~ .extra,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-hiddencheckbox:checked
+  ~ .sheet-extra,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   > .repitem
-  .container-single-spell
-  .hiddencheckbox:checked
-  ~ .extra,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-hiddencheckbox:checked
+  ~ .sheet-extra,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   > .repitem
-  .container-single-spell
-  .hiddencheckbox:checked
-  ~ .extra,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-hiddencheckbox:checked
+  ~ .sheet-extra,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   > .repitem
-  .container-single-spell
-  .hiddencheckbox:checked
-  ~ .extra,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-hiddencheckbox:checked
+  ~ .sheet-extra,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   > .repitem
-  .container-single-spell
-  .hiddencheckbox:checked
-  ~ .extra {
+  .sheet-container-single-spell
+  .sheet-hiddencheckbox:checked
+  ~ .sheet-extra {
   display: grid;
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   > .repitem
-  .container-single-spell
-  .hiddencheckbox:checked
-  ~ span.hiddencheckboxcover,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-hiddencheckbox:checked
+  ~ span.sheet-hiddencheckboxcover,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   > .repitem
-  .container-single-spell
-  .hiddencheckbox:checked
-  ~ span.hiddencheckboxcover,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-hiddencheckbox:checked
+  ~ span.sheet-hiddencheckboxcover,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   > .repitem
-  .container-single-spell
-  .hiddencheckbox:checked
-  ~ span.hiddencheckboxcover,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-hiddencheckbox:checked
+  ~ span.sheet-hiddencheckboxcover,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   > .repitem
-  .container-single-spell
-  .hiddencheckbox:checked
-  ~ span.hiddencheckboxcover,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-hiddencheckbox:checked
+  ~ span.sheet-hiddencheckboxcover,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   > .repitem
-  .container-single-spell
-  .hiddencheckbox:checked
-  ~ span.hiddencheckboxcover {
+  .sheet-container-single-spell
+  .sheet-hiddencheckbox:checked
+  ~ span.sheet-hiddencheckboxcover {
   color: var(--title-color);
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   > .repitem
-  .container-single-spell
-  .hiddencheckbox:hover
-  ~ .hiddencheckboxcover,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-hiddencheckbox:hover
+  ~ .sheet-hiddencheckboxcover,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   > .repitem
-  .container-single-spell
-  .hiddencheckbox:hover
-  ~ .hiddencheckboxcover,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-hiddencheckbox:hover
+  ~ .sheet-hiddencheckboxcover,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   > .repitem
-  .container-single-spell
-  .hiddencheckbox:hover
-  ~ .hiddencheckboxcover,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-hiddencheckbox:hover
+  ~ .sheet-hiddencheckboxcover,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   > .repitem
-  .container-single-spell
-  .hiddencheckbox:hover
-  ~ .hiddencheckboxcover,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-hiddencheckbox:hover
+  ~ .sheet-hiddencheckboxcover,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   > .repitem
-  .container-single-spell
-  .hiddencheckbox:hover
-  ~ .hiddencheckboxcover {
+  .sheet-container-single-spell
+  .sheet-hiddencheckbox:hover
+  ~ .sheet-hiddencheckboxcover {
   color: var(--icon-hover);
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   > .repitem
-  .container-single-spell
-  span.hiddencheckboxcover,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  span.sheet-hiddencheckboxcover,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   > .repitem
-  .container-single-spell
-  span.hiddencheckboxcover,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  span.sheet-hiddencheckboxcover,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   > .repitem
-  .container-single-spell
-  span.hiddencheckboxcover,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  span.sheet-hiddencheckboxcover,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   > .repitem
-  .container-single-spell
-  span.hiddencheckboxcover,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  span.sheet-hiddencheckboxcover,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   > .repitem
-  .container-single-spell
-  span.hiddencheckboxcover {
+  .sheet-container-single-spell
+  span.sheet-hiddencheckboxcover {
   position: absolute;
   font-family: "Pictos";
   font-size: 20px;
@@ -2014,51 +2116,51 @@ h6 {
   z-index: 1;
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   > .repitem
-  .container-single-spell
-  .extra,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-extra,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   > .repitem
-  .container-single-spell
-  .extra,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-extra,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   > .repitem
-  .container-single-spell
-  .extra,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-extra,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   > .repitem
-  .container-single-spell
-  .extra,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-extra,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   > .repitem
-  .container-single-spell
-  .extra {
+  .sheet-container-single-spell
+  .sheet-extra {
   display: none;
   grid-column: 1/5;
   width: 100%;
@@ -2072,160 +2174,160 @@ h6 {
   color: var(--icon-color);
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   > .repitem
-  .container-single-spell
-  .extra
+  .sheet-container-single-spell
+  .sheet-extra
   span,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   > .repitem
-  .container-single-spell
-  .extra
+  .sheet-container-single-spell
+  .sheet-extra
   span,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   > .repitem
-  .container-single-spell
-  .extra
+  .sheet-container-single-spell
+  .sheet-extra
   span,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   > .repitem
-  .container-single-spell
-  .extra
+  .sheet-container-single-spell
+  .sheet-extra
   span,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   > .repitem
-  .container-single-spell
-  .extra
+  .sheet-container-single-spell
+  .sheet-extra
   span {
   display: inline-flex;
   height: 100%;
   align-items: center;
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   > .repitem
-  .container-single-spell
-  .extra
+  .sheet-container-single-spell
+  .sheet-extra
   input,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   > .repitem
-  .container-single-spell
-  .extra
+  .sheet-container-single-spell
+  .sheet-extra
   select,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   > .repitem
-  .container-single-spell
-  .extra
+  .sheet-container-single-spell
+  .sheet-extra
   input,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   > .repitem
-  .container-single-spell
-  .extra
+  .sheet-container-single-spell
+  .sheet-extra
   select,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   > .repitem
-  .container-single-spell
-  .extra
+  .sheet-container-single-spell
+  .sheet-extra
   input,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   > .repitem
-  .container-single-spell
-  .extra
+  .sheet-container-single-spell
+  .sheet-extra
   select,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   > .repitem
-  .container-single-spell
-  .extra
+  .sheet-container-single-spell
+  .sheet-extra
   input,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   > .repitem
-  .container-single-spell
-  .extra
+  .sheet-container-single-spell
+  .sheet-extra
   select,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   > .repitem
-  .container-single-spell
-  .extra
+  .sheet-container-single-spell
+  .sheet-extra
   input,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   > .repitem
-  .container-single-spell
-  .extra
+  .sheet-container-single-spell
+  .sheet-extra
   select {
   width: 100%;
   background-color: transparent;
@@ -2235,163 +2337,163 @@ h6 {
   border-bottom: 2px solid var(--icon-color);
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   > .repitem
-  .container-single-spell
-  .extra
-  .cd,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-extra
+  .sheet-cd,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   > .repitem
-  .container-single-spell
-  .extra
-  .cd,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-extra
+  .sheet-cd,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   > .repitem
-  .container-single-spell
-  .extra
-  .cd,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-extra
+  .sheet-cd,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   > .repitem
-  .container-single-spell
-  .extra
-  .cd,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-extra
+  .sheet-cd,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   > .repitem
-  .container-single-spell
-  .extra
-  .cd {
+  .sheet-container-single-spell
+  .sheet-extra
+  .sheet-cd {
   text-align: center;
   justify-content: center;
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   > .repitem
-  .container-single-spell
-  .extra
-  .singleline,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-extra
+  .sheet-singleline,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   > .repitem
-  .container-single-spell
-  .extra
-  .singleline,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-extra
+  .sheet-singleline,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   > .repitem
-  .container-single-spell
-  .extra
-  .singleline,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-extra
+  .sheet-singleline,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   > .repitem
-  .container-single-spell
-  .extra
-  .singleline,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-extra
+  .sheet-singleline,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   > .repitem
-  .container-single-spell
-  .extra
-  .singleline {
+  .sheet-container-single-spell
+  .sheet-extra
+  .sheet-singleline {
   grid-column: 2/5;
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   > .repitem
-  .container-single-spell
-  .extra
-  .fullline,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-extra
+  .sheet-fullline,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   > .repitem
-  .container-single-spell
-  .extra
-  .fullline,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-extra
+  .sheet-fullline,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   > .repitem
-  .container-single-spell
-  .extra
-  .fullline,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-extra
+  .sheet-fullline,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   > .repitem
-  .container-single-spell
-  .extra
-  .fullline,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+  .sheet-container-single-spell
+  .sheet-extra
+  .sheet-fullline,
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   > .repitem
-  .container-single-spell
-  .extra
-  .fullline {
+  .sheet-container-single-spell
+  .sheet-extra
+  .sheet-fullline {
   grid-column: 1/5;
   display: inline-flex;
   justify-content: center;
@@ -2399,55 +2501,55 @@ h6 {
   width: 100%;
 }
 
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells1"]
   > .repitem
-  .container-single-spell
-  .extra
+  .sheet-container-single-spell
+  .sheet-extra
   textarea,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells2"]
   > .repitem
-  .container-single-spell
-  .extra
+  .sheet-container-single-spell
+  .sheet-extra
   textarea,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells3"]
   > .repitem
-  .container-single-spell
-  .extra
+  .sheet-container-single-spell
+  .sheet-extra
   textarea,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells4"]
   > .repitem
-  .container-single-spell
-  .extra
+  .sheet-container-single-spell
+  .sheet-extra
   textarea,
-.main
-  .left-container
-  .spells
-  .inside-negative-corner
-  .containerspelllist
+.sheet-main
+  .sheet-left-container
+  .sheet-spells
+  .sheet-inside-negative-corner
+  .sheet-containerspelllist
   .repcontainer[data-groupname="repeating_spells5"]
   > .repitem
-  .container-single-spell
-  .extra
+  .sheet-container-single-spell
+  .sheet-extra
   textarea {
   font-size: 12px;
   grid-column: 1/5;
@@ -2456,28 +2558,28 @@ h6 {
   border: 2px solid var(--icon-color);
 }
 
-.main .left-container .powers-and-abilities {
+.sheet-main .sheet-left-container .sheet-powers-and-abilities {
   width: 100%;
   display: block;
   margin-bottom: 22px;
 }
 
-.main
-  .left-container
-  .powers-and-abilities
-  .inside-negative-corner
-  .content-grid {
+.sheet-main
+  .sheet-left-container
+  .sheet-powers-and-abilities
+  .sheet-inside-negative-corner
+  .sheet-content-grid {
   margin-bottom: 5px;
   display: grid;
   grid-template-columns: 1fr 1fr;
 }
 
-.main
-  .left-container
-  .powers-and-abilities
-  .inside-negative-corner
-  .content-grid
-  .grid-title {
+.sheet-main
+  .sheet-left-container
+  .sheet-powers-and-abilities
+  .sheet-inside-negative-corner
+  .sheet-content-grid
+  .sheet-grid-title {
   width: 100%;
   display: flex;
   justify-content: center;
@@ -2493,41 +2595,41 @@ h6 {
   text-transform: uppercase;
 }
 
-.main
-  .left-container
-  .powers-and-abilities
-  .inside-negative-corner
-  .vertical-line {
+.sheet-main
+  .sheet-left-container
+  .sheet-powers-and-abilities
+  .sheet-inside-negative-corner
+  .sheet-vertical-line {
   width: 1px;
   background-color: var(--accent-color);
   height: 96%;
 }
 
-.main
-  .left-container
-  .powers-and-abilities
-  .inside-negative-corner
-  .container-reapeater {
+.sheet-main
+  .sheet-left-container
+  .sheet-powers-and-abilities
+  .sheet-inside-negative-corner
+  .sheet-container-reapeater {
   box-sizing: border-box;
   margin-top: 4px;
   border: 0;
 }
 
-.main
-  .left-container
-  .powers-and-abilities
-  .inside-negative-corner
-  .container-reapeater:nth-child(odd) {
+.sheet-main
+  .sheet-left-container
+  .sheet-powers-and-abilities
+  .sheet-inside-negative-corner
+  .sheet-container-reapeater:nth-child(odd) {
   border-right: 1px solid var(--accent-color);
 }
 
-.main .right-container {
+.sheet-main .sheet-right-container {
   width: 100%;
   display: flex;
   flex-direction: column;
 }
 
-.main .right-container .logo-level {
+.sheet-main .sheet-right-container .sheet-logo-level {
   display: flex;
   width: 100%;
   flex-direction: column;
@@ -2536,36 +2638,52 @@ h6 {
   row-gap: 10px;
 }
 
-/* .main .right-container .logo-level .container-logo {
+/* .sheet-main .sheet-right-container .sheet-logo-level .container-logo {
   height: 76px;
 } */
 
-.main .right-container .logo-level .container-logo-ghanor {
+.sheet-main .sheet-right-container .sheet-logo-level .container-logo-ghanor {
   height: 150px;
 }
 
-.main .right-container .logo-level .container-logo .logo-ordem-paranormal {
+.sheet-main
+  .sheet-right-container
+  .sheet-logo-level
+  .sheet-container-logo
+  .sheet-logo-ordem-paranormal {
   width: 100%;
   user-select: none;
 }
 
-.main .right-container .logo-level .container-logo img {
+.sheet-main .sheet-right-container .sheet-logo-level .container-logo img {
   object-fit: cover;
 }
 
-.main .right-container .logo-level .container-logo .logo-ghanor {
+.sheet-main
+  .sheet-right-container
+  .sheet-logo-level
+  .container-logo
+  .logo-ghanor {
   width: 100%;
   user-select: none;
 }
 
-.main .right-container .logo-level .char-level-container {
+.sheet-main
+  .sheet-right-container
+  .sheet-logo-level
+  .sheet-char-level-container {
   display: flex;
   width: 100%;
   align-items: flex-end;
   justify-content: center;
 }
 
-.main .right-container .logo-level .char-level-container .total-level span {
+.sheet-main
+  .sheet-right-container
+  .sheet-logo-level
+  .sheet-char-level-container
+  .sheet-total-level
+  span {
   display: inline-block;
   line-height: 24px;
   font-size: 12px;
@@ -2574,7 +2692,12 @@ h6 {
   font-weight: bold;
 }
 
-.main .right-container .logo-level .char-level-container .total-level input {
+.sheet-main
+  .sheet-right-container
+  .sheet-logo-level
+  .sheet-char-level-container
+  .sheet-total-level
+  input {
   display: inline-block;
   text-align: center;
   width: 40px;
@@ -2585,22 +2708,25 @@ h6 {
   padding-right: 2px;
 }
 
-.main .right-container .skills-container {
+.sheet-main .sheet-right-container .sheet-skills-container {
   width: 100%;
   display: block;
   margin-top: 15px;
   margin-bottom: 16px;
 }
 
-.main .right-container .skills-container .inside-negative-corner {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner {
   min-height: 780px;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template {
   display: grid;
   width: 100%;
   padding: 8px 8px;
@@ -2608,7 +2734,9 @@ h6 {
   row-gap: 0.5rem;
 }
 
-.condition-container .inside-negative-corner .condition-grid-template {
+.sheet-condition-container
+  .sheet-inside-negative-corner
+  .sheet-condition-grid-template {
   display: grid;
   width: 100%;
   padding-left: 7px;
@@ -2617,52 +2745,54 @@ h6 {
   border-bottom: 1px solid #e3e3e3;
 }
 
-.skills-container .repcontainer,
-.skills-container .repcontrol {
+.sheet-skills-container .repcontainer,
+.sheet-skills-container .repcontrol {
   grid-column: 1/13;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .repitem {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-repitem {
   display: grid;
   grid-template-columns: auto 12px 48px 12px 35px 12px 12px 80px 12px 24px 12px 35px;
 }
 
-.inside-negative-corner .condition-grid-template .repitem {
+.sheet-inside-negative-corner .sheet-condition-grid-template .repitem {
   display: grid;
   grid-template-columns: 20px auto 170px;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template.header,
-.inside-negative-corner .condition-grid-template.header {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template.header,
+.sheet-inside-negative-corner .sheet-condition-grid-template.header {
   height: 30px;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template.header
-  .pericias-titulo,
-.inside-negative-corner .condition-grid-template.header .pericias-titulo {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template.header
+  .sheet-pericias-titulo,
+.sheet-inside-negative-corner
+  .sheet-condition-grid-template.header
+  .sheet-pericias-titulo {
   grid-column: 1/3;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .signal,
-.inside-negative-corner .condition-grid-template .signal {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-signal,
+.sheet-inside-negative-corner .sheet-condition-grid-template .sheet-signal {
   /* font-family: Arial, Verdana; */
   width: 100%;
   height: 24px;
@@ -2675,20 +2805,20 @@ h6 {
   text-align: center;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
   input[type="text"],
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
   select,
-.inside-negative-corner .condition-grid-template input[type="text"],
-.inside-negative-corner .condition-grid-template select {
+.sheet-inside-negative-corner .sheet-condition-grid-template input[type="text"],
+.sheet-inside-negative-corner .sheet-condition-grid-template select {
   height: 24px;
   text-align: center;
   border: 0;
@@ -2696,77 +2826,89 @@ h6 {
   width: 100%;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
   input[type="text"].total,
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
   select.total,
-.inside-negative-corner .condition-grid-template input[type="text"].total,
-.inside-negative-corner .condition-grid-template select.total {
+.sheet-inside-negative-corner
+  .sheet-condition-grid-template
+  input[type="text"].total,
+.sheet-inside-negative-corner .sheet-condition-grid-template select.total {
   border: 2px solid var(--accent-color);
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  input[type="text"].total.first,
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  select.total.first,
-.inside-negative-corner .condition-grid-template input[type="text"].total.first,
-.inside-negative-corner .condition-grid-template select.total.first {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  input[type="text"].sheet-total.sheet-first,
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  select.sheet-total.sheet-first,
+.sheet-inside-negative-corner
+  .sheet-condition-grid-template
+  input[type="text"].sheet-total.sheet-first,
+.sheet-inside-negative-corner
+  .sheet-condition-grid-template
+  select.sheet-total.sheet-first {
   border-top: 2px solid var(--accent-color);
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  input[type="text"].total.last,
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  select.total.last,
-.inside-negative-corner .condition-grid-template input[type="text"].total.last,
-.inside-negative-corner .condition-grid-template select.total.last {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  input[type="text"].sheet-total.sheet-last,
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  select.sheet-total.sheet-last,
+.sheet-inside-negative-corner
+  .sheet-condition-grid-template
+  input[type="text"].sheet-total.sheet-last,
+.sheet-inside-negative-corner
+  .sheet-condition-grid-template
+  select.sheet-total.sheet-last {
   border-bottom: 2px solid var(--accent-color);
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
   select,
-.inside-negative-corner .condition-grid-template select {
+.sheet-inside-negative-corner .sheet-condition-grid-template select {
   font-size: 9px;
   padding-left: 1px;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .legenda-pericias,
-.inside-negative-corner .condition-grid-template .legenda-pericias {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-legenda-pericias,
+.sheet-inside-negative-corner
+  .sheet-condition-grid-template
+  .sheet-legenda-pericias {
   height: 14px;
   margin-top: 4px;
   padding-top: 4px;
@@ -2781,40 +2923,43 @@ h6 {
   font-family: "PT Sans";
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .legenda-pericias
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-legenda-pericias
   i,
-.inside-negative-corner .condition-grid-template .legenda-pericias i {
+.sheet-inside-negative-corner
+  .sheet-condition-grid-template
+  .sheet-legenda-pericias
+  i {
   display: inline;
   font-family: "Alegreya Sans SC";
   font-style: normal;
   margin-left: 1rem;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .legenda-pericias
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-legenda-pericias
   i:last-child,
-.inside-negative-corner
-  .condition-grid-template
-  .legenda-pericias
+.sheet-inside-negative-corner
+  .sheet-condition-grid-template
+  .sheet-legenda-pericias
   i:last-child {
   margin-left: 12px;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .profissao {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-profissao {
   width: 100%;
   display: flex;
   justify-self: start;
@@ -2823,13 +2968,13 @@ h6 {
   font-family: "Alegreya Sans SC";
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .profissao
-  input.nome-profissao {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-profissao
+  input.sheet-nome-profissao {
   width: 50px;
   margin-left: 8px;
   padding: 0;
@@ -2842,13 +2987,13 @@ h6 {
   position: relative;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .profissao
-  input.nome-profissao::before {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-profissao
+  input.sheet-nome-profissao::before {
   content: "*";
   position: absolute;
   height: 20px;
@@ -2858,7 +3003,7 @@ h6 {
   vertical-align: super;
 }
 
-.nome-profissao-extra {
+.sheet-nome-profissao-extra {
   width: 75px;
   margin-left: 8px;
   padding: 0;
@@ -2872,7 +3017,7 @@ h6 {
   position: relative;
 }
 
-.nome-profissao-extra::before {
+.sheet-nome-profissao-extra::before {
   content: "*";
   position: absolute;
   height: 20px;
@@ -2882,14 +3027,17 @@ h6 {
   vertical-align: super;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .profissao
-  .skill-button,
-.inside-negative-corner .condition-grid-template .profissao .skill-button {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-profissao
+  .sheet-skill-button,
+.sheet-inside-negative-corner
+  .sheet-condition-grid-template
+  .sheet-profissao
+  .sheet-skill-button {
   width: auto;
   text-align: left;
   font-family: inherit;
@@ -2900,15 +3048,19 @@ h6 {
   font-size: inherit;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .profissao
-  .skill-button
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-profissao
+  .sheet-skill-button
   span,
-.inside-negative-corner .condition-grid-template .profissao .skill-button span {
+.sheet-inside-negative-corner
+  .sheet-condition-grid-template
+  .sheet-profissao
+  .sheet-skill-button
+  span {
   display: inline-flex;
   height: 100%;
   align-items: center;
@@ -2917,23 +3069,23 @@ h6 {
   padding-right: 2px;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .profissao
-  .skill-button:hover {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-profissao
+  .sheet-skill-button:hover {
   color: var(--highligth-color);
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .skill-name,
-.inside-negative-corner .condition-grid-template .skill-name {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-skill-name,
+.sheet-inside-negative-corner .sheet-condition-grid-template .sheet-skill-name {
   width: 100%;
   display: flex;
   justify-self: start;
@@ -2943,14 +3095,17 @@ h6 {
   font-family: "Alegreya Sans SC";
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .skill-name
-  .skill-button,
-.inside-negative-corner .condition-grid-template .skill-name .skill-button {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-skill-name
+  .sheet-skill-button,
+.sheet-inside-negative-corner
+  .sheet-condition-grid-template
+  .sheet-skill-name
+  .sheet-skill-button {
   width: 100%;
   text-align: left;
   font-family: inherit;
@@ -2961,18 +3116,18 @@ h6 {
   font-size: inherit;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .skill-name
-  .skill-button
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-skill-name
+  .sheet-skill-button
   span,
-.inside-negative-corner
-  .condition-grid-template
-  .skill-name
-  .skill-button
+.sheet-inside-negative-corner
+  .sheet-condition-grid-template
+  .sheet-skill-name
+  .sheet-skill-button
   span {
   display: inline-flex;
   height: 100%;
@@ -2981,49 +3136,49 @@ h6 {
   width: auto;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .skill-name
-  .skill-button:hover,
-.inside-negative-corner
-  .condition-grid-template
-  .skill-name
-  .skill-button:hover {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-skill-name
+  .sheet-skill-button:hover,
+.sheet-inside-negative-corner
+  .sheet-condition-grid-template
+  .sheet-skill-name
+  .sheet-skill-button:hover {
   color: var(--highligth-color);
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .skill-name
-  .skill-button
-  .sup-penalidade,
-.inside-negative-corner
-  .condition-grid-template
-  .skill-name
-  .skill-button
-  .sup-penalidade {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-skill-name
+  .sheet-skill-button
+  .sheet-sup-penalidade,
+.sheet-inside-negative-corner
+  .sheet-condition-grid-template
+  .sheet-skill-name
+  .sheet-skill-button
+  .sheet-sup-penalidade {
   position: relative;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .skill-name
-  .skill-button
-  .sup-penalidade::after,
-.inside-negative-corner
-  .condition-grid-template
-  .skill-name
-  .skill-button
-  .sup-penalidade::after {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-skill-name
+  .sheet-skill-button
+  .sheet-sup-penalidade::after,
+.sheet-inside-negative-corner
+  .sheet-condition-grid-template
+  .sheet-skill-name
+  .sheet-skill-button
+  .sheet-sup-penalidade::after {
   content: "+";
   position: absolute;
   height: 20px;
@@ -3033,35 +3188,35 @@ h6 {
   vertical-align: super;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .skill-name
-  .skill-button
-  .sup-treinada,
-.inside-negative-corner
-  .condition-grid-template
-  .skill-name
-  .skill-button
-  .sup-treinada {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-skill-name
+  .sheet-skill-button
+  .sheet-sup-treinada,
+.sheet-inside-negative-corner
+  .sheet-condition-grid-template
+  .sheet-skill-name
+  .sheet-skill-button
+  .sheet-sup-treinada {
   position: relative;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .skill-name
-  .skill-button
-  .sup-treinada::before,
-.inside-negative-corner
-  .condition-grid-template
-  .skill-name
-  .skill-button
-  .sup-treinada::before {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-skill-name
+  .sheet-skill-button
+  .sheet-sup-treinada::before,
+.sheet-inside-negative-corner
+  .sheet-condition-grid-template
+  .sheet-skill-name
+  .sheet-skill-button
+  .sheet-sup-treinada::before {
   content: "*";
   position: absolute;
   height: 20px;
@@ -3071,35 +3226,35 @@ h6 {
   vertical-align: super;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .skill-name
-  .skill-button
-  .sup-treinada-penalidade,
-.inside-negative-corner
-  .condition-grid-template
-  .skill-name
-  .skill-button
-  .sup-treinada-penalidade {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-skill-name
+  .sheet-skill-button
+  .sheet-sup-treinada-penalidade,
+.sheet-inside-negative-corner
+  .sheet-condition-grid-template
+  .sheet-skill-name
+  .sheet-skill-button
+  .sheet-sup-treinada-penalidade {
   position: relative;
 }
 
-.main
-  .right-container
-  .skills-container
-  .inside-negative-corner
-  .skill-grid-template
-  .skill-name
-  .skill-button
-  .sup-treinada-penalidade::before,
-.inside-negative-corner
-  .condition-grid-template
-  .skill-name
-  .skill-button
-  .sup-treinada-penalidade::before {
+.sheet-main
+  .sheet-right-container
+  .sheet-skills-container
+  .sheet-inside-negative-corner
+  .sheet-skill-grid-template
+  .sheet-skill-name
+  .sheet-skill-button
+  .sheet-sup-treinada-penalidade::before,
+.sheet-inside-negative-corner
+  .sheet-condition-grid-template
+  .sheet-skill-name
+  .sheet-skill-button
+  .sheet-sup-treinada-penalidade::before {
   content: "+*";
   position: absolute;
   height: 20px;
@@ -3109,21 +3264,24 @@ h6 {
   vertical-align: super;
 }
 
-.main .right-container .equipment-container {
+.sheet-main .sheet-right-container .sheet-equipment-container {
   width: 100%;
   display: block;
   margin-bottom: 22px;
 }
 
-.main .right-container .equipment-container .inside-negative-corner {
+.sheet-main
+  .sheet-right-container
+  .sheet-equipment-container
+  .sheet-inside-negative-corner {
   padding: 5px;
 }
 
-.main
-  .right-container
-  .equipment-container
-  .inside-negative-corner
-  .container-money {
+.sheet-main
+  .sheet-right-container
+  .sheet-equipment-container
+  .sheet-inside-negative-corner
+  .sheet-container-money {
   width: 100%;
   height: 26px;
   font-weight: bold;
@@ -3133,17 +3291,17 @@ h6 {
   align-items: center;
 }
 
-.main
-  .right-container
-  .equipment-container
-  .inside-negative-corner
-  .container-money
+.sheet-main
+  .sheet-right-container
+  .sheet-equipment-container
+  .sheet-inside-negative-corner
+  .sheet-container-money
   input,
-.main
-  .right-container
-  .equipment-container
-  .inside-negative-corner
-  .container-money
+.sheet-main
+  .sheet-right-container
+  .sheet-equipment-container
+  .sheet-inside-negative-corner
+  .sheet-container-money
   span {
   display: inline-flex;
   text-align: center;
@@ -3151,21 +3309,21 @@ h6 {
   line-height: 26px;
 }
 
-.main
-  .right-container
-  .equipment-container
-  .inside-negative-corner
-  .container-money
+.sheet-main
+  .sheet-right-container
+  .sheet-equipment-container
+  .sheet-inside-negative-corner
+  .sheet-container-money
   span {
   text-transform: uppercase;
   min-width: 60px;
 }
 
-.main
-  .right-container
-  .equipment-container
-  .inside-negative-corner
-  .container-money
+.sheet-main
+  .sheet-right-container
+  .sheet-equipment-container
+  .sheet-inside-negative-corner
+  .sheet-container-money
   input {
   border: 0;
   border-bottom: 1px solid var(--accent-color);
@@ -3174,70 +3332,73 @@ h6 {
   width: 70px;
 }
 
-.main
-  .right-container
-  .equipment-container
-  .inside-negative-corner
-  .container-money
+.sheet-main
+  .sheet-right-container
+  .sheet-equipment-container
+  .sheet-inside-negative-corner
+  .sheet-container-money
   input:read-only {
   cursor: default;
 }
 
-.main
-  .right-container
-  .equipment-container
-  .inside-negative-corner
-  .container-money
-  .cargainput {
+.sheet-main
+  .sheet-right-container
+  .sheet-equipment-container
+  .sheet-inside-negative-corner
+  .sheet-container-money
+  .sheet-cargainput {
   width: 70px;
 }
 
-.main
-  .right-container
-  .equipment-container
-  .inside-negative-corner
-  .container-money
-  .cargainput:read-only {
+.sheet-main
+  .sheet-right-container
+  .sheet-equipment-container
+  .sheet-inside-negative-corner
+  .sheet-container-money
+  .sheet-cargainput:read-only {
   background-color: var(--background-color);
 }
 
-.main
-  .right-container
-  .equipment-container
-  .inside-negative-corner
-  .container-money
-  .cargalimite {
+.sheet-main
+  .sheet-right-container
+  .sheet-equipment-container
+  .sheet-inside-negative-corner
+  .sheet-container-money
+  .sheet-cargalimite {
   width: 70px;
 }
 
-.main
-  .right-container
-  .equipment-container
-  .inside-negative-corner
-  .container-money
-  .cargalimite:read-only {
+.sheet-main
+  .sheet-right-container
+  .sheet-equipment-container
+  .sheet-inside-negative-corner
+  .sheet-container-money
+  .sheet-cargalimite:read-only {
   background-color: var(--background-color);
 }
 
-.main
-  .right-container
-  .equipment-container
-  .inside-negative-corner
-  .container-money
-  .cargamaxima {
+.sheet-main
+  .sheet-right-container
+  .sheet-equipment-container
+  .sheet-inside-negative-corner
+  .sheet-container-money
+  .sheet-cargamaxima {
   width: 70px;
 }
 
-.main
-  .right-container
-  .equipment-container
-  .inside-negative-corner
-  .container-money
-  .cargamaxima:read-only {
+.sheet-main
+  .sheet-right-container
+  .sheet-equipment-container
+  .sheet-inside-negative-corner
+  .sheet-container-money
+  .sheet-cargamaxima:read-only {
   background-color: var(--background-color);
 }
 
-.main .right-container .equipment-container .grid-equipment {
+.sheet-main
+  .sheet-right-container
+  .sheet-equipment-container
+  .sheet-grid-equipment {
   display: grid;
   grid-template-columns: 40px auto 120px 40px;
   column-gap: 7px;
@@ -3246,19 +3407,19 @@ h6 {
   padding-right: 14px;
 }
 
-.main
-  .right-container
-  .equipment-container
+.sheet-main
+  .sheet-right-container
+  .sheet-equipment-container
   .repcontainer[data-groupname="repeating_equipment"] {
   margin-top: 5px;
 }
 
-.main
-  .right-container
-  .equipment-container
+.sheet-main
+  .sheet-right-container
+  .sheet-equipment-container
   .repcontainer[data-groupname="repeating_equipment"]
   > .repitem
-  .grid-equipment {
+  .sheet-grid-equipment {
   width: 100%;
   display: grid;
   grid-template-columns: 40px auto 120px 40px;
@@ -3266,12 +3427,12 @@ h6 {
   margin-bottom: 7px;
 }
 
-.main
-  .right-container
-  .equipment-container
+.sheet-main
+  .sheet-right-container
+  .sheet-equipment-container
   .repcontainer[data-groupname="repeating_equipment"]
   > .repitem
-  .grid-equipment
+  .sheet-grid-equipment
   input {
   text-align: center;
   width: 100%;
@@ -3279,34 +3440,34 @@ h6 {
   border-bottom: 2px solid var(--accent-color);
 }
 
-.main .charnotes-container {
+.sheet-main .sheet-charnotes-container {
   width: 100%;
   display: block;
   grid-column: 1/3;
 }
 
-.main .charnotes-container .inside-negative-corner {
+.sheet-main .sheet-charnotes-container .sheet-inside-negative-corner {
   padding: 7px;
   padding-top: 0;
 }
 
-.main .charnotes-container .inside-negative-corner textarea {
+.sheet-main .sheet-charnotes-container .sheet-inside-negative-corner textarea {
   width: 100%;
   min-height: 180px;
   height: 100%;
 }
 
-.main .smaller-text {
+.sheet-main .sheet-smaller-text {
   font-size: 10px;
   font-weight: bold;
 }
 
-.main .input-with-text-bellow {
+.sheet-main .sheet-input-with-text-bellow {
   display: flex;
   flex-direction: column;
 }
 
-.main .input-with-text-bellow input {
+.sheet-main .sheet-input-with-text-bellow input {
   width: 100%;
   height: 24px;
   border: 0;
@@ -3316,7 +3477,7 @@ h6 {
   padding-right: 2px;
 }
 
-.main .input-with-text-bellow span {
+.sheet-main .sheet-input-with-text-bellow span {
   display: block;
   padding-top: 2px;
   padding-left: 2px;
@@ -3326,12 +3487,12 @@ h6 {
   text-transform: uppercase;
 }
 
-.main .input-with-text-right {
+.sheet-main .sheet-input-with-text-right {
   display: flex;
   column-gap: 0.5rem;
 }
 
-.main .input-with-text-right input {
+.sheet-main .sheet-input-with-text-right input {
   width: 100%;
   height: 24px;
   border: 0;
@@ -3341,7 +3502,7 @@ h6 {
   padding-right: 2px;
 }
 
-.main .input-with-text-right span {
+.sheet-main .sheet-input-with-text-right span {
   display: block;
   padding-top: 2px;
   padding-left: 2px;
@@ -3352,28 +3513,28 @@ h6 {
   text-align: end;
 }
 
-.main .input-with-text-bellow.char-name {
+.sheet-main .sheet-input-with-text-bellow.sheet-char-name {
   padding-top: 15px;
   grid-column: 1/3;
 }
 
-.main .input-with-text-bellow.char-player {
+.sheet-main .sheet-input-with-text-bellow.sheet-char-player {
   padding-top: 15px;
 }
 
-.main .input-with-text-bellow.char-player-ghanor {
+.sheet-main .sheet-input-with-text-bellow.sheet-char-player-ghanor {
   padding-top: 15px;
   grid-column: 3/5;
 }
 
-.main .outer-container-negative-corner {
+.sheet-main .sheet-outer-container-negative-corner {
   position: relative;
   width: 100%;
   height: 100%;
   padding-bottom: 10px;
 }
 
-.main .outer-container-negative-corner .oval {
+.sheet-main .sheet-outer-container-negative-corner .sheet-oval {
   position: absolute;
   background-color: var(--background-color);
   border: 2px solid var(--accent-color);
@@ -3389,7 +3550,7 @@ h6 {
   overflow: hidden;
 }
 
-.main .outer-container-negative-corner .oval input {
+.sheet-main .sheet-outer-container-negative-corner .sheet-oval input {
   border: 0;
   height: 20px;
   width: 22px;
@@ -3399,10 +3560,10 @@ h6 {
   background-color: transparent;
 }
 
-.main
-  .outer-container-negative-corner
-  .inside-negative-corner
-  button.button-title-attribute {
+.sheet-main
+  .sheet-outer-container-negative-corner
+  .sheet-inside-negative-corner
+  button.sheet-button-title-attribute {
   background-color: transparent;
   font-size: 14px;
   border: 0;
@@ -3417,17 +3578,17 @@ h6 {
   transition: color 1s;
 }
 
-.main
-  .outer-container-negative-corner
-  .inside-negative-corner
-  button.button-title-attribute:hover {
+.sheet-main
+  .sheet-outer-container-negative-corner
+  .sheet-inside-negative-corner
+  button.sheet-button-title-attribute:hover {
   color: var(--highligth-color);
 }
 
-.main
-  .outer-container-negative-corner
-  .inside-negative-corner
-  span.button-title-attribute {
+.sheet-main
+  .sheet-outer-container-negative-corner
+  .sheet-inside-negative-corner
+  span.sheet-button-title-attribute {
   background-color: transparent;
   font-size: 14px;
   border: 0;
@@ -3444,13 +3605,16 @@ h6 {
   transition: color 1s;
 }
 
-.character-attributes .inside-negative-corner:hover {
+.sheet-character-attributes .sheet-inside-negative-corner:hover {
   background-color: var(--accent-color-hover) !important;
 
   transition: background 1s;
 }
 
-.main .outer-container-negative-corner .inside-negative-corner input.fake-mod {
+.sheet-main
+  .sheet-outer-container-negative-corner
+  .sheet-inside-negative-corner
+  input.sheet-fake-mod {
   background-color: transparent;
   font-size: 24px;
   border: 0;
@@ -3465,7 +3629,7 @@ h6 {
   width: 100%;
 }
 
-.main .container-negative-corner {
+.sheet-main .sheet-container-negative-corner {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -3474,7 +3638,7 @@ h6 {
   overflow: hidden;
 }
 
-.main .container-negative-corner .inside-negative-corner {
+.sheet-main .sheet-container-negative-corner .sheet-inside-negative-corner {
   box-sizing: border-box;
   position: relative;
   border: 2px solid var(--accent-color);
@@ -3487,7 +3651,10 @@ h6 {
   justify-content: center;
 }
 
-.main .container-negative-corner .inside-negative-corner .span-fake-mod {
+.sheet-main
+  .sheet-container-negative-corner
+  .sheet-inside-negative-corner
+  .sheet-span-fake-mod {
   font-size: 16px;
   font-weight: bold;
   color: var(--highligth-color);
@@ -3495,14 +3662,20 @@ h6 {
   width: 100%;
 }
 
-.main .container-negative-corner .inside-negative-corner .content-centered {
+.sheet-main
+  .sheet-container-negative-corner
+  .sheet-inside-negative-corner
+  .sheet-content-centered {
   display: flex;
   justify-content: center;
   align-items: center;
   width: 100%;
 }
 
-.main .container-negative-corner .inside-negative-corner .small-title {
+.sheet-main
+  .sheet-container-negative-corner
+  .sheet-inside-negative-corner
+  .sheet-small-title {
   width: 100%;
   display: flex;
   justify-content: center;
@@ -3516,7 +3689,10 @@ h6 {
   user-select: none;
 }
 
-.main .container-negative-corner .inside-negative-corner .default-title {
+.sheet-main
+  .sheet-container-negative-corner
+  .sheet-inside-negative-corner
+  .sheet-default-title {
   width: 100%;
   display: flex;
   justify-content: center;
@@ -3532,7 +3708,10 @@ h6 {
   text-transform: uppercase;
 }
 
-.main .container-negative-corner .inside-negative-corner .grid-title {
+.sheet-main
+  .sheet-container-negative-corner
+  .sheet-inside-negative-corner
+  .sheet-grid-title {
   width: 100%;
   display: flex;
   justify-content: center;
@@ -3548,7 +3727,10 @@ h6 {
   text-transform: uppercase;
 }
 
-.main .container-negative-corner .inside-negative-corner textarea {
+.sheet-main
+  .sheet-container-negative-corner
+  .sheet-inside-negative-corner
+  textarea {
   border: 0;
   text-align: left;
   padding: 5px;
@@ -3556,7 +3738,10 @@ h6 {
   background-color: transparent;
 }
 
-.main .container-negative-corner .inside-negative-corner .corner {
+.sheet-main
+  .sheet-container-negative-corner
+  .sheet-inside-negative-corner
+  .sheet-corner {
   position: absolute;
   background-color: var(--background-color);
   border-top: 2px solid transparent;
@@ -3569,31 +3754,43 @@ h6 {
   pointer-events: none;
 }
 
-.main .container-negative-corner .inside-negative-corner .corner.top-left {
+.sheet-main
+  .sheet-container-negative-corner
+  .sheet-inside-negative-corner
+  .sheet-corner.sheet-top-left {
   top: -12px;
   left: -12px;
 }
 
-.main .container-negative-corner .inside-negative-corner .corner.top-right {
+.sheet-main
+  .sheet-container-negative-corner
+  .sheet-inside-negative-corner
+  .sheet-corner.sheet-top-right {
   top: -12px;
   right: -12px;
   transform: rotate(90deg);
 }
 
-.main .container-negative-corner .inside-negative-corner .corner.bottom-left {
+.sheet-main
+  .sheet-container-negative-corner
+  .sheet-inside-negative-corner
+  .sheet-corner.sheet-bottom-left {
   bottom: -12px;
   left: -12px;
   transform: rotate(-90deg);
 }
 
-.main .container-negative-corner .inside-negative-corner .corner.bottom-right {
+.sheet-main
+  .sheet-container-negative-corner
+  .sheet-inside-negative-corner
+  .sheet-corner.sheet-bottom-right {
   bottom: -12px;
   right: -12px;
   transform: rotate(180deg);
 }
 
-.main .repcontainer[data-groupname="repeating_abilities"],
-.main .repcontainer[data-groupname="repeating_powers"] {
+.sheet-main .repcontainer[data-groupname="repeating_abilities"],
+.sheet-main .repcontainer[data-groupname="repeating_powers"] {
   min-height: 10px;
   display: flex;
   flex-direction: column;
@@ -3602,14 +3799,14 @@ h6 {
   align-items: center;
 }
 
-.main .repcontainer[data-groupname="repeating_abilities"] .itemcontrol,
-.main .repcontainer[data-groupname="repeating_powers"] .itemcontrol {
+.sheet-main .repcontainer[data-groupname="repeating_abilities"] .itemcontrol,
+.sheet-main .repcontainer[data-groupname="repeating_powers"] .itemcontrol {
   z-index: 99;
   font-family: "Pictos";
 }
 
-.main .repcontainer[data-groupname="repeating_abilities"] > .repitem,
-.main .repcontainer[data-groupname="repeating_powers"] > .repitem {
+.sheet-main .repcontainer[data-groupname="repeating_abilities"] > .repitem,
+.sheet-main .repcontainer[data-groupname="repeating_powers"] > .repitem {
   display: inline-block;
   width: 100%;
   box-sizing: border-box;
@@ -3619,12 +3816,12 @@ h6 {
   border: 0;
 }
 
-.main
+.sheet-main
   .repcontainer[data-groupname="repeating_abilities"]
-  .container-ability-power,
-.main
+  .sheet-container-ability-power,
+.sheet-main
   .repcontainer[data-groupname="repeating_powers"]
-  .container-ability-power {
+  .sheet-container-ability-power {
   position: relative;
   padding-left: 3px;
   padding-right: 3px;
@@ -3635,14 +3832,14 @@ h6 {
   width: 100%;
 }
 
-.main
+.sheet-main
   .repcontainer[data-groupname="repeating_abilities"]
-  .container-ability-power
-  .buttonshowinfo,
-.main
+  .sheet-container-ability-power
+  .sheet-buttonshowinfo,
+.sheet-main
   .repcontainer[data-groupname="repeating_powers"]
-  .container-ability-power
-  .buttonshowinfo {
+  .sheet-container-ability-power
+  .sheet-buttonshowinfo {
   background-color: transparent;
   font-family: "Pictos";
   color: var(--icon-color);
@@ -3654,35 +3851,35 @@ h6 {
   cursor: pointer;
 }
 
-.main
+.sheet-main
   .repcontainer[data-groupname="repeating_abilities"]
-  .container-ability-power
-  .buttonshowinfo:hover,
-.main
+  .sheet-container-ability-power
+  .sheet-buttonshowinfo:hover,
+.sheet-main
   .repcontainer[data-groupname="repeating_powers"]
-  .container-ability-power
-  .buttonshowinfo:hover {
+  .sheet-container-ability-power
+  .sheet-buttonshowinfo:hover {
   color: var(--icon-hover);
 }
 
-.main
+.sheet-main
   .repcontainer[data-groupname="repeating_abilities"]
-  .container-ability-power
-  .buttonshowinfo:active,
-.main
+  .sheet-container-ability-power
+  .sheet-buttonshowinfo:active,
+.sheet-main
   .repcontainer[data-groupname="repeating_powers"]
-  .container-ability-power
-  .buttonshowinfo:active {
+  .sheet-container-ability-power
+  .sheet-buttonshowinfo:active {
   font-size: 18px;
 }
 
-.main
+.sheet-main
   .repcontainer[data-groupname="repeating_abilities"]
-  .container-ability-power
+  .sheet-container-ability-power
   input,
-.main
+.sheet-main
   .repcontainer[data-groupname="repeating_powers"]
-  .container-ability-power
+  .sheet-container-ability-power
   input {
   height: 20px;
   border: 0;
@@ -3693,14 +3890,14 @@ h6 {
   border-bottom: 2px solid var(--accent-color);
 }
 
-.main
+.sheet-main
   .repcontainer[data-groupname="repeating_abilities"]
-  .container-ability-power
-  .hiddencheckbox,
-.main
+  .sheet-container-ability-power
+  .sheet-hiddencheckbox,
+.sheet-main
   .repcontainer[data-groupname="repeating_powers"]
-  .container-ability-power
-  .hiddencheckbox {
+  .sheet-container-ability-power
+  .sheet-hiddencheckbox {
   width: 20px;
   height: 20px;
   border: 0;
@@ -3714,53 +3911,53 @@ h6 {
   cursor: pointer;
 }
 
-.main
+.sheet-main
   .repcontainer[data-groupname="repeating_abilities"]
-  .container-ability-power
-  .hiddencheckbox:checked
-  ~ .extra,
-.main
+  .sheet-container-ability-power
+  .sheet-hiddencheckbox:checked
+  ~ .sheet-extra,
+.sheet-main
   .repcontainer[data-groupname="repeating_powers"]
-  .container-ability-power
-  .hiddencheckbox:checked
-  ~ .extra {
+  .sheet-container-ability-power
+  .sheet-hiddencheckbox:checked
+  ~ .sheet-extra {
   display: flex;
 }
 
-.main
+.sheet-main
   .repcontainer[data-groupname="repeating_abilities"]
-  .container-ability-power
-  .hiddencheckbox:checked
-  ~ span.hiddencheckboxcover,
-.main
+  .sheet-container-ability-power
+  .sheet-hiddencheckbox:checked
+  ~ span.sheet-hiddencheckboxcover,
+.sheet-main
   .repcontainer[data-groupname="repeating_powers"]
-  .container-ability-power
-  .hiddencheckbox:checked
-  ~ span.hiddencheckboxcover {
+  .sheet-container-ability-power
+  .sheet-hiddencheckbox:checked
+  ~ span.sheet-hiddencheckboxcover {
   color: var(--title-color);
 }
 
-.main
+.sheet-main
   .repcontainer[data-groupname="repeating_abilities"]
-  .container-ability-power
-  .hiddencheckbox:hover
-  ~ .hiddencheckboxcover,
-.main
+  .sheet-container-ability-power
+  .sheet-hiddencheckbox:hover
+  ~ .sheet-hiddencheckboxcover,
+.sheet-main
   .repcontainer[data-groupname="repeating_powers"]
-  .container-ability-power
-  .hiddencheckbox:hover
-  ~ .hiddencheckboxcover {
+  .sheet-container-ability-power
+  .sheet-hiddencheckbox:hover
+  ~ .sheet-hiddencheckboxcover {
   color: var(--icon-hover);
 }
 
-.main
+.sheet-main
   .repcontainer[data-groupname="repeating_abilities"]
-  .container-ability-power
-  span.hiddencheckboxcover,
-.main
+  .sheet-container-ability-power
+  span.sheet-hiddencheckboxcover,
+.sheet-main
   .repcontainer[data-groupname="repeating_powers"]
-  .container-ability-power
-  span.hiddencheckboxcover {
+  .sheet-container-ability-power
+  span.sheet-hiddencheckboxcover {
   position: absolute;
   font-family: "Pictos";
   font-size: 20px;
@@ -3775,14 +3972,14 @@ h6 {
   z-index: 1;
 }
 
-.main
+.sheet-main
   .repcontainer[data-groupname="repeating_abilities"]
-  .container-ability-power
-  .extra,
-.main
+  .sheet-container-ability-power
+  .sheet-extra,
+.sheet-main
   .repcontainer[data-groupname="repeating_powers"]
-  .container-ability-power
-  .extra {
+  .sheet-container-ability-power
+  .sheet-extra {
   display: none;
   grid-column: 2/4;
   width: 100%;
@@ -3790,15 +3987,15 @@ h6 {
   border: solid 2px var(--accent-color);
 }
 
-.main
+.sheet-main
   .repcontainer[data-groupname="repeating_abilities"]
-  .container-ability-power
-  .extra
+  .sheet-container-ability-power
+  .sheet-extra
   textarea,
-.main
+.sheet-main
   .repcontainer[data-groupname="repeating_powers"]
-  .container-ability-power
-  .extra
+  .sheet-container-ability-power
+  .sheet-extra
   textarea {
   width: 100%;
   height: 100%;
@@ -3806,7 +4003,7 @@ h6 {
   margin-bottom: 8px;
 }
 
-.main .fake-checkbox {
+.sheet-main .sheet-fake-checkbox {
   display: inline-flex;
   justify-content: center;
   align-items: center;
@@ -3816,12 +4013,12 @@ h6 {
   padding: 0;
 }
 
-.main .fake-checkbox input[type="checkbox"] {
+.sheet-main .sheet-fake-checkbox input[type="checkbox"] {
   display: none;
   visibility: hidden;
 }
 
-.main .fake-checkbox .fake-checkbox-status {
+.sheet-main .sheet-fake-checkbox .sheet-fake-checkbox-status {
   position: relative;
   width: 16px;
   height: 16px;
@@ -3831,7 +4028,7 @@ h6 {
   border-radius: 50%;
 }
 
-.main .fake-checkbox .fake-checkbox-status::before {
+.sheet-main .sheet-fake-checkbox .sheet-fake-checkbox-status::before {
   content: "";
   color: var(--accent-color);
   position: absolute;
@@ -3845,14 +4042,14 @@ h6 {
   transform: translate(-50%, -50%);
 }
 
-.main
-  .fake-checkbox
+.sheet-main
+  .sheet-fake-checkbox
   input[type="checkbox"]:checked
-  ~ .fake-checkbox-status::before {
+  ~ .sheet-fake-checkbox-status::before {
   content: "3";
 }
 
-.navegacao {
+.sheet-navegacao {
   border-bottom: 1px solid #969696;
   overflow: hidden;
   width: 100%;
@@ -3861,7 +4058,7 @@ h6 {
   list-style: none;
 }
 
-.navegacao label {
+.sheet-navegacao label {
   position: relative;
   background: var(--background-color);
   background-image: linear-gradient(to bottom, var(--background-color), #ddd);
@@ -3876,18 +4073,18 @@ h6 {
   transition: background 0.5s, color 0.5s;
 }
 
-.navegacao label:hover,
-.navegacao label:hover::after,
-.navegacao label:focus,
-.navegacao label:focus::after {
+.sheet-navegacao label:hover,
+.sheet-navegacao label:hover::after,
+.sheet-navegacao label:focus,
+.sheet-navegacao label:focus::after {
   background: var(--switch-hover-color);
 }
 
-.navegacao label:focus {
+.sheet-navegacao label:focus {
   outline: 0;
 }
 
-.navegacao label::after {
+.sheet-navegacao label::after {
   content: "";
   position: absolute;
   z-index: 1;
@@ -3904,18 +4101,18 @@ h6 {
   transition: background 0.5s, color 0.5s;
 }
 
-.navegacao label,
-.navegacao label::after {
+.sheet-navegacao label,
+.sheet-navegacao label::after {
   background: var(--background-color);
   z-index: 3;
 }
 
-.switch-selected::after {
+.sheet-switch-selected::after {
   background: var(--switch-selected-color) !important;
   z-index: 3;
 }
 
-.navegacao > input {
+.sheet-navegacao > input {
   width: 50px;
   height: 12px;
   font-size: 7px;
@@ -3928,7 +4125,7 @@ h6 {
   outline: none;
 }
 
-.main .hide-author > input {
+.sheet-main .sheet-hide-author > input {
   width: 50px;
   height: 12px;
   font-size: 7px;
@@ -3942,7 +4139,7 @@ h6 {
   outline: none;
 }
 
-.main .hide-author span {
+.sheet-main .sheet-hide-author span {
   color: var(--icon-hover);
   height: 12px;
   font-size: 9px;
@@ -4286,7 +4483,7 @@ h6 {
   .sheet-rollbox-container
   .sheet-rollbox
   .sheet-roll-label
-  .crit {
+  .sheet-crit {
   color: green;
   margin-left: 2px;
   font-weight: normal;
@@ -4336,7 +4533,7 @@ h6 {
 .sheet-rolltemplate-ordem-paranormal-attack
   .sheet-rollbox-container
   .sheet-rollbox
-  .divisor {
+  .sheet-divisor {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -4346,7 +4543,7 @@ h6 {
 .sheet-rolltemplate-ordem-paranormal-attack
   .sheet-rollbox-container
   .sheet-rollbox
-  .divisor
+  .sheet-divisor
   span {
   width: 1px;
   height: 70%;
@@ -4498,7 +4695,7 @@ h6 {
 .sheet-rolltemplate-ordem-paranormal-info
   .sheet-rollbox-container
   .sheet-rollbox
-  .info-title {
+  .sheet-info-title {
   width: 100%;
   font-style: italic;
   display: flex;
@@ -4852,8 +5049,8 @@ h6 {
 .sheet-rolltemplate-custom
   .sheet-rollbox-container
   .sheet-rollbox
-  .props
-  .content {
+  .sheet-props
+  .sheet-content {
   font-weight: normal !important;
   margin-bottom: 2px;
 }
@@ -4891,25 +5088,25 @@ h6 {
   font-size: 13px;
 }
 
-.rolltemplate-darkmode {
+.sheet-rolltemplate-darkmode {
   color: black !important;
 }
 
-.deityAndLevel {
+.sheet-deityAndLevel {
   display: grid;
   grid-template-columns: 1fr 5fr;
   grid-gap: 20px;
 }
 
-.dado {
+.sheet-dado {
   margin: auto !important;
 }
-.ataque_rolagens {
+.sheet-ataque_rolagens {
   justify-content: center;
 }
 
 /* The switch - the box around the slider */
-.switch {
+.sheet-switch {
   position: relative;
   display: inline-block;
   height: 20px !important;
@@ -4919,7 +5116,7 @@ h6 {
 }
 
 /* Hide default HTML checkbox */
-.switch input {
+.sheet-switch input {
   display: none;
   opacity: 0;
   width: 0;
@@ -4927,14 +5124,14 @@ h6 {
 }
 
 /* The slider */
-.slider {
+.sheet-slider {
   cursor: pointer;
   height: 20px !important;
   -webkit-transition: 0.4s;
   transition: 0.4s;
 }
 
-.switch-selected {
+.sheet-switch-selected {
   background-color: var(--switch-selected-color) !important;
   color: var(--switch-selected-text-color) !important;
 }
@@ -4952,127 +5149,127 @@ input:checked + .slider:before {
 
 /* Rounded sliders */
 
-.menace-spam {
+.sheet-menace-spam {
   font-family: "Alegreya Sans SC";
   font-weight: bold;
   font-size: 14px;
 }
 
-.main .menace-container {
+.sheet-main .menace-container {
   width: 100%;
   display: flex;
   flex-direction: column;
   grid-column: 1/3;
 }
 
-.menace-powers .repcontrol_add,
-.menace-powers .repcontrol_edit,
-.menace-spells .repcontrol_add,
-.menace-spells .repcontrol_edit,
-.menace-attacks .repcontrol_add,
-.menace-attacks .repcontrol_edit {
+.sheet-menace-powers .repcontrol_add,
+.sheet-menace-powers .repcontrol_edit,
+.sheet-menace-spells .repcontrol_add,
+.sheet-menace-spells .repcontrol_edit,
+.sheet-menace-attacks .repcontrol_add,
+.sheet-menace-attacks .repcontrol_edit {
   display: none !important;
 }
 
-.menace-attacks .repcontainer,
-.menace-attacks .repitem {
+.sheet-menace-attacks .repcontainer,
+.sheet-menace-attacks .repitem {
   display: inline-block;
 }
 
-.menace-spells .container-menace-ability-power {
+.sheet-menace-spells .container-menace-ability-power {
   display: list-item;
   list-style-position: inside;
 }
 
-.hiddenelement {
+.sheet-hiddenelement {
   display: none !important;
 }
 
-.menace-container input {
+.sheet-menace-container input {
   border: none;
   background-color: transparent;
   color: var(--highligth-color);
 }
 
-.container-logo {
+.sheet-container-logo {
   display: flex;
   justify-content: end;
 }
 
-.container-logo-ghanor {
+.sheet-container-logo-ghanor {
   display: flex;
   justify-content: end;
   height: 150px;
 }
 
-.menace-header {
+.sheet-menace-header {
   display: grid;
   grid-template-columns: 5fr 1fr;
 }
 
-.menace-header .name-div {
+.sheet-menace-header .name-div {
   align-self: center;
 }
 
-.menace-header .menace-nd {
+.sheet-menace-header .menace-nd {
   display: grid;
   grid-template-columns: 1fr 3fr;
 }
 
-.menace-header span {
+.sheet-menace-header span {
   font-size: 25px;
   font-family: "Alegreya Sans SC";
   font-weight: bold;
   color: var(--highligth-color);
 }
 
-.menace-name {
+.sheet-menace-name {
   width: 100%;
   font-family: "Alegreya Sans SC" !important;
   font-weight: bold;
   font-size: 30px !important;
 }
 
-.menace-nd {
+.sheet-menace-nd {
   width: 70%;
   font-family: "Alegreya Sans SC" !important;
   font-weight: bold;
   font-size: 25px !important;
 }
 
-.menace-creature {
+.sheet-menace-creature {
   font-style: italic;
   width: 100%;
 }
 
-.menace-base-info,
-.menace-attributes {
+.sheet-menace-base-info,
+.sheet-menace-attributes {
   border-top: 2px var(--highligth-color) solid;
   border-bottom: 2px var(--highligth-color) solid;
 }
 
-.menace-base-info span,
-.menace-rolls span,
-.menace-attributes span,
-.menace-skills span,
-.menace-treasures span {
+.sheet-menace-base-info span,
+.sheet-menace-rolls span,
+.sheet-menace-attributes span,
+.sheet-menace-skills span,
+.sheet-menace-treasures span {
   font-size: 14px;
   font-weight: bold;
   color: var(--highligth-color);
 }
 
-.menace-container input,
-.menace-container span {
+.sheet-menace-container input,
+.sheet-menace-container span {
   padding: 0px;
 }
 
-.menace-nd {
+.sheet-menace-nd {
   margin-bottom: 10px;
   margin-left: 5px;
 }
 
-.menace-perception,
-.menace-resistence {
+.sheet-menace-perception,
+.sheet-menace-resistence {
   width: 100% !important;
   padding-left: 0px;
   text-align: left !important;
@@ -5080,62 +5277,62 @@ input:checked + .slider:before {
   resize: none;
 }
 
-.menace-desloc-vida,
-.menace-mana {
+.sheet-menace-desloc-vida,
+.sheet-menace-mana {
   padding-left: 3px;
   width: 70% !important;
   text-align: left !important;
 }
 
-.span-menace {
+.sheet-span-menace {
   width: 30px;
   color: var(--accent-color);
 }
 
-.menace-creature-type input,
-.menace-base-info input {
+.sheet-menace-creature-type input,
+.sheet-menace-base-info input {
   color: var(--accent-color) !important;
 }
 
-.infos {
+.sheet-infos {
   color: var(--accent-color) !important;
   padding-left: 3px !important;
   font-weight: initial !important;
 }
 
-.menace-base-info input,
-.menace-attributes input {
+.sheet-menace-base-info input,
+.sheet-menace-attributes input {
   width: 20px;
   text-align: right;
   vertical-align: baseline;
 }
 
-.menace-container .btn {
+.sheet-menace-container .btn {
   vertical-align: baseline !important;
 }
 
-.melee,
-.distance {
+.sheet-melee,
+.sheet-distance {
   font-weight: bold !important;
 }
 
-.left-global-container {
+.sheet-left-global-container {
   width: 100%;
   display: flex;
   flex-direction: column;
 }
 
-.right-global-container {
+.sheet-right-global-container {
   width: 100%;
   display: flex;
   flex-direction: column;
 }
 
-.domains-container {
+.sheet-domains-container {
   grid-column: 1/3;
 }
 
-.domain-header {
+.sheet-domain-header {
   margin: 0 auto;
   font-family: "PT Sans", sans-serif;
   font-size: 13px;
@@ -5148,20 +5345,20 @@ input:checked + .slider:before {
   background-color: var(--background-color);
 }
 
-.domain-terrain {
+.sheet-domain-terrain {
   display: grid;
   column-gap: 22px;
   grid-template-columns: 516px 146px 146px;
 }
 
-.domain-header-info {
+.sheet-domain-header-info {
   display: grid;
   column-gap: 22px;
   grid-template-columns: 400px auto;
 }
 
-.court-container,
-.popularity-container {
+.sheet-court-container,
+.sheet-popularity-container {
   display: grid;
   column-gap: 22px;
   grid-template-columns: auto auto auto;
@@ -5169,8 +5366,8 @@ input:checked + .slider:before {
   margin-bottom: 30px;
 }
 
-.court-level-container,
-.popularity-level-container {
+.sheet-court-level-container,
+.sheet-popularity-level-container {
   display: grid;
   column-gap: 22px;
   grid-template-columns: auto auto;
@@ -5179,71 +5376,53 @@ input:checked + .slider:before {
   padding: 15px 0px 0px 15px;
 }
 
-.regent-player {
+.sheet-regent-player {
   padding-top: 15px;
   grid-column: 1/2;
 }
 
-.domain-level {
+.sheet-domain-level {
   padding-top: 15px;
 }
 
-/* .global-container {
-  margin: 0 auto;
-  font-family: "PT Sans", sans-serif;
-  font-size: 13px;
-  display: grid;
-  width: 860px;
-  background-repeat: no-repeat;
-  background-size: cover;
-  column-gap: 22px;
-  grid-template-columns: 516px 312px;
-  background-color: var(--background-color);
-} */
-
-.global-columns {
+.sheet-global-columns {
   display: grid;
   grid-template-columns: 75% 25%;
   margin-bottom: 5px;
 }
 
-.global-rolls {
+.sheet-global-rolls {
   margin-top: 15px;
 }
 
-.global-conditions {
+.sheet-global-conditions {
   margin-top: 15px;
 }
 
-.left-global-container .character-attributes,
-.right-global-container .character-attributes {
+.sheet-left-global-container .sheet-character-attributes,
+.sheet-right-global-container .sheet-character-attributes {
   width: 100%;
   margin-top: 15px;
   height: 223px;
-  /* display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  column-gap: 30px;
-  row-gap: 10px;
-  padding-top: 15px; */
 
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
 }
 
-.left-container .character-attributes > div {
+.sheet-left-container .sheet-character-attributes > div {
   width: 84px;
   height: 89px;
 }
 
-.left-global-container .character-attributes > div,
-.right-global-container .character-attributes > div {
+.sheet-left-global-container .sheet-character-attributes > div,
+.sheet-right-global-container .sheet-character-attributes > div {
   width: 84px;
   height: 89px;
 }
 
-.left-global-container .button-title-attribute,
-.right-global-container .button-title-attribute {
+.sheet-left-global-container .sheet-button-title-attribute,
+.sheet-right-global-container .sheet-button-title-attribute {
   background-color: transparent;
   font-size: 14px;
   border: 0;
@@ -5256,8 +5435,8 @@ input:checked + .slider:before {
   user-select: none;
 }
 
-.left-global-container .attacks-container .attacksgrid,
-.right-global-container .attacks-container .attacksgrid {
+.sheet-left-global-container .sheet-attacks-container .sheet-attacksgrid,
+.sheet-right-global-container .sheet-attacks-container .sheet-attacksgrid {
   display: grid;
   padding-left: 10px;
   padding-right: 10px;
@@ -5267,8 +5446,8 @@ input:checked + .slider:before {
   padding-bottom: 20px;
 }
 
-.left-global-container .small-title,
-.right-global-container .small-title {
+.sheet-left-global-container .sheet-small-title,
+.sheet-right-global-container .sheet-small-title {
   width: 100%;
   display: flex;
   justify-content: center;
@@ -5282,8 +5461,11 @@ input:checked + .slider:before {
   user-select: none;
 }
 
-.left-global-container .attacks-container .attacksgrid input,
-.right-global-container .attacks-container .attacksgrid input {
+.sheet-left-global-container .sheet-attacks-container .sheet-attacksgrid input,
+.sheet-right-global-container
+  .sheet-attacks-container
+  .sheet-attacksgrid
+  input {
   display: inline-block;
   height: 24px;
   font-size: 12px;
@@ -5294,8 +5476,8 @@ input:checked + .slider:before {
   width: 100%;
 }
 
-.left-global-container .defense-container .defensegrid,
-.right-global-container .defense-container .defensegrid {
+.sheet-left-global-container .sheet-defense-container .sheet-defensegrid,
+.sheet-right-global-container .sheet-defense-container .sheet-defensegrid {
   display: grid;
   padding-left: 10px;
   padding-right: 10px;
@@ -5305,8 +5487,11 @@ input:checked + .slider:before {
   padding-bottom: 20px;
 }
 
-.left-global-container .defense-container .defensegrid input,
-.right-global-container .defense-container .defensegrid input {
+.sheet-left-global-container .sheet-defense-container .sheet-defensegrid input,
+.sheet-right-global-container
+  .sheet-defense-container
+  .sheet-defensegrid
+  input {
   display: inline-block;
   height: 24px;
   font-size: 12px;
@@ -5317,43 +5502,43 @@ input:checked + .slider:before {
   width: 100%;
 }
 
-.attribute-center {
+.sheet-attribute-center {
   text-align: center;
 }
 
-.attack-icon,
-.damage-icon,
-.roll-icon,
-.skills-icon,
-.defense-icon,
-.armor-icon,
-.shield-icon,
-.resist-icon {
+.sheet-attack-icon,
+.sheet-damage-icon,
+.sheet-roll-icon,
+.sheet-skills-icon,
+.sheet-defense-icon,
+.sheet-armor-icon,
+.sheet-shield-icon,
+.sheet-resist-icon {
   height: 20px;
   filter: invert(11%) sepia(83%) saturate(4245%) hue-rotate(348deg)
     brightness(97%) contrast(87%);
 }
 
-.attack-span,
-.damage-span,
-.roll-span,
-.skills-span,
-.defense-span,
-.armor-span,
-.shield-span,
-.resist-span {
+.sheet-attack-span,
+.sheet-damage-span,
+.sheet-roll-span,
+.sheet-skills-span,
+.sheet-defense-span,
+.sheet-armor-span,
+.sheet-shield-span,
+.sheet-resist-span {
   font-size: 15px;
   font-weight: bold;
   color: var(--highligth-color);
 }
 
-.defesacaido-color {
+.sheet-defesacaido-color {
   font-size: 11px;
   font-weight: bold;
   color: var(--highligth-color);
 }
 
-.global-color {
+.sheet-global-color {
   background-color: var(--highligth-color);
   color: var(--background-color);
   font-size: 15px !important;
@@ -5364,276 +5549,51 @@ input:checked + .slider:before {
   padding: 0px 10px 0px 10px;
 }
 
-.header-global {
+.sheet-header-global {
   height: 84px;
   width: 100%;
   position: relative;
 }
 
-.header-global-ghanor {
-  height: 145px;
-  width: 100%;
-  position: relative;
-}
-
-.header-position {
+.sheet-header-position {
   position: absolute;
   bottom: 0px;
 }
 
-.header-button-position {
+.sheet-header-button-position {
   position: absolute;
   bottom: 0px;
   right: 0px;
 }
 
-.erase-global {
+.sheet-erase-global {
   margin-left: 35px;
 }
 
-.global-title {
+.sheet-global-title {
   font-size: 25px;
   font-family: "Alegreya Sans SC";
   font-weight: bold;
   color: var(--highligth-color) !important;
 }
 
-.right-icons {
+.sheet-right-icons {
   text-align: right;
 }
 
-.span-middle {
+.sheet-span-middle {
   display: table;
 }
 
-.span-middle div {
+.sheet-span-middle div {
   display: table-cell;
   vertical-align: middle;
 }
 
-.council-container > .counchil-header {
-  display: grid;
-  grid-template-columns: 100px 100px;
-  column-gap: 15px;
-}
-
-.council-input .repcontainer[data-groupname="repeating_council"] {
-  margin-top: 5px;
-}
-
-.council-input
-  .repcontainer[data-groupname="repeating_council"]
-  > .repitem
-  .grid-council {
-  width: 100%;
-  display: grid;
-  grid-template-columns: 100px 100px;
-  column-gap: 7px;
-  margin-bottom: 7px;
-}
-
-.council-input
-  .repcontainer[data-groupname="repeating_council"]
-  > .repitem
-  .grid-council
-  input {
-  text-align: center;
-  width: 100%;
-  border: 0;
-  border-bottom: 2px solid var(--accent-color);
-}
-
-.council-input
-  .repcontainer[data-groupname="repeating_council"]
-  > .repitem
-  .itemcontrol {
-  z-index: 99;
-  font-family: "Pictos";
-}
-
-.council-input
-  .repcontainer[data-groupname="repeating_council"]
-  > .repitem
-  .repcontrol_del {
-  font-family: "Pictos";
-  background-color: var(--highligth-color);
-  background-image: none;
-  position: absolute;
-  z-index: 99 !important;
-  top: 0;
-  right: 0;
-}
-
-.council-input
-  .repcontainer[data-groupname="repeating_council"]
-  > .repitem
-  .editmode
-  ~ .repcontrol_edit::before {
-  content: "Aplicar";
-}
-
-.fortification-container {
-  align-content: center;
-  justify-content: center;
-  display: grid;
-}
-
-.council-container span,
-.fortification-container span {
-  font-size: 15px;
-  font-weight: bolder;
-}
-
-.fortification-container textarea {
-  resize: none;
-  border: 3px solid #ab893a;
-}
-
-.span-court {
-  font-size: 20px;
-  padding: 5px 30px 5px 30px;
-  color: var(--background-color);
-  background-color: #ab893a;
-}
-
-.court_span {
-  color: var(--accent-color);
-  font-size: 15px;
-}
-
-.court_description {
-  color: var(--accent-color);
-  font-size: 11px;
-  font-weight: 100;
-}
-
-.court_sub_desc {
-  color: var(--accent-color);
-  font-weight: 100;
-  font-style: italic;
-  font-size: 13px;
-}
-
-.grid-buildings {
-  display: grid;
-  grid-template-columns: auto auto auto;
-  column-gap: 22px;
-  align-items: center;
-  justify-items: center;
-  margin-top: 7px;
-  margin-bottom: 7px;
-  padding-left: 15px;
-  padding-right: 15px;
-}
-
-.grid-buildings-body {
-  display: grid;
-  grid-template-columns: 350px 55px auto;
-  column-gap: 22px;
-  margin-top: 7px;
-  margin-bottom: 7px;
-  padding-left: 15px;
-  padding-right: 15px;
-}
-
-.grid-buildings .grid-title {
-  justify-content: start !important;
-  font-size: 15px !important;
-}
-
-.grid-buildings .small-title {
-  justify-content: start !important;
-}
-
-.grid-buildings-body input,
-.grid-troop input {
-  border: 0;
-  border-bottom: 2px solid var(--accent-color);
-  width: 100%;
-}
-
-.grid-troop {
-  display: grid;
-  grid-template-columns: 300px auto auto auto auto auto auto;
-  column-gap: 22px;
-  align-items: center;
-  justify-items: start;
-  margin-top: 7px;
-  margin-bottom: 7px;
-  padding-left: 15px;
-  padding-right: 15px;
-}
-
-.grid-troop .grid-title {
-  justify-content: start !important;
-  font-size: 15px !important;
-}
-
-.grid-troop .small-title {
-  justify-content: start !important;
-}
-
-.buildings-container,
-.troop-container {
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
-.fortification-container span {
-  font-size: 20px;
-  padding: 5px 30px 5px 30px;
-  color: var(--background-color);
-  background-color: #ab893a;
-  text-align: center;
-}
-
-.ghanor-color-border-1 {
-  border: 1px solid #ab893a !important;
-}
-
-.ghanor-color-border-2 {
-  border: 2px solid #ab893a !important;
-}
-
-.ghanor-color-border-3 {
-  border: 3px solid #ab893a !important;
-}
-
-.ghanor-color-background {
-  background-color: #ab893a !important;
-}
-
-.ghanor-box-shadow {
-  box-shadow: 0 0 1px #ab893a;
-}
-
-.container-negative-corner-ghanor {
-  border-right: 2px solid #ab893a !important;
-  border-bottom: 2px solid #ab893a !important;
-}
-
-.menace-base-info-ghanor,
-.menace-attributes-ghanor {
-  border-top: 2px #ab893a solid !important;
-  border-bottom: 2px #ab893a solid !important;
-}
-
-.ghanor-color {
-  color: #ab893a !important;
-}
-
-.menace-treasures textarea {
-  resize: none;
-}
-
-.character-attributes-ghanor {
-  margin-top: -5px !important;
-}
-
-.background-tormenta {
+.sheet-background-tormenta {
   background-color: var(--highligth-color) !important;
 }
 
-.border-tormenta {
+.sheet-border-tormenta {
   border: 3px solid var(--highligth-color) !important;
 }

--- a/Ordem Paranormal/ordemparanormal.html
+++ b/Ordem Paranormal/ordemparanormal.html
@@ -319,7 +319,7 @@
           data-i18n-title="spam-attack"
         ></span>
         <img
-          src="https://raw.githubusercontent.com/RoenMidnight/roll20-character-sheets/ordem-paranormal-goty-menace-character-sheet/Tormenta20%20-%20Jogo%20do%20Ano/icons/punch.png"
+          src="https://raw.githubusercontent.com/RoenMidnight/roll20-character-sheets/t20-goty-menace-character-sheet/Tormenta20%20-%20Jogo%20do%20Ano/icons/punch.png"
           class="attack-icon hiddenelement"
           title="Ataque"
           data-i18n-title="spam-attack"
@@ -332,7 +332,7 @@
           data-i18n-title="spam-damage"
         ></span>
         <img
-          src="https://raw.githubusercontent.com/RoenMidnight/roll20-character-sheets/ordem-paranormal-goty-menace-character-sheet/Tormenta20%20-%20Jogo%20do%20Ano/icons/explosion.png"
+          src="https://raw.githubusercontent.com/RoenMidnight/roll20-character-sheets/t20-goty-menace-character-sheet/Tormenta20%20-%20Jogo%20do%20Ano/icons/explosion.png"
           class="damage-icon hiddenelement"
           title="Dano"
           data-i18n-title="spam-damage"
@@ -345,7 +345,7 @@
           data-i18n-title="spam-roll"
         ></span>
         <img
-          src="https://raw.githubusercontent.com/RoenMidnight/roll20-character-sheets/ordem-paranormal-goty-menace-character-sheet/Tormenta20%20-%20Jogo%20do%20Ano/icons/numerology.png"
+          src="https://raw.githubusercontent.com/RoenMidnight/roll20-character-sheets/t20-goty-menace-character-sheet/Tormenta20%20-%20Jogo%20do%20Ano/icons/numerology.png"
           class="roll-icon hiddenelement"
           title="Rolagem"
           data-i18n-title="spam-roll"
@@ -358,7 +358,7 @@
           data-i18n-title="spam-skills"
         ></span>
         <img
-          src="https://raw.githubusercontent.com/RoenMidnight/roll20-character-sheets/ordem-paranormal-goty-menace-character-sheet/Tormenta20%20-%20Jogo%20do%20Ano/icons/skills.png"
+          src="https://raw.githubusercontent.com/RoenMidnight/roll20-character-sheets/t20-goty-menace-character-sheet/Tormenta20%20-%20Jogo%20do%20Ano/icons/skills.png"
           class="skills-icon hiddenelement"
           title="Perícias"
           data-i18n-title="spam-skills"
@@ -371,7 +371,7 @@
           data-i18n-title="resistance"
         ></span>
         <img
-          src="https://raw.githubusercontent.com/RoenMidnight/roll20-character-sheets/ordem-paranormal-goty-menace-character-sheet/Tormenta20%20-%20Jogo%20do%20Ano/icons/resistence.png"
+          src="https://raw.githubusercontent.com/RoenMidnight/roll20-character-sheets/t20-goty-menace-character-sheet/Tormenta20%20-%20Jogo%20do%20Ano/icons/resistence.png"
           class="resist-icon hiddenelement"
           title="Resistências"
           data-i18n-title="resistencias"
@@ -384,7 +384,7 @@
           data-i18n-title="spam-defense"
         ></span>
         <img
-          src="https://raw.githubusercontent.com/RoenMidnight/roll20-character-sheets/ordem-paranormal-goty-menace-character-sheet/Tormenta20%20-%20Jogo%20do%20Ano/icons/antivirus.png"
+          src="https://raw.githubusercontent.com/RoenMidnight/roll20-character-sheets/t20-goty-menace-character-sheet/Tormenta20%20-%20Jogo%20do%20Ano/icons/antivirus.png"
           class="defense-icon hiddenelement"
           title="Defesa"
           data-i18n-title="spam-defense"
@@ -397,7 +397,7 @@
           data-i18n-title="spam-armor"
         ></span>
         <img
-          src="https://raw.githubusercontent.com/RoenMidnight/roll20-character-sheets/ordem-paranormal-goty-menace-character-sheet/Tormenta20%20-%20Jogo%20do%20Ano/icons/armor.png"
+          src="https://raw.githubusercontent.com/RoenMidnight/roll20-character-sheets/t20-goty-menace-character-sheet/Tormenta20%20-%20Jogo%20do%20Ano/icons/armor.png"
           class="armor-icon hiddenelement"
           title="Armadura"
           data-i18n-title="spam-armor"
@@ -410,7 +410,7 @@
           data-i18n-title="spam-shield"
         ></span>
         <img
-          src="https://raw.githubusercontent.com/RoenMidnight/roll20-character-sheets/ordem-paranormal-goty-menace-character-sheet/Tormenta20%20-%20Jogo%20do%20Ano/icons/shield.png"
+          src="https://raw.githubusercontent.com/RoenMidnight/roll20-character-sheets/t20-goty-menace-character-sheet/Tormenta20%20-%20Jogo%20do%20Ano/icons/shield.png"
           class="shield-icon hiddenelement"
           title="Escudo"
           data-i18n-title="spam-shield"
@@ -6255,26 +6255,9 @@
             });
           });
 
-         on(`sheet:opened`, function(){
-             getAttrs([
-                 "game_system", "ficha_modificadores",
-             ], function(v){
-                $20('.span-court').addClass('background-tormenta');
-
-                $20('.fortification-container span').addClass('background-tormenta');
-                $20('.fortification-container textarea').addClass('border-tormenta');
-
-                 if(v.ficha_modificadores == 1){
-                     $20('.mod').removeClass('hiddenelement');
-                 }
-             });
-         });
-
          on(`sheet:opened change:rolltemp change:ataquetemp change:danotemp change:resistemp change:periciatemp change:passivatemp change:bloqueiotemp change:esquivatemp change:rdtemp change:fortemp change:agitemp change:vigtemp change:inttemp change:sabtemp change:cartemp change:abalado change:agarrado change:alquebrado change:apavorado change:atordoado change:caido change:cego change:confuso change:debilitado  change:desprevenido change:doente change:emchama change:enfeiticado change:enjoado change:enreado change:envenenado change:esmorecido change:exausto change:fascinado change:fatigado change:fraco change:frustrado change:imovel change:inconsciente change:indefeso change:lento change:ofuscado change:paralizado change:pasmo change:petrificacao change:sangrando change:surdo change:surpreendido change:vulneravel`, function(){
              getAttrs([
-                     "abalado","agarrado","alquebrado","apavorado","atordoado","caido","cego","confuso","debilitado","desprevenido","doente","emchama","enfeiticado","enjoado","enreado",
-                     "envenenado","esmorecido","exausto","fascinado","fatigado","fraco","frustrado","imovel","inconsciente","indefeso","lento","ofuscado","paralizado","pasmo","petrificacao",
-                     "sangrando","surdo","surpreendido","vulneravel", "desafesaoutrostemp",
+                     "desafesaoutrostemp",
                      "rolltemp", "ataquetemp", "periciatemp", "danotemp", "resistemp", "passivatemp", "bloqueiotemp", "esquivatemp", "rdtemp",
                      "fortemp", "agitemp", "vigtemp", "inttemp", "sabtemp", "cartemp"
                  ], function(v){
@@ -6286,53 +6269,6 @@
                  let reflexo = 0;
                  let passiva = 0;
                  let show_global = false;
-
-                 if(v.abalado == 1){ pericia = -2; show_global = true;}
-                 if(v.agarrado == 1){ ataque = -2; setAttrs({"desprevenido": 1, "imovel": 1});  show_global = true;}
-                 if(v.atordoado == 1){ setAttrs({"desprevenido": 1});  show_global = true;}
-                 if(v.enreado == 1){ setAttrs({"lento":1, "vulneravel":1}); ataque = -2;  show_global = true;}
-                 if(v.exausto == 1){ setAttrs({"debilitado": 1, "lento": 1, "vulneravel":1});  show_global = true;}
-                 if(v.fatigado == 1){ setAttrs({"fraco": 1, "vulneravel":1});  show_global = true;}
-                 if(v.fraco == 1){ pericia_fisica = -2;  show_global = true;}
-                 if(v.frustrado == 1){ pericia_mental = -2;  show_global = true;}
-                 if(v.inconsciente == 1){ setAttrs({"indefeso":1});  show_global = true;}
-                 if(v.ofuscado == 1){ ataque = percepcao = -2;  show_global = true;}
-                 if(v.paralizado == 1){ setAttrs({"imovel":1, "indefeso": 1 });  show_global = true;}
-                 if(v.petrificacao == 1){ setAttrs({"inconsciente":1});  show_global = true;}
-                 if(v.surpreendido == 1){ setAttrs({"desprevenido":1});  show_global = true;}
-                 if(v.vulneravel == 1){ passiva = -2;  show_global = true; }
-                 if(v.surdo == 1){ iniciativa = -5;  show_global = true;}
-                 if(v.apavorado == 1){ pericia = -5;  show_global = true;}
-                 if(v.fascinado == 1){ percepcao = -5;  show_global = true;}
-                 if(v.cego == 1){ cego = -5; setAttrs({"desprevenido": 1, "lento": 1});  show_global = true;}
-                 if(v.debilitado  == 1){ pericia_fisica = -5;  show_global = true;}
-                 if(v.esmorecido == 1){ pericia_mental = -5;  show_global = true;}
-                 if(v.desprevenido == 1){ passiva = reflexo = -5;  show_global = true;}
-                 if(v.indefeso == 1){ setAttrs({"desprevenido":1}); passiva = -10;  show_global = true;}
-                 if(v.alquebrado == 1) { show_global = true; }
-                 if(v.confuso == 1) { show_global = true; }
-                 if(v.emchama == 1) { show_global = true; }
-                 if(v.doente == 1) { show_global = true; }
-                 if(v.enfeiticado == 1) { show_global = true; }
-                 if(v.enjoado == 1) { show_global = true; }
-                 if(v.envenenado == 1) { show_global = true; }
-                 if(v.imovel == 1) { show_global = true; }
-                 if(v.lento == 1) { show_global = true; }
-                 if(v.imovel == 1) { show_global = true; }
-                 if(v.sangrando == 1){ show_global = true; }
-
-                 if (parseInt(ataque)  < parseInt(ataque_cc)){ ataque_cc = 0; }
-                 if (parseInt(ataque)  < parseInt(ataque_dis)){ ataque_dis = 0 }
-                 if (parseInt(pericia) < parseInt(pericia_fisica)) { pericia_fisica = 0; }
-                 if (parseInt(pericia) < parseInt(pericia_mental)) { pericia_mental = 0; }
-                 if (parseInt(pericia) < parseInt(percepcao)) { percepcao = 0; }
-                 if (parseInt(pericia) < parseInt(iniciativa)) { iniciativa = 0; }
-                 if (parseInt(pericia) < parseInt(reflexo)) { reflexo = 0; }
-                 if (parseInt(pericia) < parseInt(cego) || parseInt(pericia_fisica) < parseInt(cego)) { cego = 0; }
-                 if (parseInt(pericia) < parseInt(ataque)) { ataque = 0; }
-
-                 $20('.passivacaido-color').addClass('hiddenelement');
-                 if(v.caido == 1){ ataque_cc -= 5; $20('.passivacaido-color').removeClass('hiddenelement'); show_global = true;  }
 
                  let global_array = [
                      [v.rolltemp, '.roll-span', '.roll-icon'],
@@ -6368,9 +6304,9 @@
                      parseInt(v.inttemp) != 0 || parseInt(v.sabtemp) != 0 || parseInt(v.cartemp) != 0 ||
                      show_global
                  ) {
-                     $20('.global-color').removeClass('hiddenelement');
+                     $20('.sheet-global-color').removeClass('hiddenelement');
                  } else {
-                     $20('.global-color').addClass('hiddenelement');
+                     $20('.sheet-global-color').addClass('hiddenelement');
                  }
 
 
@@ -6768,26 +6704,26 @@
                  let switch_selector = 'switch-selected';
 
                  if (v.cstype == 0) {
-                     $20('.left-container').removeClass('hiddenelement');
-                     $20('.right-container').removeClass('hiddenelement');
-                     $20('.charnotes-container').removeClass('hiddenelement');
+                     $20('.sheet-left-container').removeClass('hiddenelement');
+                     $20('.sheet-right-container').removeClass('hiddenelement');
+                     $20('.sheet-charnotes-container').removeClass('hiddenelement');
 
-                     $20('.left-global-container').addClass('hiddenelement');
-                     $20('.right-global-container').addClass('hiddenelement');
-                     $20('.global-columns').addClass('hiddenelement');
+                     $20('.sheet-left-global-container').addClass('hiddenelement');
+                     $20('.sheet-right-global-container').addClass('hiddenelement');
+                     $20('.sheet-global-columns').addClass('hiddenelement');
 
                      $20('.sheet-pj').addClass(switch_selector);
                      $20('.sheet-mod').removeClass(switch_selector);
                  }
 
                  if (v.cstype == 1){
-                  $20('.left-container').addClass('hiddenelement');
-                  $20('.right-container').addClass('hiddenelement');
-                  $20('.charnotes-container').addClass('hiddenelement');
+                  $20('.sheet-left-container').addClass('hiddenelement');
+                  $20('.sheet-right-container').addClass('hiddenelement');
+                  $20('.sheet-charnotes-container').addClass('hiddenelement');
 
-                  $20('.left-global-container').removeClass('hiddenelement');
-                  $20('.right-global-container').removeClass('hiddenelement');
-                  $20('.global-columns').removeClass('hiddenelement');
+                  $20('.sheet-left-global-container').removeClass('hiddenelement');
+                  $20('.sheet-right-global-container').removeClass('hiddenelement');
+                  $20('.sheet-global-columns').removeClass('hiddenelement');
 
                   $20('.sheet-pj').removeClass(switch_selector);
                   $20('.sheet-mod').addClass(switch_selector);

--- a/Ordem Paranormal/ordemparanormal.html
+++ b/Ordem Paranormal/ordemparanormal.html
@@ -5649,7 +5649,7 @@
   </div>
 
   <div class="hide-author">
-    <span>FICHA BY PIXEL CRÍTICO</span>
+    <span>FICHA BY DRARKORS, MIGUEL BEHOLDER E HEITHOR</span>
   </div>
 </div>
 <!-- Rollers -->

--- a/Ordem Paranormal/sheet.json
+++ b/Ordem Paranormal/sheet.json
@@ -1,9 +1,9 @@
 {
   "html": "ordemparanormal.html",
   "css": "ordemparanormal.css",
-  "authors": "Rafael Figueiredo Zanetti",
+  "authors": "Rafael 'Drarkors' Figueiredo Zanetti, Miguel 'Beholder' de Souza Silva e Heitor Andrade",
   "preview": "ordemparanormal.png",
-  "instructions": "Ficha de Ordem Paranormal desenvolvida pela Pixel Crítico em parceria com Jambo Editora.",
+  "instructions": "Ficha de Ordem Paranormal fanmade.",
   "legacy": true,
   "printable": false,
   "useroptions": [


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [X] The pull request title clearly contains the name of the sheet I am editing.
- [X] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [X] The pull request makes changes to files in only one sub-folder.
- [X] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

## New Sheet Details

<!-- If you are submitting a new sheet to the repository, please fill in any empty spaces indicated by < >. -->

- The name of this game is: Ordem Paranormal  _(i.e. Dungeons & Dragons 5th Edition, The Dresden Files RPG)_
- The publisher of this game is: Jambo _(i.e. Wizards of the Coast, Evil Hat)_
- The name of this game system/family is: Ordem Paranormal _(i.e. Dungeons & Dragons, FATE)_

- [X] I have followed the [Character Sheets Standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) when building this sheet.

<!-- Please check any that apply: -->

- [X] This sheet has been made on behalf of, or by, the game's publisher.
- [ ] This game is not a traditionally published game, but a copy of the game rules can be purchased/downloaded/found at: <   >
- [ ] This sheet is for an unofficial fan game, modification to an existing game, or a homebrew system.

# Changes / Description

Adding the `sheet-` prefixs to CSS classes. Couldn't visualize this problem during tests on the custom sheet sandbox, so it passed without us realizing it was happening.