### PR TITLE
HeroSystem6eHeroic: New Feature - Rolls Output Display

### DIFF
--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -4553,6 +4553,7 @@
 	
 	/* Three different Templates for attacks, armor activation, and skills ability checks. */
 	.sheet-rolltemplate-custom,
+	.sheet-rolltemplate-custom-success-roll,
 	.sheet-rolltemplate-custom-normal-attack,
 	.sheet-rolltemplate-custom-power-attack,
 	.sheet-rolltemplate-custom-attack,
@@ -4563,6 +4564,7 @@
 	}
 	
 	.withoutavatars .sheet-rolltemplate-custom,
+	.withoutavatars .sheet-rolltemplate-custom-success-roll,
 	.withoutavatars .sheet-rolltemplate-custom-normal-attack,
 	.withoutavatars .sheet-rolltemplate-custom-power-attack,
 	.withoutavatars .sheet-rolltemplate-custom-attack,
@@ -4573,6 +4575,7 @@
 	}
 	
 	.sheet-rolltemplate-custom .sheet-container,
+	.sheet-rolltemplate-custom-success-roll .sheet-container,
 	.sheet-rolltemplate-custom-normal-attack .sheet-container,
 	.sheet-rolltemplate-custom-power-attack .sheet-container,
 	.sheet-rolltemplate-custom-attack .sheet-container,
@@ -4584,7 +4587,8 @@
 	}
 	
 	/* Header formatting - title and subtitle */
-	.sheet-rolltemplate-custom .sheet-header {
+	.sheet-rolltemplate-custom .sheet-header,
+	.sheet-rolltemplate-custom-success-roll .sheet-header {
 		background-color: orange;
 		/* change text-align to center to center the header text */
 		text-align: left;
@@ -4633,6 +4637,7 @@
 	}
 	
 	.sheet-rolltemplate-custom .sheet-title,
+	.sheet-rolltemplate-custom-success-roll .sheet-title,
 	.sheet-rolltemplate-custom-normal-attack .sheet-title,
 	.sheet-rolltemplate-custom-power-attack .sheet-title,
 	.sheet-rolltemplate-custom-attack .sheet-title,
@@ -4642,6 +4647,7 @@
 	}
 	
 	.sheet-rolltemplate-custom .sheet-subtitle,
+	.sheet-rolltemplate-custom-success-roll .sheet-subtitle,
 	.sheet-rolltemplate-custom-normal-attack .sheet-subtitle,
 	.sheet-rolltemplate-custom-power-attack .sheet-subtitle,
 	.sheet-rolltemplate-custom-attack .sheet-subtitle,
@@ -4653,6 +4659,7 @@
 	
 	/* example colors */
 	.sheet-rolltemplate-custom .sheet-container,
+	.sheet-rolltemplate-custom-success-roll .sheet-container,
 	.sheet-rolltemplate-custom-normal-attack .sheet-container,
 	.sheet-rolltemplate-custom-power-attack .sheet-container,
 	.sheet-rolltemplate-custom-attack .sheet-container,
@@ -4665,6 +4672,7 @@
 	
 	/* Allprops part */
 	.sheet-rolltemplate-custom .sheet-content,
+	.sheet-rolltemplate-custom-success-roll .sheet-content,
 	.sheet-rolltemplate-custom-normal-attack .sheet-content,
 	.sheet-rolltemplate-custom-power-attack .sheet-content,
 	.sheet-rolltemplate-custom-attack .sheet-content,
@@ -4679,6 +4687,7 @@
 	}
 	
 	.sheet-rolltemplate-custom .sheet-content > div,
+	.sheet-rolltemplate-custom-success-roll .sheet-content > div,
 	.sheet-rolltemplate-custom-normal-attack .sheet-content > div,
 	.sheet-rolltemplate-custom-power-attack .sheet-content > div,
 	.sheet-rolltemplate-custom-attack .sheet-content > div,
@@ -4689,6 +4698,7 @@
 	
 	/* Left column */
 	.sheet-rolltemplate-custom .sheet-content .sheet-key,
+	.sheet-rolltemplate-custom-success-roll .sheet-content .sheet-key,
 	.sheet-rolltemplate-custom-normal-attack .sheet-content .sheet-key,
 	.sheet-rolltemplate-custom-power-attack .sheet-content .sheet-key,
 	.sheet-rolltemplate-custom-attack .sheet-content .sheet-key,
@@ -4702,6 +4712,7 @@
 	
 	/* Right column. Color to fix dark mode in Chrome. */
 	.sheet-rolltemplate-custom .sheet-value,
+	.sheet-rolltemplate-custom-success-roll .sheet-value,
 	.sheet-rolltemplate-custom-normal-attack .sheet-value,
 	.sheet-rolltemplate-custom-power-attack .sheet-value,
 	.sheet-rolltemplate-custom-attack .sheet-value,
@@ -4713,6 +4724,8 @@
 	/* Make even-numbered rows grey */
 	.sheet-rolltemplate-custom .sheet-content :nth-child(4n+3),
 	.sheet-rolltemplate-custom .sheet-content :nth-child(4n),
+	.sheet-rolltemplate-custom-success-roll .sheet-content :nth-child(4n+3),
+	.sheet-rolltemplate-custom-success-roll .sheet-content :nth-child(4n),
 	.sheet-rolltemplate-custom-normal-attack .sheet-content :nth-child(4n+3),
 	.sheet-rolltemplate-custom-normal-attack .sheet-content :nth-child(4n),
 	.sheet-rolltemplate-custom-power-attack .sheet-content :nth-child(4n+3),
@@ -4728,6 +4741,7 @@
 	
 	/* Description field */
 	.sheet-rolltemplate-custom .sheet-desc,
+	.sheet-rolltemplate-custom-success-roll .sheet-desc,
 	.sheet-rolltemplate-custom-normal-attack .sheet-desc,
 	.sheet-rolltemplate-custom-power-attack .sheet-desc,
 	.sheet-rolltemplate-custom-attack .sheet-desc,
@@ -4741,6 +4755,7 @@
 	
 	/* Dice roll face colors. Needed to prevent problems with dark mode. */
 	.sheet-rolltemplate-custom .inlinerollresult,
+	.sheet-rolltemplate-custom-success-roll .inlinerollresult,
 	.sheet-rolltemplate-custom-normal-attack .inlinerollresult,
 	.sheet-rolltemplate-custom-power-attack .inlinerollresult,
 	.sheet-rolltemplate-custom-attack .inlinerollresult,
@@ -4754,6 +4769,7 @@
 	}
 	
 	.sheet-rolltemplate-custom .sheet-template-wrapper .inlinerollresult,
+	.sheet-rolltemplate-custom-success-roll .sheet-template-wrapper .inlinerollresult,
 	.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult,
 	.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult,
 	.sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult,
@@ -4764,6 +4780,7 @@
 	}
 	
 	.sheet-rolltemplate-custom .sheet-template-wrapper .inlinerollresult.fullcrit,
+	.sheet-rolltemplate-custom-success-roll .sheet-template-wrapper .inlinerollresult.fullcrit,
 	.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
 	.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
 	.sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
@@ -4773,6 +4790,7 @@
 	}
 	
 	.sheet-rolltemplate-custom .sheet-template-wrapper .inlinerollresult.fullfail,
+	.sheet-rolltemplate-custom-success-roll .sheet-template-wrapper .inlinerollresult.fullfail,
 	.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult.fullfail,
 	.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult.fullfail,
 	.sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult.fullfail,

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -1312,7 +1312,7 @@
 		background-color: #fff990;
 		margin: 5px;
 		width: 450px;
-		height: 255px;
+		height: 280px;
 		margin: 0px;
 		border: solid 2px goldenrod;
 		border-radius: 3px;

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -1516,6 +1516,9 @@
 	}
 	
 	.buttonRollShow {
+		margin-right: 3px;
+		margin-left: 3px;
+		border-radius: 3px;
 		background-color: lightslategray;
 		min-width: 36px;
 		max-width: 38px;

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -1499,7 +1499,10 @@
 	}
 	
 	.buttonRollActivate {
+		margin-right: 3px;
+		margin-left: 3px;
 		background-color: steelblue;
+		border-radius: 3px;
 	}
 	
 	.buttonRollNormalAttack {

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -1312,7 +1312,7 @@
 		background-color: #fff990;
 		margin: 5px;
 		width: 450px;
-		height: 225px;
+		height: 255px;
 		margin: 0px;
 		border: solid 2px goldenrod;
 		border-radius: 3px;

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -1487,7 +1487,10 @@
 	}
 	
 	.buttonRoll {
+		margin-right: 3px;
+		margin-left: 3px;
 		background-color: orange;
+		border-radius: 3px;
 	}
 	
 	.buttonRollAttack {
@@ -2931,7 +2934,7 @@
 		max-width: 45px;
 		margin-right: 5px;
 		padding-bottom: 1px;
-		max-height: height: 22px;
+		max-height: 22px;
 		border: solid 1px palegoldenrod;
 	}
 	

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -5485,6 +5485,14 @@
 				<h1>Takes No STUN</h1>
 			</div>
 
+			<div class="item-options-row">
+				<label class="container-checkbox">
+					<input type="checkbox" checked="checked" name="attr_displayDegreeOfSuccess">
+					<span class="checkmark" title="@{displayDegreeOfSuccess}"></span>
+				</label>
+				<h1>Display Degree of Success</h1>
+			</div>
+
 			<div class="item-version-row">
 				<div class="item-version-label">
 					<h2>Version:</h2>
@@ -7340,19 +7348,31 @@
 	
 	var characteristics = ['strength', 'dexterity', 'constitution', 'intelligence', 'ego', 'presence']
 	characteristics.forEach(characteristic => {
-		var displayName = characteristic.charAt(0).toUpperCase() + characteristic.slice(1);
 		on (`clicked:${characteristic}`, (info) => {
-			var theRoll = "&{template:custom-success-roll} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses "+displayName+" }} ";
-			if (characteristic == 'dexterity') {
-				theRoll += "{{SUCCESS=[[@{dexterityChance}[Dexterity Chance]+@{weightDexDCVPenalty}[Weight Penalty]-3d6cf6cs1[Roll]+?{Modifiers|0}[Modifiers]]] }}";
-			} else {
-				theRoll += "{{SUCCESS=[[@{"+characteristic+"Chance}["+displayName+" Chance]-3d6cf6cs1[Roll]+?{Modifiers|0}[Modifiers]]] }}";
-			}
-
-			startRoll(theRoll, (results) => {
-				finishRoll(results.rollId,{
-					SUCCESS:results.results.SUCCESS.result
-				});
+			getAttrs(["displayDegreeOfSuccess"], function(values) {
+				var displayName = characteristic.charAt(0).toUpperCase() + characteristic.slice(1);
+				var theRoll = "";
+	
+				if (values.displayDegreeOfSuccess != 0) {
+					theRoll += "&{template:custom-success-roll} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses "+displayName+" }} ";
+					if (characteristic == 'dexterity') {
+						theRoll += "{{SUCCESS=[[@{dexterityChance}[Dexterity Chance]+@{weightDexDCVPenalty}[Weight Penalty]-3d6cf6cs1[Roll]+?{Modifiers|0}[Modifiers]]] }}";
+					} else {
+						theRoll += "{{SUCCESS=[[@{"+characteristic+"Chance}["+displayName+" Chance]-3d6cf6cs1[Roll]+?{Modifiers|0}[Modifiers]]] }}";
+					}
+				} else {
+					theRoll += "&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses "+displayName+"}} "
+					if (characteristic == 'dexterity') {
+						theRoll += "{{Base Chance = [[@{dexterityChance}[Dexterity Chance]+@{weightDexDCVPenalty}[Weight Penalty]+?{Modifiers|0}[Modifier]]] }}";
+					} else {
+						theRoll += "{{Base Chance = [[@{"+characteristic+"Chance}["+displayName+" Chance]+?{Modifiers|0}[Modifier]]] }}"
+					}
+					theRoll += "{{Roll=[[3d6cf6cs1]]}}";
+				}
+	
+				startRoll(theRoll, (results) => {
+					finishRoll(results.rollId,{});
+				});	
 			});
 		});
 	});
@@ -7361,17 +7381,29 @@
 	perceptionTypes.forEach(percType => {
 		var subtitleExt = (percType != '') ? " - @{perception"+percType+"Label}" : "";
 		on (`clicked:perceptionRoll${percType}`, (info) => {
-			var theRoll = "&{template:custom-success-roll} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses Perception"+subtitleExt+" }} "
-				+ "{{SUCCESS= [[@{intelligenceChance}[Intelligence Chance]+@{enhancedPerceptionModifier}[Perception Modifier]-3d6cf6cs1[Roll]";
-			if (percType != '') {
-				theRoll += "+@{perceptionModifier"+percType+"}[@{perception"+percType+"Label} Modifier]";
-			}
-			theRoll += "+?{Modifiers|0}[Modifier]]] }}"
+			getAttrs(["displayDegreeOfSuccess"], function(values) {
+				var theRoll = "";
 
-			startRoll(theRoll, (results) => {
-				finishRoll(results.rollId,{
-					SUCCESS:results.results.SUCCESS.result
+				if (values.displayDegreeOfSuccess != 0) {
+					theRoll += "&{template:custom-success-roll} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses Perception"+subtitleExt+" }} "
+						+ "{{SUCCESS= [[@{intelligenceChance}[Intelligence Chance]+@{enhancedPerceptionModifier}[Perception Modifier]-3d6cf6cs1[Roll]";
+					if (percType != '') {
+						theRoll += "+@{perceptionModifier"+percType+"}[@{perception"+percType+"Label} Modifier]";
+					}
+					theRoll += "+?{Modifiers|0}[Modifier]]] }}"
+				} else {
+					theRoll += "&{template:custom} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses Perception"+subtitleExt+" }} "
+						+ "{{Base Chance = [[@{intelligenceChance}[Intelligence Chance]+@{enhancedPerceptionModifier}[Perception Modifier]";
+					if (percType != '') {
+						theRoll += "+@{perceptionModifier"+percType+"}[@{perception"+percType+"Label} Modifier]";
+					}
+					theRoll += "+?{Modifiers|0}[Modifier]]] }} {{Roll=[[3d6cf6cs1]]}}"
+				}
+
+				startRoll(theRoll, (results) => {
+					finishRoll(results.rollId,{});
 				});
+
 			});
 		});
 	});
@@ -7379,13 +7411,20 @@
 	arrayOf(maxSkillNum).forEach(num => {
 		var skillId = String(num).padStart(2,'0');	
 		on(`clicked:testSkill${skillId}`, (info) => {
-			var theRoll = "&{template:custom-success-roll} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName"+skillId+"}}} "
-			+ "{{SUCCESS=[[@{skillRollChance"+skillId+"}[Skill Chance]-3d6cf6cs1[Roll]+?{Modifiers|0}[Modifiers]]] }}"
+			getAttrs(["displayDegreeOfSuccess"], function(values) {
+				var theRoll = "";
 
-			startRoll(theRoll, (results) => {
-				finishRoll(results.rollId,{
-					SUCCESS:results.results.SUCCESS.result
-				});
+				if (values.displayDegreeOfSuccess != 0) {
+					theRoll += "&{template:custom-success-roll} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName"+skillId+"}}} "
+						+ "{{SUCCESS=[[@{skillRollChance"+skillId+"}[Skill Chance]-3d6cf6cs1[Roll]+?{Modifiers|0}[Modifiers]]] }}"
+				} else {
+					theRoll += "&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName"+skillId+"}}} "
+						+ "{{Base Chance = [[@{skillRollChance"+skillId+"}[Skill Chance]+?{Modifiers|0}[Modifiers]]] }} {{Roll=[[3d6cf6cs1]]}}"
+				}
+	
+				startRoll(theRoll, (results) => {
+					finishRoll(results.rollId,{});
+				});	
 			});
 		});
 	});
@@ -7747,7 +7786,7 @@
 							
 			if (values.optionLiteracyCostsPoints!=0) {
 				literacyCost = 1;
-						}
+			}
 						
 			let skill41Cost = calculateLanguageSkillCost( values.skillFluency41 , values.skillLiteracy41, linguist, literacyCost);
 			let skill42Cost = calculateLanguageSkillCost( values.skillFluency42 , values.skillLiteracy42, linguist, literacyCost);

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1642,7 +1642,7 @@
 				</div>
 				
 				<input type="text" value="0" name="attr_skillRollChance01" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill01" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName01}}} {{Base Chance = [[@{skillRollChance01}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}">Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill01" title="%{testSkill01}" tabindex="-1">Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP01" tabindex="301"/>
 			</div>
 			
@@ -1685,7 +1685,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance02" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill02" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName02}}} {{Base Chance = [[@{skillRollChance02}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill02" tabindex="-1" title="%{testSkill02}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP02" tabindex="303"/>
 			</div>
 			
@@ -1728,7 +1728,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance03" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill03" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName03}}} {{Base Chance = [[@{skillRollChance03}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill03" tabindex="-1" title="%{testSkill03}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP03" tabindex="305"/>
 			</div>
 			
@@ -1771,7 +1771,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance04" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill04" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName04}}} {{Base Chance = [[@{skillRollChance04}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill04" tabindex="-1" title="%{testSkill04}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP04" tabindex="307"/>
 			</div>
 			
@@ -1814,7 +1814,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance05" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill05" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName05}}} {{Base Chance = [[@{skillRollChance05}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill05" tabindex="-1" title="%{testSkill05}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP05" tabindex="309"/>
 			</div>
 			
@@ -1857,7 +1857,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance06" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill06" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName06}}} {{Base Chance = [[@{skillRollChance06}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill06" tabindex="-1" title="%{testSkill06}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP06" tabindex="311"/>
 			</div>
 			
@@ -1900,7 +1900,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance07" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill07" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName07}}} {{Base Chance = [[@{skillRollChance07}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill07" tabindex="-1" title="%{testSkill07}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP07" tabindex="313"/>
 			</div>
 			
@@ -1943,7 +1943,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance08" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill08" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName08}}} {{Base Chance = [[@{skillRollChance08}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill08" tabindex="-1" title="%{testSkill08}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP08" tabindex="315"/>
 			</div>
 			
@@ -1986,7 +1986,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance09" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill09" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName09}}} {{Base Chance = [[@{skillRollChance09}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill09" tabindex="-1" title="%{testSkill09}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP09" tabindex="317"/>
 			</div>
 			
@@ -2029,7 +2029,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance10" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill10" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName10}}} {{Base Chance = [[@{skillRollChance10}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill10" tabindex="-1" title="%{testSkill10}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP10" tabindex="319"/>
 			</div>
 		</div>
@@ -2076,7 +2076,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance11" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill11" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName11}}} {{Base Chance = [[@{skillRollChance11}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill11" tabindex="-1" title="%{testSkill11}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP11" tabindex="321"/>
 			</div>
 			
@@ -2119,7 +2119,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance12" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill12" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName12}}} {{Base Chance = [[@{skillRollChance12}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill12" tabindex="-1" title="%{testSkill12}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP12" tabindex="323"/>
 			</div>
 			
@@ -2162,7 +2162,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance13" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill13" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName13}}} {{Base Chance = [[@{skillRollChance13}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill13" tabindex="-1" title="%{testSkill13}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP13" tabindex="325"/>
 			</div>
 			
@@ -2205,7 +2205,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance14" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill14" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName14}}} {{Base Chance = [[@{skillRollChance14}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill14" tabindex="-1" title="%{testSkill14}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP14" tabindex="327"/>
 			</div>
 			
@@ -2248,7 +2248,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance15" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill15" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName15}}} {{Base Chance = [[@{skillRollChance15}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill15" tabindex="-1" title="%{testSkill15}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP15" tabindex="329"/>
 			</div>
 			
@@ -2291,7 +2291,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance16" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill16" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName16}}} {{Base Chance = [[@{skillRollChance16}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill16" tabindex="-1" title="%{testSkill16}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP16" tabindex="331"/>
 			</div>
 			
@@ -2334,7 +2334,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance17" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill17" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName17}}} {{Base Chance = [[@{skillRollChance17}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill17" tabindex="-1" title="%{testSkill17}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP17" tabindex="333"/>
 			</div>
 			
@@ -2377,7 +2377,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance18" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill18" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName18}}} {{Base Chance = [[@{skillRollChance18}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill18" tabindex="-1" title="%{testSkill18}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP18" tabindex="335"/>
 			</div>
 			
@@ -2420,7 +2420,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance19" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill19" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName19}}} {{Base Chance = [[@{skillRollChance19}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill19" tabindex="-1" title="%{testSkill19}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP19" tabindex="337"/>
 			</div>
 			
@@ -2463,7 +2463,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance20" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill20" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName20}}} {{Base Chance = [[@{skillRollChance20}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill20" tabindex="-1" title="%{testSkill20}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP20" tabindex="339"/>
 			</div>
 		</div>
@@ -2510,7 +2510,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance21" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill21" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName21}}} {{Base Chance = [[@{skillRollChance21}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill21" tabindex="-1" title="%{testSkill21}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP21" tabindex="341"/>
 			</div>
 			
@@ -2553,7 +2553,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance22" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill22" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName22}}} {{Base Chance = [[@{skillRollChance22}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill22" tabindex="-1" title="%{testSkill22}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP22" tabindex="343"/>
 			</div>
 			
@@ -2596,7 +2596,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance23" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill23" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName23}}} {{Base Chance = [[@{skillRollChance23}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill23" tabindex="-1" title="%{testSkill23}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP23" tabindex="345"/>
 			</div>
 			
@@ -2639,7 +2639,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance24" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill24" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName24}}} {{Base Chance = [[@{skillRollChance24}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill24" tabindex="-1" title="%{testSkill24}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP24" tabindex="347"/>
 			</div>
 			
@@ -2682,7 +2682,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance25" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill25" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName25}}} {{Base Chance = [[@{skillRollChance25}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill25" tabindex="-1" title="%{testSkill25}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP25" tabindex="349"/>
 			</div>
 			
@@ -2725,7 +2725,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance26" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill26" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName26}}} {{Base Chance = [[@{skillRollChance26}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill26" tabindex="-1" title="%{testSkill26}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP26" tabindex="351"/>
 			</div>
 			
@@ -2768,7 +2768,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance27" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill27" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName27}}} {{Base Chance = [[@{skillRollChance27}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill27" tabindex="-1" title="%{testSkill27}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP27" tabindex="353"/>
 			</div>
 			
@@ -2811,7 +2811,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance28" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill28" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName28}}} {{Base Chance = [[@{skillRollChance28}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill28" tabindex="-1" title="%{testSkill28}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP28" tabindex="355"/>
 			</div>
 			
@@ -2854,7 +2854,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance29" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill29" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName29}}} {{Base Chance = [[@{skillRollChance29}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill29" tabindex="-1" title="%{testSkill29}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP29" tabindex="357"/>
 			</div>
 			
@@ -2897,7 +2897,7 @@
 					</select>
 				</div>
 				<input type="text" value="0" name="attr_skillRollChance30" readonly tabindex="-1"/>
-				<button type="roll" class='button buttonRoll' name="roll_testSkill30" tabindex="-1" value="&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName30}}} {{Base Chance = [[@{skillRollChance30}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+				<button type="action" class='button buttonRoll' name="act_testSkill30" tabindex="-1" title="%{testSkill30}" >Roll</button>
 				<input type="number" value="0" min="0" name="attr_skillCP30" tabindex="359"/>
 			</div>
 		</div>
@@ -7172,7 +7172,7 @@
 			theSkillRollChance = theBaseSkillRoll+theSkillBonus+additionalLevels;
 		}
 		return theSkillRollChance;
-			}
+	}
 			
 	function knowledgeIntSkillChance(theBaseSkillRoll, enhancer, skillCP, additionalLevels) {
 		// Knowledge, Professional, and Science Skills can be purchased as Intelligence-based skills. In such a case 
@@ -7304,6 +7304,23 @@
 				attributes["skillCP"+highId] = values["skillCP"+lowId];
 			
 				setAttrs(attributes);
+			});
+		});
+	});
+
+	/* ------------------- */
+	/* Skill Rolls         */
+	/* ------------------- */
+					
+	arrayOf(maxSkillNum).forEach(num => {
+		var skillId = String(num).padStart(2,'0');	
+		on(`clicked:testSkill${skillId}`, (info) => {
+			var theRoll = "&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName"+skillId+"}}} "
+			+ "{{Base Chance = [[@{skillRollChance"+skillId+"}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}";
+
+			startRoll(theRoll, (results) => {
+
+				finishRoll(results.rollId,{});
 			});
 		});
 	});

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -483,7 +483,7 @@
 							<option value="18" selected>NA</option>
 						</select>
 					</div>
-					<button type="roll" class="button buttonRollActivate" tabindex="-1" name="roll_armorActivation01" title="%{armorActivation01}" value="&{template:custom-activate} {{title=@{character_name} - @{character_title}}} {{subtitle= Defends with @{armorName01}**}} {{Activate on = [[@{armorActivation01}]] **or less**}} {{Result = [[3d6cf6cs1]]}} {{Resistant Defense = **rPD ``@{armorPD01}`` rED ``@{armorED01}``**}} {{Total Defense = **PD ``@{totalPD01}`` ED ``@{totalED01}``**}}" >Roll</button>
+					<button type="action" class="button buttonRollActivate" tabindex="-1" name="act_armorActivation01" title="%{armorActivation01}" >Roll</button>
 					<input type="text" class="armorLocationsText" name="attr_armorLocations01" title="@{armorLocations01}" maxlength="24" tabindex="54"/>
 					<input type="number" name="attr_armorMass01" title="@{armorMass01}" value="0" min="0" step="0.1" tabindex="55"/>
 				</div>
@@ -518,7 +518,7 @@
 							<option value="18" selected>NA</option>
 						</select>
 					</div>
-					<button type="roll" class="button buttonRollActivate" tabindex="-1" name="roll_armorActivation02" title="%{armorActivation02}" value="&{template:custom-activate} {{title=@{character_name} - @{character_title}}} {{subtitle= Defends with @{armorName02}**}} {{Activate on = [[@{armorActivation02}]] **or less**}} {{Result = [[3d6cf6cs1]]}} {{Resistant Defense = **rPD ``@{armorPD02}`` rED ``@{armorED02}``**}} {{Total Defense = **PD ``@{totalPD02}`` ED ``@{totalED02}``**}}" >Roll</button>
+					<button type="action" class="button buttonRollActivate" tabindex="-1" name="act_armorActivation02" title="%{armorActivation02}" >Roll</button>
 					<input type="text" class="armorLocationsText" name="attr_armorLocations02" title="@{armorLocations02}" maxlength="24" tabindex="59"/>
 					<input type="number" name="attr_armorMass02" title="@{armorMass02}" value="0" min="0" step="0.1" tabindex="60"/>
 				</div>
@@ -553,7 +553,7 @@
 							<option value="18" selected>NA</option>
 						</select>
 					</div>
-					<button type="roll" class="button buttonRollActivate" tabindex="-1" name="roll_armorActivation03" title="%{armorActivation03}" value="&{template:custom-activate} {{title=@{character_name} - @{character_title}}} {{subtitle= Defends with @{armorName03}**}} {{Activate on = [[@{armorActivation03}]] **or less**}} {{Result = [[3d6cf6cs1]]}} {{Resistant Defense = **rPD ``@{armorPD03}`` rED ``@{armorED03}``**}} {{Total Defense = **PD ``@{totalPD03}`` ED ``@{totalED03}``**}}" >Roll</button>
+					<button type="action" class="button buttonRollActivate" tabindex="-1" name="act_armorActivation03" title="%{armorActivation03}" >Roll</button>
 					<input type="text" class="armorLocationsText" name="attr_armorLocations03" title="@{armorLocations03}" maxlength="24" tabindex="64"/>
 					<input type="number" name="attr_armorMass03" title="@{armorMass03}" value="0" min="0" step="0.1" tabindex="65"/>
 				</div>
@@ -588,7 +588,7 @@
 							<option value="18" selected>NA</option>
 						</select>
 					</div>
-					<button type="roll" class="button buttonRollActivate" tabindex="-1" name="roll_armorActivation04" title="%{armorActivation04}" value="&{template:custom-activate} {{title=@{character_name} - @{character_title}}} {{subtitle= Defends with @{armorName04}**}} {{Activate on = [[@{armorActivation04}]] **or less**}} {{Result = [[3d6cf6cs1]]}} {{Resistant Defense = **rPD ``@{armorPD04}`` rED ``@{armorED04}``**}} {{Total Defense = **PD ``@{totalPD04}`` ED ``@{totalED04}``**}}" >Roll</button>
+					<button type="action" class="button buttonRollActivate" tabindex="-1" name="act_armorActivation04" title="%{armorActivation04}" >Roll</button>
 					<input type="text" class="armorLocationsText" name="attr_armorLocations04" title="@{armorLocations04}" maxlength="24" tabindex="69"/>
 					<input type="number" name="attr_armorMass04" title="@{armorMass04}" value="0" min="0" step="0.1" tabindex="70"/>
 				</div>
@@ -5832,6 +5832,7 @@
 	/* Functions used sheet-wide */
 	/* ------------------------- */
 	
+	const maxArmorNum = 4;
 	const maxWeaponNum = 5;
 	const maxEquipmentNum = 16;
 	const maxSkillNum = 30;
@@ -8058,6 +8059,30 @@
 		setAttrs({sheetTab:"characteristics"});
 	});
 	
+	/* ----------------------- */
+	/* --- Armor Functions --- */
+	/* ----------------------- */
+
+	arrayOf(maxArmorNum).forEach(num => {
+		var armorId = String(num).padStart(2,'0');	
+		on(`clicked:armorActivation${armorId}`, (info) => {
+			getAttrs(["whisperToGM"], function(values) {
+				var theRoll = values.whisperToGM != 0 ? "/w GM " : "";
+				
+				theRoll += "&{template:custom-activate} {{title=@{character_name} - @{character_title}}} "
+					+ "{{subtitle= Defends with @{armorName"+armorId+"}**}} "
+					+ "{{Activate on = [[@{armorActivation"+armorId+"}]] **or less**}} "
+					+ "{{Result = [[3d6cf6cs1]]}} "
+					+ "{{Resistant Defense = **rPD ``@{armorPD"+armorId+"}`` rED ``@{armorED"+armorId+"}``**}} "
+					+ "{{Total Defense = **PD ``@{totalPD"+armorId+"}`` ED ``@{totalED"+armorId+"}``**}}";
+				
+				startRoll(theRoll, (results) => {
+					finishRoll(results.rollId, {});
+				});
+			});
+		});
+	});
+
 	/* ------------------------------------------------ */
 	/* --- Weapon Attacks and Hit Location Helpers  --- */
 	/* ------------------------------------------------ */

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -5493,6 +5493,14 @@
 				<h1>Display Degree of Success</h1>
 			</div>
 
+			<div class="item-options-row">
+				<label class="container-checkbox">
+					<input type="checkbox" name="attr_whisperToGM">
+					<span class="checkmark" title="@{whisperToGM}"></span>
+				</label>
+				<h1>Whisper Rolls to GM</h1>
+			</div>
+
 			<div class="item-version-row">
 				<div class="item-version-label">
 					<h2>Version:</h2>
@@ -7056,26 +7064,30 @@
 	arrayOf(maxPowerNum).forEach(num => {
 		var powerId = String(num).padStart(2,'0');
 		on("clicked:powerRoll"+powerId, function() {
-			var theRoll = "&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} "
-				+ "{{subtitle= @{powerName"+powerId+"} - @{powerEffect"+powerId+"}}} {{desc=@{powerText"+powerId+"}}} "
-				+ "{{Activate On = [[?{Modifiers|0}+@{powerSkillRoll"+powerId+"}]] **or less**}} "
-				+ "{{Success Roll=[[3d6cf6cs1]]}} {{Attack Roll=[[3d6cf6cs1]]}} "
-				+ "{{Effect Roll=[[@{hiddenPowerDice"+powerId+"}sd]]}} "
-				+ "{{END=[[@{powerEND"+powerId+"}]] (@{CurrentEND})}}";
+			getAttrs(["displayDegreeOfSuccess", "whisperToGM"], function(values) {
+				var theRoll = values.whisperToGM != 0 ? "/w gm " : "";
 
-			startRoll(theRoll, (results) => {
-				// Roll activation and effect dice. If the option to auto apply endurance is TRUE, subtract the power's END once from endurance.
-				getAttrs(["optionAutoSubtractEND", "powerEND"+powerId], function(values) {
-					let powerEND = parseInt(values["powerEND"+powerId])||0;
+				theRoll += "&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} "
+					+ "{{subtitle= @{powerName"+powerId+"} - @{powerEffect"+powerId+"}}} {{desc=@{powerText"+powerId+"}}} "
+					+ "{{Activate On = [[?{Modifiers|0}+@{powerSkillRoll"+powerId+"}]] **or less**}} "
+					+ "{{Success Roll=[[3d6cf6cs1]]}} {{Attack Roll=[[3d6cf6cs1]]}} "
+					+ "{{Effect Roll=[[@{hiddenPowerDice"+powerId+"}sd]]}} "
+					+ "{{END=[[@{powerEND"+powerId+"}]] (@{CurrentEND})}}";
 
-					if (values.optionAutoSubtractEND != 0)
-						subtractEndurance(powerEND);
+				startRoll(theRoll, (results) => {
+					// Roll activation and effect dice. If the option to auto apply endurance is TRUE, subtract the power's END once from endurance.
+					getAttrs(["optionAutoSubtractEND", "powerEND"+powerId], function(values) {
+						let powerEND = parseInt(values["powerEND"+powerId])||0;
+
+						if (values.optionAutoSubtractEND != 0)
+							subtractEndurance(powerEND);
+					});
+
+					finishRoll(results.rollId, {});
 				});
-
-				finishRoll(results.rollId, {});
-			});
 			});
 		});
+	});
 	
 	// Update Tally Bar after change to any Power's CP cost.
 	on("change:powerCP01 change:powerCP02 change:powerCP03 change:powerCP04 change:powerCP05 change:powerCP06 change:powerCP07 change:powerCP08 change:powerCP09 change:powerCP10 change:powerCP11 change:powerCP12 change:powerCP13 change:powerCP14 change:powerCP15 change:powerCP16 change:powerCP17", function () {
@@ -7349,9 +7361,9 @@
 	var characteristics = ['strength', 'dexterity', 'constitution', 'intelligence', 'ego', 'presence']
 	characteristics.forEach(characteristic => {
 		on (`clicked:${characteristic}`, (info) => {
-			getAttrs(["displayDegreeOfSuccess"], function(values) {
+			getAttrs(["displayDegreeOfSuccess", "whisperToGM"], function(values) {
+				var theRoll = values.whisperToGM != 0 ? "/w gm " : "";
 				var displayName = characteristic.charAt(0).toUpperCase() + characteristic.slice(1);
-				var theRoll = "";
 	
 				if (values.displayDegreeOfSuccess != 0) {
 					theRoll += "&{template:custom-success-roll} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses "+displayName+" }} ";
@@ -7381,8 +7393,8 @@
 	perceptionTypes.forEach(percType => {
 		var subtitleExt = (percType != '') ? " - @{perception"+percType+"Label}" : "";
 		on (`clicked:perceptionRoll${percType}`, (info) => {
-			getAttrs(["displayDegreeOfSuccess"], function(values) {
-				var theRoll = "";
+			getAttrs(["displayDegreeOfSuccess", "whisperToGM"], function(values) {
+				var theRoll = values.whisperToGM != 0 ? "/w gm " : "";
 
 				if (values.displayDegreeOfSuccess != 0) {
 					theRoll += "&{template:custom-success-roll} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses Perception"+subtitleExt+" }} "
@@ -7411,8 +7423,8 @@
 	arrayOf(maxSkillNum).forEach(num => {
 		var skillId = String(num).padStart(2,'0');	
 		on(`clicked:testSkill${skillId}`, (info) => {
-			getAttrs(["displayDegreeOfSuccess"], function(values) {
-				var theRoll = "";
+			getAttrs(["displayDegreeOfSuccess", "whisperToGM"], function(values) {
+				var theRoll = values.whisperToGM != 0 ? "/w gm " : "";
 
 				if (values.displayDegreeOfSuccess != 0) {
 					theRoll += "&{template:custom-success-roll} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName"+skillId+"}}} "
@@ -8319,7 +8331,8 @@
 			// Roll attack and damage dice for Weapon XX.
 			
 			getAttrs(["weaponNormalDamage"+weaponId, "weaponStunMod"+weaponId, "weaponEndurance"+weaponId, "weaponAreaEffect"+weaponId,
-					"optionAutoSubtractEND", "optionHitLocationSystem"], function(values) {
+					"optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM"], function(values) {
+				var theRoll = values.whisperToGM != 0 ? "/w gm " : "";
 				let areaOfEffect = values["weaponAreaEffect"+weaponId] != 0;
 				let useHitLocations = values.optionHitLocationSystem != 0;
 				let isNormalDamage = values["weaponNormalDamage"+weaponId] != 0;
@@ -8331,7 +8344,7 @@
 				let otherDmgType = isNormalDamage ? "BODY" : "STUN";
 				
 				// If isNormalDamage is TRUE, use the Normal Damage template.
-				var theRoll = "&{template:custom"+(isNormalDamage ? "-normal" : "")+"-attack} {{title=@{character_name} - @{character_title}}} "
+				theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "")+"-attack} {{title=@{character_name} - @{character_title}}} "
 						+ "{{subtitle= Makes a " + (isNormalDamage ? "normal" : "killing") + " attack with @{weaponName"+weaponId+"}}} "
 						+ "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{weaponOCV"+weaponId+"}[WeaponOCV]-[["+ (areaOfEffect ? 0 : 1) +"*@{targetOCVPenalty}]][TargetOCV]+?{Modifiers|0}[Modifier]]]}} "
 						+ (subtractENDAmt ? "{{END=[[@{weaponEndurance"+weaponId+"}]] (@{currentEND})}} " : "")
@@ -8381,7 +8394,8 @@
 	on('clicked:attackShield', (info) => {
 		// Roll attack and damage dice for the shield.
 						
-		getAttrs(["shieldNormalDamage", "shieldStunMod", "shieldEndurance", "optionAutoSubtractEND", "optionHitLocationSystem"], function(values) {
+		getAttrs(["shieldNormalDamage", "shieldStunMod", "shieldEndurance", "optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM"], function(values) {
+			var theRoll = values.whisperToGM != 0 ? "/w GM " : "";
 			let useHitLocations = values.optionHitLocationSystem != 0;
 			let isNormalDamage = values.shieldNormalDamage != 0;
 			let stunMod = parseInt(values.shieldStunMod)||0;
@@ -8392,7 +8406,7 @@
 			let otherDmgType = isNormalDamage ? "BODY" : "STUN";
 
 			// If isNormalDamage is TRUE, use the Normal Damage template.
-			var theRoll = "&{template:custom"+(isNormalDamage ? "-normal" : "")+"-attack} {{title=@{character_name} - @{character_title}}} "
+			theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "")+"-attack} {{title=@{character_name} - @{character_title}}} "
 					+ "{{subtitle= Makes a " + (isNormalDamage ? "normal" : "killing") + " attack with @{shieldName}}} "
 					+ "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{shieldOCV}[Shield OCV]-[[abs(?{Blocking|Yes,1|No,-1}-1)/2*@{targetOCVpenalty}]][TargetOCV]+[[?{Blocking}*@{shieldDCV}]][ShieldDCV]+?{Modifiers|0}[Modifier]]]}} "
 					+ (subtractENDAmt ? "{{END=[[[[abs(?{Blocking}-1)/2]][Blocking]*@{shieldEndurance}[Endurance Cost]]] (@{currentEND})}} " : "")
@@ -8452,12 +8466,13 @@
 	on('clicked:standardAttackRoll', (info) => {
 		// Roll attack and damage dice for standardAttack
 
-		getAttrs(["hiddenBasicEndurance", "optionAutoSubtractEND", "optionHitLocationSystem"], function(values) {
+		getAttrs(["hiddenBasicEndurance", "optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM"], function(values) {
+			var theRoll = values.whisperToGM != 0 ? "/w GM " : "";
 			let useHitLocations = values.optionHitLocationSystem != 0;
 
 			let subtractENDAmt = parseInt(values.hiddenBasicEndurance)||0;
 
-			let theRoll = "&{template:custom-normal-attack} {{title=@{character_name} - @{character_title}}} "
+			theRoll += "&{template:custom-normal-attack} {{title=@{character_name} - @{character_title}}} "
 				+ "{{subtitle= Makes a normal attack with Strength @{strength}}} "
 				+ "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]-@{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} "
 				+ (subtractENDAmt ? "{{END=[[@{hiddenBasicEndurance}]] (@{currentEND})}} " : "")

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -347,7 +347,7 @@
 						<div class="subitem-characteristics-perception-column-container">
 							<input type="text" name="attr_intelligenceChance" title="@{intelligenceChance}" value="11" readonly tabindex="-1">
 							<span>+<input type="number" name="attr_enhancedPerceptionModifier" title="@{enhancedPerceptionModifier}" value="0" min="-10" max="10" step="1" tabindex="29"></span>
-							<button type="roll" class="button buttonRoll" tabindex="-1" name="roll_perceptionRoll" title="%{perceptionRoll}" value="&{template:custom} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses Perception}} {{Base Chance = [[@{intelligenceChance}[Intelligence Chance]+@{enhancedPerceptionModifier}[Perception Modifier]+?{Modifiers|0}[Modifier]]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+							<button type="action" class="button buttonRoll" tabindex="-1" name="act_perceptionRoll" title="%{perceptionRoll}" >Roll</button>
 						</div>
 					</div>
 					
@@ -356,7 +356,7 @@
 						<div class="subitem-characteristics-perception-column-container">
 							<input type="text" name="attr_perceptionEnhanced" title="@{perceptionEnhanced}" value="11" readonly tabindex="-1">
 							<span>+<input type="number" name="attr_perceptionModifierVision" title="@{perceptionModifierVision}" value="0" min="-10" max="10" step="1" tabindex="31"></span>
-							<button type="roll" class="button buttonRoll" tabindex="-1" name="roll_perceptionRollVision" title="%{roll_perceptionRollVision}" value="&{template:custom} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses Perception - @{perceptionVisionLabel} }} {{Base Chance = [[@{intelligenceChance}[Intelligence Chance]+@{enhancedPerceptionModifier}[Perception Modifier]+@{perceptionModifierVision}[@{perceptionVisionLabel} Modifier]+?{Modifiers|0}[Modifier]]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+							<button type="action" class="button buttonRoll" tabindex="-1" name="act_perceptionRollVision" title="%{roll_perceptionRollVision}" >Roll</button>
 						</div>
 					</div>
 					
@@ -365,7 +365,7 @@
 						<div class="subitem-characteristics-perception-column-container">
 							<input type="text" name="attr_perceptionEnhanced" title="@{perceptionEnhanced}" value="11" readonly tabindex="-1">
 							<span>+<input type="number" name="attr_perceptionModifierHearing" title="@{perceptionModifierHearing}" value="0" min="-10" max="10" step="1" tabindex="33"></span>
-							<button type="roll" class="button buttonRoll" tabindex="-1" name="roll_perceptionRollHearing" title="%{roll_perceptionRollHearing}" value="&{template:custom} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses Perception - @{perceptionHearingLabel} }} {{Base Chance = [[?{Modifiers|0}+@{intelligenceChance}[Intelligence Chance]+@{enhancedPerceptionModifier}[Perception Modifier]+@{perceptionModifierHearing}[@{perceptionHearingLabel} Modifier]+?{Modifiers|0}[Modifier]]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+							<button type="action" class="button buttonRoll" tabindex="-1" name="act_perceptionRollHearing" title="%{roll_perceptionRollHearing}" >Roll</button>
 						</div>
 					</div>
 					
@@ -374,7 +374,7 @@
 						<div class="subitem-characteristics-perception-column-container">
 							<input type="text" name="attr_perceptionEnhanced" title="@{perceptionEnhanced}" value="11" readonly tabindex="-1">
 							<span>+<input type="number" name="attr_perceptionModifierSmell" title="@{perceptionModifierSmell}" value="0" min="-10" max="10" step="1" tabindex="35"></span>
-							<button type="roll" class="button buttonRoll" tabindex="-1" name="roll_perceptionRollSmell" title="%{roll_perceptionRollSmell}" value="&{template:custom} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses Perception - @{perceptionSmellLabel} }} {{Base Chance = [[?{Modifiers|0}+@{intelligenceChance}[Intelligence Chance]+@{enhancedPerceptionModifier}[Perception Modifier]+@{perceptionModifierSmell}[@{perceptionSmellLabel} Modifier]+?{Modifiers|0}[Modifier]]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+							<button type="action" class="button buttonRoll" tabindex="-1" name="act_perceptionRollSmell" title="%{roll_perceptionRollSmell}" >Roll</button>
 						</div>
 					</div>
 				</div>
@@ -7335,7 +7335,7 @@
 	});
 
 	/* ------------------- */
-	/* Success Rolls         */
+	/* Success Rolls       */
 	/* ------------------- */
 	
 	var characteristics = ['strength', 'dexterity', 'constitution', 'intelligence', 'ego', 'presence']
@@ -7348,6 +7348,25 @@
 			} else {
 				theRoll += "{{SUCCESS=[[@{"+characteristic+"Chance}["+displayName+" Chance]-3d6cf6cs1[Roll]+?{Modifiers|0}[Modifiers]]] }}";
 			}
+
+			startRoll(theRoll, (results) => {
+				finishRoll(results.rollId,{
+					SUCCESS:results.results.SUCCESS.result
+				});
+			});
+		});
+	});
+
+	var perceptionTypes = ['', 'Vision', 'Hearing', 'Smell']
+	perceptionTypes.forEach(percType => {
+		var subtitleExt = (percType != '') ? " - @{perception"+percType+"Label}" : "";
+		on (`clicked:perceptionRoll${percType}`, (info) => {
+			var theRoll = "&{template:custom-success-roll} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses Perception"+subtitleExt+" }} "
+				+ "{{SUCCESS= [[@{intelligenceChance}[Intelligence Chance]+@{enhancedPerceptionModifier}[Perception Modifier]-3d6cf6cs1[Roll]";
+			if (percType != '') {
+				theRoll += "+@{perceptionModifier"+percType+"}[@{perception"+percType+"Label} Modifier]";
+			}
+			theRoll += "+?{Modifiers|0}[Modifier]]] }}"
 
 			startRoll(theRoll, (results) => {
 				finishRoll(results.rollId,{

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -5578,7 +5578,33 @@
 		</div>
 	  </div>
 	</div>
-</rolltemplate> 
+</rolltemplate>
+
+<rolltemplate class="sheet-rolltemplate-custom-success-roll">
+	<div class="template-wrapper">
+		<div class="sheet-container sheet-color-{{color}}">
+			<div class="sheet-header">
+				{{#title}}<div class="sheet-title">{{title}}</div>{{/title}}
+				{{#subtitle}}<div class="sheet-subtitle">{{subtitle}}</div>{{/subtitle}}
+			</div>
+			<div class="sheet-content">
+				{{#rollGreater() computed::SUCCESS -1}}
+				<div class="sheet-key">Degree of Success</div>
+				<div class="sheet-value">{{SUCCESS}}</div>
+				{{/rollGreater() computed::SUCCESS -1}}
+				{{#rollLess() computed::SUCCESS 0}}
+				<div class="sheet-key">Degree of Failure</div>
+				<div class="sheet-value">{{SUCCESS}}</div>
+				{{/rollLess() computed::SUCCESS 0}}
+				{{#allprops() title subtitle desc color SUCCESS}}
+				<div class="sheet-key">{{key}}</div>
+				<div class="sheet-value">{{value}}</div>
+				{{/allprops() title subtitle desc color SUCCESS}}
+				{{#desc}}<div class="sheet-desc">{{desc}}</div>{{/desc}}
+			</div>
+		</div>
+	</div>
+</rolltemplate>
 
 <!-- Jackob's Roll Template for normal damage attacks -->
 <!-- Includes row for computed BODY damage using July, 2021 Roll Parsing feature -->
@@ -7315,12 +7341,13 @@
 	arrayOf(maxSkillNum).forEach(num => {
 		var skillId = String(num).padStart(2,'0');	
 		on(`clicked:testSkill${skillId}`, (info) => {
-			var theRoll = "&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName"+skillId+"}}} "
-			+ "{{Base Chance = [[@{skillRollChance"+skillId+"}+?{Modifiers|0}]] }} {{Roll=[[3d6cf6cs1]]}} {{}}";
+			var theRoll = "&{template:custom-success-roll} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName"+skillId+"}}} "
+			+ "{{SUCCESS=[[@{skillRollChance"+skillId+"}[Skill Chance]-3d6cf6cs1[Roll]+?{Modifiers|0}[Modifiers]]] }}"
 
 			startRoll(theRoll, (results) => {
-
-				finishRoll(results.rollId,{});
+				finishRoll(results.rollId,{
+					SUCCESS:results.results.SUCCESS.result
+				});
 			});
 		});
 	});

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -5728,10 +5728,20 @@
 				{{#subtitle}}<div class="sheet-subtitle">{{subtitle}}</div>{{/subtitle}}
 			</div>
 			<div class="sheet-content">
-				{{#allprops() title subtitle desc color}}
+				{{#SUCCESS}}
+					{{#rollGreater() computed::SUCCESS -1}}
+					<div class="sheet-key">Activate Power</div>
+					<div class="sheet-value">{{SUCCESS}}</div>
+					{{/rollGreater() computed::SUCCESS -1}}
+					{{#rollLess() computed::SUCCESS 0}}
+					<div class="sheet-key">Failed to Activate</div>
+					<div class="sheet-value">{{SUCCESS}}</div>
+					{{/rollLess() computed::SUCCESS 0}}
+				{{/SUCCESS}}
+				{{#allprops() title subtitle desc color SUCCESS}}
 				<div class="sheet-key">{{key}}</div>
 				<div class="sheet-value">{{value}}</div>
-				{{/allprops() title subtitle desc color}}
+				{{/allprops() title subtitle desc color SUCCESS}}
 				{{#desc}}<div class="sheet-desc">{{desc}}</div>{{/desc}}
 			</div>
 		</div>
@@ -7082,10 +7092,14 @@
 				var theRoll = values.whisperToGM != 0 ? "/w gm " : "";
 
 				theRoll += "&{template:custom-power-attack} {{title=@{character_name} - @{character_title}}} "
-					+ "{{subtitle= @{powerName"+powerId+"} - @{powerEffect"+powerId+"}}} {{desc=@{powerText"+powerId+"}}} "
-					+ "{{Activate On = [[?{Modifiers|0}+@{powerSkillRoll"+powerId+"}]] **or less**}} "
-					+ "{{Success Roll=[[3d6cf6cs1]]}} {{Attack Roll=[[3d6cf6cs1]]}} "
-					+ "{{Effect Roll=[[@{hiddenPowerDice"+powerId+"}sd]]}} "
+					+ "{{subtitle= @{powerName"+powerId+"} - @{powerEffect"+powerId+"}}} {{desc=@{powerText"+powerId+"}}} ";
+				if (values.displayDegreeOfSuccess != 0) {
+					theRoll += "{{SUCCESS=[[@{powerSkillRoll"+powerId+"}[Activation]-3d6cf6cs1[Roll]+?{Modifiers|0}[Modifiers]]]}} "
+				} else {
+					theRoll += "{{Activate On = [[@{powerSkillRoll"+powerId+"}[Activation]+?{Modifiers|0}[Modifiers]]] **or less**}} "
+						+ "{{Success Roll=[[3d6cf6cs1]]}} {{Attack Roll=[[3d6cf6cs1]]}} ";
+				}
+				theRoll += "{{Effect Roll=[[@{hiddenPowerDice"+powerId+"}sd]]}} "
 					+ "{{END=[[@{powerEND"+powerId+"}]] (@{CurrentEND})}}";
 
 				startRoll(theRoll, (results) => {

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -5604,6 +5604,7 @@
 				{{#subtitle}}<div class="sheet-subtitle">{{subtitle}}</div>{{/subtitle}}
 			</div>
 			<div class="sheet-content">
+				{{#SUCCESS}}
 				{{#rollGreater() computed::SUCCESS -1}}
 				<div class="sheet-key">Degree of Success</div>
 				<div class="sheet-value">{{SUCCESS}}</div>
@@ -5612,6 +5613,7 @@
 				<div class="sheet-key">Degree of Failure</div>
 				<div class="sheet-value">{{SUCCESS}}</div>
 				{{/rollLess() computed::SUCCESS 0}}
+				{{/SUCCESS}}
 				{{#allprops() title subtitle desc color SUCCESS}}
 				<div class="sheet-key">{{key}}</div>
 				<div class="sheet-value">{{value}}</div>
@@ -5697,10 +5699,20 @@
 		  {{#subtitle}}<div class="sheet-subtitle">{{subtitle}}</div>{{/subtitle}}
 		</div>
 		<div class="sheet-content">
-		  {{#allprops() title subtitle desc color}}
+		  {{#SUCCESS}}
+			{{#rollGreater() computed::SUCCESS -1}}
+			<div class="sheet-key">Activate Armor</div>
+			<div class="sheet-value">{{SUCCESS}}</div>
+			{{/rollGreater() computed::SUCCESS -1}}
+			{{#rollLess() computed::SUCCESS 0}}
+			<div class="sheet-key">Failed to Activate</div>
+			<div class="sheet-value">{{SUCCESS}}</div>
+			{{/rollLess() computed::SUCCESS 0}}
+		  {{/SUCCESS}}
+		  {{#allprops() title subtitle desc color SUCCESS}}
 		  <div class="sheet-key">{{key}}</div>
 		  <div class="sheet-value">{{value}}</div>
-		  {{/allprops() title subtitle desc color}}
+		  {{/allprops() title subtitle desc color SUCCESS}}
 		  {{#desc}}<div class="sheet-desc">{{desc}}</div>{{/desc}}
 		</div>
 	  </div>
@@ -8065,16 +8077,25 @@
 	/* ----------------------- */
 
 	arrayOf(maxArmorNum).forEach(num => {
-		var armorId = String(num).padStart(2,'0');	
+		var armorId = String(num).padStart(2,'0');
 		on(`clicked:armorActivation${armorId}`, (info) => {
-			getAttrs(["whisperToGM"], function(values) {
+			getAttrs(["whisperToGM", "displayDegreeOfSuccess", "armorActivation"+armorId, "armorLocations"+armorId], function(values) {
 				var theRoll = values.whisperToGM != 0 ? "/w GM " : "";
+				var actOn = values["armorActivation"+armorId]||18;
+				var locations = values["armorLocations"+armorId]||"";
 				
 				theRoll += "&{template:custom-activate} {{title=@{character_name} - @{character_title}}} "
-					+ "{{subtitle= Defends with @{armorName"+armorId+"}**}} "
-					+ "{{Activate on = [[@{armorActivation"+armorId+"}]] **or less**}} "
-					+ "{{Result = [[3d6cf6cs1]]}} "
-					+ "{{Resistant Defense = **rPD ``@{armorPD"+armorId+"}`` rED ``@{armorED"+armorId+"}``**}} "
+					+ "{{subtitle= Defends with @{armorName"+armorId+"}**}} ";
+				if (actOn >= 18 && locations != "") {
+					theRoll += "{{Locations=@{armorLocations"+armorId+"}}}";
+				} else if (values.displayDegreeOfSuccess != 0) {
+					theRoll += "{{SUCCESS=[[@{armorActivation"+armorId+"}[Armor Activation]-3d6cf6cs1[Roll]]]}} ";
+				} else {
+					theRoll += "{{Activate on = [[@{armorActivation"+armorId+"}]] **or less**}} "
+						+ "{{Result = [[3d6cf6cs1]]}} ";
+				}
+
+				theRoll += "{{Resistant Defense = **rPD ``@{armorPD"+armorId+"}`` rED ``@{armorED"+armorId+"}``**}} "
 					+ "{{Total Defense = **PD ``@{totalPD"+armorId+"}`` ED ``@{totalED"+armorId+"}``**}}";
 				
 				startRoll(theRoll, (results) => {

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -5141,7 +5141,7 @@
 				</div>
 				
 				<input type="text" name="attr_talentName01" value="" maxlength="32" tabindex="600"/>
-				<button type="roll" class="button buttonRollShow" tabindex="-1" name="roll_showTalentRoll01" value="&{template:custom-show} {{title=@{character_name} - @{character_title}}} {{subtitle= Perks & Talents - @{talentName01}}} {{desc=@{talentText01}}}">Show</button>
+				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showTalentRoll01" title="%{showTalentRoll01}">Show</button>
 				<h1>CP:</h1>
 				<input type="number" name="attr_talentCP01" value="0" min="0" tabindex="601"/>
 			</div>
@@ -5163,7 +5163,7 @@
 				</div>
 				
 				<input type="text" name="attr_talentName02" value="" maxlength="32" tabindex="603"/>
-				<button type="roll" class="button buttonRollShow" tabindex="-1" name="roll_showTalentRoll02" value="&{template:custom-show} {{title=@{character_name} - @{character_title}}} {{subtitle= Perks & Talents - @{talentName02}}} {{desc=@{talentText02}}}">Show</button>
+				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showTalentRoll02" title="%{showTalentRoll02}">Show</button>
 				<h1>CP:</h1>
 				<input type="number" name="attr_talentCP02" value="0" min="0" tabindex="604"/>
 			</div>
@@ -5185,7 +5185,7 @@
 				</div>
 				
 				<input type="text" name="attr_talentName03" value="" maxlength="32"tabindex="606"/>
-				<button type="roll" class="button buttonRollShow" tabindex="-1" name="roll_showTalentRoll03" value="&{template:custom-show} {{title=@{character_name} - @{character_title}}} {{subtitle= Perks & Talents - @{talentName03}}} {{desc=@{talentText03}}}">Show</button>
+				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showTalentRoll03" title="%{showTalentRoll03}">Show</button>
 				<h1>CP:</h1>
 				<input type="number" name="attr_talentCP03" value="0" min="0" tabindex="607"/>
 			</div>
@@ -5207,7 +5207,7 @@
 				</div>
 				
 				<input type="text" name="attr_talentName04" value="" maxlength="32" tabindex="609"/>
-				<button type="roll" class="button buttonRollShow" tabindex="-1" name="roll_showTalentRoll04" value="&{template:custom-show} {{title=@{character_name} - @{character_title}}} {{subtitle= Perks & Talents - @{talentName04}}} {{desc=@{talentText04}}}">Show</button>
+				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showTalentRoll04" title="%{showTalentRoll04}">Show</button>
 				<h1>CP:</h1>
 				<input type="number" name="attr_talentCP04" value="0" min="0" tabindex="610"/>
 			</div>
@@ -5229,7 +5229,7 @@
 				</div>
 				
 				<input type="text" name="attr_talentName05" value="" maxlength="32" tabindex="612"/>
-				<button type="roll" class="button buttonRollShow" tabindex="-1" name="roll_showTalentRoll05" value="&{template:custom-show} {{title=@{character_name} - @{character_title}}} {{subtitle= Perks & Talents - @{talentName05}}} {{desc=@{talentText05}}}">Show</button>
+				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showTalentRoll05" title="%{showTalentRoll05}">Show</button>
 				<h1>CP:</h1>
 				<input type="number" name="attr_talentCP05" value="0" min="0" tabindex="613"/>
 			</div>
@@ -5251,7 +5251,7 @@
 				</div>
 				
 				<input type="text" name="attr_talentName06" value="" maxlength="32" tabindex="615"/>
-				<button type="roll" class="button buttonRollShow" tabindex="-1" name="roll_showTalentRoll06" value="&{template:custom-show} {{title=@{character_name} - @{character_title}}} {{subtitle= Perks & Talents - @{talentName06}}} {{desc=@{talentText06}}}">Show</button>
+				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showTalentRoll06" title="%{showTalentRoll06}">Show</button>
 				<h1>CP:</h1>
 				<input type="number" name="attr_talentCP06" value="0" min="0" tabindex="616"/>
 			</div>
@@ -5273,7 +5273,7 @@
 				</div>
 				
 				<input type="text" name="attr_talentName07" value="" maxlength="32" tabindex="618"/>
-				<button type="roll" class="button buttonRollShow" tabindex="-1" name="roll_showTalentRoll07" value="&{template:custom-show} {{title=@{character_name} - @{character_title}}} {{subtitle= Perks & Talents - @{talentName07}}} {{desc=@{talentText07}}}">Show</button>
+				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showTalentRoll07" title="%{showTalentRoll07}">Show</button>
 				<h1>CP:</h1>
 				<input type="number" name="attr_talentCP07" value="0" min="0" tabindex="619"/>
 			</div>
@@ -5300,7 +5300,7 @@
 				</div>
 				
 				<input type="text" name="attr_complicationName01" value="" maxlength="32" tabindex="630"/>
-				<button type="roll" class="button buttonRollShow" tabindex="-1" name="roll_showComplicationRoll01" value="&{template:custom-show} {{title=@{character_name} - @{character_title}}} {{subtitle= Complication - @{complicationName01}}} {{desc=@{complicationText01}}}">Show</button>
+				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showComplicationRoll01" title="%{showComplicationRoll01}">Show</button>
 				<h1>CP:</h1>
 				<input type="number" name="attr_complicationCP01" value="0" min="0" tabindex="631"/>
 			</div>
@@ -5322,7 +5322,7 @@
 				</div>
 				
 				<input type="text" name="attr_complicationName02" value="" maxlength="32" tabindex="633"/>
-				<button type="roll" class="button buttonRollShow" tabindex="-1" name="roll_showComplicationRoll02" value="&{template:custom-show} {{title=@{character_name} - @{character_title}}} {{subtitle= Complication - @{complicationName02}}} {{desc=@{complicationText02}}}">Show</button>
+				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showComplicationRoll02" title="%{showComplicationRoll02}">Show</button>
 				<h1>CP:</h1>
 				<input type="number" name="attr_complicationCP02" value="0" min="0" tabindex="634"/>
 			</div>
@@ -5344,7 +5344,7 @@
 				</div>
 				
 				<input type="text" name="attr_complicationName03" value="" maxlength="32" tabindex="636"/>
-				<button type="roll" class="button buttonRollShow" tabindex="-1" name="roll_showComplicationRoll03" value="&{template:custom-show} {{title=@{character_name} - @{character_title}}} {{subtitle= Complication - @{complicationName03}}} {{desc=@{complicationText03}}}">Show</button>
+				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showComplicationRoll03" title="%{showComplicationRoll03}">Show</button>
 				<h1>CP:</h1>
 				<input type="number" name="attr_complicationCP03" value="0" min="0" tabindex="637"/>
 			</div>
@@ -5366,7 +5366,7 @@
 				</div>
 				
 				<input type="text" name="attr_complicationName04" value="" maxlength="32" tabindex="639"/>
-				<button type="roll" class="button buttonRollShow" tabindex="-1" name="roll_showComplicationRoll04" value="&{template:custom-show} {{title=@{character_name} - @{character_title}}} {{subtitle= Complication - @{complicationName04}}} {{desc=@{complicationText04}}}">Show</button>
+				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showComplicationRoll04" title="%{showComplicationRoll04}">Show</button>
 				<h1>CP:</h1>
 				<input type="number" name="attr_complicationCP04" value="0" min="0" tabindex="640"/>
 			</div>
@@ -5388,7 +5388,7 @@
 				</div>
 				
 				<input type="text" name="attr_complicationName05" value="" maxlength="32" tabindex="642"/>
-				<button type="roll" class="button buttonRollShow" tabindex="-1" name="roll_showComplicationRoll05" value="&{template:custom-show} {{title=@{character_name} - @{character_title}}} {{subtitle= Complication - @{complicationName05}}} {{desc=@{complicationText05}}}">Show</button>
+				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showComplicationRoll05" title="%{showComplicationRoll05}">Show</button>
 				<h1>CP:</h1>
 				<input type="number" name="attr_complicationCP05" value="0" min="0" tabindex="643"/>
 			</div>
@@ -5410,7 +5410,7 @@
 				</div>
 				
 				<input type="text" name="attr_complicationName06" value="" maxlength="32" tabindex="645"/>
-				<button type="roll" class="button buttonRollShow" tabindex="-1" name="roll_showComplicationRoll06" value="&{template:custom-show} {{title=@{character_name} - @{character_title}}} {{subtitle= Complication - @{complicationName06}}} {{desc=@{complicationText06}}}">Show</button>
+				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showComplicationRoll06" title="%{showComplicationRoll06}">Show</button>
 				<h1>CP:</h1>
 				<input type="number" name="attr_complicationCP06" value="0" min="0" tabindex="646"/>
 			</div>
@@ -8108,7 +8108,6 @@
 		});
 	});
 
-
 	/* ------------------------------------------------ */
 	/* --- Weapon Attacks and Hit Location Helpers  --- */
 	/* ------------------------------------------------ */
@@ -8576,9 +8575,9 @@
 		});
 	});
 	
-	/* ------------- */
-	/* Talent Movers */
-	/* ------------- */
+	/* ---------------- */
+	/* Talent Functions */
+	/* ---------------- */
 	
 	arrayOf(maxTalentNum).forEach(num => {
 		var lowId = String(num).padStart(2,'0');
@@ -8597,10 +8596,27 @@
 			});
 		});
 	});
+
+	arrayOf(maxTalentNum).forEach(num => {
+		var talentId = String(num).padStart(2,'0');	
+		on(`clicked:showTalentRoll${talentId}`, (info) => {
+			getAttrs(["whisperToGM"], function(values) {
+				var theRoll = values.whisperToGM != 0 ? "/w GM " : "";
+				
+				theRoll += "&{template:custom-show} {{title=@{character_name} - @{character_title}}} "
+					+ "{{subtitle= Perks & Talents - @{talentName"+talentId+"}}} "
+					+ "{{desc=@{talentText"+talentId+"}}}";
+				
+				startRoll(theRoll, (results) => {
+					finishRoll(results.rollId, {});
+				});
+			});
+		});
+	});
 	
-	/* ------------------- */
-	/* Complication Movers */
-	/* ------------------- */
+	/* ---------------------- */
+	/* Complication Functions */
+	/* ---------------------- */
 						
 	arrayOf(maxComplicationNum).forEach(num => {
 		var lowId = String(num).padStart(2,'0');
@@ -8616,6 +8632,23 @@
 				attributes["complicationCP"+highId] = values["complicationCP"+lowId];
 							
 				setAttrs(attributes);
+			});
+		});
+	});
+
+	arrayOf(maxComplicationNum).forEach(num => {
+		var complicationId = String(num).padStart(2,'0');	
+		on(`clicked:showComplicationRoll${complicationId}`, (info) => {
+			getAttrs(["whisperToGM"], function(values) {
+				var theRoll = values.whisperToGM != 0 ? "/w GM " : "";
+				
+				theRoll += "&{template:custom-show} {{title=@{character_name} - @{character_title}}} "
+					+ "{{subtitle= Complication - @{complicationName"+complicationId+"}}} "
+					+ "{{desc=@{complicationText"+complicationId+"}}}";
+				
+				startRoll(theRoll, (results) => {
+					finishRoll(results.rollId, {});
+				});
 			});
 		});
 	});

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -5140,13 +5140,13 @@
 					</div>
 				</div>
 				
-				<input type="text" name="attr_talentName01" value="" maxlength="32" tabindex="600"/>
+				<input type="text" name="attr_talentName01" title="@{talentName01}" value="" maxlength="32" tabindex="600"/>
 				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showTalentRoll01" title="%{showTalentRoll01}">Show</button>
 				<h1>CP:</h1>
-				<input type="number" name="attr_talentCP01" value="0" min="0" tabindex="601"/>
+				<input type="number" name="attr_talentCP01" title="@{talentCP01}" value="0" min="0" tabindex="601"/>
 			</div>
 			<div class="item-talent-textbox">
-				<textarea name="attr_talentText01" maxlength="240" tabindex="602"></textarea>
+				<textarea name="attr_talentText01" title="@{talentText01}" maxlength="240" tabindex="602"></textarea>
 			</div>
 			
 			<!-- Talent 02 -->
@@ -5162,13 +5162,13 @@
 					</div>
 				</div>
 				
-				<input type="text" name="attr_talentName02" value="" maxlength="32" tabindex="603"/>
+				<input type="text" name="attr_talentName02" title="@{talentName02}" value="" maxlength="32" tabindex="603"/>
 				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showTalentRoll02" title="%{showTalentRoll02}">Show</button>
 				<h1>CP:</h1>
-				<input type="number" name="attr_talentCP02" value="0" min="0" tabindex="604"/>
+				<input type="number" name="attr_talentCP02" title="@{talentCP02}" value="0" min="0" tabindex="604"/>
 			</div>
 			<div class="item-talent-textbox">
-				<textarea name="attr_talentText02" maxlength="240" tabindex="605"></textarea>
+				<textarea name="attr_talentText02" title="@{talentText02}" maxlength="240" tabindex="605"></textarea>
 			</div>
 			
 			<!-- Talent 03 -->
@@ -5184,13 +5184,13 @@
 					</div>
 				</div>
 				
-				<input type="text" name="attr_talentName03" value="" maxlength="32"tabindex="606"/>
+				<input type="text" name="attr_talentName03" title="@{talentName03}" value="" maxlength="32"tabindex="606"/>
 				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showTalentRoll03" title="%{showTalentRoll03}">Show</button>
 				<h1>CP:</h1>
-				<input type="number" name="attr_talentCP03" value="0" min="0" tabindex="607"/>
+				<input type="number" name="attr_talentCP03" title="@{talentCP03}" value="0" min="0" tabindex="607"/>
 			</div>
 			<div class="item-talent-textbox">
-				<textarea name="attr_talentText03" maxlength="240" tabindex="608"></textarea>
+				<textarea name="attr_talentText03" title="@{talentText03}" maxlength="240" tabindex="608"></textarea>
 			</div>
 			
 			<!-- Talent 04 -->
@@ -5206,13 +5206,13 @@
 					</div>
 				</div>
 				
-				<input type="text" name="attr_talentName04" value="" maxlength="32" tabindex="609"/>
+				<input type="text" name="attr_talentName04" title="@{talentName04}" value="" maxlength="32" tabindex="609"/>
 				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showTalentRoll04" title="%{showTalentRoll04}">Show</button>
 				<h1>CP:</h1>
-				<input type="number" name="attr_talentCP04" value="0" min="0" tabindex="610"/>
+				<input type="number" name="attr_talentCP04" title="@{talentCP04}" value="0" min="0" tabindex="610"/>
 			</div>
 			<div class="item-talent-textbox">
-				<textarea name="attr_talentText04" maxlength="240" tabindex="611"></textarea>
+				<textarea name="attr_talentText04" title="@{talentText04}" maxlength="240" tabindex="611"></textarea>
 			</div>
 			
 			<!-- Talent 05 -->
@@ -5228,13 +5228,13 @@
 					</div>
 				</div>
 				
-				<input type="text" name="attr_talentName05" value="" maxlength="32" tabindex="612"/>
+				<input type="text" name="attr_talentName05" title="@{talentName05}" value="" maxlength="32" tabindex="612"/>
 				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showTalentRoll05" title="%{showTalentRoll05}">Show</button>
 				<h1>CP:</h1>
-				<input type="number" name="attr_talentCP05" value="0" min="0" tabindex="613"/>
+				<input type="number" name="attr_talentCP05" title="@{talentCP05}" value="0" min="0" tabindex="613"/>
 			</div>
 			<div class="item-talent-textbox">
-				<textarea name="attr_talentText05" maxlength="240" tabindex="614"></textarea>
+				<textarea name="attr_talentText05" title="@{talentText05}" maxlength="240" tabindex="614"></textarea>
 			</div>
 			
 			<!-- Talent 06 -->
@@ -5250,13 +5250,13 @@
 					</div>
 				</div>
 				
-				<input type="text" name="attr_talentName06" value="" maxlength="32" tabindex="615"/>
+				<input type="text" name="attr_talentName06" title="@{talentName06}" value="" maxlength="32" tabindex="615"/>
 				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showTalentRoll06" title="%{showTalentRoll06}">Show</button>
 				<h1>CP:</h1>
-				<input type="number" name="attr_talentCP06" value="0" min="0" tabindex="616"/>
+				<input type="number" name="attr_talentCP06" title="@{talentCP06}" value="0" min="0" tabindex="616"/>
 			</div>
 			<div class="item-talent-textbox">
-				<textarea name="attr_talentText06" maxlength="240" tabindex="617"></textarea>
+				<textarea name="attr_talentText06" title="@{talentText06}" maxlength="240" tabindex="617"></textarea>
 			</div>
 			
 			<!-- Talent 07 -->
@@ -5272,13 +5272,13 @@
 					</div>
 				</div>
 				
-				<input type="text" name="attr_talentName07" value="" maxlength="32" tabindex="618"/>
+				<input type="text" name="attr_talentName07" title="@{talentName07}" value="" maxlength="32" tabindex="618"/>
 				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showTalentRoll07" title="%{showTalentRoll07}">Show</button>
 				<h1>CP:</h1>
-				<input type="number" name="attr_talentCP07" value="0" min="0" tabindex="619"/>
+				<input type="number" name="attr_talentCP07" title="@{talentCP07}" value="0" min="0" tabindex="619"/>
 			</div>
 			<div class="item-talent-textbox">
-				<textarea name="attr_talentText07" maxlength="240" tabindex="620"></textarea>
+				<textarea name="attr_talentText07" title="@{talentText07}" maxlength="240" tabindex="620"></textarea>
 			</div>
 		</div>
 		
@@ -5299,13 +5299,13 @@
 					</div>
 				</div>
 				
-				<input type="text" name="attr_complicationName01" value="" maxlength="32" tabindex="630"/>
+				<input type="text" name="attr_complicationName01" title="@{complicationName01}" value="" maxlength="32" tabindex="630"/>
 				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showComplicationRoll01" title="%{showComplicationRoll01}">Show</button>
 				<h1>CP:</h1>
-				<input type="number" name="attr_complicationCP01" value="0" min="0" tabindex="631"/>
+				<input type="number" name="attr_complicationCP01" title="@{complicationCP01}" value="0" min="0" tabindex="631"/>
 			</div>
 			<div class="item-complication-textbox">
-				<textarea name="attr_complicationText01" maxlength="240" tabindex="632"></textarea>
+				<textarea name="attr_complicationText01" title="@{complicationText01}" maxlength="240" tabindex="632"></textarea>
 			</div>
 			
 			<!-- Complication 02 -->
@@ -5321,13 +5321,13 @@
 					</div>
 				</div>
 				
-				<input type="text" name="attr_complicationName02" value="" maxlength="32" tabindex="633"/>
+				<input type="text" name="attr_complicationName02" title="@{complicationName02}" value="" maxlength="32" tabindex="633"/>
 				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showComplicationRoll02" title="%{showComplicationRoll02}">Show</button>
 				<h1>CP:</h1>
-				<input type="number" name="attr_complicationCP02" value="0" min="0" tabindex="634"/>
+				<input type="number" name="attr_complicationCP02" title="@{complicationCP02}" value="0" min="0" tabindex="634"/>
 			</div>
 			<div class="item-complication-textbox">
-				<textarea name="attr_complicationText02" maxlength="240" tabindex="635"></textarea>
+				<textarea name="attr_complicationText02" title="@{complicationText02}" maxlength="240" tabindex="635"></textarea>
 			</div>
 			
 			<!-- Complication 03 -->
@@ -5343,13 +5343,13 @@
 					</div>
 				</div>
 				
-				<input type="text" name="attr_complicationName03" value="" maxlength="32" tabindex="636"/>
+				<input type="text" name="attr_complicationName03" title="@{complicationName03}" value="" maxlength="32" tabindex="636"/>
 				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showComplicationRoll03" title="%{showComplicationRoll03}">Show</button>
 				<h1>CP:</h1>
-				<input type="number" name="attr_complicationCP03" value="0" min="0" tabindex="637"/>
+				<input type="number" name="attr_complicationCP03" title="@{complicationCP03}" value="0" min="0" tabindex="637"/>
 			</div>
 			<div class="item-complication-textbox">
-				<textarea name="attr_complicationText03" maxlength="240" tabindex="638"></textarea>
+				<textarea name="attr_complicationText03" title="@{complicationText03}" maxlength="240" tabindex="638"></textarea>
 			</div>
 			
 			<!-- Complication 04 -->
@@ -5365,13 +5365,13 @@
 					</div>
 				</div>
 				
-				<input type="text" name="attr_complicationName04" value="" maxlength="32" tabindex="639"/>
+				<input type="text" name="attr_complicationName04" title="@{complicationName04}" value="" maxlength="32" tabindex="639"/>
 				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showComplicationRoll04" title="%{showComplicationRoll04}">Show</button>
 				<h1>CP:</h1>
-				<input type="number" name="attr_complicationCP04" value="0" min="0" tabindex="640"/>
+				<input type="number" name="attr_complicationCP04" title="@{complicationCP04}" value="0" min="0" tabindex="640"/>
 			</div>
 			<div class="item-complication-textbox">
-				<textarea name="attr_complicationText04" maxlength="240" tabindex="641"></textarea>
+				<textarea name="attr_complicationText04" title="@{complicationText04}" maxlength="240" tabindex="641"></textarea>
 			</div>
 			
 			<!-- Complication 05 -->
@@ -5387,13 +5387,13 @@
 					</div>
 				</div>
 				
-				<input type="text" name="attr_complicationName05" value="" maxlength="32" tabindex="642"/>
+				<input type="text" name="attr_complicationName05" title="@{complicationName05}" value="" maxlength="32" tabindex="642"/>
 				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showComplicationRoll05" title="%{showComplicationRoll05}">Show</button>
 				<h1>CP:</h1>
-				<input type="number" name="attr_complicationCP05" value="0" min="0" tabindex="643"/>
+				<input type="number" name="attr_complicationCP05" title="@{complicationCP05}" value="0" min="0" tabindex="643"/>
 			</div>
 			<div class="item-complication-textbox">
-				<textarea name="attr_complicationText05" maxlength="240" tabindex="644"></textarea>
+				<textarea name="attr_complicationText05" title="@{complicationText05}" maxlength="240" tabindex="644"></textarea>
 			</div>
 			
 			<!-- Complication 06 -->
@@ -5409,20 +5409,20 @@
 					</div>
 				</div>
 				
-				<input type="text" name="attr_complicationName06" value="" maxlength="32" tabindex="645"/>
+				<input type="text" name="attr_complicationName06" title="@{complicationName06}" value="" maxlength="32" tabindex="645"/>
 				<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showComplicationRoll06" title="%{showComplicationRoll06}">Show</button>
 				<h1>CP:</h1>
-				<input type="number" name="attr_complicationCP06" value="0" min="0" tabindex="646"/>
+				<input type="number" name="attr_complicationCP06" title="@{complicationCP06}" value="0" min="0" tabindex="646"/>
 			</div>
 			<div class="item-complication-textbox">
-				<textarea name="attr_complicationText06" maxlength="240" tabindex="647"></textarea>
+				<textarea name="attr_complicationText06" title="@{complicationText06}" maxlength="240" tabindex="647"></textarea>
 			</div>
 		</div>
 		
 		<!-- Complications Notes -->
 		<div class="flex-container-complications-bottom">
-			<textarea name="attr_complicationsTextLeft" maxlength="2048" tabindex="648"></textarea>
-			<textarea name="attr_complicationsTextRight" maxlength="2048" tabindex="649"></textarea>
+			<textarea name="attr_complicationsTextLeft" title="@{complicationsTextLeft}" maxlength="2048" tabindex="648"></textarea>
+			<textarea name="attr_complicationsTextRight" title="@{complicationsTextRight}" maxlength="2048" tabindex="649"></textarea>
 		</div>
 	</div>
 </div>

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -8402,7 +8402,7 @@
 			// Roll attack and damage dice for Weapon XX.
 			
 			getAttrs(["weaponNormalDamage"+weaponId, "weaponStunMod"+weaponId, "weaponEndurance"+weaponId, "weaponAreaEffect"+weaponId,
-					"optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM"], function(values) {
+					"optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM", "displayDegreeOfSuccess"], function(values) {
 				var theRoll = values.whisperToGM != 0 ? "/w gm " : "";
 				let areaOfEffect = values["weaponAreaEffect"+weaponId] != 0;
 				let useHitLocations = values.optionHitLocationSystem != 0;
@@ -8416,9 +8416,14 @@
 				
 				// If isNormalDamage is TRUE, use the Normal Damage template.
 				theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "")+"-attack} {{title=@{character_name} - @{character_title}}} "
-						+ "{{subtitle= Makes a " + (isNormalDamage ? "normal" : "killing") + " attack with @{weaponName"+weaponId+"}}} "
-						+ "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{weaponOCV"+weaponId+"}[WeaponOCV]-[["+ (areaOfEffect ? 0 : 1) +"*@{targetOCVPenalty}]][TargetOCV]+?{Modifiers|0}[Modifier]]]}} "
-						+ (subtractENDAmt ? "{{END=[[@{weaponEndurance"+weaponId+"}]] (@{currentEND})}} " : "")
+						+ "{{subtitle= Makes a " + (isNormalDamage ? "normal" : "killing") + " attack with @{weaponName"+weaponId+"}}} ";
+				if (values.displayDegreeOfSuccess != 0) {
+					theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{weaponOCV"+weaponId+"}[WeaponOCV]-[["+ (areaOfEffect ? 0 : 1) +"*@{targetOCVPenalty}]][TargetOCV]+?{Modifiers|0}[Modifier]]]}} ";
+				} else {
+					theRoll += "{{OCV=[[@{ocv}[OCV]+@{weaponOCV"+weaponId+"}[WeaponOCV]-[["+ (areaOfEffect ? 0 : 1) +"*@{targetOCVPenalty}]][TargetOCV]+?{Modifiers|0}[Modifier]]]}} "
+						+ "{{Result=[[3d6cf6cs1]]}}"
+				}
+				theRoll	+= (subtractENDAmt ? "{{END=[[@{weaponEndurance"+weaponId+"}]] (@{currentEND})}} " : "")
 						+ "{{"+dmgType+"=[[@{hiddenWeaponDamage"+weaponId+"}]]}} "
 						+ "{{"+otherDmgType+"=[[0[See "+dmgType+"]]]}}";
 				if (useHitLocations)
@@ -8465,11 +8470,12 @@
 	on('clicked:attackShield', (info) => {
 		// Roll attack and damage dice for the shield.
 						
-		getAttrs(["shieldNormalDamage", "shieldStunMod", "shieldEndurance", "optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM"], function(values) {
+		getAttrs(["shieldNormalDamage", "shieldStunMod", "shieldEndurance", "optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM", "displayDegreeOfSuccess"], function(values) {
 			var theRoll = values.whisperToGM != 0 ? "/w GM " : "";
 			let useHitLocations = values.optionHitLocationSystem != 0;
 			let isNormalDamage = values.shieldNormalDamage != 0;
 			let stunMod = parseInt(values.shieldStunMod)||0;
+			let dispDoS = values.displayDegreeOfSuccess != 0;
 
 			let subtractENDAmt = parseInt(values.shieldEndurance)||0;
 
@@ -8478,9 +8484,14 @@
 
 			// If isNormalDamage is TRUE, use the Normal Damage template.
 			theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "")+"-attack} {{title=@{character_name} - @{character_title}}} "
-					+ "{{subtitle= Makes a " + (isNormalDamage ? "normal" : "killing") + " attack with @{shieldName}}} "
-					+ "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{shieldOCV}[Shield OCV]-[[abs(?{Blocking|Yes,1|No,-1}-1)/2*@{targetOCVpenalty}]][TargetOCV]+[[?{Blocking}*@{shieldDCV}]][ShieldDCV]+?{Modifiers|0}[Modifier]]]}} "
-					+ (subtractENDAmt ? "{{END=[[[[abs(?{Blocking}-1)/2]][Blocking]*@{shieldEndurance}[Endurance Cost]]] (@{currentEND})}} " : "")
+					+ "{{subtitle= Makes a " + (isNormalDamage ? "normal" : "killing") + " attack with @{shieldName}}} ";
+			if (dispDoS) {
+				theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{shieldOCV}[Shield OCV]-[[abs(?{Blocking|Yes,1|No,-1}-1)/2*@{targetOCVpenalty}]][TargetOCV]+[[?{Blocking}*@{shieldDCV}]][ShieldDCV]+?{Modifiers|0}[Modifier]]]}} ";
+			} else {
+				theRoll += "{{OCV=[[@{ocv}[OCV]+@{shieldOCV}[Shield OCV]-[[abs(?{Blocking|Yes,1|No,-1}-1)/2*@{targetOCVpenalty}]][TargetOCV]+[[?{Blocking}*@{shieldDCV}]][ShieldDCV]+?{Modifiers|0}[Modifier]]]}} "
+					+ "{{Result=[[3d6cf6cs1]]}}";
+			}
+			theRoll += (subtractENDAmt ? "{{END=[[[[abs(?{Blocking}-1)/2]][Blocking]*@{shieldEndurance}[Endurance Cost]]] (@{currentEND})}} " : "")
 					+ "{{"+dmgType+"=[[@{hiddenShieldDamage01}]]}} "
 					+ "{{"+otherDmgType+"=[[0[See "+dmgType+"]]]}}";
 			if (useHitLocations)
@@ -8493,7 +8504,7 @@
 
 				// Little hacky get whether or not the person is blocking.
 				let regex = /\+(-?\d+)\[ShieldDCV\]/g
-				let isBlocking = parseInt(regex.exec(results.results["Hit DCV"].expression)) > 0;
+				let isBlocking = parseInt(regex.exec(results.results[(dispDoS ? "Hit DCV" : "OCV")].expression)) > 0;
 
 				// Get hit location message if system used.
 				if (useHitLocations && !isBlocking) {
@@ -8537,16 +8548,21 @@
 	on('clicked:standardAttackRoll', (info) => {
 		// Roll attack and damage dice for standardAttack
 
-		getAttrs(["hiddenBasicEndurance", "optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM"], function(values) {
+		getAttrs(["hiddenBasicEndurance", "optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM", "displayDegreeOfSuccess"], function(values) {
 			var theRoll = values.whisperToGM != 0 ? "/w GM " : "";
 			let useHitLocations = values.optionHitLocationSystem != 0;
 
 			let subtractENDAmt = parseInt(values.hiddenBasicEndurance)||0;
 
 			theRoll += "&{template:custom-normal-attack} {{title=@{character_name} - @{character_title}}} "
-				+ "{{subtitle= Makes a normal attack with Strength @{strength}}} "
-				+ "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]-@{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} "
-				+ (subtractENDAmt ? "{{END=[[@{hiddenBasicEndurance}]] (@{currentEND})}} " : "")
+				+ "{{subtitle= Makes a normal attack with Strength @{strength}}} ";
+			if (values.displayDegreeOfSuccess != 0) {
+				theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]-@{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} ";
+			} else {
+				theRoll += "{{OCV=[[@{ocv}[OCV]-@{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} "
+					+ "{{Result=[[3d6cf6cs1]]}}";
+			}
+			theRoll += (subtractENDAmt ? "{{END=[[@{hiddenBasicEndurance}]] (@{currentEND})}} " : "")
 				+ "{{STUN=[[@{hiddenManeuverDamage01}]]}} "
 				+ "{{BODY=[[0[See STUN]]]}}";
 			if (useHitLocations)

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -100,17 +100,17 @@
 				<div class="item-characteristics-primary-attributes-rollButtons">
 					<h1>&#8205;</h1> <!-- Invisible character -->
 					
-					<button type="roll" class="button buttonRoll" tabindex="-1" name="roll_strength" title="%{strength}" value="&{template:custom} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses Strength }} {{Base Chance = [[@{strengthChance}[Strength Chance]+?{Modifiers|0}[Modifier]]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+					<button type="action" class="button buttonRoll" tabindex="-1" name="act_strength" title="%{strength}" >Roll</button>
 					
-					<button type="roll" class="button buttonRoll" tabindex="-1" name="roll_dexterity" title="%{dexterity}" value="&{template:custom} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses Dexterity }} {{Base Chance = [[@{dexterityChance}[Dexterity Chance]+@{weightDexDCVPenalty}[Weight Penalty]+?{Modifiers|0}[Modifier]]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+					<button type="action" class="button buttonRoll" tabindex="-1" name="act_dexterity" title="%{dexterity}" >Roll</button>
 					
-					<button type="roll" class="button buttonRoll" tabindex="-1" name="roll_constitution" title="%{constitution}" value="&{template:custom} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses Constitution}} {{Base Chance = [[@{constitutionChance}[Constitution Chance]+?{Modifiers|0}[Modifier]]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+					<button type="action" class="button buttonRoll" tabindex="-1" name="act_constitution" title="%{constitution}" >Roll</button>
 					
-					<button type="roll" class="button buttonRoll" tabindex="-1" name="roll_intelligence" title="%{intelligence}" value="&{template:custom} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses Intelligence}} {{Base Chance = [[@{intelligenceChance}[Intelligence Chance]+?{Modifiers|0}[Modifier]]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+					<button type="action" class="button buttonRoll" tabindex="-1" name="act_intelligence" title="%{intelligence}" >Roll</button>
 					
-					<button type="roll" class="button buttonRoll" tabindex="-1" name="roll_ego" title="%{ego}" value="&{template:custom} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses Ego}} {{Base Chance = [[@{egoChance}[Ego Chance]+?{Modifiers|0}[Modifier]]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+					<button type="action" class="button buttonRoll" tabindex="-1" name="act_ego" title="%{ego}" >Roll</button>
 					
-					<button type="roll" class="button buttonRoll" tabindex="-1" name="roll_presence" title="%{presence}" value="&{template:custom} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses Presence}} {{Base Chance = [[@{presenceChance}[Presence Chance]+?{Modifiers|0}[Modifier]]] }} {{Roll=[[3d6cf6cs1]]}} {{}}" >Roll</button>
+					<button type="action" class="button buttonRoll" tabindex="-1" name="act_presence" title="%{presence}" >Roll</button>
 				</div>
 				
 				<div class="item-characteristics-primary-attributes-costs">
@@ -7335,9 +7335,28 @@
 	});
 
 	/* ------------------- */
-	/* Skill Rolls         */
+	/* Success Rolls         */
 	/* ------------------- */
-					
+	
+	var characteristics = ['strength', 'dexterity', 'constitution', 'intelligence', 'ego', 'presence']
+	characteristics.forEach(characteristic => {
+		var displayName = characteristic.charAt(0).toUpperCase() + characteristic.slice(1);
+		on (`clicked:${characteristic}`, (info) => {
+			var theRoll = "&{template:custom-success-roll} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses "+displayName+" }} ";
+			if (characteristic == 'dexterity') {
+				theRoll += "{{SUCCESS=[[@{dexterityChance}[Dexterity Chance]+@{weightDexDCVPenalty}[Weight Penalty]-3d6cf6cs1[Roll]+?{Modifiers|0}[Modifiers]]] }}";
+			} else {
+				theRoll += "{{SUCCESS=[[@{"+characteristic+"Chance}["+displayName+" Chance]-3d6cf6cs1[Roll]+?{Modifiers|0}[Modifiers]]] }}";
+			}
+
+			startRoll(theRoll, (results) => {
+				finishRoll(results.rollId,{
+					SUCCESS:results.results.SUCCESS.result
+				});
+			});
+		});
+	});
+
 	arrayOf(maxSkillNum).forEach(num => {
 		var skillId = String(num).padStart(2,'0');	
 		on(`clicked:testSkill${skillId}`, (info) => {

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1212,7 +1212,7 @@
 							<div class="subitem-tab-gear-slide-flex-container-martial-name-and-points-row">
 								<h1>CP:</h1>
 								<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP01" title="@{martialManeuverCP01}" tabindex="165"/>
-								<button type="roll" class="button buttonRollShow" tabindex="-1" name="roll_showMartialRoll01" title="%{showMartialRoll01}" value="&{template:custom-show} {{title=@{character_name} - @{character_title}}} {{subtitle= Martial Maneuver - @{martialManeuverName01}}} {{Phases=@{martialManeuverPhase01}}} {{OCV = @{martialManeuverOCV01}}} {{DCV = @{martialManeuverDCV01}}} {{desc=@{martialManeuverEffect01}}}">Show</button>
+								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll01" title="%{showMartialRoll01}" >Show</button>
 							</div>
 						</div>
 						<input type="text" value="1/2" name="attr_martialManeuverPhase01" title="@{martialManeuverPhase01}" tabindex="166"/>
@@ -1227,7 +1227,7 @@
 							<div class="subitem-tab-gear-slide-flex-container-martial-name-and-points-row">
 								<h1>CP:</h1>
 								<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP02" title="@{martialManeuverCP02}" tabindex="171"/>
-								<button type="roll" class="button buttonRollShow" tabindex="-1" name="roll_showMartialRoll02" title="%{showMartialRoll02}" value="&{template:custom-show} {{title=@{character_name} - @{character_title}}} {{subtitle= Martial Maneuver - @{martialManeuverName02}}} {{Phases=@{martialManeuverPhase02}}} {{OCV = @{martialManeuverOCV02}}} {{DCV = @{martialManeuverDCV02}}} {{desc=@{martialManeuverEffect02}}}">Show</button>
+								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll02" title="%{showMartialRoll02}" >Show</button>
 							</div>
 						</div>
 						<input type="text" value="1/2" name="attr_martialManeuverPhase02" title="@{martialManeuverPhase02}" tabindex="172"/>
@@ -1242,7 +1242,7 @@
 							<div class="subitem-tab-gear-slide-flex-container-martial-name-and-points-row">
 								<h1>CP:</h1>
 								<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP03" title="@{martialManeuverCP03}" tabindex="177"/>
-								<button type="roll" class="button buttonRollShow" tabindex="-1" name="roll_showMartialRoll03" title="%{showMartialRoll03}" value="&{template:custom-show} {{title=@{character_name} - @{character_title}}} {{subtitle= Martial Maneuver - @{martialManeuverName03}}} {{Phases=@{martialManeuverPhase03}}} {{OCV = @{martialManeuverOCV03}}} {{DCV = @{martialManeuverDCV03}}} {{desc=@{martialManeuverEffect03}}}">Show</button>
+								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll03" title="%{showMartialRoll03}" >Show</button>
 							</div>
 						</div>
 						<input type="text" value="1/2" name="attr_martialManeuverPhase03" title="@{martialManeuverPhase03}" tabindex="178"/>
@@ -1257,7 +1257,7 @@
 							<div class="subitem-tab-gear-slide-flex-container-martial-name-and-points-row">
 								<h1>CP:</h1>
 								<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP04" title="@{martialManeuverCP04}" tabindex="183"/>
-								<button type="roll" class="button buttonRollShow" tabindex="-1" name="roll_showMartialRoll04" title="%{showMartialRoll04}" value="&{template:custom-show} {{title=@{character_name} - @{character_title}}} {{subtitle= Martial Maneuver - @{martialManeuverName04}}} {{Phases=@{martialManeuverPhase04}}} {{OCV = @{martialManeuverOCV04}}} {{DCV = @{martialManeuverDCV04}}} {{desc=@{martialManeuverEffect04}}}">Show</button>
+								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll04" title="%{showMartialRoll04}" >Show</button>
 							</div>
 						</div>
 						<input type="text" value="1/2" name="attr_martialManeuverPhase04" title="@{martialManeuverPhase04}" tabindex="184"/>
@@ -1272,7 +1272,7 @@
 							<div class="subitem-tab-gear-slide-flex-container-martial-name-and-points-row">
 								<h1>CP:</h1>
 								<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP05" title="@{martialManeuverCP05}" tabindex="189"/>
-								<button type="roll" class="button buttonRollShow" tabindex="-1" name="roll_showMartialRoll05" title="%{showMartialRoll05}" value="&{template:custom-show} {{title=@{character_name} - @{character_title}}} {{subtitle= Martial Maneuver - @{martialManeuverName05}}} {{Phases=@{martialManeuverPhase05}}} {{OCV = @{martialManeuverOCV05}}} {{DCV = @{martialManeuverDCV05}}} {{desc=@{martialManeuverEffect05}}}">Show</button>
+								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll05" title="%{showMartialRoll05}" >Show</button>
 							</div>
 						</div>
 						<input type="text" value="1/2" name="attr_martialManeuverPhase05" title="@{martialManeuverPhase05}" tabindex="190"/>
@@ -1287,7 +1287,7 @@
 							<div class="subitem-tab-gear-slide-flex-container-martial-name-and-points-row">
 								<h1>CP:</h1>
 								<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP06" title="@{martialManeuverCP06}" tabindex="195"/>
-								<button type="roll" class="button buttonRollShow" tabindex="-1" name="roll_showMartialRoll06" title="%{showMartialRoll06}" value="&{template:custom-show} {{title=@{character_name} - @{character_title}}} {{subtitle= Martial Maneuver - @{martialManeuverName06}}} {{Phases=@{martialManeuverPhase06}}} {{OCV = @{martialManeuverOCV06}}} {{DCV = @{martialManeuverDCV06}}} {{desc=@{martialManeuverEffect06}}}">Show</button>
+								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll06" title="%{showMartialRoll06}" >Show</button>
 							</div>
 						</div>
 						<input type="text" value="1/2" name="attr_martialManeuverPhase06" title="@{martialManeuverPhase06}" tabindex="196"/>
@@ -5835,6 +5835,7 @@
 	const maxArmorNum = 4;
 	const maxWeaponNum = 5;
 	const maxEquipmentNum = 16;
+	const maxManeuverNum = 6;
 	const maxSkillNum = 30;
 	const maxPowerNum = 17;
 	const maxTalentNum = 7;
@@ -8082,6 +8083,31 @@
 			});
 		});
 	});
+
+	/* -------------------------- */
+	/* --- Maneuver Functions --- */
+	/* -------------------------- */
+
+	arrayOf(maxManeuverNum).forEach(num => {
+		var maneuverId = String(num).padStart(2,'0');	
+		on(`clicked:showMartialRoll${maneuverId}`, (info) => {
+			getAttrs(["whisperToGM"], function(values) {
+				var theRoll = values.whisperToGM != 0 ? "/w GM " : "";
+				
+				theRoll += "&{template:custom-show} {{title=@{character_name} - @{character_title}}} "
+					+ "{{subtitle= Martial Maneuver - @{martialManeuverName"+maneuverId+"}}} "
+					+ "{{Phases=@{martialManeuverPhase"+maneuverId+"}}} "
+					+ "{{OCV = @{martialManeuverOCV"+maneuverId+"}}} "
+					+ "{{DCV = @{martialManeuverDCV"+maneuverId+"}}} "
+					+ "{{desc=@{martialManeuverEffect"+maneuverId+"}}}";
+				
+				startRoll(theRoll, (results) => {
+					finishRoll(results.rollId, {});
+				});
+			});
+		});
+	});
+
 
 	/* ------------------------------------------------ */
 	/* --- Weapon Attacks and Hit Location Helpers  --- */


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description
- Now shows Degree of Success instead of separate chance/roll lines
  - This can be disabled through Options menu
  - Currently Applies to:
    - Characteristics Rolls
    - Perception Rolls
    - Skill Rolls
    - Armor Activation
    - Power Activation
    - Weapon/Shield/Basic Attacks
- Armor Activation of N/A will now show Locations if they contain information
- Option to Whisper Rolls to GM
- Tooltips added to Talents & Complications Page

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->




