### PR TITLE
Shadowrun Sixth World v.81 - 1 bugfix, 2 new features

### DIFF
--- a/Shadowrun Sixth World/CHANGELOG.md
+++ b/Shadowrun Sixth World/CHANGELOG.md
@@ -1,5 +1,8 @@
 Change Log
 ==============================================
+**2023-05-22 ** v.81 Chuz (James Culp)
+	Bugfix - More weapon dicepool tweaks
+	
 **2023-05-18 ** v.80 Chuz (James Culp)
 	Bugfix - PC Qualities were always showing up as Negative regardless of the actual type.
 	Bugfix - PC->Spells Ranges of Touch were showing up as LOS.

--- a/Shadowrun Sixth World/CHANGELOG.md
+++ b/Shadowrun Sixth World/CHANGELOG.md
@@ -2,7 +2,7 @@ Change Log
 ==============================================
 **2023-05-22 ** v.81 Chuz (James Culp)
 	Bugfix - More weapon dicepool tweaks
-	
+	NPC->Spirits made spirits awakened and now display the spells section for them.  Dicepool does not auto-update when spirit force changes, that is an exercise for the user.
 **2023-05-18 ** v.80 Chuz (James Culp)
 	Bugfix - PC Qualities were always showing up as Negative regardless of the actual type.
 	Bugfix - PC->Spells Ranges of Touch were showing up as LOS.

--- a/Shadowrun Sixth World/CHANGELOG.md
+++ b/Shadowrun Sixth World/CHANGELOG.md
@@ -2,7 +2,8 @@ Change Log
 ==============================================
 **2023-05-22 ** v.81 Chuz (James Culp)
 	Bugfix - More weapon dicepool tweaks
-	NPC->Spirits made spirits awakened and now display the spells section for them.  Dicepool does not auto-update when spirit force changes, that is an exercise for the user.
+	New Feature - NPC->Spirits made spirits awakened and now display the spells section for them.  Dicepool does not auto-update when spirit force changes, that is an exercise for the user.
+	New Feature - Added Critter Powers drag and drop from the compendium for spirits and grunts.
 **2023-05-18 ** v.80 Chuz (James Culp)
 	Bugfix - PC Qualities were always showing up as Negative regardless of the actual type.
 	Bugfix - PC->Spells Ranges of Touch were showing up as LOS.

--- a/Shadowrun Sixth World/Shadowrun6thEdition.html
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.html
@@ -3475,9 +3475,10 @@
 							<div name="changelog" class="changelog">
 								<h1 class="changelog-header">Most Recent Updates</h1>
 								<span class="changelog-entry">**2023-05-22 ** v.81 Chuz (James Culp)</span>
-									<li><span class="bullet">F</span><b>New Feature</b> - NPC->Spirits made spirits awakened and now display the spells section for them.  Dicepool does not auto-update when spirit force changes, that is an exercise for the user.
 								<ul>
 									<li><span class="bullet">A</span><b>Bugfix</b> - More weapon dicepool tweaks
+									<li><span class="bullet">F</span><b>New Feature</b> - NPC->Spirits made spirits awakened and now display the spells section for them.  Dicepool does not auto-update when spirit force changes, that is an exercise for the user.
+									<li><span class="bullet">F</span><b>New Feature</b> - Added Critter Powers drag and drop from the compendium for spirits and grunts.
 								</ul>
 								<span class="changelog-entry">**2023-05-18 ** v.80 Chuz (James Culp)</span>
 								<ul>

--- a/Shadowrun Sixth World/Shadowrun6thEdition.html
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.html
@@ -3475,6 +3475,7 @@
 							<div name="changelog" class="changelog">
 								<h1 class="changelog-header">Most Recent Updates</h1>
 								<span class="changelog-entry">**2023-05-22 ** v.81 Chuz (James Culp)</span>
+									<li><span class="bullet">F</span><b>New Feature</b> - NPC->Spirits made spirits awakened and now display the spells section for them.  Dicepool does not auto-update when spirit force changes, that is an exercise for the user.
 								<ul>
 									<li><span class="bullet">A</span><b>Bugfix</b> - More weapon dicepool tweaks
 								</ul>
@@ -3550,59 +3551,6 @@
 									<li><span class="bullet">F</span><b>New Feature</b> - Added weapon info to Ranged attack Roll Templates
 									<li><span class="bullet">F</span><b>New Feature</b> - Added weapon info to Ranged (Burst Fire Wide) attack Roll Templates
 									<li><span class="bullet">F</span><b>New Feature</b> - Added weapon info to Melee attack Roll Templates
-								</ul>
-								<span class="changelog-entry">**2023-02-06 ** v.70 Chuz (James Culp)</span>
-								<ul>
-									<li><span class="bullet">A</span><b>Bugfix</b> - PC Condition Monitor boxes broke if the maximum value was below 8.  Changed the minimum to 6 which is 0 body with Neoteny so should be unattainable.
-								</ul>
-								<span class="changelog-entry">**2023-01-17 ** v.69 Chuz (James Culp)</span>
-								<ul>
-									<li><span class="bullet">F</span><b>New Feature</b> - Add Contacts drag and drop capability, you can now drag ANY NPC from the compendium and their name and description will be added to your contacts, also loyalty, connections and favors if the NPC has those attributes (currently none do)
-									<li><span class="bullet">F</span><b>New Feature</b> - NPCs->Powers text added for all NPCs not just Awakened
-									<li><span class="bullet">F</span><b>New Feature</b> - NPCs->Weaknesses text added for all NPCs
-									<li><span class="bullet">F</span><b>New Feature</b> - NPCs->Spirits added Weaknesses to the Spirts sheet auto-generation code.
-									<li><span class="bullet">A</span><b>Bugfix</b> - PCs->Armor didn't update DR when deleting armor entries
-								</ul>
-								<span class="changelog-entry">**2023-01-05 ** v.68 Chuz (James Culp)</span>
-								<ul>
-									<li><span class="bullet">A</span><b>Bugfix</b> - drag and drop QSR Combat spells
-									<li><span class="bullet">A</span><b>Bugfix</b> - Sprite sheet matrix_max
-									<li><span class="bullet">A</span><b>Bugfix</b> - Bugfix - PC -> Modifications - changing astral_initiative_dice_mod was doing strange things to the astral initiative dice.  This has been fixed but if your character ended up with a messed up astral_initiative_dice amount look in "Attributes & Abilities" for "astral_initiative_dice" and change it to the correct ammount.
-									<li><span class="bullet">F</span><b>New Feature</b> - Sprite drag and drop
-									<li><span class="bullet">F</span><b>New Feature</b> - Complex Forms drag and drop
-								</ul>
-								<span class="changelog-entry">**2022-12-12 ** v.67 Chuz (James Culp)</span>
-								<ul>
-									<li><span class="bullet">E</span><b>Update</b> - PC -> Magic -> Meta Tradition Hermeticism now displays as "Hermeticism (Logic)" and Shamanism now displays as "Shamanism (Charisma)" for clarity
-									<li><span class="bullet">A</span><b>Bugfix</b> - NPC -> Vehicles - fixed vehicle/drone default actions
-									<li><span class="bullet">F</span><b>New Feature</b> - added alternate melee/ranged roll buttons on npc sheets.  If there's no dicepool set the alternate button prompts for skill and attribute values.
-									<li><span class="bullet">F</span><b>New Feature</b> - PC sheet Weapon Mods now allows JSON imports via Notes field.
-								</ul>
-								<span class="changelog-entry">**2022-12-05 ** v.66 Chuz (James Culp)</span>
-								<ul>
-									<li><span class="bullet">F</span><b>New Feature</b> - Added modifiers for primary_range_weapon_close_mod, primary_range_weapon_near_mod, primary_range_weapon_medium_mod, primary_range_weapon_far_mod, primary_range_weapon_extreme_mod, primary_range_weapon_damage_mod for changing the ARs at various ranges and the damage for the primary weapon.
-									<li><span class="bullet">F</span><b>New Feature</b> - Added modifiers for single_shot_penalty_mod, semi_auto_penalty_mod, burst_fire_penalty_mod, burst_wide_penalty_mod, full_auto_penalty_mod for changing the AR penalties for firing modes.
-									<li><span class="bullet">F</span><b>New Feature</b> - Primary Weapon Mods section that allows a list of mods to be added and turned on/off to apply bonuses/penalties to ARs, DV, dicepool (not reflected in listed dicepool) and firing mode penalties.  Upon changing primary ranged weapon, mods will be disabled, if the weapon has the "Has Mods" checkbox checked the screen will switch to the Mod selection screen.
-									<li><span class="bullet">F</span><b>New Feature</b> - Added Blood and the various Insect spirits from Street Wyrd
-									<li><span class="bullet">F</span><b>New Feature</b> - Updated spirits to allow my templates to have more than one melee or ranged attack.
-									<li><span class="bullet">E</span><b>Update</b> - There are now a maximum of 30 physical and 21 stun condition monitor boxes for PCs, these numbers should exceed the current theoretical maximums.
-									<li><span class="bullet">A</span><b>Bugfix</b> - Skill name for multi-word skills wasn't being formatted properly.
-									<li><span class="bullet">A</span><b>Bugfix</b> - At some point NPC -> Vehicle DR input and button disappeared, they've been found and replaced
-								</ul>
-								<span class="changelog-entry">**2022-11-21 ** v.65 Chuz (James Culp)</span>
-								<ul>
-									<li><span class="bullet">A</span><b>Bugfix</b> - PC Weapon skills weren't applying the -1 unskilled penalty to some skills, this has been updated however users will need to update the skill to something else and back to trigger the data change.
-									<li><span class="bullet">A</span><b>Bugfix</b> - PC Sheet imported from Genesis in a non-English language had many problems mostly related to skills.  I believe I've fixed these issues please report any new ones
-									<li><span class="bullet">A</span><b>Bugfix</b> - NPC Spell roll template issue where if drain was under 2 it added "Drain: 2" at the bottom of the description.
-								</ul>
-								<span class="changelog-entry">**2022-11-14 ** v.64 Chuz (James Culp)</span>
-								<ul>
-									<li><span class="bullet">A</span><b>Bugfix</b> - PC Judge Intentions wasn't updating on Willpower changes.
-								</ul>
-								<span class="changelog-entry">**2022-10-31 ** v.63 Chuz (James Culp)</span>
-								<ul>
-									<li><span class="bullet">F</span><b>New Feature</b> - PC Attribute roll buttons now prompt for a second attribute or custom dice modifier for those occasions when the DM says Roll Reaction+Intuition instead of Roll Defense
-									<li><span class="bullet">A</span><b>Bugfix</b> - PC Defense, Direct Magic Defense and Indirect Magic Defense roll buttons didn't include Wound Penalties (defense pretended to but didn't apply the penalty)
 								</ul>
 							</div>
 						</div>
@@ -4499,7 +4447,7 @@
 			<div class="rows">
 			  <h1 data-i18n="options">Options</h1>
 			</div>
-			<div class="rows grunt">
+			<div class="rows grunt spirit">
 			  <label class="settings" data-i18n-title="archetype" title="Archetype">
 				 <h2 data-i18n="archetype">Archetype</h2>
 				 <select name="attr_flag_special">
@@ -5058,7 +5006,7 @@
 
 
 		<!-- NEW npcspell repeating section -->
-		 <div class="rows grunt repeating-container spells hide-magic">
+		 <div class="rows grunt spirit repeating-container spells hide-magic">
 			<h1 data-i18n="spells">Spells</h1>
 			<div class="row-long">
 				<button type="roll" name="roll_magic_ar" value="@{gm_toggle} &{template:rolls-computed}{{header=@{character_name}}}{{base=^{magic} ^{attack} ^{rating}}}{{rating=@{magic_ar}}}">
@@ -6388,6 +6336,9 @@ on("sheet:opened", function() {
 				case (v.data_version < 0.80):
 					_v80_update();
 					console.log("Data now fits v.80");
+				case (v.data_version < 0.81):
+					_v81_update();
+					console.log("Data now fits v.81");
 				default:
 					setAttrs({
 						'data_version': v.sheet_version
@@ -6408,6 +6359,16 @@ var show_changelog = () => {
 	});
 };
 
+
+var _v81_update = () => {
+	getAttrs(["sheet_type"], (v) => {
+		if(v.sheet_type == 'spirit') {
+			setAttrs({
+				flag_special: 'magic'
+			});
+		}
+	});
+};
 
 var _v80_update = () => {
 	getAttrs(["sheet_type", "defense_rating", "armor_rating"], (v) => {
@@ -9780,7 +9741,7 @@ console.log(s);
 			}
 
 
-			// Apply dicepool mod if that changed
+1			// Apply dicepool mod if that changed
 			if(eventInfo.sourceAttribute.endsWith('_dicepool_modifier')) {
 console.log("updating dicepool for dicepool_modifier change");
 				let nv = parseInt(eventInfo.newValue) || 0;
@@ -11487,7 +11448,8 @@ var spirit_update = () => {
 		}
 
 		setAttrs({
-			grunt_group_member: 0
+			grunt_group_member: 0,
+			flag_special: 'magic'
 		});
 	});
 };
@@ -12483,7 +12445,7 @@ var compendiumAddArmor = function(data) {
 
 
 var compendiumAddSpell = function(data) {
-	getAttrs(["magic", "sorcery", "sheet_type"], (v) => {
+	getAttrs(["magic", "sorcery", "force", "sheet_type"], (v) => {
 		rowattrs = {};
 		row_id = generateRowID();
 
@@ -12495,9 +12457,10 @@ var compendiumAddSpell = function(data) {
 
 		let spell_type = 'spell';
 console.log("Adding Spell: "+data["data-name"]);
-console.log(v);
-		if(v.sheet_type != 'pc' && v.magic && v.sorcery) {
+		if(v.sheet_type != 'pc' && v.magic > 0 && v.sorcery > 0) {
 			rowattrs["repeating_" + spell_type + "_" + row_id + "_dicepool"] = parseInt(v.magic) + parseInt(v.sorcery);
+		} else if(v.sheet_type == 'spirit' && (! v.sorcery || v.sorcery == '0')) {
+			rowattrs["repeating_" + spell_type + "_" + row_id + "_dicepool"] = parseInt(v.magic) + parseInt(v.force);
 		} else {
 			rowattrs["repeating_" + spell_type + "_" + row_id + "_dicepool"] = 0;
 		}

--- a/Shadowrun Sixth World/Shadowrun6thEdition.html
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.html
@@ -11619,6 +11619,7 @@ let priorities = {
 	'Weapon Both': 33,
 	'Devices': 34,
 	'Programs':	35,
+	'Critter Powers': 36,
 };
 
 
@@ -11761,6 +11762,9 @@ console.log(data);
 			break;
 		case 'Powers':
 			compendiumAddPower(data);
+			break;
+		case 'Critter Powers':
+			compendiumAddCritterPower(data);
 			break;
 		case 'Metamagic':
 			compendiumAddMetamagic(data);
@@ -12582,6 +12586,41 @@ var compendiumAddPower = function(data) {
 	rowattrs["repeating_" + rep_type + "_" + row_id + "_modifications"] = data["data-modifications"] || '';
 
 	setAttrs(rowattrs);
+};
+
+
+var compendiumAddCritterPower = function(data) {
+console.log("Critter Power Drop");
+	getAttrs(['sheet_type', 'powers'], (v) => {
+		if(v.sheet_type == 'grunt') {
+			let powers = v.powers;
+			let re = /\((.*?)\)/gi;
+			let parens = powers.match(re);
+
+			powers.replace(re, parens);
+			powers = v.powers.split(/,\s*/);
+
+			let powerName = data["data-name"];
+
+			v.powers = [v.powers, powerName].join(', ');
+
+			setAttrs({
+				powers: v.powers
+			}, {silent: true});
+		} else if(v.sheet_type == 'spirit') {
+			rowattrs = {};
+
+			row_id = generateRowID();
+			var rep_type = 'powers';
+
+			rowattrs["repeating_" + rep_type + "_" + row_id + "_flag"] = false;
+			rowattrs["repeating_" + rep_type + "_" + row_id + "_display_flag"] = 'on';
+			rowattrs["repeating_" + rep_type + "_" + row_id + "_name"] = data["data-name"] || 'No Name';
+			rowattrs["repeating_" + rep_type + "_" + row_id + "_notes"] = data["data-description"];
+
+			setAttrs(rowattrs);
+		}
+	});
 };
 
 

--- a/Shadowrun Sixth World/Shadowrun6thEdition.html
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.html
@@ -3474,6 +3474,10 @@
 						<div class="notes-changelog">
 							<div name="changelog" class="changelog">
 								<h1 class="changelog-header">Most Recent Updates</h1>
+								<span class="changelog-entry">**2023-05-22 ** v.81 Chuz (James Culp)</span>
+								<ul>
+									<li><span class="bullet">A</span><b>Bugfix</b> - More weapon dicepool tweaks
+								</ul>
 								<span class="changelog-entry">**2023-05-18 ** v.80 Chuz (James Culp)</span>
 								<ul>
 									<li><span class="bullet">A</span><b>Bugfix</b> - PC Qualities were always showing up as Negative regardless of the actual type.
@@ -6302,7 +6306,7 @@
 <input type="hidden" name="attr_spellcasting_expert" value="0" />
 <input type="hidden" name="attr_universal_dicepool_adjustment" value="0" />
 
-<input type="hidden" name="attr_sheet_version" value="0.80">
+<input type="hidden" name="attr_sheet_version" value="0.81">
 <input type="hidden" name="attr_data_version" value="0">
 <script type="text/worker">
 // Sheet workers
@@ -9298,79 +9302,6 @@ function repeatingStringBuilder(v, keyBase) {
 }
 
 
-/* vvv Commented out 2023-03-04 vvv */
-/*
-on("change:repeating_weapon", () => {
-	const source = "repeating_weapon_name";
-	 getAttrs([`${source}_range`, `${source}_type`, `${source}_dv`, `${source}_ap`, `${source}_mode`, `${source}_rc`, `${source}_ammo`, `${source}_note`, `${source}_primary`], (v) => {
-		  // Local builder putting the needed variables into scope for repeatingStringBuilder
-		  const b = repeatingStringBuilder(v, `${source}_`);
-		  // Determine fields to display and in their proper order and formatting
-		  // Anonymous function is purely stylistic and adds more overhead than just a simple switch/case.  Personally I find the function looks cleaner and hides any internal scope that might conflict with outside
-		  const display = (() => {
-				// 0 for weapon_range is a ranged weapon. A 1 is a melee weapon.
-				switch(v.repeating_weapon_range) {
-					 case '0':
-					 // Not a fan of how ammo has to be handled.  Could potentially be placed in the repeatingStringBuilder if used more often for other change:repeating functions as some sort of suffix parameter
-					 const ammo = b('amm');
-					 return [
-						  b('type'),
-						  b('dv', 'DV'),
-						  b('mode'),
-						  ammo ? `${ammo} (c)` : '',
-						  b('note')
-					 ];
-					 case '1': return [
-						  b('type'),
-						  b('dv', 'DV'),
-						  b('note')
-					 ];
-					 default: return [
-						  b('type'),
-						  b('dv', 'DV'),
-						  b('note')
-					 ];
-				}
-		  })()
-				// Remove all empty strings
-				.filter(s => s)
-				// Concat all the strings and add comma between
-				.join(', ');
-
-		  let update = {};
-		  update[`${source}`] = `[${display}]`;
-
-		  // Finally wrap square brackets around the weapon display
-		  setAttrs(update);
-	 });
-});
-*/
-/* ^^^ Commented out 2023-03-04 ^^^ */
-
-/* vvv Commented out 2023-03-04 vvv */
-/*
-//Spell displays set into an Array
-on("change:repeating_NPCspell", () => {
-	 getAttrs(["repeating_NPCspell_combat_type", "repeating_NPCspell_type", "repeating_NPCspell_range", "repeating_NPCspell_damage", "repeating_NPCspell_duration", "repeating_NPCspell_drain", "repeating_NPCspell_note"], (v) =>{
-		  const com = v.repeating_NPCspell_combat_type;
-		  const typ = `Type ${v.repeating_NPCspell_type}, `;
-		const ran = `${v.repeating_NPCspell_range}, `;
-		const dam = `Damage ${v.repeating_NPCspell_damage}, `;
-		const dur = `Duration ${v.repeating_NPCspell_duration}, `;
-		const not = `, ${v.repeating_NPCspell_note}`;
-		const dra = v.repeating_NPCspell_drain;
-
-		const drain = (dra > 0) ? `F+${dra} ` : (dra < 0) ? `F${dra} ` :"F ";
-		const info = `[${typ}${ran}${dam}${dur}${drain}${not}]`;
-
-		display = (com === "Direct, Force ") ? ` (Direct) ${info}` :
-			(com === "Indirect, Force ?{Force|}, AP -") ? ` (Indirect) ${info}` : `${info}`;
-		  setAttrs({repeating_NPCspell_spell: display});
-	 });
-});
-*/
-/* ^^^ Commented out 2023-03-04 ^^^ */
-
 
 //IC displays are set into an Array
 on("change:repeating_IC", () => {
@@ -9773,7 +9704,6 @@ console.log(toSet);
 				return;
 			}
 
-
 console.log(eventInfo);
 			if(eventInfo.sourceAttribute.endsWith("dicepool") && eventInfo.newValue && eventInfo.newValue != "0") {
 				if(eventInfo.sourceType === 'player') {
@@ -9783,6 +9713,12 @@ console.log("updating dicepool_base to: "+v[`${weap}_dicepool`]);
 					}, {silent: true});
 				}
 				return;
+			} else if(eventInfo.sourceAttribute.endsWith("dicepool") && ! eventInfo.newValue) {
+console.log("updating dicepool and dicepool_base to 0");
+				setAttrs({
+					[`${weap}_dicepool_base`]: 0,
+					[`${weap}_dicepool`]: 0
+				}, {silent: true});
 			} else if(v[`${weap}_dicepool_base`] && v[`${weap}_dicepool_base`] != v[`${weap}_dicepool`]) {
 console.log("updating dicepool_base to: "+v[`${weap}_dicepool`]);
 //				let diff = parseInt(v[`${weap}_dicepool_base`]) - parseInt(v[`${weap}_dicepool`]);
@@ -9796,13 +9732,15 @@ console.log("updating dicepool_base to: "+v[`${weap}_dicepool`]);
 //				v[`${weap}_dicepool_base`] = v[`${weap}_dicepool`];
 //			}
 
-			// If this is a vehicle/drone sheet there's nothing more to do
+			// If this is a vehicle/drone or spirit sheet there's nothing more to do
 			if(v.sheet_type == 'vehicle' || v.sheet_type == 'spirit') {
 				return;
 			}
 
+console.log(v.sheet_type);
 			// We only auto-fill the dicepool if it's empty or 0
-			if(! v[`${weap}_dicepool`] || v[`${weap}_dicepool`] == 0) {
+			if(v.sheet_type == 'pc' || (! v[`${weap}_dicepool`] || v[`${weap}_dicepool`] == 0)) {
+console.log("dicepool recalculation");
 				const mod = parseInt(v[`${weap}_dicepool_modifier`]) || 0;
 				const spec = parseInt(v[`${weap}_spec`]) || 0;
 				const expert = parseInt(v[`${weap}_expert`]) || 0;
@@ -9822,6 +9760,7 @@ console.log("updating dicepool_base to: "+v[`${weap}_dicepool`]);
 				}
 
 				getAttrs([`${skill}`, `${attribute}`], (s) => {
+console.log(s);
 					rating = s[`${skill}`] || -1;
 					if(rating <= 0) {
 						rating = -1;
@@ -9843,6 +9782,7 @@ console.log("updating dicepool_base to: "+v[`${weap}_dicepool`]);
 
 			// Apply dicepool mod if that changed
 			if(eventInfo.sourceAttribute.endsWith('_dicepool_modifier')) {
+console.log("updating dicepool for dicepool_modifier change");
 				let nv = parseInt(eventInfo.newValue) || 0;
 				let pv = parseInt(eventInfo.previousValue) || 0;
 				let delta = nv - pv;


### PR DESCRIPTION
- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

- [x] I have followed the [Character Sheets Standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) when building this sheet.

# Changes / Description

	Bugfix - More weapon dicepool tweaks
	New Feature - NPC->Spirits made spirits awakened and now display the spells section for them.  Dicepool does not auto-update when spirit force changes, that is an exercise for the user.
	New Feature - Added Critter Powers drag and drop from the compendium for spirits and grunts.



