### PR TITLE
Upgrade Mythras to v3.2, two fixes to default settings

### DIFF
--- a/Mythras/CHANGELOG.md
+++ b/Mythras/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the Mythras sheet will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## 3.2
+### Fixed
+- Issue causing default setting of Mythic Britain to actually be Mythic Babylon and visa-versa.
+- Fixed issue with default "whisper rolls to GM" being set incorrectly.
+
 ## 3.1
 ### Added
 - Added a button in the help section that will re-attempt the upgrade to v3 if someone ran into issues the first time around.

--- a/Mythras/sheet.json
+++ b/Mythras/sheet.json
@@ -109,7 +109,7 @@
         "disabled",
         "enabled"
       ],
-      "default": "/w gm ",
+      "default": "/w gm",
       "description": "Rolls are only shown to the GM and the player making the roll.",
       "descriptiontranslationkey": "roll_display_description-u"
     },
@@ -148,8 +148,8 @@
         "lyonesse",
         "m-space",
         "monster_island",
-        "mythic_britain",
         "mythic_babylon",
+        "mythic_britain",
         "mythic_constantinople",
         "mythic_rome",
         "mythras_imperative",

--- a/Mythras/templates/sheet.js
+++ b/Mythras/templates/sheet.js
@@ -353,7 +353,7 @@ function upgradeGeneric3Dot1() {
  * @param version the sheet version already parse to a float or 0 if not a valid float
  */
 function versioning(sheet_type, version) {
-    const latestVersion = '3.1';
+    const latestVersion = '3.2';
     if (debug) {console.log(`Current sheet version = ${version}`);}
     version = parseFloat(version) || 0;
     /* Eval sheet version and run upgrade functions as needed, note we have dropped functions of old versions */
@@ -376,8 +376,8 @@ function versioning(sheet_type, version) {
         else if (sheet_type === 'solar_system') {upgradeGeneric3Dot1();}
         else if (sheet_type === 'vehicle') {upgradeGeneric3Dot1();}
         versioning(sheet_type, '3.1');
-    } else if (version === 3.1) {
-        setAttrs({"version": "3.1"});
+    } else if (version >= 3.1) { /* TODO change this when we next introduce a version that requires updating */
+        setAttrs({"version": "3.2"});
     }
 }
 


### PR DESCRIPTION
# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

- [ ] This sheet has been made on behalf of, or by, the game's publisher.
- [ ] This game is not a traditionally published game, but a copy of the game rules can be purchased/downloaded/found at: <   >
- [ ] This sheet is for an unofficial fan game, modification to an existing game, or a homebrew system.

# Changes / Description

## 3.2
### Fixed
- Issue causing default setting of Mythic Britain to actually be Mythic Babylon and visa-versa.
- Fixed issue with default "whisper rolls to GM" being set incorrectly.




