### PR TITLE
[Ars Magica 5th] fix Roll20/roll20-character-sheets#11951: fix font imports

### DIFF
--- a/Ars_Magica_5th/Ars_Magica_5th.css
+++ b/Ars_Magica_5th/Ars_Magica_5th.css
@@ -1,6 +1,6 @@
 @import url("https://fonts.googleapis.com/css?family=Material+Icons&display=swap");
-@import url("https://fonts.googleapis.com/css?family=Material+Icons|Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap");
-@import url("https://fonts.googleapis.com/css?family=Delius|Bilbo+Swash+Caps|Kavivanar|Fredericka+the+Great|Macondo|Uncial+Antiqua|Material+Icons|Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap");
+@import url("https://fonts.googleapis.com/css?family=Material+Icons|Material+Symbols+Outlined&display=swap");
+@import url("https://fonts.googleapis.com/css?family=Delius|Bilbo+Swash+Caps|Kavivanar|Fredericka+the+Great|Macondo|Uncial+Antiqua|Material+Icons&display=swap");
 .tabs__container:not(.k-active-tab) {
   display: none !important;
 }

--- a/Ars_Magica_5th/Ars_Magica_5th.html
+++ b/Ars_Magica_5th/Ars_Magica_5th.html
@@ -4469,8 +4469,6 @@ const kDeleteAlert = function ({ trigger, attributes, sections }) {
 };
 
 k.registerFuncs({ "kDeleteAlert": kDeleteAlert });
-
-
   
   
    
@@ -4663,6 +4661,21 @@ const updateToKScaffold = function updateToKScaffold({ trigger, attributes, sect
     }
 };
 k.registerFuncs({ updateToKScaffold }, { type: ["new"] });
+
+// const _testAlerts = function ({ trigger, attributes, sections }) {
+//     ["info", "warning", "error", "success"].forEach(level => {
+//         kCreateAlert({
+//             name: "global-alerts",
+//             title: "test alert",
+//             text: "test alert\nnewline",
+//             level,
+//             attributes,
+//             sections
+
+//         });
+//     });
+// }
+// k.registerFuncs({ _testAlerts }, { type: ["opener"] });
 
 // const displayKScaffoldArgs = function ({ trigger, attributes, sections, casc }) {
 //     console.log("Displaying kScaffold arguments");

--- a/Ars_Magica_5th/__tests__/testFramework.js
+++ b/Ars_Magica_5th/__tests__/testFramework.js
@@ -1727,8 +1727,6 @@ const kDeleteAlert = function ({ trigger, attributes, sections }) {
 };
 
 k.registerFuncs({ "kDeleteAlert": kDeleteAlert });
-
-
   
   
    
@@ -1921,6 +1919,21 @@ const updateToKScaffold = function updateToKScaffold({ trigger, attributes, sect
     }
 };
 k.registerFuncs({ updateToKScaffold }, { type: ["new"] });
+
+// const _testAlerts = function ({ trigger, attributes, sections }) {
+//     ["info", "warning", "error", "success"].forEach(level => {
+//         kCreateAlert({
+//             name: "global-alerts",
+//             title: "test alert",
+//             text: "test alert\nnewline",
+//             level,
+//             attributes,
+//             sections
+
+//         });
+//     });
+// }
+// k.registerFuncs({ _testAlerts }, { type: ["opener"] });
 
 // const displayKScaffoldArgs = function ({ trigger, attributes, sections, casc }) {
 //     console.log("Displaying kScaffold arguments");

--- a/Ars_Magica_5th/source/Ars_Magica_5th.scss
+++ b/Ars_Magica_5th/source/Ars_Magica_5th.scss
@@ -7,7 +7,7 @@
 @use 'elements/_elements.scss';
 @use 'header/_header.scss';
 
-@import url('https://fonts.googleapis.com/css?family=Delius|Bilbo+Swash+Caps|Kavivanar|Fredericka+the+Great|Macondo|Uncial+Antiqua|Material+Icons|Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap');
+@import url('https://fonts.googleapis.com/css?family=Delius|Bilbo+Swash+Caps|Kavivanar|Fredericka+the+Great|Macondo|Uncial+Antiqua|Material+Icons&display=swap');
 
 
 /*

--- a/Ars_Magica_5th/source/helpers/_helpers.scss
+++ b/Ars_Magica_5th/source/helpers/_helpers.scss
@@ -1,6 +1,6 @@
 @use 'k-scaffold' as k;
 @use '../shared/heading_label.scss';
-@import url('https://fonts.googleapis.com/css?family=Material+Icons|Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap');
+@import url('https://fonts.googleapis.com/css?family=Material+Icons|Material+Symbols+Outlined&display=swap');
 
 
 .ui-dialog .tab-content .charsheet {

--- a/Ars_Magica_5th/source/helpers/helpers.sheet.js
+++ b/Ars_Magica_5th/source/helpers/helpers.sheet.js
@@ -38,4 +38,3 @@ const kDeleteAlert = function ({ trigger, attributes, sections }) {
 };
 
 k.registerFuncs({ "kDeleteAlert": kDeleteAlert });
-

--- a/Ars_Magica_5th/source/updates/updates.sheet.js
+++ b/Ars_Magica_5th/source/updates/updates.sheet.js
@@ -189,6 +189,21 @@ const updateToKScaffold = function updateToKScaffold({ trigger, attributes, sect
 };
 k.registerFuncs({ updateToKScaffold }, { type: ["new"] });
 
+// const _testAlerts = function ({ trigger, attributes, sections }) {
+//     ["info", "warning", "error", "success"].forEach(level => {
+//         kCreateAlert({
+//             name: "global-alerts",
+//             title: "test alert",
+//             text: "test alert\nnewline",
+//             level,
+//             attributes,
+//             sections
+
+//         });
+//     });
+// }
+// k.registerFuncs({ _testAlerts }, { type: ["opener"] });
+
 // const displayKScaffoldArgs = function ({ trigger, attributes, sections, casc }) {
 //     console.log("Displaying kScaffold arguments");
 //     console.log(trigger);


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

- Split out the Material Symbol import into a different `@import` statement, so that it doesn't interfere with other fonts
- Removed the variable font axes selection from the import. Those use nonstandard character for an import URL that the sanitizer likely trips on, and aren't apparently necessary




