### PR TITLE
[Warhammer 4e Character Sheet] v1.66 Add Practical Armor Quality

### DIFF
--- a/Warhammer 4e Character Sheet/README.md
+++ b/Warhammer 4e Character Sheet/README.md
@@ -81,11 +81,17 @@ Note conditions are not intended for out of combat situations, GM simply makes t
  
 ///// ============ Change Log ============ /////  
 
+June 30nd 2023 v1.66
+
+- Added Practical Quality option tick box to all Mail/Plate Armor, this will reduce all penalties by -10 on the given armor piece and update the penalties boxes accordingly.
+- Corrected issue on Armor Tab where Shield Durability was adding to AP on the hit locatiojns display to the right.
+
+
 June 22nd 2023 v1.65c
 
 - Added the Norse Race (Sea of Claws), same attribute as humans with default size average.
 - Fixed some rolls not working under certain conditions.
-- Fixed some failed roll Talent modifier text not displeying correctly. eg - You may Reverse Dice
+- Fixed some failed roll Talent modifier text not displaying correctly. eg - You may Reverse Dice
 
 
 February 28th 2023 v1.65b

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -130,7 +130,6 @@
 			</div>
 		</div>
 
-
 		<div class="row">
 			<div class="col-1-2 pad-r-sm pad-t-md">
 			<div class="col-1 seperator-cap left mar-l-md" >
@@ -523,6 +522,7 @@
 				<button type="action" class="hidden" name="act_shieldbash" />
 				<button type="action" class="hidden" name="act_furiousassaultoff" />
 
+			<input type="hidden" name="attr_pagemode" value="[[1d100]]" disabled />
 			<input type="hidden" name="attr_d100" value="[[1d100]]" disabled />
 			<input type="hidden" name="attr_LastCritRoll" value="0" disabled />
 			<input type="hidden" name="attr_LastRollOff" value="0" disabled />
@@ -26634,21 +26634,22 @@
 					</div>
 					<div class="row sub-header relative">
 						<div class="col-1-20 center small-label vert-bottom"><span data-i18n="WORN">Worn</span></div>
-						<div class="col-1-10t center small-label vert-bottom"><span data-i18n="TYPE">Type</span></div>
+						<div class="col-1-10 center small-label vert-bottom"><span data-i18n="TYPE">Type</span></div>
 						<div class="col-7-22 center small-label vert-bottom"><span data-i18n="NAME">Name</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ENCUMBRANCE">Enc</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="MOD">Mod</span></div>
-						<div class="col-1-12 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ARMOR-POINTS">AP</span></div>
+						<div class="col-1-14 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ARMOR-POINTS">AP</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="DURABLE">Durable</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="DMG-RED">Dmg</span></div>
 						<div class="col-1-12 center small-label vert-bottom"><span data-i18n="DMG-PTS">Dmg Pts.</span></div>
+						<div class="col-1-18 center small-label vert-bottom"><span data-i18n="ABBREVIATE-PRACTICAL"  data-i18n-title="PRACTICAL" title=" Practical ">Prac.</span></div>
 					</div>
 					<div class="row">
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveH1" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="LIGHT-ARMOUR">Light</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="LIGHT-ARMOUR" style="font-size: 11px">Light</span>
 						</div>
 						<div class="col-7-22 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameH1" />
@@ -26660,7 +26661,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusH1" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPH1" value="( ((( (((1+@{armormagicbonusH1}+@{armordurableH1}-@{armordamageH1}) + (1+@{armormagicbonusH1})) - abs((1+@{armormagicbonusH1}+@{armordurableH1}-@{armordamageH1}) - (1+@{armormagicbonusH1}))) / 2 ) + 0) + abs(( (((1+@{armormagicbonusH1}+@{armordurableH1}-@{armordamageH1}) + (1+@{armormagicbonusH1})) - abs((1+@{armormagicbonusH1}+@{armordurableH1}-@{armordamageH1}) - (1+@{armormagicbonusH1}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -26677,8 +26678,8 @@
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveH2" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="MEDIUM">Medium</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="MEDIUM" style="font-size: 11px">Medium</span>
 						</div>
 						<div class="col-7-22 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameH2" />
@@ -26690,7 +26691,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusH2" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPH2" value="( ((( (((2+@{armormagicbonusH2}+@{armordurableH2}-@{armordamageH2}) + (2+@{armormagicbonusH2})) - abs((2+@{armormagicbonusH2}+@{armordurableH2}-@{armordamageH2}) - (2+@{armormagicbonusH2}))) / 2 ) + 0) + abs(( (((2+@{armormagicbonusH2}+@{armordurableH2}-@{armordamageH2}) + (2+@{armormagicbonusH2})) - abs((2+@{armormagicbonusH2}+@{armordurableH2}-@{armordamageH2}) - (2+@{armormagicbonusH2}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -26702,19 +26703,22 @@
 						<div class="col-1-12 vert-middle pad-r-sm">
 							<input type="number" name="attr_armorptsH2" value="2+@{armordurableH2}+@{armormagicbonusH2}-@{armordamageH2}" disabled />
 						</div>
+						<div class="col-1-18 sheet-center pad-r-sm">
+							<input type="checkbox" name="attr_armorpracH2" value="1" />
+						</div>
 					</div>
 					<div class="row">
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveH3" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="HEAVY">Heavy</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="HEAVY" style="font-size: 11px">Heavy</span>
 						</div>
 						<div class="col-5-21 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameH3" />
 						</div>
 						<div class="col-2-25 vert-middle center pad-r-sm">
-							<input type="checkbox" name="attr_armorOpenH3" value="1"data-i18n-title="OPEN?" title=" Open? " />
+							<input type="checkbox" name="attr_armorOpenH3" value="1" data-i18n-title="OPEN?" title=" Open? " />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armorEncH3" value="0" min="0" />
@@ -26722,7 +26726,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusH3" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPH3" value="( ((( (((2+@{armormagicbonusH3}+@{armordurableH3}-@{armordamageH3}) + (2+@{armormagicbonusH3})) - abs((2+@{armormagicbonusH3}+@{armordurableH3}-@{armordamageH3}) - (2+@{armormagicbonusH3}))) / 2 ) + 0) + abs(( (((2+@{armormagicbonusH3}+@{armordurableH3}-@{armordamageH3}) + (2+@{armormagicbonusH3})) - abs((2+@{armormagicbonusH3}+@{armordurableH3}-@{armordamageH3}) - (2+@{armormagicbonusH3}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -26734,6 +26738,9 @@
 						<div class="col-1-12 vert-middle pad-r-sm">
 							<input type="number" name="attr_armorptsH3" value="2+@{armordurableH3}+@{armormagicbonusH3}-@{armordamageH3}" disabled />
 						</div>
+						<div class="col-1-18 sheet-center pad-r-sm">
+							<input type="checkbox" name="attr_armorpracH3" value="1" />
+						</div>
 					</div>
 
 					<div class="row spell-header">
@@ -26743,21 +26750,22 @@
 					</div>
 					<div class="row sub-header relative">
 						<div class="col-1-20 center small-label vert-bottom"><span data-i18n="WORN">Worn</span></div>
-						<div class="col-1-10t center small-label vert-bottom"><span data-i18n="TYPE">Type</span></div>
+						<div class="col-1-10 center small-label vert-bottom"><span data-i18n="TYPE">Type</span></div>
 						<div class="col-7-22 center small-label vert-bottom"><span data-i18n="NAME">Name</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ENCUMBRANCE">Enc</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="MOD">Mod</span></div>
-						<div class="col-1-12 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ARMOR-POINTS">AP</span></div>
+						<div class="col-1-14 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ARMOR-POINTS">AP</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="DURABLE">Durable</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="DMG-RED">Dmg</span></div>
 						<div class="col-1-12 center small-label vert-bottom"><span data-i18n="DMG-PTS">Dmg Pts.</span></div>
+						<div class="col-1-18 center small-label vert-bottom"><span data-i18n="ABBREVIATE-PRACTICAL">Prac.</span></div>
 					</div>
 					<div class="row">
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveT1" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="LIGHT-ARMOUR">Light</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="LIGHT-ARMOUR" style="font-size: 11px">Light</span>
 						</div>
 						<div class="col-7-22 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameT1" />
@@ -26768,7 +26776,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusT1" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPT1" value="( ((( (((1+@{armormagicbonusT1}+@{armordurableT1}-@{armordamageT1}) + (1+@{armormagicbonusT1})) - abs((1+@{armormagicbonusT1}+@{armordurableT1}-@{armordamageT1}) - (1+@{armormagicbonusT1}))) / 2 ) + 0) + abs(( (((1+@{armormagicbonusT1}+@{armordurableT1}-@{armordamageT1}) + (1+@{armormagicbonusT1})) - abs((1+@{armormagicbonusT1}+@{armordurableT1}-@{armordamageT1}) - (1+@{armormagicbonusT1}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -26785,8 +26793,8 @@
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveT2" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="MEDIUM">Medium</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="MEDIUM" style="font-size: 11px">Medium</span>
 						</div>
 						<div class="col-7-22 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameT2" />
@@ -26797,7 +26805,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusT2" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPT2" value="( ((( (((2+@{armormagicbonusT2}+@{armordurableT2}-@{armordamageT2}) + (2+@{armormagicbonusT2})) - abs((2+@{armormagicbonusT2}+@{armordurableT2}-@{armordamageT2}) - (2+@{armormagicbonusT2}))) / 2 ) + 0) + abs(( (((2+@{armormagicbonusT2}+@{armordurableT2}-@{armordamageT2}) + (2+@{armormagicbonusT2})) - abs((2+@{armormagicbonusT2}+@{armordurableT2}-@{armordamageT2}) - (2+@{armormagicbonusT2}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -26809,13 +26817,16 @@
 						<div class="col-1-12 vert-middle pad-r-sm">
 							<input type="number" name="attr_armorptsT2" value="2+@{armordurableT2}+@{armormagicbonusT2}-@{armordamageT2}" disabled />
 						</div>
+						<div class="col-1-18 sheet-center pad-r-sm">
+							<input type="checkbox" name="attr_armorpracT2" value="1" />
+						</div>
 					</div>
 					<div class="row">
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveT3" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="HEAVY">Heavy</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="HEAVY" style="font-size: 11px">Heavy</span>
 						</div>
 						<div class="col-7-22 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameT3" />
@@ -26826,7 +26837,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusT3" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPT3" value="( ((( (((2+@{armormagicbonusT3}+@{armordurableT3}-@{armordamageT3}) + (2+@{armormagicbonusT3})) - abs((2+@{armormagicbonusT3}+@{armordurableT3}-@{armordamageT3}) - (2+@{armormagicbonusT3}))) / 2 ) + 0) + abs(( (((2+@{armormagicbonusT3}+@{armordurableT3}-@{armordamageT3}) + (2+@{armormagicbonusT3})) - abs((2+@{armormagicbonusT3}+@{armordurableT3}-@{armordamageT3}) - (2+@{armormagicbonusT3}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -26838,6 +26849,9 @@
 						<div class="col-1-12 vert-middle pad-r-sm">
 							<input type="number" name="attr_armorptsT3" value="2+@{armordurableT3}+@{armormagicbonusT3}-@{armordamageT3}" disabled />
 						</div>
+						<div class="col-1-18 sheet-center pad-r-sm">
+							<input type="checkbox" name="attr_armorpracT3" value="1" />
+						</div>
 					</div>
 					<div class="row spell-header">
 						<div class="col-1 vert-bottom center small-label mar-t-md">
@@ -26846,21 +26860,22 @@
 					</div>
 					<div class="row sub-header relative">
 						<div class="col-1-20 center small-label vert-bottom"><span data-i18n="WORN">Worn</span></div>
-						<div class="col-1-10t center small-label vert-bottom"><span data-i18n="TYPE">Type</span></div>
+						<div class="col-1-10 center small-label vert-bottom"><span data-i18n="TYPE">Type</span></div>
 						<div class="col-7-22 center small-label vert-bottom"><span data-i18n="NAME">Name</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ENCUMBRANCE">Enc</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="MOD">Mod</span></div>
-						<div class="col-1-12 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ARMOR-POINTS">AP</span></div>
+						<div class="col-1-14 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ARMOR-POINTS">AP</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="DURABLE">Durable</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="DMG-RED">Dmg</span></div>
 						<div class="col-1-12 center small-label vert-bottom"><span data-i18n="DMG-PTS">Dmg Pts.</span></div>
+						<div class="col-1-18 center small-label vert-bottom"><span data-i18n="ABBREVIATE-PRACTICAL">Prac.</span></div>
 					</div>
 					<div class="row">
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveLA1" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="LIGHT-ARMOUR">Light</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="LIGHT-ARMOUR" style="font-size: 11px">Light</span>
 						</div>
 						<div class="col-7-22 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameLA1" />
@@ -26871,7 +26886,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusLA1" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPLA1" value="( ((( (((1+@{armormagicbonusLA1}+@{armordurableLA1}-@{armordamageLA1}) + (1+@{armormagicbonusLA1})) - abs((1+@{armormagicbonusLA1}+@{armordurableLA1}-@{armordamageLA1}) - (1+@{armormagicbonusLA1}))) / 2 ) + 0) + abs(( (((1+@{armormagicbonusLA1}+@{armordurableLA1}-@{armordamageLA1}) + (1+@{armormagicbonusLA1})) - abs((1+@{armormagicbonusLA1}+@{armordurableLA1}-@{armordamageLA1}) - (1+@{armormagicbonusLA1}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -26888,8 +26903,8 @@
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveLA2" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="MEDIUM">Medium</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="MEDIUM" style="font-size: 11px">Medium</span>
 						</div>
 						<div class="col-7-22 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameLA2" />
@@ -26900,7 +26915,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusLA2" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPLA2" value="( ((( (((2+@{armormagicbonusLA2}+@{armordurableLA2}-@{armordamageLA2}) + (2+@{armormagicbonusLA2})) - abs((2+@{armormagicbonusLA2}+@{armordurableLA2}-@{armordamageLA2}) - (2+@{armormagicbonusLA2}))) / 2 ) + 0) + abs(( (((2+@{armormagicbonusLA2}+@{armordurableLA2}-@{armordamageLA2}) + (2+@{armormagicbonusLA2})) - abs((2+@{armormagicbonusLA2}+@{armordurableLA2}-@{armordamageLA2}) - (2+@{armormagicbonusLA2}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -26912,13 +26927,16 @@
 						<div class="col-1-12 vert-middle pad-r-sm">
 							<input type="number" name="attr_armorptsLA2" value="2+@{armordurableLA2}+@{armormagicbonusLA2}-@{armordamageLA2}" disabled />
 						</div>
+						<div class="col-1-18 sheet-center pad-r-sm">
+							<input type="checkbox" name="attr_armorpracLA2" value="1" />
+						</div>
 					</div>
 					<div class="row">
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveLA3" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="HEAVY">Heavy</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="HEAVY" style="font-size: 11px">Heavy</span>
 						</div>
 						<div class="col-7-22 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameLA3" />
@@ -26929,7 +26947,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusLA3" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPLA3" value="( ((( (((2+@{armormagicbonusLA3}+@{armordurableLA3}-@{armordamageLA3}) + (2+@{armormagicbonusLA3})) - abs((2+@{armormagicbonusLA3}+@{armordurableLA3}-@{armordamageLA3}) - (2+@{armormagicbonusLA3}))) / 2 ) + 0) + abs(( (((2+@{armormagicbonusLA3}+@{armordurableLA3}-@{armordamageLA3}) + (2+@{armormagicbonusLA3})) - abs((2+@{armormagicbonusLA3}+@{armordurableLA3}-@{armordamageLA3}) - (2+@{armormagicbonusLA3}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -26941,6 +26959,9 @@
 						<div class="col-1-12 vert-middle pad-r-sm">
 							<input type="number" name="attr_armorptsLA3" value="2+@{armordurableLA3}+@{armormagicbonusLA3}-@{armordamageLA3}" disabled />
 						</div>
+						<div class="col-1-18 sheet-center pad-r-sm">
+							<input type="checkbox" name="attr_armorpracLA3" value="1" />
+						</div>
 					</div>
 					<div class="row spell-header">
 						<div class="col-1 vert-bottom center small-label mar-t-md">
@@ -26949,21 +26970,22 @@
 					</div>
 					<div class="row sub-header relative">
 						<div class="col-1-20 center small-label vert-bottom"><span data-i18n="WORN">Worn</span></div>
-						<div class="col-1-10t center small-label vert-bottom"><span data-i18n="TYPE">Type</span></div>
+						<div class="col-1-10 center small-label vert-bottom"><span data-i18n="TYPE">Type</span></div>
 						<div class="col-7-22 center small-label vert-bottom"><span data-i18n="NAME">Name</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ENCUMBRANCE">Enc</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="MOD">Mod</span></div>
-						<div class="col-1-12 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ARMOR-POINTS">AP</span></div>
+						<div class="col-1-14 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ARMOR-POINTS">AP</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="DURABLE">Durable</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="DMG-RED">Dmg</span></div>
 						<div class="col-1-12 center small-label vert-bottom"><span data-i18n="DMG-PTS">Dmg Pts.</span></div>
+						<div class="col-1-18 center small-label vert-bottom"><span data-i18n="ABBREVIATE-PRACTICAL">Prac.</span></div>
 					</div>
 					<div class="row">
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveLA1" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="LIGHT-ARMOUR">Light</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="LIGHT-ARMOUR" style="font-size: 11px">Light</span>
 						</div>
 						<div class="col-7-22 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameRA1" />
@@ -26974,7 +26996,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusRA1" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPRA1" value="( ((( (((1+@{armormagicbonusRA1}+@{armordurableRA1}-@{armordamageRA1}) + (1+@{armormagicbonusRA1})) - abs((1+@{armormagicbonusRA1}+@{armordurableRA1}-@{armordamageRA1}) - (1+@{armormagicbonusRA1}))) / 2 ) + 0) + abs(( (((1+@{armormagicbonusRA1}+@{armordurableRA1}-@{armordamageRA1}) + (1+@{armormagicbonusRA1})) - abs((1+@{armormagicbonusRA1}+@{armordurableRA1}-@{armordamageRA1}) - (1+@{armormagicbonusRA1}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -26991,8 +27013,8 @@
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveLA2" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="MEDIUM">Medium</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="MEDIUM" style="font-size: 11px">Medium</span>
 						</div>
 						<div class="col-7-22 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameRA2" />
@@ -27003,7 +27025,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusRA2" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPRA2" value="( ((( (((2+@{armormagicbonusRA2}+@{armordurableRA2}-@{armordamageRA2}) + (2+@{armormagicbonusRA2})) - abs((2+@{armormagicbonusRA2}+@{armordurableRA2}-@{armordamageRA2}) - (2+@{armormagicbonusRA2}))) / 2 ) + 0) + abs(( (((2+@{armormagicbonusRA2}+@{armordurableRA2}-@{armordamageRA2}) + (2+@{armormagicbonusRA2})) - abs((2+@{armormagicbonusRA2}+@{armordurableRA2}-@{armordamageRA2}) - (2+@{armormagicbonusRA2}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -27015,13 +27037,16 @@
 						<div class="col-1-12 vert-middle pad-r-sm">
 							<input type="number" name="attr_armorptsRA2" value="2+@{armordurableRA2}+@{armormagicbonusRA2}-@{armordamageRA2}" disabled />
 						</div>
+						<div class="col-1-18 sheet-center pad-r-sm">
+							<input type="checkbox" name="attr_armorpracLA2" value="1" />
+						</div>
 					</div>
 					<div class="row">
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveLA3" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="HEAVY">Heavy</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="HEAVY" style="font-size: 11px">Heavy</span>
 						</div>
 						<div class="col-7-22 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameLA3" />
@@ -27032,7 +27057,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusRA3" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPRA3" value="( ((( (((2+@{armormagicbonusRA3}+@{armordurableRA3}-@{armordamageRA3}) + (2+@{armormagicbonusRA3})) - abs((2+@{armormagicbonusRA3}+@{armordurableRA3}-@{armordamageRA3}) - (2+@{armormagicbonusRA3}))) / 2 ) + 0) + abs(( (((2+@{armormagicbonusRA3}+@{armordurableRA3}-@{armordamageRA3}) + (2+@{armormagicbonusRA3})) - abs((2+@{armormagicbonusRA3}+@{armordurableRA3}-@{armordamageRA3}) - (2+@{armormagicbonusRA3}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -27044,6 +27069,9 @@
 						<div class="col-1-12 vert-middle pad-r-sm">
 							<input type="number" name="attr_armorptsRA3" value="2+@{armordurableRA3}+@{armormagicbonusRA3}-@{armordamageRA3}" disabled />
 						</div>
+						<div class="col-1-18 sheet-center pad-r-sm">
+							<input type="checkbox" name="attr_armorpracLA3" value="1" />
+						</div>
 					</div>
 					<div class="row spell-header">
 						<div class="col-1 vert-bottom center small-label mar-t-md">
@@ -27052,21 +27080,22 @@
 					</div>
 					<div class="row sub-header relative">
 						<div class="col-1-20 center small-label vert-bottom"><span data-i18n="WORN">Worn</span></div>
-						<div class="col-1-10t center small-label vert-bottom"><span data-i18n="TYPE">Type</span></div>
+						<div class="col-1-10 center small-label vert-bottom"><span data-i18n="TYPE">Type</span></div>
 						<div class="col-7-22 center small-label vert-bottom"><span data-i18n="NAME">Name</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ENCUMBRANCE">Enc</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="MOD">Mod</span></div>
-						<div class="col-1-12 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ARMOR-POINTS">AP</span></div>
+						<div class="col-1-14 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ARMOR-POINTS">AP</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="DURABLE">Durable</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="DMG-RED">Dmg</span></div>
 						<div class="col-1-12 center small-label vert-bottom"><span data-i18n="DMG-PTS">Dmg Pts.</span></div>
+						<div class="col-1-18 center small-label vert-bottom"><span data-i18n="ABBREVIATE-PRACTICAL">Prac.</span></div>
 					</div>
 					<div class="row">
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveLL1" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="LIGHT-ARMOUR">Light</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="LIGHT-ARMOUR" style="font-size: 11px">Light</span>
 						</div>
 						<div class="col-7-22 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameLL1" />
@@ -27077,7 +27106,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusLL1" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPLL1" value="( ((( (((1+@{armormagicbonusLL1}+@{armordurableLL1}-@{armordamageLL1}) + (1+@{armormagicbonusLL1})) - abs((1+@{armormagicbonusLL1}+@{armordurableLL1}-@{armordamageLL1}) - (1+@{armormagicbonusLL1}))) / 2 ) + 0) + abs(( (((1+@{armormagicbonusLL1}+@{armordurableLL1}-@{armordamageLL1}) + (1+@{armormagicbonusLL1})) - abs((1+@{armormagicbonusLL1}+@{armordurableLL1}-@{armordamageLL1}) - (1+@{armormagicbonusLL1}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -27087,15 +27116,15 @@
 							<input type="number" name="attr_armordamageLL1" value="0" min="0" />
 						</div>
 						<div class="col-1-12 vert-middle pad-r-sm">
-							<input type="number" name="attr_armorptsLL2" value="1+@{armordurableLL1}+@{armormagicbonusLL1}-@{armordamageLL1}" disabled />
+							<input type="number" name="attr_armorptsLL1" value="1+@{armordurableLL1}+@{armormagicbonusLL1}-@{armordamageLL1}" disabled />
 						</div>
 					</div>
 					<div class="row">
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveLL2" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="MEDIUM">Medium</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="MEDIUM" style="font-size: 11px">Medium</span>
 						</div>
 						<div class="col-7-22 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameLL2" />
@@ -27106,7 +27135,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusLL2" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPLL2" value="( ((( (((2+@{armormagicbonusLL2}+@{armordurableLL2}-@{armordamageLL2}) + (2+@{armormagicbonusLL2})) - abs((2+@{armormagicbonusLL2}+@{armordurableLL2}-@{armordamageLL2}) - (2+@{armormagicbonusLL2}))) / 2 ) + 0) + abs(( (((2+@{armormagicbonusLL2}+@{armordurableLL2}-@{armordamageLL2}) + (2+@{armormagicbonusLL2})) - abs((2+@{armormagicbonusLL2}+@{armordurableLL2}-@{armordamageLL2}) - (2+@{armormagicbonusLL2}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -27118,13 +27147,16 @@
 						<div class="col-1-12 vert-middle pad-r-sm">
 							<input type="number" name="attr_armorptsLL2" value="2+@{armordurableLL2}+@{armormagicbonusLL2}-@{armordamageLL2}" disabled />
 						</div>
+						<div class="col-1-18 sheet-center pad-r-sm">
+							<input type="checkbox" name="attr_armorpracLL2" value="1" />
+						</div>
 					</div>
 					<div class="row">
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveLL3" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="HEAVY">Heavy</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="HEAVY" style="font-size: 11px">Heavy</span>
 						</div>
 						<div class="col-7-22 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameLL3" />
@@ -27135,7 +27167,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusLL3" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPLL3" value="( ((( (((2+@{armormagicbonusLL3}+@{armordurableLL3}-@{armordamageLL3}) + (2+@{armormagicbonusLL3})) - abs((2+@{armormagicbonusLL3}+@{armordurableLL3}-@{armordamageLL3}) - (2+@{armormagicbonusLL3}))) / 2 ) + 0) + abs(( (((2+@{armormagicbonusLL3}+@{armordurableLL3}-@{armordamageLL3}) + (2+@{armormagicbonusLL3})) - abs((2+@{armormagicbonusLL3}+@{armordurableLL3}-@{armordamageLL3}) - (2+@{armormagicbonusLL3}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -27147,6 +27179,9 @@
 						<div class="col-1-12 vert-middle pad-r-sm">
 							<input type="number" name="attr_armorptsLL3" value="2+@{armordurableLL3}+@{armormagicbonusLL3}-@{armordamageLL3}" disabled />
 						</div>
+						<div class="col-1-18 sheet-center pad-r-sm">
+							<input type="checkbox" name="attr_armorpracLL3" value="1" />
+						</div>
 					</div>
 					<div class="row spell-header">
 						<div class="col-1 vert-bottom center small-label mar-t-md">
@@ -27155,21 +27190,22 @@
 					</div>
 					<div class="row sub-header relative">
 						<div class="col-1-20 center small-label vert-bottom"><span data-i18n="WORN">Worn</span></div>
-						<div class="col-1-10t center small-label vert-bottom"><span data-i18n="TYPE">Type</span></div>
+						<div class="col-1-10 center small-label vert-bottom"><span data-i18n="TYPE">Type</span></div>
 						<div class="col-7-22 center small-label vert-bottom"><span data-i18n="NAME">Name</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ENCUMBRANCE">Enc</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="MOD">Mod</span></div>
-						<div class="col-1-12 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ARMOR-POINTS">AP</span></div>
+						<div class="col-1-14 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ARMOR-POINTS">AP</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="DURABLE">Durable</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="DMG-RED">Dmg</span></div>
 						<div class="col-1-12 center small-label vert-bottom"><span data-i18n="DMG-PTS">Dmg Pts.</span></div>
+						<div class="col-1-18 center small-label vert-bottom"><span data-i18n="ABBREVIATE-PRACTICAL">Prac.</span></div>
 					</div>
 					<div class="row">
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveLL1" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="LIGHT-ARMOUR">Light</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="LIGHT-ARMOUR" style="font-size: 11px">Light</span>
 						</div>
 						<div class="col-7-22 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameRL1" />
@@ -27181,7 +27217,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusRL1" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPRL1" value="( ((( (((1+@{armormagicbonusRL1}+@{armordurableRL1}-@{armordamageRL1}) + (1+@{armormagicbonusRL1})) - abs((1+@{armormagicbonusRL1}+@{armordurableRL1}-@{armordamageRL1}) - (1+@{armormagicbonusRL1}))) / 2 ) + 0) + abs(( (((1+@{armormagicbonusRL1}+@{armordurableRL1}-@{armordamageRL1}) + (1+@{armormagicbonusRL1})) - abs((1+@{armormagicbonusRL1}+@{armordurableRL1}-@{armordamageRL1}) - (1+@{armormagicbonusRL1}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -27198,8 +27234,8 @@
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveLL2" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="MEDIUM">Medium</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="MEDIUM" style="font-size: 11px">Medium</span>
 						</div>
 						<div class="col-7-22 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameRL2" />
@@ -27210,7 +27246,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusRL2" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPRL2" value="( ((( (((2+@{armormagicbonusRL2}+@{armordurableRL2}-@{armordamageRL2}) + (2+@{armormagicbonusRL2})) - abs((2+@{armormagicbonusRL2}+@{armordurableRL2}-@{armordamageRL2}) - (2+@{armormagicbonusRL2}))) / 2 ) + 0) + abs(( (((2+@{armormagicbonusRL2}+@{armordurableRL2}-@{armordamageRL2}) + (2+@{armormagicbonusRL2})) - abs((2+@{armormagicbonusRL2}+@{armordurableRL2}-@{armordamageRL2}) - (2+@{armormagicbonusRL2}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -27222,13 +27258,16 @@
 						<div class="col-1-12 vert-middle pad-r-sm">
 							<input type="number" name="attr_armorptsRL2" value="2+@{armordurableRL2}+@{armormagicbonusRL2}-@{armordamageRL2}" disabled />
 						</div>
+						<div class="col-1-18 sheet-center pad-r-sm">
+							<input type="checkbox" name="attr_armorpracLL2" value="1" />
+						</div>
 					</div>
 					<div class="row">
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveLL3" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="HEAVY">Heavy</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="HEAVY" style="font-size: 11px">Heavy</span>
 						</div>
 						<div class="col-7-22 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameRL3" />
@@ -27240,7 +27279,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusRL3" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPRL3" value="( ((( (((2+@{armormagicbonusRL3}+@{armordurableRL3}-@{armordamageRL3}) + (2+@{armormagicbonusRL3})) - abs((2+@{armormagicbonusRL3}+@{armordurableRL3}-@{armordamageRL3}) - (2+@{armormagicbonusRL3}))) / 2 ) + 0) + abs(( (((2+@{armormagicbonusRL3}+@{armordurableRL3}-@{armordamageRL3}) + (2+@{armormagicbonusRL3})) - abs((2+@{armormagicbonusRL3}+@{armordurableRL3}-@{armordamageRL3}) - (2+@{armormagicbonusRL3}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -27252,6 +27291,9 @@
 						<div class="col-1-12 vert-middle pad-r-sm">
 							<input type="number" name="attr_armorptsRL3" value="2+@{armordurableRL3}+@{armormagicbonusRL3}-@{armordamageRL3}" disabled />
 						</div>
+						<div class="col-1-18 sheet-center pad-r-sm">
+							<input type="checkbox" name="attr_armorpracLL3" value="1" />
+						</div>
 					</div>
 					<div class="row spell-header">
 						<div class="col-1 vert-bottom center small-label mar-t-md">
@@ -27260,11 +27302,11 @@
 					</div>
 					<div class="row sub-header relative">
 						<div class="col-1-20 center small-label vert-bottom"><span data-i18n="WORN">Worn</span></div>
-						<div class="col-1-10t center small-label vert-bottom"><span data-i18n="TYPE">Type</span></div>
+						<div class="col-1-10 center small-label vert-bottom"><span data-i18n="TYPE">Type</span></div>
 						<div class="col-7-22 center small-label vert-bottom"><span data-i18n="NAME">Name</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ENCUMBRANCE">Enc</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="MOD">Mod</span></div>
-						<div class="col-1-12 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ARMOR-POINTS">AP</span></div>
+						<div class="col-1-14 center small-label vert-bottom"><span data-i18n="ABBREVIATE-ARMOR-POINTS">AP</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="DURABLE">Durable</span></div>
 						<div class="col-2-25 center small-label vert-bottom"><span data-i18n="DMG-RED">Dmg</span></div>
 						<div class="col-1-12 center small-label vert-bottom"><span data-i18n="DMG-PTS">Dmg Pts.</span></div>
@@ -27273,8 +27315,8 @@
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveS1" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="LIGHT-ARMOUR">Light</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="LIGHT-ARMOUR" style="font-size: 11px">Light</span>
 						</div>
 						<div class="col-7-22 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameS1" />
@@ -27286,7 +27328,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusS1" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPS1" value="( ((( (((1+@{armormagicbonusS1}+@{armordurableS1}-@{armordamageS1}) + (1+@{armormagicbonusS1})) - abs((1+@{armormagicbonusS1}+@{armordurableS1}-@{armordamageS1}) - (1+@{armormagicbonusS1}))) / 2 ) + 0) + abs(( (((1+@{armormagicbonusS1}+@{armordurableS1}-@{armordamageS1}) + (1+@{armormagicbonusS1})) - abs((1+@{armormagicbonusS1}+@{armordurableS1}-@{armordamageS1}) - (1+@{armormagicbonusS1}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -27296,15 +27338,15 @@
 							<input type="number" name="attr_armordamageS1" value="0" min="0" />
 						</div>
 						<div class="col-1-12 vert-middle pad-r-sm">
-							<input type="number" name="attr_armortotalAPS1" value="1+@{armordurableS1}+@{armormagicbonusS1}-@{armordamageS1}" disabled />
+							<input type="number" name="attr_armorptsS1" value="1+@{armordurableS1}+@{armormagicbonusS1}-@{armordamageS1}" disabled />
 						</div>
 					</div>
 					<div class="row">
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveS2" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="MEDIUM">Medium</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="MEDIUM" style="font-size: 11px">Medium</span>
 						</div>
 						<div class="col-7-22 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameS2" />
@@ -27316,7 +27358,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusS2" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPS2" value="( ((( (((2+@{armormagicbonusS2}+@{armordurableS2}-@{armordamageS2}) + (2+@{armormagicbonusS2})) - abs((2+@{armormagicbonusS2}+@{armordurableS2}-@{armordamageS2}) - (2+@{armormagicbonusS2}))) / 2 ) + 0) + abs(( (((2+@{armormagicbonusS2}+@{armordurableS2}-@{armordamageS2}) + (2+@{armormagicbonusS2})) - abs((2+@{armormagicbonusS2}+@{armordurableS2}-@{armordamageS2}) - (2+@{armormagicbonusS2}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -27326,15 +27368,15 @@
 							<input type="number" name="attr_armordamageS2" value="0" min="0" />
 						</div>
 						<div class="col-1-12 vert-middle pad-r-sm">
-							<input type="number" name="attr_armortotalAPS2" value="2+@{armordurableS2}+@{armormagicbonusS2}-@{armordamageS2}" disabled />
+							<input type="number" name="attr_armorptsAPS2" value="2+@{armordurableS2}+@{armormagicbonusS2}-@{armordamageS2}" disabled />
 						</div>
 					</div>
 					<div class="row">
 						<div class="col-1-20 center vert-middle">
 							<input type="checkbox" name="attr_armoractiveS3" value="1" />
 						</div>
-						<div class="col-1-10t center vert-middle pad-r-sm">
-							<span data-i18n="HEAVY">Heavy</span>
+						<div class="col-1-10 center vert-middle pad-r-sm">
+							<span data-i18n="HEAVY" style="font-size: 11px">Heavy</span>
 						</div>
 						<div class="col-7-22 vert-middle pad-r-sm">
 							<input type="text" name="attr_armornameS3" />
@@ -27346,7 +27388,7 @@
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input type="number" name="attr_armormagicbonusS3" value="0" />
 						</div>
-						<div class="col-1-12 vert-middle pad-r-sm">
+						<div class="col-1-14 vert-middle pad-r-sm">
 							<input type="number" name="attr_armortotalAPS3" value="( ((( (((3+@{armormagicbonusS3}+@{armordurableS3}-@{armordamageS3}) + (3+@{armormagicbonusS3})) - abs((3+@{armormagicbonusS3}+@{armordurableS3}-@{armordamageS3}) - (3+@{armormagicbonusS3}))) / 2 ) + 0) + abs(( (((3+@{armormagicbonusS3}+@{armordurableS3}-@{armordamageS3}) + (3+@{armormagicbonusS3})) - abs((3+@{armormagicbonusS3}+@{armordurableS3}-@{armordamageS3}) - (3+@{armormagicbonusS3}))) / 2 ) - 0)) / 2 )" disabled />
 						</div>
 						<div class="col-2-25 vert-middle pad-r-sm">
@@ -27356,12 +27398,12 @@
 							<input type="number" name="attr_armordamageS3" value="0" min="0" />
 						</div>
 						<div class="col-1-12 vert-middle pad-r-sm">
-							<input type="number" name="attr_armortotalAPS3" value="3+@{armordurableS3}+@{armormagicbonusS3}-@{armordamageS3}" disabled />
+							<input type="number" name="attr_armorptsAPS3" value="3+@{armordurableS3}+@{armormagicbonusS3}-@{armordamageS3}" disabled />
 						</div>
 					</div>
 					<div class="row">
 						<div class="col-1-20 center vert-middle"></div>
-						<div class="col-1-10t center vert-middle pad-r-sm"></div>
+						<div class="col-1-10 center vert-middle pad-r-sm"></div>
 						<div class="col-7-22 vert-middle pad-r-sm"></div>
 						<div class="col-2-25 vert-middle pad-r-sm">
 							<input class="center" type="value" name="attr_armortotalenc" value="(((((@{armorEncH1}-1}) + 0) + abs((@{armorEncH1}-1) - 0))/2)*@{armoractiveH1})+(((((@{armorEncH2}-1}) + 0) + abs((@{armorEncH2}-1) - 0))/2)*@{armoractiveH2})+(((((@{armorEncH3}-1}) + 0) + abs((@{armorEncH3}-1) - 0))/2)*@{armoractiveH3})+(((((@{armorEncT1}-1}) + 0) + abs((@{armorEncT1}-1) - 0))/2)*@{armoractiveT1})+(((((@{armorEncT2}-1}) + 0) + abs((@{armorEncT2}-1) - 0))/2)*@{armoractiveT2})+(((((@{armorEncT3}-1}) + 0) + abs((@{armorEncT3}-1) - 0))/2)*@{armoractiveT3})+(((((@{armorEncLA1}-1}) + 0) + abs((@{armorEncLA1}-1) - 0))/2)*@{armoractiveLA1})+(((((@{armorEncLA2}-1}) + 0) + abs((@{armorEncLA2}-1) - 0))/2)*@{armoractiveLA2})+(((((@{armorEncLA3}-1}) + 0) + abs((@{armorEncLA3}-1) - 0))/2)*@{armoractiveLA3})+(((((@{armorEncLL1}-1}) + 0) + abs((@{armorEncLL1}-1) - 0))/2)*@{armoractiveLL1})+(((((@{armorEncLL2}-1}) + 0) + abs((@{armorEncLL2}-1) - 0))/2)*@{armoractiveLL2})+(((((@{armorEncLL3}-1}) + 0) + abs((@{armorEncLL3}-1) - 0))/2)*@{armoractiveLL3})+(((((@{armorEncS1}}) + 0) + abs((@{armorEncS1}) - 0))/2)*@{armoractiveS1})+(((((@{armorEncS2}}) + 0) + abs((@{armorEncS2}) - 0))/2)*@{armoractiveS2})+(((((@{armorEncS3}}) + 0) + abs((@{armorEncS3}) - 0))/2)*@{armoractiveS3})" min="0" disabled />
@@ -28287,17 +28329,11 @@
 
 							</div>
 							<div class="col-13-40 right">
-	<input type="checkbox" name="attr_talentmode" class="hidden hider" value="2"  />
 							<div class="col-1-10 left">
-								<input type="checkbox" name="attr_UsedSpell1" value="1" style="right: 60px; position: relative; bottom: 5px " />
 							</div>
-	<input type="checkbox" name="attr_talentmode" class="hidden hider" value="2"  />
 							<div class="col-1-10 left">
-								<input type="checkbox" name="attr_UsedSpell2" value="1" style="right: 60px; position: relative; bottom: 5px " />
 							</div>
-	<input type="checkbox" name="attr_talentmode" class="hidden hider" value="2"  />
-							<div class="col-1-10 left">
-								<input type="checkbox" name="attr_UsedSpell3" value="1" style="right: 60px; position: relative; bottom: 5px " />
+							<div class="col-1-12 left">
 							</div>
 							<div class="col-1-3 right">
 									<span data-i18n="MEMORISED">Memorised</span>:
@@ -30824,6 +30860,24 @@
 				</div>
 			</div>
 		<hr />
+			<div class="row spell-header">
+				<div class="col-1 vert-bottom left small-label pad-l-md">
+					<span >Pagemode</span>
+				</div>
+			</div>
+			<div class="row mar-b-md">
+				<div class="col-1 pad-r-md">		
+			<select class="select-no-arrow-center" name="attr_pagemode" style="height: 22px; padding-top: 0px; padding-bottom: 0px; font-weight: bold;">
+			<option value="0" selected="selected" >Chooser</option>
+			<option value="1" data-i18n="CHARACTER">Character</option>
+			<option value="2" data-i18n="MONSTER">Monster</option>
+			<option value="3" data-i18n="VEHICLE">Vehicle</option>
+			</select>	
+				</div>
+			</div>
+		<hr />
+		
+		
 		<div class="spacer-xl"></div>
 		<div class="row center">
 		<button type="roll" name="roll_url_notes" class="center" value="https://github.com/Roll20/roll20-character-sheets/blob/master/Warhammer%204e%20Character%20Sheet/README.md"> Release Notes </button>
@@ -30833,7 +30887,7 @@
 		<div class="spacer-xl"></div>
 		<!-- FOOTER -->
 		<div class="row footer">
-			<div class="col-1 small-label center">Sheet version 1.65 : December 20th 2022 | by Djjus & Pote</div>
+			<div class="col-1 small-label center">Sheet version 1.66 : June 30th 2023 | by Djjus & Pote</div>
 		</div>
 		</div>
 	</div>
@@ -30842,9 +30896,14 @@
 	</div>
 </div>
 	</div>
+</div>
+		</div>
 </div>
 						</div>
-</div>
+						</div>
+						</div>
+						</div>
+			</div>
 
 	<rolltemplate class="sheet-rolltemplate-whfrp2e">
 		<div class="rt-card">
@@ -45947,13 +46006,29 @@ on('sheet:opened change:Talents_XP_Dis change:XP_Display3 change:XP_Mode', funct
 });
 
 on('sheet:opened', function() {
-			getAttrs(["sheetcheck"], function(c) {
-            console.log(c.sheetcheck);
+			getAttrs(["sheetcheck", "pagemode", "WeaponSkill"], function(c) {
+            console.log(c.sheetcheck);	
+			if (c.pagemode > 0) {} else {	
+			
+			if (c.WeaponSkill > 0) {
+		setAttrs({
+			"pagemode": 1,
+	    }, {silent: true});
+		
+		
+		} else {
+		setAttrs({
+			"pagemode": 0,
+	    }, {silent: true});
+		
+		
+		}
 			if (c.sheetcheck == 10) return;
 			if (c.sheetcheck == 0) {	
 		setAttrs({
 			"MeleeOffType": 0,
-	    }, {silent: true});}
+	    }, {silent: true});}}
+		
 			
 		setAttrs({
 			"Talentmode": 1,
@@ -50324,7 +50399,7 @@ on("change:repeating_spellbookarcane:UsedSpell1 change:repeating_spellbookarcane
 	});			
 });		
 
-on('change:armoractiveH1 change:armoractiveH2 change:armoractiveH3 change:armoractiveT1 change:armoractiveT2 change:armoractiveT3 change:armoractiveLA1 change:armoractiveLA2 change:armoractiveLA3 change:armoractiveLL1 change:armoractiveLL2 change:armoractiveLL3 change:armoropenh3', function(event){
+on('change:armoractiveH1 change:armoractiveH2 change:armoractiveH3 change:armoractiveT1 change:armoractiveT2 change:armoractiveT3 change:armoractiveLA1 change:armoractiveLA2 change:armoractiveLA3 change:armoractiveLL1 change:armoractiveLL2 change:armoractiveLL3 change:armoropenh3 change:armorpracH1 change:armorpracH2 change:armorpracH3 change:armorpracT1 change:armorpracT2 change:armorpracT3 change:armorpracLA1 change:armorpracLA2 change:armorpracLA3 change:armorpracLL1 change:armorpracLL2 change:armorpracLL3', function(event){
         if (event.sourceType === 'sheetworker') return;
     console.log("Armor Change");	
 	
@@ -50344,23 +50419,22 @@ on('change:armoractiveH1 change:armoractiveH2 change:armoractiveH3 change:armora
 
 		});	
 	}
-	if (trigger = "armoractiveh2") {
-   getAttrs(["armoractiveh1", "armoractiveh2", "armoractiveh3"], function(v) {	
+	if ((trigger = "armoractiveh2") || (trigger = "armorproch2")) {
+   getAttrs(["armoractiveh1", "armoractiveh2", "armoractiveh3", "armorprach1", "armorprach2", "armorprach3"], function(v) {	
 
 	ar = v.armoractiveh1*1 + v.armoractiveh2*1 + v.armoractiveh3*1;
 	if (ar > 0) {ar = 1;} else {ar = 0;}
 	
 			setAttrs({
 				"armorpartial": ar,
-				"armorcoifpenalty": v.armoractiveh2*10,
+				"armorcoifpenalty": v.armoractiveh2*10-v.armorprach2*10,
 			}, {silent: true});	
 
 		});
-   getAttrs(["armoractiveh2", "armoractivet2", "armoractivela2", "armoractivell2"], function(v) {	
+   getAttrs(["armoractiveh2", "armoractivet2", "armoractivela2", "armoractivell2", "armorprach2", "armorpract2", "armorpracla2", "armorpracll2"], function(v) {	
 
-	ar2 = v.armoractiveh2*1 + v.armoractivet2*1 + v.armoractivela2*1 + v.armoractivell2*1;
+	ar2 = Math.max(v.armoractiveh2*1-v.armorprach2*1, 0) + Math.max(v.armoractivet2*1-v.armorpract2*1, 0) + Math.max(v.armoractivela2*1-v.armorpracla2*1, 0) + Math.max(v.armoractivell2*1-v.armorpracll2*1, 0);
 	if (ar2 > 0) {ar2 = 10;} else {ar2 = 0;}
-
 			setAttrs({
 				"armormailpenalty": ar2,
 			}, {silent: true});	
@@ -50368,15 +50442,18 @@ on('change:armoractiveH1 change:armoractiveH2 change:armoractiveH3 change:armora
 		});			
 	}
 	
-	if (trigger = "armoractiveh3") {
-   getAttrs(["armoractiveh1", "armoractiveh2", "armoractiveh3", "armoropenh3", "armoractivet3", "armoractivela3", "armoractivell3"], function(v) {	
+	if ((trigger = "armoractiveh3") || (trigger = "armorprach3")) {
+   getAttrs(["armoractiveh1", "armoractiveh2", "armoractiveh3", "armoropenh3", "armoractivet3", "armoractivela3", "armoractivell3", "armorprach3"], function(v) {	
 
 	ar = v.armoractiveh1*1 + v.armoractiveh2*1 + v.armoractiveh3*1;
 	peq = v.armoractiveh3*1 + v.armoractivet3*1 + v.armoractivela3*1 + v.armoractivell3*1
 	
 	if (ar > 0) {ar = 1;} else {ar = 0;}
 	if (peq > 0) {peq = 1;}
-	if (v.armoropenh3 === "1") { helm = 10; } else { helm = 20; peq = 1; }
+	
+	if (v.armoropenh3 === "1") {if (v.armorprach3 === "1") {helm = 0;} else { helm = 10; }} else {if (v.armorprach3 === "1") {helm = 10; peq = 1;} else { helm = 20; peq = 1; }}
+	
+	ar2 = v.armoractiveh3*helm;
 	
 			setAttrs({
 				"armorpartial": ar,
@@ -50386,9 +50463,9 @@ on('change:armoractiveH1 change:armoractiveH2 change:armoractiveH3 change:armora
 			}, {silent: true});	
 
 		});
-   getAttrs(["armoractiveh3", "armoractivet3", "armoractivela3", "armoractivell3"], function(v) {	
+   getAttrs(["armoractiveh3", "armoractivet3", "armoractivela3", "armoractivell3", "armorprach3", "armorpract3", "armorpracla3", "armorpracll3"], function(v) {	
 
-	ar3 = v.armoractiveh3*1 + v.armoractivet3*1 + v.armoractivela3*1 + v.armoractivell3*1;
+	ar3 = Math.max(v.armoractiveh3*1-v.armorprach3*1, 0) + Math.max(v.armoractivet3*1-v.armorpract3*1, 0) + Math.max(v.armoractivela3*1-v.armorpracla3*1, 0) + Math.max(v.armoractivell3*1-v.armorpracll3*1, 0);
 	if (ar3 > 0) {ar3 = 10;} else {ar3 = 0;}
 
 			setAttrs({
@@ -50397,7 +50474,7 @@ on('change:armoractiveH1 change:armoractiveH2 change:armoractiveH3 change:armora
 
 		});		
 	}
-	if (trigger = "armoropenh3") {
+	if (trigger === "armoropenh3") {
    getAttrs(["armoractiveh1", "armoractiveh2", "armoractiveh3", "armoropenh3"], function(v) {	
 
 	ar = v.armoractiveh1*1 + v.armoractiveh2*1 + v.armoractiveh3*1;
@@ -50412,12 +50489,11 @@ on('change:armoractiveH1 change:armoractiveH2 change:armoractiveH3 change:armora
 		});	
 	}
 	
-	if (trigger = "armoractivet2") {
-   getAttrs(["armoractiveh2", "armoractivet2", "armoractivela2", "armoractivell2"], function(v) {	
+	if ((trigger = "armoractivet2") || (trigger = "armorpract2")  || (trigger = "armorpracla2")  || (trigger = "armorpracll2")) {
+   getAttrs(["armoractiveh2", "armoractivet2", "armoractivela2", "armoractivell2", "armorprach2", "armorpract2", "armorpracla2", "armorpracll2"], function(v) {	
 
-	ar = v.armoractiveh2*1 + v.armoractivet2*1 + v.armoractivela2*1 + v.armoractivell2*1;
+	ar = Math.max(v.armoractiveh2*1-v.armorprach2*1, 0) + Math.max(v.armoractivet2*1-v.armorpract2*1, 0) + Math.max(v.armoractivela2*1-v.armorpracla2*1, 0) + Math.max(v.armoractivell2*1-v.armorpracll2*1, 0);
 	if (ar > 0) {ar = 10;} else {ar = 0;}
-
 			setAttrs({
 				"armormailpenalty": ar,
 			}, {silent: true});	
@@ -50425,10 +50501,10 @@ on('change:armoractiveH1 change:armoractiveH2 change:armoractiveH3 change:armora
 		});	
 	}	
 	
-	if (trigger = "armoractivet3") {
-   getAttrs(["armoractiveh3", "armoractivet3", "armoractivela3", "armoractivell3", "armoropenh3"], function(v) {	
-
-	ar = v.armoractiveh3*1 + v.armoractivet3*1 + v.armoractivela3*1 + v.armoractivell3*1;
+	if ((trigger = "armoractivet3") || (trigger = "armorpract3")  || (trigger = "armorpracla3")  || (trigger = "armorpracll3")) {
+   getAttrs(["armoractiveh3", "armoractivet3", "armoractivela3", "armoractivell3", "armoropenh3", "armorprach3", "armorpract3", "armorpracla3", "armorpracll3"], function(v) {	
+   
+	ar = Math.max(v.armoractiveh3*1-v.armorprach3*1, 0) + Math.max(v.armoractivet3*1-v.armorpract3*1, 0) + Math.max(v.armoractivela3*1-v.armorpracla3*1, 0) + Math.max(v.armoractivell3*1-v.armorpracll3*1, 0);
 	helm = (v.armoractiveh3*1-v.armoropenh3);
 	if (helm < 0) {helm = 0;}
 	peq = helm + v.armoractivet3*1 + v.armoractivela3*1 + v.armoractivell3*1;
@@ -50446,9 +50522,9 @@ on('change:armoractiveH1 change:armoractiveH2 change:armoractiveH3 change:armora
 	}	
 	
 	if (trigger = "armoractivell3") {
-   getAttrs(["armoractiveh3", "armoractivet3", "armoractivela3", "armoractivell3", "armoropenh3"], function(v) {	
+   getAttrs(["armoractiveh3", "armoractivet3", "armoractivela3", "armoractivell3", "armoropenh3", "armorprach3", "armorpract3", "armorpracla3", "armorpracll3"], function(v) {	
 
-	ar = v.armoractiveh3*1 + v.armoractivet3*1 + v.armoractivela3*1 + v.armoractivell3*1;
+	ar = Math.max(v.armoractiveh3*1-v.armorprach3*1, 0) + Math.max(v.armoractivet3*1-v.armorpract3*1, 0) + Math.max(v.armoractivela3*1-v.armorpracla3*1, 0) + Math.max(v.armoractivell3*1-v.armorpracll3*1, 0);
 	helm = (v.armoractiveh3*1-v.armoropenh3);
 	if (helm < 0) {helm = 0;}
 	peq = helm + v.armoractivet3*1 + v.armoractivela3*1 + v.armoractivell3*1;
@@ -50457,7 +50533,7 @@ on('change:armoractiveH1 change:armoractiveH2 change:armoractiveH3 change:armora
 
 			setAttrs({
 				"armorplatepenalty": ar,
-				"armorplatelegspenalty": v.armoractivell3*10,
+				"armorplatelegspenalty": Math.max(v.armoractivell3*1-v.armorpracll3*1, 0)*10,
 				"armorimpenetrable": peq,
 				"armorweakpoints": peq,
 			}, {silent: true});	
@@ -50535,14 +50611,17 @@ on('change:Medium_armor_equip', function(event){
 		
 		}
 		
-	getAttrs(["armoractiveh1", "armoractiveh3"], function(v) {	
+	getAttrs(["armoractiveh1", "armoractiveh2", "armoractiveh3", "armorprach2", "armorpract2", "armorpracla2", "armorpracll2", "armoractivet2", "armoractivela2", "armoractivell2"], function(v) {
 	ar = trigger + v.armoractiveh1*1 + v.armoractiveh3*1;
+	ar2 = Math.max(v.armoractiveh2-v.armorprach2*1, 0);
+	ar3 = Math.max(v.armoractiveh2*1-v.armorprach2*1, 0) + Math.max(v.armoractivet2*1-v.armorpract2*1, 0) + Math.max(v.armoractivela2*1-v.armorpracla2*1, 0) + Math.max(v.armoractivell2*1-v.armorpracll2*1, 0);
+	
 	if (ar > 0) {ar = 1;} else {ar = 0;}
-
+	if (ar3 > 0) {ar3 = 1;} else {ar3 = 0;}
 			setAttrs({
 				"Armorpartial": ar,
-				"armorcoifpenalty": trigger*10,
-				"armormailpenalty": trigger*10,
+				"armorcoifpenalty": ar2*10,
+				"armormailpenalty": ar3*10,
 			}, {silent: true});	
 
 		});	
@@ -50581,15 +50660,20 @@ on('change:Heavy_armor_equip', function(event){
 		
 		}
 		
-	getAttrs(["armoractiveh1", "armoractiveh2", "armoropenh3"], function(v) {	
+	getAttrs(["armoractiveh1", "armoractiveh2", "armoropenh3", "armoractiveh3", "armorprach3", "armorpract3", "armorpracla3", "armorpracll3", "armoractivet3", "armoractivela3", "armoractivell3"], function(v) {	
 	ar = trigger + v.armoractiveh1*1 + v.armoractiveh2*1;
+	ar2 = Math.max(v.armoractiveh3-v.armorprach3*1, 0);
+	ar3 = Math.max(v.armoractiveh3*1-v.armorprach3*1, 0) + Math.max(v.armoractivet3*1-v.armorpract3*1, 0) + Math.max(v.armoractivela3*1-v.armorpracla3*1, 0) + Math.max(v.armoractivell3*1-v.armorpracll3*1, 0);
+	ar4 = Math.max(v.armorpracll3-v.armorpracll3*1, 0);
 	if (ar > 0) {ar = 1;} else {ar = 0;}
-	if (v.armoropenh3 === "1") { helm = 10; } else { helm = 20; }
+	if (ar3 > 0) {ar3 = 1;} else {ar3 = 0;}
+	if (v.armoropenh3 === "1") { helm = 10-v.armorprach3*10; } else { helm = 20-v.armorprach3*10; }
 	
 			setAttrs({
 				"Armorpartial": ar,
 				"armorhelmpenalty": trigger*helm,
-				"armorplatepenalty": trigger*10,
+				"armorplatepenalty": ar3*10,
+				"armorplatelegspenalty": ar4*10,
 			}, {silent: true});	
 		});	
 	});	

--- a/Warhammer 4e Character Sheet/translation.json
+++ b/Warhammer 4e Character Sheet/translation.json
@@ -1573,6 +1573,9 @@
 	"CUSTOM-TALENTS": "CUSTOM TALENTS",
 	"ENABLE-XP": "Enable Auto-XP",
 	"NORSE": "Norse",
+	"MONSTER": "Monster",
+	"CHARACTER": "Character",
+	"ABBREVIATE-PRACTICAL": "Prac.",
 	
 	"OOPS-TABLE": "Fumble/Oops Rules",
 	"HOUSERULE1-OOPS-TABLE": "Houserule 1: Core Rule Book (Default)",


### PR DESCRIPTION

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

June 30nd 2023 v1.66

- Added Practical Quality option tick box to all Mail/Plate Armor, this will reduce all penalties by -10 on the given armor piece and update the penalties boxes accordingly.
- Corrected issue on Armor Tab where Shield Durability was adding to AP on the hit locatiojns display to the right.



