### PR TITLE
D&D 4E: Roll template updates to fix layout and text issues

### DIFF
--- a/D&D_4E/D&D_4E.css
+++ b/D&D_4E/D&D_4E.css
@@ -675,17 +675,6 @@
     background-color: #333;
 }
 
-/* Adjustment for New Chat Output 06/26/2018 */
-.sheet-rolltemplate-dnd4epower table>thead>tr>th, 
-.sheet-rolltemplate-dnd4epower table>tbody>tr>th, 
-.sheet-rolltemplate-dnd4epower table>tfoot>tr>th, 
-.sheet-rolltemplate-dnd4epower table>thead>tr>td, 
-.sheet-rolltemplate-dnd4epower table>tbody>tr>td, 
-.sheet-rolltemplate-dnd4epower table>tfoot>tr>td { 
-    padding: 0px 0px 0px 5px;
-    border: none; 
-}
-
 /* Power Roll Template */
 .sheet-rolltemplate-dnd4epower table {
     width: 98%;

--- a/D&D_4E/D&D_4E.css
+++ b/D&D_4E/D&D_4E.css
@@ -689,81 +689,81 @@
 }
 
 .sheet-rolltemplate-dnd4epower table {
-    width: 98%;
-    padding: 2px;
-    border: 1px solid;
-    background-color: #ffffff;
-    font-family: Arial, Helvetica, sans-serif;
+	width: 98%;
+	padding: 2px;
+	border: 1px solid;
+	background-color: #ffffff;
+	font-family: Arial, Helvetica, sans-serif;
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-emote {
-    color: var(--chat-text-color);
-    padding-left: 5px;
-    padding-bottom: 5px;
-    line-height: 1em;
+	color: var(--chat-text-color);
+	padding-left: 5px;
+	padding-bottom: 5px;
+	line-height: 1em;
 	font-size: 1em;
-    font-style: italic;
-    text-align: left;
+	font-style: italic;
+	text-align: left;
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-power-header {
 	color: #ffffff;
-    padding-left: 5px;
+	padding-left: 5px;
 	line-height: 1.6em;
 	font-size: 1.2em;
-    text-align: left;
+	text-align: left;
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-atwill {
-    background-color: #3a7042;
+	background-color: #3a7042;
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-encounter {
-    background-color: #7d0824;
+	background-color: #7d0824;
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-daily {
-    background-color: #333333;
+	background-color: #333333;
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-item {
-    background-color: #E6B800;
+	background-color: #E6B800;
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-other {
-    background-color: #000000;
+	background-color: #000000;
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-ability {
-    background-color: #483D8B;
+	background-color: #483D8B;
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-skill {
-    background-color: #3A5ECA;
+	background-color: #3A5ECA;
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-monster {
-    background: -webkit-linear-gradient(left, darkgreen, chartreuse); /* For Safari 5.1 to 6.0 */
-    background: -o-linear-gradient(right, darkgreen, chartreuse); /* For Opera 11.1 to 12.0 */
-    background: -moz-linear-gradient(right, darkgreen, chartreuse); /* For Firefox 3.6 to 15 */
-    background: linear-gradient(to right, darkgreen , chartreuse); /* Standard syntax (must be last) */
+	background: -webkit-linear-gradient(left, darkgreen, chartreuse); /* For Safari 5.1 to 6.0 */
+	background: -o-linear-gradient(right, darkgreen, chartreuse); /* For Opera 11.1 to 12.0 */
+	background: -moz-linear-gradient(right, darkgreen, chartreuse); /* For Firefox 3.6 to 15 */
+	background: linear-gradient(to right, darkgreen , chartreuse); /* Standard syntax (must be last) */
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-subheader-alignright {
-    color: #ffffff;
-    padding-left: 5px;
-    padding-right: 5px;
+	color: #ffffff;
+	padding-left: 5px;
+	padding-right: 5px;
 	line-height: 1em;
 	font-size: 1em;
-    text-align: right;
+	text-align: right;
 }
 
 /* Odd Row Background (Hex Value #D9D1C7) */
 .sheet-rolltemplate-dnd4epower tr:nth-of-type(odd) {
-    background: -webkit-linear-gradient(left,rgba(217, 209, 199,1),rgba(217, 209, 199,0.25)); /*Safari 5.1-6*/
-    background: -o-linear-gradient(right,rgba(217, 209, 199,1),rgba(217, 209, 199,0.25)); /*Opera 11.1-12*/
-    background: -moz-linear-gradient(right,rgba(217, 209, 199,1),rgba(217, 209, 199,0.25)); /*Fx 3.6-15*/
-    background: linear-gradient(to right, rgba(217, 209, 199,1), rgba(217, 209, 199,0.25)); /*Standard*/
+	background: -webkit-linear-gradient(left,rgba(217, 209, 199,1),rgba(217, 209, 199,0.25)); /*Safari 5.1-6*/
+	background: -o-linear-gradient(right,rgba(217, 209, 199,1),rgba(217, 209, 199,0.25)); /*Opera 11.1-12*/
+	background: -moz-linear-gradient(right,rgba(217, 209, 199,1),rgba(217, 209, 199,0.25)); /*Fx 3.6-15*/
+	background: linear-gradient(to right, rgba(217, 209, 199,1), rgba(217, 209, 199,0.25)); /*Standard*/
 }
 
 .sheet-rolltemplate-dnd4epower td {
@@ -775,21 +775,21 @@
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-td-critical {
-	color: #3FB315;
-	line-height: 1.1em;
-	font-size: 1.1em;
+    color: #3FB315;
+    line-height: 1.1em;
+    font-size: 1.1em;
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-td-red {
-	color: #B31515;
+    color: #B31515;
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-template-bold {
-	font-weight: bold;
+    font-weight: bold;
 }
 
 .sheet-rolltemplate-dnd4epower .inlinerollresult,
-.textchatcontainer .inlinerollresult {
+.textchatcontainer .sheet-rolltemplate-dnd4epower .inlinerollresult {
 	background-color: transparent;
 	border: none;
 	color: var(--roll-result-color);

--- a/D&D_4E/D&D_4E.css
+++ b/D&D_4E/D&D_4E.css
@@ -161,7 +161,7 @@
 	margin-right: 0 !important;
 }
 
-/* Row And Items */{}
+/* Row And Items */
 
 .charsheet .sheet-wrapper .sheet-row {
     height: 34px;
@@ -254,7 +254,7 @@
     display: none;
 }
 
-/* Base Info */{}
+/* Base Info */
 
 .sheet-baseinfo {
 	display: inline-block;
@@ -275,7 +275,7 @@
     width: 100px;
 }
 
-/* Stat Blocks */{}
+/* Stat Blocks */
 
 .charsheet .sheet-wrapper .sheet-statblock {
 	display: block;
@@ -368,7 +368,7 @@
     visibility: hidden;
 }
 
-/* Hidden Roll buttons */{}
+/* Hidden Roll buttons */
 
 .charsheet .sheet-wrapper button[type="roll"]:before {
     content: ""!important;
@@ -676,6 +676,18 @@
 }
 
 /* Power Roll Template */
+
+.sheet-rolltemplate-dnd4epower {
+	/* 2023-09-01 (scarletcs):
+	 * Whenever Roll20 rolls out a chat text color variable, we can just use that here.
+	 * Until then, we need to manually adjust the font color to what Roll20 uses.
+	 */
+	--chat-text-color: inherit;
+}
+.sheet-rolltemplate-dnd4epower.sheet-rolltemplate-darkmode {
+	--chat-text-color: var(--dark-secondarytext);
+}
+
 .sheet-rolltemplate-dnd4epower table {
     width: 98%;
     padding: 2px;
@@ -685,7 +697,7 @@
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-emote {
-    color: inherit;
+    color: var(--chat-text-color);
     padding-left: 5px;
     padding-bottom: 5px;
     line-height: 1em;

--- a/D&D_4E/D&D_4E.css
+++ b/D&D_4E/D&D_4E.css
@@ -753,13 +753,12 @@
     background: linear-gradient(to right, rgba(217, 209, 199,1), rgba(217, 209, 199,0.25)); /*Standard*/
 }
 
-
 .sheet-rolltemplate-dnd4epower td {
     color: #000000;
-    padding-left: 5px;
-	line-height: 1em;
+	line-height: 1.33em;
 	font-size: 1em;
     text-align: left;
+	padding: 0 5px;
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-td-critical {

--- a/D&D_4E/D&D_4E.css
+++ b/D&D_4E/D&D_4E.css
@@ -766,43 +766,42 @@
 }
 
 .sheet-rolltemplate-dnd4epower td {
-    color: #000000;
+	color: #000000;
 	line-height: 1.33em;
 	font-size: 1em;
-    text-align: left;
+	text-align: left;
 	padding: 0 5px;
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-td-critical {
-    color: #3FB315;
-    line-height: 1.1em;
-    font-size: 1.1em;
+	color: #3FB315;
+	line-height: 1.1em;
+	font-size: 1.1em;
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-td-red {
-    color: #B31515;
+	color: #B31515;
 }
 
 .sheet-rolltemplate-dnd4epower .sheet-template-bold {
-    font-weight: bold;
+	font-weight: bold;
 }
 
-.sheet-rolltemplate-dnd4epower .inlinerollresult  {
-    background-color: transparent;
-    border: none;
+.sheet-rolltemplate-dnd4epower .inlinerollresult,
+.textchatcontainer .inlinerollresult {
+	background-color: transparent;
+	border: none;
+	color: var(--roll-result-color);
 }
 
 .sheet-rolltemplate-dnd4epower .inlinerollresult.fullcrit {
-    color: #3FB315;
-    border: none;
+	--roll-result-color: #3FB315;
 }
 
 .sheet-rolltemplate-dnd4epower .inlinerollresult.fullfail {
-	color: #B31515;
-    border: none;
+	--roll-result-color: #B31515;
 }
 
 .sheet-rolltemplate-dnd4epower .inlinerollresult.importantroll {
-	color: #4A57ED;
-    border: none;
+	--roll-result-color: #4A57ED;
 }

--- a/D&D_4E/D&D_4E.css
+++ b/D&D_4E/D&D_4E.css
@@ -752,6 +752,7 @@
 .sheet-rolltemplate-dnd4epower .sheet-subheader-alignright {
     color: #ffffff;
     padding-left: 5px;
+    padding-right: 5px;
 	line-height: 1em;
 	font-size: 1em;
     text-align: right;

--- a/D&D_4E/D&D_4E.html
+++ b/D&D_4E/D&D_4E.html
@@ -26911,7 +26911,7 @@ An example of an Initiative check for the character bob would be "%{bob|-initiat
         <tr><th class="sheet-subheader-alignright{{#atwill}} sheet-atwill{{/atwill}}{{#encounter}} sheet-encounter{{/encounter}}{{#daily}} sheet-daily{{/daily}}{{#item}} sheet-item{{/item}}{{#other}} sheet-other{{/other}}{{#ability}} sheet-ability{{/ability}}{{#skill}} sheet-skill{{/skill}}{{#monster}} sheet-monster{{/monster}}">{{class}} {{level}}</th></tr>
 	{{#type}}    
 		<tr><td><span class="sheet-template-bold">
-    		{{type}} {{keywords}}
+    		{{type}} &#10022; {{keywords}}
         </span></td></tr>
 	{{/type}}
 	{{#attacktechnique}}


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

Several changes made to repair the D&D 4e roll template layout, which has drifted out of date in recent years.

- Emote text (above the table) now uses the text color. Roll20 doesn't appear to specify a single css variable like `--chat-text-color` that specifies the chat text color regardless of mode, so I had to set per-theme the way Roll20 sets it.
- Table header has slight padding on the right now.
- All rows have slight padding and line height increase. Somewhere along the way the table became incredibly cramped, or maybe it was that way since the beginning.
- Rolls are now colored correctly and no longer spill outside the cell they're in.
- Added a ✦ to the center of the keyword line, which is a staple separator on this line of D&D 4e power templates.

Additionally did some cleanup:

- Reduced some errant `{}`'s that were in the CSS.
- Removed a block labelled “Adjustment for New Chat Output 06/26/2018” because it seems to have no relation to anything Roll20 currently does, and it was resetting/removing all padding specified elsewhere.

# Screenshots

## New (dark & light mode)
![2023-09-01_21-39-12](https://github.com/Roll20/roll20-character-sheets/assets/4585677/36731a71-37f2-47c4-8c14-2fd9428fb892) ![2023-09-01_21-39-18](https://github.com/Roll20/roll20-character-sheets/assets/4585677/066ac564-e767-4eb3-8831-1834ca2e2f51)


## Old (dark & light mode)
![2023-09-01_21-29-20_firefox](https://github.com/Roll20/roll20-character-sheets/assets/4585677/6900e6fc-96a2-4ca9-85fd-313be2b164ea) ![2023-09-01_21-29-26](https://github.com/Roll20/roll20-character-sheets/assets/4585677/368218d4-be34-4e47-8081-34b9768b54c6)




