### PR TITLE
[MERP] Typo/bugfix/enhancement

### DIFF
--- a/MERP/merp_2nd_ed_sheet.html
+++ b/MERP/merp_2nd_ed_sheet.html
@@ -19,11 +19,11 @@
         <button type="roll" class="rolld100" name="attr_1d100_roll" title="1d100 roll" value="@{wtype} &{template:1d100} {{type=1d100}} {{character=@{character_name}}} {{subtags=Generic}} {{roll=[[1d100 + ?{Modifier|0}[MODIFIER]]]}}"><!-- --></button>
         <span class="horizontal-spacer">&nbsp;</span>
         <span class="skill-label" title="Roll for 1d100. Keep rolling while the outcome is equal to or greater than 95 and add up the results.">Open-ended: </span>
-        <button type="roll" class="rolld100" name="attr_openended_roll" title="Open-ended roll" value="@{wtype} &{template:openended} {{type=Open-ended 1d100}} {{character=@{character_name}}} {{subtags=Generic}} {{roll=[[1d100!>95cs>95cf<5 + ?{Modifier|0}[MODIFIER]]]}} {{underflow=[[1d100!>95 * -1]]}}"><!-- --></button>
+        <button type="roll" class="rolld100" name="attr_openended_roll" title="Open-ended roll" value="@{wtype} &{template:openended} {{type=Open-ended 1d100}} {{character=@{character_name}}} {{subtags=Generic}} {{roll=[[1d100!>96cs>96cf<5 + ?{Modifier|0}[MODIFIER]]]}} {{underflow=[[1d100!>96 * -1]]}}"><!-- --></button>
         <span class="horizontal-spacer">&nbsp;</span>                                
         <span class="skill-label" title="Roll 1d100 for orientation">Orientation: </span>
         <button type="roll" class="rolld100" name="attr_orientation2_roll" title="Orientation roll" 
-        value="@{wtype} &{template:staticmaneuver} {{type=Orientation}} {{character=@{character_name}}} {{subtags=Static Maneuver}} {{roll=[[1d100!>95cs>95cf<5 + @{skill_perception_total_bonus}[SKILL] + @{activity_penalty}[ACT. PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{sm_penalty=[[@{activity_penalty}]]}} {{skill=[[@{skill_perception_total_bonus}]]}}"><!-- --></button>
+        value="@{wtype} &{template:staticmaneuver} {{type=Orientation}} {{character=@{character_name}}} {{subtags=Static Maneuver}} {{roll=[[1d100!>96cs>96cf<5 + @{skill_perception_total_bonus}[SKILL] + @{activity_penalty}[ACT. PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{sm_penalty=[[@{activity_penalty}]]}} {{skill=[[@{skill_perception_total_bonus}]]}}"><!-- --></button>
         <span class="horizontal-spacer">&nbsp;</span>                                
         <span class="skill-label" title="Roll 1d100 for fumble">Fumble: </span>
         <button type="roll" class="rolld100" name="attr_fumble_roll" title="Fumble roll" value="@{wtype} &{template:1d100} {{type=Fumble}} {{character=@{character_name}}} {{subtags=Generic}} {{roll=[[1d100 + ?{Modifier|0}[MODIFIER]]]}}"><!-- --></button>
@@ -860,7 +860,7 @@
                             <span class="action-type-label" title="moving maneuver">MM</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_noarmor_mm" title="No armor moving maneuver" value="@{wtype} &{template:movingmaneuver} {{type=No Armor}} {{character=@{character_name}}} {{subtags=Moving Maneuver}} {{roll=[[1d100!>95cs>95cf<05 + @{skill_noarmor_total_bonus}[SKILL] + @{total_mm_penalty}[MM PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{mm_penalty=[[@{total_mm_penalty}]]}} {{skill=[[@{skill_noarmor_total_bonus}]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_noarmor_mm" title="No armor moving maneuver" value="@{wtype} &{template:movingmaneuver} {{type=No Armor}} {{character=@{character_name}}} {{subtags=Moving Maneuver}} {{roll=[[1d100!>96cs>96cf<5 + @{skill_noarmor_total_bonus}[SKILL] + @{total_mm_penalty}[MM PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{mm_penalty=[[@{total_mm_penalty}]]}} {{skill=[[@{skill_noarmor_total_bonus}]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>
                     </tr>
@@ -896,7 +896,7 @@
                             <span class="action-type-label" title="Moving Maneuver">MM</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_softleather_mm" title="Soft leather moving maneuver" value="@{wtype} &{template:movingmaneuver} {{type=Soft Leather Armor}} {{character=@{character_name}}} {{subtags=Moving Maneuver}} {{roll=[[1d100 + @{skill_softleather_total_bonus}[SKILL] + @{total_mm_penalty}[MM PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{mm_penalty=[[@{total_mm_penalty}]]}} {{skill=[[@{skill_softleather_total_bonus}]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_softleather_mm" title="Soft leather moving maneuver" value="@{wtype} &{template:movingmaneuver} {{type=Soft Leather Armor}} {{character=@{character_name}}} {{subtags=Moving Maneuver}} {{roll=[[1d100 + @{skill_softleather_total_bonus}[SKILL] + @{total_mm_penalty}[MM PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{mm_penalty=[[@{total_mm_penalty}]]}} {{skill=[[@{skill_softleather_total_bonus}]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>
                     </tr>
@@ -934,7 +934,7 @@
                             <span class="action-type-label" title="Moving maneuver">MM</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_rigidleather_mm" title="Rigid leather moving maneuver" value="@{wtype} &{template:movingmaneuver} {{type=Rigid Leather Armor}} {{character=@{character_name}}} {{subtags=Moving Maneuver}} {{roll=[[1d100!>95cs>95cf<05 + @{skill_rigidleather_total_bonus}[SKILL] + @{total_mm_penalty}[MM PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{mm_penalty=[[@{total_mm_penalty}]]}} {{skill=[[@{skill_rigidleather_total_bonus}]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_rigidleather_mm" title="Rigid leather moving maneuver" value="@{wtype} &{template:movingmaneuver} {{type=Rigid Leather Armor}} {{character=@{character_name}}} {{subtags=Moving Maneuver}} {{roll=[[1d100!>96cs>96cf<5 + @{skill_rigidleather_total_bonus}[SKILL] + @{total_mm_penalty}[MM PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{mm_penalty=[[@{total_mm_penalty}]]}} {{skill=[[@{skill_rigidleather_total_bonus}]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>                    
                     </tr>
@@ -974,7 +974,7 @@
                             <span class="action-type-label" title="Moving maneuver">MM</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_chain_mm" title="Chain moving maneuver" value="@{wtype} &{template:movingmaneuver} {{type=Chain Armor}} {{character=@{character_name}}} {{subtags=Moving maNeuver}} {{roll=[[1d100!>95cs>95cf<05 + @{skill_chain_total_bonus}[SKILL] + @{total_mm_penalty}[MM PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{mm_penalty=[[@{total_mm_penalty}]]}} {{skill=[[@{skill_chain_total_bonus}]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_chain_mm" title="Chain moving maneuver" value="@{wtype} &{template:movingmaneuver} {{type=Chain Armor}} {{character=@{character_name}}} {{subtags=Moving maNeuver}} {{roll=[[1d100!>96cs>96cf<5 + @{skill_chain_total_bonus}[SKILL] + @{total_mm_penalty}[MM PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{mm_penalty=[[@{total_mm_penalty}]]}} {{skill=[[@{skill_chain_total_bonus}]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>                    
                     </tr>
@@ -1015,7 +1015,7 @@
                             <span class="action-type-label" title="Moving maneuver">MM</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_plate_mm" title="Plate moving maneuver" value="@{wtype} &{template:movingmaneuver} {{type=Plate Armor}} {{character=@{character_name}}} {{subtags=Moving maNeuver}} {{roll=[[1d100!>95cs>95cf<05 + @{skill_plate_total_bonus}[SKILL] + @{total_mm_penalty}[MM PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{mm_penalty=[[@{total_mm_penalty}]]}} {{skill=[[@{skill_plate_total_bonus}]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_plate_mm" title="Plate moving maneuver" value="@{wtype} &{template:movingmaneuver} {{type=Plate Armor}} {{character=@{character_name}}} {{subtags=Moving maNeuver}} {{roll=[[1d100!>96cs>96cf<5 + @{skill_plate_total_bonus}[SKILL] + @{total_mm_penalty}[MM PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{mm_penalty=[[@{total_mm_penalty}]]}} {{skill=[[@{skill_plate_total_bonus}]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>                    
                     </tr>
@@ -1079,7 +1079,7 @@
                             <span class="action-type-label" title="Offensive bonus">OB</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_1hedged_ob" title="1-H Edged Attack Roll" value="@{wtype} &{template:attack} {{type=1-Handed Edged Weapon}} {{character=@{character_name}}} {{subtags=Melee Attack}} {{roll=[[1d100!>95cs>95cf<8 + @{skill_1hedged_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_1hedged_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_1hedged_ob" title="1-H Edged Attack Roll" value="@{wtype} &{template:attack} {{type=1-Handed Edged Weapon}} {{character=@{character_name}}} {{subtags=Melee Attack}} {{roll=[[1d100!>96cs>96cf<8 + @{skill_1hedged_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_1hedged_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>
                     </tr>
@@ -1131,7 +1131,7 @@
                             <input type="number" class="autocalc-bonus sheet-autocalc-total" name="attr_skill_1hconc_total_display_bonus" value="(@{skill_1hconc_total_bonus})" disabled />
                             <span class="action-type-label" title="Offensive bonus">OB</span></td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_1hconc_ob" title="1-H Concussion Attack Roll" value="@{wtype} &{template:attack} {{type=1-Handed Concussion Weapon}} {{character=@{character_name}}} {{subtags=Melee Attack}} {{roll=[[1d100!>95cs>95cf<8 + @{skill_1hconc_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY] ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_1hconc_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_1hconc_ob" title="1-H Concussion Attack Roll" value="@{wtype} &{template:attack} {{type=1-Handed Concussion Weapon}} {{character=@{character_name}}} {{subtags=Melee Attack}} {{roll=[[1d100!>96cs>96cf<8 + @{skill_1hconc_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY] ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_1hconc_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>
                     </tr>
@@ -1183,7 +1183,7 @@
                             <span class="action-type-label" title="Offensive bonus">OB</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_2handed_ob" title="2-Handed Attack Roll" value="@{wtype} &{template:attack} {{type=2-Handed Weapon}} {{character=@{character_name}}} {{subtags=Melee Attack}} {{roll=[[1d100!>95cs>95cf<8 + @{skill_2handed_total_bonus} + @{total_ob_penalty}[OB PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_2handed_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_2handed_ob" title="2-Handed Attack Roll" value="@{wtype} &{template:attack} {{type=2-Handed Weapon}} {{character=@{character_name}}} {{subtags=Melee Attack}} {{roll=[[1d100!>96cs>96cf<8 + @{skill_2handed_total_bonus} + @{total_ob_penalty}[OB PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_2handed_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>                    
                     </tr>
@@ -1234,7 +1234,7 @@
                             <input type="number" class="autocalc-bonus sheet-autocalc-total" name="attr_skill_thrown_total_display_bonus" value="(@{skill_thrown_total_bonus})" disabled />
                             <span class="action-type-label" title="Offensive bonus">OB</span></td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_thrown_ob" title="Thrown Attack Roll" value="@{wtype} &{template:attack} {{type=Thrown Weapon}} {{character=@{character_name}}} {{subtags=Missile Attack}} {{roll=[[1d100!>95cs>95cf<8 + @{skill_thrown_total_bonus} + @{total_ob_penalty}[OB PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_thrown_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_thrown_ob" title="Thrown Attack Roll" value="@{wtype} &{template:attack} {{type=Thrown Weapon}} {{character=@{character_name}}} {{subtags=Missile Attack}} {{roll=[[1d100!>96cs>96cf<8 + @{skill_thrown_total_bonus} + @{total_ob_penalty}[OB PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_thrown_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>                    
                     </tr>
@@ -1286,7 +1286,7 @@
                             <span class="action-type-label" title="Offensive bonus">OB</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_missile_ob" title="Missile Attack Roll" value="@{wtype} &{template:attack} {{type=Missile Weapon}} {{character=@{character_name}}} {{subtags=Missile Attack}} {{roll=[[1d100!>95cs>95cf<8 + @{skill_missile_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY] ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_missile_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_missile_ob" title="Missile Attack Roll" value="@{wtype} &{template:attack} {{type=Missile Weapon}} {{character=@{character_name}}} {{subtags=Missile Attack}} {{roll=[[1d100!>96cs>96cf<8 + @{skill_missile_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY] ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_missile_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>                    
                     </tr>
@@ -1338,7 +1338,7 @@
                             <span class="action-type-label" title="Offensive bonus">OB</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_polearm_ob" title="Polearm Attack Roll" value="@{wtype} &{template:attack} {{type=Pole-arm}} {{character=@{character_name}}} {{subtags=Melee Attack}} {{roll=[[1d100!>95cs>95cf<8 + @{skill_polearm_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY]+ ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_polearm_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_polearm_ob" title="Polearm Attack Roll" value="@{wtype} &{template:attack} {{type=Pole-arm}} {{character=@{character_name}}} {{subtags=Melee Attack}} {{roll=[[1d100!>96cs>96cf<8 + @{skill_polearm_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY]+ ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_polearm_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>                    
                     </tr>
@@ -1399,7 +1399,7 @@
                             <input type="number" class="autocalc-bonus sheet-autocalc-total" name="attr_skill_climb_total_display_bonus" disabled value="(@{skill_climb_total_bonus})"/>
                             <span class="action-type-label" title="Moving maneuver">MM</span></td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_climb_mm" title="Climbing moving maneuver" value="@{wtype} &{template:movingmaneuver} {{type=Climbing}} {{character=@{character_name}}} {{subtags=Moving maneuver}} {{roll=[[1d100!>95cs>95cf<05 + @{skill_climb_total_bonus}[SKILL] + @{total_mm_penalty}[MM PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{mm_penalty=[[@{total_mm_penalty}]]}} {{skill=[[@{skill_climb_total_bonus}]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_climb_mm" title="Climbing moving maneuver" value="@{wtype} &{template:movingmaneuver} {{type=Climbing}} {{character=@{character_name}}} {{subtags=Moving maneuver}} {{roll=[[1d100!>96cs>96cf<5 + @{skill_climb_total_bonus}[SKILL] + @{total_mm_penalty}[MM PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{mm_penalty=[[@{total_mm_penalty}]]}} {{skill=[[@{skill_climb_total_bonus}]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>
                     </tr>
@@ -1451,7 +1451,7 @@
                             <span class="action-type-label" title="Moving maneuver">MM</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_ride_mm" title="Riding moving maneuver" value="@{wtype} &{template:movingmaneuver} {{type=Riding}} {{character=@{character_name}}} {{subtags=Moving Maneuver}} {{roll=[[1d100!>95cs>95cf<05 + @{skill_ride_total_bonus}[SKILL] + @{total_mm_penalty}[MM PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{mm_penalty=[[@{total_mm_penalty}]]}} {{skill=[[@{skill_ride_total_bonus}]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_ride_mm" title="Riding moving maneuver" value="@{wtype} &{template:movingmaneuver} {{type=Riding}} {{character=@{character_name}}} {{subtags=Moving Maneuver}} {{roll=[[1d100!>96cs>96cf<5 + @{skill_ride_total_bonus}[SKILL] + @{total_mm_penalty}[MM PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{mm_penalty=[[@{total_mm_penalty}]]}} {{skill=[[@{skill_ride_total_bonus}]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>                    
                     </tr>
@@ -1503,7 +1503,7 @@
                             <span class="action-type-label" title="Moving maneuver">MM</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_swim_mm" title="Swimming moving maneuver" value="@{wtype} &{template:movingmaneuver} {{type=Swimming}} {{character=@{character_name}}} {{subtags=Moving maNeuver}} {{roll=[[1d100!>95cs>95cf<05 + @{skill_swim_total_bonus}[SKILL] + @{total_mm_penalty}[MM PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{mm_penalty=[[@{total_mm_penalty}]]}} {{skill=[[@{skill_swim_total_bonus}]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_swim_mm" title="Swimming moving maneuver" value="@{wtype} &{template:movingmaneuver} {{type=Swimming}} {{character=@{character_name}}} {{subtags=Moving maNeuver}} {{roll=[[1d100!>96cs>96cf<5 + @{skill_swim_total_bonus}[SKILL] + @{total_mm_penalty}[MM PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{mm_penalty=[[@{total_mm_penalty}]]}} {{skill=[[@{skill_swim_total_bonus}]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>                    
                     </tr>
@@ -1554,7 +1554,7 @@
                             <span class="action-type-label" title="Static maneuver">SM</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_track_sm" title="Tracking static maneuver" value="@{wtype} &{template:staticmaneuver} {{type=Tracking}} {{character=@{character_name}}} {{subtags=Static Maneuver}} {{roll=[[1d100!>95cs>95cf<05 + @{skill_track_total_bonus}[SKILL] + @{activity_penalty}[ACT. PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{sm_penalty=[[@{activity_penalty}]]}} {{skill=[[@{skill_track_total_bonus}]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_track_sm" title="Tracking static maneuver" value="@{wtype} &{template:staticmaneuver} {{type=Tracking}} {{character=@{character_name}}} {{subtags=Static Maneuver}} {{roll=[[1d100!>96cs>96cf<5 + @{skill_track_total_bonus}[SKILL] + @{activity_penalty}[ACT. PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{sm_penalty=[[@{activity_penalty}]]}} {{skill=[[@{skill_track_total_bonus}]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>
                     </tr>
@@ -1659,7 +1659,7 @@
                             <span class="action-type-label" title="Special: Movement manuver / Static maneuver">SP</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_stalkhide_mm" title="Stalk/hide maneuver" value="@{wtype} &{template:stalkhide} {{type=Stalk/hide maneuver}} {{character=@{character_name}}} {{subtags=Movement & Static Maneuver}} {{mm_roll=[[1d100!>95cs>95cf<05 + @{skill_stalkhide_total_bonus}[SKILL] + @{total_mm_penalty}[MM PENALTY]]]}} {{sm_roll=[[1d100!>95cs>95cf<05 + @{skill_stalkhide_total_bonus}[SKILL] + @{activity_penalty}[ACT. PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{sm_penalty=[[@{activity_penalty}]]}} {{mm_penalty=[[@{total_mm_penalty}]]}} {{skill=[[@{skill_stalkhide_total_bonus}]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_stalkhide_mm" title="Stalk/hide maneuver" value="@{wtype} &{template:stalkhide} {{type=Stalk/hide maneuver}} {{character=@{character_name}}} {{subtags=Movement & Static Maneuver}} {{mm_roll=[[1d100!>96cs>96cf<5 + @{skill_stalkhide_total_bonus}[SKILL] + @{total_mm_penalty}[MM PENALTY]]]}} {{sm_roll=[[1d100!>96cs>96cf<5 + @{skill_stalkhide_total_bonus}[SKILL] + @{activity_penalty}[ACT. PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{sm_penalty=[[@{activity_penalty}]]}} {{mm_penalty=[[@{total_mm_penalty}]]}} {{skill=[[@{skill_stalkhide_total_bonus}]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>
                     </tr>
@@ -1712,7 +1712,7 @@
                             <span class="action-type-label" title="Static maneuver">SM</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_picklock_sm" title="Pick lock static maneuver" value="@{wtype} &{template:staticmaneuver} {{type=Picking Locks}} {{character=@{character_name}}} {{subtags=Static Maneuver}}} {{roll=[[1d100!>95cs>95cf<05 + @{skill_picklock_total_bonus}[SKILL] + @{activity_penalty}[ACT. PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{sm_penalty=[[@{activity_penalty}]]}} {{skill=[[@{skill_picklock_total_bonus}]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_picklock_sm" title="Pick lock static maneuver" value="@{wtype} &{template:staticmaneuver} {{type=Picking Locks}} {{character=@{character_name}}} {{subtags=Static Maneuver}}} {{roll=[[1d100!>96cs>96cf<5 + @{skill_picklock_total_bonus}[SKILL] + @{activity_penalty}[ACT. PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{sm_penalty=[[@{activity_penalty}]]}} {{skill=[[@{skill_picklock_total_bonus}]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>
                     </tr>
@@ -1765,7 +1765,7 @@
                             <span class="action-type-label" title="Static maneuver">SM</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_disarmtrap_sm" title="Disarm trap static maneuver" value="@{wtype} &{template:staticmaneuver} {{type=Disarming Traps}} {{character=@{character_name}}} {{subtags=Static Maneuver}} {{roll=[[1d100!>95cs>95cf<05 + @{skill_disarmtrap_total_bonus}[SKILL] + @{activity_penalty}[ACT. PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{sm_penalty=[[@{activity_penalty}]]}} {{skill=[[@{skill_disarmtrap_total_bonus}]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_disarmtrap_sm" title="Disarm trap static maneuver" value="@{wtype} &{template:staticmaneuver} {{type=Disarming Traps}} {{character=@{character_name}}} {{subtags=Static Maneuver}} {{roll=[[1d100!>96cs>96cf<5 + @{skill_disarmtrap_total_bonus}[SKILL] + @{activity_penalty}[ACT. PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{sm_penalty=[[@{activity_penalty}]]}} {{skill=[[@{skill_disarmtrap_total_bonus}]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>
                     </tr>
@@ -1829,7 +1829,7 @@
                             <span class="action-type-label" title="Static maneuver">SM</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_readrunes_sm" title="Read runes static maneuver" value="@{wtype} &{template:staticmaneuver} {{type=Reading Runes}} {{character=@{character_name}}} {{subtags=Static Maneuver}} {{roll=[[1d100!>95cs>95cf<05 + @{skill_readrunes_total_bonus}[SKILL] + @{activity_penalty}[ACT. PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{sm_penalty=[[@{activity_penalty}]]}} {{skill=[[@{skill_readrunes_total_bonus}]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_readrunes_sm" title="Read runes static maneuver" value="@{wtype} &{template:staticmaneuver} {{type=Reading Runes}} {{character=@{character_name}}} {{subtags=Static Maneuver}} {{roll=[[1d100!>96cs>96cf<5 + @{skill_readrunes_total_bonus}[SKILL] + @{activity_penalty}[ACT. PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{sm_penalty=[[@{activity_penalty}]]}} {{skill=[[@{skill_readrunes_total_bonus}]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>
                     </tr>
@@ -1881,7 +1881,7 @@
                             <span class="action-type-label" title="Static maneuver">SM</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_useitems_sm" title="Use items static maneuver" value="@{wtype} &{template:staticmaneuver} {{type=Using Items}} {{character=@{character_name}}} {{subtags=Static Maneuver}} {{roll=[[1d100!>95cs>95cf<05 + @{skill_useitems_total_bonus} + @{activity_penalty} + ?{Modifier|0}]]}} {{sm_penalty=[[@{activity_penalty}]]}} {{skill=[[@{skill_useitems_total_bonus}]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_useitems_sm" title="Use items static maneuver" value="@{wtype} &{template:staticmaneuver} {{type=Using Items}} {{character=@{character_name}}} {{subtags=Static Maneuver}} {{roll=[[1d100!>96cs>96cf<5 + @{skill_useitems_total_bonus} + @{activity_penalty} + ?{Modifier|0}]]}} {{sm_penalty=[[@{activity_penalty}]]}} {{skill=[[@{skill_useitems_total_bonus}]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>                    
                     </tr>
@@ -1931,7 +1931,7 @@
                             <span class="action-type-label" title="Offensive Bonus">OB</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_directedspells_ob" title="Directed spells attack" value="@{wtype} &{template:attack} {{type=Directed Spell}} {{character=@{character_name}}} {{subtags=Spell Attack}} {{roll=[[1d100!>95cs>95cf<8 + @{skill_directedspells_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_directedspells_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_directedspells_ob" title="Directed spells attack" value="@{wtype} &{template:attack} {{type=Directed Spell}} {{character=@{character_name}}} {{subtags=Spell Attack}} {{roll=[[1d100!>96cs>96cf<8 + @{skill_directedspells_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_directedspells_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>
                     </tr>
@@ -1993,7 +1993,7 @@
                             <span class="action-type-label" title="Offensive Bonus">OB</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_novicestriking_ob" title="Novice Striking Attack Roll" value="@{wtype} &{template:attack} {{type=Novice Striking}} {{character=@{character_name}}} {{subtags=Martial Art Melee Attack}} {{roll=[[1d100!>95cs>95cf<8 + @{skill_novicestriking_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY] ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_novicestriking_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_novicestriking_ob" title="Novice Striking Attack Roll" value="@{wtype} &{template:attack} {{type=Novice Striking}} {{character=@{character_name}}} {{subtags=Martial Art Melee Attack}} {{roll=[[1d100!>96cs>96cf<8 + @{skill_novicestriking_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY] ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_novicestriking_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>
                     </tr>
@@ -2045,7 +2045,7 @@
                             <span class="action-type-label" title="Offensive Bonus">OB</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_standardstriking_ob" title="Standard Striking Attack Roll" value="@{wtype} &{template:attack} {{type=Stardard Striking}} {{character=@{character_name}}} {{subtags=Martial Art Melee Attack}} {{roll=[[1d100!>95cs>95cf<8 + @{skill_standardstriking_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY] ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_standardstriking_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_standardstriking_ob" title="Standard Striking Attack Roll" value="@{wtype} &{template:attack} {{type=Stardard Striking}} {{character=@{character_name}}} {{subtags=Martial Art Melee Attack}} {{roll=[[1d100!>96cs>96cf<8 + @{skill_standardstriking_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY] ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_standardstriking_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>
                     </tr>
@@ -2097,7 +2097,7 @@
                             <span class="action-type-label" title="Offensive Bonus">OB</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_expertstriking_ob" title="Expert Striking Attack Roll" value="@{wtype} &{template:attack} {{type=Expert Striking}} {{character=@{character_name}}} {{subtags=Martial Art Melee Attack}} {{roll=[[1d100!>95cs>95cf<8 + @{skill_expertstriking_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY] ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_expertstriking_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_expertstriking_ob" title="Expert Striking Attack Roll" value="@{wtype} &{template:attack} {{type=Expert Striking}} {{character=@{character_name}}} {{subtags=Martial Art Melee Attack}} {{roll=[[1d100!>96cs>96cf<8 + @{skill_expertstriking_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY] ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_expertstriking_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>
                     </tr>
@@ -2149,7 +2149,7 @@
                             <span class="action-type-label" title="Offensive Bonus">OB</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_novicesweeps_ob" title="Novice Sweeps Attack Roll" value="@{wtype} &{template:attack} {{type=Novice Sweeps}} {{character=@{character_name}}} {{subtags=Martial Art Melee Attack}} {{roll=[[1d100!>95cs>95cf<8 + @{skill_novicesweeps_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY] ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_novicesweeps_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_novicesweeps_ob" title="Novice Sweeps Attack Roll" value="@{wtype} &{template:attack} {{type=Novice Sweeps}} {{character=@{character_name}}} {{subtags=Martial Art Melee Attack}} {{roll=[[1d100!>96cs>96cf<8 + @{skill_novicesweeps_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY] ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_novicesweeps_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>
                     </tr>
@@ -2201,7 +2201,7 @@
                             <span class="action-type-label" title="Offensive Bonus">OB</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_standardsweeps_ob" title="Standard Sweeps Attack Roll" value="@{wtype} &{template:attack} {{type=Stardard Sweeps}} {{character=@{character_name}}} {{subtags=Martial Art Melee Attack}} {{roll=[[1d100!>95cs>95cf<8 + @{skill_standardsweeps_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY] ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_standardsweeps_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_standardsweeps_ob" title="Standard Sweeps Attack Roll" value="@{wtype} &{template:attack} {{type=Stardard Sweeps}} {{character=@{character_name}}} {{subtags=Martial Art Melee Attack}} {{roll=[[1d100!>96cs>96cf<8 + @{skill_standardsweeps_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY] ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_standardsweeps_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>
                     </tr>
@@ -2253,7 +2253,7 @@
                             <span class="action-type-label" title="Offensive Bonus">OB</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_expertsweeps_ob" title="Expert Sweeps Attack Roll" value="@{wtype} &{template:attack} {{type=Expert Sweeps}} {{character=@{character_name}}} {{subtags=Martial Art Melee Attack}} {{roll=[[1d100!>95cs>95cf<8 + @{skill_expertsweeps_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY] ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_expertsweeps_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_expertsweeps_ob" title="Expert Sweeps Attack Roll" value="@{wtype} &{template:attack} {{type=Expert Sweeps}} {{character=@{character_name}}} {{subtags=Martial Art Melee Attack}} {{roll=[[1d100!>96cs>96cf<8 + @{skill_expertsweeps_total_bonus}[SKILL] + @{total_ob_penalty}[OB PENALTY] ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_expertsweeps_total_bonus}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>96 * -1]]}}">
                             </button>
                         </td>
                     </tr>
@@ -2312,7 +2312,7 @@
                             <span class="action-type-label" title="Static maneuver">SM</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_perception_sm" title="Perception static maneuver" value="@{wtype} &{template:staticmaneuver} {{type=Perception}} {{character=@{character_name}}} {{subtags=Static Maneuver}} {{roll=[[1d100!>95cs>95cf<05 + @{skill_perception_total_bonus}[SKILL] + @{activity_penalty}[ACT. PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{sm_penalty=[[@{activity_penalty}]]}} {{skill=[[@{skill_perception_total_bonus}]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_perception_sm" title="Perception static maneuver" value="@{wtype} &{template:staticmaneuver} {{type=Perception}} {{character=@{character_name}}} {{subtags=Static Maneuver}} {{roll=[[1d100!>96cs>96cf<5 + @{skill_perception_total_bonus}[SKILL] + @{activity_penalty}[ACT. PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{sm_penalty=[[@{activity_penalty}]]}} {{skill=[[@{skill_perception_total_bonus}]]}} {{underflow=[[1d100!>96 * -1]]}}">
                                 <!-- -->
                             </button>
                         </td>
@@ -2455,7 +2455,7 @@
                             <span class="action-type-label" title="Offensive Bonus">OB</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_basespell_ob" title="Base spell attack" value="@{wtype} &{template:attack} {{type=Base Spells}} {{character=@{character_name}}} {{subtags=Spell Attack (UM)}} {{roll=[[1d100cf<0+ @{skill_basespell_total_bonus}[SKILL] + @{total_ob_penalty}[OB_PENALTY] + ?{Modifier|0}]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_basespell_total_bonus}]]}} {{underflow=[[1d100!>95 * -1]]}} {{fumble_roll=[[1d100]]}}">
+                            <button type="roll" class="rolld100" name="attr_basespell_ob" title="Base spell attack" value="@{wtype} &{template:attack} {{type=Base Spells}} {{character=@{character_name}}} {{subtags=Spell Attack (UM)}} {{roll=[[1d100cf<0+ @{skill_basespell_total_bonus}[SKILL] + @{total_ob_penalty}[OB_PENALTY] + ?{Modifier|0}]]}} {{ob_penalty=[[@{total_ob_penalty}]]}} {{skill=[[@{skill_basespell_total_bonus}]]}} {{underflow=[[1d100!>96 * -1]]}} {{fumble_roll=[[1d100]]}}">
                                 <!-- -->
                             </button>
                         </td>
@@ -2482,7 +2482,7 @@
                             <span class="action-type-label" title="Static maneuver">SM</span>
                         </td>
                         <td>
-                            <button type="roll" class="rolld100" name="attr_leadership_sm" title="Leadership maneuver" value="@{wtype} &{template:staticmaneuver} {{type=Leadership}} {{character=@{character_name}}} {{subtags=Static Maneuver}} {{roll=[[1d100!>95cs>95cf<05 + @{skill_leadership_total_bonus}[SKILL] + @{activity_penalty}[ACT. PENALTY]]]}} {{sm_penalty=[[@{activity_penalty} + ?{Modifier|0}]]}} {{skill=[[@{skill_leadership_total_bonus}]]}} {{underflow=[[1d100!>95 * -1]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_leadership_sm" title="Leadership maneuver" value="@{wtype} &{template:staticmaneuver} {{type=Leadership}} {{character=@{character_name}}} {{subtags=Static Maneuver}} {{roll=[[1d100!>96cs>96cf<5 + @{skill_leadership_total_bonus}[SKILL] + @{activity_penalty}[ACT. PENALTY]]]}} {{sm_penalty=[[@{activity_penalty} + ?{Modifier|0}]]}} {{skill=[[@{skill_leadership_total_bonus}]]}} {{underflow=[[1d100!>96 * -1]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{underflow=[[1d100!>96 * -1]]}}">
                                 <!-- -->
                             </button>
                         </td>                        
@@ -2607,7 +2607,7 @@
                                 </select>
                             </div>
                             <div class="table-cell sheet-secondaryskill-cell">
-                                <button type="roll" class="rolld100" name="attr_secondaryskill_roll" title="@{skill_secondaryskill_name} maneuver" value="@{wtype} &{template:secondaryskill} {{type=@{skill_secondaryskill_name}}} {{character=@{character_name}}} {{@{skill_secondaryskill_type}=1}} {{mm_roll=[[1d100!>95cs>95cf<05 + @{skill_secondaryskill_total_bonus} + @{total_mm_penalty} + ?{Modifier|0}]]}} {{sm_roll=[[1d100!>95cs>95cf<05 + @{skill_secondaryskill_total_bonus} + @{activity_penalty} + ?{Modifier|0}]]}} {{sm_penalty=[[@{activity_penalty}]]}} {{mm_penalty=[[@{total_mm_penalty}]]}} {{skill=[[@{skill_secondaryskill_total_bonus}]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                                <button type="roll" class="rolld100" name="attr_secondaryskill_roll" title="@{skill_secondaryskill_name} maneuver" value="@{wtype} &{template:secondaryskill} {{type=@{skill_secondaryskill_name}}} {{character=@{character_name}}} {{@{skill_secondaryskill_type}=1}} {{mm_roll=[[1d100!>96cs>96cf<5 + @{skill_secondaryskill_total_bonus} + @{total_mm_penalty} + ?{Modifier|0}]]}} {{sm_roll=[[1d100!>96cs>96cf<5 + @{skill_secondaryskill_total_bonus} + @{activity_penalty} + ?{Modifier|0}]]}} {{sm_penalty=[[@{activity_penalty}]]}} {{mm_penalty=[[@{total_mm_penalty}]]}} {{skill=[[@{skill_secondaryskill_total_bonus}]]}} {{underflow=[[1d100!>96 * -1]]}}">
                                     <!-- -->
                                 </button>
                             </div>                        
@@ -2632,10 +2632,11 @@
                         <label title="The available number of power points is based on stats (IG or IT) and level.">Power Points:</label>
                     </div>
                     <div class="table-cell">
-                        <input type="hidden" name="attr_power_points_base" value="0"/>
-                        <input type="hidden" name="attr_effective_pp_multiplier" value="(((@{power_point_multiplier} + 1) + abs(@{power_point_multiplier} - 1))/2)"/>
+                        <input type="hidden" name="attr_power_points_base" value="0" />
+                        <input type="hidden" name="attr_effective_pp_multiplier" value="(((@{power_point_multiplier} + 1) + abs(@{power_point_multiplier} - 1))/2)" />
                         <input type="number" name="attr_power_points" value="0" />/
-                        <input type="number" name="attr_total_power_points" value="(@{power_points_base} * @{level} * @{effective_pp_multiplier})" disabled />
+                        <input type="hidden" name="attr_total_power_points" value="(@{power_points_base} * @{level} * @{effective_pp_multiplier})" disabled />
+                        <input type="number" name="attr_power_points_max" value="(@{power_points_base} * @{level} * @{effective_pp_multiplier})" disabled />
                     </div>
                     <div class="table-cell">
                         <label title="Multiplies the power points available per day">PP Multipliers:</label>
@@ -3026,7 +3027,7 @@
                                     <option value="Crush(C)">CR(C)</option>
                                     <option value="Crush(D)">CR(D)</option>
                                 </optgroup>
-                                <optgroup label="Crush">
+                                <optgroup label="Slash">
                                     <option value="Slash">SL</option>
                                     <option value="Slash(A)">SL(A)</option>
                                     <option value="Slash(B)">SL(B)</option>
@@ -3094,7 +3095,7 @@
                                     <option value="Crush(C)">CR(C)</option>
                                     <option value="Crush(D)">CR(D)</option>
                                 </optgroup>
-                                <optgroup label="Crush">
+                                <optgroup label="Slash">
                                     <option value="Slash">SL</option>
                                     <option value="Slash(A)">SL(A)</option>
                                     <option value="Slash(B)">SL(B)</option>
@@ -3166,7 +3167,7 @@
                             <input type="number" name="attr_total_wpn_ob_display_bonus" value="@{total_wpn_ob_bonus}" disabled/>
                         </div>
                         <div class="table-cell">
-                            <button type="roll" class="rolld100" name="attr_weapon_roll" title="Weapon Attack Roll" value="@{wtype} &{template:weaponattack} {{type=@{weapon_name}}} {{character=@{character_name}}} {{roll=[[1d100!>95cs>95cf<[[@{weapon_fumble_max}]] + @{total_wpn_ob_bonus}[TOTAL OB] + @{total_ob_penalty} [OB PENALTY] + ?{Modifier|0} [MODIFIER] ]]}} {{fumble_roll=[[1d100]]}} {{fumble_severity=@{weapon_fumble_severity}}} {{primary_critical=[[1d100]] @{weapon_primary_critical}}} {{secondary_critical=[[1d100]] @{weapon_secondary_critical}}} {{reloadpenalty=@{weapon_reload_penalty}}} {{noleather=@{weapon_noleather_bonus}}} {{chainplate=@{weapon_chainplate_bonus}}} {{subtags=Weapon attack}} {{ob_skill=[[@{weapon_skill_bonus}]]}} {{wpn_bonus=[[@{weapon_item_bonus}]]}} {{modifier=[[?{Modifier|0}]]}} {{ob_penalty=[[@{total_ob_penalty}]]}}">
+                            <button type="roll" class="rolld100" name="attr_weapon_roll" title="Weapon Attack Roll" value="@{wtype} &{template:weaponattack} {{type=@{weapon_name}}} {{character=@{character_name}}} {{roll=[[1d100!>96cs>96cf<[[@{weapon_fumble_max}]] + @{total_wpn_ob_bonus}[TOTAL OB] + @{total_ob_penalty} [OB PENALTY] + ?{Modifier|0} [MODIFIER] ]]}} {{fumble_roll=[[1d100]]}} {{fumble_severity=@{weapon_fumble_severity}}} {{primary_critical=[[1d100]] @{weapon_primary_critical}}} {{secondary_critical=[[1d100]] @{weapon_secondary_critical}}} {{reloadpenalty=@{weapon_reload_penalty}}} {{noleather=@{weapon_noleather_bonus}}} {{chainplate=@{weapon_chainplate_bonus}}} {{subtags=Weapon attack}} {{ob_skill=[[@{weapon_skill_bonus}]]}} {{wpn_bonus=[[@{weapon_item_bonus}]]}} {{modifier=[[?{Modifier|0}]]}} {{ob_penalty=[[@{total_ob_penalty}]]}}">
                             </button>
                         </div>
                     </fieldset>
@@ -3430,7 +3431,7 @@
                         <div class="table-cell">
                             <span class="horizontal-spacer">&nbsp;</span>
                             <span class="skill-label" title="Roll for 1d100. Keep rolling while the outcome is equal to or greater than 95 and add up the results.">Open-ended: </span>
-                            <button type="roll" class="rolld100" name="attr_openended_roll" title="Open-ended roll" value="@{wtype} &{template:openended} {{type=Open-ended 1d100}} {{character=@{character_name}}} {{subtags=Generic}} {{roll=[[1d100!>95cs>95cf<5 + ?{Modifier|0}]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            <button type="roll" class="rolld100" name="attr_openended_roll" title="Open-ended roll" value="@{wtype} &{template:openended} {{type=Open-ended 1d100}} {{character=@{character_name}}} {{subtags=Generic}} {{roll=[[1d100!>96cs>96cf<5 + ?{Modifier|0}]]}} {{underflow=[[1d100!>96 * -1]]}}">
                                 <!-- -->
                             </button>
                         </div>
@@ -3438,7 +3439,7 @@
                             <span class="horizontal-spacer">&nbsp;</span>                                
                             <span class="skill-label" title="Roll 1d100 for orientation">Orientation: </span>
                             <button type="roll" class="rolld100" name="attr_orientation2_roll" title="Orientation roll" 
-                            value="@{wtype} &{template:staticmaneuver} {{type=Orientation}} {{character=@{character_name}}} {{subtags=Static Maneuver}} {{roll=[[1d100!>95cs>95cf<5 +  + @{creature_activity_penalty}[PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{sm_penalty=[[@{creature_activity_penalty}]]}} {{skill=[[@{skill_perception_total_bonus}]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                            value="@{wtype} &{template:staticmaneuver} {{type=Orientation}} {{character=@{character_name}}} {{subtags=Static Maneuver}} {{roll=[[1d100!>96cs>96cf<5 + @{creature_activity_penalty}[PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{sm_penalty=[[@{creature_activity_penalty}]]}} {{skill=[[@{skill_perception_total_bonus}]]}} {{underflow=[[1d100!>96 * -1]]}}">
                                 <!-- -->
                             </button>
                         </div>                                
@@ -3778,11 +3779,11 @@
                                         <span class="skill-label" title="The effective movement maneuver bonus equals MM bonus from Movement Speed minus the total MM penalty">Effective MM Bonus:</span>
                                     </div>
                                     <div class="table-cell">
-                                        <input type="hidden" name="attr_creature_total_mm_penalty" value="0" />
-                                        <input type="number" class="autocalc-total sheet-autocalc-bonus" name="attr_creature_total_mm_display_penalty" value="(@{creature_total_mm_penalty})" disabled/> feet/rnd
+                                        <input type="hidden" name="attr_creature_effective_mm_bonus" value="0" />
+                                        <input type="number" class="autocalc-total sheet-autocalc-bonus" name="attr_creature_effective_mm_display_bonus" value="(@{creature_mm_bonus}+@{creature_total_mm_penalty})" disabled/> feet/rnd
 
                                         <span class="action-type-label" title="Movement maneuver bonus">MM</span> 
-                                        <button type="roll" class="rolld100" name="attr_creature_mm" title="Creature moving maneuver" value="@{wtype} &{template:movingmaneuver} {{type=Basic}} {{character=@{character_name}}} {{subtags=Moving Maneuver}} {{roll=[[1d100!>95cs>95cf<05 + @{creature_mm_bonus}[BONUS] + @{creature_total_mm_penalty}[PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{mm_penalty=[[@{creature_total_mm_penalty}]]}} {{skill=[[@{creature_mm_bonus}]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                                        <button type="roll" class="rolld100" name="attr_creature_mm" title="Creature moving maneuver" value="@{wtype} &{template:movingmaneuver} {{type=Basic}} {{character=@{character_name}}} {{subtags=Moving Maneuver}} {{roll=[[1d100!>96cs>96cf<5 + @{creature_mm_bonus}[BONUS] + @{creature_total_mm_penalty}[PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{mm_penalty=[[@{creature_total_mm_penalty}]]}} {{skill=[[@{creature_mm_bonus}]]}} {{underflow=[[1d100!>96 * -1]]}}">
                                             <!-- -->
                                         </button>
                                     </div>
@@ -3849,7 +3850,7 @@
                                 <input type="number" name="attr_attack1_ob" value="0"/> <span class="action-type-label" title="Offensive bonus">OB</span>
                             </td>
                             <td>
-                                <button type="roll" class="rolld100" name="attr_primary_ob" title="Primary Attack Roll" value="@{wtype} &{template:attack} {{type=@{attack1_name}}} {{character=@{character_name}}} {{subtags=@{attack1_size} @{attack1_type} Attack}} {{roll=[[1d100!>95cs>95cf<8 + @{attack1_ob}[BONUS] + @{creature_total_ob_penalty}[PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{creature_total_ob_penalty}]]}} {{skill=[[@{attack1_ob}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                                <button type="roll" class="rolld100" name="attr_primary_ob" title="Primary Attack Roll" value="@{wtype} &{template:attack} {{type=@{attack1_name}}} {{character=@{character_name}}} {{subtags=@{attack1_size} @{attack1_type} Attack}} {{roll=[[1d100!>96cs>96cf<8 + @{attack1_ob}[BONUS] + @{creature_total_ob_penalty}[PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{creature_total_ob_penalty}]]}} {{skill=[[@{attack1_ob}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>96 * -1]]}}">
                                     <!-- -->
                                 </button>
                             </td>
@@ -3886,7 +3887,7 @@
                                 <input type="number" name="attr_attack2_ob" value="0"/> <span class="action-type-label" title="Offensive bonus">OB</span>
                             </td>
                             <td>
-                                <button type="roll" class="rolld100" name="attr_secondary_ob" title="Secondary Attack Roll" value="@{wtype} &{template:attack} {{type=@{attack2_name}}} {{character=@{character_name}}} {{subtags=@{attack2_size} @{attack2_type} Attack}} {{roll=[[1d100!>95cs>95cf<8 + @{attack2_ob}[BONUS] + @{creature_total_ob_penalty}[PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{creature_total_ob_penalty}]]}} {{skill=[[@{attack2_ob}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                                <button type="roll" class="rolld100" name="attr_secondary_ob" title="Secondary Attack Roll" value="@{wtype} &{template:attack} {{type=@{attack2_name}}} {{character=@{character_name}}} {{subtags=@{attack2_size} @{attack2_type} Attack}} {{roll=[[1d100!>96cs>96cf<8 + @{attack2_ob}[BONUS] + @{creature_total_ob_penalty}[PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{creature_total_ob_penalty}]]}} {{skill=[[@{attack2_ob}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>96 * -1]]}}">
                                     <!-- -->
                                 </button>
                             </td>
@@ -3923,7 +3924,7 @@
                                 <input type="number" name="attr_attack3_ob" value="0"/> <span class="action-type-label" title="Offensive bonus">OB</span>
                             </td>
                             <td>
-                                <button type="roll" class="rolld100" name="attr_tertiary_ob" title="Tertiary Attack Roll" value="@{wtype} &{template:attack} {{type=@{attack3_name}}} {{character=@{character_name}}} {{subtags=@{attack3_size} @{attack3_type} Attack}} {{roll=[[1d100!>95cs>95cf<8 + @{attack3_ob}[BONUS] + @{creature_total_ob_penalty}[PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{creature_total_ob_penalty}]]}} {{skill=[[@{attack3_ob}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                                <button type="roll" class="rolld100" name="attr_tertiary_ob" title="Tertiary Attack Roll" value="@{wtype} &{template:attack} {{type=@{attack3_name}}} {{character=@{character_name}}} {{subtags=@{attack3_size} @{attack3_type} Attack}} {{roll=[[1d100!>96cs>96cf<8 + @{attack3_ob}[BONUS] + @{creature_total_ob_penalty}[PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{creature_total_ob_penalty}]]}} {{skill=[[@{attack3_ob}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>96 * -1]]}}">
                                     <!-- -->
                                 </button>
                             </td>
@@ -3960,7 +3961,7 @@
                                 <input type="number" name="attr_attack4_ob" value="0"/> <span class="action-type-label" title="Offensive bonus">OB</span>
                             </td>
                             <td>
-                                <button type="roll" class="rolld100" name="attr_quaterary_ob" title="Quaternary Attack Roll" value="@{wtype} &{template:attack} {{type=@{attack4_name}}} {{character=@{character_name}}} {{subtags=@{attack4_size} @{attack4_type} Attack}} {{roll=[[1d100!>95cs>95cf<8 + @{attack4_ob}[BONUS] + @{creature_total_ob_penalty}[PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{creature_total_ob_penalty}]]}} {{skill=[[@{attack4_ob}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                                <button type="roll" class="rolld100" name="attr_quaterary_ob" title="Quaternary Attack Roll" value="@{wtype} &{template:attack} {{type=@{attack4_name}}} {{character=@{character_name}}} {{subtags=@{attack4_size} @{attack4_type} Attack}} {{roll=[[1d100!>96cs>96cf<8 + @{attack4_ob}[BONUS] + @{creature_total_ob_penalty}[PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{creature_total_ob_penalty}]]}} {{skill=[[@{attack4_ob}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>96 * -1]]}}">
                                     <!-- -->
                                 </button>
                             </td>
@@ -3997,7 +3998,7 @@
                                 <input type="number" name="attr_attack5_ob" value="0"/> <span class="action-type-label" title="Offensive bonus">OB</span>
                             </td>
                             <td>
-                                <button type="roll" class="rolld100" name="attr_quinary_ob" title="Quinary Attack Roll" value="@{wtype} &{template:attack} {{type=@{attack5_name}}} {{character=@{character_name}}} {{subtags=@{attack5_size} @{attack5_type} Attack}} {{roll=[[1d100!>95cs>95cf<8 + @{attack5_ob}[BONUS] + @{creature_total_ob_penalty}[PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{creature_total_ob_penalty}]]}} {{skill=[[@{attack5_ob}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>95 * -1]]}}">
+                                <button type="roll" class="rolld100" name="attr_quinary_ob" title="Quinary Attack Roll" value="@{wtype} &{template:attack} {{type=@{attack5_name}}} {{character=@{character_name}}} {{subtags=@{attack5_size} @{attack5_type} Attack}} {{roll=[[1d100!>96cs>96cf<8 + @{attack5_ob}[BONUS] + @{creature_total_ob_penalty}[PENALTY] + ?{Modifier|0}[MODIFIER]]]}} {{ob_penalty=[[@{creature_total_ob_penalty}]]}} {{skill=[[@{attack5_ob}]]}} {{primary_critical=[[1d100]]}} {{secondary_critical=[[1d100]]}} {{fumble_roll=[[1d100]]}} {{underflow=[[1d100!>96 * -1]]}}">
                                     <!-- -->
                                 </button>
                             </td>
@@ -4976,7 +4977,8 @@ on("sheet:opened change:hit_points change:skill_bodydev_total_bonus", function()
         TAS.log("HIT LOSS PENALTY hp:" + hp + " hpTotal:" + hp_total + " => " + hlp); 
 
         setAttrs({
-            "total_hitloss_penalty": hlp
+            "total_hitloss_penalty": hlp,
+            "hit_points_max": hp_total
         });
     });
 });
@@ -6812,7 +6814,8 @@ on("sheet:opened change:creature_hit_points change:creature_total_hit_points", f
         TAS.log("CREATURE HIT LOSS PENALTY hp:" + hp + " hpTotal:" + hp_total + " => " + hlp); 
 
         setAttrs({
-            "creature_hitloss_penalty": hlp
+            "creature_hitloss_penalty": hlp,
+            "creature_hit_points_max": hp_total
         });
     });
 });
@@ -6861,15 +6864,18 @@ on("sheet:opened change:creature_activity_penalty change:creature_hitloss_penalt
  * Creature movement rate worker 
  * --------------------------------------------------------------------------------------------------- */
 on("sheet:opened change:creature_total_mm_penalty change:creature_base_movement_rate", function() {
-    getAttrs(["creature_total_mm_penalty", "creature_base_movement_rate"], function(values) {
+    getAttrs(["creature_total_mm_penalty", "creature_base_movement_rate", "creature_mm_bonus"], function(values) {
 
-        let base_movement_rate = parseInt(values["creature_base_movement_rate"], 10) || 0;        
+        let base_movement_rate = parseInt(values["creature_base_movement_rate"], 10) || 0;
         let total_mm_penalty = parseInt(values["creature_total_mm_penalty"], 10) || 0;
+        let mm_bonus = parseInt(values["creature_mm_bonus"], 10) || 0;
 
-        let effective_rate = base_movement_rate + total_mm_penalty
+        let effective_rate = base_movement_rate + total_mm_penalty;
+        let effective_mm_bonus = mm_bonus+total_mm_penalty;
 
-        setAttrs({
-            "creature_effective_movement_rate": effective_rate
+         setAttrs({
+            "creature_effective_movement_rate": effective_rate,
+            "creature_effective_mm_bonus": effective_mm_bonus
         });
     });
 });


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

## New Sheet Details

<!-- If you are submitting a new sheet to the repository, please fill in any empty spaces indicated by < >. -->

- The name of this game is: <   >  _(i.e. Dungeons & Dragons 5th Edition, The Dresden Files RPG)_
- The publisher of this game is: <   > _(i.e. Wizards of the Coast, Evil Hat)_
- The name of this game system/family is: <   > _(i.e. Dungeons & Dragons, FATE)_

- [ ] I have followed the [Character Sheets Standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) when building this sheet.

<!-- Please check any that apply: -->

- [ ] This sheet has been made on behalf of, or by, the game's publisher.
- [ ] This game is not a traditionally published game, but a copy of the game rules can be purchased/downloaded/found at: <   >
- [ ] This sheet is for an unofficial fan game, modification to an existing game, or a homebrew system.

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->


* Typo: Slash in equipment critical dropdowns had Crush headers
* Fix:  Exploding dice should be >96 (means >=96 in roll20)
* Fix:  Effective MM Bonus on NPC/Equipment only showed penalty, not bonus+penalty.  Display issue only.
* Fix:  Orientation on NPC/Creature tab always rolling 0
* Enhancement: Enable _max for hit points and power points so token bars will work when the related attribute is linked.

