### PR TITLE
Mongoose Traveller 2E - Ship, Vehicle and Psionic Enhancements

### DIFF
--- a/Mongoose_Traveller2e/MongooseTraveller.css
+++ b/Mongoose_Traveller2e/MongooseTraveller.css
@@ -1,3 +1,4 @@
+
 select[multiple]:focus option:checked {
   background: red linear-gradient(0deg, red 0%, red 100%);
 }
@@ -130,6 +131,10 @@ input[type="number"]:hover {
     padding: 2px;
 }
 
+.sheet-redborder textarea {
+    height: 75px;
+}
+
 .sheet-bold {
     font-weight: bold;
 }
@@ -147,6 +152,10 @@ input[type="number"]:hover {
     margin-top: 3px !important;
     margin-bottom: 3px !important;
     font-weight: bold !important;
+}
+
+.sheet-med {
+    font-size: 1em;
 }
 
 .sheet-big {
@@ -189,6 +198,7 @@ input:focus,
 textarea:focus,
 select:focus {
     outline-color: red;
+    outline-style: solid;
 }
 
 input[type="text"].sheet-input {
@@ -289,7 +299,7 @@ input[type="number"].sheet-weaponweight::-webkit-inner-spin-button {
 }
 
 .sheet-armournote {
-    width: 98%;
+    width: 98% !important;
     height: 50px;
 }
 
@@ -328,7 +338,7 @@ input[type="number"].sheet-weaponweight::-webkit-inner-spin-button {
 .sheet-weaponrollbutton {
     font-family: "Pictos";
     color: red;
-    font-size: 0.9em;
+    font-size: 12px;
 }
 
 .sheet-weaponspacer {
@@ -558,6 +568,9 @@ button[type="roll"]:hover label, button[type="roll"]:hover input {
 }
 
 /* ----- Sheet-button Reset ----- */
+span.sheet-button {
+    margin-right: 5px;
+}
 
 button.sheet-button[type="roll"], button.sheet-button[type="action"] {
     width: 95%;
@@ -625,6 +638,11 @@ input.sheet-rollselect[value="bane"] ~ .sheet-button:not(.sheet-roll_bane) {
     background-color: white;
     border-color: red;
     color: black
+}
+
+.sheet-mod_toggle button,
+.sheet-roll_toggle button {
+    width: 100px !important;
 }
 
 .sheet-mod-switch[value="1"] ~ .sheet-mod_toggle,
@@ -992,6 +1010,7 @@ input.sheet-power[type="checkbox"]:checked + span::before {
 .sheet-rolltemplate-freight td,
 .sheet-rolltemplate-trade-broker td {
     padding: 0px;
+    padding-top: 5px;
     text-shadow: none;
     font-weight: bold;
     font-style: italic;
@@ -1005,10 +1024,17 @@ input.sheet-power[type="checkbox"]:checked + span::before {
 .sheet-rolltemplate-power tr:nth-child(2) td,
 .sheet-rolltemplate-passengers tr:nth-child(2) td,
 .sheet-rolltemplate-freight tr:nth-child(2) td,
-.sheet-rolltemplate-trade-broker tr:nth-child(2) td  {
+.sheet-rolltemplate-trade-broker tr:nth-child(2) {
     padding-bottom: 10px;
     padding-top: 5px;
     text-align: center;
+}
+
+.sheet-rolltemplate-trade-broker tr:nth-child(3) td {
+    padding-bottom: 5px;
+    padding-top: 5px;
+    text-align: center;
+    font-size: 0.8em;
 }
 
 .sheet-rolltemplate-skill-general .inlinerollresult,
@@ -1310,11 +1336,15 @@ button.btn.repcontrol_edit::after {
     margin-top: 5px;
 }
 
+.sheet-speculative-subpanel div {
+    margin-top: 5px;
+}
+
 .sheet-speculativebutton {
     font-family: "Pictos";
     color: red;
     font-size: 0.9em;
-    width: 5%;
+    width: 5% !important;
 }
 
 .sheet-speculativezerobutton {
@@ -1403,6 +1433,11 @@ div.sheet-speculativestarport-row {
     text-align: right;
 }
 
+.sheet-textright-margin {
+    text-align: right;
+    margin-left: 25px;
+}
+
 .sheet-textcentre {
     text-align: center;
 }
@@ -1451,10 +1486,20 @@ span.sheet-vehiclecomponent {
     -webkit-box-sizing: border-box;
 }
 
+sheet-vehicle h3 {
+    margin-right: 5px;
+}
+
 .sheet-uwpbutton {
     height: 23px !important;
     line-height: 0px !important;
     border: red 1px solid !important;
+}
+
+.sheet-uwptext {
+    height: 23px !important;
+    line-height: 0px !important;
+    margin-bottom: 4px !important;
 }
 
 .sheet-laf-characteristics {
@@ -1507,9 +1552,23 @@ span.sheet-vehiclecomponent {
 }
 
 .sheet-laf-4colrow1311 {
-    grid-template-columns: 1fr 3fr 1fr 1fr;
+    grid-template-columns: 0.25fr 2fr 0.25fr 0.25fr 2fr;
     grid-template-rows: none;
     width: 100%;
+}
+
+.sheet-laf-4colrow1311 button {
+    width: 25px;
+}
+
+.sheet-laf-5colrow13111 {
+    grid-template-columns: 0.25fr 2fr 0.5fr 0.5fr 2fr;
+    grid-template-rows: none;
+    width: 100%;
+}
+
+.sheet-laf-5colrow13111 button {
+    width: 25px !important;
 }
 
 .sheet-laf-4colrow1313 {
@@ -1529,6 +1588,19 @@ span.sheet-vehiclecomponent {
     margin-right:0;
 }
 
+.sheet-groupfunds h2 {
+    width: 30%;
+}
+
+.sheet-groupfunds h3 {
+    text-align: right;
+    width: 80%;
+}
+
+.sheet-groupfunds input {
+    width: 15% !important;
+}
+
 .sheet-laf-skillsummaryrow {
     grid-template-columns: 1px 1.5fr 1px 1.5fr 1px 1.5fr 1px 1.5fr 1px 1.9fr 1px 1.5fr 1px 2fr;
     grid-template-rows: none;
@@ -1544,6 +1616,10 @@ span.sheet-vehiclecomponent {
     grid-template-columns: 0.5fr 2fr 2fr 2fr 0.75fr 1fr 1.2fr 1fr 1fr;
     grid-template-rows: none;
     margin-bottom: 3px;
+}
+
+.sheet-laf-otherskillrow button {
+    width: 25px;
 }
 
 .sheet-laf-centre-checkbox {
@@ -1627,8 +1703,13 @@ span.sheet-vehiclecomponent {
     margin-bottom: 3px;
 }
 
+.sheet-laf-otherwealth input[type="number"] {
+    width: 100px !important;
+}
+
 .sheet-laf-otherwealth textarea {
     grid-column: 1 / 4;
+    width: 99%;
 }
 
 .sheet-laf-initbutton {
@@ -1640,13 +1721,19 @@ span.sheet-vehiclecomponent {
 }
 
 .sheet-laf-power {
-    grid-template-columns: 1fr 3fr 3fr 1fr;
+    grid-template-columns: 0.15fr 1fr 1fr 0.25fr;
     grid-template-rows: none;
     margin-bottom: 3px;
 }
 
+.sheet-laf-power button {
+    width: 25px !important;
+}
+
 .sheet-laf-power textarea {
-    grid-column: 1 / 5;
+    grid-column: 1 / 4;
+    height: 30px !important;
+    width: 99% !important;
 }
 
 .sheet-laf-armourlist {
@@ -1665,8 +1752,13 @@ span.sheet-vehiclecomponent {
     margin-bottom: 3px;
 }
 
+.sheet-laf-weaponlist button {
+    width: 25px;
+}
+
 .sheet-laf-weaponlist textarea {
     grid-column: 1 / 10;
+    height: 30px !important;
 }
 
 .sheet-laf-ship {
@@ -1701,6 +1793,11 @@ span.sheet-vehiclecomponent {
     grid-template-columns: 0.25fr 1fr 0.25fr;
 }
 
+.sheet-laf-animal-init {
+    width: 75%;
+    grid-template-columns: 0.25fr 0.25fr 1fr 0.01fr;
+}
+
 .sheet-laf-animal-detail {
     grid-template-columns: 3fr 1fr 0.25fr;
 }
@@ -1714,9 +1811,27 @@ span.sheet-vehiclecomponent {
     grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
 }
 
+.sheet-laf-vehicle-div {
+    width: 90% !important;
+}
+
 .sheet-laf-vehicle-data {
     width: 90% !important;
-    grid-template-columns: 9fr 0.75fr 10fr 0.75fr;
+    grid-template-columns: 9fr 0.75fr 10.5fr 0.75fr;
+}
+
+.sheet-laf-vehicle-sensors {
+    width: 90% !important;
+    grid-template-columns: 2fr 0.25fr 0.25fr 0.1fr 5fr;
+}
+
+.sheet-laf-vehicle-sensors span,
+.sheet-laf-vehicle-sensors input[type="number"] {
+    width: 90px !important;
+}
+
+.sheet-laf-vehicle-sensors button {
+    width: 25px !important;
 }
 
 .sheet-laf-vehicle-textarea {
@@ -1738,11 +1853,9 @@ span.sheet-vehiclecomponent {
 
 .sheet-laf-vehicle-weaponsrow {
     width: 100%;
-    grid-template-columns: 2.5fr 1fr 1fr 1fr 1fr 1fr 1.5fr 0.8fr 0.25fr;
+    grid-template-columns: 1.25fr 2fr 1fr 1fr 1fr 1fr 1.5fr 1.5fr 0.25fr;
     grid-auto-flow: column;
 }
-
-
 
 .sheet-laf-ship-components {
     grid-template-columns: 2fr 3fr 1fr 1fr 0.35fr;
@@ -1758,8 +1871,6 @@ span.sheet-vehiclecomponent {
                          "components components components xxx"
                          "components components components xxx";
 }
-
-
 
 .sheet-laf-ship-components-p {
     margin-right: 3px;
@@ -1799,6 +1910,10 @@ input.sheet-laf-ship-component-hider {
     grid-area: crew;
     width: 200px;
     margin-bottom: 3px;
+}
+
+.sheet-laf-ship-crew-p textarea {
+    height: 80px;
 }
 
 .sheet-laf-ship-runningcosts-p {
@@ -1845,7 +1960,7 @@ input.sheet-laf-ship-component-hider {
 }
 
 .sheet-laf-ship-hardpoint {
-margin-top: 3px !important;
+    margin-top: 3px !important;
     background-color: lightgrey;
     grid-template-columns: 0.25fr 2.2fr 1fr 1fr 1.5fr 1fr 0.5fr 0.5fr 1.5fr 0.25fr;
 }
@@ -1887,6 +2002,12 @@ margin-top: 3px !important;
 
 .sheet-laf-custom-characteristics button {
     margin-top: 3px !important;
+    width: 25px !important;
+    padding: 0;
+}
+
+.sheet-laf-custom-characteristics span:first-child {
+    width: 210px;
 }
 
 .sheet-boldspan {
@@ -1935,4 +2056,93 @@ margin-top: 3px !important;
 
 .sheet-passenger-content div:first-child {
     margin-right: 3px;
+}
+
+/*
+.sheet-auto-expand {
+  position: relative;
+  cursor: text;
+  word-wrap: break-word;
+  box-sizing: border-box;
+}
+
+.sheet-auto-expand span {
+  visibility: hidden;
+  white-space: pre-wrap;
+  display: block;
+}
+
+.sheet-auto-expand textarea {
+  position: absolute;
+  overflow: hidden;
+  z-index: 1;
+  top: 0;
+  left: 0;
+  margin: 0;
+  resize: none;
+  height: 100%;
+  min-height: 20px;
+  word-wrap: break-word;
+  padding: inherit;
+  font: inherit;
+  color: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+  text-align: inherit;
+  box-sizing: border-box;
+}
+*/
+
+.sheet-gearnotes {
+    width:97.5% !important;
+    height:40px !important;
+}
+
+.sheet-power-detail {
+}
+
+.sheet-power-detail input:first-child {
+    width: 45% !important;
+}
+
+.sheet-power-detail input:nth-child(3) {
+    width: 31% !important;
+}
+
+.sheet-wide-button {
+    width: 100% !important;
+    margin-top: 4px !important;
+}
+
+.sheet-wide-button span {
+    font-size: 1em;
+}
+
+.sheet-trade-broker-section {
+    margin-top: 3px !important;
+    height: 25px !important;
+}
+
+.sheet-acknowledgement {
+    text-align: center;
+    color: darkgray;
+}
+
+.sheet-notes-textarea {
+    width: 99% !important;
+    height:500px !important;
+}
+
+.sheet-mail-attrs {
+    color: maroon;
+}
+
+.sheet-npc-movement {
+    display: grid;
+    width: 140px;
+    grid-template-columns: 1fr 1fr 1fr;
+}
+
+.sheet-laf-vehicle-mount {
+    width: 90% !important;
 }

--- a/Mongoose_Traveller2e/MongooseTraveller.html
+++ b/Mongoose_Traveller2e/MongooseTraveller.html
@@ -24,26 +24,37 @@
         <option value="2" data-i18n="no-u">No</option>
         <option selected value="3" data-i18n="toggle-u">Toggle</option>
     </select> </span> <input type="checkbox" name="attr_initiative_effect" value="-8" class="sheet-button">
-        <span class="sheet-button" style="margin-left: 3px; font-weight: bold; font-size: 0.8em;">Initiative Effect</span>
+        <span class="sheet-button sheet-checkbox-option">Initiative Effect</span>
     </div>
-    <span> <input type="hidden" name="attr_ro_default" class="sheet-roll-switch">
+    <span>
+        <input type="hidden" name="attr_ro_default" class="sheet-roll-switch">
         <input type="hidden" name="attr_mod_default" class="sheet-mod-switch" value="3">
-        <span class="sheet-roll_toggle"> <span data-i18n="rolltype-u"></span>
+        <span class="sheet-roll_toggle">
+            <span data-i18n="rolltype-u"></span>
             <input type="hidden" class="sheet-rollselect" name="attr_ro_toggle_sel" value="normal"/>
-            <button type="action" style="width:100px" class="sheet-button sheet-roll_boon" name="act_boon">
-                <span class="sheet-button_header" data-i18n="boon-u"></span></button>
-            <button type="action" style="width:100px" class="sheet-button sheet-roll_normal" name="act_normal">
-                <span class="sheet-button_header" data-i18n="normal-u"></span></button>
-            <button type="action" style="width:100px" class="sheet-button sheet-roll_bane" name="act_bane">
-                <span class="sheet-button_header" data-i18n="bane-u"></span></button>
-        </span> <span>&nbsp;&nbsp;</span> <span class="sheet-mod_toggle"> <span data-i18n="modprompt-u"></span>
+            <button type="action" class="sheet-button sheet-roll_boon" name="act_boon">
+                <span class="sheet-button_header" data-i18n="boon-u"></span>
+            </button>
+            <button type="action" class="sheet-button sheet-roll_normal" name="act_normal">
+                <span class="sheet-button_header" data-i18n="normal-u"></span>
+            </button>
+            <button type="action" class="sheet-button sheet-roll_bane" name="act_bane">
+                <span class="sheet-button_header" data-i18n="bane-u"></span>
+            </button>
+        </span>
+        <span>&nbsp;&nbsp;</span>
+        <span class="sheet-mod_toggle"> <span data-i18n="modprompt-u"></span>
             <input type="hidden" class="sheet-modselect" name="attr_mod_toggle_sel" value="yes"/>
-            <button type="action" style="width:100px" class="sheet-button sheet-mod_yes" name="act_modyes">
-                <span class="sheet-button_header" data-i18n="yes-u"></span></button>
-            <button type="action" style="width:100px" class="sheet-button sheet-mod_no" name="act_modno">
-                <span class="sheet-button_header" data-i18n="no-u"></span></button>
-        </span> <span>&nbsp;&nbsp;</span>
-        <input type="checkbox" name="attr_whispertoggle" value="/w gm" class="sheet-button"/><span class="sheet-button" style="margin-left: 3px; font-weight: bold; font-size: 0.8em;" data-i18n="whisper-u"></span>
+            <button type="action" class="sheet-button sheet-mod_yes" name="act_modyes">
+                <span class="sheet-button_header" data-i18n="yes-u"></span>
+            </button>
+            <button type="action" class="sheet-button sheet-mod_no" name="act_modno">
+                <span class="sheet-button_header" data-i18n="no-u"></span>
+            </button>
+        </span>
+        <span>&nbsp;&nbsp;</span>
+        <input type="checkbox" name="attr_whispertoggle" value="/w gm" class="sheet-button"/>
+        <span class="sheet-button sheet-checkbox-option" data-i18n="whisper-u"></span>
     </span>
 </div><!--    Top Bar -->
 <div class="sheet-topbar">
@@ -155,14 +166,14 @@
                     <input type="number" class="sheet-input" name="attr_study-periods" value="0"/>
                     <input type="text" class="sheet-input" name="attr_study-skill"/>
                 </div>
-                <textarea style="height: 60px;" class="sheet-laf-spangrid-textarea" name="attr_studynotes" placeholder="Study Notes"></textarea>
+                <textarea class="sheet-armournote" name="attr_studynotes" placeholder="Study Notes"></textarea>
             </div>
         </div>
         <br>
         <div class="sheet-redborder">
             <h3 data-i18n="characteristics-u">Characteristics</h3>
             <div class="sheet-laf-centredgrid sheet-laf-custom-characteristics">
-                <span style="width: 210px;" class="sheet-header">Name</span>
+                <span class="sheet-header">Name</span>
                 <span class="sheet-header">Rating</span>
                 <span class="sheet-header">Temp</span>
                 <span class="sheet-header">Mod</span>
@@ -182,7 +193,7 @@
         <br>
         <div class="sheet-redborder">
             <h3 data-i18n="characterhistorytitle-u">Character History</h3>
-            <textarea name="attr_character_history" placeholder="Character History" class="sheet-laf-borderbox" style="height: 50px;"></textarea>
+            <textarea name="attr_character_history" placeholder="Character History" class="sheet-laf-borderbox"></textarea>
         </div>
         <br>
         <div class="sheet-tabbed-panel sheet-redborder">
@@ -193,7 +204,7 @@
                     <input class="sheet-input" type="text" name="attr_history-event"/>
                     <span data-i18n="recenteventdate-u">Event Date</span>
                     <input class="sheet-input" type="text" name="attr_history-date"/>
-                    <textarea style="height: 40px;" name="attr_note-history" placeholder="Event Details"></textarea>
+                    <textarea name="attr_note-history" placeholder="Event Details"></textarea>
                 </div>
                 <br>
             </fieldset>
@@ -214,8 +225,8 @@
                         <input class="sheet-input" type="text" name="attr_reference-allies" placeholder="Sector"/>
                         <input class="sheet-input" type="text" name="attr_name-allies2" placeholder="Allies Name"/>
                         <input class="sheet-input" type="text" name="attr_reference-allies2" placeholder="Sector"/>
-                        <textarea style="height:40px;" wrap="soft" class="sheet-laf-spangrid-textarea" name="attr_note-allies" placeholder="Allies Notes"></textarea>
-                        <textarea style="height:40px;" wrap="soft" class="sheet-laf-spangrid-textarea" name="attr_note-allies2" placeholder="Allies Notes"></textarea>
+                        <textarea wrap="soft" class="sheet-laf-spangrid-textarea" name="attr_note-allies" placeholder="Allies Notes"></textarea>
+                        <textarea wrap="soft" class="sheet-laf-spangrid-textarea" name="attr_note-allies2" placeholder="Allies Notes"></textarea>
                     </div>
                     <br>
                 </fieldset>
@@ -236,8 +247,8 @@
                         <input class="sheet-input" type="text" name="attr_reference-contact" placeholder="Sector"/>
                         <input class="sheet-input" type="text" name="attr_name-contact2" placeholder="Contact Name"/>
                         <input class="sheet-input" type="text" name="attr_reference-contact2" placeholder="Sector"/>
-                        <textarea style="height:40px;" wrap="soft" class="sheet-laf-spangrid-textarea" name="attr_note-contact" placeholder="Contact Notes"></textarea>
-                        <textarea style="height:40px;" wrap="soft" class="sheet-laf-spangrid-textarea" name="attr_note-contact2" placeholder="Contact Notes"></textarea>
+                        <textarea wrap="soft" class="sheet-laf-spangrid-textarea" name="attr_note-contact" placeholder="Contact Notes"></textarea>
+                        <textarea wrap="soft" class="sheet-laf-spangrid-textarea" name="attr_note-contact2" placeholder="Contact Notes"></textarea>
 
                     </div>
                     <br>
@@ -259,8 +270,8 @@
                         <input class="sheet-input" type="text" name="attr_reference-enemy" placeholder="Sector"/>
                         <input class="sheet-input" type="text" name="attr_name-enemy2" placeholder="Enemy Name"/>
                         <input class="sheet-input" type="text" name="attr_reference-enemy2" placeholder="Sector"/>
-                        <textarea style="height:40px;" wrap="soft" class="sheet-laf-spangrid-textarea" name="attr_note-enemy" placeholder="Enemy Notes"></textarea>
-                        <textarea style="height:40px;" wrap="soft" class="sheet-laf-spangrid-textarea" name="attr_note-enemy2" placeholder="Enemy Notes"></textarea>
+                        <textarea wrap="soft" class="sheet-laf-spangrid-textarea" name="attr_note-enemy" placeholder="Enemy Notes"></textarea>
+                        <textarea wrap="soft" class="sheet-laf-spangrid-textarea" name="attr_note-enemy2" placeholder="Enemy Notes"></textarea>
 
                     </div>
                     <br>
@@ -282,8 +293,8 @@
                         <input class="sheet-input" type="text" name="attr_reference-rivals" placeholder="Sector"/>
                         <input class="sheet-input" type="text" name="attr_name-rivals2" placeholder="rivals Name"/>
                         <input class="sheet-input" type="text" name="attr_reference-rivals2" placeholder="Sector"/>
-                        <textarea style="height:40px;" wrap="soft" class="sheet-laf-spangrid-textarea" name="attr_note-rivals" placeholder="Rivals Notes"></textarea>
-                        <textarea style="height:40px;" wrap="soft" class="sheet-laf-spangrid-textarea" name="attr_note-rivals2" placeholder="Rivals Notes"></textarea>
+                        <textarea wrap="soft" class="sheet-laf-spangrid-textarea" name="attr_note-rivals" placeholder="Rivals Notes"></textarea>
+                        <textarea wrap="soft" class="sheet-laf-spangrid-textarea" name="attr_note-rivals2" placeholder="Rivals Notes"></textarea>
 
                     </div>
                     <br>
@@ -1610,9 +1621,8 @@
             <span data-i18n="skilltabletotalmodifier-u">Total</span>
         </div>
         <fieldset class="repeating_otherspec">
-
             <div class="sheet-laf-centredgrid sheet-laf-otherskillrow sheet-bold">
-                <button name="roll_Otherspec" type="roll" style="width:20px;" value='@{whispertoggle}&{template:skill-general} {{skill= @{skillName-Other} }} {{spec= @{skillSpeciality-Other} }} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-Other}]] @{ro_default_mod}]] }} '>
+                <button name="roll_Otherspec" type="roll" value='@{whispertoggle}&{template:skill-general} {{skill= @{skillName-Other} }} {{spec= @{skillSpeciality-Other} }} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-Other}]] @{ro_default_mod}]] }} '>
                     <div class="sheet-button_header_rep">b</div>
                 </button>
                 <input type="text" class="sheet-input sheet-bold" name="attr_skillName-Other"/>
@@ -1666,7 +1676,7 @@
                             <input type="number" class="sheet-input_II" name="attr_massleft" value="0" step="0.05"/>
                             <input type="hidden" class="sheet-input" name="attr_masstotalleft" value="0" step="0.05"/>
                         </div>
-                        <textarea style="width:97.5%; height:40px;" class="sheet-input" name="attr_gearnotes-left"></textarea>
+                        <textarea class="sheet-input sheet-gearnotes" name="attr_gearnotes-left"></textarea>
                     </div>
                     <div class='sheet-col'>
                         <span data-i18n="gearequipped-u">Carried</span>
@@ -1680,7 +1690,7 @@
                             <input type="number" class="sheet-input_II" name="attr_massright" value="0" step="0.05"/>
                             <input type="hidden" class="sheet-input" name="attr_masstotalright" value="0" step="0.05"/>
                         </div>
-                        <textarea style="width:97.5%; height:40px;" class="sheet-input" name="attr_gearnotes-right"></textarea>
+                        <textarea class="sheet-input sheet-gearnotes" name="attr_gearnotes-right"></textarea>
                     </div>
                 </div>
             </fieldset>
@@ -1709,13 +1719,11 @@
             <span data-i18n="otherwealthlocation-u" class="sheet-header">Location</span>
         </div>
         <fieldset class="repeating_otherweath">
-            <div class="sheet-laf-centredgrid sheet-laf-otherwealth">
+            <div class="sheet-laf-centredgrid sheet-laf-otherwealth sheet-redborder">
                 <input class="sheet-input sheet-redbold" type="text" name="attr_otherwealth_name" placeholder="Item Name"/>
-                <input class="sheet-input" type="number" value="0" name="attr_otherwealth_value"/>
+                <input class="sheet-input" type="number" value="0" step="10" name="attr_otherwealth_value"/>
                 <input class="sheet-input" type="text" name="attr_otherwealth_location" placeholder="Item Location"/>
-            </div>
-            <div class="sheet-laf-centredgrid sheet-laf-otherwealth">
-                <textarea style="height:40px;" wrap="soft" class="sheet-input" name="attr_otherwealth_item_note" placeholder="Item Details"></textarea>
+                <textarea wrap="soft" class="sheet-input" name="attr_otherwealth_item_note" placeholder="Item Details"></textarea>
             </div>
         </fieldset>
     </div>
@@ -1723,14 +1731,12 @@
     <div class="sheet-tab-content sheet-combat sheet-pc">
         <div>
             <h3 data-i18n="shiparmour-u">Armour</h3>
-            <div class="sheet-laf-centredgrid sheet-laf-armourlist sheet-bold">
+            <div class="sheet-laf-centredgrid sheet-laf-armourlist sheet-bold sheet-redborder">
                 <span data-i18n="armourtype-u">Type</span> <span data-i18n="armourtechlevel-u">TL</span>
                 <span data-i18n="armourprotection-u">Protection</span>
                 <span data-i18n="armourprotectionlaser-u">Protection (Laser)</span>
                 <span data-i18n="armourrads-u">Rad</span> <span data-i18n="armourkgweight-u">KG</span>
                 <span data-i18n="armourskill-u">Required Skill</span>
-                <!--            </div>-->
-                <!--            <div class="sheet-laf-centredgrid sheet-laf-armourlist">-->
                 <input type="text" class="sheet-input sheet-redbold" name="attr_armour-type"/>
                 <input type="number" name="attr_armour-tl"/> <input type="number" name="attr_armour-protection"/>
                 <input type="number" name="attr_armour-protection-laser"/>
@@ -1744,10 +1750,10 @@
                     <option value="4" data-i18n="armourvaccsuit3-u">Vacc Suit 3</option>
                     <option value="5" data-i18n="armourvaccsuit4-u">Vacc Suit 4</option>
                 </select>
-                <textarea style="height: 40px;" class="sheet-input sheet-gridspan18 sheet-laf-wauto" name="attr_armornotes"></textarea>
+                <textarea class="sheet-input sheet-gridspan18 sheet-laf-wauto" name="attr_armornotes"></textarea>
             </div>
             <fieldset class="repeating_armour">
-                <div class="sheet-laf-centredgrid sheet-laf-armourlist">
+                <div class="sheet-laf-centredgrid sheet-laf-armourlist sheet-redborder">
                     <input type="text" class="sheet-input sheet-redbold" name="attr_reparmour-type"/>
                     <input type="number" class="sheet-input" name="attr_reparmour-tl"/>
                     <input type="number" class="sheet-input" name="attr_reparmour-protection"/>
@@ -1762,7 +1768,7 @@
                         <option value="4" data-i18n="armourvaccsuit3-u">Vacc Suit 3</option>
                         <option value="5" data-i18n="armourvaccsuit4-u">Vacc Suit 4</option>
                     </select>
-                    <textarea style="height:40px;" class="sheet-input sheet-gridspan18 sheet-laf-wauto" name="attr_reparmornotes"></textarea>
+                    <textarea class="sheet-input sheet-gridspan18 sheet-laf-wauto" name="attr_reparmornotes"></textarea>
                 </div>
             </fieldset>
             <br>
@@ -1778,19 +1784,19 @@
             <div class="sheet-row-panel">
                 <br>
                 <h3 data-i18n="weaponstitle-u">Weapons</h3>
-                <div class="sheet-laf-centredgrid sheet-laf-weaponlist">
+                <div class="sheet-laf-centredgrid sheet-laf-weaponlist sheet-bold">
                     <span data-i18n="weaponroll-u">Roll</span> <span data-i18n="weaponweapon-u">Weapon</span>
                     <span data-i18n="weaponskilltotal-u">Skill Total</span> <span data-i18n="weapondicemod-u">DM</span>
                     <span data-i18n="weapondamage-u">Damage</span> <span data-i18n="weapontechlevel-u">TL</span>
                     <span data-i18n="weaponrange-u">Range</span> <span data-i18n="weaponweight-u">KG</span>
                     <span data-i18n="weaponmagazine-u">Magazine</span>
                 </div>
-                <div class="sheet-laf-centredgrid sheet-laf-weaponlist">
-                    <button class="sheet-weaponroll" style="width:25px;" name="act_roll-weapon-1" type="action">
+                <div class="sheet-laf-centredgrid sheet-laf-weaponlist sheet-redborder">
+                    <button class="sheet-weaponroll" name="act_roll-weapon-1" type="action">
                         <div class="sheet-weaponrollbutton">b</div>
                     </button>
                     <input class="sheet-input sheet-redbold" type="text" name="attr_weapon_name-1"/>
-                    <input class="sheet-input" style="width:62px; margin-right: 3px;" type="number" name="attr_weapon_skill-1" value="0"/>
+                    <input class="sheet-input" type="number" name="attr_weapon_skill-1" value="0"/>
                     <select class="sheet-input" type="text" name="attr_weapon_DM-1" value="0" style="width:85px">
                         <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                         <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
@@ -1799,14 +1805,14 @@
                     <input class="sheet-input" type="text" name="attr_weapon_range-1" value="0"/>
                     <input class="sheet-input" type="number" name="attr_weapon_weight-1" value="0" step="0.05"/>
                     <input class="sheet-input" type="text" name="attr_weapon_magazine-1" value="0"/>
-                    <textarea style="height: 40px;" class="sheet-input sheet-laf-wauto" name="attr_weapon_note-1"></textarea>
+                    <textarea class="sheet-input sheet-laf-wauto" name="attr_weapon_note-1"></textarea>
                 </div>
-                <div class="sheet-laf-centredgrid sheet-laf-weaponlist">
-                    <button class="sheet-weaponroll" style="width:25px;" name="act_roll-weapon-2" type="action">
+                <div class="sheet-laf-centredgrid sheet-laf-weaponlist sheet-redborder">
+                    <button class="sheet-weaponroll" name="act_roll-weapon-2" type="action">
                         <div class="sheet-weaponrollbutton">b</div>
                     </button>
                     <input class="sheet-weaponweapon sheet-input sheet-redbold" type="text" name="attr_weapon_name-2"/>
-                    <input class="sheet-weaponskill sheet-input" style="width:62px; margin-right: 3px;" type="number" name="attr_weapon_skill-2" value="0"/>
+                    <input class="sheet-weaponskill sheet-input" type="number" name="attr_weapon_skill-2" value="0"/>
                     <select class="sheet-weapondm sheet-input" type="text" name="attr_weapon_DM-2" value="0" style="width:85px">
                         <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                         <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
@@ -1816,14 +1822,14 @@
                     <input class="sheet-weaponrange sheet-input" type="text" name="attr_weapon_range-2" value="0" style="width:70px"/>
                     <input class="sheet-weaponweight sheet-input" type="number" name="attr_weapon_weight-2" value="0" step="0.05"/>
                     <input class="sheet-weaponmag sheet-input" type="text" name="attr_weapon_magazine-2" value="0"/>
-                    <textarea style="height: 40px;" class="sheet-input sheet-laf-wauto" name="attr_weapon_note-2"></textarea>
+                    <textarea class="sheet-input sheet-laf-wauto" name="attr_weapon_note-2"></textarea>
                 </div>
-                <div class="sheet-laf-centredgrid sheet-laf-weaponlist">
-                    <button class="sheet-weaponroll" style="width:25px;" name="act_roll-weapon-3" type="action">
+                <div class="sheet-laf-centredgrid sheet-laf-weaponlist  sheet-redborder">
+                    <button class="sheet-weaponroll" name="act_roll-weapon-3" type="action">
                         <div class="sheet-weaponrollbutton">b</div>
                     </button>
                     <input class="sheet-weaponweapon sheet-input sheet-redbold" type="text" name="attr_weapon_name-3"/>
-                    <input class="sheet-weaponskill sheet-input" style="width:62px; margin-right: 3px;" type="number" name="attr_weapon_skill-3" value="0"/>
+                    <input class="sheet-weaponskill sheet-input" type="number" name="attr_weapon_skill-3" value="0"/>
                     <select class="sheet-weapondm sheet-input" type="text" name="attr_weapon_DM-3" value="0" style="width:85px">
                         <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                         <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
@@ -1833,14 +1839,14 @@
                     <input class="sheet-weaponrange sheet-input" type="text" name="attr_weapon_range-3" value="0" style="width:70px"/>
                     <input class="sheet-weaponweight sheet-input" type="number" name="attr_weapon_weight-3" value="0" step="0.05"/>
                     <input class="sheet-weaponmag sheet-input" type="text" name="attr_weapon_magazine-3" value="0"/>
-                    <textarea style="height: 40px;" class="sheet-input sheet-laf-wauto" name="attr_weapon_note-3"></textarea>
+                    <textarea class="sheet-input sheet-laf-wauto" name="attr_weapon_note-3"></textarea>
                 </div>
-                <div class="sheet-laf-centredgrid sheet-laf-weaponlist">
-                    <button class="sheet-weaponroll" style="width:25px;" name="act_roll-weapon-4" type="action">
+                <div class="sheet-laf-centredgrid sheet-laf-weaponlist sheet-redborder">
+                    <button class="sheet-weaponroll" name="act_roll-weapon-4" type="action">
                         <div class="sheet-weaponrollbutton">b</div>
                     </button>
                     <input class="sheet-weaponweapon sheet-input sheet-redbold" type="text" name="attr_weapon_name-4"/>
-                    <input class="sheet-weaponskill sheet-input" style="width:62px; margin-right: 3px;" type="number" name="attr_weapon_skill-4" value="0"/>
+                    <input class="sheet-weaponskill sheet-input" type="number" name="attr_weapon_skill-4" value="0"/>
                     <select class="sheet-weapondm sheet-input" type="text" name="attr_weapon_DM-4" value="0" style="width:85px">
                         <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                         <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
@@ -1850,14 +1856,14 @@
                     <input class="sheet-weaponrange sheet-input" type="text" name="attr_weapon_range-4" value="0" style="width:70px"/>
                     <input class="sheet-weaponweight sheet-input" type="number" name="attr_weapon_weight-4" value="0" step="0.05"/>
                     <input class="sheet-weaponmag sheet-input" type="text" name="attr_weapon_magazine-4" value="0"/>
-                    <textarea style="height: 40px;" class="sheet-input sheet-laf-wauto" name="attr_weapon_note-4"></textarea>
+                    <textarea class="sheet-input sheet-laf-wauto" name="attr_weapon_note-4"></textarea>
                 </div>
-                <div class="sheet-laf-centredgrid sheet-laf-weaponlist">
-                    <button class="sheet-weaponroll" style="width:25px;" name="act_roll-weapon-5" type="action">
+                <div class="sheet-laf-centredgrid sheet-laf-weaponlist sheet-redborder">
+                    <button class="sheet-weaponroll" name="act_roll-weapon-5" type="action">
                         <div class="sheet-weaponrollbutton">b</div>
                     </button>
                     <input class="sheet-weaponweapon sheet-input sheet-redbold" type="text" name="attr_weapon_name-5"/>
-                    <input class="sheet-weaponskill sheet-input" style="width:62px; margin-right: 3px;" type="number" name="attr_weapon_skill-5" value="0"/>
+                    <input class="sheet-weaponskill sheet-input" type="number" name="attr_weapon_skill-5" value="0"/>
                     <select class="sheet-weapondm sheet-input" type="text" name="attr_weapon_DM-5" value="0" style="width:85px">
                         <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                         <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
@@ -1867,14 +1873,14 @@
                     <input class="sheet-weaponrange sheet-input" type="text" name="attr_weapon_range-5" value="0" style="width:70px"/>
                     <input class="sheet-weaponweight sheet-input" type="number" name="attr_weapon_weight-5" value="0" step="0.05"/>
                     <input class="sheet-weaponmag sheet-input" type="text" name="attr_weapon_magazine-5" value="0"/>
-                    <textarea style="height: 40px;" class="sheet-input sheet-laf-wauto" name="attr_weapon_note-5"></textarea>
+                    <textarea class="sheet-input sheet-laf-wauto" name="attr_weapon_note-5"></textarea>
                 </div>
-                <div class="sheet-laf-centredgrid sheet-laf-weaponlist">
-                    <button class="sheet-weaponroll" style="width:25px;" name="act_roll-weapon-6" type="action">
+                <div class="sheet-laf-centredgrid sheet-laf-weaponlist sheet-redborder">
+                    <button class="sheet-weaponroll" name="act_roll-weapon-6" type="action">
                         <div class="sheet-weaponrollbutton">b</div>
                     </button>
                     <input class="sheet-weaponweapon sheet-input sheet-redbold" type="text" name="attr_weapon_name-6"/>
-                    <input class="sheet-weaponskill sheet-input" style="width:62px; margin-right: 3px;" type="number" name="attr_weapon_skill-6" value="0"/>
+                    <input class="sheet-weaponskill sheet-input" type="number" name="attr_weapon_skill-6" value="0"/>
                     <select class="sheet-weapondm sheet-input" type="text" name="attr_weapon_DM-6" value="0" style="width:85px">
                         <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                         <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
@@ -1884,15 +1890,15 @@
                     <input class="sheet-weaponrange sheet-input" type="text" name="attr_weapon_range-6" value="0" style="width:70px"/>
                     <input class="sheet-weaponweight sheet-input" type="number" name="attr_weapon_weight-6" value="0" step="0.05"/>
                     <input class="sheet-weaponmag sheet-input" type="text" name="attr_weapon_magazine-6" value="0"/>
-                    <textarea style="height: 40px;" class="sheet-input sheet-laf-wauto" name="attr_weapon_note-6"></textarea>
+                    <textarea class="sheet-input sheet-laf-wauto" name="attr_weapon_note-6"></textarea>
                 </div>
                 <fieldset class="repeating_weapons">
-                    <div class="sheet-laf-centredgrid sheet-laf-weaponlist">
-                        <button class="sheet-weaponroll" style="width:25px;" name="act_roll-weapon-rep" type="action">
+                    <div class="sheet-laf-centredgrid sheet-laf-weaponlist sheet-redborder">
+                        <button class="sheet-weaponroll" name="act_roll-weapon-rep" type="action">
                             <div class="sheet-weaponrollbutton">b</div>
                         </button>
                         <input class="sheet-weaponweapon sheet-input sheet-redbold" type="text" name="attr_weapon_name-rep"/>
-                        <input class="sheet-weaponskill sheet-input" style="width:62px; margin-right: 3px;" type="number" name="attr_weapon_skill-rep" value="0"/>
+                        <input class="sheet-weaponskill sheet-input" type="number" name="attr_weapon_skill-rep" value="0"/>
                         <select class="sheet-weapondm sheet-input" type="text" name="attr_weapon_DM-rep" value="0" style="width:85px">
                             <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                             <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity
@@ -1903,7 +1909,7 @@
                         <input class="sheet-weaponrange sheet-input" type="text" name="attr_weapon_range-rep" value="0" style="width:70px"/>
                         <input class="sheet-weaponweight sheet-input" type="number" name="attr_weapon_weight-rep" value="0" step="0.05"/>
                         <input class="sheet-weaponmag sheet-input" type="text" name="attr_weapon_magazine-rep" value="0"/>
-                        <textarea style="height: 40px;" class="sheet-input sheet-laf-wauto" name="attr_weapon_note-rep"></textarea>
+                        <textarea class="sheet-input sheet-laf-wauto" name="attr_weapon_note-rep"></textarea>
                     </div>
                 </fieldset>
             </div>
@@ -1914,7 +1920,6 @@
             <div class="sheet-laf-centredgrid sheet-laf-psistr">
                 <span></span> <span data-i18n="rating-u">Rating</span> <span data-i18n="temp-u">Temp</span>
                 <span data-i18n="mod-u">Mod</span>
-
                 <button class="sheet-button" name="roll_PsionicStrength" type="roll" value='@{whispertoggle}&{template:power} {{power=^{psionicstrength-u}}} {{character= @{character_name} }} @{ro_default_rolltype} + @{mod-PsionicStrength} @{ro_default_mod}]] }}'>
                     <div class="sheet-button_header" data-i18n="psionicstrength-u">Psionic Strength</div>
                 </button>
@@ -1924,61 +1929,253 @@
                 <input type="hidden" name="attr_calc-PsionicStrength" value="0"/>
             </div>
         </div>
-        <hr class="sheet-hr">
-
-        <div class="sheet-laf-centredgrid sheet-laf-power sheet-bold">
-            <span data-i18n="skilltableroll-u">Roll</span> <span data-i18n="skilltablename-u">Name</span>
+        <br>
+        <div class="sheet-laf-centredgrid sheet-laf-skillrow sheet-redborder sheet-bold">
+            <span data-i18n="skilltabletalent-u">Talent</span>
             <span data-i18n="skilltablecharacteristic-u">Characteristic</span>
+            <span data-i18n="skilltabledicemodifier-u">DM</span>
             <span data-i18n="skilltableskilllevel-u">Skill Level</span>
-
-            <button type="roll" class="sheet-button" name="roll_skill-power" value='@{whispertoggle}&{template:power} {{power= @{skillSpeciality-power} }} {{character= @{character_name} }} @{ro_default_rolltype} + @{skillCharacteristicDM-power} + @{skilllevel-power} @{ro_default_mod}]] }} {{note= @{skillnote-power} }} '>
-                <div class="sheet-weaponrollbutton">b</div>
-            </button>
-            <input type="text" class="sheet-input sheet-redbold" name="attr_skillSpeciality-power"/>
-            <select type="text" class="sheet-input" name="attr_skillCharacteristicDM-power" value="0">
-                <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
-                <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
-                <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
-                <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
-                <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
-                <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
-                <option value="@{mod-PsionicStrength}" selected data-i18n="psionicstrength-u">Psionic Strength
-                </option>
-            </select> <input type="number" class="sheet-input" name="attr_skilllevel-power" value="0"/>
-            <textarea style="height:40px;" name="attr_skillnote-power" placeholder="Power Notes"></textarea>
+            <span data-i18n="skilltablemiscmodifier-u">Misc. Mod.</span>
+            <span data-i18n="skilltabletrained-u">Trained</span>
+            <span data-i18n="skilltabletotalmodifier-u">Total</span>
+            <span data-i18n="skilltablespecialty-u">Speciality</span>
         </div>
-
-        <fieldset class="repeating_powers">
+        <div class="sheet-redborder sheet-laf-centredgrid sheet-laf-skillrow">
+            <button name="roll_Telepathy" type="roll" value='@{whispertoggle}&{template:skill-general} {{skill=^{telepathy-u}}} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-Telepathy}]] @{ro_default_mod}]] }} '>
+                <div class="sheet-button_header" data-i18n="telepathy-u">Telepathy</div>
+            </button>
+            <select type="text" class="sheet-input sheet-laf-wauto" name="attr_skillCharacteristicDM-Telepathy" value="0">
+                <option value="@{mod-PsionicStrength}" data-i18n="psionicstrength-u">Psionic Strength</option>
+            </select>
+            <input type="number" class="sheet-input" name="attr_skillDM-Telepathy" value="@{skillCharacteristicDM-Telepathy}" disabled/>
+            <input type="number" class="sheet-input" name="attr_skilllevel-Telepathy" value="0"/>
+            <input type="number" class="sheet-input" name="attr_skillmodifier-Telepathy" value="0"/>
+            <input type="checkbox" class="sheet-untrained sheet-laf-centre-checkbox sheet-grid-c6r1" checked name="attr_untrained-Telepathy" value="-3"/><span class="sheet-laf-centre-checkbox sheet-grid-c6r1"></span>
+            <input type="number" class="sheet-input" name="attr_skilltotal-Telepathy" value="@{skillDM-Telepathy} + @{skilllevel-Telepathy} + @{skillmodifier-Telepathy} + @{untrained-Telepathy}" disabled/>
+            <input type="checkbox" name="attr_Telepathy_spec_show" class="sheet-power sheet-hider sheet-laf-centre-checkbox sheet-grid-c8r1" value="1"/><span class=" sheet-hider sheet-laf-centre-checkbox sheet-grid-c8r1"></span>
+            <div class="sheet-gridspan19">
+                <input type="checkbox" name="attr_Telepathy_spec_show" class="sheet-power sheet-hidden" value="1"/>
+                <div class="sheet-laf-gridbody">
+                    <div class="sheet-laf-centredgrid sheet-laf-5colrow13111 sheet-bold">
+                        <span data-i18n="skilltableroll-u">Roll</span>
+                        <span data-i18n="skilltablepower-u">Power</span>
+                        <span data-i18n="skilltablelevel-u">Level</span>
+                        <span data-i18n="skilltabletotalmodifier-u">Total</span>
+                        <span>PSI Cost</span>
+                    </div>
+                    <fieldset class="repeating_telepathyspec">
+                        <div class="sheet-laf-centredgrid sheet-laf-5colrow13111">
+                            <button name="roll_Telepathyspec" type="roll" value='@{whispertoggle}&{template:skill-general} {{skill=^{telepathy-u}}} {{spec= @{skillSpeciality-Telepathyspec} }} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-Telepathyspec}]] @{ro_default_mod}]] }} '>
+                                <div class="sheet-button_header_rep">b</div>
+                            </button>
+                            <input type="text" class="sheet-input" name="attr_skillSpeciality-Telepathyspec" placeholder="Specialty Name"/>
+                            <input type="number" class="sheet-input" name="attr_skilllevel-Telepathyspec" value="0"/>
+                            <input type="number" class="sheet-input" name="attr_skilltotal-Telepathyspec" value="@{skillCharacteristicDM-Telepathy} + @{skilllevel-Telepathyspec} + @{skilllevel-Telepathy} + @{skillmodifier-Telepathy}" disabled/>
+                            <input type="number" class="sheet-input" name="attr_skillpsicost-Telepathyspec" value="0"/>
+                        </div>
+                    </fieldset>
+                </div>
+            </div>
+        </div>
+        <div class="sheet-redborder sheet-laf-centredgrid sheet-laf-skillrow">
+            <button name="roll_Clairvoyance" type="roll" value='@{whispertoggle}&{template:skill-general} {{skill=^{clairvoyance-u}}} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-Clairvoyance}]] @{ro_default_mod}]] }} '>
+                <div class="sheet-button_header" data-i18n="clairvoyance-u">Clairvoyance</div>
+            </button>
+            <select type="text" class="sheet-input sheet-laf-wauto" name="attr_skillCharacteristicDM-Clairvoyance" value="0">
+                <option value="@{mod-PsionicStrength}" data-i18n="psionicstrength-u">Psionic Strength</option>
+            </select>
+            <input type="number" class="sheet-input" name="attr_skillDM-Clairvoyance" value="@{skillCharacteristicDM-Clairvoyance}" disabled/>
+            <input type="number" class="sheet-input" name="attr_skilllevel-Clairvoyance" value="0"/>
+            <input type="number" class="sheet-input" name="attr_skillmodifier-Clairvoyance" value="0"/>
+            <input type="checkbox" class="sheet-untrained sheet-laf-centre-checkbox sheet-grid-c6r1" checked name="attr_untrained-Clairvoyance" value="-3"/><span class="sheet-laf-centre-checkbox sheet-grid-c6r1"></span>
+            <input type="number" class="sheet-input" name="attr_skilltotal-Clairvoyance" value="@{skillDM-Clairvoyance} + @{skilllevel-Clairvoyance} + @{skillmodifier-Clairvoyance} + @{untrained-Clairvoyance}" disabled/>
+            <input type="checkbox" name="attr_Clairvoyance_spec_show" class="sheet-power sheet-hider sheet-laf-centre-checkbox sheet-grid-c8r1" value="1"/><span class=" sheet-hider sheet-laf-centre-checkbox sheet-grid-c8r1"></span>
+            <div class="sheet-gridspan19">
+                <input type="checkbox" name="attr_Clairvoyance_spec_show" class="sheet-power sheet-hidden" value="1"/>
+                <div class="sheet-laf-gridbody">
+                    <div class="sheet-laf-centredgrid sheet-laf-5colrow13111 sheet-bold">
+                        <span data-i18n="skilltableroll-u">Roll</span>
+                        <span data-i18n="skilltablespecialty-u">Speciality</span>
+                        <span data-i18n="skilltablelevel-u">Level</span>
+                        <span data-i18n="skilltabletotalmodifier-u">Total</span>
+                        <span>PSI Cost</span>
+                    </div>
+                    <fieldset class="repeating_clairvoyancespec">
+                        <div class="sheet-laf-centredgrid sheet-laf-5colrow13111">
+                            <button name="roll_Clairvoyancespec" type="roll" value='@{whispertoggle}&{template:skill-general} {{skill=^{clairvoyance-u}}} {{spec= @{skillSpeciality-Clairvoyancespec} }} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-Clairvoyancespec}]] @{ro_default_mod}]] }} '>
+                                <div class="sheet-button_header_rep">b</div>
+                            </button>
+                            <input type="text" class="sheet-input" name="attr_skillSpeciality-Clairvoyancespec" placeholder="Specialty Name"/>
+                            <input type="number" class="sheet-input" name="attr_skilllevel-Clairvoyancespec" value="0"/>
+                            <input type="number" class="sheet-input" name="attr_skilltotal-Clairvoyancespec" value="@{skillCharacteristicDM-Clairvoyance} + @{skilllevel-Clairvoyancespec} + @{skilllevel-Clairvoyance} + @{skillmodifier-Clairvoyance}" disabled/>
+                            <input type="number" class="sheet-input" name="attr_skillpsicost-Clairvoyancespec" value="0"/>
+                        </div>
+                    </fieldset>
+                </div>
+            </div>
+        </div>
+        <div class="sheet-redborder sheet-laf-centredgrid sheet-laf-skillrow">
+            <button name="roll_Telekinesis" type="roll" value='@{whispertoggle}&{template:skill-general} {{skill=^{telekinesis-u}}} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-Telekinesis}]] @{ro_default_mod}]] }} '>
+                <div class="sheet-button_header" data-i18n="telekinesis-u">Telekinesis</div>
+            </button>
+            <select type="text" class="sheet-input sheet-laf-wauto" name="attr_skillCharacteristicDM-Telekinesis" value="0">
+                <option value="@{mod-PsionicStrength}" data-i18n="psionicstrength-u">Psionic Strength</option>
+            </select>
+            <input type="number" class="sheet-input" name="attr_skillDM-Telekinesis" value="@{skillCharacteristicDM-Telekinesis}" disabled/>
+            <input type="number" class="sheet-input" name="attr_skilllevel-Telekinesis" value="0"/>
+            <input type="number" class="sheet-input" name="attr_skillmodifier-Telekinesis" value="0"/>
+            <input type="checkbox" class="sheet-untrained sheet-laf-centre-checkbox sheet-grid-c6r1" checked name="attr_untrained-Telekinesis" value="-3"/><span class="sheet-laf-centre-checkbox sheet-grid-c6r1"></span>
+            <input type="number" class="sheet-input" name="attr_skilltotal-Telekinesis" value="@{skillDM-Telekinesis} + @{skilllevel-Telekinesis} + @{skillmodifier-Telekinesis} + @{untrained-Telekinesis}" disabled/>
+            <input type="checkbox" name="attr_Telekinesis_spec_show" class="sheet-power sheet-hider sheet-laf-centre-checkbox sheet-grid-c8r1" value="1"/><span class=" sheet-hider sheet-laf-centre-checkbox sheet-grid-c8r1"></span>
+            <div class="sheet-gridspan19">
+                <input type="checkbox" name="attr_Telekinesis_spec_show" class="sheet-power sheet-hidden" value="1"/>
+                <div class="sheet-laf-gridbody">
+                    <div class="sheet-laf-centredgrid sheet-laf-5colrow13111 sheet-bold">
+                        <span data-i18n="skilltableroll-u">Roll</span>
+                        <span data-i18n="skilltablespecialty-u">Speciality</span>
+                        <span data-i18n="skilltablelevel-u">Level</span>
+                        <span data-i18n="skilltabletotalmodifier-u">Total</span>
+                        <span>PSI Cost</span>
+                    </div>
+                    <fieldset class="repeating_telekinesisspec">
+                        <div class="sheet-laf-centredgrid sheet-laf-5colrow13111">
+                            <button name="roll_Telekinesisspec" type="roll" value='@{whispertoggle}&{template:skill-general} {{skill=^{telekinesis-u}}} {{spec= @{skillSpeciality-Telekinesisspec} }} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-Telekinesisspec}]] @{ro_default_mod}]] }} '>
+                                <div class="sheet-button_header_rep">b</div>
+                            </button>
+                            <input type="text" class="sheet-input" name="attr_skillSpeciality-Telekinesisspec" placeholder="Specialty Name"/>
+                            <input type="number" class="sheet-input" name="attr_skilllevel-Telekinesisspec" value="0"/>
+                            <input type="number" class="sheet-input" name="attr_skilltotal-Telekinesisspec" value="@{skillCharacteristicDM-Telekinesis} + @{skilllevel-Telekinesisspec} + @{skilllevel-Telekinesis} + @{skillmodifier-Telekinesis}" disabled/>
+                            <input type="number" class="sheet-input" name="attr_skillpsicost-Telekinesisspec" value="0"/>
+                        </div>
+                    </fieldset>
+                </div>
+            </div>
+        </div>
+        <div class="sheet-redborder sheet-laf-centredgrid sheet-laf-skillrow">
+            <button name="roll_Awareness" type="roll" value='@{whispertoggle}&{template:skill-general} {{skill=^{awareness-u}}} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-Awareness}]] @{ro_default_mod}]] }} '>
+                <div class="sheet-button_header" data-i18n="awareness-u">Awareness</div>
+            </button>
+            <select type="text" class="sheet-input sheet-laf-wauto" name="attr_skillCharacteristicDM-Awareness" value="0">
+                <option value="@{mod-PsionicStrength}" data-i18n="psionicstrength-u">Psionic Strength</option>
+            </select>
+            <input type="number" class="sheet-input" name="attr_skillDM-Awareness" value="@{skillCharacteristicDM-Awareness}" disabled/>
+            <input type="number" class="sheet-input" name="attr_skilllevel-Awareness" value="0"/>
+            <input type="number" class="sheet-input" name="attr_skillmodifier-Awareness" value="0"/>
+            <input type="checkbox" class="sheet-untrained sheet-laf-centre-checkbox sheet-grid-c6r1" checked name="attr_untrained-Awareness" value="-3"/><span class="sheet-laf-centre-checkbox sheet-grid-c6r1"></span>
+            <input type="number" class="sheet-input" name="attr_skilltotal-Awareness" value="@{skillDM-Awareness} + @{skilllevel-Awareness} + @{skillmodifier-Awareness} + @{untrained-Awareness}" disabled/>
+            <input type="checkbox" name="attr_Awareness_spec_show" class="sheet-power sheet-hider sheet-laf-centre-checkbox sheet-grid-c8r1" value="1"/><span class=" sheet-hider sheet-laf-centre-checkbox sheet-grid-c8r1"></span>
+            <div class="sheet-gridspan19">
+                <input type="checkbox" name="attr_Awareness_spec_show" class="sheet-power sheet-hidden" value="1"/>
+                <div class="sheet-laf-gridbody">
+                    <div class="sheet-laf-centredgrid sheet-laf-5colrow13111 sheet-bold">
+                        <span data-i18n="skilltableroll-u">Roll</span>
+                        <span data-i18n="skilltablespecialty-u">Speciality</span>
+                        <span data-i18n="skilltablelevel-u">Level</span>
+                        <span data-i18n="skilltabletotalmodifier-u">Total</span>
+                        <span>PSI Cost</span>
+                    </div>
+                    <fieldset class="repeating_awarenessspec">
+                        <div class="sheet-laf-centredgrid sheet-laf-5colrow13111">
+                            <button name="roll_Awarenessspec" type="roll" value='@{whispertoggle}&{template:skill-general} {{skill=^{awareness-u}}} {{spec= @{skillSpeciality-Awarenessspec} }} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-Awarenessspec}]] @{ro_default_mod}]] }} '>
+                                <div class="sheet-button_header_rep">b</div>
+                            </button>
+                            <input type="text" class="sheet-input" name="attr_skillSpeciality-Awarenessspec" placeholder="Specialty Name"/>
+                            <input type="number" class="sheet-input" name="attr_skilllevel-Awarenessspec" value="0"/>
+                            <input type="number" class="sheet-input" name="attr_skilltotal-Awarenessspec" value="@{skillCharacteristicDM-Awareness} + @{skilllevel-Awarenessspec} + @{skilllevel-Awareness} + @{skillmodifier-Awareness}" disabled/>
+                            <input type="number" class="sheet-input" name="attr_skillpsicost-Awarenessspec" value="0"/>
+                        </div>
+                    </fieldset>
+                </div>
+            </div>
+        </div>
+        <div class="sheet-redborder sheet-laf-centredgrid sheet-laf-skillrow">
+            <button name="roll_Teleportation" type="roll" value='@{whispertoggle}&{template:skill-general} {{skill=^{teleportation-u}}} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-Teleportation}]] @{ro_default_mod}]] }} '>
+                <div class="sheet-button_header" data-i18n="teleportation-u">Teleportation</div>
+            </button>
+            <select type="text" class="sheet-input sheet-laf-wauto" name="attr_skillCharacteristicDM-Teleportation" value="0">
+                <option value="@{mod-PsionicStrength}" data-i18n="psionicstrength-u">Psionic Strength</option>
+            </select>
+            <input type="number" class="sheet-input" name="attr_skillDM-Teleportation" value="@{skillCharacteristicDM-Teleportation}" disabled/>
+            <input type="number" class="sheet-input" name="attr_skilllevel-Teleportation" value="0"/>
+            <input type="number" class="sheet-input" name="attr_skillmodifier-Teleportation" value="0"/>
+            <input type="checkbox" class="sheet-untrained sheet-laf-centre-checkbox sheet-grid-c6r1" checked name="attr_untrained-Teleportation" value="-3"/><span class="sheet-laf-centre-checkbox sheet-grid-c6r1"></span>
+            <input type="number" class="sheet-input" name="attr_skilltotal-Teleportation" value="@{skillDM-Teleportation} + @{skilllevel-Teleportation} + @{skillmodifier-Teleportation} + @{untrained-Teleportation}" disabled/>
+            <input type="checkbox" name="attr_Teleportation_spec_show" class="sheet-power sheet-hider sheet-laf-centre-checkbox sheet-grid-c8r1" value="1"/><span class=" sheet-hider sheet-laf-centre-checkbox sheet-grid-c8r1"></span>
+            <div class="sheet-gridspan19">
+                <input type="checkbox" name="attr_Teleportation_spec_show" class="sheet-power sheet-hidden" value="1"/>
+                <div class="sheet-laf-gridbody">
+                    <div class="sheet-laf-centredgrid sheet-laf-5colrow13111 sheet-bold">
+                        <span data-i18n="skilltableroll-u">Roll</span>
+                        <span data-i18n="skilltablespecialty-u">Speciality</span>
+                        <span data-i18n="skilltablelevel-u">Level</span>
+                        <span data-i18n="skilltabletotalmodifier-u">Total</span>
+                        <span>PSI Cost</span>
+                    </div>
+                    <fieldset class="repeating_teleportationspec">
+                        <div class="sheet-laf-centredgrid sheet-laf-5colrow13111">
+                            <button name="roll_Teleportationspec" type="roll" value='@{whispertoggle}&{template:skill-general} {{skill=^{teleportation-u}}} {{spec= @{skillSpeciality-Teleportationspec} }} {{character= @{character_name} }} @{ro_default_rolltype} + [[@{skilltotal-Teleportationspec}]] @{ro_default_mod}]] }} '>
+                                <div class="sheet-button_header_rep">b</div>
+                            </button>
+                            <input type="text" class="sheet-input" name="attr_skillSpeciality-Teleportationspec" placeholder="Specialty Name"/>
+                            <input type="number" class="sheet-input" name="attr_skilllevel-Teleportationspec" value="0"/>
+                            <input type="number" class="sheet-input" name="attr_skilltotal-Teleportationspec" value="@{skillCharacteristicDM-Teleportation} + @{skilllevel-Teleportationspec} + @{skilllevel-Teleportation} + @{skillmodifier-Teleportation}" disabled/>
+                            <input type="number" class="sheet-input" name="attr_skillpsicost-Teleportationspec" value="0"/>
+                        </div>
+                    </fieldset>
+                </div>
+            </div>
+        </div>
+        <br>
+        <hr class="sheet-hr">
+        <span class="sheet-bold">Legacy Psionics</span><input type="checkbox" name="attr_legacypsi_spec_show" class="sheet-power sheet-hider sheet-laf-centre-checkbox sheet-grid-c8r1" value="1"><span></span>
+        <div class="sheet-body">
             <div class="sheet-laf-centredgrid sheet-laf-power sheet-bold">
-                <button type="roll" class="sheet-button" name="roll_skill-reppower" value='@{whispertoggle}&{template:power} {{power= @{skillSpeciality-reppower} }} {{character= @{character_name} }} @{ro_default_rolltype} + @{skillCharacteristicDM-reppower} + @{skilllevel-reppower} @{ro_default_mod}]] }} {{note= @{skillnote-reppower} }}'>
+                <span data-i18n="skilltableroll-u">Roll</span> <span data-i18n="skilltablename-u">Talent</span>
+                <span data-i18n="skilltablecharacteristic-u">Characteristic</span>
+                <span data-i18n="skilltableskilllevel-u">Skill Level</span>
+                <button type="roll" class="sheet-button" name="roll_skill-power" value='@{whispertoggle}&{template:power} {{power= @{skillSpeciality-power} }} {{character= @{character_name} }} @{ro_default_rolltype} + @{skillCharacteristicDM-power} + @{skilllevel-power} @{ro_default_mod}]] }} {{note= @{skillnote-power} }} '>
                     <div class="sheet-weaponrollbutton">b</div>
                 </button>
-                <input type="text" class="sheet-input sheet-redbold" name="attr_skillSpeciality-reppower"/>
-                <select type="text" class="sheet-input" name="attr_skillCharacteristicDM-reppower" value="0">
-                    <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
-                    <option value="@{mod-Intellect}" data-i18n="skillintellectoption-u">Intellect</option>
-                    <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
-                    <option value="@{mod-Education}" data-i18n="skilleducationoption-u">Education</option>
-                    <option value="@{mod-Endurance}" data-i18n="skillenduranceoption-u">Endurance</option>
-                    <option value="@{mod-Social}" data-i18n="skillsocialoption-u">Social</option>
-                    <option value="@{mod-PsionicStrength}" selected data-i18n="psionicstrength-u">Psionic Strength
-                    </option>
-                </select> <input type="number" class="sheet-input" name="attr_skilllevel-reppower" value="0"/>
-                <textarea style="height:40px;" name="attr_skillnote-reppower" placeholder="Power Notes"></textarea>
+                <select style="width:100%" type="text" class="sheet-input sheet-redbold" name="attr_skillSpeciality-talent">
+                    <option>Telepathy</option>
+                    <option>Clairvoyance</option>
+                    <option>Telekinesis</option>
+                    <option>Awareness</option>
+                    <option>Teleportation</option>
+                </select>
+                <input type="text" class="sheet-input sheet-redbold" name="attr_skillSpeciality-power"/>
+                <input type="number" class="sheet-input" name="attr_skilllevel-power" value="0"/>
+                <textarea name="attr_skillnote-power" placeholder="Power Notes"></textarea>
             </div>
-        </fieldset>
+            <fieldset class="repeating_powers">
+                <div class="sheet-laf-centredgrid sheet-laf-power sheet-bold">
+                    <button type="roll" class="sheet-button" name="roll_skill-reppower" value='@{whispertoggle}&{template:power} {{power= @{skillSpeciality-reppower} }} {{character= @{character_name} }} @{ro_default_rolltype} + @{mod-PsionicStrength} + @{skilllevel-reppower} @{ro_default_mod}]] }} {{note= @{skillnote-reppower} }}'>
+                        <div class="sheet-weaponrollbutton">b</div>
+                    </button>
+                    <select style="width:100%" type="text" class="sheet-input sheet-redbold" name="attr_skillSpeciality-talent">
+                        <option>Telepathy</option>
+                        <option>Clairvoyance</option>
+                        <option>Telekinesis</option>
+                        <option>Awareness</option>
+                        <option>Teleportation</option>
+                    </select>
+                    <input type="text" class="sheet-input sheet-redbold" name="attr_skillSpeciality-reppower"/>
+                    <input type="number" class="sheet-input" name="attr_skilllevel-reppower" value="0"/>
+                    <textarea name="attr_skillnote-reppower" placeholder="Power Notes"></textarea>
+                </div>
+            </fieldset>
+        </div>
     </div>
     <!--    Notes   -->
     <div class="sheet-tab-content sheet-notes sheet-pc">
-        <textarea name="attr_notes" style="width: 98%;height:500px;"></textarea>
+        <textarea name="attr_notes" class="sheet-notes-textarea"></textarea>
     </div>
 </div>
 <div class="sheet-tab-content sheet-npc">
     <div class="sheet-redborder">
-
         <h4 data-i18n="npcskills-u">NPC Skills</h4><br>
-        <div style="display: flex; width: 140px;">
-            <span class="sheet-header sheet-bordered-width" data-i18n="movement-u">Movement</span>:&nbsp;
+        <div class="sheet-npc-movement">
+            <span class="sheet-header sheet-bordered-width">Movement:&nbsp;</span>
             <input type="number" class="sheet-input" name="attr_character_movement">
             <span class="sheet-header sheet-bordered-width">m</span>
         </div>
@@ -2026,37 +2223,50 @@
         </button>
     </div>
     <br>
-    <div class="sheet-redborder" style="margin-top: 2px;">
+    <div class="sheet-redborder">
         <h3 data-i18n="shiparmour-u">Armour</h3>
-        <div class="sheet-armourlist">
-            <div class="sheet-armouritem">
-                <div class="sheet-th sheet-armourtype" data-i18n="armourtype-u">Type</div>
-                <div class="sheet-th sheet-armourtl" data-i18n="armourtechlevel-u">TL</div>
-                <div class="sheet-th sheet-armourprotection" data-i18n="armourprotection-u">Protection</div>
-                <div class="sheet-th sheet-armourlaser" data-i18n="armourprotectionlaser-u">Protection (Laser)</div>
-                <div class="sheet-th sheet-armourrad" data-i18n="armourrads-u">Rad</div>
-                <div class="sheet-th sheet-armourweight" data-i18n="armourkgweight-u">KG</div>
-                <div class="sheet-th sheet-armourskill" data-i18n="armourskill-u">Required Skill</div>
-            </div>
-        </div>
-        <div class="sheet-armourlist">
-            <input type="text" style="width: 162px;" class="sheet-input" name="attr_armour-type"/>
-            <input type="number" style="width: 65px;" class="sheet-input" name="attr_armour-tl"/>
-            <input type="number" style="width: 93px;" class="sheet-input" name="attr_armour-protection"/>
-            <input type="number" style="width: 164px;" class="sheet-input" name="attr_armour-protection-laser"/>
-            <input type="number" style="width: 67px;" class="sheet-input" name="attr_armour-rads"/>
-            <input type="number" style="width: 67px;" class="sheet-input" name="attr_armour-mass"/>
-            <select type="text" class="sheet-input" name="attr_armour-RequiredSkill" value="0">
+        <div class="sheet-laf-centredgrid sheet-laf-armourlist sheet-bold sheet-redborder">
+            <span data-i18n="armourtype-u">Type</span> <span data-i18n="armourtechlevel-u">TL</span>
+            <span data-i18n="armourprotection-u">Protection</span>
+            <span data-i18n="armourprotectionlaser-u">Protection (Laser)</span>
+            <span data-i18n="armourrads-u">Rad</span> <span data-i18n="armourkgweight-u">KG</span>
+            <span data-i18n="armourskill-u">Required Skill</span>
+            <input type="text" class="sheet-input sheet-redbold" name="attr_armour-type"/>
+            <input type="number" name="attr_armour-tl"/> <input type="number" name="attr_armour-protection"/>
+            <input type="number" name="attr_armour-protection-laser"/>
+            <input type="number" name="attr_armour-rads"/>
+            <input type="number" name="attr_armour-mass" step="0.05"/>
+            <select type="text" name="attr_armour-RequiredSkill" value="0">
                 <option value="0" data-i18n="armournoneskill-u">None</option>
                 <option value="1" data-i18n="armourvaccsuit0-u">Vacc Suit 0</option>
                 <option value="2" data-i18n="armourvaccsuit1-u">Vacc Suit 1</option>
                 <option value="3" data-i18n="armourvaccsuit2-u">Vacc Suit 2</option>
                 <option value="4" data-i18n="armourvaccsuit3-u">Vacc Suit 3</option>
                 <option value="5" data-i18n="armourvaccsuit4-u">Vacc Suit 4</option>
-            </select> <textarea style="width:99%; height:40px;" class="sheet-input" name="attr_armornotes"></textarea>
+            </select>
+            <textarea class="sheet-input sheet-gridspan18 sheet-laf-wauto" name="attr_armornotes"></textarea>
         </div>
+        <fieldset class="repeating_armour">
+            <div class="sheet-laf-centredgrid sheet-laf-armourlist sheet-redborder">
+                <input type="text" class="sheet-input sheet-redbold" name="attr_reparmour-type"/>
+                <input type="number" class="sheet-input" name="attr_reparmour-tl"/>
+                <input type="number" class="sheet-input" name="attr_reparmour-protection"/>
+                <input type="number" class="sheet-input" name="attr_reparmour-protection-laser"/>
+                <input type="number" class="sheet-input" name="attr_reparmour-rads"/>
+                <input type="number" class="sheet-input" name="attr_reparmour-mass" step="0.05"/>
+                <select type="text" class="sheet-input" name="attr_reparmour-RequiredSkill" value="0">
+                    <option value="0" data-i18n="armournoneskill-u">None</option>
+                    <option value="1" data-i18n="armourvaccsuit0-u">Vacc Suit 0</option>
+                    <option value="2" data-i18n="armourvaccsuit1-u">Vacc Suit 1</option>
+                    <option value="3" data-i18n="armourvaccsuit2-u">Vacc Suit 2</option>
+                    <option value="4" data-i18n="armourvaccsuit3-u">Vacc Suit 3</option>
+                    <option value="5" data-i18n="armourvaccsuit4-u">Vacc Suit 4</option>
+                </select>
+                <textarea class="sheet-input sheet-gridspan18 sheet-laf-wauto" name="attr_reparmornotes"></textarea>
+            </div>
+        </fieldset>
     </div>
-    <div class="sheet-redborder" style="margin-top: 2px;">
+    <div class="sheet-redborder">
         <h3 data-i18n="shipweapons-u">Weapons</h3>
         <div class="sheet-weaponlist">
             <div class="sheet-laf-centredgrid sheet-laf-weaponlist">
@@ -2071,11 +2281,11 @@
                 <span data-i18n="weaponmagazine-u">Magazine</span>
             </div>
             <div class="sheet-laf-centredgrid sheet-laf-weaponlist">
-                <button class="sheet-weaponroll" style="width:25px;" name="act_roll-weapon-1" type="action">
+                <button class="sheet-weaponroll" name="act_roll-weapon-1" type="action">
                     <div class="sheet-weaponrollbutton">b</div>
                 </button>
                 <input class="sheet-input sheet-redbold" type="text" name="attr_weapon_name-1"/>
-                <input class="sheet-input" style="width:62px; margin-right: 3px;" type="number" name="attr_weapon_skill-1" value="0"/>
+                <input class="sheet-input" type="number" name="attr_weapon_skill-1" value="0"/>
                 <select class="sheet-input" type="text" name="attr_weapon_DM-1" value="0" style="width:85px">
                     <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                     <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity</option>
@@ -2084,15 +2294,15 @@
                 <input class="sheet-input" type="text" name="attr_weapon_range-1" value="0""/>
                 <input class="sheet-input" type="number" name="attr_weapon_weight-1" value="0" step="0.05"/>
                 <input class="sheet-input" type="text" name="attr_weapon_magazine-1" value="0"/>
-                <textarea style="height: 40px;" class="sheet-input sheet-laf-wauto" name="attr_weapon_note-1"></textarea>
+                <textarea class="sheet-input sheet-laf-wauto" name="attr_weapon_note-1"></textarea>
             </div>
             <fieldset class="repeating_weapons">
                 <div class="sheet-laf-centredgrid sheet-laf-weaponlist">
-                    <button class="sheet-weaponroll" style="width:25px;" name="act_roll-weapon-rep" type="action">
+                    <button class="sheet-weaponroll" name="act_roll-weapon-rep" type="action">
                         <div class="sheet-weaponrollbutton">b</div>
                     </button>
                     <input class="sheet-weaponweapon sheet-input sheet-redbold" type="text" name="attr_weapon_name-rep"/>
-                    <input class="sheet-weaponskill sheet-input" style="width:62px; margin-right: 3px;" type="number" name="attr_weapon_skill-rep" value="0"/>
+                    <input class="sheet-weaponskill sheet-input" type="number" name="attr_weapon_skill-rep" value="0"/>
                     <select class="sheet-weapondm sheet-input" type="text" name="attr_weapon_DM-rep" value="0" style="width:85px">
                         <option value="@{mod-Strength}" data-i18n="skillstrengthoption-u">Strength</option>
                         <option value="@{mod-Dexterity}" data-i18n="skilldexterityoption-u">Dexterity
@@ -2103,7 +2313,7 @@
                     <input class="sheet-weaponrange sheet-input" type="text" name="attr_weapon_range-rep" value="0" style="width:70px"/>
                     <input class="sheet-weaponweight sheet-input" type="number" name="attr_weapon_weight-rep" value="0" step="0.05"/>
                     <input class="sheet-weaponmag sheet-input" type="text" name="attr_weapon_magazine-rep" value="0"/>
-                    <textarea style="height: 40px;" class="sheet-input sheet-laf-wauto" name="attr_weapon_note-rep"></textarea>
+                    <textarea class="sheet-input sheet-laf-wauto" name="attr_weapon_note-rep"></textarea>
                 </div>
             </fieldset>
         </div>
@@ -2163,8 +2373,15 @@
             </div>
         </fieldset>
     </div>
+    <br>
+    <div class="sheet-redborder sheet-laf-centredgrid sheet-laf-animal-init" style="width">
+        <span style="margin-top: 5px;" class="sheet-bold">Mod:&nbsp;</span>
+        <input type="number" class="sheet-input" name="attr_animal_initmod" value="0">
+        <button style="margin-right: 3px;" class="sheet-laf-initbutton btn ui-draggable sheet-wide-button" type="roll" name="roll_initiative" value="@{whispertoggle} &{template:skill-general} {{skill=^{initiative-u}}} {{character= @{character_name} }} @{ro_default_rolltype}+@{animal_initmod}+@{initiative_effect} @{ro_default_mod} &{tracker}]]}}">
+            <div class="sheet-button_header">Roll Initiative (Select Token)</div>
+        </button>
+    </div>
 </div>
-
 <div class="sheet-tab-content sheet-ship">
     <br>
     <div class="sheet-laf-centredgrid sheet-laf-ship">
@@ -2213,8 +2430,8 @@
         <input type="checkbox" name="attr_shipcrit_more_show" class="sheet-hider sheet-hidden sheet-grid-c6r2" value="1"/>
         <div class="sheet-body sheet-laf-ship-component-rep2">
             <fieldset class="repeating_shipcrit">
-                <div style="margin-top: 3px;" class="sheet-laf-centredgrid sheet-laf-ship-hulldamage">
-                    <span style="margin-top: 3px;" class="sheet-header sheet-shipcomponent">Critical Damage</span>
+                <div class="sheet-laf-centredgrid sheet-laf-ship-hulldamage">
+                    <span class="sheet-header sheet-shipcomponent">Critical Damage</span>
                     <span class="sheet-header sheet-textright" data-i18n="hulllocations-u"></span>
                     <select class="sheet-input" name="attr_ship_loc-rep" value="0">
                         <option selected></option>
@@ -2240,8 +2457,30 @@
         </div>
     </div>
     <br>
+    <div class="sheet-redborder">
+        <h4>Sensors</h4>
+        <div class="sheet-laf-centredgrid sheet-laf-vehicle-sensors sheet-bold">
+            <span style="width: 210px !important;">Type</span>
+            <span>Sensor Mod</span>
+            <span>Player Mod</span>
+            <span>Roll</span>
+            <span></span>
+            <!--        </div>-->
+            <!--        <fieldset class="repeating_shipsensor">-->
+            <!--            <div class="sheet-laf-centredgrid sheet-laf-vehicle-sensors">-->
+            <input class="sheet-redbold" type="text" name="attr_ship_sensor_type">
+            <input class="" type="number" value="0" name="attr_ship_sensor_playermod">
+            <input class="" type="number" value="0" name="attr_ship_sensor_sensormod">
+            <button type="roll" class="sheet-button btn ui-draggable" name="roll_vehicle-sensor" value="@{whispertoggle}&{template:skill-attrib} {{skill=Sensor: @{ship_sensor_type}}} {{character= @{character_name} }} @{ro_default_rolltype} + @{ship_sensor_playermod} + @{ship_sensor_sensormod} @{ro_default_mod}]] }}  }}">
+                <div class="sheet-weaponrollbutton">b</div>
+            </button>
+        </div>
+        <!--        </fieldset>-->
+    </div>
+    <br>
     <div class="sheet-redborder sheet-laf-centredgrid">
-        <h4>Firmpoints/Hardpoints [<span name="attr_ship_numhardpoints"></span>]</h4>
+        <h4>Hardpoints/Firmpoints [<span name="attr_ship_numhardpoints"></span>]</h4>
+        <input type="hidden" name="attr_ship_numhardpoints" value="0">
         <p>Add a hardpoint then add the weapons below for that hardpoint. Destructive weapons should have their damage in the form e.g.: 2DD</p>
         <span class="sheet-redbold-noborder" name="attr_hardpoint_error"></span>
         <fieldset class="repeating_shiphardpoint">
@@ -2304,16 +2543,6 @@
         </div>
         <fieldset class="repeating_shipweapon">
             <div class="sheet-laf-centredgrid sheet-laf-ship-hardpoint">
-                <!--                <span>Hardpoint Name</span>-->
-                <!--                <span>Type</span>-->
-                <!--                <span>TL</span>-->
-                <!--                <span>Power</span>-->
-                <!--                <span>Range</span>-->
-                <!--                <span>Cost (MCr)</span>-->
-                <!--                <span>Damage</span>-->
-                <!--                <span>Traits</span>-->
-                <!--                <span>#</span>-->
-                <!--                <span></span>-->
                 <input class="sheet-laf-ship-traitstext sheet-redbold" type="text" min="0" name="attr_w_hardpoint_name">
                 <input class="sheet-redbold" type="text" name="attr_w_type">
                 <input class="sheet-laf-wnum" type="number" min="0" name="attr_w_tl">
@@ -2323,7 +2552,7 @@
                 <input class="sheet-laf-wnum" type="text" name="attr_w_damage">
                 <input class="sheet-laf-ship-traitstext" type="text" name="attr_w_traits">
                 <input class="sheet-laf-wnum" type="number" min="0" name="attr_w_num">
-                <button class="sheet-weaponroll" style="width:25px;" name="act_ship-weapon" type="action">
+                <button class="sheet-weaponroll" name="act_ship-weapon" type="action">
                     <div class="sheet-weaponrollbutton">b</div>
                 </button>
                 <input class="sheet-hidden" type="text" name="attr_w_hardpoint_id">
@@ -2370,10 +2599,10 @@
             </div>
             <div class="sheet-laf-centredgrid sheet-laf-ship-components sheet-bold">
                 <span type="text" data-i18n="shippower-u">Power Plant</span>
-                <div>
-                    <input style="width: 45% !important;" type="text" name="attr_shippower_detail"/>
+                <div class="sheet-power-detail">
+                    <input type="text" name="attr_shippower_detail"/>
                     <span>&nbsp;Power:</span>
-                    <input style="width: 31% !important;" type="text" value="0" min="0" name="attr_shippower_rating"/>
+                    <input type="text" value="0" min="0" name="attr_shippower_rating"/>
                 </div>
                 <input type="text" name="attr_shippower_tons" value="0" min="0"/>
                 <input type="text" name="attr_shippower_cost" value="0" min="0"/>
@@ -2600,7 +2829,7 @@
 
         <div class="sheet-redborder sheet-laf-ship-crew-p">
             <h4>Crew</h4>
-            <textarea style="height: 80px;" class="sheet-laf-borderbox" name="attr_crew"></textarea>
+            <textarea class="sheet-laf-borderbox" name="attr_crew"></textarea>
         </div>
         <div class="sheet-redborder sheet-laf-ship-runningcosts-p">
             <h4>Running Costs</h4>
@@ -2611,6 +2840,7 @@
         </div>
         <div class="sheet-redborder sheet-laf-ship-power-p">
             <h4>Power [<span name="attr_ship_totalpower"></span>/<span name="attr_shippower_rating"></span>]</h4>
+            <input type="hidden" name="attr_ship_totalpower" value="0">
             <h5>Manoeuvre Drive</h5>
             <input class="sheet-input" type="number" name="attr_power_manu" value="0" min="0">
             <h5>Jump Drive</h5>
@@ -2637,7 +2867,7 @@
     </div>
 </div>
 <div class="sheet-tab-content sheet-vehicle">
-    <h3 style="margin-right: 5px;" class="sheet-header">Vehicle Name</h3>
+    <h3 class="sheet-header">Vehicle Name</h3>
     <div>
         <input type="text" class="sheet-input sheet-laf-vehicle-textarea sheet-redbold" name="attr_vehicle_name">
     </div>
@@ -2677,8 +2907,8 @@
         <span>Cost</span>
         <input type="text" name="attr_vehicle_cost">
     </div>
-    <hr class="sheet-hr">
-    <div class="sheet-redborder sheet-laf-centredgrid sheet sheet-laf-vehicle-data sheet-bold">
+    <br>
+    <div class="sheet-redborder sheet-laf-centredgrid sheet-laf-vehicle-data sheet-bold">
         <span>Autopilot (skill level)</span>
         <div class="sheet-trade_content">
             <input type="number" name="attr_vehicle_autopilot" value="0">
@@ -2717,57 +2947,103 @@
             </button>
         </div>
     </div>
-    <hr class="sheet-hr">
     <br>
-    <h4>Weapons</h4>
     <div class="sheet-redborder">
-        <span><strong>Note:</strong> For Destructive weapons enter the damage as e.g. 3DD.</span>
-        <hr class="sheet-hr">
-        <div class="sheet-laf-centredgrid sheet-laf-vehicle-weaponsrow sheet-bold sheet-laf-wauto">
-            <span>Weapon</span>
-            <span>Range</span>
-            <span>Damage</span>
-            <span>Magazine</span>
-            <span>Mag. Cost</span>
-            <span>Traits</span>
-            <span>Fire Control</span>
-            <span>Mod.</span>
+        <h4>Sensors</h4>
+        <div class="sheet-laf-centredgrid sheet-laf-vehicle-sensors sheet-bold">
+            <span style="width: 210px !important;">Type</span>
+            <span>Sensor Mod</span>
+            <span>Player Mod</span>
+            <span>Roll</span>
             <span></span>
+            <input class="sheet-redbold" type="text" name="attr_vehicle_sensor_type">
+            <input class="" type="number" value="0" name="attr_vehicle_sensor_playermod">
+            <input class="" type="number" value="0" name="attr_vehicle_sensor_sensormod">
+            <button type="roll" class="sheet-button btn ui-draggable" name="roll_vehicle-sensor" value="@{whispertoggle}&{template:skill-attrib} {{skill=Sensor: @{vehicle_sensor_type}}} {{character= @{character_name} }} @{ro_default_rolltype} + @{vehicle_sensor_playermod} + @{vehicle_sensor_sensormod} @{ro_default_mod}]] }}  }}">
+                <div class="sheet-weaponrollbutton">b</div>
+            </button>
         </div>
-        <div>
-            <fieldset class="repeating_vehicle-weapons">
-                <div class="sheet-laf-centredgrid sheet-laf-vehicle-weaponsrow sheet-bold sheet-laf-wauto">
-                    <input class="sheet-redbold" type="text" name="attr_weapon">
-                    <input type="text" name="attr_range">
-                    <input type="text" name="attr_damage">
-                    <input type="text" name="attr_magazine">
-                    <input type="text" name="attr_magcost">
-                    <input type="text" name="attr_traits">
-                    <input type="text" name="attr_firecontrol">
-                    <input type="number" name="attr_mod" value="0">
-                    <button class="sheet-weaponroll" name="act_vehicle-weapon" type="action">
-                        <span class="sheet-weaponrollbutton">b</span>
-                    </button>
+    </div>
+    <br>
+    <div class="sheet-redborder">
+        <div class="sheet-redborder sheet-laf-centredgrid">
+            <h4>Mounts</h4>
+            <p>Add a mount then add the weapons below for that mount. Destructive weapons should have their damage in the form e.g.: 2DD</p>
+            <span class="sheet-redbold-noborder" name="attr_vehiclemount_error"></span>
+            <fieldset class="repeating_vehiclemount">
+                <div class="sheet-laf-ship-hardpoint">
+                    <div class="sheet-redborder sheet-boldspan">
+                        <span>Name: </span>
+                        <input class="sheet-laf-ship-traitstext sheet-redbold" type="text" name="attr_mount_name">
+                        <span>Type: </span>
+                        <input type="text" name="attr_hp_type">
+                        <span>Gunner Skill:</span>
+                        <input class="sheet-laf-wnum" type="number" name="attr_gunner" value="0">
+                        <span>DEX Mod.</span>
+                        <input class="sheet-laf-wnum" type="number" name="attr_dexmod" value="0">
+                        <span>Custom Mod.</span>
+                        <input class="sheet-laf-wnum" type="number" name="attr_custommod" value="0">
+                        <input class="sheet-hidden" type="text" name="attr_mount_id">
+
+                    </div>
                 </div>
             </fieldset>
+        </div>
+        <br>
+        <h4>Weapons</h4>
+        <div class="sheet-redborder">
+            <span><strong>Note:</strong> For Destructive weapons enter the damage as e.g. 3DD.</span>
+            <br>
+            <span class="sheet-redbold-noborder" name="attr_vehicleweapon_error"></span>
+            <hr class="sheet-hr">
+            <div class="sheet-laf-centredgrid sheet-laf-vehicle-weaponsrow sheet-bold sheet-laf-wauto">
+                <span>Mount</span>
+                <span>Weapon</span>
+                <span>Range</span>
+                <span>Damage</span>
+                <span>Magazine</span>
+                <span>Mag. Cost</span>
+                <span>Traits</span>
+                <span>Fire Control</span>
+                <!--            <span>Mod.</span>-->
+                <span></span>
+            </div>
+            <div>
+                <fieldset class="repeating_vehicleweapons">
+                    <div class="sheet-laf-centredgrid sheet-laf-vehicle-weaponsrow sheet-bold sheet-laf-wauto">
+                        <input class="sheet-redbold" type="text" name="attr_mount_name">
+                        <input class="sheet-redbold" type="text" name="attr_weapon">
+                        <input type="text" name="attr_range">
+                        <input type="text" name="attr_damage">
+                        <input type="text" name="attr_magazine">
+                        <input type="text" name="attr_magcost">
+                        <input type="text" name="attr_traits">
+                        <input type="text" name="attr_firecontrol">
+                        <!--                    <input type="number" name="attr_mod" value="0">-->
+                        <button class="sheet-weaponroll" name="act_vehicle-weapon" type="action">
+                            <span class="sheet-weaponrollbutton">b</span>
+                        </button>
+                    </div>
+                </fieldset>
+            </div>
         </div>
     </div>
     <br>
     <hr class="sheet-hr">
     <h4>Traits</h4>
-    <textarea class="sheet-laf-vehicle-textarea" style="height: 30px;" name="attr_vehicle_traits"></textarea>
+    <textarea style="height: 40px;" class="sheet-laf-vehicle-textarea" name="attr_vehicle_traits"></textarea>
     <br>
     <hr class="sheet-hr">
     <h4>Equipment</h4>
-    <textarea class="sheet-laf-vehicle-textarea" style="height: 30px;" name="attr_vehicle_equipment"></textarea>
+    <textarea style="height: 60px;" class="sheet-laf-vehicle-textarea" name="attr_vehicle_equipment"></textarea>
     <br>
     <hr class="sheet-hr">
     <h4>Description</h4>
-    <textarea class="sheet-laf-vehicle-textarea" style="height: 30px;" name="attr_vehicle_description"></textarea>
+    <textarea style="height: 60px;" class="sheet-laf-vehicle-textarea" name="attr_vehicle_description"></textarea>
     <br>
     <hr class="sheet-hr">
     <h4>Notes</h4>
-    <textarea class="sheet-laf-vehicle-textarea" style="height: 50px;" name="attr_vehicle_weapons"></textarea>
+    <textarea style="height: 75px;" class="sheet-laf-vehicle-textarea" name="attr_vehicle_weapons"></textarea>
 </div>
 <div class="sheet-tab-content sheet-trade">
     <!-- Sub-tabs-->
@@ -2787,18 +3063,18 @@
     <span class="sheet-bold">(It is recommended using the Purchase and Sale UWPs as these will auto-fill attributes across all Trade types)</span>
     <br>
     <span class="sheet-bold sheet-textright">Purchase UWP: </span>
-    <input type="text" name="attr_trade_purchase_uwp" placeholder="CA6A643-9 N Ri Wa" style="height: 20px;margin-bottom: 3px;" class="sheet-redbold">
+    <input type="text" name="attr_trade_purchase_uwp" placeholder="CA6A643-9 N Ri Wa" class="sheet-redbold sheet-uwptext">
     <button type="action" name="act_trade-purchase-uwp" class="sheet-type sheet-type-speculative sheet-manifest-button sheet-uwpbutton">Apply
     </button>
-    <span class="sheet-bold sheet-textright" style="margin-left: 25px;">Sale UWP: </span>
-    <input type="text" name="attr_trade_sale_uwp" placeholder="CA6A643-9 N Ri Wa" style="height: 20px;margin-bottom: 3px;" class="sheet-redbold">
+    <span class="sheet-bold sheet-textright-margin">Sale UWP: </span>
+    <input type="text" name="attr_trade_sale_uwp" placeholder="CA6A643-9 N Ri Wa" class="sheet-redbold sheet-uwptext">
     <button type="action" name="act_trade-sale-uwp" class="sheet-type sheet-type-speculative sheet-manifest-button sheet-uwpbutton">Apply
     </button>
     <div class="sheet-speculative-subpanel sheet-hazard-border">
         <div class="sheet-groupfunds">
-            <h2 class="sheet-bold sheet-mod" style="width: 30%;">&nbsp;Cargo Manifest</h2>
-            <h3 style="text-align: right;width: 80%;">Group Funds: Cr</h3>
-            <input name="attr_group_funds" type="number" value="0" style="width: 15%;">
+            <h2 class="sheet-bold sheet-mod">&nbsp;Cargo Manifest</h2>
+            <h3>Group Funds: Cr</h3>
+            <input name="attr_group_funds" type="number" value="0">
             <input name="attr_speculative_sg_tons_total" type="number" value="0" class="sheet-hidden">
             <input name="attr_speculative_fg_tons_total" type="number" value="0" class="sheet-hidden">
             <input name="attr_speculative_og_tons_total" type="number" value="0" class="sheet-hidden">
@@ -2896,7 +3172,8 @@
             <span>Broker, Carouse or Streetwise Check Effect</span>
             <input type="number" class="sheet-input sheet-bold" name="attr_passengers_effect_broker" value="0">
         </div>
-        <div class="sheet-redborder" style="margin-top: 10px;">
+        <br>
+        <div class="sheet-redborder">
             <span>Highest Steward Skill on Ship</span>
             <input type="number" class="sheet-input sheet-bold" name="attr_passengers_mod_steward" value="0">
         </div>
@@ -2979,7 +3256,8 @@
                     </tr>
                     <tr>
                         <td>
-                            <input type="radio" name="attr_passengers_src_population" value="na" checked> <span>Other</span>
+                            <input type="radio" name="attr_passengers_src_population" value="na" checked>
+                            <span>Other</span>
                         </td>
                     </tr>
                 </table>
@@ -3136,16 +3414,15 @@
         </div>
         <br>
         <div class="sheet-redborder">
-            <div class="sheet-redborder" style="margin-top: 10px;">
+            <div class="sheet-redborder">
                 <span>Custom modifier:</span>
                 <input type="number" class="sheet-input sheet-bold" name="attr_passengers_mod_custom" value="0">
             </div>
             <div>
-                <button type="action" style="width: 100%; margin-top: 5px;" class="sheet-button sheet-roll_boon" name="act_passengers-calculate">
-                    <span class="sheet-button_header" style="font-size: 1em;">Calculate Passengers</span>
+                <button type="action" class="sheet-button sheet-roll_boon sheet-wide-button" name="act_passengers-calculate">
+                    <span class="sheet-button_header">Calculate Passengers</span>
                 </button>
                 <input name="attr_passenger_info" type="text" class="sheet-hidden" value="" disabled>
-                <!--                <textarea style="width: 99%; height: 90px;" name="attr_passenger_info" readonly></textarea>-->
                 <br> <br>
                 <div class="sheet-freight-info-row">
                     <h5>Type</h5>
@@ -3173,10 +3450,11 @@
                 </div>
                 <div class="sheet-freight-info-row">
                     <span>Low Passage</span> <input name="attr_passengers_low_num_take" type="number" value="0" min="0">
-                    <span name="attr_passengers_low_num_available"></span> <span name="attr_passengers_low_cost"></span>
+                    <span name="attr_passengers_low_num_available"></span>
+                    <span name="attr_passengers_low_cost"></span>
                 </div>
-                <button type="action" style="width: 100%; margin-top: 5px;" class="sheet-button sheet-roll_boon" name="act_passengers-take">
-                    <span class="sheet-button_header" style="font-size: 1em;">Take Passengers</span></button>
+                <button type="action" class="sheet-button sheet-roll_boon sheet-wide-button" name="act_passengers-take">
+                    <span class="sheet-button_header sheet-med">Take Passengers</span></button>
             </div>
         </div>
     </div>
@@ -3186,11 +3464,11 @@
         <div class="sheet-redborder">
             <span>Broker or Streetwise Check Effect</span>
             <input type="number" class="sheet-input sheet-bold" name="attr_freight_effect_broker" value="0">
-            <span style="color: maroon;">Highest Naval or Scout DM</span>
+            <span class="sheet-mail-attrs">Highest Naval or Scout DM</span>
             <input type="number" class="sheet-input sheet-bold" name="attr_freight_navalscout" value="0">
-            <span style="color: maroon;">Highest Society DM</span>
+            <span class="sheet-mail-attrs">Highest Society DM</span>
             <input type="number" class="sheet-input sheet-bold" name="attr_freight_society" value="0">
-            <span style="color: maroon;">Ship Armed?</span>
+            <span class="sheet-mail-attrs">Ship Armed?</span>
             <input type="checkbox" name="attr_freight_shiparmed" value="on" class="sheet-button">
         </div>
         <br>
@@ -3213,7 +3491,7 @@
                     </td>
                     <td>
                         <input type="radio" name="attr_freight_cargotype" value="Mail">
-                        <span style="color: maroon;">Mail</span>
+                        <span class="sheet-mail-attrs">Mail</span>
                     </td>
                 </tr>
             </table>
@@ -3320,7 +3598,7 @@
                     <tr>
                         <td>
                             <input type="radio" name="attr_freight_src_techlevel" value="tl5">
-                            <span style="color: maroon;">&lt;=5</span>
+                            <span class="sheet-mail-attrs">&lt;=5</span>
                         </td>
                     </tr>
                     <tr>
@@ -3435,7 +3713,7 @@
                     <tr>
                         <td>
                             <input type="radio" name="attr_freight_dest_techlevel" value="tl5">
-                            <span style="color: maroon;">&lt;=5</span>
+                            <span class="sheet-mail-attrs">&lt;=5</span>
                         </td>
                     </tr>
                     <tr>
@@ -3455,7 +3733,7 @@
                         </td>
                     </tr>
                 </table>
-                <table class="sheet-redborder sheet-trade-block" style="margin-right: 0px;">
+                <table class="sheet-redborder sheet-trade-block">
                     <tr>
                         <td class="sheet-bold">Zone</td>
                     </tr>
@@ -3480,13 +3758,13 @@
         </div>
         <br>
         <div class="sheet-redborder">
-            <div class="sheet-redborder" style="margin-top: 10px;">
+            <div class="sheet-redborder">
                 <span>Custom modifier:</span>
                 <input type="number" class="sheet-input sheet-bold" name="attr_freight_mod_custom" value="0">
             </div>
             <div>
-                <button type="action" style="width: 100%; margin-top: 5px;" class="sheet-button sheet-roll_boon" name="act_freight-calculate">
-                    <span class="sheet-button_header" style="font-size: 1em;">Calculate Freight</span>
+                <button type="action" class="sheet-button sheet-roll_boon sheet-wide-button" name="act_freight-calculate">
+                    <span class="sheet-button_header">Calculate Freight</span>
                 </button>
                 <input name="attr_freight_modifier" type="number" class="sheet-hidden" value="0">
                 <input name="attr_freight_info" type="text" class="sheet-hidden" value=""> <br> <br>
@@ -3529,15 +3807,14 @@
                     <span name="attr_freight_mail_price_per_ton"></span>
                     <span name="attr_freight_mail_price_per_lot"></span>
                 </div>
-                <button type="action" style="width: 100%; margin-top: 5px; margin-bottom: 3px;" class="sheet-button sheet-roll_boon" name="act_freight-take">
-                    <span class="sheet-button_header" style="font-size: 1em;">Take Freight</span>
+                <button type="action" class="sheet-button sheet-roll_boon sheet-wide-button" name="act_freight-take">
+                    <span class="sheet-button_header">Take Freight</span>
                 </button>
                 <span class="sheet-bold">Freight Late?</span>
                 <input type="checkbox" name="attr_freight_late" value="on" class="sheet-button">
-                <button type="action" style="width: 100%; margin-top: 5px;" class="sheet-button sheet-roll_boon" name="act_freight-deliver">
-                    <span class="sheet-button_header" style="font-size: 1em;">Deliver Freight</span>
+                <button type="action" class="sheet-button sheet-roll_boon sheet-wide-button" name="act_freight-deliver">
+                    <span class="sheet-button_header">Deliver Freight</span>
                 </button>
-                <!--                    <textarea style="height: 90px; width:99%; resize: vertical;" name="attr_freight_info" readonly></textarea>-->
             </div>
         </div>
     </div>
@@ -3566,46 +3843,46 @@
                     <input type="radio" name="attr_speculative_purchase_starport_dm" value="0" checked>
                 </div>
                 <input type="text" name="attr_speculative_purchase_blackmarket" class="sheet-hidden">
-                <div class="sheet-redborder" style="margin-top: 3px;">
+                <div class="sheet-redborder">
                     <input type="text" name="attr_speculative_purchase_broker_type" class="sheet-hidden" value="">
                     <p>
                         <input type="text" name="attr_speculative_purchase_broker_type_normal" class="sheet-hidden" value="">
                         <span class="sheet-speculativemarker" name="attr_speculative_purchase_broker_type_normal"></span>Finding a Regular Supplier or Broker: Broker EDU or SOC DM:
                         <input type="number" class="sheet-input sheet-bold" name="attr_speculative_purchase_broker_dm" value="0">
-                        <button type="action" style="width: 5%;" class="sheet-speculativebutton" name="act_speculative-purchase-broker-find">b
+                        <button type="action" class="sheet-speculativebutton" name="act_speculative-purchase-broker-find">b
                         </button>
                     </p>
                     <p>
                         <input type="text" name="attr_speculative_purchase_broker_type_illegal" class="sheet-hidden" value="">
                         <span class="sheet-speculativemarker" name="attr_speculative_purchase_broker_type_illegal"></span>Finding a Black Market Supplier or Broker of Illegal Goods: Streetwise EDU or SOC DM:
                         <input type="number" class="sheet-input sheet-bold" name="attr_speculative_purchase_illegalbroker_dm" value="0">
-                        <button type="action" style="width: 5%;" class="sheet-speculativebutton" name="act_speculative-purchase-illegalbroker-find">b
+                        <button type="action" class="sheet-speculativebutton" name="act_speculative-purchase-illegalbroker-find">b
                         </button>
                     </p>
                     <p>
                         <input type="text" name="attr_speculative_purchase_broker_type_online" class="sheet-hidden" value="">
                         <span class="sheet-speculativemarker" name="attr_speculative_purchase_broker_type_online">&nbsp;</span>Finding an Online Supplier or Broker (TL8+ worlds only): EDU DM:
                         <input type="number" class="sheet-input sheet-bold" name="attr_speculative_purchase_onlinebroker_dm" value="0">
-                        <button type="action" style="width: 5%;" class="sheet-speculativebutton" name="act_speculative-purchase-onlinebroker-find">b
+                        <button type="action" class="sheet-speculativebutton" name="act_speculative-purchase-onlinebroker-find">b
                         </button>
                     </p>
                 </div>
-                <div class="sheet-redborder" style="margin-top: 3px; height: 25px;">
+                <div class="sheet-redborder sheet-trade-broker-section">
                     <p>
                         <input type="radio" name="attr_speculative_purchase_localbroker_flag" value="false" checked>Traveller's Broker skill:
                         <input type="number" class="sheet-input sheet-bold" name="attr_speculative_purchase_broker_skill" value="0">
                     </p>
                 </div>
-                <div class="sheet-redborder" style="margin-top: 3px; height: 25px;">
+                <div class="sheet-redborder sheet-trade-broker-section">
                     <p>
                         <input type="radio" name="attr_speculative_purchase_localbroker_flag" value="true">Local Broker (Takes 10% of gross (20% on illegal)). Click for their broker skill.
-                        <button type="action" style="width: 5%;" class="sheet-speculativebutton" name="act_speculative-purchase-localbroker-skill">b
+                        <button type="action" class="sheet-speculativebutton" name="act_speculative-purchase-localbroker-skill">b
                         </button>
                         <input type="number" class="sheet-input sheet-bold" name="attr_speculative_purchase_localbroker_skill" value="0"> Negotiation skill:
                         <input type="number" class="sheet-input sheet-bold" name="attr_speculative_purchase_localbroker_negskill" value="2">
                     </p>
                 </div>
-                <div class="sheet-redborder" style="margin-top: 3px; height: 25px;">
+                <div class="sheet-redborder sheet-trade-broker-section">
                     <p>Supplier's Broker Skill:
                         <input type="number" class="sheet-input sheet-bold" name="attr_speculative_purchase_supplier_skill" value="2">
                     </p>
@@ -3636,62 +3913,80 @@
                         <table>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_purchase_tc_agricultural" value="1" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Agricultural</span>
+                                    <input type="checkbox" name="attr_purchase_tc_agricultural" value="1" class="sheet-button"/>
+                                    <span class="sheet-button" class="sheet-mail-attrs">Agricultural</span>
                                 </td>
                                 <td>
-                                    <input type="checkbox" name="attr_purchase_tc_asteroid" value="2" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Asteroid</span>
+                                    <input type="checkbox" name="attr_purchase_tc_asteroid" value="2" class="sheet-button"/>
+                                    <span class="sheet-button" class="sheet-mail-attrs">Asteroid</span>
                                 </td>
                                 <td>
-                                    <input type="checkbox" name="attr_purchase_tc_barren" value="3" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Barren</span>
+                                    <input type="checkbox" name="attr_purchase_tc_barren" value="3" class="sheet-button"/>
+                                    <span class="sheet-button" class="sheet-mail-attrs">Barren</span>
                                 </td>
                                 <td>
-                                    <input type="checkbox" name="attr_purchase_tc_desert" value="4" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Desert</span>
+                                    <input type="checkbox" name="attr_purchase_tc_desert" value="4" class="sheet-button"/>
+                                    <span class="sheet-button" class="sheet-mail-attrs">Desert</span>
                                 </td>
                                 <td>
-                                    <input type="checkbox" name="attr_purchase_tc_fluid_oceans" value="5" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Fluid Oceans</span>
+                                    <input type="checkbox" name="attr_purchase_tc_fluid_oceans" value="5" class="sheet-button"/>
+                                    <span class="sheet-button" class="sheet-mail-attrs">Fluid Oceans</span>
                                 </td>
                                 <td>
-                                    <input type="checkbox" name="attr_purchase_tc_garden" value="6" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Garden</span>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <input type="checkbox" name="attr_purchase_tc_high_population" value="7" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">High Population</span>
-                                </td>
-                                <td>
-                                    <input type="checkbox" name="attr_purchase_tc_high_tech" value="8" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">High Tech</span>
-                                </td>
-                                <td>
-                                    <input type="checkbox" name="attr_purchase_tc_ice_capped" value="9" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Ice-Capped</span>
-                                </td>
-                                <td>
-                                    <input type="checkbox" name="attr_purchase_tc_industrial" value="10" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Industrial</span>
-                                </td>
-                                <td>
-                                    <input type="checkbox" name="attr_purchase_tc_low_population" value="11" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Low Population</span>
-                                </td>
-                                <td>
-                                    <input type="checkbox" name="attr_purchase_tc_low_tech" value="12" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Low Tech</span>
+                                    <input type="checkbox" name="attr_purchase_tc_garden" value="6" class="sheet-button"/>
+                                    <span class="sheet-button" class="sheet-mail-attrs">Garden</span>
                                 </td>
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="attr_purchase_tc_non_agricultural" value="13" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Non-Agricultural</span>
+                                    <input type="checkbox" name="attr_purchase_tc_high_population" value="7" class="sheet-button"/>
+                                    <span class="sheet-button" class="sheet-mail-attrs">High Population</span>
                                 </td>
                                 <td>
-                                    <input type="checkbox" name="attr_purchase_tc_non_industrial" value="14" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Non-Industrial</span>
+                                    <input type="checkbox" name="attr_purchase_tc_high_tech" value="8" class="sheet-button"/>
+                                    <span class="sheet-button" class="sheet-mail-attrs">High Tech</span>
                                 </td>
                                 <td>
-                                    <input type="checkbox" name="attr_purchase_tc_poor" value="15" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Poor</span>
+                                    <input type="checkbox" name="attr_purchase_tc_ice_capped" value="9" class="sheet-button"/>
+                                    <span class="sheet-button" class="sheet-mail-attrs">Ice-Capped</span>
                                 </td>
                                 <td>
-                                    <input type="checkbox" name="attr_purchase_tc_rich" value="16" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Rich</span>
+                                    <input type="checkbox" name="attr_purchase_tc_industrial" value="10" class="sheet-button"/>
+                                    <span class="sheet-button" class="sheet-mail-attrs">Industrial</span>
                                 </td>
                                 <td>
-                                    <input type="checkbox" name="attr_purchase_tc_vacuum" value="17" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Vacuum</span>
+                                    <input type="checkbox" name="attr_purchase_tc_low_population" value="11" class="sheet-button"/>
+                                    <span class="sheet-button" class="sheet-mail-attrs">Low Population</span>
                                 </td>
                                 <td>
-                                    <input type="checkbox" name="attr_purchase_tc_waterworld" value="18" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Water World</span>
+                                    <input type="checkbox" name="attr_purchase_tc_low_tech" value="12" class="sheet-button"/>
+                                    <span class="sheet-button" class="sheet-mail-attrs">Low Tech</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <input type="checkbox" name="attr_purchase_tc_non_agricultural" value="13" class="sheet-button"/>
+                                    <span class="sheet-button" class="sheet-mail-attrs">Non-Agricultural</span>
+                                </td>
+                                <td>
+                                    <input type="checkbox" name="attr_purchase_tc_non_industrial" value="14" class="sheet-button"/>
+                                    <span class="sheet-button" class="sheet-mail-attrs">Non-Industrial</span>
+                                </td>
+                                <td>
+                                    <input type="checkbox" name="attr_purchase_tc_poor" value="15" class="sheet-button"/>
+                                    <span class="sheet-button" class="sheet-mail-attrs">Poor</span>
+                                </td>
+                                <td>
+                                    <input type="checkbox" name="attr_purchase_tc_rich" value="16" class="sheet-button"/>
+                                    <span class="sheet-button" class="sheet-mail-attrs">Rich</span>
+                                </td>
+                                <td>
+                                    <input type="checkbox" name="attr_purchase_tc_vacuum" value="17" class="sheet-button"/>
+                                    <span class="sheet-button" class="sheet-mail-attrs">Vacuum</span>
+                                </td>
+                                <td>
+                                    <input type="checkbox" name="attr_purchase_tc_waterworld" value="18" class="sheet-button"/>
+                                    <span class="sheet-button" class="sheet-mail-attrs">Water World</span>
                                 </td>
                             </tr>
                         </table>
@@ -3774,46 +4069,46 @@
                     <input type="radio" name="attr_speculative_sale_starport_dm" value="0" checked>
                 </div>
                 <input type="text" name="attr_speculative_sale_blackmarket" class="sheet-hidden">
-                <div class="sheet-redborder" style="margin-top: 3px;">
+                <div class="sheet-redborder">
                     <input type="text" name="attr_speculative_sale_broker_type" class="sheet-hidden" value="">
                     <p>
                         <input type="text" name="attr_speculative_sale_broker_type_normal" class="sheet-hidden" value="">
                         <span class="sheet-speculativemarker" name="attr_speculative_sale_broker_type_normal"></span>Finding a Regular Buyer or Broker: Broker EDU or SOC DM:
                         <input type="number" class="sheet-input sheet-bold" name="attr_speculative_sale_broker_dm" value="0">
-                        <button type="action" style="width: 5%;" class="sheet-speculativebutton" name="act_speculative-sale-broker-find">b
+                        <button type="action" class="sheet-speculativebutton" name="act_speculative-sale-broker-find">b
                         </button>
                     </p>
                     <p>
                         <input type="text" name="attr_speculative_sale_broker_type_illegal" class="sheet-hidden" value="">
                         <span class="sheet-speculativemarker" name="attr_speculative_sale_broker_type_illegal"></span>Finding a Black Market Buyer or Broker of Illegal Goods: Streetwise EDU or SOC DM:
                         <input type="number" class="sheet-input sheet-bold" name="attr_speculative_sale_illegalbroker_dm" value="0">
-                        <button type="action" style="width: 5%;" class="sheet-speculativebutton" name="act_speculative-sale-illegalbroker-find">b
+                        <button type="action" class="sheet-speculativebutton" name="act_speculative-sale-illegalbroker-find">b
                         </button>
                     </p>
                     <p>
                         <input type="text" name="attr_speculative_sale_broker_type_online" class="sheet-hidden" value="">
                         <span class="sheet-speculativemarker" name="attr_speculative_sale_broker_type_online">&nbsp;</span>Finding an Online Buyer or Broker (TL8+ worlds only): EDU DM:
                         <input type="number" class="sheet-input sheet-bold" name="attr_speculative_sale_onlinebroker_dm" value="0">
-                        <button type="action" style="width: 5%;" class="sheet-speculativebutton" name="act_speculative-sale-onlinebroker-find">b
+                        <button type="action" class="sheet-speculativebutton" name="act_speculative-sale-onlinebroker-find">b
                         </button>
                     </p>
                 </div>
-                <div class="sheet-redborder" style="margin-top: 3px; height: 25px;">
+                <div class="sheet-redborder sheet-trade-broker-section">
                     <p>
                         <input type="radio" name="attr_speculative_sale_localbroker_flag" value="false" checked>Traveller's Broker skill:
                         <input type="number" class="sheet-input sheet-bold" name="attr_speculative_sale_broker_skill" value="0">
                     </p>
                 </div>
-                <div class="sheet-redborder" style="margin-top: 3px; height: 25px;">
+                <div class="sheet-redborder sheet-trade-broker-section">
                     <p>
                         <input type="radio" name="attr_speculative_sale_localbroker_flag" value="true">Local Broker (Takes 10% of gross (20% on illegal)). Click for their broker skill.
-                        <button type="action" style="width: 5%;" class="sheet-speculativebutton" name="act_speculative-sale-localbroker-skill">b
+                        <button type="action" class="sheet-speculativebutton" name="act_speculative-sale-localbroker-skill">b
                         </button>
                         <input type="number" class="sheet-input sheet-bold" name="attr_speculative_sale_localbroker_skill" value="0"> Negotiation skill:
                         <input type="number" class="sheet-input sheet-bold" name="attr_speculative_sale_localbroker_negskill" value="2">
                     </p>
                 </div>
-                <div class="sheet-redborder" style="margin-top: 3px; height: 25px;">
+                <div class="sheet-redborder sheet-trade-broker-section">
                     <p>Buyer's Broker Skill:
                         <input type="number" class="sheet-input sheet-bold" name="attr_speculative_sale_supplier_skill" value="2">
                     </p>
@@ -3831,62 +4126,62 @@
                     <table>
                         <tr>
                             <td>
-                                <input type="checkbox" name="attr_sale_tc_agricultural" value="1" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Agricultural</span>
+                                <input type="checkbox" name="attr_sale_tc_agricultural" value="1" class="sheet-button"/><span class="sheet-button" class="sheet-mail-attrs">Agricultural</span>
                             </td>
                             <td>
-                                <input type="checkbox" name="attr_sale_tc_asteroid" value="2" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Asteroid</span>
+                                <input type="checkbox" name="attr_sale_tc_asteroid" value="2" class="sheet-button"/><span class="sheet-button" class="sheet-mail-attrs">Asteroid</span>
                             </td>
                             <td>
-                                <input type="checkbox" name="attr_sale_tc_barren" value="3" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Barren</span>
+                                <input type="checkbox" name="attr_sale_tc_barren" value="3" class="sheet-button"/><span class="sheet-button" class="sheet-mail-attrs">Barren</span>
                             </td>
                             <td>
-                                <input type="checkbox" name="attr_sale_tc_desert" value="4" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Desert</span>
+                                <input type="checkbox" name="attr_sale_tc_desert" value="4" class="sheet-button"/><span class="sheet-button" class="sheet-mail-attrs">Desert</span>
                             </td>
                             <td>
-                                <input type="checkbox" name="attr_sale_tc_fluid_oceans" value="5" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Fluid Oceans</span>
+                                <input type="checkbox" name="attr_sale_tc_fluid_oceans" value="5" class="sheet-button"/><span class="sheet-button" class="sheet-mail-attrs">Fluid Oceans</span>
                             </td>
                             <td>
-                                <input type="checkbox" name="attr_sale_tc_garden" value="6" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Garden</span>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <input type="checkbox" name="attr_sale_tc_high_population" value="7" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">High Population</span>
-                            </td>
-                            <td>
-                                <input type="checkbox" name="attr_sale_tc_high_tech" value="8" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">High Tech</span>
-                            </td>
-                            <td>
-                                <input type="checkbox" name="attr_sale_tc_ice_capped" value="9" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Ice-Capped</span>
-                            </td>
-                            <td>
-                                <input type="checkbox" name="attr_sale_tc_industrial" value="10" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Industrial</span>
-                            </td>
-                            <td>
-                                <input type="checkbox" name="attr_sale_tc_low_population" value="11" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Low Population</span>
-                            </td>
-                            <td>
-                                <input type="checkbox" name="attr_sale_tc_low_tech" value="12" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Low Tech</span>
+                                <input type="checkbox" name="attr_sale_tc_garden" value="6" class="sheet-button"/><span class="sheet-button" class="sheet-mail-attrs">Garden</span>
                             </td>
                         </tr>
                         <tr>
                             <td>
-                                <input type="checkbox" name="attr_sale_tc_non_agricultural" value="13" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Non-Agricultural</span>
+                                <input type="checkbox" name="attr_sale_tc_high_population" value="7" class="sheet-button"/><span class="sheet-button" class="sheet-mail-attrs">High Population</span>
                             </td>
                             <td>
-                                <input type="checkbox" name="attr_sale_tc_non_industrial" value="14" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Non-Industrial</span>
+                                <input type="checkbox" name="attr_sale_tc_high_tech" value="8" class="sheet-button"/><span class="sheet-button" class="sheet-mail-attrs">High Tech</span>
                             </td>
                             <td>
-                                <input type="checkbox" name="attr_sale_tc_poor" value="15" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Poor</span>
+                                <input type="checkbox" name="attr_sale_tc_ice_capped" value="9" class="sheet-button"/><span class="sheet-button" class="sheet-mail-attrs">Ice-Capped</span>
                             </td>
                             <td>
-                                <input type="checkbox" name="attr_sale_tc_rich" value="16" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Rich</span>
+                                <input type="checkbox" name="attr_sale_tc_industrial" value="10" class="sheet-button"/><span class="sheet-button" class="sheet-mail-attrs">Industrial</span>
                             </td>
                             <td>
-                                <input type="checkbox" name="attr_sale_tc_vacuum" value="17" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Vacuum</span>
+                                <input type="checkbox" name="attr_sale_tc_low_population" value="11" class="sheet-button"/><span class="sheet-button" class="sheet-mail-attrs">Low Population</span>
                             </td>
                             <td>
-                                <input type="checkbox" name="attr_sale_tc_waterworld" value="18" class="sheet-button"/><span class="sheet-button" style="margin-right: 5px;">Water World</span>
+                                <input type="checkbox" name="attr_sale_tc_low_tech" value="12" class="sheet-button"/><span class="sheet-button" class="sheet-mail-attrs">Low Tech</span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <input type="checkbox" name="attr_sale_tc_non_agricultural" value="13" class="sheet-button"/><span class="sheet-button" class="sheet-mail-attrs">Non-Agricultural</span>
+                            </td>
+                            <td>
+                                <input type="checkbox" name="attr_sale_tc_non_industrial" value="14" class="sheet-button"/><span class="sheet-button" class="sheet-mail-attrs">Non-Industrial</span>
+                            </td>
+                            <td>
+                                <input type="checkbox" name="attr_sale_tc_poor" value="15" class="sheet-button"/><span class="sheet-button" class="sheet-mail-attrs">Poor</span>
+                            </td>
+                            <td>
+                                <input type="checkbox" name="attr_sale_tc_rich" value="16" class="sheet-button"/><span class="sheet-button" class="sheet-mail-attrs">Rich</span>
+                            </td>
+                            <td>
+                                <input type="checkbox" name="attr_sale_tc_vacuum" value="17" class="sheet-button"/><span class="sheet-button" class="sheet-mail-attrs">Vacuum</span>
+                            </td>
+                            <td>
+                                <input type="checkbox" name="attr_sale_tc_waterworld" value="18" class="sheet-button"/><span class="sheet-button" class="sheet-mail-attrs">Water World</span>
                             </td>
                         </tr>
                     </table>
@@ -3964,11 +4259,10 @@
     <div class="sheet-tab-content sheet-tradelog">
         <h3 class="sheet-bold">Trade Log</h3>
         <p>The information below is logged from the various trade operations to give diagnostic information.</p>
-        <div style="display: flex;">
-            <input type="text" name="attr_find_value" style="height: 24px; width: 50%;">
-            <button class="sheet-redborder sheet-bordered-width" type="action" name="act_find-value">Find Attr Value
-            </button>
-            <input type="text" name="attr_show_value" style="height: 24px; width: 50%;" readonly>
+        <div class="sheet-laf-centredgrid sheet-laf-animal">
+            <input type="text" name="attr_find_value">
+            <button class="sheet-redborder sheet-bordered-width" type="action" name="act_find-value">Find Attr Value</button>
+            <input type="text" name="attr_show_value" readonly>
         </div>
         <button type="action" name="act_show-trade-log-messages" class="sheet-redborder sheet-bordered-width">Show Trade Log Messages
         </button>
@@ -3977,7 +4271,7 @@
 </div>
 <div style="text-align: center;color: darkgray; font-size: smaller">Background image: https://www.deviantart.com/elcapitan1023654/art/Free-Sci-fi-Ship-Panel-767780402
 </div>
-<div style="text-align: center;color: darkgray;">The Traveller game in all forms is owned by Far Future Enterprises. Copyright © 1977 – 2023 Far Future Enterprises.
+<div class="sheet-acknowledgement">The Traveller game in all forms is owned by Far Future Enterprises. Copyright © 1977 – 2023 Far Future Enterprises.
 </div>
 <div>
     <rolltemplate class="sheet-rolltemplate-power">
@@ -4169,7 +4463,7 @@
                 <td colspan="2">{{message}}</td>
             </tr>
             <tr>
-                <td style="font-size: 0.8em;" colspan="2">{{roll}}</td>
+                <td colspan="2">{{roll}}</td>
             </tr>
         </table>
     </rolltemplate>
@@ -8044,41 +8338,129 @@
             });
         });
 
-        on("clicked:repeating_vehicle-weapons:vehicle-weapon", (info) => {
+        on("change:repeating_vehiclemount:mount_name", (info) => {
+            console.log("MgT2E: Mount name change: " + JSON.stringify(info));
 
-            console.log("MgT2E: Vehicle weapon: " + JSON.stringify(info))
+            // Check for duplicates in name
+            getSectionIDs("repeating_vehiclemount", function(idArray) {
+                var attrs = [];
+                idArray.forEach(id => {
+                    attrs.push("repeating_vehiclemount_" + id + "_mount_name");
+                });
+                getAttrs(attrs, function(v) {
+                    const values = Object.values(v)
+                    if(values.length !== new Set(values).size) {
+                        // We have duplicates
+                        setAttrs({vehiclemount_error: "Duplicate mount name found!"});
+                    }
+                    else {
+                        setAttrs({vehiclemount_error: " "});
+                    }
+                });
+            });
+        });
 
+        on("change:repeating_vehicleweapons:mount_name", (info) => {
+
+            console.log("MgT2E: Vehicle Weapon mount name change: " + JSON.stringify(info));
+
+            // Validate the hardpoint name against the hardpoints
+            getSectionIDs("repeating_vehiclemount", function(idArray) {
+                var attrs = [];
+                idArray.forEach(id => {
+                    attrs.push("repeating_vehiclemount_" + id + "_mount_name");
+                });
+                getAttrs(attrs, function(v) {
+                    // See if our mount exists
+                    console.log("- Mount names: " + Object.values(v));
+                    if(Object.values(v).includes(info.newValue)) {
+                        // Mount is good, set the row id into the weapon. We have checked for duplicate hardpoints
+                        // when the hardpoint names are set so we assume there is only one hardpoint with the
+                        // name we need
+                        var mountKey = Object.keys(v).find(key => v[key] === info.newValue)
+                        // Strip off the name attribute to leave us with a prefix so when we fire weapons and need
+                        // to pull down the hardpoint e.g. gunner skill we can do it all in one go
+                        mountKey = mountKey.replace("mount_name", "");
+
+                        console.log("- Mount key: " + mountKey);
+                        var attrsToSet = {};
+                        attrsToSet.vehicleweapon_error = " ";
+                        attrsToSet[info.sourceAttribute.replace("mount_name", "mount_id")] = mountKey;
+                        setAttrs(attrsToSet);
+                    }
+                    else {
+                        // Mount name does not match, display error
+                        //console.log("- Hardpoint NOT found: " + Object.values(v));
+                        setAttrs({vehicleweapon_error: "Error: Mount: " + info.newValue + " does not exist!"})
+                    }
+                });
+            });
+        });
+
+        on("clicked:repeating_vehicleweapons:vehicle-weapon", (info) => {
+
+            console.log("MgT2E: Vehicle weapon click: " + JSON.stringify(info));
             const rowId = info.sourceAttribute.split('_')[2];
-            const weaponName   = "repeating_vehicle-weapons_" + rowId + "_weapon";
-            const weaponDamage = "repeating_vehicle-weapons_" + rowId + "_damage";
-            const weaponMod = "repeating_vehicle-weapons_" + rowId + "_mod";
 
-            getAttrs([weaponName, weaponDamage, weaponMod], function(v) {
+            // All we need first is the mount id
+            var attrs = [info.sourceAttribute.replace("vehicle-weapon", "mount_id")];
+            getAttrs(attrs, function(v) {
 
-                // Parse destructive weapons
-                var damageDice = v[weaponDamage].toUpperCase();
-                var destructive = false;
-                if(damageDice.includes("DD")) {
-                    destructive = true;
-                    damageDice = damageDice.replace("DD", "D6*10");
-                }
+                var mountPrefix = v[attrs[0]];
+                console.log("- Mount prefix: " + mountPrefix);
 
-                //console.log("- Roll: " + "@{whispertoggle}&{template:range} {{character=@{character_name}}} {{weapon=" + v[weaponName] + "}}  @{ro_default_rolltype} + " + v[weaponMod] + " ]]}} {{damage=[[" damageDice + "]]}}");
+                // Bootstrap off the hardpoint prefix to get everything we need
+                var weaponPrefix = info.sourceAttribute.replace("vehicle-weapon", "")
+                attrs=[];
+                ["weapon", "damage"].forEach(attr => {
+                    attrs.push(weaponPrefix + attr);
+                });
+                ["gunner", "dexmod", "custommod", "mount_name"].forEach(attr => {
+                    attrs.push(mountPrefix + attr);
+                });
+                getAttrs(attrs, function(v) {
+                    // Now we should have everything we need, add some local vars for clarity
+                    var mountName = v[mountPrefix + "mount_name"];
 
-                startRoll("@{whispertoggle}&{template:range} {{character=@{character_name}}} {{weapon=" + v[weaponName] + "}}  @{ro_default_rolltype} + " + v[weaponMod] + " ]]}} {{damage=[[" + damageDice + "]]}}", (results) => {
-                    const toHit = results.results.roll.result;
-                    var damage = results.results.damage.result
-                    if(toHit > 8 && !destructive) {
-                        damage += (toHit - 8);
+                    if(!mountName) {
+                        setAttrs({vehicleweapon_error: "Mount is not set!"});
+                        return;
+                    }
+                    setAttrs({vehicleweapon_error: " "});
+
+                    var gunnerDM = v[mountPrefix + "gunner"];
+                    var dexMod = v[mountPrefix + "dexmod"];
+                    var customMod = v[mountPrefix + "custommod"];
+
+                    var weaponType = v[weaponPrefix + "weapon"];
+                    var weaponDamage = v[weaponPrefix + "damage"];
+
+                    console.log("- mountName: " + mountName + ", gunnerDM: " + gunnerDM + ", dexMod: " + dexMod + ", customMod: " + customMod);
+                    console.log("- weaponType: " + weaponType + ", weaponDamage: " + weaponDamage);
+
+                    // We need to handle the weapon damage based on a) are they Destructive (DD) and b) number of weapons which adds the number of damage dice as extra damage
+                    if(weaponDamage.includes("DD")) {
+                        weaponDamage = weaponDamage.replace("DD", "D6*10");
                     }
 
-                    finishRoll(
-                        results.rollId,
-                        {
-                            roll: toHit,
-                            damage: damage
+                    startRoll("@{whispertoggle}&{template:range} {{character=@{character_name}}} {{weapon=" + mountName + ":" + weaponType + "}}  @{ro_default_rolltype} + " + gunnerDM + " + " + dexMod + " + " + customMod + " @{ro_default_mod}]]}} {{damage=[[" + weaponDamage + "]]}}", (results) => {
+                        const toHit = results.results.roll.result;
+                        var damage = results.results.damage.result
+
+                        /*
+                        if(toHit > 8) {
+                            damage += (toHit - 8);
                         }
-                    );
+                        */
+
+                        finishRoll(
+                            results.rollId,
+                            {
+                                roll: toHit,
+                                damage: damage,
+                            }
+                        );
+                    });
                 });
             });
         });
@@ -8202,10 +8584,11 @@
                     console.log("- weaponType: " + weaponType + ", weaponDamage: " + weaponDamage + ", numWeapons: " + numWeapons);
 
                     // We need to handle the weapon damage based on a) are they Destructive (DD) and b) number of weapons which adds the number of damage dice as extra damage
+                    var damageMod = +numWeapons - 1;
                     if(weaponDamage.includes("DD")) {
                         weaponDamage = weaponDamage.replace("DD", "D6*10");
+                        damageMod = 0;
                     }
-                    damageMod = +numWeapons - 1
 
                     // Damage mod is not applied if missiles
                     if(weaponType.toLowerCase().includes("missile")) {
@@ -8217,9 +8600,11 @@
                     const toHit = results.results.roll.result;
                     var damage = results.results.damage.result
 
+                    /*
                     if(toHit > 8) {
                         damage += (toHit - 8);
                     }
+                    */
 
                     finishRoll(
                         results.rollId,
@@ -8232,8 +8617,6 @@
                 });
             });
         });
-
-
 
 
 

--- a/Mongoose_Traveller2e/translation.json
+++ b/Mongoose_Traveller2e/translation.json
@@ -33,6 +33,7 @@
 	"skills-all-u": "All",
 	"skills-combat-u": "Combat",
 	"skilltableskill-u": "Skill",
+	"skilltabletalent-u": "Talent",
 	"skilltablecharacteristic-u": "Characteristic",
 	"skilltabledicemodifier-u": "DM",
 	"skilltableskilllevel-u": "Skill Level",
@@ -41,6 +42,7 @@
 	"skilltabletrained-u": "Trained",
 	"skilltabletotalmodifier-u": "Total",
 	"skilltablespecialty-u": "Speciality",
+	"skilltablepower-u": "Power",
 	"skilltablelevel-u": "Level",
 	"skillstrengthoption-u": "Strength",
 	"skillintellectoption-u": "Intellect",
@@ -214,5 +216,10 @@
 	"boonbane-u": "Boon/Bane",
 	"misc-u": "Misc",
 	"attack-u": "Attack",
-	"initiative-u": "Initiative"
+	"initiative-u": "Initiative",
+	"telepathy-u": "Telepathy",
+	"clairvoyance-u": "Clairvoyance",
+	"telekinesis-u": "Telekinesis",
+	"awareness-u": "Awareness",
+	"teleportation-u": "Teleportation"
 }


### PR DESCRIPTION
- NPC Armour wrapping
- Vehicle now has Mounts and Weapons with same logic as Ship
- Animal has initiative
- Ship hard point title Hardpoints/Firmpoints has properly defaulted [0] for number of hard points based on tonnage (and is flipped to Hardpoint/Firmpoint
- Ship Power title now has [0/0] properly defaulted showing Used/Total
- Vehicle and Ship now have repeating Sensor rows with Player and Sensor Mod and roll button
- Psionics now represented like skills with the five Talents and then repeating Powers
- Fixed bug in Passengers where wrong dice result being used for quantity
- Fixed input focus colour in Firefox to be red as per Chrome
- Minor styling based on CSS refactoring
- Minor descriptive text changes/additions e.g. recommending using Source and Destination UWPs on Trade tab as defaults all fields for Passengers, Freight & speculative
- 90% of inline styles have been removed

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

## New Sheet Details

<!-- If you are submitting a new sheet to the repository, please fill in any empty spaces indicated by < >. -->

- The name of this game is: <   >  _(i.e. Dungeons & Dragons 5th Edition, The Dresden Files RPG)_
- The publisher of this game is: <   > _(i.e. Wizards of the Coast, Evil Hat)_
- The name of this game system/family is: <   > _(i.e. Dungeons & Dragons, FATE)_

- [x] I have followed the [Character Sheets Standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) when building this sheet.

<!-- Please check any that apply: -->

- [ ] This sheet has been made on behalf of, or by, the game's publisher.
- [ ] This game is not a traditionally published game, but a copy of the game rules can be purchased/downloaded/found at: <   >
- [x] This sheet is for an unofficial fan game, modification to an existing game, or a homebrew system.

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

- NPC Armour wrapping
- Vehicle now has Mounts and Weapons with same logic as Ship
- Animal has initiative
- Ship hard point title Hardpoints/Firmpoints has properly defaulted [0] for number of hard points based on tonnage (and is flipped to Hardpoint/Firmpoint
- Ship Power title now has [0/0] properly defaulted showing Used/Total
- Vehicle and Ship now have repeating Sensor rows with Player and Sensor Mod and roll button
- Psionics now represented like skills with the five Talents and then repeating Powers
- Fixed bug in Passengers where wrong dice result being used for quantity
- Fixed input focus colour in Firefox to be red as per Chrome
- Minor styling based on CSS refactoring
- Minor descriptive text changes/additions e.g. recommending using Source and Destination UWPs on Trade tab as defaults all fields for Passengers, Freight & speculative
- 90% of inline styles have been removed


