### PR TITLE
Godbound Minor Feature Update

### DIFF
--- a/Godbound/Godbound.html
+++ b/Godbound/Godbound.html
@@ -708,7 +708,7 @@
 									<input type="number" class="input-center" name="attr_weapon_damage_bonus_repeat" value="0" title="Attribute modifier already included in damage"/>
 								</div>
 								<div class="col-1-20 attr vert-middle center pad-r-sm">
-									<button type="roll" class="button" name="roll_weapon_repeat" value="&{template:godbound} {{name=@{character_name}}} {{title=Weapon}} {{roll=@{weapon_name_repeat} Attack}} {{range=@{weapon_range_repeat}}} {{area=@{weapon_area_repeat}}} {{weapon=[[1d20 + @{base_attack_bonus} + @{weapon_attribute_repeat} + @{weapon_bonus_repeat} + ?{Targets AC|9} + ?{Misc Attack Bonus|0}]]}} {{target=[[20]]}} {{damage=[[@{weapon_damage_die_repeat} + @{weapon_attribute_repeat} + @{weapon_damage_bonus_repeat}]]}} {{damage0=[[0]]}} {{damage1=[[1]]}} {{damage2=[[2]]}} {{damage4=[[4]]}}"></button>
+									<button type="roll" class="button" name="roll_weapon_repeat" value="&{template:godbound} {{name=@{character_name}}} {{title=Weapon}} {{roll=@{weapon_name_repeat} Attack}} {{range=@{weapon_range_repeat}}} {{area=@{weapon_area_repeat}}} {{weapon=[[20 - 1d20 - @{base_attack_bonus} - @{weapon_attribute_repeat} - @{weapon_bonus_repeat} - ?{Misc Attack Modifier|0}]]}} {{damage=[[@{weapon_damage_die_repeat} + @{weapon_attribute_repeat} + @{weapon_damage_bonus_repeat}]]}} {{damage0=[[0]]}} {{damage1=[[1]]}} {{damage2=[[2]]}} {{damage4=[[4]]}}"></button>
 								</div>
 							</div>
 						</fieldset>
@@ -1772,7 +1772,7 @@
 						<input type="number" name="attr_npc_attack_bonus" value="0"/>
 					</div>
 					<div class="col-1-10 attr vert-middle center pad-l-smd pad-r-sm pad-b-sm">
-						<button type="roll" class="button" name="roll_npc_attack" value="&{template:godbound} {{name=@{character_name}}} {{title=Attack}} {{roll=NPC Attack}} {{range=@{npc_attack_range}}} {{area=@{npc_attack_area}}} {{npcattack=[[1d20 + @{npc_attack_bonus} + ?{Targets AC|9} + ?{Modifier|0}]]}} {{target=[[20]]}}"></button>
+						<button type="roll" class="button" name="roll_npc_attack" value="&{template:godbound} {{name=@{character_name}}} {{title=Attack}} {{roll=NPC Attack}} {{range=@{npc_attack_range}}} {{area=@{npc_attack_area}}} {{npcattack=[[20 - 1d20 - @{npc_attack_bonus} - ?{Misc Attack Modifier|0}]]}}"></button>
 					</div>
 					<div class="col-1-4 attr vert-middle right pad-l-sm pad-t-sm pad-r-md pad-b-sm">
 						Damage
@@ -1814,7 +1814,7 @@
 							<input type="text" class="input-center" name="attr_npcweapon_damage_repeat" value="1d8 + 0"/>
 						</div>
 						<div class="col-1-10 attr vert-middle center pad-t-sm pad-r-sm pad-b-sm">
-							<button type="roll" class="button" name="roll_weapon_repeat" value="&{template:godbound} {{name=@{character_name}}} {{title=Weapon}} {{roll=@{npcweapon_name_repeat} Attack}} {{range=@{npcweapon_range_repeat}}} {{area=@{npcweapon_area_repeat}}} {{weapon=[[1d20 + @{npcweapon_attack_repeat} + ?{Targets AC|9} + ?{Modifier|0}]]}} {{target=[[20]]}} {{damage=[[@{npcweapon_damage_repeat}]]}} {{damage0=[[0]]}} {{damage1=[[1]]}} {{damage2=[[2]]}} {{damage4=[[4]]}}"></button>
+							<button type="roll" class="button" name="roll_weapon_repeat" value="&{template:godbound} {{name=@{character_name}}} {{title=Weapon}} {{roll=@{npcweapon_name_repeat} Attack}} {{range=@{npcweapon_range_repeat}}} {{area=@{npcweapon_area_repeat}}} {{weapon=[[20 - 1d20 - @{npcweapon_attack_repeat} - ?{Misc Attack Modifier|0}]]}} {{damage=[[@{npcweapon_damage_repeat}]]}} {{damage0=[[0]]}} {{damage1=[[1]]}} {{damage2=[[2]]}} {{damage4=[[4]]}}"></button>
 						</div>
 						<div class="col-1-10 attr vert-middle center underline pad-t-sm pad-r-sm pad-b-sm">
 							<input type="checkbox" class="circle-check" name="attr_npcweapon_description_show_repeat" value="1"><span></span>
@@ -3415,293 +3415,103 @@
 			{{/fray}}
 			{{#weapon}}
 				<div class="sheet-row">
-					<div class="sheet-col-2-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-						Range
+					<div class="sheet-col-1-2 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
+						Attack Range
 					</div>
-					<div class="sheet-col-3-5 sheet-bold sheet-pad-r-sm sheet-pad-b-sm">
+					<div class="sheet-col-1-2 sheet-bold sheet-pad-r-sm sheet-pad-b-sm">
 						{{range}}
 					</div>
 				</div>
 				<div class="sheet-row">
-					<div class="sheet-col-2-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-						Area
+					<div class="sheet-col-1-2 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
+						Attack Area
 					</div>
-					<div class="sheet-col-3-5 sheet-bold sheet-pad-r-sm sheet-pad-b-sm">
+					<div class="sheet-col-1-2 sheet-bold sheet-pad-r-sm sheet-pad-b-sm">
 						{{area}}
 					</div>
 				</div>
 				<div class="sheet-row">
-					<div class="sheet-col-3-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-						Attack Roll
+					<div class="sheet-col-1-2 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
+						Attack Result
 					</div>
-					<div class="sheet-col-2-5 sheet-pad-r-sm sheet-pad-b-sm">
-						{{weapon}}
+					<div class="sheet-col-1-2 sheet-pad-r-sm sheet-pad-b-sm">
+						Hit AC {{weapon}} or higher
 					</div>
 				</div>
 				<div class="sheet-row">
-					<div class="sheet-col-3-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-						Target
+					<div class="sheet-col-1-2 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
+						Straight Damage
 					</div>
-					<div class="sheet-col-2-5 sheet-pad-r-sm sheet-pad-b-sm">
-						{{target}}
+					<div class="sheet-col-1-52sheet-pad-r-sm sheet-pad-b-sm">
+						{{damage}}
 					</div>
 				</div>
-				{{#rollWasFumble() weapon}}
+				{{#rollLess() damage 2}}
 					<div class="sheet-row">
-						<div class="sheet-col-1 sheet-title-banner-subheading sheet-center sheet-pad-t-md sheet-pad-r-sm sheet-pad-b-sm sheet-mar-t-md sheet-mar-b-sm">
-							<h3>Miss!</h3>
+						<div class="sheet-col-1-2 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
+							Normal Damage
+						</div>
+						<div class="sheet-col-1-2 sheet-pad-r-sm sheet-pad-b-sm">
+							{{damage0}}
 						</div>
 					</div>
-				{{/rollWasFumble() weapon}}
-				{{#rollWasCrit() weapon}}
+				{{/rollLess() damage 2}}
+				{{#rollBetween() damage 2 5}}
 					<div class="sheet-row">
-						<div class="sheet-col-1 sheet-title-banner-subheading sheet-center sheet-pad-t-md sheet-pad-r-sm sheet-pad-b-sm sheet-mar-t-md sheet-mar-b-sm">
-							<h3>Hit!</h3>
+						<div class="sheet-col-1-2 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
+							Normal Damage
+						</div>
+						<div class="sheet-col-1-2 sheet-pad-r-sm sheet-pad-b-sm">
+							{{damage1}}
 						</div>
 					</div>
+				{{/rollBetween() damage 2 5}}
+				{{#rollBetween() damage 6 9}}
 					<div class="sheet-row">
-						<div class="sheet-col-3-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-							Straight Damage
+						<div class="sheet-col-1-2 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
+							Normal Damage
 						</div>
-						<div class="sheet-col-2-5 sheet-pad-r-sm sheet-pad-b-sm">
-							{{damage}}
+						<div class="sheet-col-1-2 sheet-pad-r-sm sheet-pad-b-sm">
+							{{damage2}}
 						</div>
 					</div>
-					{{#rollLess() damage 2}}
-						<div class="sheet-row">
-							<div class="sheet-col-3-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-								Normal Damage
-							</div>
-							<div class="sheet-col-2-5 sheet-pad-r-sm sheet-pad-b-sm">
-								{{damage0}}
-							</div>
+				{{/rollBetween() damage 6 9}}
+				{{#rollGreater() damage 9}}
+					<div class="sheet-row">
+						<div class="sheet-col-1-2 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
+							Normal Damage
 						</div>
-					{{/rollLess() damage 2}}
-					{{#rollBetween() damage 2 5}}
-						<div class="sheet-row">
-							<div class="sheet-col-3-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-								Normal Damage
-							</div>
-							<div class="sheet-col-2-5 sheet-pad-r-sm sheet-pad-b-sm">
-								{{damage1}}
-							</div>
+						<div class="sheet-col-1-2 sheet-pad-r-sm sheet-pad-b-sm">
+							{{damage4}}
 						</div>
-					{{/rollBetween() damage 2 5}}
-					{{#rollBetween() damage 6 9}}
-						<div class="sheet-row">
-							<div class="sheet-col-3-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-								Normal Damage
-							</div>
-							<div class="sheet-col-2-5 sheet-pad-r-sm sheet-pad-b-sm">
-								{{damage2}}
-							</div>
-						</div>
-					{{/rollBetween() damage 6 9}}
-					{{#rollGreater() damage 9}}
-						<div class="sheet-row">
-							<div class="sheet-col-3-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-								Normal Damage
-							</div>
-							<div class="sheet-col-2-5 sheet-pad-r-sm sheet-pad-b-sm">
-								{{damage4}}
-							</div>
-						</div>
-					{{/rollGreater() damage 9}}
-				{{/rollWasCrit() weapon}}
-				{{#^rollWasCrit() weapon}}
-					{{#^rollWasFumble() weapon}}
-						{{#rollLess() weapon target}}
-							<div class="sheet-row">
-								<div class="sheet-col-1 sheet-title-banner-subheading sheet-center sheet-pad-t-md sheet-pad-r-sm sheet-pad-b-sm sheet-mar-t-md sheet-mar-b-sm">
-									<h3>Miss!</h3>
-								</div>
-							</div>
-						{{/rollLess() weapon target}}
-						{{#rollTotal() weapon target}}
-							<div class="sheet-row">
-								<div class="sheet-col-1 sheet-title-banner-subheading sheet-center sheet-pad-t-md sheet-pad-r-sm sheet-pad-b-sm sheet-mar-t-md sheet-mar-b-sm">
-									<h3>Hit!</h3>
-								</div>
-							</div>
-							<div class="sheet-row">
-								<div class="sheet-col-3-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-									Straight Damage
-								</div>
-								<div class="sheet-col-2-5 sheet-pad-r-sm sheet-pad-b-sm">
-									{{damage}}
-								</div>
-							</div>
-							{{#rollLess() damage 2}}
-								<div class="sheet-row">
-									<div class="sheet-col-3-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-										Normal Damage
-									</div>
-									<div class="sheet-col-2-5 sheet-pad-r-sm sheet-pad-b-sm">
-										{{damage0}}
-									</div>
-								</div>
-							{{/rollLess() damage 2}}
-							{{#rollBetween() damage 2 5}}
-								<div class="sheet-row">
-									<div class="sheet-col-3-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-										Normal Damage
-									</div>
-									<div class="sheet-col-2-5 sheet-pad-r-sm sheet-pad-b-sm">
-										{{damage1}}
-									</div>
-								</div>
-							{{/rollBetween() damage 2 5}}
-							{{#rollBetween() damage 6 9}}
-								<div class="sheet-row">
-									<div class="sheet-col-3-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-										Normal Damage
-									</div>
-									<div class="sheet-col-2-5 sheet-pad-r-sm sheet-pad-b-sm">
-										{{damage2}}
-									</div>
-								</div>
-							{{/rollBetween() damage 6 9}}
-							{{#rollGreater() damage 9}}
-								<div class="sheet-row">
-									<div class="sheet-col-3-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-										Normal Damage
-									</div>
-									<div class="sheet-col-2-5 sheet-pad-r-sm sheet-pad-b-sm">
-										{{damage4}}
-									</div>
-								</div>
-							{{/rollGreater() damage 9}}
-						{{/rollTotal() weapon target}}
-						{{#rollGreater() weapon target}}
-							<div class="sheet-row">
-								<div class="sheet-col-1 sheet-title-banner-subheading sheet-center sheet-pad-t-md sheet-pad-r-sm sheet-pad-b-sm sheet-mar-t-md sheet-mar-b-sm">
-									<h3>Hit!</h3>
-								</div>
-							</div>
-							<div class="sheet-row">
-								<div class="sheet-col-3-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-									Straight Damage
-								</div>
-								<div class="sheet-col-2-5 sheet-pad-r-sm sheet-pad-b-sm">
-									{{damage}}
-								</div>
-							</div>
-							{{#rollLess() damage 2}}
-								<div class="sheet-row">
-									<div class="sheet-col-3-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-										Normal Damage
-									</div>
-									<div class="sheet-col-2-5 sheet-pad-r-sm sheet-pad-b-sm">
-										{{damage0}}
-									</div>
-								</div>
-							{{/rollLess() damage 2}}
-							{{#rollBetween() damage 2 5}}
-								<div class="sheet-row">
-									<div class="sheet-col-3-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-										Normal Damage
-									</div>
-									<div class="sheet-col-2-5 sheet-pad-r-sm sheet-pad-b-sm">
-										{{damage1}}
-									</div>
-								</div>
-							{{/rollBetween() damage 2 5}}
-							{{#rollBetween() damage 6 9}}
-								<div class="sheet-row">
-									<div class="sheet-col-3-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-										Normal Damage
-									</div>
-									<div class="sheet-col-2-5 sheet-pad-r-sm sheet-pad-b-sm">
-										{{damage2}}
-									</div>
-								</div>
-							{{/rollBetween() damage 6 9}}
-							{{#rollGreater() damage 9}}
-								<div class="sheet-row">
-									<div class="sheet-col-3-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-										Normal Damage
-									</div>
-									<div class="sheet-col-2-5 sheet-pad-r-sm sheet-pad-b-sm">
-										{{damage4}}
-									</div>
-								</div>
-							{{/rollGreater() damage 9}}
-						{{/rollGreater() weapon target}}
-					{{/^rollWasFumble() weapon}}
-				{{/^rollWasCrit() weapon}}
+					</div>
+				{{/rollGreater() damage 9}}
 			{{/weapon}}
 			{{#npcattack}}
 				<div class="sheet-row">
-					<div class="sheet-col-2-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-						Range
+					<div class="sheet-col-1-2 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
+						Attack Range
 					</div>
-					<div class="sheet-col-3-5 sheet-bold sheet-pad-r-sm sheet-pad-b-sm">
+					<div class="sheet-col-1-2 sheet-bold sheet-pad-r-sm sheet-pad-b-sm">
 						{{range}}
 					</div>
 				</div>
 				<div class="sheet-row">
-					<div class="sheet-col-2-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-						Area
+					<div class="sheet-col-1-2 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
+						Attack Area
 					</div>
-					<div class="sheet-col-3-5 sheet-bold sheet-pad-r-sm sheet-pad-b-sm">
+					<div class="sheet-col-1-2 sheet-bold sheet-pad-r-sm sheet-pad-b-sm">
 						{{area}}
 					</div>
 				</div>
 				<div class="sheet-row">
-					<div class="sheet-col-3-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
+					<div class="sheet-col-1-2 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
 						Attack Roll
 					</div>
-					<div class="sheet-col-2-5 sheet-pad-r-sm sheet-pad-b-sm">
-						{{npcattack}}
+					<div class="sheet-col-1-2 sheet-pad-r-sm sheet-pad-b-sm">
+						Hit AC {{npcattack}} or higher
 					</div>
 				</div>
-				<div class="sheet-row">
-					<div class="sheet-col-3-5 sheet-bold sheet-pad-l-lg sheet-pad-r-md sheet-pad-b-sm">
-						Target
-					</div>
-					<div class="sheet-col-2-5 sheet-pad-r-sm sheet-pad-b-sm">
-						{{target}}
-					</div>
-				</div>
-				{{#rollWasFumble() npcattack}}
-					<div class="sheet-row">
-						<div class="sheet-col-1 sheet-title-banner-subheading sheet-center sheet-pad-t-md sheet-pad-r-sm sheet-pad-b-sm sheet-mar-t-md sheet-mar-b-sm">
-							<h3>Miss!</h3>
-						</div>
-					</div>
-				{{/rollWasFumble() npcattack}}
-				{{#rollWasCrit() npcattack}}
-					<div class="sheet-row">
-						<div class="sheet-col-1 sheet-title-banner-subheading sheet-center sheet-pad-t-md sheet-pad-r-sm sheet-pad-b-sm sheet-mar-t-md sheet-mar-b-sm">
-							<h3>Hit!</h3>
-						</div>
-					</div>
-				{{/rollWasCrit() npcattack}}
-				{{#^rollWasCrit() npcattack}}
-					{{#^rollWasFumble() npcattack}}
-						{{#rollLess() npcattack target}}
-							<div class="sheet-row">
-								<div class="sheet-col-1 sheet-title-banner-subheading sheet-center sheet-pad-t-md sheet-pad-r-sm sheet-pad-b-sm sheet-mar-t-md sheet-mar-b-sm">
-									<h3>Miss!</h3>
-								</div>
-							</div>
-						{{/rollLess() npcattack target}}
-						{{#rollTotal() npcattack target}}
-							<div class="sheet-row">
-								<div class="sheet-col-1 sheet-title-banner-subheading sheet-center sheet-pad-t-md sheet-pad-r-sm sheet-pad-b-sm sheet-mar-t-md sheet-mar-b-sm">
-									<h3>Hit!</h3>
-								</div>
-							</div>
-						{{/rollTotal() npcattack target}}
-						{{#rollGreater() npcattack target}}
-							<div class="sheet-row">
-								<div class="sheet-col-1 sheet-title-banner-subheading sheet-center sheet-pad-t-md sheet-pad-r-sm sheet-pad-b-sm sheet-mar-t-md sheet-mar-b-sm">
-									<h3>Hit!</h3>
-								</div>
-							</div>
-						{{/rollGreater() npcattack target}}
-					{{/^rollWasFumble() npcattack}}
-				{{/^rollWasCrit() npcattack}}
 			{{/npcattack}}
 			{{#freedamage}}
 				<div class="sheet-row">

--- a/Godbound/README.md
+++ b/Godbound/README.md
@@ -4,6 +4,9 @@ This sheet is created for use in Godbound games on Roll20, based on the Characte
 
 ## Features / Changelog
 
+- v3.3
+  - Minor
+    * Attacks now do not require inputting target's AC. Instead, the rolltemplate displays the AC the attack would hit. New calculation is "20 - roll - modifiers." This makes combat faster by removing one step in the sheet's rolling process.
 - v3.2
   - Minor
     * Add missing Effort entry for Invocations


### PR DESCRIPTION
# Submission Checklist
## Required

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

Changes to attack roll buttons and template to use new calculation that speeds up combat slightly. 

Attacks now do not require inputting target's AC. Instead, the rolltemplate displays the AC the attack would hit. New calculation is "20 - roll - modifiers" instead of "roll + modifiers + target's AC vs 20." This makes combat faster by removing one step in the sheet's rolling process.

This change means that AC is no longer required to be revealed before rolling, but rolling for attacks is still compliant with the game's RAW.